### PR TITLE
feat(web): show private GitLab Context coming soon

### DIFF
--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -432,8 +432,11 @@ describe("ContextPage DOM behavior", () => {
     await act(async () => disconnected.root.unmount());
   });
 
-  it("explains the anonymous-only Cloud boundary for private GitLab without degrading review automation", async () => {
-    const { ContextPage } = await import("../context.js");
+  it.each(["member", "admin"] as const)("shows the same private GitLab coming-soon state to %s users", async (role) => {
+    authMock.value = { organizationId: "org-1", role };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    const serverDetail =
+      "Private GitLab Context Tree content is unavailable in First Tree Cloud. Cloud only performs anonymous GitLab reads.";
     const privateGitlab = snapshot({
       provider: "gitlab",
       contentAvailability: {
@@ -441,22 +444,52 @@ describe("ContextPage DOM behavior", () => {
         accessMode: "anonymous",
         reason: "gitlab_authentication_required",
       },
-      repo: "https://gitlab.example/acme/private-context.git",
+      repo: "https://oauth2:secret@gitlab.example/acme/private-context.git",
       branch: "main",
       snapshotStatus: "unavailable",
       contextStatus: {
         label: "Team context unavailable",
-        detail:
-          "Private GitLab Context Tree content is unavailable in First Tree Cloud. Cloud only performs anonymous GitLab reads.",
+        detail: serverDetail,
         severity: "error",
       },
     });
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(privateGitlab);
 
-    const { container, root } = await renderDom(<ContextPage previewSnapshot={privateGitlab} />);
-    expect(container.textContent).toContain("Private GitLab content is unavailable in Cloud");
-    expect(container.textContent).toContain("local git/glab access");
-    expect(container.textContent).toContain("Webhook review automation can remain active");
-    expect(container.textContent).not.toMatch(/GitLab token|credential input|upload snapshot/iu);
+    const { ContextPage } = await import("../context.js");
+    const { container, root } = await renderDom(<ContextPage />);
+
+    await waitForText(container, "Private GitLab Context is coming soon");
+    expect(container.textContent).toContain(
+      "First Tree can’t display private GitLab Context Trees in the web app yet. Agents and Context Reviewer with repository access can continue using the tree as usual.",
+    );
+    expect(container.textContent).not.toContain(serverDetail);
+    expect(container.textContent).toContain(
+      "Repo: https://[redacted]@gitlab.example/acme/private-context.git · Branch: main",
+    );
+    expect(buttonByText(container, "Work on this in chat")).toBeNull();
+    expect(buttonByText(container, "Create an agent")).toBeNull();
+    expect(container.querySelector('[aria-label="Agent for the Context Tree chat"]')).toBeNull();
+    expect(agentApiMocks.listManagedAgents).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it("keeps public GitLab snapshots on the live Context page", async () => {
+    const { ContextPage } = await import("../context.js");
+    const publicGitlab = snapshot({
+      provider: "gitlab",
+      contentAvailability: {
+        status: "available",
+        accessMode: "anonymous",
+      },
+      repo: "https://gitlab.com/acme/public-context.git",
+      branch: "main",
+      snapshotStatus: "active",
+      contextStatus: { label: "Live", detail: null, severity: "ok" },
+    });
+
+    const { container, root } = await renderDom(<ContextPage previewSnapshot={publicGitlab} />);
+    expect(container.textContent).toContain("LIVE");
+    expect(container.textContent).not.toContain("coming soon");
     await act(async () => root.unmount());
   });
 
@@ -489,6 +522,38 @@ describe("ContextPage DOM behavior", () => {
     expect(container.textContent).toContain(title);
     expect(container.textContent).toContain(recovery);
     expect(container.textContent).toContain("Webhook");
+    await act(async () => root.unmount());
+  });
+
+  it("keeps recoverable GitLab unavailable states chat-first for admins", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(
+      snapshot({
+        provider: "gitlab",
+        contentAvailability: {
+          status: "unavailable",
+          accessMode: "anonymous",
+          reason: "gitlab_dns_unavailable",
+        },
+        repo: "https://gitlab.example/acme/context-tree.git",
+        branch: "main",
+        snapshotStatus: "unavailable",
+        contextStatus: {
+          label: "Team context unavailable",
+          detail: "Provider-specific diagnostic",
+          severity: "error",
+        },
+      }),
+    );
+
+    const { ContextPage } = await import("../context.js");
+    const { container, root } = await renderDom(<ContextPage />);
+
+    await waitForText(container, "Work on this in chat");
+    expect(container.textContent).toContain("First Tree cannot resolve this GitLab address");
+    expect(container.textContent).toContain("Provider-specific diagnostic");
+    expect(agentApiMocks.listManagedAgents).toHaveBeenCalled();
     await act(async () => root.unmount());
   });
 

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -646,6 +646,10 @@ function UnavailableState({
       : null;
   const unavailableGitlabContent = gitlabContentAvailability !== null;
   const gitlabUnavailableReason = gitlabContentAvailability?.reason ?? null;
+  const privateGitlabContextUnavailable =
+    snapshot.provider === "gitlab" &&
+    snapshot.contentAvailability?.status === "unavailable" &&
+    snapshot.contentAvailability.reason === "gitlab_authentication_required";
   const gitlabCopy = gitlabUnavailableReason ? gitlabUnavailableCopy(gitlabUnavailableReason) : null;
   const title = snapshot.repo
     ? unavailableGitlabContent
@@ -664,7 +668,7 @@ function UnavailableState({
     : isAdmin
       ? "Your agent can build it with you in a chat. Share a local project folder or GitHub repository URL there."
       : "Ask an admin to set up your team's Context Tree.";
-  const syncDetail = snapshot.contextStatus.detail;
+  const syncDetail = privateGitlabContextUnavailable ? null : snapshot.contextStatus.detail;
   const repoLabel = snapshot.repo ? redactRepoForDisplay(snapshot.repo) : null;
   return (
     <Panel>
@@ -681,10 +685,10 @@ function UnavailableState({
                 {syncDetail}
               </div>
             ) : null}
-            {/* Every admin-facing unavailable state continues in the same
-                chat-first setup flow. The tab never diagnoses or mutates source
-                access itself; the agent inspects the real workspace and tree. */}
-            {canOpenChat ? (
+            {/* Recoverable admin-facing unavailable states continue in the
+                chat-first setup flow. Private GitLab is a product capability
+                gap, so the same coming-soon state is shown to every role. */}
+            {canOpenChat && !privateGitlabContextUnavailable ? (
               <div style={{ marginTop: "var(--sp-3)" }}>
                 <ContextTreeBuildEntry intent={snapshot.repo ? "recover" : "build"} />
               </div>
@@ -707,9 +711,9 @@ function gitlabUnavailableCopy(reason: string): { title: string; detail: string 
   switch (reason) {
     case "gitlab_authentication_required":
       return {
-        title: "Private GitLab content is unavailable in Cloud",
+        title: "Private GitLab Context is coming soon",
         detail:
-          "First Tree Cloud only reads GitLab repositories anonymously. Make the Context Tree repository anonymously readable, or use an Agent on a host with local git/glab access. Webhook review automation can remain active.",
+          "First Tree can’t display private GitLab Context Trees in the web app yet. Agents and Context Reviewer with repository access can continue using the tree as usual.",
       };
     case "gitlab_origin_not_authorized":
       return {


### PR DESCRIPTION
## Summary

- show the confirmed coming-soon state only for private GitLab Context Trees reported as `gitlab_authentication_required`
- use identical copy for admins and members while hiding sync detail and all agent/chat setup entry points
- keep the redacted repository and branch visible, and preserve public GitLab plus other unavailable recovery states

## Context Tree

- Draft Context Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/839
- Merge this implementation first; the Tree PR will then be reconciled against shipped behavior and marked ready.

## Validation

- `pnpm --filter @first-tree/web exec vitest run src/pages/__tests__/context-page-dom.test.tsx --maxWorkers=2` (21 tests passed)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/web/src/pages/context.tsx packages/web/src/pages/__tests__/context-page-dom.test.tsx`
- `git diff --check`
