### PR TITLE
fix(web): align private GitLab Setup state

### DIFF
--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -531,6 +531,36 @@ describe("settings panels", () => {
     await act(async () => admin.root.unmount());
   });
 
+  it("does not mark private GitLab Web Context as admin setup attention", async () => {
+    const { SettingsLayout } = await import("../settings.js");
+    const capabilities = teamSetupCapabilities();
+    capabilities.contextTree.binding = {
+      state: "bound",
+      provider: "gitlab",
+      repo: "https://gitlab.example/acme/context-tree.git",
+      branch: "main",
+    };
+    setupCapabilitiesMocks.getTeamSetupCapabilitiesAt.mockResolvedValueOnce(capabilities);
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValueOnce({
+      snapshotStatus: "unavailable",
+      provider: "gitlab",
+      contentAvailability: {
+        status: "unavailable",
+        accessMode: "anonymous",
+        reason: "gitlab_authentication_required",
+      },
+    });
+
+    const admin = await renderDom(<SettingsLayout />, "/settings/account");
+    await waitForCondition(
+      () => contextApiMocks.getContextTreeSnapshot.mock.calls.length === 1,
+      "Expected the private GitLab Context Tree snapshot to load",
+    );
+
+    expect(admin.container.querySelector("[data-setup-attention]")).toBeNull();
+    await act(async () => admin.root.unmount());
+  });
+
   it("ignores cached unavailable snapshots when the current owner facts are unbound or failed", async () => {
     const { SettingsLayout } = await import("../settings.js");
     const snapshotKey = ["context-tree-snapshot", "org-1", "7d", false] as const;

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -101,9 +101,9 @@ export function SettingsLayout({ activePathname, children }: { activePathname?: 
     },
     enabled: teamAttentionEnabled && contextBound,
   });
-  const currentContextTreeSnapshotStatus =
+  const currentContextTreeSnapshot =
     teamAttentionEnabled && setupCapabilitiesQuery.isSuccess && contextBound && contextTreeSnapshotQuery.isSuccess
-      ? contextTreeSnapshotQuery.data.snapshotStatus
+      ? contextTreeSnapshotQuery.data
       : undefined;
   const setupNeedsAttention =
     personalSetupNeedsAttention({
@@ -112,7 +112,7 @@ export function SettingsLayout({ activePathname, children }: { activePathname?: 
       onboardingCompletedAt,
     }) ||
     teamSetupNeedsAttention(currentCapabilities, role) ||
-    contextTreeSnapshotNeedsAttention(currentContextTreeSnapshotStatus, role);
+    contextTreeSnapshotNeedsAttention(currentContextTreeSnapshot, role);
   // DEV preview galleries render this real layout below their own route. Let
   // those galleries supply the path whose heading/nav state they are showing;
   // production always follows the actual router location.

--- a/packages/web/src/pages/settings/__tests__/setup-attention.test.ts
+++ b/packages/web/src/pages/settings/__tests__/setup-attention.test.ts
@@ -129,10 +129,24 @@ describe("Setup navigation attention", () => {
   });
 
   it("uses the owner snapshot only for admin-recoverable unavailable Tree attention", () => {
-    expect(contextTreeSnapshotNeedsAttention("unavailable", "admin")).toBe(true);
-    expect(contextTreeSnapshotNeedsAttention("unavailable", "member")).toBe(false);
-    expect(contextTreeSnapshotNeedsAttention("stale", "admin")).toBe(false);
-    expect(contextTreeSnapshotNeedsAttention("active", "admin")).toBe(false);
+    expect(contextTreeSnapshotNeedsAttention({ snapshotStatus: "unavailable" }, "admin")).toBe(true);
+    expect(contextTreeSnapshotNeedsAttention({ snapshotStatus: "unavailable" }, "member")).toBe(false);
+    expect(contextTreeSnapshotNeedsAttention({ snapshotStatus: "stale" }, "admin")).toBe(false);
+    expect(contextTreeSnapshotNeedsAttention({ snapshotStatus: "active" }, "admin")).toBe(false);
+    expect(
+      contextTreeSnapshotNeedsAttention(
+        {
+          snapshotStatus: "unavailable",
+          provider: "gitlab",
+          contentAvailability: {
+            status: "unavailable",
+            accessMode: "anonymous",
+            reason: "gitlab_authentication_required",
+          },
+        },
+        "admin",
+      ),
+    ).toBe(false);
     expect(contextTreeSnapshotNeedsAttention(undefined, "admin")).toBe(false);
   });
 

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -129,7 +129,7 @@ function facts(overrides: Partial<SetupFacts> = {}): SetupFacts {
     },
     repositories: { state: "ready", value: 2 },
     capabilities: { state: "ready", value: capabilityFixture() },
-    contextTreeSnapshot: { state: "ready", value: "active" },
+    contextTreeSnapshot: { state: "ready", value: { snapshotStatus: "active" } },
     ...overrides,
   };
 }
@@ -347,7 +347,7 @@ describe("Settings Setup overview", () => {
         computers: { state: "ready", value: { connected: 0, saved: 0, connectedHostname: null } },
         repositories: { state: "error" },
         capabilities: { state: "ready", value: mixed },
-        contextTreeSnapshot: { state: "ready", value: "stale" },
+        contextTreeSnapshot: { state: "ready", value: { snapshotStatus: "stale" } },
       }),
     );
     const expectation = [
@@ -648,11 +648,58 @@ describe("Settings Setup overview", () => {
     ["stale", "Available · update delayed", "pending", "Manage", "acme/context-tree · Review on"],
     ["unavailable", "Needs recovery", "attention", "Recover", "acme/context-tree · main branch · GitHub"],
   ] as const)("maps bound Context Tree snapshot %s without equating binding to health", (value, label, kind, action, detail) => {
-    const row = rowFor("context-tree", facts({ contextTreeSnapshot: { state: "ready", value } }));
+    const row = rowFor(
+      "context-tree",
+      facts({ contextTreeSnapshot: { state: "ready", value: { snapshotStatus: value } } }),
+    );
 
     expect(row.status).toMatchObject({ label, kind });
     expect(row.status.detail).toBe(detail);
     expect(row.action?.label).toBe(action);
+  });
+
+  it("keeps private GitLab Web Context neutral and role-consistent", () => {
+    const capabilities = capabilityFixture({
+      binding: {
+        state: "bound",
+        provider: "gitlab",
+        repo: "https://gitlab.example/acme/context-tree.git",
+        branch: "main",
+      },
+    });
+    const privateGitlabSnapshot = {
+      snapshotStatus: "unavailable",
+      provider: "gitlab",
+      contentAvailability: {
+        status: "unavailable",
+        accessMode: "anonymous",
+        reason: "gitlab_authentication_required",
+      },
+    } as const;
+    const admin = rowFor(
+      "context-tree",
+      facts({
+        capabilities: { state: "ready", value: capabilities },
+        contextTreeSnapshot: { state: "ready", value: privateGitlabSnapshot },
+      }),
+    );
+    const member = rowFor(
+      "context-tree",
+      facts({
+        role: "member",
+        capabilities: { state: "ready", value: capabilities },
+        contextTreeSnapshot: { state: "ready", value: privateGitlabSnapshot },
+      }),
+    );
+
+    for (const row of [admin, member]) {
+      expect(row.status).toMatchObject({ label: "Coming soon", kind: "neutral" });
+      expect(row.status.detail).toContain("First Tree can’t display private GitLab Context Trees");
+      expect(row.status.detail).toContain("Agents and Context Reviewer");
+      expect(row.status.detail).not.toContain("recover");
+    }
+    expect(admin.action?.label).toBe("Manage");
+    expect(member.action).toEqual({ label: "View", to: "/context" });
   });
 
   it("keeps unbound optional and invalid role-aware", () => {
@@ -727,7 +774,7 @@ describe("Settings Setup overview", () => {
       "context-tree",
       facts({
         role: "member",
-        contextTreeSnapshot: { state: "ready", value: "unavailable" },
+        contextTreeSnapshot: { state: "ready", value: { snapshotStatus: "unavailable" } },
       }),
     );
 
@@ -1238,6 +1285,48 @@ describe("Settings Setup overview", () => {
     const view = await renderSettingsSetupPage();
     const row = await waitForRowText(view.host, "context-tree", expected);
     expect(row.textContent).toContain(expected);
+    await act(async () => view.root.unmount());
+  });
+
+  it("suppresses private GitLab recovery chat while keeping independent review controls", async () => {
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(
+      capabilityFixture({
+        binding: {
+          state: "bound",
+          provider: "gitlab",
+          repo: "https://gitlab.example/acme/context-tree.git",
+          branch: "main",
+        },
+      }),
+    );
+    contextTreeMocks.getContextTreeSnapshot.mockResolvedValue({
+      snapshotStatus: "unavailable",
+      provider: "gitlab",
+      contentAvailability: {
+        status: "unavailable",
+        accessMode: "anonymous",
+        reason: "gitlab_authentication_required",
+      },
+      contextStatus: {
+        severity: "error",
+        label: "Team context unavailable",
+        detail: "Private GitLab server diagnostic",
+      },
+    });
+
+    const view = await renderSettingsSetupPage();
+    const row = await waitForRowText(view.host, "context-tree", "Coming soon");
+    const manage = [...row.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+
+    expect(row.textContent).not.toContain("Needs recovery");
+    expect(row.textContent).not.toContain("Private GitLab server diagnostic");
+    await act(async () => manage?.click());
+    const controls = await waitForSelector<HTMLElement>(row, '[data-setup-owner-controls="context-tree"]');
+    expect(controls.textContent).toContain("Open Context");
+    expect(controls.textContent).toContain("Automatic review");
+    expect(controls.textContent).not.toContain("Work on this in chat");
     await act(async () => view.root.unmount());
   });
 

--- a/packages/web/src/pages/settings/setup-attention.ts
+++ b/packages/web/src/pages/settings/setup-attention.ts
@@ -1,4 +1,9 @@
-import type { ContextTreeSnapshotStatus, SetupBlocker, TeamSetupCapabilities } from "@first-tree/shared";
+import type { ContextTreeSnapshot, SetupBlocker, TeamSetupCapabilities } from "@first-tree/shared";
+
+export type ContextTreeSnapshotAvailability = Pick<
+  ContextTreeSnapshot,
+  "snapshotStatus" | "provider" | "contentAvailability"
+>;
 
 function hasAdminOwnedBlocker(blockers: SetupBlocker[]): boolean {
   return blockers.some((blocker) => blocker.resolutionOwner === "admin");
@@ -31,10 +36,20 @@ export function teamSetupNeedsAttention(
 }
 
 export function contextTreeSnapshotNeedsAttention(
-  snapshotStatus: ContextTreeSnapshotStatus | null | undefined,
+  snapshot: ContextTreeSnapshotAvailability | null | undefined,
   role: string | null,
 ): boolean {
-  return role === "admin" && snapshotStatus === "unavailable";
+  return role === "admin" && snapshot?.snapshotStatus === "unavailable" && !isPrivateGitlabContextUnavailable(snapshot);
+}
+
+export function isPrivateGitlabContextUnavailable(
+  snapshot: ContextTreeSnapshotAvailability | null | undefined,
+): boolean {
+  return (
+    snapshot?.provider === "gitlab" &&
+    snapshot.contentAvailability?.status === "unavailable" &&
+    snapshot.contentAvailability.reason === "gitlab_authentication_required"
+  );
 }
 
 export function personalSetupNeedsAttention({

--- a/packages/web/src/pages/settings/setup-context-tree-controls.tsx
+++ b/packages/web/src/pages/settings/setup-context-tree-controls.tsx
@@ -15,6 +15,7 @@ type ContextTreeAvailability = "active" | "stale" | "unavailable" | "checking" |
 export function SetupContextTreeControls({
   binding,
   availability,
+  privateGitlabContextUnavailable = false,
   loadSetting = getRawContextTreeSetting,
   saveSetting = putContextTreeSetting,
   refreshFacts,
@@ -22,6 +23,7 @@ export function SetupContextTreeControls({
 }: {
   binding: SetupContextTreeBinding;
   availability: ContextTreeAvailability;
+  privateGitlabContextUnavailable?: boolean;
   loadSetting?: (organizationId: string) => Promise<OrgContextTreeOutput>;
   saveSetting?: (organizationId: string, input: OrgContextTreeInput) => Promise<OrgContextTreeOutput>;
   refreshFacts?: (organizationId: string) => Promise<void>;
@@ -85,7 +87,8 @@ export function SetupContextTreeControls({
 
   const hasBoundTree = binding.state === "bound";
   const chatIntent = hasBoundTree ? "recover" : "build";
-  const shouldOfferChat = binding.state === "unbound" || (hasBoundTree && availability === "unavailable");
+  const shouldOfferChat =
+    binding.state === "unbound" || (hasBoundTree && availability === "unavailable" && !privateGitlabContextUnavailable);
   const bindingSummary = savedBinding?.repo
     ? `${repositoryLabel(savedBinding.repo)} · ${savedBinding.branch ?? "main"} branch · ${
         savedBinding.provider ?? "provider pending"

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -1,4 +1,5 @@
 import type {
+  ContextTreeSnapshot,
   SetupActionKind,
   SetupAutomaticReview,
   SetupBlocker,
@@ -38,6 +39,7 @@ import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { cn } from "../../lib/utils.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { ContextEnablement } from "./context-enablement.js";
+import { isPrivateGitlabContextUnavailable } from "./setup-attention.js";
 import { SetupContextTreeControls } from "./setup-context-tree-controls.js";
 import { SetupReviewerControls } from "./setup-reviewer-controls.js";
 
@@ -52,7 +54,10 @@ type Fact<T> =
 type ContextTreeFact = {
   binding: SetupContextTreeBinding;
   availability: "active" | "stale" | "unavailable" | "checking" | "unknown" | null;
+  privateGitlabContextUnavailable: boolean;
 };
+
+type ContextTreeSnapshotFact = Pick<ContextTreeSnapshot, "snapshotStatus" | "provider" | "contentAvailability">;
 
 export type SetupStatusKind =
   | "ready"
@@ -75,7 +80,7 @@ export type SetupFacts = {
   computers: Fact<{ connected: number; saved: number; connectedHostname: string | null }>;
   repositories: Fact<number>;
   capabilities: Fact<TeamSetupCapabilities>;
-  contextTreeSnapshot: Fact<"active" | "stale" | "unavailable" | null>;
+  contextTreeSnapshot: Fact<ContextTreeSnapshotFact | null>;
 };
 
 export type SetupRowModel = {
@@ -103,24 +108,37 @@ function queryFact<T>(query: { data: T | undefined; isPending: boolean; isError:
 
 function contextTreeFact(
   capabilities: Fact<TeamSetupCapabilities>,
-  snapshot: Fact<"active" | "stale" | "unavailable" | null>,
+  snapshot: Fact<ContextTreeSnapshotFact | null>,
 ): Fact<ContextTreeFact> {
   if (capabilities.state === "loading") return { state: "loading" };
   if (capabilities.state === "error") return { state: "error" };
 
   const binding = capabilities.value.contextTree.binding;
   if (binding.state !== "bound") {
-    return { state: "ready", value: { binding, availability: null } };
+    return {
+      state: "ready",
+      value: { binding, availability: null, privateGitlabContextUnavailable: false },
+    };
   }
   if (snapshot.state === "loading") {
-    return { state: "ready", value: { binding, availability: "checking" } };
+    return {
+      state: "ready",
+      value: { binding, availability: "checking", privateGitlabContextUnavailable: false },
+    };
   }
   if (snapshot.state === "error") {
-    return { state: "ready", value: { binding, availability: "unknown" } };
+    return {
+      state: "ready",
+      value: { binding, availability: "unknown", privateGitlabContextUnavailable: false },
+    };
   }
   return {
     state: "ready",
-    value: { binding, availability: snapshot.value ?? "unknown" },
+    value: {
+      binding,
+      availability: snapshot.value?.snapshotStatus ?? "unknown",
+      privateGitlabContextUnavailable: isPrivateGitlabContextUnavailable(snapshot.value),
+    },
   };
 }
 
@@ -337,7 +355,7 @@ function contextTreeStatus(
   if (contextTree.state === "loading") return loadingStatus();
   if (contextTree.state === "error") return unknownStatus();
 
-  const { binding, availability } = contextTree.value;
+  const { binding, availability, privateGitlabContextUnavailable } = contextTree.value;
   if (binding.state === "unbound") {
     return {
       label: "Not set up",
@@ -362,6 +380,13 @@ function contextTreeStatus(
   ].join(" · ");
   const issueDetail = blockerDetail(blockers, isAdmin);
   const detail = [bindingDetail, issueDetail].filter((item): item is string => Boolean(item)).join(" · ");
+  if (privateGitlabContextUnavailable) {
+    return {
+      label: "Coming soon",
+      detail: `${bindingDetail} · First Tree can’t display private GitLab Context Trees in the web app yet. Agents and Context Reviewer with repository access can continue using the tree as usual.`,
+      kind: "neutral",
+    };
+  }
   if (availability === "active") return { label: "Available", detail, kind: "ready" };
   if (availability === "stale") return { label: "Available · update delayed", detail, kind: "pending" };
   if (availability === "unavailable") {
@@ -379,7 +404,7 @@ function contextTreeStatus(
 
 function contextTreeAction(contextTree: Fact<ContextTreeFact>, isAdmin: boolean): SetupRowModel["action"] | undefined {
   if (contextTree.state !== "ready") return undefined;
-  const { binding, availability } = contextTree.value;
+  const { binding, availability, privateGitlabContextUnavailable } = contextTree.value;
   if (binding.state === "unbound") {
     return isAdmin
       ? { label: "Set up", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
@@ -388,6 +413,11 @@ function contextTreeAction(contextTree: Fact<ContextTreeFact>, isAdmin: boolean)
   if (binding.state === "invalid") {
     return isAdmin
       ? { label: "Repair", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
+      : { label: "View", to: "/context" };
+  }
+  if (privateGitlabContextUnavailable) {
+    return isAdmin
+      ? { label: "Manage", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
       : { label: "View", to: "/context" };
   }
   if (availability === "unavailable") {
@@ -698,7 +728,14 @@ export function SettingsSetupPage() {
       ? { state: "loading" }
       : contextSnapshotQuery.isError || !contextSnapshotQuery.data
         ? { state: "error" }
-        : { state: "ready", value: contextSnapshotQuery.data.snapshotStatus };
+        : {
+            state: "ready",
+            value: {
+              snapshotStatus: contextSnapshotQuery.data.snapshotStatus,
+              provider: contextSnapshotQuery.data.provider,
+              contentAvailability: contextSnapshotQuery.data.contentAvailability,
+            },
+          };
 
   const facts: SetupFacts = {
     role,
@@ -786,6 +823,7 @@ export function SettingsSetupPage() {
                     key={`context-tree-${organizationId}`}
                     binding={contextTree.value.binding}
                     availability={contextTree.value.availability}
+                    privateGitlabContextUnavailable={contextTree.value.privateGitlabContextUnavailable}
                   >
                     {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ? (
                       <SetupReviewerControls

--- a/packages/web/src/pages/setup-preview.tsx
+++ b/packages/web/src/pages/setup-preview.tsx
@@ -191,7 +191,7 @@ function previewFacts(role: PreviewRole, state: PreviewState): SetupFacts {
       },
       repositories: { state: "error" },
       capabilities: { state: "ready", value: MIXED_CAPABILITIES },
-      contextTreeSnapshot: { state: "ready", value: "stale" },
+      contextTreeSnapshot: { state: "ready", value: { snapshotStatus: "stale" } },
     };
   }
 
@@ -209,7 +209,7 @@ function previewFacts(role: PreviewRole, state: PreviewState): SetupFacts {
     },
     repositories: { state: "ready", value: 3 },
     capabilities: { state: "ready", value: PREVIEW_CAPABILITIES },
-    contextTreeSnapshot: { state: "ready", value: "active" },
+    contextTreeSnapshot: { state: "ready", value: { snapshotStatus: "active" } },
   };
 }
 


### PR DESCRIPTION
## Summary

- carry provider-specific Context Tree content availability into Settings Setup
- show private GitLab Web Context as a neutral coming-soon state instead of recoverable setup debt
- suppress the recovery chat and Settings attention dot only for `gitlab_authentication_required`, while preserving binding management and Automatic Review
- keep all other unavailable snapshot reasons on the existing recovery path

Follow-up to #2048, which introduced the same private GitLab state on the Context tab.

## Validation

- `pnpm --filter @first-tree/web exec vitest run src/pages/settings/__tests__/setup-dom.test.tsx src/pages/settings/__tests__/setup-attention.test.ts src/pages/__tests__/settings-panels-dom.test.tsx --maxWorkers=2` (84 tests passed)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/web/src/pages/settings.tsx packages/web/src/pages/settings/setup.tsx packages/web/src/pages/settings/setup-attention.ts packages/web/src/pages/settings/setup-context-tree-controls.tsx packages/web/src/pages/setup-preview.tsx packages/web/src/pages/settings/__tests__/setup-dom.test.tsx packages/web/src/pages/settings/__tests__/setup-attention.test.ts packages/web/src/pages/__tests__/settings-panels-dom.test.tsx`
- `git diff --check`

## QA

Deterministic Web behavior is covered by product tests. Formal QA was not run.
