### PR TITLE
fix(web): make pinned chat selection responsive

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
@@ -298,16 +298,25 @@ describe("ChatByIdView and CenterPanel", () => {
     // palette stores a bare ListMeChatsResponse. Seed both so the mark-read
     // patch is exercised against each cache shape it must handle.
     const paletteKey = ["me", "chats", "palette"];
-    const infinite = (rows: MeChatRow[]): InfiniteData<ListMeChatsResponse> => ({
-      pages: [{ rows, nextCursor: null, priorityRows: { attention: [], pinned: [] } }],
+    const infinite = (
+      rows: MeChatRow[],
+      priorityRows: ListMeChatsResponse["priorityRows"] = { attention: [], pinned: [] },
+    ): InfiniteData<ListMeChatsResponse> => ({
+      pages: [{ rows, nextCursor: null, priorityRows }],
       pageParams: [undefined],
     });
-    queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(allKey, infinite([currentUnread, otherUnread]));
-    queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(unreadKey, infinite([currentUnread, otherUnread]));
+    queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(
+      allKey,
+      infinite([currentUnread, otherUnread], { attention: [], pinned: [currentUnread] }),
+    );
+    queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(
+      unreadKey,
+      infinite([currentUnread, otherUnread], { attention: [], pinned: [currentUnread] }),
+    );
     queryClient.setQueryData<ListMeChatsResponse>(paletteKey, {
       rows: [currentUnread, otherUnread],
       nextCursor: null,
-      priorityRows: { attention: [], pinned: [] },
+      priorityRows: { attention: [currentUnread], pinned: [] },
     });
 
     const { container, root } = await renderDom(
@@ -326,6 +335,12 @@ describe("ChatByIdView and CenterPanel", () => {
       pinnedAt: null,
       activityAt: null,
     });
+    expect(
+      queryClient.getQueryData<InfiniteData<ListMeChatsResponse>>(allKey)?.pages[0]?.priorityRows.pinned[0],
+    ).toMatchObject({
+      unreadMentionCount: 0,
+      chatHasExplicitMentionToMe: false,
+    });
     expect(allRows?.find((row) => row.chatId === "chat-2")).toMatchObject({
       unreadMentionCount: 1,
       chatHasExplicitMentionToMe: true,
@@ -336,9 +351,16 @@ describe("ChatByIdView and CenterPanel", () => {
       .getQueryData<InfiniteData<ListMeChatsResponse>>(unreadKey)
       ?.pages.flatMap((p) => p.rows);
     expect(unreadRows?.map((row) => row.chatId)).toEqual(["chat-2"]);
+    expect(
+      queryClient.getQueryData<InfiniteData<ListMeChatsResponse>>(unreadKey)?.pages[0]?.priorityRows.pinned,
+    ).toEqual([]);
     // The bare-response (palette / mobile) shape is patched in place too.
     const patchedPalette = queryClient.getQueryData<ListMeChatsResponse>(paletteKey);
     expect(patchedPalette?.rows.find((row) => row.chatId === "chat-1")).toMatchObject({ unreadMentionCount: 0 });
+    expect(patchedPalette?.priorityRows.attention[0]).toMatchObject({
+      unreadMentionCount: 0,
+      chatHasExplicitMentionToMe: false,
+    });
     expect(chatViewMocks.props.at(-1)).toMatchObject({
       agentId: "agent-1",
       chatId: "chat-1",

--- a/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
@@ -279,6 +279,9 @@ describe("ChatByIdView and CenterPanel", () => {
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
     const allKey = ["me", "chats", "all", "active", false, null, null];
     const unreadKey = ["me", "chats", "unread", "active", false, null, null];
+    const mobileAllKey = ["me", "chats", "mobile", "work-list", "org-1", "active", false, "all"];
+    const mobileUnreadKey = ["me", "chats", "mobile", "work-list", "org-1", "active", false, "unread"];
+    const mobileSourceCountsKey = ["me", "chats", "mobile", "work-source-counts", "org-1", "active", false];
     const currentUnread = meChatRow({
       chatId: "chat-1",
       unreadMentionCount: 2,
@@ -318,6 +321,17 @@ describe("ChatByIdView and CenterPanel", () => {
       nextCursor: null,
       priorityRows: { attention: [currentUnread], pinned: [] },
     });
+    queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(
+      mobileAllKey,
+      infinite([currentUnread, otherUnread], { attention: [currentUnread], pinned: [currentUnread] }),
+    );
+    queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(
+      mobileUnreadKey,
+      infinite([currentUnread, otherUnread], { attention: [currentUnread], pinned: [currentUnread] }),
+    );
+    queryClient.setQueryData(mobileSourceCountsKey, {
+      counts: { manual: { chatCount: 2, unreadChatCount: 2 } },
+    });
 
     const { container, root } = await renderDom(
       <ChatByIdView chatId="chat-1" narrow onShowConversations={onShowConversations} />,
@@ -327,7 +341,9 @@ describe("ChatByIdView and CenterPanel", () => {
     await waitForText(container, "ChatView agent-1 chat-1");
     expect(chatMocks.getChat).toHaveBeenCalledWith("chat-1");
     expect(meChatMocks.markMeChatRead).toHaveBeenCalledTimes(1);
-    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["me", "chats", "mobile", "work-source-counts"],
+    });
     const allRows = queryClient.getQueryData<InfiniteData<ListMeChatsResponse>>(allKey)?.pages.flatMap((p) => p.rows);
     expect(allRows?.find((row) => row.chatId === "chat-1")).toMatchObject({
       unreadMentionCount: 0,
@@ -361,6 +377,21 @@ describe("ChatByIdView and CenterPanel", () => {
       unreadMentionCount: 0,
       chatHasExplicitMentionToMe: false,
     });
+    const mobileAll = queryClient.getQueryData<InfiniteData<ListMeChatsResponse>>(mobileAllKey)?.pages[0];
+    expect(mobileAll?.rows.find((row) => row.chatId === "chat-1")).toMatchObject({
+      unreadMentionCount: 0,
+      chatHasExplicitMentionToMe: false,
+    });
+    expect(mobileAll?.priorityRows.attention[0]).toMatchObject({ unreadMentionCount: 0 });
+    expect(mobileAll?.priorityRows.pinned[0]).toMatchObject({ unreadMentionCount: 0 });
+    const mobileUnread = queryClient.getQueryData<InfiniteData<ListMeChatsResponse>>(mobileUnreadKey)?.pages[0];
+    expect(mobileUnread?.rows.map((row) => row.chatId)).toEqual(["chat-2"]);
+    expect(mobileUnread?.priorityRows.attention).toEqual([]);
+    expect(mobileUnread?.priorityRows.pinned).toEqual([]);
+    expect(queryClient.getQueryData(mobileSourceCountsKey)).toEqual({
+      counts: { manual: { chatCount: 2, unreadChatCount: 2 } },
+    });
+    expect(queryClient.getQueryState(mobileSourceCountsKey)?.isInvalidated).toBe(true);
     expect(chatViewMocks.props.at(-1)).toMatchObject({
       agentId: "agent-1",
       chatId: "chat-1",

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -39,10 +39,34 @@ function pickPrimaryAgent(participants: { agentId: string; type: string }[], myA
   return nonSelf[0]?.agentId ?? null;
 }
 
+type MeChatsCache = InfiniteData<ListMeChatsResponse> | ListMeChatsResponse;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function isListResponse(value: unknown): value is ListMeChatsResponse {
+  if (!isRecord(value) || !Array.isArray(value.rows) || !isRecord(value.priorityRows)) return false;
+  return Array.isArray(value.priorityRows.attention) && Array.isArray(value.priorityRows.pinned);
+}
+
+function isMeChatsCache(value: unknown): value is MeChatsCache {
+  if (isListResponse(value)) return true;
+  return isRecord(value) && Array.isArray(value.pages) && value.pages.every(isListResponse);
+}
+
+function isUnreadListQuery(queryKey: readonly unknown[]): boolean {
+  if (queryKey[2] === "unread") return true;
+  return queryKey[2] === "mobile" && queryKey[3] === "work-list" && queryKey[7] === "unread";
+}
+
 function patchReadChatInCachedLists(queryClient: QueryClient, chatId: string, unreadMentionCount: number): void {
   const cachedQueries = queryClient.getQueryCache().findAll({ queryKey: ["me", "chats"] });
   for (const query of cachedQueries) {
-    const unreadFilter = query.queryKey[2] === "unread";
+    const previous = query.state.data;
+    if (!isMeChatsCache(previous)) continue;
+
+    const unreadFilter = isUnreadListQuery(query.queryKey);
     // Update the opened chat wherever the response projects it; in the
     // unread-only view drop it once it reaches zero.
     const patchRows = (rows: MeChatRow[]): { rows: MeChatRow[]; changed: boolean } => {
@@ -72,23 +96,26 @@ function patchReadChatInCachedLists(queryClient: QueryClient, chatId: string, un
             : response.priorityRows,
       };
     };
-    // The desktop rail stores `InfiniteData` (`useInfiniteQuery`); the command
-    // palette and mobile lists store a bare `ListMeChatsResponse`. The prefix
-    // `findAll(["me","chats"])` matches both, so patch whichever this holds.
-    queryClient.setQueryData<InfiniteData<ListMeChatsResponse> | ListMeChatsResponse>(query.queryKey, (prev) => {
-      if (!prev) return prev;
-      if ("pages" in prev) {
-        let changed = false;
-        const pages = prev.pages.map((page) => {
-          const next = patchResponse(page);
-          if (next !== page) changed = true;
-          return next;
-        });
-        return changed ? { ...prev, pages } : prev;
-      }
-      return patchResponse(prev);
-    });
+
+    if ("pages" in previous) {
+      let changed = false;
+      const pages = previous.pages.map((page) => {
+        const next = patchResponse(page);
+        if (next !== page) changed = true;
+        return next;
+      });
+      if (changed) queryClient.setQueryData(query.queryKey, { ...previous, pages });
+      continue;
+    }
+
+    const patched = patchResponse(previous);
+    if (patched !== previous) queryClient.setQueryData(query.queryKey, patched);
   }
+
+  // Source counts have a different cache shape and are server-owned aggregates.
+  // Refresh active mobile count projections instead of trying to derive them
+  // from whichever paginated list rows happen to be cached.
+  void queryClient.invalidateQueries({ queryKey: ["me", "chats", "mobile", "work-source-counts"] });
 }
 
 export function ChatByIdView({

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -43,7 +43,7 @@ function patchReadChatInCachedLists(queryClient: QueryClient, chatId: string, un
   const cachedQueries = queryClient.getQueryCache().findAll({ queryKey: ["me", "chats"] });
   for (const query of cachedQueries) {
     const unreadFilter = query.queryKey[2] === "unread";
-    // Decrement the opened chat's unread within a single page's rows; in the
+    // Update the opened chat wherever the response projects it; in the
     // unread-only view drop it once it reaches zero.
     const patchRows = (rows: MeChatRow[]): { rows: MeChatRow[]; changed: boolean } => {
       let changed = false;
@@ -55,6 +55,23 @@ function patchReadChatInCachedLists(queryClient: QueryClient, chatId: string, un
       });
       return { rows: next, changed };
     };
+    const patchResponse = (response: ListMeChatsResponse): ListMeChatsResponse => {
+      const rows = patchRows(response.rows);
+      const attention = patchRows(response.priorityRows.attention);
+      const pinned = patchRows(response.priorityRows.pinned);
+      if (!rows.changed && !attention.changed && !pinned.changed) return response;
+      return {
+        ...response,
+        rows: rows.changed ? rows.rows : response.rows,
+        priorityRows:
+          attention.changed || pinned.changed
+            ? {
+                attention: attention.changed ? attention.rows : response.priorityRows.attention,
+                pinned: pinned.changed ? pinned.rows : response.priorityRows.pinned,
+              }
+            : response.priorityRows,
+      };
+    };
     // The desktop rail stores `InfiniteData` (`useInfiniteQuery`); the command
     // palette and mobile lists store a bare `ListMeChatsResponse`. The prefix
     // `findAll(["me","chats"])` matches both, so patch whichever this holds.
@@ -63,14 +80,13 @@ function patchReadChatInCachedLists(queryClient: QueryClient, chatId: string, un
       if ("pages" in prev) {
         let changed = false;
         const pages = prev.pages.map((page) => {
-          const res = patchRows(page.rows);
-          if (res.changed) changed = true;
-          return res.changed ? { ...page, rows: res.rows } : page;
+          const next = patchResponse(page);
+          if (next !== page) changed = true;
+          return next;
         });
         return changed ? { ...prev, pages } : prev;
       }
-      const res = patchRows(prev.rows);
-      return res.changed ? { ...prev, rows: res.rows } : prev;
+      return patchResponse(prev);
     });
   }
 }

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -765,15 +765,37 @@ describe("ConversationList", () => {
     }
   });
 
-  it("marks the selected row with aria-current and reveals the row-actions kebab on touch", async () => {
-    const container = await renderDom(<StatefulList selectedChatId="chat-manual" />);
+  it("separates row selection from its actions and keeps the kebab reachable on touch", async () => {
+    const onSelectChat = vi.fn();
+    const pinnedRow = row({
+      chatId: "chat-pinned",
+      title: "Pinned planning",
+      pinnedAt: "2026-05-28T11:30:00.000Z",
+    });
+    const client = createClient([...BASE_ROWS, pinnedRow], null);
+    const container = await renderDom(
+      <StatefulList selectedChatId="chat-pinned" onSelectChat={onSelectChat} />,
+      client,
+    );
+    const selectedRow = rowButton(container, "Pinned planning");
     // Row selection is exposed to assistive tech (was tint + left bar only).
-    expect(rowButton(container, "Manual planning").getAttribute("aria-current")).toBe("page");
+    expect(selectedRow.getAttribute("aria-current")).toBe("page");
     expect(rowButton(container, "Broken deploy").getAttribute("aria-current")).toBeNull();
+    expect(selectedRow.className).toContain("cursor-pointer");
+    expect(selectedRow.className).toContain("active:bg-[var(--bg-active)]");
+    await click(selectedRow);
+    expect(onSelectChat).toHaveBeenCalledWith("chat-pinned");
     // The row-actions kebab (the only Pin entry point) reveals on coarse (touch)
     // pointers, not hover-only, so Pin is reachable on phones / the narrow overlay.
-    const kebab = container.querySelector('button[aria-label="Manage chat"]');
+    const kebab = selectedRow.parentElement?.querySelector<HTMLButtonElement>('button[aria-label="Manage chat"]');
+    expect(kebab).not.toBeNull();
     expect(kebab?.className).toContain("pointer-coarse:opacity-100");
+    expect(kebab?.className).toContain("pointer-events-none");
+    expect(kebab?.className).toContain("group-hover:pointer-events-auto");
+    // The main selector and action menu are sibling hit regions. The action no
+    // longer sits absolutely over the selector's right edge.
+    expect(kebab?.parentElement?.parentElement?.parentElement).toBe(selectedRow.parentElement);
+    expect(kebab?.parentElement?.parentElement?.className).not.toContain("absolute");
     // ...and the trailing metadata cluster hides on coarse pointers so the
     // always-visible kebab never overlaps the row's time / status (R5).
     expect(container.querySelector('[class~="pointer-coarse:opacity-0"]')).not.toBeNull();

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -545,7 +545,17 @@ export function ConversationList({
                   // avatar corner mark, while the left bar remains the selected
                   // affordance only.
                   return (
-                    <div key={row.chatId} className="group relative">
+                    <div
+                      key={row.chatId}
+                      className="group flex items-center transition-colors hover:bg-[var(--bg-hover)]"
+                      style={{
+                        background: isSelected ? "var(--brand-bg)" : "transparent",
+                        // Left bar is the SELECTED affordance only (DESIGN.md:
+                        // selected = green left-rail + tint). Attention no longer
+                        // doubles up here; it reads from the avatar corner mark.
+                        borderLeft: `var(--hairline-bold) solid ${isSelected ? "var(--brand)" : "transparent"}`,
+                      }}
+                    >
                       <button
                         type="button"
                         onClick={() => onSelectChat(row.chatId)}
@@ -554,21 +564,17 @@ export function ConversationList({
                         // the New-chat button's `aria-current`.
                         aria-current={isSelected ? "page" : undefined}
                         className={cn(
-                          "w-full text-left transition-colors flex items-center",
-                          "hover:bg-[var(--bg-hover)]",
+                          "min-w-0 flex-1 text-left cursor-pointer transition-colors flex items-center",
+                          "active:bg-[var(--bg-active)]",
                         )}
                         style={{
                           // Single-line rows tuned for desktop-inbox density:
                           // tightened vertical padding (--sp-2) now that the
                           // preview subtitle line is gone, so more conversations
                           // fit per screen without reading as a dense wall.
-                          padding: "var(--sp-2) var(--sp-3)",
+                          padding: "var(--sp-2) var(--sp-1) var(--sp-2) var(--sp-3)",
                           gap: "var(--sp-2)",
-                          background: isSelected ? "var(--brand-bg)" : "transparent",
-                          // Left bar is the SELECTED affordance only (DESIGN.md:
-                          // selected = green left-rail + tint). Attention no longer
-                          // doubles up here; it reads from the avatar corner mark.
-                          borderLeft: `var(--hairline-bold) solid ${isSelected ? "var(--brand)" : "transparent"}`,
+                          background: "transparent",
                         }}
                       >
                         <ChatRowAvatar
@@ -616,13 +622,9 @@ export function ConversationList({
                           ) : null}
                         </span>
                       </button>
-                      <div
-                        className="absolute"
-                        style={{
-                          top: "var(--sp-2)",
-                          right: "var(--sp-3)",
-                        }}
-                      >
+                      {/* Keep the row action in its own hit target instead of
+                          absolutely overlaying the chat-selection button. */}
+                      <div className="shrink-0" style={{ padding: "0 var(--sp-3) 0 var(--sp-1)" }}>
                         <RowEngagementMenu
                           chatId={row.chatId}
                           status={row.engagementStatus}

--- a/packages/web/src/pages/workspace/conversations/row-engagement-menu.tsx
+++ b/packages/web/src/pages/workspace/conversations/row-engagement-menu.tsx
@@ -71,8 +71,9 @@ function actionsFor({
 // rarely fires `focus-visible`, so hover-only would leave the kebab — the only
 // Pin entry point — permanently invisible and untappable on phones and the
 // narrow-overlay rail; `pointer-coarse:opacity-100` keeps it always shown there.
+// While visually hidden it must not intercept the chat row's click target.
 const TRIGGER_HOVER_REVEAL =
-  "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 aria-expanded:opacity-100 pointer-coarse:opacity-100";
+  "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto aria-expanded:opacity-100 aria-expanded:pointer-events-auto pointer-coarse:opacity-100 pointer-coarse:pointer-events-auto";
 
 export function RowEngagementMenu({
   chatId,


### PR DESCRIPTION
## Summary

- render conversation selection and row actions as sibling hit targets so the transparent action trigger cannot cover the chat selector
- disable pointer events while the hover-revealed action trigger is visually hidden
- patch mark-read results across ordinary, Attention, and Pinned list projections
- add deterministic regressions for Pinned selection, action hit targets, and priority-row read state

## Verification

- `pnpm --filter @first-tree/web exec vitest run src/__tests__/app-routes.test.tsx src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx src/pages/workspace/conversations/__tests__/row-engagement-menu-dom.test.tsx src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx` — 48 passed
- `pnpm check` — passed with pre-existing warnings only
- `pnpm typecheck` — passed
- `pnpm test` — relevant Web suites passed; the parallel monorepo run hit two unrelated load-sensitive timeouts:
  - `@first-tree/client` capability probe passed when rerun alone (51 passed)
  - `first-tree-dev` context-policy runtime layout passed when rerun alone with a 60-second hook timeout (4 passed; actual duration 4.8 seconds)

## Browser QA

Validated the real layout in a separate headed browser at the DEV-only `/preview/conversation-list` route:

- clicking the Pinned row selected it
- clicking its visible row-action trigger opened the Unpin / Mark as unread / Archive / Delete menu without changing the selection
- the selector and row action rendered as distinct sibling controls with no overlap

The preview emitted only the expected bootstrap proxy error because no local API server was running.
