### PR TITLE
fix(web): restore compact conversation rows

### DIFF
--- a/packages/web/src/components/ui/row-actions-menu.tsx
+++ b/packages/web/src/components/ui/row-actions-menu.tsx
@@ -98,7 +98,7 @@ export function RowActionsMenu({
       {open && (
         <div
           role="menu"
-          className="absolute right-0 z-30 rounded-[var(--radius-panel)] border bg-popover shadow-[var(--shadow-md)]"
+          className="absolute right-0 z-30 pointer-events-auto rounded-[var(--radius-panel)] border bg-popover shadow-[var(--shadow-md)]"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
           style={{

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -765,7 +765,7 @@ describe("ConversationList", () => {
     }
   });
 
-  it("separates row selection from its actions and keeps the kebab reachable on touch", async () => {
+  it("preserves the dense row layout while gating the hidden kebab hit target", async () => {
     const onSelectChat = vi.fn();
     const pinnedRow = row({
       chatId: "chat-pinned",
@@ -781,8 +781,9 @@ describe("ConversationList", () => {
     // Row selection is exposed to assistive tech (was tint + left bar only).
     expect(selectedRow.getAttribute("aria-current")).toBe("page");
     expect(rowButton(container, "Broken deploy").getAttribute("aria-current")).toBeNull();
-    expect(selectedRow.className).toContain("cursor-pointer");
-    expect(selectedRow.className).toContain("active:bg-[var(--bg-active)]");
+    expect(selectedRow.className).toContain("w-full");
+    expect(selectedRow.className).toContain("hover:bg-[var(--bg-hover)]");
+    expect(selectedRow.className).not.toContain("active:bg-[var(--bg-active)]");
     await click(selectedRow);
     expect(onSelectChat).toHaveBeenCalledWith("chat-pinned");
     // The row-actions kebab (the only Pin entry point) reveals on coarse (touch)
@@ -792,10 +793,10 @@ describe("ConversationList", () => {
     expect(kebab?.className).toContain("pointer-coarse:opacity-100");
     expect(kebab?.className).toContain("pointer-events-none");
     expect(kebab?.className).toContain("group-hover:pointer-events-auto");
-    // The main selector and action menu are sibling hit regions. The action no
-    // longer sits absolutely over the selector's right edge.
+    // Keep the pre-existing compact overlay layout: only the visible action
+    // trigger owns the trailing hit target.
     expect(kebab?.parentElement?.parentElement?.parentElement).toBe(selectedRow.parentElement);
-    expect(kebab?.parentElement?.parentElement?.className).not.toContain("absolute");
+    expect(kebab?.parentElement?.parentElement?.className).toContain("absolute");
     // ...and the trailing metadata cluster hides on coarse pointers so the
     // always-visible kebab never overlaps the row's time / status (R5).
     expect(container.querySelector('[class~="pointer-coarse:opacity-0"]')).not.toBeNull();

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -796,7 +796,12 @@ describe("ConversationList", () => {
     // Keep the pre-existing compact overlay layout: only the visible action
     // trigger owns the trailing hit target.
     expect(kebab?.parentElement?.parentElement?.parentElement).toBe(selectedRow.parentElement);
-    expect(kebab?.parentElement?.parentElement?.className).toContain("absolute");
+    const actionOverlay = kebab?.parentElement?.parentElement;
+    expect(actionOverlay?.className).toContain("absolute");
+    expect(actionOverlay?.className).toContain("pointer-events-none");
+    if (!kebab) throw new Error("Missing row action trigger");
+    await click(kebab);
+    expect(container.querySelector('[role="menu"]')?.className).toContain("pointer-events-auto");
     // ...and the trailing metadata cluster hides on coarse pointers so the
     // always-visible kebab never overlaps the row's time / status (R5).
     expect(container.querySelector('[class~="pointer-coarse:opacity-0"]')).not.toBeNull();

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -545,17 +545,7 @@ export function ConversationList({
                   // avatar corner mark, while the left bar remains the selected
                   // affordance only.
                   return (
-                    <div
-                      key={row.chatId}
-                      className="group flex items-center transition-colors hover:bg-[var(--bg-hover)]"
-                      style={{
-                        background: isSelected ? "var(--brand-bg)" : "transparent",
-                        // Left bar is the SELECTED affordance only (DESIGN.md:
-                        // selected = green left-rail + tint). Attention no longer
-                        // doubles up here; it reads from the avatar corner mark.
-                        borderLeft: `var(--hairline-bold) solid ${isSelected ? "var(--brand)" : "transparent"}`,
-                      }}
-                    >
+                    <div key={row.chatId} className="group relative">
                       <button
                         type="button"
                         onClick={() => onSelectChat(row.chatId)}
@@ -564,17 +554,21 @@ export function ConversationList({
                         // the New-chat button's `aria-current`.
                         aria-current={isSelected ? "page" : undefined}
                         className={cn(
-                          "min-w-0 flex-1 text-left cursor-pointer transition-colors flex items-center",
-                          "active:bg-[var(--bg-active)]",
+                          "w-full text-left transition-colors flex items-center",
+                          "hover:bg-[var(--bg-hover)]",
                         )}
                         style={{
                           // Single-line rows tuned for desktop-inbox density:
                           // tightened vertical padding (--sp-2) now that the
                           // preview subtitle line is gone, so more conversations
                           // fit per screen without reading as a dense wall.
-                          padding: "var(--sp-2) var(--sp-1) var(--sp-2) var(--sp-3)",
+                          padding: "var(--sp-2) var(--sp-3)",
                           gap: "var(--sp-2)",
-                          background: "transparent",
+                          background: isSelected ? "var(--brand-bg)" : "transparent",
+                          // Left bar is the SELECTED affordance only (DESIGN.md:
+                          // selected = green left-rail + tint). Attention no longer
+                          // doubles up here; it reads from the avatar corner mark.
+                          borderLeft: `var(--hairline-bold) solid ${isSelected ? "var(--brand)" : "transparent"}`,
                         }}
                       >
                         <ChatRowAvatar
@@ -622,9 +616,13 @@ export function ConversationList({
                           ) : null}
                         </span>
                       </button>
-                      {/* Keep the row action in its own hit target instead of
-                          absolutely overlaying the chat-selection button. */}
-                      <div className="shrink-0" style={{ padding: "0 var(--sp-3) 0 var(--sp-1)" }}>
+                      <div
+                        className="absolute"
+                        style={{
+                          top: "var(--sp-2)",
+                          right: "var(--sp-3)",
+                        }}
+                      >
                         <RowEngagementMenu
                           chatId={row.chatId}
                           status={row.engagementStatus}

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -617,7 +617,7 @@ export function ConversationList({
                         </span>
                       </button>
                       <div
-                        className="absolute"
+                        className="absolute pointer-events-none"
                         style={{
                           top: "var(--sp-2)",
                           right: "var(--sp-3)",


### PR DESCRIPTION
## Summary

- restore the conversation row to its pre-#2047 single-column, full-width layout
- restore the original padding, hover, selected, and cursor behavior
- keep the hidden row-action pointer-event guard and mark-read cache fixes from #2047
- update the DOM regression to protect the compact overlay layout and gated action hit target

## Why

The flex sibling layout introduced by #2047 permanently reserved a 28px action column in the narrow conversation rail. That reduced title space and changed hover, selected, and pressed states. The layout change is not required to prevent an invisible action trigger from intercepting row selection: the existing absolute action can stay visually unchanged while its transparent trigger remains `pointer-events: none` until it is visible.

## Verification

- Targeted Web regression suite: 48/48 passed
- Monorepo `check`: passed (pre-existing warnings only)
- Monorepo `typecheck`: 11/11 tasks passed
- Biome on changed files: passed
- Independent headed-browser verification:
  - compact single-column layout restored
  - first Pinned row remains selectable
  - visible row-action menu remains independently operable

## Scope

This PR only restores the row UI. Investigation of the separate first-Pinned-row production symptom will continue independently.
