### PR TITLE
test(cli): isolate portable update shims

### DIFF
--- a/apps/cli/src/__tests__/update-portable-install.test.ts
+++ b/apps/cli/src/__tests__/update-portable-install.test.ts
@@ -1,9 +1,9 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const childRegistryMocks = vi.hoisted(() => ({
@@ -20,6 +20,13 @@ let tmpDirs: string[] = [];
 const originalPlatform = process.platform;
 const originalArch = process.arch;
 const originalPath = process.env.PATH;
+
+function isolatedPortablePath(binDir: string): string {
+  const hostEntries = (originalPath ?? "")
+    .split(delimiter)
+    .filter((entry) => entry.length > 0 && !existsSync(join(entry, "first-tree")) && !existsSync(join(entry, "ft")));
+  return [binDir, ...hostEntries].join(delimiter);
+}
 
 function tempDir(name: string): string {
   const dir = mkdtempSync(join(tmpdir(), name));
@@ -211,6 +218,12 @@ async function importProdUpdateModule(
 beforeEach(() => {
   vi.clearAllMocks();
   childRegistryMocks.classify.mockReturnValue({ kind: "permanent", reasonCode: "classified" });
+  const binDir = tempDir("ft-portable-bin-");
+  writeFileSync(join(binDir, "first-tree"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  // Portable updates intentionally rewrite the first installed shim on PATH.
+  // Keep every test inside a disposable shim directory and exclude operator
+  // installs from the inherited PATH so a test can never rewrite them.
+  vi.stubEnv("PATH", isolatedPortablePath(binDir));
 });
 
 afterEach(() => {
@@ -413,7 +426,7 @@ describe("installPortableSpec", () => {
     vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
     vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
     vi.stubEnv("HOME", home);
-    vi.stubEnv("PATH", `${binDir}:${process.env.PATH ?? ""}`);
+    vi.stubEnv("PATH", `${binDir}${delimiter}${process.env.PATH ?? ""}`);
 
     const { installPortableSpec } = await importProdUpdateModule();
     await expect(installPortableSpec("latest")).resolves.toEqual({

--- a/apps/cli/src/__tests__/update-portable-install.test.ts
+++ b/apps/cli/src/__tests__/update-portable-install.test.ts
@@ -21,11 +21,16 @@ const originalPlatform = process.platform;
 const originalArch = process.arch;
 const originalPath = process.env.PATH;
 
-function isolatedPortablePath(binDir: string): string {
-  const hostEntries = (originalPath ?? "")
+function sanitizedHostPath(): string {
+  return (originalPath ?? "")
     .split(delimiter)
-    .filter((entry) => entry.length > 0 && !existsSync(join(entry, "first-tree")) && !existsSync(join(entry, "ft")));
-  return [binDir, ...hostEntries].join(delimiter);
+    .filter((entry) => entry.length > 0 && !existsSync(join(entry, "first-tree")) && !existsSync(join(entry, "ft")))
+    .join(delimiter);
+}
+
+function isolatedPortablePath(binDir: string): string {
+  const hostPath = sanitizedHostPath();
+  return hostPath.length > 0 ? `${binDir}${delimiter}${hostPath}` : binDir;
 }
 
 function tempDir(name: string): string {
@@ -463,7 +468,7 @@ describe("installPortableSpec", () => {
     vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
     vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
     vi.stubEnv("HOME", home);
-    vi.stubEnv("PATH", "/usr/bin:/bin");
+    vi.stubEnv("PATH", sanitizedHostPath());
 
     const { installPortableSpec } = await importProdUpdateModule();
     await expect(installPortableSpec("latest")).resolves.toEqual({


### PR DESCRIPTION
## What changed

- Give every portable-update test a disposable shim directory at the front of `PATH`.
- Remove inherited `PATH` entries containing an installed `first-tree` or `ft` shim.
- Use the platform path delimiter when composing test paths.

## Why

`installPortableSpec` intentionally rewrites the first installed shim it finds on `PATH`. The tests isolated `HOME` and the portable root but inherited the operator's real `PATH`, so a local `/opt/homebrew/bin/first-tree` or `ft` could be overwritten with a temporary test runtime and left dangling after cleanup.

## Impact

Portable update tests can no longer modify an operator's installed First Tree command. Production update behavior is unchanged.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/update-portable-install.test.ts` (22 passed)
- `pnpm --filter first-tree-dev test` (23/23 batches; 1439 passed, 1 skipped)
- Compared the production `first-tree`/`ft` symlink type, inode, timestamps, target, and target SHA-256 before and after the full CLI suite: unchanged