### PR TITLE
feat: support GitLab project hooks

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1139,10 +1139,11 @@ exists, the forge webhook creates or reuses its stable provider-scoped
 Reviewer Chat and trusted review run. Writers do not create or wake a review
 Chat, repair the change, publish a verdict, or merge. GitHub uses the App
 webhook and App review path. GitLab uses a processable Merge Request event from
-the Team's inbound System Hook; the Reviewer reads and mutates GitLab with
-host-local `git` and `glab` credentials. System Hooks do not deliver Note
-events, and a normal GitLab Note never starts Context Review, so a Reviewer
-note cannot self-trigger another run.
+the Team's inbound System or Project Hook; a processed System Hook MR remains
+the connection-readiness requirement. The Reviewer reads and mutates GitLab
+with host-local `git` and `glab` credentials. Project Hook Notes can supply
+ordinary entity attention but never start Context Review, so a Reviewer note
+cannot self-trigger another run.
 
 `first-tree tree review` is the GitHub App publication command and is available
 only inside an active GitHub Context Reviewer runtime session. It accepts a

--- a/packages/qa/cases/cross-surface/gitlab-context-tree-lifecycle.md
+++ b/packages/qa/cases/cross-surface/gitlab-context-tree-lifecycle.md
@@ -27,9 +27,11 @@ runtime, network, credential, and cross-surface behavior.
   and an eligible Work Agent plus independent Review Agent.
 - Configure one exact GitLab connection and an instance-wide System Hook from
   the derived `/admin/hooks` page, with Push and Merge Request events enabled,
-  the default payload, and no custom template. First Tree must observe a
-  processable Merge Request event before routing or Context Review is treated
-  as ready. Connection creation must not depend on Web Context egress policy.
+  the default payload, and no custom template. Reuse the same one-time URL in a
+  trusted Project Hook with Merge Request, Issue, and Note events enabled.
+  First Tree must observe a processable System Hook Merge Request event before
+  routing or Context Review is treated as ready. Connection creation must not
+  depend on Web Context egress policy.
   For a Self-Managed origin, the deployment operator—not the Team
   admin—separately authorizes the exact HTTPS origin through
   `FIRST_TREE_GITLAB_ALLOWED_ORIGINS`. Retain evidence of policy shape but no
@@ -58,8 +60,14 @@ runtime, network, credential, and cross-surface behavior.
 - Deliver old-GitLab open/reopen/update and draft-to-ready MR payloads. Confirm
   the current exact connection/project/binding and configured active Review
   Agent select one stable MR-scoped Reviewer Chat. Replay a stable delivery id,
-  replace the connection, send a wrong project/host, and send ordinary Notes.
-  Require deduplication/fencing, no stale dispatch, and no Note self-trigger.
+  deliver the same MR occurrence through System and Project Hooks in both
+  orders, replace the connection, send a wrong project/host, and send ordinary
+  Project Hook Notes. Require one card/Reviewer dispatch for each overlapping
+  MR occurrence, System Hook readiness evidence even when its copy is
+  suppressed, ordinary Issue/Note routing, no stale dispatch, and no Note
+  self-trigger. Repeat an MR pair without `updated_at`, `oldrev`, or `changes`
+  and confirm the documented fail-open duplicate risk rather than false
+  suppression.
   Generic GitLab entity attention remains independently observable.
 - On a ready same-project MR, confirm the Reviewer resolves live state with the
   exact-host `glab` identity, fetches a detached exact head, runs

--- a/packages/server/src/__tests__/gitlab-cross-hook-dedup.test.ts
+++ b/packages/server/src/__tests__/gitlab-cross-hook-dedup.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildGitlabCrossHookFingerprint,
+  GITLAB_CROSS_HOOK_DEDUP_TTL_MS,
+  isGitlabCrossHookDuplicate,
+  rememberSuccessfulGitlabHookEvent,
+  resetGitlabCrossHookDedupForTests,
+  withGitlabCrossHookDedupFence,
+} from "../services/gitlab-cross-hook-dedup.js";
+
+const occurrence = {
+  connectionId: "connection-1",
+  projectId: 99,
+  mrIid: 7,
+  action: "update",
+  updatedAt: "2026-07-28T10:00:00.000Z",
+  oldrev: "abc123",
+};
+
+describe("GitLab cross-hook dedup", () => {
+  afterEach(() => {
+    resetGitlabCrossHookDedupForTests();
+  });
+
+  it("builds the same fingerprint for canonically equal change objects", () => {
+    const first = buildGitlabCrossHookFingerprint({
+      ...occurrence,
+      changes: {
+        title: { previous: "Before", current: "After" },
+        labels: { previous: [], current: [{ title: "ready", color: "#fff" }] },
+      },
+    });
+    const second = buildGitlabCrossHookFingerprint({
+      ...occurrence,
+      changes: {
+        labels: { current: [{ color: "#fff", title: "ready" }], previous: [] },
+        title: { current: "After", previous: "Before" },
+      },
+    });
+
+    expect(first).toBe(second);
+  });
+
+  it("fails open when the payload has no reliable occurrence field", () => {
+    expect(
+      buildGitlabCrossHookFingerprint({
+        ...occurrence,
+        updatedAt: null,
+        oldrev: null,
+        changes: null,
+      }),
+    ).toBeNull();
+    expect(
+      buildGitlabCrossHookFingerprint({
+        ...occurrence,
+        updatedAt: null,
+        oldrev: null,
+        changes: {},
+      }),
+    ).toBeNull();
+  });
+
+  it("suppresses only the opposite source inside the 60-second window", () => {
+    const fingerprint = buildGitlabCrossHookFingerprint({ ...occurrence, changes: null });
+    expect(fingerprint).not.toBeNull();
+    if (!fingerprint) return;
+
+    rememberSuccessfulGitlabHookEvent({ fingerprint, hookSource: "system", processedAt: 1_000 });
+
+    expect(isGitlabCrossHookDuplicate({ fingerprint, hookSource: "system", now: 2_000 })).toBe(false);
+    expect(isGitlabCrossHookDuplicate({ fingerprint, hookSource: "project", now: 2_000 })).toBe(true);
+    expect(
+      isGitlabCrossHookDuplicate({
+        fingerprint,
+        hookSource: "project",
+        now: 1_000 + GITLAB_CROSS_HOOK_DEDUP_TTL_MS + 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("serializes same-connection work through the post-processing boundary", async () => {
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = withGitlabCrossHookDedupFence("connection-1", async () => {
+      order.push("first:start");
+      await firstGate;
+      order.push("first:end");
+    });
+    const second = withGitlabCrossHookDedupFence("connection-1", async () => {
+      order.push("second:start");
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+    releaseFirst?.();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first:start", "first:end", "second:start"]);
+  });
+});

--- a/packages/server/src/__tests__/gitlab-webhook-normalize.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-normalize.test.ts
@@ -30,6 +30,7 @@ function mergeRequestBody() {
       action: "open",
       title: "System Hook MR",
       url: "https://gitlab.internal/Acme/API/-/merge_requests/7",
+      updated_at: "2026-07-28T10:00:00.000Z",
     },
   };
 }
@@ -136,6 +137,33 @@ describe("GitLab webhook normalization", () => {
         body: { ...mergeRequestBody(), event_type: "push" },
       }),
     ).toThrow("event_type does not match event_name or object_kind");
+  });
+
+  it("derives one cross-hook fingerprint without treating missing occurrence fields as duplicates", () => {
+    const system = normalizeGitlabWebhook({
+      ...base,
+      eventHeader: "System Hook",
+      body: mergeRequestBody(),
+    });
+    const projectHook = normalizeGitlabWebhook({
+      ...base,
+      eventHeader: "Merge Request Hook",
+      body: mergeRequestBody(),
+    });
+
+    expect(system.hookSource).toBe("system");
+    expect(projectHook.hookSource).toBe("project");
+    expect(system.crossHookFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(projectHook.crossHookFingerprint).toBe(system.crossHookFingerprint);
+
+    const body = mergeRequestBody();
+    const { updated_at: _updatedAt, ...objectAttributes } = body.object_attributes;
+    const failOpen = normalizeGitlabWebhook({
+      ...base,
+      eventHeader: "Merge Request Hook",
+      body: { ...body, object_attributes: objectAttributes },
+    });
+    expect(failOpen.crossHookFingerprint).toBeNull();
   });
 
   it("normalizes merge request, issue, and note payloads without exposing raw provider fields", () => {

--- a/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
@@ -10,6 +10,7 @@ import { gitlabEntityChatMappings } from "../db/schema/gitlab-entity-chat-mappin
 import { gitlabIdentityLinks } from "../db/schema/gitlab-identity-links.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
+import { organizationSettings } from "../db/schema/organization-settings.js";
 import { processedEvents } from "../db/schema/processed-events.js";
 import { createAgent } from "../services/agent.js";
 import {
@@ -27,7 +28,8 @@ import {
 import * as gitlabEntityFollowService from "../services/gitlab-entity-follow.js";
 import { createOrganization } from "../services/organization.js";
 import * as scmCardDelivery from "../services/scm-card-delivery.js";
-import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
+import { getTeamSetupCapabilities } from "../services/setup-capabilities.js";
+import { createTestAdmin, createTestAgent, seedHealthyAgentRuntime, useTestApp } from "./helpers.js";
 
 const { declareGitlabEntityFollow, observeGitlabEntityAndResolveFollowers, removeGitlabEntityFollow } =
   gitlabEntityFollowService;
@@ -60,10 +62,13 @@ function issuePayload(iid = 42, input: { projectId?: number; projectPath?: strin
 function mergeRequestPayload(
   iid = 52,
   input: {
-    action?: "open" | "merge";
+    action?: "open" | "update" | "merge";
     state?: "opened" | "merged";
     projectId?: number;
     projectPath?: string;
+    updatedAt?: string;
+    oldrev?: string;
+    changes?: Record<string, unknown>;
   } = {},
 ) {
   const projectId = input.projectId ?? 501;
@@ -77,6 +82,7 @@ function mergeRequestPayload(
     },
     user: { username: "alice" },
     reviewers: [],
+    ...(input.changes ? { changes: input.changes } : {}),
     object_attributes: {
       iid,
       action: input.action ?? "open",
@@ -84,6 +90,8 @@ function mergeRequestPayload(
       description: "",
       url: `https://gitlab.internal/${projectPath}/-/merge_requests/${iid}`,
       state: input.state ?? "opened",
+      updated_at: input.updatedAt ?? "2026-07-28T10:00:00.000Z",
+      ...(input.oldrev ? { oldrev: input.oldrev } : {}),
     },
   };
 }
@@ -177,21 +185,19 @@ describe("GitLab Stage 2A backend", () => {
       stableId: `before-regeneration-${randomUUID()}`,
     });
     expect(observed.statusCode).toBe(200);
-    const rejectedProjectHook = await postWebhook(
-      app,
-      first.bearer,
-      { object_kind: "merge_request" },
-      { event: "Merge Request Hook" },
-    );
-    expect(rejectedProjectHook.statusCode).toBe(400);
+    const duplicateProjectHook = await postWebhook(app, first.bearer, mergeRequestPayload(), {
+      event: "Merge Request Hook",
+    });
+    expect(duplicateProjectHook.statusCode).toBe(200);
+    expect(duplicateProjectHook.json()).toMatchObject({ outcome: "cross_hook_duplicate" });
     expect(await getGitlabConnectionSummary(app.db, first.connectionId)).toMatchObject({
       endpointSeen: true,
       stableDeliveryObserved: true,
       health: {
         lastValidInboundAt: expect.any(String),
         lastSystemHookMergeRequestInboundAt: expect.any(String),
-        lastProcessingFailureAt: expect.any(String),
-        lastProcessingFailureCode: "unsupported_hook_type",
+        lastProcessingFailureAt: null,
+        lastProcessingFailureCode: null,
       },
     });
 
@@ -385,6 +391,148 @@ describe("GitLab Stage 2A backend", () => {
     expect(afterWebhookId).toHaveLength(before + 1);
   });
 
+  it("deduplicates matching MR events only across System and Project Hook sources", async () => {
+    const app = getApp();
+    const first = await connection(app);
+    const chatId = `chat_${randomUUID()}`;
+    await app.db
+      .insert(chats)
+      .values({ id: chatId, organizationId: first.admin.organizationId, type: "group", metadata: {} });
+    await app.db.insert(chatMembership).values({
+      chatId,
+      agentId: first.admin.humanAgentUuid,
+      role: "owner",
+      accessMode: "speaker",
+    });
+    for (const iid of [91, 92, 93]) {
+      await declareGitlabEntityFollow(app.db, {
+        organizationId: first.admin.organizationId,
+        connectionId: first.connectionId,
+        chatId,
+        declaredByAgentId: first.admin.humanAgentUuid,
+        humanAgentId: first.admin.humanAgentUuid,
+        delegateAgentId: first.admin.humanAgentUuid,
+        entityUrl: `https://gitlab.internal/Acme/API/-/merge_requests/${iid}`,
+      });
+    }
+
+    const projectFirst = await postWebhook(app, first.bearer, mergeRequestPayload(91), {
+      event: "Merge Request Hook",
+    });
+    expect(projectFirst.json()).toMatchObject({ outcome: "delivered" });
+    const systemDuplicate = await postWebhook(app, first.bearer, mergeRequestPayload(91));
+    expect(systemDuplicate.json()).toMatchObject({ outcome: "cross_hook_duplicate" });
+
+    const systemFirst = await postWebhook(app, first.bearer, mergeRequestPayload(92));
+    expect(systemFirst.json()).toMatchObject({ outcome: "delivered" });
+    const projectDuplicate = await postWebhook(app, first.bearer, mergeRequestPayload(92), {
+      event: "Merge Request Hook",
+    });
+    expect(projectDuplicate.json()).toMatchObject({ outcome: "cross_hook_duplicate" });
+
+    const distinctUpdate = await postWebhook(
+      app,
+      first.bearer,
+      mergeRequestPayload(92, {
+        action: "update",
+        updatedAt: "2026-07-28T10:01:00.000Z",
+        changes: { title: { previous: "System Hook MR", current: "Updated MR" } },
+      }),
+      { event: "Merge Request Hook" },
+    );
+    expect(distinctUpdate.json()).toMatchObject({ outcome: "delivered" });
+
+    const concurrent = await Promise.all([
+      postWebhook(app, first.bearer, mergeRequestPayload(93)),
+      postWebhook(app, first.bearer, mergeRequestPayload(93), { event: "Merge Request Hook" }),
+    ]);
+    expect(concurrent.map((response) => response.json().outcome).sort()).toEqual(["cross_hook_duplicate", "delivered"]);
+
+    expect(
+      await app.db
+        .select()
+        .from(messages)
+        .where(and(eq(messages.chatId, chatId), eq(messages.source, "gitlab"))),
+    ).toHaveLength(4);
+    expect((await getGitlabConnectionSummary(app.db, first.connectionId)).health).toMatchObject({
+      readiness: "routing_verified",
+      lastSystemHookMergeRequestInboundAt: expect.any(String),
+      lastProcessingFailureAt: null,
+      lastProcessingFailureCode: null,
+    });
+
+    const reviewer = await createTestAgent(app, { displayName: "GitLab Context Reviewer" });
+    const capabilityObservedAt = new Date();
+    await seedHealthyAgentRuntime(app, {
+      agentUuid: reviewer.agent.uuid,
+      clientId: reviewer.clientId,
+      now: capabilityObservedAt,
+    });
+    await app.db.insert(organizationSettings).values([
+      {
+        organizationId: first.admin.organizationId,
+        namespace: "context_tree",
+        value: {
+          provider: "gitlab",
+          repo: "https://gitlab.internal/acme/context-tree.git",
+          branch: "main",
+        },
+        version: 1,
+        updatedBy: first.admin.userId,
+      },
+      {
+        organizationId: first.admin.organizationId,
+        namespace: "context_tree_features",
+        value: {
+          contextReviewer: {
+            enabled: true,
+            agentUuid: reviewer.agent.uuid,
+          },
+        },
+        version: 1,
+        updatedBy: first.admin.userId,
+      },
+    ]);
+
+    for (const [event, objectKind] of [
+      ["Merge Request Hook", "merge_request"],
+      ["Issue Hook", "issue"],
+      ["Note Hook", "note"],
+    ] as const) {
+      const malformedProjectHook = await postWebhook(app, first.bearer, { object_kind: objectKind }, { event });
+      expect(malformedProjectHook.statusCode).toBe(400);
+    }
+    const invalidProjectJson = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/gitlab/${first.bearer}`,
+      headers: { "content-type": "application/json", "x-gitlab-event": "Note Hook" },
+      payload: "{",
+    });
+    expect(invalidProjectJson.statusCode).toBe(400);
+    expect((await getGitlabConnectionSummary(app.db, first.connectionId)).health).toMatchObject({
+      readiness: "routing_verified",
+      lastSystemHookMergeRequestInboundAt: expect.any(String),
+      lastProcessingFailureAt: null,
+      lastProcessingFailureCode: null,
+    });
+    const capabilities = await getTeamSetupCapabilities(app.db, first.admin.organizationId, {
+      now: () => capabilityObservedAt,
+      staleSeconds: 60,
+    });
+    expect(capabilities.repositoryAutomation.providers).toContainEqual(
+      expect.objectContaining({ provider: "gitlab", health: "ready", blockers: [] }),
+    );
+    expect(capabilities).toMatchObject({
+      contextTree: {
+        automaticReview: {
+          adoption: "enabled",
+          health: "ready",
+          blockers: [],
+        },
+      },
+    });
+  });
+
   it("resolves a pending follow and delivers one basic card per chat with wake and no outbound fetch", async () => {
     const app = getApp();
     const first = await connection(app);
@@ -455,7 +603,7 @@ describe("GitLab Stage 2A backend", () => {
     expect(after).toHaveLength(3);
   });
 
-  it("applies a terminal MR observation without emitting another card", async () => {
+  it("applies a terminal MR observation and routes a later Project Hook note", async () => {
     const app = getApp();
     const first = await connection(app);
     const chatId = `chat_${randomUUID()}`;
@@ -508,7 +656,15 @@ describe("GitLab Stage 2A backend", () => {
         url: "https://gitlab.internal/Acme/API/-/merge_requests/52",
       },
     };
-    expect((await postWebhook(app, first.bearer, note, { event: "Note Hook" })).statusCode).toBe(400);
+    const noteResponse = await postWebhook(app, first.bearer, note, { event: "Note Hook" });
+    expect(noteResponse.statusCode).toBe(200);
+    expect(noteResponse.json()).toMatchObject({ outcome: "delivered" });
+    expect(
+      await app.db
+        .select()
+        .from(messages)
+        .where(and(eq(messages.chatId, chatId), eq(messages.source, "gitlab"))),
+    ).toHaveLength(2);
     const [mapping] = await app.db
       .select()
       .from(gitlabEntityChatMappings)
@@ -554,14 +710,9 @@ describe("GitLab Stage 2A backend", () => {
     expect(unsupported.statusCode).toBe(200);
     expect(unsupported.json()).toMatchObject({ outcome: "provider_only" });
 
-    const projectHook = await postWebhook(
-      app,
-      first.bearer,
-      { object_kind: "merge_request" },
-      { event: "Merge Request Hook" },
-    );
-    expect(projectHook.statusCode).toBe(400);
-    expect(projectHook.json()).toMatchObject({ error: expect.stringContaining("/admin/hooks") });
+    const projectHook = await postWebhook(app, first.bearer, mergeRequestPayload(62), { event: "Merge Request Hook" });
+    expect(projectHook.statusCode).toBe(200);
+    expect(projectHook.json()).toMatchObject({ outcome: "audience_empty" });
 
     const wrongType = await app.inject({
       method: "POST",
@@ -581,13 +732,19 @@ describe("GitLab Stage 2A backend", () => {
   it("separates transport from System Hook MR processing and readiness evidence", async () => {
     const app = getApp();
     const first = await connection(app);
-    const rejectedProjectHook = await postWebhook(
-      app,
-      first.bearer,
-      { object_kind: "merge_request" },
-      { event: "Merge Request Hook" },
-    );
-    expect(rejectedProjectHook.statusCode).toBe(400);
+    const projectMergeRequest = await postWebhook(app, first.bearer, mergeRequestPayload(61), {
+      event: "Merge Request Hook",
+    });
+    expect(projectMergeRequest.statusCode).toBe(200);
+    expect(projectMergeRequest.json()).toMatchObject({ outcome: "audience_empty" });
+
+    const projectIssue = await postWebhook(app, first.bearer, issuePayload(), { event: "Issue Hook" });
+    expect(projectIssue.statusCode).toBe(200);
+    expect(projectIssue.json()).toMatchObject({ outcome: "audience_empty" });
+
+    const projectNote = await postWebhook(app, first.bearer, mergeRequestNotePayload(), { event: "Note Hook" });
+    expect(projectNote.statusCode).toBe(200);
+    expect(projectNote.json()).toMatchObject({ outcome: "audience_empty" });
 
     for (const body of [
       { event_name: "push" },
@@ -609,11 +766,11 @@ describe("GitLab Stage 2A backend", () => {
     expect(await getGitlabConnectionSummary(app.db, first.connectionId)).toMatchObject({
       endpointSeen: true,
       health: {
-        readiness: "needs_attention",
+        readiness: "transport_received",
         lastValidInboundAt: expect.any(String),
         lastSystemHookMergeRequestInboundAt: null,
-        lastProcessingFailureAt: expect.any(String),
-        lastProcessingFailureCode: "unsupported_hook_type",
+        lastProcessingFailureAt: null,
+        lastProcessingFailureCode: null,
       },
     });
 
@@ -622,8 +779,8 @@ describe("GitLab Stage 2A backend", () => {
     expect(await getGitlabConnectionSummary(app.db, first.connectionId)).toMatchObject({
       health: {
         lastSystemHookMergeRequestInboundAt: null,
-        lastProcessingFailureAt: expect.any(String),
-        lastProcessingFailureCode: "unsupported_hook_type",
+        lastProcessingFailureAt: null,
+        lastProcessingFailureCode: null,
       },
     });
 
@@ -692,6 +849,13 @@ describe("GitLab Stage 2A backend", () => {
           lastProcessingFailureCode: "processing_failed",
         },
       });
+
+      const oppositeSourceRecovery = await postWebhook(app, readyConnection.bearer, mergeRequestPayload(72), {
+        event: "Merge Request Hook",
+        stableId: `project-recovery-${randomUUID()}`,
+      });
+      expect(oppositeSourceRecovery.statusCode).toBe(200);
+      expect(oppositeSourceRecovery.json()).toMatchObject({ outcome: "audience_empty" });
 
       const duplicate = await postWebhook(app, readyConnection.bearer, mergeRequestPayload(72), {
         stableId: failedDeliveryId,
@@ -1101,6 +1265,7 @@ describe("GitLab Stage 2A backend", () => {
   it("isolates per-chat delivery failure and retains the whole-request stable claim", async () => {
     const app = getApp();
     const first = await connection(app);
+    expect((await postWebhook(app, first.bearer, mergeRequestPayload(53))).statusCode).toBe(200);
     for (const suffix of ["a", "b"]) {
       const routeAgent = await createTestAgent(app, { name: `failure-${suffix}-${randomUUID().slice(0, 8)}` });
       const chatId = `chat_${suffix}_${randomUUID()}`;
@@ -1129,14 +1294,28 @@ describe("GitLab Stage 2A backend", () => {
     const before = await app.db.select().from(messages).where(eq(messages.source, "gitlab"));
     const sendSpy = vi.spyOn(scmCardDelivery, "sendScmSystemCard").mockRejectedValueOnce(new Error("chat down"));
     const stableId = `partial-${randomUUID()}`;
-    const firstDelivery = await postWebhook(app, first.bearer, mergeRequestPayload(), { stableId });
+    const firstDelivery = await postWebhook(app, first.bearer, mergeRequestPayload(), {
+      event: "Merge Request Hook",
+      stableId,
+    });
     sendSpy.mockRestore();
     expect(firstDelivery.statusCode).toBe(200);
     expect(firstDelivery.json()).toMatchObject({ outcome: "delivered" });
     const after = await app.db.select().from(messages).where(eq(messages.source, "gitlab"));
     expect(after).toHaveLength(before.length + 1);
-    expect((await postWebhook(app, first.bearer, mergeRequestPayload(), { stableId })).json()).toMatchObject({
-      outcome: "duplicate",
+    expect(
+      (
+        await postWebhook(app, first.bearer, mergeRequestPayload(), {
+          event: "Merge Request Hook",
+          stableId,
+        })
+      ).json(),
+    ).toMatchObject({ outcome: "duplicate" });
+    expect((await getGitlabConnectionSummary(app.db, first.connectionId)).health).toMatchObject({
+      readiness: "routing_verified",
+      lastSystemHookMergeRequestInboundAt: expect.any(String),
+      lastProcessingFailureAt: null,
+      lastProcessingFailureCode: null,
     });
   });
 
@@ -1225,6 +1404,9 @@ describe("GitLab Stage 2A backend", () => {
       payload: '{"object_kind":',
     });
     expect(malformed.statusCode).toBe(400);
+    expect(
+      (await getGitlabConnectionSummary(app.db, malformedConnection.connectionId)).health.lastProcessingFailureCode,
+    ).toBe("request_rejected");
 
     const limited = await connection(app, { isolatedOrg: true });
     for (let index = 0; index < 119; index += 1) {
@@ -1246,9 +1428,9 @@ describe("GitLab Stage 2A backend", () => {
       payload: '{"object_kind":',
     });
     expect(rateLimitedBeforeJsonParsing.statusCode).toBe(429);
-    expect((await getGitlabConnectionSummary(app.db, limited.connectionId)).health.lastProcessingFailureCode).toBe(
-      "missing_or_invalid_event_header",
-    );
+    expect(
+      (await getGitlabConnectionSummary(app.db, limited.connectionId)).health.lastProcessingFailureCode,
+    ).toBeNull();
     expect((await postWebhook(app, malformedConnection.bearer, { event_name: "test" })).statusCode).toBe(200);
 
     const unknownSourceIp = "203.0.113.77";

--- a/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
@@ -70,6 +70,7 @@ function mergeRequestPayload(input: {
       description: "Please review",
       url: `https://gitlab.internal/${projectPath}/-/merge_requests/${input.iid ?? 17}`,
       state: "opened",
+      updated_at: "2026-07-28T10:00:00.000Z",
       ...(input.draft === undefined ? {} : { draft: input.draft }),
       ...(input.oldrev === undefined ? {} : { oldrev: input.oldrev }),
     },
@@ -147,7 +148,7 @@ describe("GitLab Stage 3 personnel routing", () => {
     );
 
     const payload = mergeRequestPayload({ projectPath: "Acme/Reviews" });
-    const rejectedProjectHook = await app.inject({
+    const projectHook = await app.inject({
       method: "POST",
       url: `/api/v1/webhooks/gitlab/${connection.bearer}`,
       headers: {
@@ -156,13 +157,14 @@ describe("GitLab Stage 3 personnel routing", () => {
       },
       payload: JSON.stringify(payload),
     });
-    expect(rejectedProjectHook.statusCode).toBe(400);
+    expect(projectHook.statusCode).toBe(200);
     expect(
       (await app.db.select().from(chats)).filter((chat) => chat.metadata.contextTreeReviewer === true),
-    ).toHaveLength(0);
+    ).toHaveLength(1);
 
     const first = await postMr(app, connection.bearer, payload, "context-review-old-gitlab", "GitLab/11.11.3");
     expect(first.statusCode).toBe(200);
+    expect(first.json()).toMatchObject({ outcome: "cross_hook_duplicate" });
 
     const reviewerChats = await app.db.select().from(chats).where(eq(chats.organizationId, admin.organizationId));
     const reviewerChat = reviewerChats.find((chat) => chat.metadata.contextTreeReviewer === true);
@@ -371,7 +373,7 @@ describe("GitLab Stage 3 personnel routing", () => {
         },
       }),
     });
-    expect(note.statusCode).toBe(400);
+    expect(note.statusCode).toBe(200);
     expect(
       reviewerChat ? await app.db.select().from(messages).where(eq(messages.chatId, reviewerChat.id)) : [],
     ).toHaveLength(3);

--- a/packages/server/src/api/webhooks/gitlab.ts
+++ b/packages/server/src/api/webhooks/gitlab.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { BadRequestError, NotFoundError } from "../../errors.js";
+import { createLogger } from "../../observability/index.js";
 import { handleContextReviewerMrEvent } from "../../services/context-reviewer-mr.js";
 import {
   findActiveGitlabEndpoint,
@@ -13,6 +14,11 @@ import {
   resolveGitlabReviewerMode,
   withGitlabIngressFence,
 } from "../../services/gitlab-connections.js";
+import {
+  isGitlabCrossHookDuplicate,
+  rememberSuccessfulGitlabHookEvent,
+  withGitlabCrossHookDedupFence,
+} from "../../services/gitlab-cross-hook-dedup.js";
 import {
   observeGitlabEntityAndResolveFollowers,
   refreshGitlabChatTopics,
@@ -32,6 +38,7 @@ import { processScmWebhookDelivery } from "../../services/scm-webhook-processing
 
 const MAX_GITLAB_WEBHOOK_BYTES = 512 * 1024;
 const GITLAB_CONNECTION_RATE_LIMIT = 120;
+const log = createLogger("GitlabWebhookRoute");
 
 export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
   const endpointByRequest = new WeakMap<object, NonNullable<Awaited<ReturnType<typeof findActiveGitlabEndpoint>>>>();
@@ -62,26 +69,16 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
         if (!endpoint) throw new NotFoundError("GitLab webhook endpoint not found");
         const eventHeader = request.headers["x-gitlab-event"];
         if (typeof eventHeader !== "string" || eventHeader.length === 0 || eventHeader.length > 100) {
-          await markGitlabProcessingFailure(
-            app.db,
-            endpoint.connection.id,
-            endpoint.connection.tokenHash,
-            "missing_or_invalid_event_header",
+          log.warn(
+            {
+              metric: "gitlab_hook_source_unresolved_failure_total",
+              connectionId: endpoint.connection.id,
+              reason: "missing_or_invalid_event_header",
+            },
+            "rejected GitLab webhook without a trustworthy hook source",
           );
           failureMarked.add(request);
           throw new BadRequestError("X-Gitlab-Event is required");
-        }
-        if (eventHeader !== "System Hook") {
-          await markGitlabProcessingFailure(
-            app.db,
-            endpoint.connection.id,
-            endpoint.connection.tokenHash,
-            "unsupported_hook_type",
-          );
-          failureMarked.add(request);
-          throw new BadRequestError(
-            "Only GitLab System Hooks are supported; configure this webhook URL under GitLab /admin/hooks",
-          );
         }
         eventHeaderByRequest.set(request, eventHeader);
         return payload;
@@ -90,12 +87,25 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
         if (error.statusCode === 429) return;
         const endpoint = endpointByRequest.get(request);
         if (endpoint && !failureMarked.has(request)) {
-          await markGitlabProcessingFailure(
-            app.db,
-            endpoint.connection.id,
-            endpoint.connection.tokenHash,
-            "request_rejected",
-          ).catch(() => undefined);
+          const eventHeader = eventHeaderByRequest.get(request);
+          if (eventHeader === "System Hook") {
+            await markGitlabProcessingFailure(
+              app.db,
+              endpoint.connection.id,
+              endpoint.connection.tokenHash,
+              "request_rejected",
+            ).catch(() => undefined);
+          } else {
+            log.warn(
+              {
+                err: error,
+                metric: "gitlab_project_hook_processing_failed_total",
+                connectionId: endpoint.connection.id,
+                reason: "request_rejected",
+              },
+              "Project Hook request failed without changing System Hook readiness",
+            );
+          }
         }
       },
     },
@@ -116,133 +126,207 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
         });
         const declaredVersion = parseDeclaredGitlabVersion(request.headers["user-agent"]);
         const isSystemHookMergeRequest = eventHeader === "System Hook" && normalized.hookEventKind === "merge_request";
-        const result = await withGitlabIngressFence(
-          app.db,
-          endpoint.connection.id,
-          endpoint.connection.tokenHash,
-          async (tx, fencedConnection) => {
-            const reviewerMode = resolveGitlabReviewerMode({
-              currentMode: fencedConnection.reviewerMode as "unknown" | "assignee" | "reviewers",
-              declaredVersion,
-              reviewerField: normalized.personnel.reviewerField,
-            });
-            const applied = applyGitlabPersonnelEvidence(normalized, reviewerMode);
-            let observedFollowers: Awaited<ReturnType<typeof observeGitlabEntityAndResolveFollowers>> = [];
-            const processed = await processScmWebhookDelivery({
-              db: tx,
-              ingress: normalized.ingress,
-              observation: normalized.observation,
-              event: applied.event,
-              applyObservation: async () => {
-                if (!normalized.entityIdentity) return;
-                observedFollowers = await observeGitlabEntityAndResolveFollowers(
-                  tx,
-                  fencedConnection.id,
-                  normalized.entityIdentity,
-                );
-                await refreshGitlabChatTopics(tx, fencedConnection.id, normalized.entityIdentity);
-              },
-              runProviderWork: async () => {
-                await markGitlabInboundSeen(tx, endpoint.connection.id, endpoint.connection.tokenHash);
-                if (normalized.ingress.stableDeliveryId) {
-                  await markGitlabStableDeliveryObserved(tx, fencedConnection.id);
+        const execution = await withGitlabCrossHookDedupFence(endpoint.connection.id, async () => {
+          let crossHookDuplicate = false;
+          let shouldRememberSuccessfulEvent = false;
+          const processed = await withGitlabIngressFence(
+            app.db,
+            endpoint.connection.id,
+            endpoint.connection.tokenHash,
+            async (tx, fencedConnection) => {
+              if (normalized.crossHookFingerprint) {
+                crossHookDuplicate = isGitlabCrossHookDuplicate({
+                  fingerprint: normalized.crossHookFingerprint,
+                  hookSource: normalized.hookSource,
+                });
+                if (crossHookDuplicate) {
+                  log.info(
+                    {
+                      metric: "gitlab_cross_hook_duplicate_total",
+                      connectionId: fencedConnection.id,
+                      hookSource: normalized.hookSource,
+                    },
+                    "skipping duplicate GitLab merge request from the opposite hook source",
+                  );
                 }
-                await observeGitlabCompatibility(tx, fencedConnection.id, {
-                  declaredVersion: declaredVersion?.value ?? null,
-                  reviewerMode,
-                  reviewersValid: normalized.personnel.reviewerField === "valid",
-                });
-                if (applied.schemaAnomalyCode) {
-                  await markGitlabReviewerSchemaAnomaly(tx, fencedConnection.id, applied.schemaAnomalyCode);
-                }
-                const contextReviewer = await handleContextReviewerMrEvent({
-                  database: tx,
-                  normalized,
-                  connection: fencedConnection,
-                  staleSeconds: app.config.runtime.presenceCleanupSeconds,
-                });
-                return { endpointSeen: true, contextReviewer };
-              },
-              resolveAudience: async (event) => {
-                if (!normalized.entityIdentity || !applied.event) {
-                  return { targets: [], actorHumanId: null };
-                }
-                return resolveGitlabAudience(tx, {
-                  organizationId: fencedConnection.organizationId,
-                  connectionId: fencedConnection.id,
-                  event,
-                  entityIdentity: normalized.entityIdentity,
-                  followers: observedFollowers,
-                });
-              },
-              deliver: async (event, audience) => {
-                if (!normalized.entityIdentity) return { delivered: 0, failed: 0, postCommitEffects: [] };
-                return deliverGitlabCards(app, {
-                  event,
-                  identity: normalized.entityIdentity,
-                  audience,
-                  organizationId: fencedConnection.organizationId,
-                  connectionId: fencedConnection.id,
-                  database: tx,
-                });
-              },
-            });
-            const partialCardDeliveryFailed = processed.outcome === "delivered" && processed.deliveryStats.failed > 0;
-            if (isSystemHookMergeRequest && processed.outcome !== "duplicate") {
-              if (processed.observationOutcome !== "applied") {
-                await markGitlabProcessingFailure(
-                  tx,
-                  endpoint.connection.id,
-                  endpoint.connection.tokenHash,
-                  "processing_failed",
-                );
-              } else if (partialCardDeliveryFailed) {
-                await markGitlabProcessingFailure(
-                  tx,
-                  endpoint.connection.id,
-                  endpoint.connection.tokenHash,
-                  "partial_card_delivery_failure",
-                );
-              } else {
-                await markGitlabSystemHookMergeRequestProcessed(
-                  tx,
-                  endpoint.connection.id,
-                  endpoint.connection.tokenHash,
+              } else if (normalized.hookEventKind === "merge_request") {
+                log.info(
+                  {
+                    metric: "gitlab_cross_hook_fingerprint_unavailable_total",
+                    connectionId: fencedConnection.id,
+                    hookSource: normalized.hookSource,
+                  },
+                  "GitLab merge request lacks a reliable cross-hook occurrence fingerprint",
                 );
               }
-            } else if (partialCardDeliveryFailed) {
-              await markGitlabProcessingFailure(
-                tx,
-                endpoint.connection.id,
-                endpoint.connection.tokenHash,
-                "partial_card_delivery_failure",
-              );
+
+              const reviewerMode = resolveGitlabReviewerMode({
+                currentMode: fencedConnection.reviewerMode as "unknown" | "assignee" | "reviewers",
+                declaredVersion,
+                reviewerField: normalized.personnel.reviewerField,
+              });
+              const applied = applyGitlabPersonnelEvidence(normalized, reviewerMode);
+              let observedFollowers: Awaited<ReturnType<typeof observeGitlabEntityAndResolveFollowers>> = [];
+              const processingResult = await processScmWebhookDelivery({
+                db: tx,
+                ingress: normalized.ingress,
+                observation: crossHookDuplicate ? null : normalized.observation,
+                event: crossHookDuplicate ? null : applied.event,
+                applyObservation: async () => {
+                  if (!normalized.entityIdentity) return;
+                  observedFollowers = await observeGitlabEntityAndResolveFollowers(
+                    tx,
+                    fencedConnection.id,
+                    normalized.entityIdentity,
+                  );
+                  await refreshGitlabChatTopics(tx, fencedConnection.id, normalized.entityIdentity);
+                },
+                runProviderWork: async () => {
+                  await markGitlabInboundSeen(tx, endpoint.connection.id, endpoint.connection.tokenHash);
+                  if (normalized.ingress.stableDeliveryId) {
+                    await markGitlabStableDeliveryObserved(tx, fencedConnection.id);
+                  }
+                  await observeGitlabCompatibility(tx, fencedConnection.id, {
+                    declaredVersion: declaredVersion?.value ?? null,
+                    reviewerMode,
+                    reviewersValid: normalized.personnel.reviewerField === "valid",
+                  });
+                  if (applied.schemaAnomalyCode) {
+                    await markGitlabReviewerSchemaAnomaly(tx, fencedConnection.id, applied.schemaAnomalyCode);
+                  }
+                  const contextReviewer = crossHookDuplicate
+                    ? ({ handled: false, reason: "unsupported_event" } as const)
+                    : await handleContextReviewerMrEvent({
+                        database: tx,
+                        normalized,
+                        connection: fencedConnection,
+                        staleSeconds: app.config.runtime.presenceCleanupSeconds,
+                      });
+                  return { endpointSeen: true, contextReviewer };
+                },
+                resolveAudience: async (event) => {
+                  if (!normalized.entityIdentity || !applied.event) {
+                    return { targets: [], actorHumanId: null };
+                  }
+                  return resolveGitlabAudience(tx, {
+                    organizationId: fencedConnection.organizationId,
+                    connectionId: fencedConnection.id,
+                    event,
+                    entityIdentity: normalized.entityIdentity,
+                    followers: observedFollowers,
+                  });
+                },
+                deliver: async (event, audience) => {
+                  if (!normalized.entityIdentity) return { delivered: 0, failed: 0, postCommitEffects: [] };
+                  return deliverGitlabCards(app, {
+                    event,
+                    identity: normalized.entityIdentity,
+                    audience,
+                    organizationId: fencedConnection.organizationId,
+                    connectionId: fencedConnection.id,
+                    database: tx,
+                  });
+                },
+              });
+              const partialCardDeliveryFailed =
+                processingResult.outcome === "delivered" && processingResult.deliveryStats.failed > 0;
+              if (isSystemHookMergeRequest && processingResult.outcome !== "duplicate") {
+                if (crossHookDuplicate) {
+                  await markGitlabSystemHookMergeRequestProcessed(
+                    tx,
+                    endpoint.connection.id,
+                    endpoint.connection.tokenHash,
+                  );
+                } else if (processingResult.observationOutcome !== "applied") {
+                  await markGitlabProcessingFailure(
+                    tx,
+                    endpoint.connection.id,
+                    endpoint.connection.tokenHash,
+                    "processing_failed",
+                  );
+                } else if (partialCardDeliveryFailed) {
+                  await markGitlabProcessingFailure(
+                    tx,
+                    endpoint.connection.id,
+                    endpoint.connection.tokenHash,
+                    "partial_card_delivery_failure",
+                  );
+                } else {
+                  await markGitlabSystemHookMergeRequestProcessed(
+                    tx,
+                    endpoint.connection.id,
+                    endpoint.connection.tokenHash,
+                  );
+                }
+              } else if (partialCardDeliveryFailed) {
+                log.warn(
+                  {
+                    metric: "gitlab_project_hook_processing_failed_total",
+                    connectionId: endpoint.connection.id,
+                    reason: "partial_card_delivery_failure",
+                  },
+                  "Project Hook delivery partially failed without changing System Hook readiness",
+                );
+              }
+              shouldRememberSuccessfulEvent =
+                normalized.crossHookFingerprint !== null &&
+                !crossHookDuplicate &&
+                processingResult.outcome !== "duplicate" &&
+                processingResult.observationOutcome === "applied" &&
+                !partialCardDeliveryFailed;
+              return processingResult;
+            },
+          );
+
+          if (processed.outcome === "delivered") {
+            for (const effects of processed.deliveryStats.postCommitEffects) {
+              await runDeferredScmCardPostCommitEffects(app, effects);
             }
-            return processed;
-          },
-        );
-        if (result.outcome === "delivered") {
-          for (const effects of result.deliveryStats.postCommitEffects) {
-            await runDeferredScmCardPostCommitEffects(app, effects);
           }
-        }
-        const contextReviewer = result.outcome === "duplicate" ? null : result.providerResult.contextReviewer;
-        if (contextReviewer?.handled) {
-          await runDeferredSendMessagePostCommitEffects(app.db, contextReviewer.deferredPostCommitEffects);
-          notifyRecipients(app.notifier, contextReviewer.recipients, contextReviewer.messageId);
-        }
-        return { ok: true, outcome: result.outcome };
+          const contextReviewer = processed.outcome === "duplicate" ? null : processed.providerResult.contextReviewer;
+          if (contextReviewer?.handled) {
+            await runDeferredSendMessagePostCommitEffects(app.db, contextReviewer.deferredPostCommitEffects);
+            notifyRecipients(app.notifier, contextReviewer.recipients, contextReviewer.messageId);
+          }
+          if (shouldRememberSuccessfulEvent && normalized.crossHookFingerprint) {
+            rememberSuccessfulGitlabHookEvent({
+              fingerprint: normalized.crossHookFingerprint,
+              hookSource: normalized.hookSource,
+            });
+          }
+          return { processed, crossHookDuplicate };
+        });
+        return {
+          ok: true,
+          outcome:
+            execution.crossHookDuplicate && execution.processed.outcome !== "duplicate"
+              ? "cross_hook_duplicate"
+              : execution.processed.outcome,
+        };
       } catch (err) {
         if (err instanceof GitlabPersonnelTargetLimitError) {
           failureMarked.add(request);
           throw err;
         }
-        await markGitlabProcessingFailure(
-          app.db,
-          endpoint.connection.id,
-          endpoint.connection.tokenHash,
-          err instanceof BadRequestError ? "malformed_payload" : "processing_failed",
-        ).catch(() => undefined);
+        const failureCode = err instanceof BadRequestError ? "malformed_payload" : "processing_failed";
+        if (eventHeader === "System Hook") {
+          await markGitlabProcessingFailure(
+            app.db,
+            endpoint.connection.id,
+            endpoint.connection.tokenHash,
+            failureCode,
+          ).catch(() => undefined);
+        } else {
+          log.warn(
+            {
+              err,
+              metric: "gitlab_project_hook_processing_failed_total",
+              connectionId: endpoint.connection.id,
+              reason: failureCode,
+            },
+            "Project Hook processing failed without changing System Hook readiness",
+          );
+        }
         failureMarked.add(request);
         throw err;
       }

--- a/packages/server/src/services/gitlab-cross-hook-dedup.ts
+++ b/packages/server/src/services/gitlab-cross-hook-dedup.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import { createLogger } from "../observability/index.js";
+
+const log = createLogger("GitlabCrossHookDedup");
+
+export const GITLAB_CROSS_HOOK_DEDUP_TTL_MS = 60_000;
+const MAX_GITLAB_CROSS_HOOK_DEDUP_ENTRIES = 10_000;
+
+export type GitlabHookSource = "system" | "project";
+
+type JsonObject = Record<string, unknown>;
+
+type GitlabCrossHookDedupEntry = {
+  hookSource: GitlabHookSource;
+  processedAt: number;
+};
+
+const successfulEvents = new Map<string, GitlabCrossHookDedupEntry>();
+const connectionTails = new Map<string, Promise<void>>();
+
+function canonicalizeJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeJson);
+  if (!value || typeof value !== "object") return value;
+
+  const canonical: JsonObject = {};
+  for (const [key, nestedValue] of Object.entries(value).sort(([left], [right]) => left.localeCompare(right))) {
+    canonical[key] = canonicalizeJson(nestedValue);
+  }
+  return canonical;
+}
+
+function pruneExpired(now: number): void {
+  for (const [fingerprint, entry] of successfulEvents) {
+    if (now - entry.processedAt <= GITLAB_CROSS_HOOK_DEDUP_TTL_MS) break;
+    successfulEvents.delete(fingerprint);
+  }
+}
+
+export function buildGitlabCrossHookFingerprint(input: {
+  connectionId: string;
+  projectId: number;
+  mrIid: number;
+  action: string | null;
+  updatedAt: string | null;
+  oldrev: string | null;
+  changes: JsonObject | null;
+}): string | null {
+  const hasChanges = input.changes !== null && Object.keys(input.changes).length > 0;
+  if (!input.updatedAt && !input.oldrev && !hasChanges) return null;
+
+  const canonical = canonicalizeJson({
+    connectionId: input.connectionId,
+    projectId: input.projectId,
+    mrIid: input.mrIid,
+    action: input.action,
+    updatedAt: input.updatedAt,
+    oldrev: input.oldrev,
+    changes: hasChanges ? input.changes : null,
+  });
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+export function isGitlabCrossHookDuplicate(input: {
+  fingerprint: string;
+  hookSource: GitlabHookSource;
+  now?: number;
+}): boolean {
+  const now = input.now ?? Date.now();
+  const entry = successfulEvents.get(input.fingerprint);
+  if (!entry) return false;
+  if (now - entry.processedAt > GITLAB_CROSS_HOOK_DEDUP_TTL_MS) {
+    successfulEvents.delete(input.fingerprint);
+    return false;
+  }
+  return entry.hookSource !== input.hookSource;
+}
+
+export function rememberSuccessfulGitlabHookEvent(input: {
+  fingerprint: string;
+  hookSource: GitlabHookSource;
+  processedAt?: number;
+}): void {
+  const processedAt = input.processedAt ?? Date.now();
+  pruneExpired(processedAt);
+
+  if (!successfulEvents.has(input.fingerprint) && successfulEvents.size >= MAX_GITLAB_CROSS_HOOK_DEDUP_ENTRIES) {
+    const oldestFingerprint = successfulEvents.keys().next().value;
+    if (typeof oldestFingerprint === "string") {
+      successfulEvents.delete(oldestFingerprint);
+      log.warn(
+        { metric: "gitlab_cross_hook_dedup_evicted_total" },
+        "evicted GitLab cross-hook dedup entry at capacity",
+      );
+    }
+  }
+
+  successfulEvents.delete(input.fingerprint);
+  successfulEvents.set(input.fingerprint, {
+    hookSource: input.hookSource,
+    processedAt,
+  });
+}
+
+/**
+ * Keep same-process requests for one connection ordered through the database
+ * transaction and the post-commit cache write. Cross-process delivery remains
+ * deliberately best-effort.
+ */
+export async function withGitlabCrossHookDedupFence<T>(connectionId: string, operation: () => Promise<T>): Promise<T> {
+  const previous = connectionTails.get(connectionId) ?? Promise.resolve();
+  let release: (() => void) | undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  connectionTails.set(connectionId, current);
+
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release?.();
+    if (connectionTails.get(connectionId) === current) {
+      connectionTails.delete(connectionId);
+    }
+  }
+}
+
+export function resetGitlabCrossHookDedupForTests(): void {
+  successfulEvents.clear();
+  connectionTails.clear();
+}

--- a/packages/server/src/services/gitlab-webhook.ts
+++ b/packages/server/src/services/gitlab-webhook.ts
@@ -19,6 +19,7 @@ import { createLogger } from "../observability/index.js";
 import { uuidv7 } from "../uuid.js";
 import { createChat } from "./chat.js";
 import { buildClaimReadyGitlabDeliveryId } from "./gitlab-connections.js";
+import { buildGitlabCrossHookFingerprint, type GitlabHookSource } from "./gitlab-cross-hook-dedup.js";
 import {
   type GitlabEntityIdentity,
   normalizeGitlabProjectPath,
@@ -60,6 +61,8 @@ export type GitlabHookEventKind = "merge_request" | "issue" | "note" | "test";
 
 export type NormalizedGitlabWebhook = ScmNormalizedWebhook & {
   hookEventKind: GitlabHookEventKind | null;
+  hookSource: GitlabHookSource;
+  crossHookFingerprint: string | null;
   entityIdentity: GitlabEntityIdentity | null;
   personnel: GitlabPersonnelEvidence;
 };
@@ -299,6 +302,7 @@ export function normalizeGitlabWebhook(input: {
   body: unknown;
 }): NormalizedGitlabWebhook {
   const payload = object(input.body, "GitLab webhook body");
+  const hookSource: GitlabHookSource = input.eventHeader === "System Hook" ? "system" : "project";
   const expectedKind: Record<string, GitlabHookEventKind> = {
     "Merge Request Hook": "merge_request",
     "Issue Hook": "issue",
@@ -341,6 +345,8 @@ export function normalizeGitlabWebhook(input: {
     return {
       ingress,
       hookEventKind: expected ?? null,
+      hookSource,
+      crossHookFingerprint: null,
       observation: null,
       event: null,
       entityIdentity: null,
@@ -372,6 +378,7 @@ export function normalizeGitlabWebhook(input: {
     anomalyCode: null,
   };
   let noteBody: string | undefined;
+  let mergeRequestChanges: JsonObject | null = null;
 
   if (expected === "merge_request") {
     attrs = object(payload.object_attributes, "object_attributes");
@@ -384,11 +391,11 @@ export function normalizeGitlabWebhook(input: {
       assigneeAdded: assigneeUsernames(payload, attrs, action),
       mentions: [],
     };
-    const changes = payload.changes ? object(payload.changes, "changes") : null;
-    const descriptionChanged = changes !== null && "description" in changes;
-    const titleChanged = changes !== null && "title" in changes;
+    mergeRequestChanges = payload.changes ? object(payload.changes, "changes") : null;
+    const descriptionChanged = mergeRequestChanges !== null && "description" in mergeRequestChanges;
+    const titleChanged = mergeRequestChanges !== null && "title" in mergeRequestChanges;
     const currentDescription = optionalString(attrs.description) ?? "";
-    const becameReady = draftBecameReady(changes);
+    const becameReady = draftBecameReady(mergeRequestChanges);
     if (becameReady && "reviewers" in payload) {
       const currentReviewers = optionalUserArray(payload.reviewers, "reviewers");
       personnel = { ...personnel, reviewerField: "valid", reviewerAdded: currentReviewers, anomalyCode: null };
@@ -448,6 +455,8 @@ export function normalizeGitlabWebhook(input: {
       return {
         ingress,
         hookEventKind: expected,
+        hookSource,
+        crossHookFingerprint: null,
         observation: null,
         event: null,
         entityIdentity: null,
@@ -482,6 +491,18 @@ export function normalizeGitlabWebhook(input: {
   const title = optionalString(attrs.title, 1000) ?? "";
   const description = noteBody ?? optionalString(attrs.description) ?? "";
   const action = optionalString(attrs.action, 100) ?? null;
+  const crossHookFingerprint =
+    entityType === "pull_request" && eventType === "merge_request"
+      ? buildGitlabCrossHookFingerprint({
+          connectionId: input.connectionId,
+          projectId,
+          mrIid: iid,
+          action,
+          updatedAt: optionalString(attrs.updated_at, 100) ?? null,
+          oldrev: optionalString(attrs.oldrev, 1000) ?? null,
+          changes: mergeRequestChanges,
+        })
+      : null;
   const fallbackUrl = `${projectUrl.replace(/\/$/, "")}/-/${entityType === "issue" ? "issues" : "merge_requests"}/${iid}`;
   const url = gitlabUrl(optionalString(attrs.url) ?? fallbackUrl, input.instanceOrigin, "entity url");
   const rawState = optionalString(attrs.state, 100);
@@ -542,7 +563,16 @@ export function normalizeGitlabWebhook(input: {
                 )
               : [],
         };
-  return { ingress, hookEventKind: expected, observation, event, entityIdentity, personnel };
+  return {
+    ingress,
+    hookEventKind: expected,
+    hookSource,
+    crossHookFingerprint,
+    observation,
+    event,
+    entityIdentity,
+    personnel,
+  };
 }
 
 export function applyGitlabPersonnelEvidence(

--- a/packages/web/src/pages/settings/__tests__/gitlab-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/gitlab-page-dom.test.tsx
@@ -171,12 +171,12 @@ describe("SettingsGitlabPage", () => {
     await act(async () => button(document, "Create").click());
     await flush();
     expect(document.body.textContent).toContain(webhookUrl);
-    expect(document.body.textContent).toContain("Finish GitLab System Hook setup");
+    expect(document.body.textContent).toContain("Finish GitLab webhook setup");
     expect(document.body.textContent).toContain("Push events");
     expect(document.body.textContent).toContain("Merge request events");
     expect(document.body.textContent).toContain("default payload");
-    expect(document.body.textContent).toContain("System Hooks do not deliver Issue or Note events");
-    expect(document.body.textContent).not.toContain("project webhook");
+    expect(document.body.textContent).toContain("Optionally add Project Hooks before closing");
+    expect(document.body.textContent).toContain("best-effort basis");
     expect(document.querySelector<HTMLAnchorElement>('a[href="https://gitlab.internal/admin/hooks"]')).not.toBeNull();
     expect(
       JSON.stringify(
@@ -320,7 +320,7 @@ describe("SettingsGitlabPage", () => {
     await flush();
     expect(apiMocks.regenerateGitlabBearer).toHaveBeenCalledWith("connection-1");
     expect(document.body.textContent).toContain("new-secret");
-    expect(document.body.textContent).toContain("Finish GitLab System Hook setup");
+    expect(document.body.textContent).toContain("Finish GitLab webhook setup");
     expect(document.querySelector('[data-testid="gitlab-one-time-setup-status"]')?.textContent).toContain(
       "Waiting for webhook",
     );
@@ -343,7 +343,7 @@ describe("SettingsGitlabPage", () => {
     const received = await renderPage();
     expect(received.container.textContent).toContain("Webhook received · waiting for MR event");
     expect(received.container.textContent).toContain("Finish MR verification");
-    expect(received.container.textContent).toContain("System Hooks do not deliver Issue or Note events");
+    expect(received.container.textContent).toContain("Add trusted Project Hooks with the same URL");
     expect(received.container.textContent).toContain("Regenerate only if it was not saved");
     expect(
       received.container.querySelector<HTMLAnchorElement>('a[href="https://gitlab.internal:8443/admin/hooks"]'),

--- a/packages/web/src/pages/settings/gitlab.tsx
+++ b/packages/web/src/pages/settings/gitlab.tsx
@@ -139,7 +139,7 @@ function OrganizationScopedGitlabPage(props: { role: string | null; organization
     <div className="flex flex-col" style={{ gap: "var(--sp-5)", padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
       <Section
         title="Connection"
-        description="Inbound-only GitLab Self-Managed webhooks. A System Hook provides full-instance merge request routing; First Tree never calls your GitLab server."
+        description="Inbound-only GitLab Self-Managed webhooks. A System Hook provides full-instance merge request routing; optional Project Hooks add project-level MR, Issue, and Note events. First Tree never calls your GitLab server."
         action={
           isAdmin && !connection ? (
             <Button size="sm" onClick={() => setConnectionDialog("create")}>
@@ -165,7 +165,7 @@ function OrganizationScopedGitlabPage(props: { role: string | null; organization
         isAdmin ? (
           <Section
             title="GitLab account bindings"
-            description="Bind exact GitLab usernames to Team members. System Hook merge request reviewers, assignees, and description mentions route to the current delegate."
+            description="Bind exact GitLab usernames to Team members. GitLab merge request reviewers, assignees, and description mentions route to the current delegate."
           >
             <IdentityPanel
               connection={connection}
@@ -269,7 +269,7 @@ function ConnectionSummary(props: {
       ) : null}
       <p className="m-0 text-caption text-muted-foreground">
         Regenerating invalidates the old URL immediately. Change or delete clears old entity follows and identity
-        routing; update the GitLab System Hook manually.
+        routing; update every GitLab System or Project Hook using the URL.
       </p>
     </div>
   );
@@ -296,7 +296,7 @@ function SystemHookRecovery(props: { connection: GitlabConnectionSummary; readin
       </p>
       <p className="m-0 text-label text-muted-foreground">
         {needsAttention
-          ? "The latest webhook was not fully processed. Confirm this is a System Hook using GitLab's default payload, then resend a real merge request event."
+          ? "The latest webhook was not fully processed. Confirm the System Hook uses GitLab's default payload, then resend a real merge request event."
           : received
             ? "GitLab reached First Tree. Confirm Merge request events is enabled, then create or update a merge request."
             : "Paste the one-time First Tree URL into a GitLab System Hook. Keep the default payload and SSL verification enabled."}
@@ -305,7 +305,10 @@ function SystemHookRecovery(props: { connection: GitlabConnectionSummary; readin
         Enable <strong>Push events</strong> for delivery-health evidence and <strong>Merge request events</strong> for
         full-instance MR routing.
       </p>
-      <p className="m-0 text-label text-muted-foreground">System Hooks do not deliver Issue or Note events.</p>
+      <p className="m-0 text-label text-muted-foreground">
+        System Hooks do not deliver Issue or Note events. Add trusted Project Hooks with the same URL when those events
+        are needed.
+      </p>
       <div className="flex flex-wrap items-center gap-3">
         <Button asChild size="sm" variant="outline">
           <a href={gitlabAdminHooksUrl(props.connection.instanceOrigin)} target="_blank" rel="noreferrer">
@@ -629,10 +632,11 @@ function OneTimeSecretDialog(props: {
     >
       <DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto sm:max-w-xl">
         <DialogHeader>
-          <DialogTitle>Finish GitLab System Hook setup</DialogTitle>
+          <DialogTitle>Finish GitLab webhook setup</DialogTitle>
           <DialogDescription>
             This secret is shown once. Anyone holding it can forge personnel events that route and wake Team agents, so
-            configure it only in a trusted GitLab System Hook. Closing this dialog permanently removes it from the UI.
+            configure it only in trusted GitLab System or Project Hooks. Closing this dialog permanently removes it from
+            the UI.
           </DialogDescription>
         </DialogHeader>
         <ol className="m-0 list-decimal space-y-4 pl-5 text-body">
@@ -686,7 +690,14 @@ function OneTimeSecretDialog(props: {
             <p className="m-0 text-label text-muted-foreground">
               Keep SSL verification enabled and do not use a Custom webhook template.
             </p>
-            <p className="m-0 text-label text-muted-foreground">System Hooks do not deliver Issue or Note events.</p>
+          </li>
+          <li className="space-y-1 pl-1">
+            <p className="m-0 font-medium">Optionally add Project Hooks before closing</p>
+            <p className="m-0 text-label text-muted-foreground">
+              Reuse this URL in trusted projects that need Issue or Note events. Merge Request events are also
+              supported; when both hook types send the same MR occurrence within one minute, First Tree suppresses the
+              second one on a best-effort basis.
+            </p>
           </li>
           <li className="space-y-1 pl-1">
             <p className="m-0 font-medium">Add the hook, then create or update a merge request</p>
@@ -731,7 +742,7 @@ const CONFIRM_CONTENT: Record<
 > = {
   regenerate: {
     title: "Regenerate webhook URL?",
-    description: "The old URL stops authenticating immediately. Update the GitLab System Hook manually.",
+    description: "The old URL stops authenticating immediately. Update every GitLab System or Project Hook using it.",
     confirm: "Regenerate",
     destructive: true,
   },


### PR DESCRIPTION
## Summary

- accept trusted GitLab Project Hooks alongside the instance-wide System Hook
- route Project Hook merge request, issue, and note events while keeping System Hook merge requests as the only full-instance readiness evidence
- suppress the second copy of matching System/Project merge request events with a bounded, process-local 60-second cache
- isolate Project Hook failures from System Hook readiness and Context Reviewer capability
- update GitLab setup guidance, CLI documentation, and cross-surface QA coverage

## Deduplication contract

The fingerprint is the SHA-256 of canonical JSON containing `connectionId`, `projectId`, `mrIid`, `action`, `updatedAt`, `oldrev`, and `changes`. Suppression applies only to a successfully processed event from the opposite hook source. Same-source delivery retries continue to use the existing provider delivery claim.

The cache is intentionally best-effort and fails open when occurrence evidence is unavailable, after restart, across replicas, after 60 seconds, or after bounded eviction. These cases may repeat cards, wakes, or Context Reviewer dispatches rather than suppress a distinct event.

## Companion Context Tree PR

- https://github.com/agent-team-foundation/first-tree-context/pull/831 (draft until this code PR is merged)

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/gitlab-cross-hook-dedup.test.ts src/__tests__/gitlab-webhook-normalize.test.ts src/__tests__/gitlab-webhook-stage2a.test.ts src/__tests__/gitlab-webhook-stage3.test.ts --maxWorkers=2` — 67 passed
- `pnpm --filter @first-tree/web exec vitest run src/pages/settings/__tests__/gitlab-page-dom.test.tsx --maxWorkers=2` — 9 passed
- `pnpm --filter @first-tree/server typecheck`
- `pnpm --filter @first-tree/web typecheck` (includes design-token guard)
- targeted Biome checks and `git diff --check`
- independent First Tree reviewer: approved with no remaining blockers

Full repository tests were not run; validation was scoped to the affected GitLab server and Settings surfaces.
