### PR TITLE
fix(web): neutralize non-actionable GitLab Context states

### DIFF
--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -432,17 +432,21 @@ describe("ContextPage DOM behavior", () => {
     await act(async () => disconnected.root.unmount());
   });
 
-  it.each(["member", "admin"] as const)("shows the same private GitLab coming-soon state to %s users", async (role) => {
-    authMock.value = { organizationId: "org-1", role };
+  it.each([
+    "gitlab_authentication_required",
+    "gitlab_origin_not_authorized",
+    "gitlab_dns_unavailable",
+    "gitlab_address_not_authorized",
+    "gitlab_egress_denied",
+  ] as const)("shows the same neutral GitLab Web Context state for %s", async (reason) => {
     agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
-    const serverDetail =
-      "Private GitLab Context Tree content is unavailable in First Tree Cloud. Cloud only performs anonymous GitLab reads.";
-    const privateGitlab = snapshot({
+    const serverDetail = `Provider-specific diagnostic for ${reason}`;
+    const unavailableGitlab = snapshot({
       provider: "gitlab",
       contentAvailability: {
         status: "unavailable",
         accessMode: "anonymous",
-        reason: "gitlab_authentication_required",
+        reason,
       },
       repo: "https://oauth2:secret@gitlab.example/acme/private-context.git",
       branch: "main",
@@ -453,24 +457,27 @@ describe("ContextPage DOM behavior", () => {
         severity: "error",
       },
     });
-    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(privateGitlab);
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableGitlab);
 
     const { ContextPage } = await import("../context.js");
-    const { container, root } = await renderDom(<ContextPage />);
+    for (const role of ["member", "admin"] as const) {
+      authMock.value = { organizationId: "org-1", role };
+      const { container, root } = await renderDom(<ContextPage />);
 
-    await waitForText(container, "Private GitLab Context is coming soon");
-    expect(container.textContent).toContain(
-      "First Tree can’t display private GitLab Context Trees in the web app yet. Agents and Context Reviewer with repository access can continue using the tree as usual.",
-    );
-    expect(container.textContent).not.toContain(serverDetail);
-    expect(container.textContent).toContain(
-      "Repo: https://[redacted]@gitlab.example/acme/private-context.git · Branch: main",
-    );
-    expect(buttonByText(container, "Work on this in chat")).toBeNull();
-    expect(buttonByText(container, "Create an agent")).toBeNull();
-    expect(container.querySelector('[aria-label="Agent for the Context Tree chat"]')).toBeNull();
+      await waitForText(container, "GitLab Web Context isn’t available for this repository");
+      expect(container.textContent).toContain(
+        "First Tree can’t display this Context Tree in the web app. Agents and Context Reviewer with repository access can continue using it as usual.",
+      );
+      expect(container.textContent).not.toContain(serverDetail);
+      expect(container.textContent).toContain(
+        "Repo: https://[redacted]@gitlab.example/acme/private-context.git · Branch: main",
+      );
+      expect(buttonByText(container, "Work on this in chat")).toBeNull();
+      expect(buttonByText(container, "Create an agent")).toBeNull();
+      expect(container.querySelector('[aria-label="Agent for the Context Tree chat"]')).toBeNull();
+      await act(async () => root.unmount());
+    }
     expect(agentApiMocks.listManagedAgents).not.toHaveBeenCalled();
-    await act(async () => root.unmount());
   });
 
   it("keeps public GitLab snapshots on the live Context page", async () => {
@@ -494,10 +501,7 @@ describe("ContextPage DOM behavior", () => {
   });
 
   it.each([
-    ["gitlab_origin_not_authorized", "GitLab Web Context needs deployment authorization", "ALLOWED_ORIGINS"],
-    ["gitlab_dns_unavailable", "First Tree cannot resolve this GitLab address", "check DNS and network access"],
-    ["gitlab_address_not_authorized", "GitLab resolved to an unauthorized address", "trusted private CIDRs"],
-    ["gitlab_egress_denied", "GitLab Web Context failed a network safety check", "verify the origin and DNS"],
+    ["gitlab_redirect_forbidden", "GitLab repository redirect is not allowed", "never follows"],
     ["gitlab_repository_unavailable", "GitLab repository or branch is unavailable", "allow anonymous reads"],
   ] as const)("shows actionable GitLab recovery copy for %s", async (reason, title, recovery) => {
     const { ContextPage } = await import("../context.js");
@@ -534,7 +538,7 @@ describe("ContextPage DOM behavior", () => {
         contentAvailability: {
           status: "unavailable",
           accessMode: "anonymous",
-          reason: "gitlab_dns_unavailable",
+          reason: "gitlab_repository_unavailable",
         },
         repo: "https://gitlab.example/acme/context-tree.git",
         branch: "main",
@@ -551,7 +555,7 @@ describe("ContextPage DOM behavior", () => {
     const { container, root } = await renderDom(<ContextPage />);
 
     await waitForText(container, "Work on this in chat");
-    expect(container.textContent).toContain("First Tree cannot resolve this GitLab address");
+    expect(container.textContent).toContain("GitLab repository or branch is unavailable");
     expect(container.textContent).toContain("Provider-specific diagnostic");
     expect(agentApiMocks.listManagedAgents).toHaveBeenCalled();
     await act(async () => root.unmount());

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -531,7 +531,13 @@ describe("settings panels", () => {
     await act(async () => admin.root.unmount());
   });
 
-  it("does not mark private GitLab Web Context as admin setup attention", async () => {
+  it.each([
+    "gitlab_authentication_required",
+    "gitlab_origin_not_authorized",
+    "gitlab_dns_unavailable",
+    "gitlab_address_not_authorized",
+    "gitlab_egress_denied",
+  ] as const)("does not mark non-actionable GitLab Web Context as admin setup attention for %s", async (reason) => {
     const { SettingsLayout } = await import("../settings.js");
     const capabilities = teamSetupCapabilities();
     capabilities.contextTree.binding = {
@@ -547,14 +553,14 @@ describe("settings panels", () => {
       contentAvailability: {
         status: "unavailable",
         accessMode: "anonymous",
-        reason: "gitlab_authentication_required",
+        reason,
       },
     });
 
     const admin = await renderDom(<SettingsLayout />, "/settings/account");
     await waitForCondition(
       () => contextApiMocks.getContextTreeSnapshot.mock.calls.length === 1,
-      "Expected the private GitLab Context Tree snapshot to load",
+      "Expected the non-actionable GitLab Context Tree snapshot to load",
     );
 
     expect(admin.container.querySelector("[data-setup-attention]")).toBeNull();

--- a/packages/web/src/pages/context-tree-availability.ts
+++ b/packages/web/src/pages/context-tree-availability.ts
@@ -1,0 +1,31 @@
+import type { ContextTreeContentAvailability, ContextTreeSnapshot } from "@first-tree/shared";
+
+export type ContextTreeSnapshotAvailability = Pick<
+  ContextTreeSnapshot,
+  "snapshotStatus" | "provider" | "contentAvailability"
+>;
+
+type ContextTreeUnavailableReason = Extract<ContextTreeContentAvailability, { status: "unavailable" }>["reason"];
+
+const TEAM_NON_ACTIONABLE_GITLAB_REASONS = new Set<ContextTreeUnavailableReason>([
+  "gitlab_authentication_required",
+  "gitlab_origin_not_authorized",
+  "gitlab_dns_unavailable",
+  "gitlab_address_not_authorized",
+  "gitlab_egress_denied",
+]);
+
+export const GITLAB_WEB_CONTEXT_UNAVAILABLE_TITLE = "GitLab Web Context isn’t available for this repository";
+
+export const GITLAB_WEB_CONTEXT_UNAVAILABLE_DETAIL =
+  "First Tree can’t display this Context Tree in the web app. Agents and Context Reviewer with repository access can continue using it as usual.";
+
+export function isTeamNonActionableGitlabWebContext(
+  snapshot: ContextTreeSnapshotAvailability | null | undefined,
+): boolean {
+  return (
+    snapshot?.provider === "gitlab" &&
+    snapshot.contentAvailability?.status === "unavailable" &&
+    TEAM_NON_ACTIONABLE_GITLAB_REASONS.has(snapshot.contentAvailability.reason)
+  );
+}

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -16,6 +16,11 @@ import { resolveAvatarHue } from "../components/chat/chat-row-avatar.js";
 import { Identicon } from "../components/identicon.js";
 import { PageHeader } from "../components/ui/page-header.js";
 import { Panel, PanelBody } from "../components/ui/panel.js";
+import {
+  GITLAB_WEB_CONTEXT_UNAVAILABLE_DETAIL,
+  GITLAB_WEB_CONTEXT_UNAVAILABLE_TITLE,
+  isTeamNonActionableGitlabWebContext,
+} from "./context-tree-availability.js";
 import { ContextTreeBuildEntry } from "./context-tree-build-entry.js";
 import { ContextSectionTabs } from "./docs/context-section-tabs.js";
 
@@ -646,11 +651,15 @@ function UnavailableState({
       : null;
   const unavailableGitlabContent = gitlabContentAvailability !== null;
   const gitlabUnavailableReason = gitlabContentAvailability?.reason ?? null;
-  const privateGitlabContextUnavailable =
-    snapshot.provider === "gitlab" &&
-    snapshot.contentAvailability?.status === "unavailable" &&
-    snapshot.contentAvailability.reason === "gitlab_authentication_required";
-  const gitlabCopy = gitlabUnavailableReason ? gitlabUnavailableCopy(gitlabUnavailableReason) : null;
+  const teamNonActionableGitlabWebContext = isTeamNonActionableGitlabWebContext(snapshot);
+  const gitlabCopy = teamNonActionableGitlabWebContext
+    ? {
+        title: GITLAB_WEB_CONTEXT_UNAVAILABLE_TITLE,
+        detail: GITLAB_WEB_CONTEXT_UNAVAILABLE_DETAIL,
+      }
+    : gitlabUnavailableReason
+      ? gitlabUnavailableCopy(gitlabUnavailableReason)
+      : null;
   const title = snapshot.repo
     ? unavailableGitlabContent
       ? (gitlabCopy?.title ?? "GitLab content is unavailable in Cloud")
@@ -668,7 +677,7 @@ function UnavailableState({
     : isAdmin
       ? "Your agent can build it with you in a chat. Share a local project folder or GitHub repository URL there."
       : "Ask an admin to set up your team's Context Tree.";
-  const syncDetail = privateGitlabContextUnavailable ? null : snapshot.contextStatus.detail;
+  const syncDetail = teamNonActionableGitlabWebContext ? null : snapshot.contextStatus.detail;
   const repoLabel = snapshot.repo ? redactRepoForDisplay(snapshot.repo) : null;
   return (
     <Panel>
@@ -686,9 +695,9 @@ function UnavailableState({
               </div>
             ) : null}
             {/* Recoverable admin-facing unavailable states continue in the
-                chat-first setup flow. Private GitLab is a product capability
-                gap, so the same coming-soon state is shown to every role. */}
-            {canOpenChat && !privateGitlabContextUnavailable ? (
+                chat-first setup flow. GitLab auth and operator-owned egress
+                failures are not Team setup debt. */}
+            {canOpenChat && !teamNonActionableGitlabWebContext ? (
               <div style={{ marginTop: "var(--sp-3)" }}>
                 <ContextTreeBuildEntry intent={snapshot.repo ? "recover" : "build"} />
               </div>
@@ -709,36 +718,6 @@ function UnavailableState({
 
 function gitlabUnavailableCopy(reason: string): { title: string; detail: string } {
   switch (reason) {
-    case "gitlab_authentication_required":
-      return {
-        title: "Private GitLab Context is coming soon",
-        detail:
-          "First Tree can’t display private GitLab Context Trees in the web app yet. Agents and Context Reviewer with repository access can continue using the tree as usual.",
-      };
-    case "gitlab_origin_not_authorized":
-      return {
-        title: "GitLab Web Context needs deployment authorization",
-        detail:
-          "This GitLab origin is not enabled for Web Context. Ask the deployment administrator to add its exact public origin, or its private origin with trusted CIDRs, to FIRST_TREE_GITLAB_ALLOWED_ORIGINS. Your GitLab Webhook connection remains active.",
-      };
-    case "gitlab_dns_unavailable":
-      return {
-        title: "First Tree cannot resolve this GitLab address",
-        detail:
-          "The Server could not resolve the GitLab hostname. Ask the deployment administrator to check DNS and network access from First Tree. Your GitLab Webhook connection remains active.",
-      };
-    case "gitlab_address_not_authorized":
-      return {
-        title: "GitLab resolved to an unauthorized address",
-        detail:
-          "The hostname resolved outside its authorized public or CIDR policy. Ask the deployment administrator to verify DNS and add trusted private CIDRs when needed. Your GitLab Webhook connection remains active.",
-      };
-    case "gitlab_egress_denied":
-      return {
-        title: "GitLab Web Context failed a network safety check",
-        detail:
-          "First Tree stopped the anonymous read because the destination changed or failed its egress policy. Ask the deployment administrator to verify the origin and DNS. Webhook automation remains independent.",
-      };
     case "gitlab_redirect_forbidden":
       return {
         title: "GitLab repository redirect is not allowed",

--- a/packages/web/src/pages/settings/__tests__/setup-attention.test.ts
+++ b/packages/web/src/pages/settings/__tests__/setup-attention.test.ts
@@ -133,20 +133,28 @@ describe("Setup navigation attention", () => {
     expect(contextTreeSnapshotNeedsAttention({ snapshotStatus: "unavailable" }, "member")).toBe(false);
     expect(contextTreeSnapshotNeedsAttention({ snapshotStatus: "stale" }, "admin")).toBe(false);
     expect(contextTreeSnapshotNeedsAttention({ snapshotStatus: "active" }, "admin")).toBe(false);
-    expect(
-      contextTreeSnapshotNeedsAttention(
-        {
-          snapshotStatus: "unavailable",
-          provider: "gitlab",
-          contentAvailability: {
-            status: "unavailable",
-            accessMode: "anonymous",
-            reason: "gitlab_authentication_required",
+    for (const reason of [
+      "gitlab_authentication_required",
+      "gitlab_origin_not_authorized",
+      "gitlab_dns_unavailable",
+      "gitlab_address_not_authorized",
+      "gitlab_egress_denied",
+    ] as const) {
+      expect(
+        contextTreeSnapshotNeedsAttention(
+          {
+            snapshotStatus: "unavailable",
+            provider: "gitlab",
+            contentAvailability: {
+              status: "unavailable",
+              accessMode: "anonymous",
+              reason,
+            },
           },
-        },
-        "admin",
-      ),
-    ).toBe(false);
+          "admin",
+        ),
+      ).toBe(false);
+    }
     expect(contextTreeSnapshotNeedsAttention(undefined, "admin")).toBe(false);
   });
 

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -658,7 +658,13 @@ describe("Settings Setup overview", () => {
     expect(row.action?.label).toBe(action);
   });
 
-  it("keeps private GitLab Web Context neutral and role-consistent", () => {
+  it.each([
+    "gitlab_authentication_required",
+    "gitlab_origin_not_authorized",
+    "gitlab_dns_unavailable",
+    "gitlab_address_not_authorized",
+    "gitlab_egress_denied",
+  ] as const)("keeps non-actionable GitLab Web Context neutral and role-consistent for %s", (reason) => {
     const capabilities = capabilityFixture({
       binding: {
         state: "bound",
@@ -673,7 +679,7 @@ describe("Settings Setup overview", () => {
       contentAvailability: {
         status: "unavailable",
         accessMode: "anonymous",
-        reason: "gitlab_authentication_required",
+        reason,
       },
     } as const;
     const admin = rowFor(
@@ -693,8 +699,8 @@ describe("Settings Setup overview", () => {
     );
 
     for (const row of [admin, member]) {
-      expect(row.status).toMatchObject({ label: "Coming soon", kind: "neutral" });
-      expect(row.status.detail).toContain("First Tree can’t display private GitLab Context Trees");
+      expect(row.status).toMatchObject({ label: "Web Context unavailable", kind: "neutral" });
+      expect(row.status.detail).toContain("First Tree can’t display this Context Tree in the web app");
       expect(row.status.detail).toContain("Agents and Context Reviewer");
       expect(row.status.detail).not.toContain("recover");
     }
@@ -1288,7 +1294,7 @@ describe("Settings Setup overview", () => {
     await act(async () => view.root.unmount());
   });
 
-  it("suppresses private GitLab recovery chat while keeping independent review controls", async () => {
+  it("suppresses non-actionable GitLab recovery chat while keeping independent review controls", async () => {
     setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(
       capabilityFixture({
         binding: {
@@ -1305,23 +1311,23 @@ describe("Settings Setup overview", () => {
       contentAvailability: {
         status: "unavailable",
         accessMode: "anonymous",
-        reason: "gitlab_authentication_required",
+        reason: "gitlab_origin_not_authorized",
       },
       contextStatus: {
         severity: "error",
         label: "Team context unavailable",
-        detail: "Private GitLab server diagnostic",
+        detail: "GitLab deployment allowlist diagnostic",
       },
     });
 
     const view = await renderSettingsSetupPage();
-    const row = await waitForRowText(view.host, "context-tree", "Coming soon");
+    const row = await waitForRowText(view.host, "context-tree", "Web Context unavailable");
     const manage = [...row.querySelectorAll<HTMLButtonElement>("button")].find(
       (button) => button.textContent === "Manage",
     );
 
     expect(row.textContent).not.toContain("Needs recovery");
-    expect(row.textContent).not.toContain("Private GitLab server diagnostic");
+    expect(row.textContent).not.toContain("GitLab deployment allowlist diagnostic");
     await act(async () => manage?.click());
     const controls = await waitForSelector<HTMLElement>(row, '[data-setup-owner-controls="context-tree"]');
     expect(controls.textContent).toContain("Open Context");

--- a/packages/web/src/pages/settings/setup-attention.ts
+++ b/packages/web/src/pages/settings/setup-attention.ts
@@ -1,9 +1,8 @@
-import type { ContextTreeSnapshot, SetupBlocker, TeamSetupCapabilities } from "@first-tree/shared";
-
-export type ContextTreeSnapshotAvailability = Pick<
-  ContextTreeSnapshot,
-  "snapshotStatus" | "provider" | "contentAvailability"
->;
+import type { SetupBlocker, TeamSetupCapabilities } from "@first-tree/shared";
+import {
+  type ContextTreeSnapshotAvailability,
+  isTeamNonActionableGitlabWebContext,
+} from "../context-tree-availability.js";
 
 function hasAdminOwnedBlocker(blockers: SetupBlocker[]): boolean {
   return blockers.some((blocker) => blocker.resolutionOwner === "admin");
@@ -39,16 +38,8 @@ export function contextTreeSnapshotNeedsAttention(
   snapshot: ContextTreeSnapshotAvailability | null | undefined,
   role: string | null,
 ): boolean {
-  return role === "admin" && snapshot?.snapshotStatus === "unavailable" && !isPrivateGitlabContextUnavailable(snapshot);
-}
-
-export function isPrivateGitlabContextUnavailable(
-  snapshot: ContextTreeSnapshotAvailability | null | undefined,
-): boolean {
   return (
-    snapshot?.provider === "gitlab" &&
-    snapshot.contentAvailability?.status === "unavailable" &&
-    snapshot.contentAvailability.reason === "gitlab_authentication_required"
+    role === "admin" && snapshot?.snapshotStatus === "unavailable" && !isTeamNonActionableGitlabWebContext(snapshot)
   );
 }
 

--- a/packages/web/src/pages/settings/setup-context-tree-controls.tsx
+++ b/packages/web/src/pages/settings/setup-context-tree-controls.tsx
@@ -15,7 +15,7 @@ type ContextTreeAvailability = "active" | "stale" | "unavailable" | "checking" |
 export function SetupContextTreeControls({
   binding,
   availability,
-  privateGitlabContextUnavailable = false,
+  teamNonActionableGitlabWebContext = false,
   loadSetting = getRawContextTreeSetting,
   saveSetting = putContextTreeSetting,
   refreshFacts,
@@ -23,7 +23,7 @@ export function SetupContextTreeControls({
 }: {
   binding: SetupContextTreeBinding;
   availability: ContextTreeAvailability;
-  privateGitlabContextUnavailable?: boolean;
+  teamNonActionableGitlabWebContext?: boolean;
   loadSetting?: (organizationId: string) => Promise<OrgContextTreeOutput>;
   saveSetting?: (organizationId: string, input: OrgContextTreeInput) => Promise<OrgContextTreeOutput>;
   refreshFacts?: (organizationId: string) => Promise<void>;
@@ -88,7 +88,8 @@ export function SetupContextTreeControls({
   const hasBoundTree = binding.state === "bound";
   const chatIntent = hasBoundTree ? "recover" : "build";
   const shouldOfferChat =
-    binding.state === "unbound" || (hasBoundTree && availability === "unavailable" && !privateGitlabContextUnavailable);
+    binding.state === "unbound" ||
+    (hasBoundTree && availability === "unavailable" && !teamNonActionableGitlabWebContext);
   const bindingSummary = savedBinding?.repo
     ? `${repositoryLabel(savedBinding.repo)} · ${savedBinding.branch ?? "main"} branch · ${
         savedBinding.provider ?? "provider pending"

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -37,9 +37,12 @@ import { getTeamSetupCapabilitiesAt, setupCapabilitiesQueryKey } from "../../api
 import { useAuth } from "../../auth/auth-context.js";
 import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { cn } from "../../lib/utils.js";
+import {
+  GITLAB_WEB_CONTEXT_UNAVAILABLE_DETAIL,
+  isTeamNonActionableGitlabWebContext,
+} from "../context-tree-availability.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { ContextEnablement } from "./context-enablement.js";
-import { isPrivateGitlabContextUnavailable } from "./setup-attention.js";
 import { SetupContextTreeControls } from "./setup-context-tree-controls.js";
 import { SetupReviewerControls } from "./setup-reviewer-controls.js";
 
@@ -54,7 +57,7 @@ type Fact<T> =
 type ContextTreeFact = {
   binding: SetupContextTreeBinding;
   availability: "active" | "stale" | "unavailable" | "checking" | "unknown" | null;
-  privateGitlabContextUnavailable: boolean;
+  teamNonActionableGitlabWebContext: boolean;
 };
 
 type ContextTreeSnapshotFact = Pick<ContextTreeSnapshot, "snapshotStatus" | "provider" | "contentAvailability">;
@@ -117,19 +120,19 @@ function contextTreeFact(
   if (binding.state !== "bound") {
     return {
       state: "ready",
-      value: { binding, availability: null, privateGitlabContextUnavailable: false },
+      value: { binding, availability: null, teamNonActionableGitlabWebContext: false },
     };
   }
   if (snapshot.state === "loading") {
     return {
       state: "ready",
-      value: { binding, availability: "checking", privateGitlabContextUnavailable: false },
+      value: { binding, availability: "checking", teamNonActionableGitlabWebContext: false },
     };
   }
   if (snapshot.state === "error") {
     return {
       state: "ready",
-      value: { binding, availability: "unknown", privateGitlabContextUnavailable: false },
+      value: { binding, availability: "unknown", teamNonActionableGitlabWebContext: false },
     };
   }
   return {
@@ -137,7 +140,7 @@ function contextTreeFact(
     value: {
       binding,
       availability: snapshot.value?.snapshotStatus ?? "unknown",
-      privateGitlabContextUnavailable: isPrivateGitlabContextUnavailable(snapshot.value),
+      teamNonActionableGitlabWebContext: isTeamNonActionableGitlabWebContext(snapshot.value),
     },
   };
 }
@@ -355,7 +358,7 @@ function contextTreeStatus(
   if (contextTree.state === "loading") return loadingStatus();
   if (contextTree.state === "error") return unknownStatus();
 
-  const { binding, availability, privateGitlabContextUnavailable } = contextTree.value;
+  const { binding, availability, teamNonActionableGitlabWebContext } = contextTree.value;
   if (binding.state === "unbound") {
     return {
       label: "Not set up",
@@ -380,10 +383,10 @@ function contextTreeStatus(
   ].join(" · ");
   const issueDetail = blockerDetail(blockers, isAdmin);
   const detail = [bindingDetail, issueDetail].filter((item): item is string => Boolean(item)).join(" · ");
-  if (privateGitlabContextUnavailable) {
+  if (teamNonActionableGitlabWebContext) {
     return {
-      label: "Coming soon",
-      detail: `${bindingDetail} · First Tree can’t display private GitLab Context Trees in the web app yet. Agents and Context Reviewer with repository access can continue using the tree as usual.`,
+      label: "Web Context unavailable",
+      detail: `${bindingDetail} · ${GITLAB_WEB_CONTEXT_UNAVAILABLE_DETAIL}`,
       kind: "neutral",
     };
   }
@@ -404,7 +407,7 @@ function contextTreeStatus(
 
 function contextTreeAction(contextTree: Fact<ContextTreeFact>, isAdmin: boolean): SetupRowModel["action"] | undefined {
   if (contextTree.state !== "ready") return undefined;
-  const { binding, availability, privateGitlabContextUnavailable } = contextTree.value;
+  const { binding, availability, teamNonActionableGitlabWebContext } = contextTree.value;
   if (binding.state === "unbound") {
     return isAdmin
       ? { label: "Set up", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
@@ -415,7 +418,7 @@ function contextTreeAction(contextTree: Fact<ContextTreeFact>, isAdmin: boolean)
       ? { label: "Repair", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
       : { label: "View", to: "/context" };
   }
-  if (privateGitlabContextUnavailable) {
+  if (teamNonActionableGitlabWebContext) {
     return isAdmin
       ? { label: "Manage", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
       : { label: "View", to: "/context" };
@@ -823,7 +826,7 @@ export function SettingsSetupPage() {
                     key={`context-tree-${organizationId}`}
                     binding={contextTree.value.binding}
                     availability={contextTree.value.availability}
-                    privateGitlabContextUnavailable={contextTree.value.privateGitlabContextUnavailable}
+                    teamNonActionableGitlabWebContext={contextTree.value.teamNonActionableGitlabWebContext}
                   >
                     {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ? (
                       <SetupReviewerControls


### PR DESCRIPTION
## Summary

- classify GitLab authentication and operator-owned egress failures as one Team-non-actionable Web Context state
- show the same neutral, role-consistent copy in Context and Settings
- suppress recovery chat, agent selection, Setup attention, and raw deployment diagnostics for those states
- preserve recovery behavior for invalid bindings, sync failures, forbidden redirects, and unavailable repositories

## Why

PR #2050 handled private GitLab authentication, but self-managed GitLab commonly fails earlier at the deployment allowlist, DNS, address policy, or egress boundary. Team users cannot resolve those operator-owned conditions, so presenting them as Team setup debt gives them an action that cannot succeed.

`FIRST_TREE_GITLAB_ALLOWED_ORIGINS` remains an operator security control; this change only removes it from the Team-facing recovery path.

## Validation

- `pnpm --filter @first-tree/web exec vitest run src/pages/__tests__/context-page-dom.test.tsx src/pages/settings/__tests__/setup-dom.test.tsx src/pages/settings/__tests__/setup-attention.test.ts src/pages/__tests__/settings-panels-dom.test.tsx --maxWorkers=2` (113 tests)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check` on all changed files
- `git diff --check`

No full-suite or formal QA run.
