### PR TITLE
fix: stabilize Darwin switching and skill eval tests

### DIFF
--- a/apps/cli/src/__tests__/client-switch-platform-extra.test.ts
+++ b/apps/cli/src/__tests__/client-switch-platform-extra.test.ts
@@ -36,6 +36,9 @@ const execState = vi.hoisted(() => ({
     | "daemon-untrusted"
     | "daemon-active"
     | "many-daemon-untrusted"
+    | "provider-name-in-env-only"
+    | "provider-missing-env-snapshot"
+    | "command-throw"
     | "pid-throw",
   home: "",
 }));
@@ -174,7 +177,29 @@ vi.mock("node:child_process", async (importOriginal) => {
         if (execState.mode === "daemon-untrusted") {
           return `  200 first-tree daemon start --foreground FIRST_TREE_HOME=${execState.home}\n`;
         }
+        if (execState.mode === "provider-name-in-env-only") {
+          return `  200 node vitest-worker.js FIRST_TREE_HOME=${execState.home} PATH=/opt/tools/@openai/codex/bin\n`;
+        }
+        if (execState.mode === "provider-missing-env-snapshot") {
+          return "";
+        }
         return `  200 codex exec FIRST_TREE_HOME=${execState.home} FIRST_TREE_PROVIDER=codex FIRST_TREE_CLIENT_ID=client_aabbccdd FIRST_TREE_SWITCH_DRAIN_VERSION=1\n`;
+      }
+      if (program === "ps" && args.includes("-ww") && args.includes("-axo")) {
+        if (execState.mode === "command-throw") throw new Error("command ps denied");
+        if (execState.mode === "many-daemon-untrusted") {
+          return Array.from(
+            { length: 9 },
+            (_value, index) => `  ${200 + index} first-tree daemon start --foreground`,
+          ).join("\n");
+        }
+        if (execState.mode === "daemon-active" || execState.mode === "daemon-untrusted") {
+          return "  200 first-tree daemon start --foreground\n";
+        }
+        if (execState.mode === "provider-name-in-env-only") {
+          return "  200 node vitest-worker.js\n";
+        }
+        return "  200 codex exec\n";
       }
       if (program === "ps" && args.includes("-p")) {
         if (execState.mode === "pid-throw") throw new Error("pid command denied");
@@ -349,6 +374,20 @@ describe("client switch platform drain scanning", () => {
     });
   });
 
+  it("classifies Darwin providers from argv instead of appended environment text", async () => {
+    setPlatform("darwin");
+    execState.mode = "provider-name-in-env-only";
+
+    await expect(runSwitch()).resolves.toBeUndefined();
+
+    writeClientYaml();
+    execState.mode = "provider-missing-env-snapshot";
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("without readable environment"),
+    });
+  });
+
   it("fails closed when Darwin ps inspection fails or platform is unsupported", async () => {
     setPlatform("darwin");
     execState.mode = "throw";
@@ -359,6 +398,13 @@ describe("client switch platform drain scanning", () => {
     await expect(runSwitch()).rejects.toMatchObject({
       code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
       message: expect.stringContaining("ps denied as string"),
+    });
+
+    writeClientYaml();
+    execState.mode = "command-throw";
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("process commands"),
     });
 
     writeClientYaml();

--- a/apps/cli/src/core/client-switch.ts
+++ b/apps/cli/src/core/client-switch.ts
@@ -597,9 +597,9 @@ function collectMarkedProviderProcesses(home: string, clientId: string): DrainSn
 }
 
 function collectDarwinMarkedProviders(home: string, clientId: string): DrainSnapshot {
-  let output: string;
+  let environmentOutput: string;
   try {
-    output = execFileSync("ps", ["-Eww", "-axo", "pid=,command="], {
+    environmentOutput = execFileSync("ps", ["-Eww", "-axo", "pid=,command="], {
       encoding: "utf8",
       timeout: 10_000,
       maxBuffer: 8 * 1024 * 1024,
@@ -611,18 +611,61 @@ function collectDarwinMarkedProviders(home: string, clientId: string): DrainSnap
       reason: `Unable to inspect process environment for switch drain: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
+
+  let commandOutput: string;
+  try {
+    // Darwin's `ps -E` appends every environment variable to the command
+    // column. Provider-looking text in PATH/NODE_PATH is therefore not argv
+    // and must not classify an unrelated process as Codex or Claude. Read the
+    // real argv in a second snapshot and use the `-E` output only for marker
+    // extraction.
+    commandOutput = execFileSync("ps", ["-ww", "-axo", "pid=,command="], {
+      encoding: "utf8",
+      timeout: 10_000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      reason: `Unable to inspect process commands for switch drain: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const environmentByPid = parseDarwinProcessRows(environmentOutput);
+  const commandByPid = parseDarwinProcessRows(commandOutput);
   const providers: MarkedProviderProcess[] = [];
   const issues: ProviderMarkerIssue[] = [];
-  for (const line of output.split("\n")) {
-    const match = line.match(/^\s*(\d+)\s+(.*)$/);
-    if (!match) continue;
-    const pid = Number(match[1]);
-    const command = match[2] ?? "";
-    collectSwitchDrainProcessFromEnvText({ pid, command, envText: command, home, clientId, providers, issues });
-    collectDaemonFromEnvText({ pid, command, envText: command, home, clientId, issues });
+  for (const [pid, command] of commandByPid) {
+    const envText = environmentByPid.get(pid);
+    if (envText === undefined) {
+      // The process appeared after the environment snapshot. Unknown commands
+      // carry no provider signal, but a newly observed provider/daemon cannot
+      // authorize root-state movement without readable attribution.
+      if (isSwitchDrainEnvRequired(command)) {
+        issues.push({
+          pid,
+          command,
+          reason: "process appeared during switch drain snapshot without readable environment",
+        });
+      }
+      continue;
+    }
+    collectSwitchDrainProcessFromEnvText({ pid, command, envText, home, clientId, providers, issues });
+    collectDaemonFromEnvText({ pid, command, envText, home, clientId, issues });
   }
   if (issues.length > 0) return untrustedProviderSnapshot(issues);
   return { ok: true, providers };
+}
+
+function parseDarwinProcessRows(output: string): Map<number, string> {
+  const rows = new Map<number, string>();
+  for (const line of output.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(.*)$/);
+    if (!match) continue;
+    rows.set(Number(match[1]), match[2] ?? "");
+  }
+  return rows;
 }
 
 function collectLinuxMarkedProviders(home: string, clientId: string): DrainSnapshot {

--- a/packages/skill-evals/package.json
+++ b/packages/skill-evals/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.16.0",
+    "first-tree-dev": "workspace:*",
     "tsx": "^4.21.0",
     "yaml": "^2.8.3"
   }

--- a/packages/skill-evals/src/suites/context-tree-audit/__tests__/fixture.test.ts
+++ b/packages/skill-evals/src/suites/context-tree-audit/__tests__/fixture.test.ts
@@ -343,7 +343,7 @@ describe("context-tree-audit fixture", () => {
     } finally {
       rmSync(paths.runRoot, { force: true, recursive: true });
     }
-  }, 15_000);
+  }, 30_000);
 
   it("rejects a leaked detached committed-verification worktree in focused fixture state", () => {
     const evalCase = CONTEXT_TREE_AUDIT_GATE_CASES.find((item) => item.fixture.scenario === "strong-local");

--- a/packages/skill-evals/turbo.json
+++ b/packages/skill-evals/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/skill-evals/vitest.config.ts
+++ b/packages/skill-evals/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vitest/config";
+import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
+import { isCiEnvironment, resolveVitestMaxForks } from "../../scripts/vitest-max-forks.js";
+
+const maxForks = resolveVitestMaxForks(2);
+const isCi = isCiEnvironment();
+
+export default defineConfig({
+  resolve: {
+    // Unit collection should compile workspace sources directly instead of
+    // racing a sibling package's dist cleanup/build.
+    alias: monorepoSourceAliases,
+  },
+  test: {
+    // Fixture suites create real temporary repositories and worktrees. Their
+    // previous implicit 5s ceiling measured host contention, not correctness.
+    testTimeout: 30_000,
+    fileParallelism: !isCi && maxForks > 1,
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        isolate: true,
+        maxForks,
+        minForks: 1,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.19
+      first-tree-dev:
+        specifier: workspace:*
+        version: link:../../apps/cli
       tsx:
         specifier: ^4.21.0
         version: 4.21.0


### PR DESCRIPTION
## Summary

- classify Darwin client-switch processes from a plain argv snapshot instead of the environment-appended `ps -E` command column
- keep the switch drain fail-closed when a provider or daemon appears without a readable environment snapshot
- make skill-evals wait for the real CLI build, resolve workspace imports from source, and use bounded fixture concurrency/timeouts

## Root cause

Darwin `ps -E` appends environment variables to the command column. A test worker whose `PATH` or `NODE_PATH` mentioned `@openai/codex` was therefore classified as a live Codex provider even though its real argv was unrelated.

Separately, `@first-tree/skill-evals` launches the built CLI but did not declare that build edge. Its real git/worktree fixtures also inherited Vitest's 5-second default and unbounded local file parallelism, so the root test graph could race package builds and turn host contention into fixture failures.

## Impact

The production client-switch safety gate remains fail-closed, while unrelated macOS processes no longer block a switch solely because an environment path contains a provider package name. Root test runs now build the CLI before skill-evals and execute their filesystem-heavy fixtures with deterministic bounds.

This is intentionally separate from the Codex Fast mode feature PR #2039.

## Verification

- `pnpm --filter first-tree-dev exec vitest run src/__tests__/client-switch.test.ts src/__tests__/client-switch-platform-extra.test.ts src/__tests__/client-switch-transaction-extra.test.ts` — 68/68 passed
- `pnpm exec turbo run test --filter=@first-tree/skill-evals` — 494/494 passed; 6/6 tasks successful
- `pnpm test` — 12/12 tasks successful
- `pnpm check` — passed (existing non-blocking warnings only)
- `pnpm typecheck` — 11/11 tasks successful

## QA risk

The Darwin process-attribution change touches the local-client switch safety boundary. Automated coverage exercises both the real macOS transaction path and fail-closed late-provider / process-inspection branches. Independent product regression for Codex Fast mode remains scoped to #2039.
