### PR TITLE
feat(client): inject managed MCP into Cursor and Kimi

### DIFF
--- a/packages/client/src/__tests__/cursor-handler-engine.test.ts
+++ b/packages/client/src/__tests__/cursor-handler-engine.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionEvent } from "@first-tree/shared";
@@ -182,8 +182,8 @@ afterEach(() => {
 });
 
 describe("buildCursorTurnArgs — canonical spawn contract", () => {
-  it("locks the exact canonical argv, with model/resume only when supplied", () => {
-    expect(buildCursorTurnArgs({ model: "", resumeSessionId: null })).toEqual([
+  it("locks the exact canonical argv, with MCP approval/model/resume only when supplied", () => {
+    expect(buildCursorTurnArgs({ approveMcps: false, model: "", resumeSessionId: null })).toEqual([
       "-p",
       "--output-format",
       "stream-json",
@@ -191,13 +191,14 @@ describe("buildCursorTurnArgs — canonical spawn contract", () => {
       "disabled",
       "--force",
     ]);
-    expect(buildCursorTurnArgs({ model: "composer-2.5", resumeSessionId: "abc" })).toEqual([
+    expect(buildCursorTurnArgs({ approveMcps: true, model: "composer-2.5", resumeSessionId: "abc" })).toEqual([
       "-p",
       "--output-format",
       "stream-json",
       "--sandbox",
       "disabled",
       "--force",
+      "--approve-mcps",
       "--model",
       "composer-2.5",
       "--resume",
@@ -256,14 +257,14 @@ describe("cursor handler — per-turn CLI transport", () => {
     expect(seenStdin.indexOf("the prompt body")).toBeGreaterThan(0);
   });
 
-  it("resume: passes --resume with the stream-confirmed id and the operator model verbatim", async () => {
+  it("resume: passes managed MCP approval, --resume, and the operator model verbatim", async () => {
     const events: SessionEvent[] = [];
     const { spawnFn, calls } = makeFakeSpawn([successScript({ sessionId: "sess-real-2", text: "resumed" })]);
     const payload = {
       kind: "cursor" as const,
       prompt: { append: "" },
       model: "gpt-5.3-codex-high",
-      mcpServers: [],
+      mcpServers: [{ name: "docs", transport: "stdio" as const, command: "docs-server" }],
       env: [],
       gitRepos: [],
       resourceSkills: [],
@@ -283,6 +284,7 @@ describe("cursor handler — per-turn CLI transport", () => {
       "--sandbox",
       "disabled",
       "--force",
+      "--approve-mcps",
       "--model",
       "gpt-5.3-codex-high",
       "--resume",
@@ -600,27 +602,75 @@ describe("cursor handler — per-turn CLI transport", () => {
     expect(completed.payload.args).toMatchObject({ cwd: contextTreePath });
   });
 
-  it("emits a one-time MCP unsupported diagnostic when the payload configures MCP servers", async () => {
+  it("atomically materializes all managed MCP transports and approves them for the turn", async () => {
     const events: SessionEvent[] = [];
     const payload = {
       kind: "cursor" as const,
       prompt: { append: "" },
       model: "",
-      mcpServers: [{ name: "docs", transport: "stdio" as const, command: "docs-server", args: [] }],
+      mcpServers: [
+        { name: "docs", transport: "stdio" as const, command: "docs-server", args: ["--stdio"] },
+        {
+          name: "remote",
+          transport: "http" as const,
+          url: "https://mcp.example.test/rpc",
+          headers: { "X-Test": "http" },
+        },
+        {
+          name: "events",
+          transport: "sse" as const,
+          url: "https://mcp.example.test/events",
+          headers: { "X-Test": "sse" },
+        },
+      ],
       env: [],
       gitRepos: [],
       resourceSkills: [],
     };
-    const { spawnFn } = makeFakeSpawn([successScript({ sessionId: "s-mcp", text: "done" })]);
+    const { spawnFn, calls } = makeFakeSpawn([successScript({ sessionId: "s-mcp", text: "done" })]);
     const handler = makeHandler(spawnFn, {
       agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
     });
 
     await handler.start(makeMessage("m1", "hi"), makeContext({ events }), makeToken());
 
-    const diagnostics = events.filter(
-      (e) => e.kind === "error" && e.payload.source === "runtime" && /MCP server/.test(e.payload.message),
-    );
-    expect(diagnostics).toHaveLength(1);
+    expect(calls[0]?.args).toContain("--approve-mcps");
+    const configPath = join(workspaceRoot, ".cursor", "mcp.json");
+    expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
+      mcpServers: {
+        docs: { command: "docs-server", args: ["--stdio"] },
+        remote: {
+          type: "http",
+          url: "https://mcp.example.test/rpc",
+          headers: { "X-Test": "http" },
+        },
+        events: {
+          type: "sse",
+          url: "https://mcp.example.test/events",
+          headers: { "X-Test": "sse" },
+        },
+      },
+    });
+    if (process.platform !== "win32") {
+      expect(statSync(configPath).mode & 0o777).toBe(0o600);
+    }
+    expect(readdirSync(join(workspaceRoot, ".cursor"))).toEqual(["mcp.json"]);
+    expect(
+      events.some((e) => e.kind === "error" && e.payload.source === "runtime" && /MCP server/.test(e.payload.message)),
+    ).toBe(false);
+  });
+
+  it("clears stale managed MCP config and omits approval when the payload is empty", async () => {
+    const configDir = join(workspaceRoot, ".cursor");
+    const configPath = join(configDir, "mcp.json");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ mcpServers: { stale: { command: "stale-server" } } }));
+    const { spawnFn, calls } = makeFakeSpawn([successScript({ sessionId: "s-empty-mcp", text: "done" })]);
+    const handler = makeHandler(spawnFn);
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events: [] }), makeToken());
+
+    expect(calls[0]?.args).not.toContain("--approve-mcps");
+    expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({ mcpServers: {} });
   });
 });

--- a/packages/client/src/__tests__/cursor-handler-engine.test.ts
+++ b/packages/client/src/__tests__/cursor-handler-engine.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AgentRuntimeConfigPayload, SessionEvent } from "@first-tree/shared";
+import { type AgentRuntimeConfigPayload, parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildCursorMcpEnableArgs,
@@ -721,7 +721,7 @@ describe("cursor handler — per-turn CLI transport", () => {
     expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({ mcpServers: {} });
   });
 
-  it("retries before provider spawn when targeted MCP approval fails", async () => {
+  it("settles an MCP approval-store permission failure through the terminal notice contract", async () => {
     const payload = {
       kind: "cursor" as const,
       prompt: { append: "" },
@@ -736,7 +736,7 @@ describe("cursor handler — per-turn CLI transport", () => {
     const handler = makeHandler(spawnFn, {
       agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
       cursorMcpEnableFn: async () => {
-        throw new Error("private-provider-output");
+        throw Object.assign(new Error("private-provider-output"), { code: "EACCES" });
       },
     });
     const token = makeToken();
@@ -744,14 +744,85 @@ describe("cursor handler — per-turn CLI transport", () => {
     await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
 
     expect(calls).toHaveLength(0);
-    expect(token.retried).toEqual(["cursor_mcp_projection_failed"]);
-    expect(token.completed).toEqual([]);
-    const surfaced = events.find((event) => event.kind === "error" && event.payload.source === "runtime");
-    if (!surfaced || !("message" in surfaced.payload) || typeof surfaced.payload.message !== "string") {
-      throw new Error("expected a runtime MCP setup error");
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toEqual([
+      {
+        status: "error",
+        terminal: true,
+        completion: "consumed",
+        reason: "provider_configuration_error",
+      },
+    ]);
+    const providerEvents = events
+      .filter((event) => event.kind === "error")
+      .map((event) => parseProviderRetryEventMessage(event.payload.message))
+      .filter((event) => event !== null);
+    expect(providerEvents).toMatchObject([
+      {
+        event: "provider_failure_terminal",
+        category: "configuration",
+        reasonCode: "provider_configuration_error",
+        replaySafety: "pre_provider",
+      },
+    ]);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
+    expect(JSON.stringify(events)).not.toContain("private-provider-output");
+  });
+
+  it("bounds transient MCP setup timeouts and consumes retry exhaustion", async () => {
+    vi.useFakeTimers();
+    try {
+      const timeoutError = (): Error => Object.assign(new Error("private-timeout-output"), { code: "ETIMEDOUT" });
+      const payload = {
+        kind: "cursor" as const,
+        prompt: { append: "" },
+        model: "",
+        mcpServers: [{ name: "docs", transport: "stdio" as const, command: "docs-server" }],
+        env: [],
+        gitRepos: [],
+        resourceSkills: [],
+      };
+      const events: SessionEvent[] = [];
+      const { spawnFn, calls } = makeFakeSpawn([]);
+      let enableAttempts = 0;
+      const handler = makeHandler(spawnFn, {
+        agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+        cursorMcpEnableFn: async () => {
+          enableAttempts++;
+          throw timeoutError();
+        },
+      });
+      const token = makeToken();
+
+      const started = handler.start(makeMessage("m-timeout", "hi"), makeContext({ events }), token);
+      await vi.runAllTimersAsync();
+      await started;
+
+      expect(enableAttempts).toBe(3);
+      expect(calls).toHaveLength(0);
+      expect(token.retried).toEqual([]);
+      expect(token.completed).toEqual([
+        {
+          status: "error",
+          terminal: true,
+          completion: "consumed",
+          reason: "provider_retry_exhausted",
+        },
+      ]);
+      const providerEvents = events
+        .filter((event) => event.kind === "error")
+        .map((event) => parseProviderRetryEventMessage(event.payload.message))
+        .filter((event) => event !== null);
+      expect(providerEvents.map((event) => event.event)).toEqual([
+        "provider_retry_scheduled",
+        "provider_retry_scheduled",
+        "provider_retry_exhausted",
+      ]);
+      expect(providerEvents.every((event) => event.category === "transient_transport")).toBe(true);
+      expect(JSON.stringify(events)).not.toContain("private-timeout-output");
+    } finally {
+      vi.useRealTimers();
     }
-    expect(surfaced?.payload.message).toContain("managed MCP setup failed");
-    expect(surfaced?.payload.message).not.toContain("private-provider-output");
   });
 
   it("converges add then remove from the latest payload on the same active handler", async () => {
@@ -810,7 +881,60 @@ describe("cursor handler — per-turn CLI transport", () => {
     });
   });
 
-  it("serializes projection and the full turn across handlers sharing one agent workspace", async () => {
+  it.each([
+    { label: "empty", mcpServers: [] },
+    {
+      label: "matching managed",
+      mcpServers: [{ name: "alpha", transport: "stdio" as const, command: "alpha-server" }],
+    },
+  ])("keeps $label projection turns parallel across handlers sharing one workspace", async ({ mcpServers }) => {
+    let releaseFirst: () => void = () => {};
+    const firstMayFinish = new Promise<void>((resolvePromise) => {
+      releaseFirst = resolvePromise;
+    });
+    const order: string[] = [];
+    const payload = {
+      kind: "cursor" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers,
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const firstSpawn = makeFakeSpawn([
+      (child) => {
+        order.push("first:provider");
+        void firstMayFinish.then(() => successScript({ sessionId: "s-first", text: "first" })(child));
+      },
+    ]);
+    const secondSpawn = makeFakeSpawn([
+      (child) => {
+        order.push("second:provider");
+        successScript({ sessionId: "s-second", text: "second" })(child);
+      },
+    ]);
+    const enabledServers: string[] = [];
+    const handlerConfig = {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      cursorMcpEnableFn: async ({ serverName }: { serverName: string }) => void enabledServers.push(serverName),
+    };
+    const firstHandler = makeHandler(firstSpawn.spawnFn, handlerConfig);
+    const secondHandler = makeHandler(secondSpawn.spawnFn, handlerConfig);
+
+    const first = firstHandler.start(makeMessage("m-first", "first"), makeContext({ events: [] }), makeToken());
+    await vi.waitFor(() => expect(firstSpawn.calls).toHaveLength(1));
+
+    const second = secondHandler.start(makeMessage("m-second", "second"), makeContext({ events: [] }), makeToken());
+    await vi.waitFor(() => expect(secondSpawn.calls).toHaveLength(1));
+    expect(order).toEqual(["first:provider", "second:provider"]);
+    expect(enabledServers).toEqual(mcpServers.length === 0 ? [] : ["alpha"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+  });
+
+  it("waits for active projection leases before switching a shared workspace", async () => {
     let releaseFirst: () => void = () => {};
     const firstMayFinish = new Promise<void>((resolvePromise) => {
       releaseFirst = resolvePromise;
@@ -873,6 +997,59 @@ describe("cursor handler — per-turn CLI transport", () => {
     expect(order).toEqual(["alpha:enable", "alpha:provider", "beta:enable", "beta:provider"]);
     expect(JSON.parse(readFileSync(join(workspaceRoot, ".cursor", "mcp.json"), "utf8"))).toEqual({
       mcpServers: { beta: { command: "beta-server" } },
+    });
+  });
+
+  it("invalidates shared projection state when approval fails after file replacement", async () => {
+    const payloadA = {
+      kind: "cursor" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [{ name: "alpha", transport: "stdio" as const, command: "alpha-server" }],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const payloadB = {
+      ...payloadA,
+      mcpServers: [{ name: "beta", transport: "stdio" as const, command: "beta-server" }],
+    };
+    const enabledServers: string[] = [];
+    const enableMcp = async ({ serverName }: { serverName: string }): Promise<void> => {
+      enabledServers.push(serverName);
+      if (serverName === "beta") {
+        throw Object.assign(new Error("private-approval-output"), { code: "EACCES" });
+      }
+    };
+    const firstSpawn = makeFakeSpawn([successScript({ sessionId: "s-alpha-first", text: "first" })]);
+    const failedSpawn = makeFakeSpawn([]);
+    const recoveredSpawn = makeFakeSpawn([successScript({ sessionId: "s-alpha-recovered", text: "recovered" })]);
+    const firstHandler = makeHandler(firstSpawn.spawnFn, {
+      agentConfigCache: { refresh: async () => ({ payload: payloadA }), get: () => ({ payload: payloadA }) },
+      cursorMcpEnableFn: enableMcp,
+    });
+    const failedHandler = makeHandler(failedSpawn.spawnFn, {
+      agentConfigCache: { refresh: async () => ({ payload: payloadB }), get: () => ({ payload: payloadB }) },
+      cursorMcpEnableFn: enableMcp,
+    });
+    const recoveredHandler = makeHandler(recoveredSpawn.spawnFn, {
+      agentConfigCache: { refresh: async () => ({ payload: payloadA }), get: () => ({ payload: payloadA }) },
+      cursorMcpEnableFn: enableMcp,
+    });
+
+    await firstHandler.start(makeMessage("m-alpha-first", "first"), makeContext({ events: [] }), makeToken());
+    const failedToken = makeToken();
+    await failedHandler.start(makeMessage("m-beta", "will fail"), makeContext({ events: [] }), failedToken);
+    await recoveredHandler.start(makeMessage("m-alpha-recovered", "recover"), makeContext({ events: [] }), makeToken());
+
+    expect(failedSpawn.calls).toHaveLength(0);
+    expect(failedToken.completed).toMatchObject([
+      { status: "error", completion: "consumed", reason: "provider_configuration_error" },
+    ]);
+    expect(enabledServers).toEqual(["alpha", "beta", "alpha"]);
+    expect(recoveredSpawn.calls).toHaveLength(1);
+    expect(JSON.parse(readFileSync(join(workspaceRoot, ".cursor", "mcp.json"), "utf8"))).toEqual({
+      mcpServers: { alpha: { command: "alpha-server" } },
     });
   });
 });

--- a/packages/client/src/__tests__/cursor-handler-engine.test.ts
+++ b/packages/client/src/__tests__/cursor-handler-engine.test.ts
@@ -2,9 +2,14 @@ import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SessionEvent } from "@first-tree/shared";
+import type { AgentRuntimeConfigPayload, SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildCursorTurnArgs, CURSOR_PENDING_SESSION_PREFIX, createCursorHandler } from "../handlers/cursor/index.js";
+import {
+  buildCursorMcpEnableArgs,
+  buildCursorTurnArgs,
+  CURSOR_PENDING_SESSION_PREFIX,
+  createCursorHandler,
+} from "../handlers/cursor/index.js";
 import type { DeliveryToken, SessionContext, SessionMessage, TurnOutcome } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
@@ -168,6 +173,7 @@ function makeHandler(spawnFn: unknown, extraConfig: Record<string, unknown> = {}
     workspaceRoot,
     runtimeProvider: "cursor",
     cursorSpawnFn: spawnFn,
+    cursorMcpEnableFn: async () => {},
     cursorBinaryResolver: () => ({ ok: true, binary: "/fake/bin/cursor-agent", version: "2026.07.09-test" }),
     ...extraConfig,
   });
@@ -182,8 +188,8 @@ afterEach(() => {
 });
 
 describe("buildCursorTurnArgs — canonical spawn contract", () => {
-  it("locks the exact canonical argv, with MCP approval/model/resume only when supplied", () => {
-    expect(buildCursorTurnArgs({ approveMcps: false, model: "", resumeSessionId: null })).toEqual([
+  it("locks the exact canonical argv without the broad MCP approval flag", () => {
+    expect(buildCursorTurnArgs({ model: "", resumeSessionId: null })).toEqual([
       "-p",
       "--output-format",
       "stream-json",
@@ -191,19 +197,19 @@ describe("buildCursorTurnArgs — canonical spawn contract", () => {
       "disabled",
       "--force",
     ]);
-    expect(buildCursorTurnArgs({ approveMcps: true, model: "composer-2.5", resumeSessionId: "abc" })).toEqual([
+    expect(buildCursorTurnArgs({ model: "composer-2.5", resumeSessionId: "abc" })).toEqual([
       "-p",
       "--output-format",
       "stream-json",
       "--sandbox",
       "disabled",
       "--force",
-      "--approve-mcps",
       "--model",
       "composer-2.5",
       "--resume",
       "abc",
     ]);
+    expect(buildCursorMcpEnableArgs("managed-docs")).toEqual(["mcp", "enable", "managed-docs"]);
   });
 });
 
@@ -257,9 +263,10 @@ describe("cursor handler — per-turn CLI transport", () => {
     expect(seenStdin.indexOf("the prompt body")).toBeGreaterThan(0);
   });
 
-  it("resume: passes managed MCP approval, --resume, and the operator model verbatim", async () => {
+  it("resume: precisely approves managed MCP and passes --resume plus the operator model verbatim", async () => {
     const events: SessionEvent[] = [];
     const { spawnFn, calls } = makeFakeSpawn([successScript({ sessionId: "sess-real-2", text: "resumed" })]);
+    const enabledServers: string[] = [];
     const payload = {
       kind: "cursor" as const,
       prompt: { append: "" },
@@ -271,6 +278,7 @@ describe("cursor handler — per-turn CLI transport", () => {
     };
     const handler = makeHandler(spawnFn, {
       agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      cursorMcpEnableFn: async ({ serverName }: { serverName: string }) => void enabledServers.push(serverName),
     });
 
     await handler.resume(makeMessage("m2", "continue"), "sess-real-2", makeContext({ events }), makeToken());
@@ -284,12 +292,13 @@ describe("cursor handler — per-turn CLI transport", () => {
       "--sandbox",
       "disabled",
       "--force",
-      "--approve-mcps",
       "--model",
       "gpt-5.3-codex-high",
       "--resume",
       "sess-real-2",
     ]);
+    expect(call.args).not.toContain("--approve-mcps");
+    expect(enabledServers).toEqual(["docs"]);
   });
 
   it("first-turn auth failure settles consumed-terminal, returns a synthetic id, and never resumes with it", async () => {
@@ -602,8 +611,14 @@ describe("cursor handler — per-turn CLI transport", () => {
     expect(completed.payload.args).toMatchObject({ cwd: contextTreePath });
   });
 
-  it("atomically materializes all managed MCP transports and approves them for the turn", async () => {
+  it("atomically materializes all managed MCP transports and approves only their names", async () => {
     const events: SessionEvent[] = [];
+    const enabledServers: Array<{
+      binary: string;
+      serverName: string;
+      workspaceCwd: string;
+      args: string[];
+    }> = [];
     const payload = {
       kind: "cursor" as const,
       prompt: { append: "" },
@@ -630,11 +645,39 @@ describe("cursor handler — per-turn CLI transport", () => {
     const { spawnFn, calls } = makeFakeSpawn([successScript({ sessionId: "s-mcp", text: "done" })]);
     const handler = makeHandler(spawnFn, {
       agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      cursorMcpEnableFn: async (input: { binary: string; serverName: string; workspaceCwd: string }) => {
+        enabledServers.push({
+          binary: input.binary,
+          serverName: input.serverName,
+          workspaceCwd: input.workspaceCwd,
+          args: buildCursorMcpEnableArgs(input.serverName),
+        });
+      },
     });
 
     await handler.start(makeMessage("m1", "hi"), makeContext({ events }), makeToken());
 
-    expect(calls[0]?.args).toContain("--approve-mcps");
+    expect(calls[0]?.args).not.toContain("--approve-mcps");
+    expect(enabledServers).toEqual([
+      {
+        binary: "/fake/bin/cursor-agent",
+        serverName: "docs",
+        workspaceCwd: workspaceRoot,
+        args: ["mcp", "enable", "docs"],
+      },
+      {
+        binary: "/fake/bin/cursor-agent",
+        serverName: "remote",
+        workspaceCwd: workspaceRoot,
+        args: ["mcp", "enable", "remote"],
+      },
+      {
+        binary: "/fake/bin/cursor-agent",
+        serverName: "events",
+        workspaceCwd: workspaceRoot,
+        args: ["mcp", "enable", "events"],
+      },
+    ]);
     const configPath = join(workspaceRoot, ".cursor", "mcp.json");
     expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
       mcpServers: {
@@ -666,11 +709,170 @@ describe("cursor handler — per-turn CLI transport", () => {
     mkdirSync(configDir, { recursive: true });
     writeFileSync(configPath, JSON.stringify({ mcpServers: { stale: { command: "stale-server" } } }));
     const { spawnFn, calls } = makeFakeSpawn([successScript({ sessionId: "s-empty-mcp", text: "done" })]);
-    const handler = makeHandler(spawnFn);
+    const enabledServers: string[] = [];
+    const handler = makeHandler(spawnFn, {
+      cursorMcpEnableFn: async ({ serverName }: { serverName: string }) => void enabledServers.push(serverName),
+    });
 
     await handler.start(makeMessage("m1", "hi"), makeContext({ events: [] }), makeToken());
 
     expect(calls[0]?.args).not.toContain("--approve-mcps");
+    expect(enabledServers).toEqual([]);
     expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({ mcpServers: {} });
+  });
+
+  it("retries before provider spawn when targeted MCP approval fails", async () => {
+    const payload = {
+      kind: "cursor" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [{ name: "docs", transport: "stdio" as const, command: "docs-server" }],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const events: SessionEvent[] = [];
+    const { spawnFn, calls } = makeFakeSpawn([]);
+    const handler = makeHandler(spawnFn, {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      cursorMcpEnableFn: async () => {
+        throw new Error("private-provider-output");
+      },
+    });
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(calls).toHaveLength(0);
+    expect(token.retried).toEqual(["cursor_mcp_projection_failed"]);
+    expect(token.completed).toEqual([]);
+    const surfaced = events.find((event) => event.kind === "error" && event.payload.source === "runtime");
+    if (!surfaced || !("message" in surfaced.payload) || typeof surfaced.payload.message !== "string") {
+      throw new Error("expected a runtime MCP setup error");
+    }
+    expect(surfaced?.payload.message).toContain("managed MCP setup failed");
+    expect(surfaced?.payload.message).not.toContain("private-provider-output");
+  });
+
+  it("converges add then remove from the latest payload on the same active handler", async () => {
+    const emptyPayload: AgentRuntimeConfigPayload = {
+      kind: "cursor" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const managedPayload: AgentRuntimeConfigPayload = {
+      ...emptyPayload,
+      model: "composer-managed",
+      mcpServers: [{ name: "docs", transport: "stdio" as const, command: "docs-server" }],
+    };
+    let payload = emptyPayload;
+    const enabledServers: string[] = [];
+    const { spawnFn, calls } = makeFakeSpawn([
+      successScript({ sessionId: "s-hot", text: "initial" }),
+      successScript({ sessionId: "s-hot", text: "added" }),
+      successScript({ sessionId: "s-hot", text: "removed" }),
+    ]);
+    const handler = makeHandler(spawnFn, {
+      agentConfigCache: {
+        refresh: async () => ({ payload }),
+        get: () => ({ payload }),
+      },
+      cursorMcpEnableFn: async ({ serverName }: { serverName: string }) => void enabledServers.push(serverName),
+    });
+    const sessionCtx = makeContext({ events: [] });
+
+    await handler.start(makeMessage("m1", "initial"), sessionCtx, makeToken());
+
+    payload = managedPayload;
+    const addToken = makeToken();
+    expect(handler.inject(makeMessage("m2", "add tools"), addToken)).toEqual({ kind: "owned", mode: "queued" });
+    await vi.waitFor(() => expect(addToken.completed).toHaveLength(1));
+    expect(enabledServers).toEqual(["docs"]);
+    expect(calls[1]?.args).toContain("composer-managed");
+    expect(calls[1]?.args).not.toContain("--approve-mcps");
+    expect(JSON.parse(readFileSync(join(workspaceRoot, ".cursor", "mcp.json"), "utf8"))).toEqual({
+      mcpServers: { docs: { command: "docs-server" } },
+    });
+
+    payload = emptyPayload;
+    const removeToken = makeToken();
+    expect(handler.inject(makeMessage("m3", "remove tools"), removeToken)).toEqual({ kind: "owned", mode: "queued" });
+    await vi.waitFor(() => expect(removeToken.completed).toHaveLength(1));
+    expect(enabledServers).toEqual(["docs"]);
+    expect(calls[2]?.args).not.toContain("composer-managed");
+    expect(calls[2]?.args).not.toContain("--approve-mcps");
+    expect(JSON.parse(readFileSync(join(workspaceRoot, ".cursor", "mcp.json"), "utf8"))).toEqual({
+      mcpServers: {},
+    });
+  });
+
+  it("serializes projection and the full turn across handlers sharing one agent workspace", async () => {
+    let releaseFirst: () => void = () => {};
+    const firstMayFinish = new Promise<void>((resolvePromise) => {
+      releaseFirst = resolvePromise;
+    });
+    const order: string[] = [];
+    const payloadA = {
+      kind: "cursor" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [{ name: "alpha", transport: "stdio" as const, command: "alpha-server" }],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const payloadB = {
+      ...payloadA,
+      mcpServers: [{ name: "beta", transport: "stdio" as const, command: "beta-server" }],
+    };
+    const firstSpawn = makeFakeSpawn([
+      (child) => {
+        order.push("alpha:provider");
+        void firstMayFinish.then(() => successScript({ sessionId: "s-alpha", text: "alpha" })(child));
+      },
+    ]);
+    const secondSpawn = makeFakeSpawn([
+      (child) => {
+        order.push("beta:provider");
+        successScript({ sessionId: "s-beta", text: "beta" })(child);
+      },
+    ]);
+    let secondPrepared = false;
+    const firstHandler = makeHandler(firstSpawn.spawnFn, {
+      agentConfigCache: { refresh: async () => ({ payload: payloadA }), get: () => ({ payload: payloadA }) },
+      cursorMcpEnableFn: async ({ serverName }: { serverName: string }) => void order.push(`${serverName}:enable`),
+    });
+    const secondHandler = makeHandler(secondSpawn.spawnFn, {
+      agentConfigCache: {
+        refresh: async () => {
+          secondPrepared = true;
+          return { payload: payloadB };
+        },
+        get: () => ({ payload: payloadB }),
+      },
+      cursorMcpEnableFn: async ({ serverName }: { serverName: string }) => void order.push(`${serverName}:enable`),
+    });
+
+    const first = firstHandler.start(makeMessage("m-alpha", "alpha"), makeContext({ events: [] }), makeToken());
+    await vi.waitFor(() => expect(firstSpawn.calls).toHaveLength(1));
+    expect(JSON.parse(readFileSync(join(workspaceRoot, ".cursor", "mcp.json"), "utf8"))).toEqual({
+      mcpServers: { alpha: { command: "alpha-server" } },
+    });
+
+    const second = secondHandler.start(makeMessage("m-beta", "beta"), makeContext({ events: [] }), makeToken());
+    await vi.waitFor(() => expect(secondPrepared).toBe(true));
+    expect(secondSpawn.calls).toHaveLength(0);
+    expect(order).toEqual(["alpha:enable", "alpha:provider"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["alpha:enable", "alpha:provider", "beta:enable", "beta:provider"]);
+    expect(JSON.parse(readFileSync(join(workspaceRoot, ".cursor", "mcp.json"), "utf8"))).toEqual({
+      mcpServers: { beta: { command: "beta-server" } },
+    });
   });
 });

--- a/packages/client/src/__tests__/cursor-handler-engine.test.ts
+++ b/packages/client/src/__tests__/cursor-handler-engine.test.ts
@@ -882,7 +882,7 @@ describe("cursor handler — per-turn CLI transport", () => {
   });
 
   it.each([
-    { label: "empty", mcpServers: [] },
+    { label: "empty across approval stores", mcpServers: [] },
     {
       label: "matching managed",
       mcpServers: [{ name: "alpha", transport: "stdio" as const, command: "alpha-server" }],
@@ -902,6 +902,19 @@ describe("cursor handler — per-turn CLI transport", () => {
       gitRepos: [],
       resourceSkills: [],
     };
+    const secondPayload =
+      mcpServers.length === 0
+        ? {
+            ...payload,
+            env: [
+              {
+                key: "CURSOR_DATA_DIR",
+                value: join(workspaceRoot, "unused-empty-approval-root"),
+                sensitive: false,
+              },
+            ],
+          }
+        : payload;
     const firstSpawn = makeFakeSpawn([
       (child) => {
         order.push("first:provider");
@@ -915,12 +928,19 @@ describe("cursor handler — per-turn CLI transport", () => {
       },
     ]);
     const enabledServers: string[] = [];
-    const handlerConfig = {
+    const firstHandlerConfig = {
       agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
       cursorMcpEnableFn: async ({ serverName }: { serverName: string }) => void enabledServers.push(serverName),
     };
-    const firstHandler = makeHandler(firstSpawn.spawnFn, handlerConfig);
-    const secondHandler = makeHandler(secondSpawn.spawnFn, handlerConfig);
+    const secondHandlerConfig = {
+      agentConfigCache: {
+        refresh: async () => ({ payload: secondPayload }),
+        get: () => ({ payload: secondPayload }),
+      },
+      cursorMcpEnableFn: async ({ serverName }: { serverName: string }) => void enabledServers.push(serverName),
+    };
+    const firstHandler = makeHandler(firstSpawn.spawnFn, firstHandlerConfig);
+    const secondHandler = makeHandler(secondSpawn.spawnFn, secondHandlerConfig);
 
     const first = firstHandler.start(makeMessage("m-first", "first"), makeContext({ events: [] }), makeToken());
     await vi.waitFor(() => expect(firstSpawn.calls).toHaveLength(1));
@@ -998,6 +1018,89 @@ describe("cursor handler — per-turn CLI transport", () => {
     expect(JSON.parse(readFileSync(join(workspaceRoot, ".cursor", "mcp.json"), "utf8"))).toEqual({
       mcpServers: { beta: { command: "beta-server" } },
     });
+  });
+
+  it.each([
+    { label: "CURSOR_DATA_DIR", usesDataDir: true },
+    { label: "process home", usesDataDir: false },
+  ])("treats the $label approval store as part of a matching MCP projection identity", async ({ usesDataDir }) => {
+    let releaseFirst: () => void = () => {};
+    const firstMayFinish = new Promise<void>((resolvePromise) => {
+      releaseFirst = resolvePromise;
+    });
+    const order: string[] = [];
+    const homeKey = process.platform === "win32" ? "USERPROFILE" : "HOME";
+    const firstApprovalRoot = join(workspaceRoot, "cursor-approval-a");
+    const secondApprovalRoot = join(workspaceRoot, "cursor-approval-b");
+    const payloadForApprovalRoot = (approvalRoot: string): AgentRuntimeConfigPayload => ({
+      kind: "cursor",
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [{ name: "alpha", transport: "stdio", command: "alpha-server" }],
+      env: usesDataDir
+        ? [{ key: "CURSOR_DATA_DIR", value: approvalRoot, sensitive: false }]
+        : [
+            { key: "CURSOR_DATA_DIR", value: "", sensitive: false },
+            { key: homeKey, value: approvalRoot, sensitive: false },
+          ],
+      gitRepos: [],
+      resourceSkills: [],
+    });
+    const payloadA = payloadForApprovalRoot(firstApprovalRoot);
+    const payloadB = payloadForApprovalRoot(secondApprovalRoot);
+    const firstSpawn = makeFakeSpawn([
+      (child) => {
+        order.push("first:provider");
+        void firstMayFinish.then(() => successScript({ sessionId: "s-first-root", text: "first" })(child));
+      },
+    ]);
+    const secondSpawn = makeFakeSpawn([
+      (child) => {
+        order.push("second:provider");
+        successScript({ sessionId: "s-second-root", text: "second" })(child);
+      },
+    ]);
+    const enabledApprovalRoots: string[] = [];
+    const enableMcp = async ({ env }: { env: Record<string, string> }): Promise<void> => {
+      const dataDir = env.CURSOR_DATA_DIR;
+      enabledApprovalRoots.push(dataDir !== undefined && dataDir.trim().length > 0 ? dataDir : (env[homeKey] ?? ""));
+    };
+    let secondPrepared = false;
+    const firstHandler = makeHandler(firstSpawn.spawnFn, {
+      agentConfigCache: { refresh: async () => ({ payload: payloadA }), get: () => ({ payload: payloadA }) },
+      cursorMcpEnableFn: enableMcp,
+    });
+    const secondHandler = makeHandler(secondSpawn.spawnFn, {
+      agentConfigCache: {
+        refresh: async () => {
+          secondPrepared = true;
+          return { payload: payloadB };
+        },
+        get: () => ({ payload: payloadB }),
+      },
+      cursorMcpEnableFn: enableMcp,
+    });
+
+    const first = firstHandler.start(makeMessage("m-first-root", "first"), makeContext({ events: [] }), makeToken());
+    await vi.waitFor(() => expect(firstSpawn.calls).toHaveLength(1));
+
+    const second = secondHandler.start(
+      makeMessage("m-second-root", "second"),
+      makeContext({ events: [] }),
+      makeToken(),
+    );
+    await vi.waitFor(() => expect(secondPrepared).toBe(true));
+    expect(secondSpawn.calls).toHaveLength(0);
+    expect(enabledApprovalRoots).toEqual([firstApprovalRoot]);
+    expect(order).toEqual(["first:provider"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(enabledApprovalRoots).toEqual([firstApprovalRoot, secondApprovalRoot]);
+    expect(order).toEqual(["first:provider", "second:provider"]);
+    expect(secondSpawn.calls[0]?.options.env).toMatchObject(
+      usesDataDir ? { CURSOR_DATA_DIR: secondApprovalRoot } : { CURSOR_DATA_DIR: "", [homeKey]: secondApprovalRoot },
+    );
   });
 
   it("invalidates shared projection state when approval fails after file replacement", async () => {

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -142,6 +142,7 @@ afterEach(() => {
 function makeHandler(
   fakeSession: FakeSession,
   captures: { create?: CreateSessionOptions; resume?: ResumeSessionInput },
+  extraConfig: Record<string, unknown> = {},
 ) {
   const fakeKaos = {
     withCwd: vi.fn().mockReturnThis(),
@@ -162,6 +163,7 @@ function makeHandler(
       },
       close: async () => {},
     }),
+    ...extraConfig,
   });
 }
 
@@ -181,6 +183,7 @@ describe("Kimi Code handler", () => {
       permission: "yolo",
     });
     expect(captures.create).not.toHaveProperty("model");
+    expect(captures.create).not.toHaveProperty("mcpServers");
     expect(captures.create?.roleAdditional).toContain("First Tree");
     expect(fakeSession.prompts).toEqual(["[From: human-1]\n\ndo work"]);
     expect(events.some((item) => item.kind === "thinking")).toBe(true);
@@ -199,6 +202,59 @@ describe("Kimi Code handler", () => {
     expect(token.completed).toEqual([{ status: "success" }]);
   });
 
+  it("injects every managed MCP transport directly into createSession", async () => {
+    const fakeSession = new FakeSession("kimi-session-mcp", [successfulTurn("kimi-session-mcp")]);
+    const captures: { create?: CreateSessionOptions } = {};
+    const payload: AgentRuntimeConfigPayload = {
+      kind: "kimi-code",
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [
+        { name: "docs", transport: "stdio", command: "docs-server", args: ["--stdio"] },
+        {
+          name: "remote",
+          transport: "http",
+          url: "https://mcp.example.test/rpc",
+          headers: { "X-Test": "http" },
+        },
+        {
+          name: "events",
+          transport: "sse",
+          url: "https://mcp.example.test/events",
+          headers: { "X-Test": "sse" },
+        },
+      ],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const events: SessionEvent[] = [];
+    const handler = makeHandler(fakeSession, captures, {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+
+    await handler.start(message("m1", "use managed tools"), makeContext(events), makeToken());
+
+    expect(captures.create).toHaveProperty("mcpServers", {
+      docs: { transport: "stdio", command: "docs-server", args: ["--stdio"] },
+      remote: {
+        transport: "http",
+        url: "https://mcp.example.test/rpc",
+        headers: { "X-Test": "http" },
+      },
+      events: {
+        transport: "sse",
+        url: "https://mcp.example.test/events",
+        headers: { "X-Test": "sse" },
+      },
+    });
+    expect(
+      events.some(
+        (item) => item.kind === "error" && item.payload.source === "runtime" && /MCP/.test(item.payload.message),
+      ),
+    ).toBe(false);
+  });
+
   it("resumes with roleAdditional/kaos and reapplies explicit model plus permission", async () => {
     const fakeSession = new FakeSession("kimi-session-2", [successfulTurn("kimi-session-2")]);
     const captures: { resume?: ResumeSessionInput } = {};
@@ -206,7 +262,7 @@ describe("Kimi Code handler", () => {
       kind: "kimi-code" as const,
       prompt: { append: "" },
       model: "kimi-for-coding",
-      mcpServers: [],
+      mcpServers: [{ name: "docs", transport: "stdio" as const, command: "docs-server" }],
       env: [],
       gitRepos: [],
       resourceSkills: [],
@@ -229,6 +285,9 @@ describe("Kimi Code handler", () => {
     await handler.resume(message("m2", "continue"), "kimi-session-2", makeContext([]), makeToken());
 
     expect(captures.resume).toMatchObject({ id: "kimi-session-2" });
+    expect(captures.resume).toHaveProperty("mcpServers", {
+      docs: { transport: "stdio", command: "docs-server" },
+    });
     expect(captures.resume?.roleAdditional).toContain("First Tree");
     expect(fakeSession.setPermission).toHaveBeenCalledWith("yolo");
     expect(fakeSession.setModel).toHaveBeenCalledWith("kimi-for-coding");

--- a/packages/client/src/handlers/cursor/index.ts
+++ b/packages/client/src/handlers/cursor/index.ts
@@ -1,7 +1,8 @@
-import { spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
+import { promisify } from "node:util";
 import {
   type AgentRuntimeConfigPayload,
   classifyShellCommandIo,
@@ -65,8 +66,10 @@ import { type CursorStreamEvent, CursorStreamParser, type CursorToolCall, type C
  *
  * Canonical spawn contract (human-confirmed safety posture):
  *   <binary> -p --output-format stream-json --sandbox disabled --force
- *            [--approve-mcps when managed MCP servers are configured]
  *            [--model <exact-operator-value>] [--resume <confirmed-session-id>]
+ *   Before each turn, First Tree atomically projects only its managed servers
+ *   into `.cursor/mcp.json` and runs `<binary> mcp enable <managed-name>` for
+ *   each projected entry.
  *
  * Hard constraints enforced here, not by prompt:
  *   - process cwd = agent home; prompt rides stdin only (never argv);
@@ -74,7 +77,8 @@ import { type CursorStreamEvent, CursorStreamParser, type CursorToolCall, type C
  *   - no `--trust` / `--workspace` / `--stream-partial-output`, no
  *     `CURSOR_CONFIG_DIR`, no generated `.cursor/cli.json` — the operator's
  *     own Cursor login and permission config (including explicit denies) apply.
- *     `--approve-mcps` is present only for the runtime-owned `.cursor/mcp.json`;
+ *     The broad `--approve-mcps` flag is never used: provider-native
+ *     per-server approval keeps unrelated operator MCP approval unchanged;
  *   - `--resume` only ever carries a stream-confirmed provider session id;
  *     synthetic pending ids stay runtime-local;
  *   - settlement waits for child close + stdout/stderr drain (auth, invalid
@@ -134,14 +138,14 @@ function materializeCursorMcpConfig(workspaceCwd: string, payload: AgentRuntimeC
   }
 }
 
+/** Cursor's provider-native, single-server approval command. */
+export function buildCursorMcpEnableArgs(serverName: string): string[] {
+  return ["mcp", "enable", serverName];
+}
+
 /** Build the canonical argv (exported so tests can lock the spawn contract). */
-export function buildCursorTurnArgs(input: {
-  approveMcps: boolean;
-  model: string;
-  resumeSessionId: string | null;
-}): string[] {
+export function buildCursorTurnArgs(input: { model: string; resumeSessionId: string | null }): string[] {
   const args = ["-p", "--output-format", "stream-json", "--sandbox", "disabled", "--force"];
-  if (input.approveMcps) args.push("--approve-mcps");
   if (input.model) args.push("--model", input.model);
   if (input.resumeSessionId) args.push("--resume", input.resumeSessionId);
   return args;
@@ -152,8 +156,90 @@ const STDERR_TAIL_LIMIT = 8_192;
 /** Grace between SIGTERM and SIGKILL on abort, and the final close wait. */
 const KILL_GRACE_MS = 5_000;
 const FINAL_CLOSE_WAIT_MS = 10_000;
+/** `mcp enable` is a local config operation and must not stall a delivery. */
+const CURSOR_MCP_ENABLE_TIMEOUT_MS = 10_000;
+const CURSOR_MCP_ENABLE_MAX_BUFFER = 64 * 1024;
 
 type SpawnFn = typeof spawn;
+type CursorMcpEnableFn = (input: {
+  binary: string;
+  serverName: string;
+  workspaceCwd: string;
+  env: Record<string, string>;
+  abortSignal: AbortSignal;
+}) => Promise<void>;
+
+const execFileAsync = promisify(execFile);
+
+async function enableCursorMcpServer(input: Parameters<CursorMcpEnableFn>[0]): Promise<void> {
+  try {
+    await execFileAsync(input.binary, buildCursorMcpEnableArgs(input.serverName), {
+      cwd: input.workspaceCwd,
+      env: input.env,
+      shell: false,
+      signal: input.abortSignal,
+      timeout: CURSOR_MCP_ENABLE_TIMEOUT_MS,
+      maxBuffer: CURSOR_MCP_ENABLE_MAX_BUFFER,
+      windowsHide: true,
+    });
+  } catch (err) {
+    if (input.abortSignal.aborted) throw err;
+    // The CLI may include parsed config in stderr. Do not propagate it because
+    // remote MCP headers can be sensitive; a bounded code is enough to route
+    // the operator toward the failed provider-native approval step.
+    const code = typeof err === "object" && err !== null && "code" in err ? err.code : undefined;
+    throw new Error(
+      `cursor-agent mcp enable failed for managed server "${input.serverName}"${
+        typeof code === "string" || typeof code === "number" ? ` (code ${code})` : ""
+      }`,
+    );
+  }
+}
+
+/**
+ * A Cursor process reads project MCP config from the agent workspace. Multiple
+ * chats for one agent share that workspace, so their materialize/approve/spawn
+ * sequence must not interleave. Hold this lock for the complete provider turn:
+ * that is the only provider-supported boundary at which the process is known
+ * to be done reading and using the projected file.
+ */
+const cursorWorkspaceTurnTails = new Map<string, Promise<void>>();
+
+async function withCursorWorkspaceTurnLock<T>(
+  workspaceCwd: string,
+  abortSignal: AbortSignal,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = resolve(workspaceCwd);
+  const previous = cursorWorkspaceTurnTails.get(key) ?? Promise.resolve();
+  let releaseSelf: () => void = () => {};
+  const self = new Promise<void>((resolveSelf) => {
+    releaseSelf = resolveSelf;
+  });
+  const tail = previous.catch(() => {}).then(() => self);
+  cursorWorkspaceTurnTails.set(key, tail);
+  void tail.then(() => {
+    if (cursorWorkspaceTurnTails.get(key) === tail) cursorWorkspaceTurnTails.delete(key);
+  });
+
+  if (abortSignal.aborted) {
+    releaseSelf();
+    throw new DOMException("Aborted", "AbortError");
+  }
+  let onAbort: () => void = () => {};
+  const aborted = new Promise<never>((_resolvePromise, reject) => {
+    onAbort = () => reject(new DOMException("Aborted", "AbortError"));
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+  });
+  try {
+    await Promise.race([previous.catch(() => {}), aborted]);
+    if (abortSignal.aborted) throw new DOMException("Aborted", "AbortError");
+    return await fn();
+  } finally {
+    abortSignal.removeEventListener("abort", onAbort);
+    releaseSelf();
+  }
+}
 
 function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
   if (signal.aborted) {
@@ -203,6 +289,7 @@ export const createCursorHandler: HandlerFactory = (config) => {
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
   const contextTreeBranch = (config.contextTreeBranch as string | undefined) ?? null;
   const spawnFn = (config.cursorSpawnFn as SpawnFn | undefined) ?? spawn;
+  const enableMcpServer = (config.cursorMcpEnableFn as CursorMcpEnableFn | undefined) ?? enableCursorMcpServer;
   const resolveBinary =
     (config.cursorBinaryResolver as typeof resolveCursorRuntimeBinary | undefined) ?? resolveCursorRuntimeBinary;
 
@@ -262,15 +349,12 @@ export const createCursorHandler: HandlerFactory = (config) => {
     });
   }
 
-  function buildEnv(sessionCtx: SessionContext): Record<string, string> {
+  function buildEnv(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload): Record<string, string> {
     const env: Record<string, string> = {};
     for (const [k, v] of Object.entries(process.env)) {
       if (typeof v === "string") env[k] = v;
     }
-    const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
-    if (payload) {
-      for (const e of payload.env) env[e.key] = e.value;
-    }
+    for (const e of payload.env) env[e.key] = e.value;
     // The First Tree envelope injects the runtime-session token FILE PATH and
     // identity ids — never a token value.
     const merged = sessionCtx.buildAgentEnv(env);
@@ -727,14 +811,114 @@ export const createCursorHandler: HandlerFactory = (config) => {
     token: DeliveryToken,
   ): Promise<boolean> {
     const workspaceCwd = cwd;
-    const activeBinary = binary;
-    if (!workspaceCwd || !activeBinary || !sessionActive) {
+    const fallbackPayload = activePayload;
+    if (!workspaceCwd || !binary || !fallbackPayload || !sessionActive) {
       // `sessionActive` closes the drain-vs-lifecycle race: a queued turn
       // whose drain passed its gates before suspend()/shutdown() ran must not
       // spawn a provider process on a suspended session.
       token.retry(messages, sessionActive ? "cursor_missing_workspace_or_binary" : "cursor_session_inactive");
       return false;
     }
+
+    const generation = ++turnGeneration;
+    const abort = new AbortController();
+    currentAbort = abort;
+    const turnPromise = withCursorWorkspaceTurnLock(workspaceCwd, abort.signal, async () => {
+      const activeBinary = binary;
+      if (
+        abort.signal.aborted ||
+        turnGeneration !== generation ||
+        cwd !== workspaceCwd ||
+        !activeBinary ||
+        !sessionActive
+      ) {
+        return false;
+      }
+      return runTurnLocked(
+        input,
+        sessionCtx,
+        messages,
+        token,
+        workspaceCwd,
+        activeBinary,
+        fallbackPayload,
+        generation,
+        abort,
+      );
+    }).catch((err: unknown) => {
+      if (abort.signal.aborted || turnGeneration !== generation) return false;
+      throw err;
+    });
+    currentTurnPromise = turnPromise.then(
+      () => {},
+      () => {},
+    );
+    try {
+      return await turnPromise;
+    } finally {
+      if (turnGeneration === generation) {
+        currentAbort = null;
+        currentTurnPromise = null;
+        scheduleQueuedMessagesDrain();
+      }
+    }
+  }
+
+  async function runTurnLocked(
+    input: string,
+    sessionCtx: SessionContext,
+    messages: readonly SessionMessage[],
+    token: DeliveryToken,
+    workspaceCwd: string,
+    activeBinary: string,
+    fallbackPayload: AgentRuntimeConfigPayload,
+    generation: number,
+    abort: AbortController,
+  ): Promise<boolean> {
+    // One immutable per-turn snapshot drives MCP projection, per-server
+    // approval, model, and env. SessionManager refreshes the cache before
+    // dispatch, so an active chat converges on its very next turn.
+    const turnPayload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload ?? fallbackPayload;
+    const model = turnPayload.model;
+    const env = buildEnv(sessionCtx, turnPayload);
+
+    try {
+      materializeCursorMcpConfig(workspaceCwd, turnPayload);
+      for (const server of turnPayload.mcpServers) {
+        await enableMcpServer({
+          binary: activeBinary,
+          serverName: server.name,
+          workspaceCwd,
+          env,
+          abortSignal: abort.signal,
+        });
+      }
+    } catch (err) {
+      if (abort.signal.aborted || turnGeneration !== generation) return false;
+      sessionCtx.log(
+        `cursor managed MCP projection failed before provider start: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      sessionCtx.emitEvent({
+        kind: "error",
+        payload: {
+          source: "runtime",
+          message: "Cursor managed MCP setup failed before the provider turn; delivery will retry.",
+        },
+      });
+      token.retry(messages, "cursor_mcp_projection_failed");
+      return false;
+    }
+
+    if (
+      abort.signal.aborted ||
+      turnGeneration !== generation ||
+      cwd !== workspaceCwd ||
+      binary !== activeBinary ||
+      !sessionActive
+    ) {
+      return false;
+    }
+
     // One-shot payload snapshot: a non-delivered exit (abort, retry-path
     // settlement) must put the chat-context/notice back so the redelivery
     // still carries it — otherwise the design's "spawn/transport failure must
@@ -746,13 +930,8 @@ export const createCursorHandler: HandlerFactory = (config) => {
     };
 
     token.processingStarted(messages);
-    const generation = ++turnGeneration;
-    const abort = new AbortController();
-    currentAbort = abort;
     gitWriteTracker.captureBaseline();
 
-    const model = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload?.model ?? activePayload?.model ?? "";
-    const env = buildEnv(sessionCtx);
     const turnStartedAt = Date.now();
 
     let finalText = "";
@@ -785,7 +964,6 @@ export const createCursorHandler: HandlerFactory = (config) => {
         let retryDelay = 0;
 
         const args = buildCursorTurnArgs({
-          approveMcps: (activePayload?.mcpServers.length ?? 0) > 0,
           model,
           // Only a stream-confirmed id ever reaches --resume; the first turn
           // (and any turn after a synthetic placeholder) starts fresh.
@@ -882,15 +1060,7 @@ export const createCursorHandler: HandlerFactory = (config) => {
       }
     })();
 
-    currentTurnPromise = promise;
-    try {
-      await promise;
-    } finally {
-      if (turnGeneration === generation) {
-        currentAbort = null;
-        currentTurnPromise = null;
-      }
-    }
+    await promise;
 
     if (abort.signal.aborted || turnGeneration !== generation) {
       // Suspend/shutdown/preemption raced ahead — not a delivered turn; the
@@ -962,7 +1132,6 @@ export const createCursorHandler: HandlerFactory = (config) => {
       );
     }
 
-    scheduleQueuedMessagesDrain();
     return settlement.action.kind === "complete";
   }
 
@@ -1125,7 +1294,6 @@ export const createCursorHandler: HandlerFactory = (config) => {
       briefing,
       currentSourceRepoNames: currentSourceRepoNamesFromPayload(payload, payloadResolved),
     });
-    materializeCursorMcpConfig(workspaceCwd, payload);
     markWorkspaceInitComplete(workspaceCwd);
 
     const resolution = resolveBinary(process.env);

--- a/packages/client/src/handlers/cursor/index.ts
+++ b/packages/client/src/handlers/cursor/index.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -53,7 +53,7 @@ import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../../ru
 import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
 import { chunkAssistantText } from "../assistant-text.js";
 import { formatAuthHint, isCursorAuthError } from "../auth-error-hint.js";
-import { resolveTurnSettlement } from "../turn-settlement.js";
+import { consumedErrorOutcome, resolveTurnSettlement } from "../turn-settlement.js";
 import { type CursorStreamEvent, CursorStreamParser, type CursorToolCall, type CursorUsage } from "./parser.js";
 
 /**
@@ -116,6 +116,33 @@ export function mapCursorMcpServers(payload: AgentRuntimeConfigPayload): Record<
   return servers;
 }
 
+/**
+ * Hash the shared project-state portion of one turn snapshot. Header values
+ * may contain secrets, so the coordinator retains only the digest.
+ */
+function cursorMcpProjectionFingerprint(payload: AgentRuntimeConfigPayload): string {
+  const canonicalServers = Object.entries(mapCursorMcpServers(payload))
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, config]) => {
+      if ("command" in config) {
+        return [name, { command: config.command, ...(config.args === undefined ? {} : { args: config.args }) }];
+      }
+      const headers =
+        config.headers === undefined
+          ? undefined
+          : Object.fromEntries(Object.entries(config.headers).sort(([left], [right]) => left.localeCompare(right)));
+      return [
+        name,
+        {
+          type: config.type,
+          url: config.url,
+          ...(headers === undefined ? {} : { headers }),
+        },
+      ];
+    });
+  return createHash("sha256").update(JSON.stringify(canonicalServers)).digest("hex");
+}
+
 function materializeCursorMcpConfig(workspaceCwd: string, payload: AgentRuntimeConfigPayload): void {
   const configDir = join(workspaceCwd, ".cursor");
   const configPath = join(configDir, "mcp.json");
@@ -171,6 +198,82 @@ type CursorMcpEnableFn = (input: {
 
 const execFileAsync = promisify(execFile);
 
+type CursorMcpSetupPhase = "projection" | "approval";
+
+class CursorMcpSetupError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string | number,
+  ) {
+    super(message);
+    this.name = "CursorMcpSetupError";
+  }
+}
+
+class CursorMcpProjectionSettlementError extends Error {
+  constructor(readonly settlement: ProviderAttemptSettlement) {
+    super(`Cursor managed MCP setup stopped: ${settlement.decision.reasonCode}`);
+    this.name = "CursorMcpProjectionSettlementError";
+  }
+}
+
+function cursorMcpSetupErrorCode(err: unknown): string | number | undefined {
+  if (!err || typeof err !== "object" || !("code" in err)) return undefined;
+  const code = err.code;
+  return typeof code === "string" || typeof code === "number" ? code : undefined;
+}
+
+function cursorMcpSetupErrorIsTransient(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const record = err as Record<string, unknown>;
+  const code = cursorMcpSetupErrorCode(err);
+  const name = err instanceof Error ? err.name : typeof record.name === "string" ? record.name : "";
+  const message = err instanceof Error ? err.message : typeof record.message === "string" ? record.message : "";
+  return (
+    name === "AbortError" ||
+    name === "TimeoutError" ||
+    record.killed === true ||
+    (typeof code === "string" &&
+      /^(?:EAGAIN|EBUSY|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|EAI_AGAIN|EMFILE|ENETUNREACH|ENFILE|ENOTFOUND|EPIPE|ETIMEDOUT)$/.test(
+        code,
+      )) ||
+    /timed out|timeout|network|connection (?:refused|reset)|socket hang up/i.test(message)
+  );
+}
+
+/**
+ * Convert provider/FS output into a secret-safe error that the shared failure
+ * taxonomy can route without retaining raw stderr or projected headers.
+ */
+function sanitizeCursorMcpSetupError(
+  err: unknown,
+  phase: CursorMcpSetupPhase,
+  serverName?: string,
+): CursorMcpSetupError {
+  if (err instanceof CursorMcpSetupError) return err;
+  const code = cursorMcpSetupErrorCode(err);
+  if (phase === "approval" && code === "ENOENT") {
+    return new CursorMcpSetupError(
+      formatCursorBinaryMissingMessage("the bound cursor binary disappeared during managed MCP approval"),
+      code,
+    );
+  }
+  if (cursorMcpSetupErrorIsTransient(err)) {
+    const error = new CursorMcpSetupError(
+      "Cursor managed MCP setup timed out or hit a transient transport failure",
+      code,
+    );
+    error.name = "TimeoutError";
+    return error;
+  }
+  return new CursorMcpSetupError(
+    phase === "approval"
+      ? `Cursor managed MCP approval configuration failed${serverName ? ` for server "${serverName}"` : ""}`
+      : "Cursor managed MCP projection failed because the project configuration is invalid or unavailable (bad config)",
+    code,
+  );
+}
+
 async function enableCursorMcpServer(input: Parameters<CursorMcpEnableFn>[0]): Promise<void> {
   try {
     await execFileAsync(input.binary, buildCursorMcpEnableArgs(input.serverName), {
@@ -184,61 +287,160 @@ async function enableCursorMcpServer(input: Parameters<CursorMcpEnableFn>[0]): P
     });
   } catch (err) {
     if (input.abortSignal.aborted) throw err;
-    // The CLI may include parsed config in stderr. Do not propagate it because
-    // remote MCP headers can be sensitive; a bounded code is enough to route
-    // the operator toward the failed provider-native approval step.
-    const code = typeof err === "object" && err !== null && "code" in err ? err.code : undefined;
-    throw new Error(
-      `cursor-agent mcp enable failed for managed server "${input.serverName}"${
-        typeof code === "string" || typeof code === "number" ? ` (code ${code})` : ""
-      }`,
-    );
+    // The CLI may include parsed config in stderr. Preserve only a safe
+    // category/code; raw output can contain remote MCP headers.
+    throw sanitizeCursorMcpSetupError(err, "approval", input.serverName);
   }
 }
 
 /**
- * A Cursor process reads project MCP config from the agent workspace. Multiple
- * chats for one agent share that workspace, so their materialize/approve/spawn
- * sequence must not interleave. Hold this lock for the complete provider turn:
- * that is the only provider-supported boundary at which the process is known
- * to be done reading and using the projected file.
+ * Cursor processes share project MCP state through the agent workspace.
+ * Matching fingerprints take shared leases and keep the configured agent
+ * concurrency intact. A different fingerprint waits for the old projection's
+ * live turns to release, then performs one exclusive materialize/approval
+ * transition before its cohort starts.
  */
-const cursorWorkspaceTurnTails = new Map<string, Promise<void>>();
+type CursorWorkspaceProjectionLease = { release(): void };
+type CursorWorkspaceProjectionWaiter = {
+  fingerprint: string;
+  setup: () => Promise<void>;
+  abortSignal: AbortSignal;
+  resolve: (lease: CursorWorkspaceProjectionLease) => void;
+  reject: (err: unknown) => void;
+  onAbort: () => void;
+  phase: "queued" | "transitioning" | "settled";
+};
+type CursorWorkspaceProjectionState = {
+  fingerprint: string | null;
+  activeLeases: number;
+  transitioning: boolean;
+  queue: CursorWorkspaceProjectionWaiter[];
+};
 
-async function withCursorWorkspaceTurnLock<T>(
-  workspaceCwd: string,
-  abortSignal: AbortSignal,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const key = resolve(workspaceCwd);
-  const previous = cursorWorkspaceTurnTails.get(key) ?? Promise.resolve();
-  let releaseSelf: () => void = () => {};
-  const self = new Promise<void>((resolveSelf) => {
-    releaseSelf = resolveSelf;
-  });
-  const tail = previous.catch(() => {}).then(() => self);
-  cursorWorkspaceTurnTails.set(key, tail);
-  void tail.then(() => {
-    if (cursorWorkspaceTurnTails.get(key) === tail) cursorWorkspaceTurnTails.delete(key);
-  });
+const cursorWorkspaceProjectionStates = new Map<string, CursorWorkspaceProjectionState>();
 
-  if (abortSignal.aborted) {
-    releaseSelf();
-    throw new DOMException("Aborted", "AbortError");
-  }
-  let onAbort: () => void = () => {};
-  const aborted = new Promise<never>((_resolvePromise, reject) => {
-    onAbort = () => reject(new DOMException("Aborted", "AbortError"));
-    abortSignal.addEventListener("abort", onAbort, { once: true });
+function cursorAbortError(): DOMException {
+  return new DOMException("Aborted", "AbortError");
+}
+
+function settleCursorProjectionWaiterWithError(waiter: CursorWorkspaceProjectionWaiter, err: unknown): void {
+  if (waiter.phase === "settled") return;
+  waiter.phase = "settled";
+  waiter.abortSignal.removeEventListener("abort", waiter.onAbort);
+  waiter.reject(err);
+}
+
+function grantCursorProjectionLease(
+  state: CursorWorkspaceProjectionState,
+  waiter: CursorWorkspaceProjectionWaiter,
+): void {
+  if (waiter.phase === "settled") return;
+  waiter.phase = "settled";
+  waiter.abortSignal.removeEventListener("abort", waiter.onAbort);
+  state.activeLeases++;
+  let released = false;
+  waiter.resolve({
+    release: () => {
+      if (released) return;
+      released = true;
+      state.activeLeases = Math.max(0, state.activeLeases - 1);
+      drainCursorProjectionQueue(state);
+    },
   });
-  try {
-    await Promise.race([previous.catch(() => {}), aborted]);
-    if (abortSignal.aborted) throw new DOMException("Aborted", "AbortError");
-    return await fn();
-  } finally {
-    abortSignal.removeEventListener("abort", onAbort);
-    releaseSelf();
+}
+
+function drainCursorProjectionQueue(state: CursorWorkspaceProjectionState): void {
+  if (state.transitioning) return;
+
+  while (state.queue[0]?.abortSignal.aborted) {
+    const aborted = state.queue.shift();
+    if (aborted) settleCursorProjectionWaiterWithError(aborted, cursorAbortError());
   }
+  const first = state.queue[0];
+  if (!first) return;
+
+  if (state.activeLeases > 0) {
+    // Preserve FIFO transition fairness: matching turns may share the current
+    // projection only until a different fingerprint reaches the queue head.
+    while (state.queue[0]?.fingerprint === state.fingerprint) {
+      const matching = state.queue.shift();
+      if (matching) grantCursorProjectionLease(state, matching);
+    }
+    return;
+  }
+
+  if (state.fingerprint === first.fingerprint) {
+    while (state.queue[0]?.fingerprint === state.fingerprint) {
+      const matching = state.queue.shift();
+      if (matching) grantCursorProjectionLease(state, matching);
+    }
+    return;
+  }
+
+  const transition = state.queue.shift();
+  if (!transition) return;
+  transition.phase = "transitioning";
+  state.transitioning = true;
+  void transition.setup().then(
+    () => {
+      state.transitioning = false;
+      if (transition.abortSignal.aborted) {
+        // Setup may already have replaced the shared file before observing
+        // abort. Treat the live projection as unknown until the next owner
+        // materializes it again.
+        state.fingerprint = null;
+        settleCursorProjectionWaiterWithError(transition, cursorAbortError());
+      } else {
+        state.fingerprint = transition.fingerprint;
+        grantCursorProjectionLease(state, transition);
+      }
+      drainCursorProjectionQueue(state);
+    },
+    (err: unknown) => {
+      state.transitioning = false;
+      // A failed approval can follow a successful atomic file replacement.
+      // Never let the previous fingerprint lease that potentially-new file.
+      state.fingerprint = null;
+      settleCursorProjectionWaiterWithError(transition, err);
+      drainCursorProjectionQueue(state);
+    },
+  );
+}
+
+function acquireCursorWorkspaceProjectionLease(input: {
+  workspaceCwd: string;
+  fingerprint: string;
+  abortSignal: AbortSignal;
+  setup: () => Promise<void>;
+}): Promise<CursorWorkspaceProjectionLease> {
+  if (input.abortSignal.aborted) return Promise.reject(cursorAbortError());
+  const key = resolve(input.workspaceCwd);
+  let state = cursorWorkspaceProjectionStates.get(key);
+  if (!state) {
+    state = { fingerprint: null, activeLeases: 0, transitioning: false, queue: [] };
+    cursorWorkspaceProjectionStates.set(key, state);
+  }
+  const projectionState = state;
+  return new Promise<CursorWorkspaceProjectionLease>((resolveLease, reject) => {
+    const waiter: CursorWorkspaceProjectionWaiter = {
+      fingerprint: input.fingerprint,
+      setup: input.setup,
+      abortSignal: input.abortSignal,
+      resolve: resolveLease,
+      reject,
+      onAbort: () => {
+        if (waiter.phase !== "queued") return;
+        const index = projectionState.queue.indexOf(waiter);
+        if (index >= 0) projectionState.queue.splice(index, 1);
+        settleCursorProjectionWaiterWithError(waiter, cursorAbortError());
+        drainCursorProjectionQueue(projectionState);
+      },
+      phase: "queued",
+    };
+    input.abortSignal.addEventListener("abort", waiter.onAbort, { once: true });
+    projectionState.queue.push(waiter);
+    drainCursorProjectionQueue(projectionState);
+  });
 }
 
 function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
@@ -347,6 +549,93 @@ export const createCursorHandler: HandlerFactory = (config) => {
         message: encodeProviderRetryEventMessage(settlement.eventPayload),
       },
     });
+  }
+
+  function consumedReasonForProviderSettlement(settlement: ProviderAttemptSettlement): TurnConsumedErrorReason {
+    return settlement.decision.action === "stop" && settlement.decision.terminalKind === "capacity_wait_required"
+      ? "capacity_wait_required"
+      : settlement.decision.action === "stop" && settlement.decision.terminalKind === "exhausted"
+        ? "provider_retry_exhausted"
+        : settlement.decision.reasonCode;
+  }
+
+  async function prepareCursorMcpProjection(input: {
+    workspaceCwd: string;
+    activeBinary: string;
+    turnPayload: AgentRuntimeConfigPayload;
+    env: Record<string, string>;
+    sessionCtx: SessionContext;
+    generation: number;
+    abortSignal: AbortSignal;
+  }): Promise<void> {
+    for (let attempt = 1; ; attempt++) {
+      let setupError: CursorMcpSetupError | null = null;
+      try {
+        materializeCursorMcpConfig(input.workspaceCwd, input.turnPayload);
+      } catch (err) {
+        setupError = sanitizeCursorMcpSetupError(err, "projection");
+      }
+
+      if (!setupError) {
+        for (const server of input.turnPayload.mcpServers) {
+          try {
+            await enableMcpServer({
+              binary: input.activeBinary,
+              serverName: server.name,
+              workspaceCwd: input.workspaceCwd,
+              env: input.env,
+              abortSignal: input.abortSignal,
+            });
+          } catch (err) {
+            if (input.abortSignal.aborted || turnGeneration !== input.generation) throw cursorAbortError();
+            setupError = sanitizeCursorMcpSetupError(err, "approval", server.name);
+            break;
+          }
+        }
+      }
+
+      if (!setupError) {
+        if (input.abortSignal.aborted || turnGeneration !== input.generation) throw cursorAbortError();
+        return;
+      }
+      if (input.abortSignal.aborted || turnGeneration !== input.generation) throw cursorAbortError();
+
+      const providerAttempt = new ProviderAttempt({
+        provider: runtimeProvider,
+        scope: "provider_turn",
+        source: "stream",
+        replaySafety: "pre_provider",
+      });
+      providerAttempt.recordSignal({ kind: "local_error", error: setupError });
+      const settlement = providerAttempt.settle({ attempt });
+      if (!settlement) throw setupError;
+      emitProviderTurnSettlementEvent(input.sessionCtx, settlement);
+
+      if (settlement.decision.action === "retry") {
+        input.sessionCtx.log(
+          `cursor managed MCP setup retry ${attempt}/${providerTurnMaxRetries + 1} ` +
+            `after ${settlement.decision.delayMs}ms; ${settlement.classification.category}/` +
+            settlement.decision.reasonCode,
+        );
+        await sleepWithAbort(settlement.decision.delayMs, input.abortSignal);
+        continue;
+      }
+
+      input.sessionCtx.log(
+        `cursor managed MCP setup stopped before provider start: ${settlement.classification.category}/` +
+          settlement.decision.reasonCode,
+      );
+      input.sessionCtx.emitEvent({
+        kind: "error",
+        payload: {
+          source: "sdk",
+          message:
+            `Cursor managed MCP setup failed (${settlement.classification.category}/` +
+            `${settlement.decision.reasonCode}).`,
+        },
+      });
+      throw new CursorMcpProjectionSettlementError(settlement);
+    }
   }
 
   function buildEnv(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload): Record<string, string> {
@@ -820,32 +1109,72 @@ export const createCursorHandler: HandlerFactory = (config) => {
       return false;
     }
 
+    const activeBinary = binary;
+    // One immutable per-turn snapshot drives MCP projection, targeted
+    // approval, model, and env. SessionManager refreshes the cache before
+    // dispatch, so an active chat converges on its very next turn even when a
+    // projection transition must wait for older live turns to drain.
+    const turnPayload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload ?? fallbackPayload;
+    const model = turnPayload.model;
+    const env = buildEnv(sessionCtx, turnPayload);
+    const projectionFingerprint = cursorMcpProjectionFingerprint(turnPayload);
     const generation = ++turnGeneration;
     const abort = new AbortController();
     currentAbort = abort;
-    const turnPromise = withCursorWorkspaceTurnLock(workspaceCwd, abort.signal, async () => {
-      const activeBinary = binary;
-      if (
-        abort.signal.aborted ||
-        turnGeneration !== generation ||
-        cwd !== workspaceCwd ||
-        !activeBinary ||
-        !sessionActive
-      ) {
-        return false;
+    const turnPromise = (async () => {
+      let projectionLease: CursorWorkspaceProjectionLease;
+      try {
+        projectionLease = await acquireCursorWorkspaceProjectionLease({
+          workspaceCwd,
+          fingerprint: projectionFingerprint,
+          abortSignal: abort.signal,
+          setup: () =>
+            prepareCursorMcpProjection({
+              workspaceCwd,
+              activeBinary,
+              turnPayload,
+              env,
+              sessionCtx,
+              generation,
+              abortSignal: abort.signal,
+            }),
+        });
+      } catch (err) {
+        if (abort.signal.aborted || turnGeneration !== generation) return false;
+        if (err instanceof CursorMcpProjectionSettlementError) {
+          sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+          await token.complete(messages, consumedErrorOutcome(consumedReasonForProviderSettlement(err.settlement)));
+          return true;
+        }
+        throw err;
       }
-      return runTurnLocked(
-        input,
-        sessionCtx,
-        messages,
-        token,
-        workspaceCwd,
-        activeBinary,
-        fallbackPayload,
-        generation,
-        abort,
-      );
-    }).catch((err: unknown) => {
+
+      try {
+        if (
+          abort.signal.aborted ||
+          turnGeneration !== generation ||
+          cwd !== workspaceCwd ||
+          binary !== activeBinary ||
+          !sessionActive
+        ) {
+          return false;
+        }
+        return await runTurnWithProjection(
+          input,
+          sessionCtx,
+          messages,
+          token,
+          workspaceCwd,
+          activeBinary,
+          model,
+          env,
+          generation,
+          abort,
+        );
+      } finally {
+        projectionLease.release();
+      }
+    })().catch((err: unknown) => {
       if (abort.signal.aborted || turnGeneration !== generation) return false;
       throw err;
     });
@@ -864,51 +1193,18 @@ export const createCursorHandler: HandlerFactory = (config) => {
     }
   }
 
-  async function runTurnLocked(
+  async function runTurnWithProjection(
     input: string,
     sessionCtx: SessionContext,
     messages: readonly SessionMessage[],
     token: DeliveryToken,
     workspaceCwd: string,
     activeBinary: string,
-    fallbackPayload: AgentRuntimeConfigPayload,
+    model: string,
+    env: Record<string, string>,
     generation: number,
     abort: AbortController,
   ): Promise<boolean> {
-    // One immutable per-turn snapshot drives MCP projection, per-server
-    // approval, model, and env. SessionManager refreshes the cache before
-    // dispatch, so an active chat converges on its very next turn.
-    const turnPayload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload ?? fallbackPayload;
-    const model = turnPayload.model;
-    const env = buildEnv(sessionCtx, turnPayload);
-
-    try {
-      materializeCursorMcpConfig(workspaceCwd, turnPayload);
-      for (const server of turnPayload.mcpServers) {
-        await enableMcpServer({
-          binary: activeBinary,
-          serverName: server.name,
-          workspaceCwd,
-          env,
-          abortSignal: abort.signal,
-        });
-      }
-    } catch (err) {
-      if (abort.signal.aborted || turnGeneration !== generation) return false;
-      sessionCtx.log(
-        `cursor managed MCP projection failed before provider start: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      sessionCtx.emitEvent({
-        kind: "error",
-        payload: {
-          source: "runtime",
-          message: "Cursor managed MCP setup failed before the provider turn; delivery will retry.",
-        },
-      });
-      token.retry(messages, "cursor_mcp_projection_failed");
-      return false;
-    }
-
     if (
       abort.signal.aborted ||
       turnGeneration !== generation ||

--- a/packages/client/src/handlers/cursor/index.ts
+++ b/packages/client/src/handlers/cursor/index.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import {
   type AgentRuntimeConfigPayload,
@@ -64,14 +65,16 @@ import { type CursorStreamEvent, CursorStreamParser, type CursorToolCall, type C
  *
  * Canonical spawn contract (human-confirmed safety posture):
  *   <binary> -p --output-format stream-json --sandbox disabled --force
+ *            [--approve-mcps when managed MCP servers are configured]
  *            [--model <exact-operator-value>] [--resume <confirmed-session-id>]
  *
  * Hard constraints enforced here, not by prompt:
  *   - process cwd = agent home; prompt rides stdin only (never argv);
  *   - args go to `spawn` as an array with `shell: false`;
- *   - no `--trust` / `--workspace` / `--approve-mcps` / `--stream-partial-output`,
- *     no `CURSOR_CONFIG_DIR`, no generated `.cursor/cli.json` — the operator's
- *     own Cursor login and permission config (including explicit denies) apply;
+ *   - no `--trust` / `--workspace` / `--stream-partial-output`, no
+ *     `CURSOR_CONFIG_DIR`, no generated `.cursor/cli.json` — the operator's
+ *     own Cursor login and permission config (including explicit denies) apply.
+ *     `--approve-mcps` is present only for the runtime-owned `.cursor/mcp.json`;
  *   - `--resume` only ever carries a stream-confirmed provider session id;
  *     synthetic pending ids stay runtime-local;
  *   - settlement waits for child close + stdout/stderr drain (auth, invalid
@@ -86,9 +89,59 @@ export function isCursorPendingSessionId(sessionId: string): boolean {
   return sessionId.startsWith(CURSOR_PENDING_SESSION_PREFIX);
 }
 
+type CursorMcpServerConfig =
+  | { command: string; args?: string[] }
+  | { type: "http" | "sse"; url: string; headers?: Record<string, string> };
+
+export function mapCursorMcpServers(payload: AgentRuntimeConfigPayload): Record<string, CursorMcpServerConfig> {
+  const servers: Record<string, CursorMcpServerConfig> = {};
+  for (const server of payload.mcpServers) {
+    if (server.transport === "stdio") {
+      servers[server.name] = {
+        command: server.command,
+        ...(server.args === undefined ? {} : { args: server.args }),
+      };
+    } else {
+      servers[server.name] = {
+        type: server.transport,
+        url: server.url,
+        ...(server.headers === undefined ? {} : { headers: server.headers }),
+      };
+    }
+  }
+  return servers;
+}
+
+function materializeCursorMcpConfig(workspaceCwd: string, payload: AgentRuntimeConfigPayload): void {
+  const configDir = join(workspaceCwd, ".cursor");
+  const configPath = join(configDir, "mcp.json");
+  const temporaryPath = join(configDir, `.mcp.json.${process.pid}.${randomUUID()}.tmp`);
+  mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify({ mcpServers: mapCursorMcpServers(payload) }, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(temporaryPath, configPath);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {
+      // The write may have failed before the temporary file was created.
+    }
+    throw error;
+  }
+}
+
 /** Build the canonical argv (exported so tests can lock the spawn contract). */
-export function buildCursorTurnArgs(input: { model: string; resumeSessionId: string | null }): string[] {
+export function buildCursorTurnArgs(input: {
+  approveMcps: boolean;
+  model: string;
+  resumeSessionId: string | null;
+}): string[] {
   const args = ["-p", "--output-format", "stream-json", "--sandbox", "disabled", "--force"];
+  if (input.approveMcps) args.push("--approve-mcps");
   if (input.model) args.push("--model", input.model);
   if (input.resumeSessionId) args.push("--resume", input.resumeSessionId);
   return args;
@@ -161,7 +214,6 @@ export const createCursorHandler: HandlerFactory = (config) => {
   let providerSessionId: string | null = null;
   /** Runtime-local placeholder returned when the first turn settled before init. */
   let pendingSyntheticId: string | null = null;
-  let mcpDiagnosticEmitted = false;
   /**
    * Session-liveness fence for the run-to-completion transport. True from the
    * end of prepareSession until suspend()/shutdown(). Queued drains and
@@ -270,21 +322,6 @@ export const createCursorHandler: HandlerFactory = (config) => {
 
   function declareSourceRepos(payload: AgentRuntimeConfigPayload, workspaceCwd: string): void {
     sourceReposForPrompt = declaredSourceRepos(workspaceCwd, payload);
-  }
-
-  function emitMcpUnsupportedDiagnosticOnce(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload): void {
-    if (mcpDiagnosticEmitted || payload.mcpServers.length === 0) return;
-    mcpDiagnosticEmitted = true;
-    sessionCtx.emitEvent({
-      kind: "error",
-      payload: {
-        source: "runtime",
-        message:
-          `cursor provider does not materialize First Tree-managed MCP servers in v1; ` +
-          `${payload.mcpServers.length} configured MCP server(s) are NOT loaded for this agent. ` +
-          "The session continues without them (the operator's own Cursor config still applies).",
-      },
-    });
   }
 
   function cursorNativePathRefs(filePath: string | null, origin: "tool_arg" | "file_change"): ToolFileRef[] {
@@ -748,6 +785,7 @@ export const createCursorHandler: HandlerFactory = (config) => {
         let retryDelay = 0;
 
         const args = buildCursorTurnArgs({
+          approveMcps: (activePayload?.mcpServers.length ?? 0) > 0,
           model,
           // Only a stream-confirmed id ever reaches --resume; the first turn
           // (and any turn after a synthetic placeholder) starts fresh.
@@ -1087,9 +1125,8 @@ export const createCursorHandler: HandlerFactory = (config) => {
       briefing,
       currentSourceRepoNames: currentSourceRepoNamesFromPayload(payload, payloadResolved),
     });
+    materializeCursorMcpConfig(workspaceCwd, payload);
     markWorkspaceInitComplete(workspaceCwd);
-
-    emitMcpUnsupportedDiagnosticOnce(sessionCtx, payload);
 
     const resolution = resolveBinary(process.env);
     if (!resolution.ok) {

--- a/packages/client/src/handlers/cursor/index.ts
+++ b/packages/client/src/handlers/cursor/index.ts
@@ -117,10 +117,32 @@ export function mapCursorMcpServers(payload: AgentRuntimeConfigPayload): Record<
 }
 
 /**
- * Hash the shared project-state portion of one turn snapshot. Header values
- * may contain secrets, so the coordinator retains only the digest.
+ * Cursor stores project MCP approvals beneath a non-blank CURSOR_DATA_DIR, or
+ * beneath the child process home otherwise. Keep the exact selector from the
+ * final child env in the coordination identity so approval in one store can
+ * never authorize a matching projection lease that reads another store.
  */
-function cursorMcpProjectionFingerprint(payload: AgentRuntimeConfigPayload): string {
+function cursorMcpApprovalStoreIdentity(env: Readonly<Record<string, string>>): {
+  source: "cursor_data_dir" | "process_home";
+  value: string | null;
+} {
+  const dataDir = env.CURSOR_DATA_DIR;
+  if (dataDir !== undefined && dataDir.trim().length > 0) {
+    return { source: "cursor_data_dir", value: dataDir };
+  }
+  const homeKey = process.platform === "win32" ? "USERPROFILE" : "HOME";
+  return { source: "process_home", value: env[homeKey] ?? null };
+}
+
+/**
+ * Hash the shared project-state portion of one turn snapshot. Header values
+ * and approval-store paths may contain secrets, so the coordinator retains
+ * only the digest.
+ */
+function cursorMcpProjectionFingerprint(
+  payload: AgentRuntimeConfigPayload,
+  env: Readonly<Record<string, string>>,
+): string {
   const canonicalServers = Object.entries(mapCursorMcpServers(payload))
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([name, config]) => {
@@ -140,7 +162,16 @@ function cursorMcpProjectionFingerprint(payload: AgentRuntimeConfigPayload): str
         },
       ];
     });
-  return createHash("sha256").update(JSON.stringify(canonicalServers)).digest("hex");
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        // An empty projection performs no approval, so approval-root changes
+        // must not serialize otherwise-identical empty turns.
+        approvalStore: canonicalServers.length > 0 ? cursorMcpApprovalStoreIdentity(env) : null,
+        servers: canonicalServers,
+      }),
+    )
+    .digest("hex");
 }
 
 function materializeCursorMcpConfig(workspaceCwd: string, payload: AgentRuntimeConfigPayload): void {
@@ -1117,7 +1148,7 @@ export const createCursorHandler: HandlerFactory = (config) => {
     const turnPayload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload ?? fallbackPayload;
     const model = turnPayload.model;
     const env = buildEnv(sessionCtx, turnPayload);
-    const projectionFingerprint = cursorMcpProjectionFingerprint(turnPayload);
+    const projectionFingerprint = cursorMcpProjectionFingerprint(turnPayload, env);
     const generation = ++turnGeneration;
     const abort = new AbortController();
     currentAbort = abort;

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -59,6 +59,37 @@ type KimiHarnessLike = Pick<KimiHarness, "createSession" | "resumeSession" | "cl
 type KimiHarnessFactory = (options: KimiHarnessOptions) => KimiHarnessLike;
 type KimiKaosFactory = () => Promise<LocalKaos>;
 
+type KimiManagedMcpServer =
+  | { transport: "stdio"; command: string; args?: string[] }
+  | { transport: "http" | "sse"; url: string; headers?: Record<string, string> };
+
+type KimiManagedMcpSessionOptions = {
+  readonly mcpServers?: Readonly<Record<string, KimiManagedMcpServer>>;
+};
+
+type KimiCreateSessionOptions = CreateSessionOptions & KimiManagedMcpSessionOptions;
+type KimiResumeSessionInput = ResumeSessionInput & KimiManagedMcpSessionOptions;
+
+export function mapKimiMcpServers(payload: AgentRuntimeConfigPayload): Record<string, KimiManagedMcpServer> {
+  const servers: Record<string, KimiManagedMcpServer> = {};
+  for (const server of payload.mcpServers) {
+    if (server.transport === "stdio") {
+      servers[server.name] = {
+        transport: "stdio",
+        command: server.command,
+        ...(server.args === undefined ? {} : { args: server.args }),
+      };
+    } else {
+      servers[server.name] = {
+        transport: server.transport,
+        url: server.url,
+        ...(server.headers === undefined ? {} : { headers: server.headers }),
+      };
+    }
+  }
+  return servers;
+}
+
 type ActiveTool = {
   name: string;
   args: unknown;
@@ -180,7 +211,6 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
   let currentTurnPromise: Promise<boolean> | null = null;
   let drainScheduled = false;
   let drainInProgress = false;
-  let mcpDiagnosticEmitted = false;
   const queuedMessages: Array<{ message: SessionMessage; token: DeliveryToken }> = [];
   const activeTools = new Map<string, ActiveTool>();
   const gitWriteTracker: ContextTreeGitWriteTracker = createContextTreeGitWriteTracker({
@@ -230,21 +260,6 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       sessionCtx.log(`fetchChatContext failed: ${error instanceof Error ? error.message : String(error)}`);
       return renderChatContextPrompt(undefined);
     }
-  }
-
-  function emitMcpUnsupportedDiagnosticOnce(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload): void {
-    if (mcpDiagnosticEmitted || payload.mcpServers.length === 0) return;
-    mcpDiagnosticEmitted = true;
-    sessionCtx.emitEvent({
-      kind: "error",
-      payload: {
-        source: "runtime",
-        message:
-          `kimi-code provider does not materialize First Tree-managed MCP servers in v1; ` +
-          `${payload.mcpServers.length} configured MCP server(s) are not loaded. ` +
-          "The operator's own Kimi MCP configuration still applies.",
-      },
-    });
   }
 
   function nativeToolRefs(name: string, args: unknown, workspaceCwd: string): ToolFileRef[] {
@@ -658,7 +673,6 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       currentSourceRepoNames: currentSourceRepoNamesFromPayload(payload, payloadResolved),
     });
     markWorkspaceInitComplete(workspaceCwd);
-    emitMcpUnsupportedDiagnosticOnce(sessionCtx, payload);
 
     const chatContext = await fetchChatContextOrLog(sessionCtx);
     const roleAdditional = [renderRuntimeOutputContract(), chatContext].filter(Boolean).join("\n\n");
@@ -733,13 +747,17 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       const explicitToken = token !== undefined;
       const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
       const prepared = await prepareSession(sessionCtx);
-      const options: CreateSessionOptions = {
+      const mcpServers = mapKimiMcpServers(prepared.payload);
+      // The pinned SDK runtime accepts caller-scoped MCP servers here even
+      // though its exported CreateSessionOptions interface omits the field.
+      const options: KimiCreateSessionOptions = {
         workDir: prepared.workspaceCwd,
         permission: "yolo",
         kaos: prepared.kaos,
         additionalDirs: prepared.additionalDirs,
         roleAdditional: prepared.roleAdditional,
         ...(prepared.payload.model ? { model: prepared.payload.model } : {}),
+        ...(prepared.payload.mcpServers.length > 0 ? { mcpServers } : {}),
       };
       const kimiHome = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
       const effectiveHomeDir = kimiHome !== null && kimiHome.length === 0 ? null : kimiHome;
@@ -765,11 +783,14 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       const explicitToken = token !== undefined;
       const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
       const prepared = await prepareSession(sessionCtx);
-      const input: ResumeSessionInput = {
+      const mcpServers = mapKimiMcpServers(prepared.payload);
+      // ResumeSessionInput has the same declaration gap as create options.
+      const input: KimiResumeSessionInput = {
         id,
         kaos: prepared.kaos,
         additionalDirs: prepared.additionalDirs,
         roleAdditional: prepared.roleAdditional,
+        ...(prepared.payload.mcpServers.length > 0 ? { mcpServers } : {}),
       };
       const kimiHome = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
       const effectiveHomeDir = kimiHome !== null && kimiHome.length === 0 ? null : kimiHome;

--- a/packages/qa/cases/runtime/cursor-provider.md
+++ b/packages/qa/cases/runtime/cursor-provider.md
@@ -1,6 +1,6 @@
 ---
 id: cursor-provider
-description: Validate the Cursor Agent CLI runtime provider end to end — external binary, in-product login, real turns, free-form model, and Context Tree I/O evidence.
+description: Validate the Cursor Agent CLI runtime provider end to end — external binary, managed MCP, real turns, free-form model, and Context Tree I/O evidence.
 areas: [runtime]
 surfaces: [web, cli, server, client]
 ---
@@ -11,7 +11,7 @@ surfaces: [web, cli, server, client]
 
 Confirm that an agent bound to the `cursor` provider runs real turns through the external Cursor Agent CLI with the
 canonical runtime posture, that credential and configuration failures surface through the existing recovery paths, and
-that cross-surface behavior (capability cards, model input, client switch, Context Tree I/O) matches the shipped
+that cross-surface behavior (capability cards, managed MCP, model input, client switch, Context Tree I/O) matches the shipped
 contract. Deterministic parser/handler behavior is covered by product tests; this case validates the live judgment
 slices those tests cannot prove.
 
@@ -43,8 +43,14 @@ that case and the run-local plan, not this one.
   capability entry, and after success a fresh turn completes. First Tree must never see or store the token.
 - Real turn posture: during an authenticated turn, verify the spawned process runs from the agent workspace root with
   the canonical arguments (`-p --output-format stream-json --sandbox disabled --force`, plus `--model` only when the
-  operator set one and `--resume` only with a stream-confirmed session id) — no `--trust`, `--workspace`,
-  `--approve-mcps`, or prompt text in argv. A follow-up message in the same chat must resume the same Cursor session id.
+  operator set one, `--approve-mcps` only when First Tree-managed MCP is non-empty, and `--resume` only with a
+  stream-confirmed session id) — no `--trust`, `--workspace`, or prompt text in argv. A follow-up message in the same
+  chat must resume the same Cursor session id.
+- Managed MCP: configure a disposable local MCP server through First Tree, then verify the client atomically projects
+  it into `<agent workspace>/.cursor/mcp.json`, keeps that file private to the OS user, and the authenticated Cursor
+  turn calls one of its tools without an approval prompt. Exercise stdio plus the remote HTTP/SSE mapping when suitable
+  disposable endpoints are available. Removing all managed servers must replace stale projected entries with an empty
+  `mcpServers` object and remove `--approve-mcps` from the next turn; do not inspect or archive literal secret headers.
 - Free-form model: set an exact model id through Web (free-form input with the `auto` hint — no reasoning-effort
   control for Cursor), confirm it round-trips and reaches the next turn's spawn; an id the provider rejects must fail
   visibly as a configuration failure with no silent fallback, and recover after an explicit config change.
@@ -58,12 +64,14 @@ that case and the run-local plan, not this one.
 
 `PASS` means the live branches above were exercised with real product evidence: an authenticated Cursor turn completed
 end to end under the canonical posture, credential failure surfaced the durable notice + login action and recovered
-in-product, model config round-tripped (including the visible rejection branch when available), and Context Tree I/O
-evidence appeared for both edit and shell-read paths.
+in-product, a First Tree-managed MCP tool was projected and called without widening the other CLI flags, model config
+round-tripped (including the visible rejection branch when available), and Context Tree I/O evidence appeared for both
+edit and shell-read paths.
 
 `FAIL` means a reproducible product issue: e.g. prompt in argv, a synthetic session id sent to `--resume`, a terminal
 failure acked without a durable chat notice, silent model fallback, missing Context Tree I/O evidence, or a drain that
-misses a live Cursor process.
+misses a live Cursor process. It also includes stale managed MCP surviving an empty config, approval enabled without
+managed MCP, or a configured MCP tool unavailable to the turn.
 
 `BLOCKED` means the CLI, account, entitlement, network, or run-cell topology (e.g. no desktop browser for OAuth)
 prevented a live branch — never a product `FAIL`. `INCONCLUSIVE` means turns ran but the evidence cannot distinguish
@@ -73,5 +81,6 @@ the claimed behavior (e.g. cannot observe the spawned argv in the run cell).
 
 Keep the capability snapshots (before/after install and login), the spawned process argv/cwd observation, the failing
 turn's runtime notice and the login action, the session id continuity across two turns, the model config write/readback
-and rejection surface, Context tab I/O rows, and the drain classification result. Redact tokens, account identifiers,
-and private chat content; never copy Cursor credential files into artifacts.
+and rejection surface, sanitized projected MCP shape/file mode plus the MCP tool-call event, Context tab I/O rows, and
+the drain classification result. Redact tokens, headers, account identifiers, and private chat content; never copy
+Cursor credential files into artifacts.

--- a/packages/qa/cases/runtime/cursor-provider.md
+++ b/packages/qa/cases/runtime/cursor-provider.md
@@ -52,8 +52,13 @@ that case and the run-local plan, not this one.
   servers retain their approval boundary. Exercise stdio plus the remote HTTP/SSE mapping when suitable disposable
   endpoints are available. On one active handler, add a managed server for the next turn and then remove all managed
   servers for the following turn; the latter must replace stale projected entries with an empty `mcpServers` object
-  and issue no managed approval command. Two concurrent chats sharing one agent workspace must not interleave
-  projection with the other chat's live provider turn. Do not inspect or archive literal secret headers.
+  and issue no managed approval command. Concurrent chats with the same projection fingerprint — including the empty
+  projection — must keep the agent's configured parallelism; a different fingerprint waits for live users of the old
+  projection to drain before one exclusive transition, so neither turn observes the other's file. Abort leaves the
+  delivery recoverable. A bounded setup timeout/transport failure follows the provider-turn retry budget, while an
+  unsupported approval command, permission/configuration failure, or retry exhaustion emits the standard terminal
+  provider event and durable runtime notice before the delivery is consumed. Do not inspect or archive literal secret
+  headers.
 - Free-form model: set an exact model id through Web (free-form input with the `auto` hint — no reasoning-effort
   control for Cursor), confirm it round-trips and reaches the next turn's spawn; an id the provider rejects must fail
   visibly as a configuration failure with no silent fallback, and recover after an explicit config change.
@@ -75,7 +80,8 @@ edit and shell-read paths.
 failure acked without a durable chat notice, silent model fallback, missing Context Tree I/O evidence, or a drain that
 misses a live Cursor process. It also includes stale managed MCP surviving an empty config, approval enabled without
 managed MCP, broad `--approve-mcps` use, a per-server approval aimed at the wrong identifier, cross-chat projection
-interleaving, or a configured MCP tool unavailable to the turn.
+interleaving, matching/empty projections being serialized for a full provider turn, unbounded redelivery after a
+deterministic setup failure, or a configured MCP tool unavailable to the turn.
 
 `BLOCKED` means the CLI, account, entitlement, network, or run-cell topology (e.g. no desktop browser for OAuth)
 prevented a live branch — never a product `FAIL`. `INCONCLUSIVE` means turns ran but the evidence cannot distinguish
@@ -86,6 +92,6 @@ the claimed behavior (e.g. cannot observe the spawned argv in the run cell).
 Keep the capability snapshots (before/after install and login), the spawned process argv/cwd observation, the failing
 turn's runtime notice and the login action, the session id continuity across two turns, the model config write/readback
 and rejection surface, sanitized projected MCP shape/file mode, targeted approval command names, add/remove and
-same-workspace ordering, plus the MCP tool-call event, Context tab I/O rows, and the drain classification result.
-Redact tokens, headers, account identifiers, and private chat content; never copy Cursor credential files into
-artifacts.
+same-workspace matching/different-fingerprint ordering, sanitized setup retry/terminal events, plus the MCP tool-call
+event, Context tab I/O rows, and the drain classification result. Redact tokens, headers, account identifiers, and
+private chat content; never copy Cursor credential files into artifacts.

--- a/packages/qa/cases/runtime/cursor-provider.md
+++ b/packages/qa/cases/runtime/cursor-provider.md
@@ -54,11 +54,13 @@ that case and the run-local plan, not this one.
   servers for the following turn; the latter must replace stale projected entries with an empty `mcpServers` object
   and issue no managed approval command. Concurrent chats with the same projection fingerprint — including the empty
   projection — must keep the agent's configured parallelism; a different fingerprint waits for live users of the old
-  projection to drain before one exclusive transition, so neither turn observes the other's file. Abort leaves the
-  delivery recoverable. A bounded setup timeout/transport failure follows the provider-turn retry budget, while an
-  unsupported approval command, permission/configuration failure, or retry exhaustion emits the standard terminal
-  provider event and durable runtime notice before the delivery is consumed. Do not inspect or archive literal secret
-  headers.
+  projection to drain before one exclusive transition, so neither turn observes the other's file. The fingerprint
+  includes the effective Cursor approval-store selector: changing `CURSOR_DATA_DIR`, or the process home used when it
+  is blank, must rerun targeted approval even when the managed MCP list is unchanged. Abort leaves the delivery
+  recoverable. A bounded setup timeout/transport failure follows the provider-turn retry budget, while an unsupported
+  approval command, permission/configuration failure, or retry exhaustion emits the standard terminal provider event
+  and durable runtime notice before the delivery is consumed. Do not inspect or archive literal secret headers or
+  approval-store paths.
 - Free-form model: set an exact model id through Web (free-form input with the `auto` hint — no reasoning-effort
   control for Cursor), confirm it round-trips and reaches the next turn's spawn; an id the provider rejects must fail
   visibly as a configuration failure with no silent fallback, and recover after an explicit config change.
@@ -81,7 +83,8 @@ failure acked without a durable chat notice, silent model fallback, missing Cont
 misses a live Cursor process. It also includes stale managed MCP surviving an empty config, approval enabled without
 managed MCP, broad `--approve-mcps` use, a per-server approval aimed at the wrong identifier, cross-chat projection
 interleaving, matching/empty projections being serialized for a full provider turn, unbounded redelivery after a
-deterministic setup failure, or a configured MCP tool unavailable to the turn.
+deterministic setup failure, reuse of a matching projection after its approval-store root changes, or a configured MCP
+tool unavailable to the turn.
 
 `BLOCKED` means the CLI, account, entitlement, network, or run-cell topology (e.g. no desktop browser for OAuth)
 prevented a live branch — never a product `FAIL`. `INCONCLUSIVE` means turns ran but the evidence cannot distinguish

--- a/packages/qa/cases/runtime/cursor-provider.md
+++ b/packages/qa/cases/runtime/cursor-provider.md
@@ -43,14 +43,17 @@ that case and the run-local plan, not this one.
   capability entry, and after success a fresh turn completes. First Tree must never see or store the token.
 - Real turn posture: during an authenticated turn, verify the spawned process runs from the agent workspace root with
   the canonical arguments (`-p --output-format stream-json --sandbox disabled --force`, plus `--model` only when the
-  operator set one, `--approve-mcps` only when First Tree-managed MCP is non-empty, and `--resume` only with a
-  stream-confirmed session id) — no `--trust`, `--workspace`, or prompt text in argv. A follow-up message in the same
-  chat must resume the same Cursor session id.
+  operator set one and `--resume` only with a stream-confirmed session id) — no `--approve-mcps`, `--trust`,
+  `--workspace`, or prompt text in argv. A follow-up message in the same chat must resume the same Cursor session id.
 - Managed MCP: configure a disposable local MCP server through First Tree, then verify the client atomically projects
-  it into `<agent workspace>/.cursor/mcp.json`, keeps that file private to the OS user, and the authenticated Cursor
-  turn calls one of its tools without an approval prompt. Exercise stdio plus the remote HTTP/SSE mapping when suitable
-  disposable endpoints are available. Removing all managed servers must replace stale projected entries with an empty
-  `mcpServers` object and remove `--approve-mcps` from the next turn; do not inspect or archive literal secret headers.
+  it into `<agent workspace>/.cursor/mcp.json`, keeps that file private to the OS user, invokes the provider-native
+  `<binary> mcp enable <managed-name>` command for that entry only, and the authenticated Cursor turn calls one of its
+  tools without an approval prompt. The broad `--approve-mcps` flag must remain absent so unrelated operator-owned MCP
+  servers retain their approval boundary. Exercise stdio plus the remote HTTP/SSE mapping when suitable disposable
+  endpoints are available. On one active handler, add a managed server for the next turn and then remove all managed
+  servers for the following turn; the latter must replace stale projected entries with an empty `mcpServers` object
+  and issue no managed approval command. Two concurrent chats sharing one agent workspace must not interleave
+  projection with the other chat's live provider turn. Do not inspect or archive literal secret headers.
 - Free-form model: set an exact model id through Web (free-form input with the `auto` hint — no reasoning-effort
   control for Cursor), confirm it round-trips and reaches the next turn's spawn; an id the provider rejects must fail
   visibly as a configuration failure with no silent fallback, and recover after an explicit config change.
@@ -71,7 +74,8 @@ edit and shell-read paths.
 `FAIL` means a reproducible product issue: e.g. prompt in argv, a synthetic session id sent to `--resume`, a terminal
 failure acked without a durable chat notice, silent model fallback, missing Context Tree I/O evidence, or a drain that
 misses a live Cursor process. It also includes stale managed MCP surviving an empty config, approval enabled without
-managed MCP, or a configured MCP tool unavailable to the turn.
+managed MCP, broad `--approve-mcps` use, a per-server approval aimed at the wrong identifier, cross-chat projection
+interleaving, or a configured MCP tool unavailable to the turn.
 
 `BLOCKED` means the CLI, account, entitlement, network, or run-cell topology (e.g. no desktop browser for OAuth)
 prevented a live branch — never a product `FAIL`. `INCONCLUSIVE` means turns ran but the evidence cannot distinguish
@@ -81,6 +85,7 @@ the claimed behavior (e.g. cannot observe the spawned argv in the run cell).
 
 Keep the capability snapshots (before/after install and login), the spawned process argv/cwd observation, the failing
 turn's runtime notice and the login action, the session id continuity across two turns, the model config write/readback
-and rejection surface, sanitized projected MCP shape/file mode plus the MCP tool-call event, Context tab I/O rows, and
-the drain classification result. Redact tokens, headers, account identifiers, and private chat content; never copy
-Cursor credential files into artifacts.
+and rejection surface, sanitized projected MCP shape/file mode, targeted approval command names, add/remove and
+same-workspace ordering, plus the MCP tool-call event, Context tab I/O rows, and the drain classification result.
+Redact tokens, headers, account identifiers, and private chat content; never copy Cursor credential files into
+artifacts.

--- a/packages/qa/cases/runtime/kimi-code-provider.md
+++ b/packages/qa/cases/runtime/kimi-code-provider.md
@@ -1,6 +1,6 @@
 ---
 id: kimi-code-provider
-description: Validate the bundled Kimi Code SDK provider end to end — host login reuse, real turns and resume, model override, failure recovery, and Context Tree I/O.
+description: Validate the bundled Kimi Code SDK provider end to end — host login reuse, managed MCP, real turns and resume, failure recovery, and Context Tree I/O.
 areas: [runtime]
 surfaces: [web, cli, server, client]
 ---
@@ -10,8 +10,8 @@ surfaces: [web, cli, server, client]
 ## Goal
 
 Confirm that an agent bound to `kimi-code` runs real turns through the pinned bundled SDK, reuses the host operator's
-Kimi Code configuration without exposing credentials, and preserves First Tree's provider-neutral delivery, retry,
-resume, event, and Context Tree contracts.
+Kimi Code configuration without exposing credentials, injects First Tree-managed MCP at the session boundary, and
+preserves First Tree's provider-neutral delivery, retry, resume, event, and Context Tree contracts.
 
 Use this case when the Kimi handler, SDK version, capability probe, provider selection, model control, failure
 classification, or Context Tree Kimi-tool derivation changes.
@@ -48,25 +48,29 @@ classification, or Context Tree Kimi-tool derivation changes.
 - Resume: suspend the chat, send a follow-up, and confirm First Tree calls SDK resume with the persisted Kimi session id,
   reapplies `roleAdditional`, cwd/env, validated external roots, and yolo permission, then completes the second turn in
   context. A permission/model initialization failure after SDK resume must close both the resumed session and harness.
+- Managed MCP: configure a disposable First Tree-managed stdio MCP server and confirm it reaches both SDK
+  `createSession` and `resumeSession` as caller-scoped `mcpServers`, the real Kimi turn calls one of its tools, and no
+  unsupported diagnostic is emitted. Verify the stdio/http/SSE projection shapes without retaining secret headers.
+  An empty managed list must omit the caller field so operator-global and project Kimi configuration keep their normal
+  behavior.
 - Failure and replay: prove a transient connection/rate error retries only before visible/unsafe output. After `Write`,
   `Edit`, or an unproven `Bash`, a failure must stop as unsafe replay rather than repeat the side effect; a later
   read-only tool must not downgrade that unsafe state.
 - Context Tree I/O: a Kimi `Read`/`Grep`/`Glob` under the bound tree records `kimi_read_tool`; `Write`/`Edit` records
   `kimi_write_tool`; a proven read-only `Bash` records `shell_command`; repo/path evidence is qualified and writes may
   carry `git_status_delta` evidence.
-- MCP boundary: if the agent config contains First Tree-managed MCP servers, the runtime emits one explicit unsupported
-  diagnostic and continues. Operator-global Kimi MCP config may still load; do not claim First Tree injected it.
 - Shutdown: suspend cancels and closes the active session while preserving its id; daemon shutdown also closes the
   harness and leaves queued delivery recoverable.
 
 ## Expected Result
 
 `PASS` requires a real authenticated First Tree/Kimi two-turn run, persisted session-id continuity, deterministic
-disposable file evidence, normalized events and Context Tree rows, and verified auth/failure boundaries.
+disposable file evidence, a First Tree-managed MCP tool call on the create/resume lifecycle, normalized events and
+Context Tree rows, and verified auth/failure boundaries.
 
 `FAIL` means a reproducible product violation such as device OAuth launched by First Tree, credentials exposed, model
 silently changed, missing standing role contract on resume, unsafe side effects replayed, terminal failure ACKed without
-the durable notice, or absent Context Tree evidence.
+the durable notice, configured caller MCP absent after create/resume, or absent Context Tree evidence.
 
 `BLOCKED` means the Kimi account, credential, provider entitlement/network, or isolated run-cell topology prevented a
 live branch. Mocked SDK unit tests do not turn a blocked live branch into PASS. `INCONCLUSIVE` means the turn ran but
@@ -75,6 +79,6 @@ the retained evidence cannot distinguish the claimed behavior.
 ## Evidence
 
 Keep sanitized capability snapshots, agent config readback, session id before/after resume, event-kind sequence and
-token totals, disposable input/output hashes, Context Tree I/O rows, failure/retry events, and relevant client logs.
-Never keep tokens, credential files, account identifiers, private prompt bodies, or raw provider payloads containing
-secrets.
+token totals, disposable input/output hashes, sanitized caller MCP shape and tool-call event, Context Tree I/O rows,
+failure/retry events, and relevant client logs. Never keep tokens, headers, credential files, account identifiers,
+private prompt bodies, or raw provider payloads containing secrets.


### PR DESCRIPTION
## Summary

- project First Tree-managed MCP servers into each Cursor agent workspace through a private, atomically replaced
  `.cursor/mcp.json`
- approve only projected managed servers with Cursor's native `mcp enable <name>` command; never use the broad
  `--approve-mcps` flag
- snapshot the current MCP/model/environment payload once per Cursor turn
- coordinate the shared workspace by a secret-safe projection fingerprint:
  - matching projections hold shared leases and run concurrently
  - non-empty projections include the effective Cursor approval-store selector from the final child environment
  - empty projections remain independent of the unused approval store and keep their configured parallelism
  - a different projection waits for active users to drain, then performs one exclusive materialize/approval transition
  - failed or aborted transitions invalidate the cached projection before another turn can lease it
- route Cursor MCP setup failures through the existing provider failure taxonomy, bounded retry budget, terminal event,
  and durable-notice-before-ACK contract
- pass caller-scoped `mcpServers` directly to Kimi Code SDK create and resume sessions without changing the pinned SDK
- update deterministic tests and live Cursor/Kimi QA cases

## Why

The effective MCP payload already reaches the client, but Cursor and Kimi Code previously emitted an unsupported
warning instead of giving their provider runtime the configured servers. This keeps the provider-neutral payload and
uses each provider's smallest native injection boundary without widening approval to operator-owned MCP configuration
or reducing the agent's configured chat concurrency.

## Code Owner review repairs

### Approval scope and current payload

- removed `--approve-mcps` in favor of native per-server project approval
- derived projection, approval, model, and environment from one current immutable turn snapshot
- covered active empty → add → remove convergence and all supported transports

### Shared-workspace concurrency

- replaced full-turn serialization with per-workspace projection leases
- allowed matching/empty fingerprints to share the live projection concurrently
- added FIFO transition fairness so a different fingerprint cannot starve
- held the old projection stable until every active lease released
- invalidated state when approval fails after the atomic file replacement

### Failure policy

- kept suspend/shutdown aborts non-terminal
- classified bounded timeout/transport-like setup failures as transient and applied the existing two-retry
  provider-turn budget
- classified missing capability, unsupported approval, permission, and configuration failures as operator-action
  terminal outcomes
- emitted standard provider retry/terminal events and completed terminal failures through the consumed-error contract,
  which posts the durable runtime notice before ACK
- sanitized provider output so projected headers or CLI stderr cannot enter events

### Approval-store identity

- verified the installed official Cursor Agent package selects project approval state from non-blank `CURSOR_DATA_DIR`,
  otherwise from the child process home (`HOME` on POSIX, `USERPROFILE` on Windows)
- included that effective selector from the exact final child environment in the secret-safe projection digest
- covered same MCP plus changed data-dir/home roots: the new cohort waits, reruns targeted approval, then starts
- kept empty MCP cohorts parallel across approval-root changes because they execute no approval

## Validation

- focused Cursor handler tests: 24 passed
- full Client suite: 1,702 passed, 3 skipped
- QA package: 4 passed
- `pnpm check` (exit 0; 16 existing warnings outside this diff)
- `pnpm build` / dependency builds exercised by root typecheck
- `pnpm typecheck`: 10/10 tasks
- changed-file Biome and `git diff --check`
- isolated Docker-backed QA harness reached READY across shipped surfaces on immutable snapshot
  `d7963abd70fb4e98b44ada763b9ee4bb3edfde08`; the later approval-store identity repair is covered deterministically at
  exact PR head
- real official Cursor Agent concurrency:
  - matching projection: the second MCP tool call completed while the first 35-second call was still live; two provider
    processes, one targeted approval, zero broad approvals
  - different projection: `beta` did not spawn while `alpha` was live; the file stayed on `alpha`, then switched once
    to `beta` after release
- real Cursor approval failure: zero provider spawn/redelivery, sanitized configuration terminal event, consumed outcome
- real Cursor empty → add → remove: correct private file snapshots and one managed tool marker
- real Kimi SDK create and resume: both turns called the injected managed MCP tool
- formal QA result for the provider behavior: PASS; evidence retained under the isolated run root with credentials and
  account identifiers excluded

## Context Tree

- companion draft: https://github.com/agent-team-foundation/first-tree-context/pull/832
- merge this code PR first, then reconcile and mark the Context Tree PR ready

## Notes

- no Server or Web contract changes
- no shared cross-provider projection framework or provider dependency upgrade
