### PR TITLE
fix(cli): enforce single daemon owner per home

### DIFF
--- a/apps/cli/src/__tests__/cli-command-actions-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-actions-extra.test.ts
@@ -14,6 +14,7 @@ const statusBlockMocks = vi.hoisted(() => ({
   renderAgentsBlock: vi.fn(),
   renderAuthBlock: vi.fn(),
   renderCliVersionBlock: vi.fn(),
+  renderDaemonRuntimeOwnerBlock: vi.fn(),
   renderHubBlock: vi.fn(),
   renderServiceBlock: vi.fn(),
 }));
@@ -49,12 +50,14 @@ describe("CLI command action coverage", () => {
     await command(root, "status").parseAsync([], { from: "user" });
     expect(statusBlockMocks.renderCliVersionBlock).toHaveBeenCalled();
     expect(statusBlockMocks.renderServiceBlock).toHaveBeenCalledTimes(1);
+    expect(statusBlockMocks.renderDaemonRuntimeOwnerBlock).toHaveBeenCalledTimes(1);
     expect(statusBlockMocks.renderHubBlock).toHaveBeenCalledTimes(1);
     expect(statusBlockMocks.renderAuthBlock).toHaveBeenCalledTimes(1);
     expect(statusBlockMocks.renderAgentsBlock).toHaveBeenCalled();
 
     await command(daemon, "status").parseAsync([], { from: "user" });
     expect(statusBlockMocks.renderServiceBlock).toHaveBeenCalledTimes(2);
+    expect(statusBlockMocks.renderDaemonRuntimeOwnerBlock).toHaveBeenCalledTimes(2);
     expect(printMocks.line.mock.calls.map((call) => String(call[0])).join("")).toContain("\n");
 
     const results = [{ label: "Node", ok: true, detail: "v24" }];

--- a/apps/cli/src/__tests__/cli-helper-surfaces-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-helper-surfaces-extra.test.ts
@@ -10,6 +10,7 @@ const doctorCoreMocks = vi.hoisted(() => ({
   checkAgentConfigs: vi.fn(),
   checkBackgroundService: vi.fn(),
   checkClientConfig: vi.fn(),
+  checkDaemonRuntimeOwnership: vi.fn(),
   checkNodeVersion: vi.fn(),
   checkServerReachable: vi.fn(),
   checkWebSocket: vi.fn(),
@@ -77,6 +78,7 @@ beforeEach(() => {
   doctorCoreMocks.checkAgentConfigs.mockReturnValue({ label: "Agents", ok: true, detail: "local" });
   doctorCoreMocks.checkBackgroundService.mockReturnValue({ label: "Service", ok: true, detail: "running" });
   doctorCoreMocks.checkClientConfig.mockReturnValue({ label: "Config", ok: true, detail: "ok" });
+  doctorCoreMocks.checkDaemonRuntimeOwnership.mockReturnValue({ label: "Owner", ok: true, detail: "pid 123" });
   doctorCoreMocks.checkNodeVersion.mockReturnValue({ label: "Node", ok: true, detail: "v24" });
   doctorCoreMocks.checkServerReachable.mockResolvedValue({ label: "Server", ok: true, detail: "ok" });
   doctorCoreMocks.checkWebSocket.mockResolvedValue({ label: "WebSocket", ok: true, detail: "ok" });
@@ -155,6 +157,7 @@ describe("doctor checks and agent resolver", () => {
       { label: "Agents", ok: true, detail: "reconciled" },
       { label: "WebSocket", ok: true, detail: "ok" },
       { label: "Service", ok: true, detail: "running" },
+      { label: "Owner", ok: true, detail: "pid 123" },
       { label: "codex", ok: true, detail: "ok — bundled" },
     ]);
     expect(configMocks.resetConfig).toHaveBeenCalled();

--- a/apps/cli/src/__tests__/command-registration-smoke.test.ts
+++ b/apps/cli/src/__tests__/command-registration-smoke.test.ts
@@ -102,6 +102,7 @@ describe("CLI command registration", () => {
       "install-codex",
       "probe",
       "refresh-unit",
+      "repair-ownership",
       "restart",
       "start",
       "status",

--- a/apps/cli/src/__tests__/daemon-refresh-unit.test.ts
+++ b/apps/cli/src/__tests__/daemon-refresh-unit.test.ts
@@ -50,6 +50,7 @@ describe("daemon namespace — hidden service-maintenance subcommands", () => {
       "install-claude",
       "install-codex",
       "probe",
+      "repair-ownership",
       "restart",
       "start",
       "status",

--- a/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
+++ b/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
@@ -68,6 +68,10 @@ function recoveryGuardPath(home: string): string {
   return `${daemonRuntimeOwnershipPath(home)}.recovery`;
 }
 
+function recoveryFencePath(home: string): string {
+  return `${daemonRuntimeOwnershipPath(home)}.recovery-fence`;
+}
+
 function writeRecoveryGuard(
   home: string,
   guard: {
@@ -98,7 +102,7 @@ function waitForChildMessage(child: ChildProcessWithoutNullStreams): () => Promi
     const message = queued.shift();
     if (message) return Promise.resolve(message);
     return new Promise<ChildMessage>((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error("timed out waiting for daemon owner child")), 10_000);
+      const timeout = setTimeout(() => reject(new Error("timed out waiting for daemon owner child")), 30_000);
       waiting.push((next) => {
         clearTimeout(timeout);
         resolve(next);
@@ -116,7 +120,7 @@ function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number | nu
 }
 
 async function waitForFile(path: string): Promise<void> {
-  const deadline = Date.now() + 10_000;
+  const deadline = Date.now() + 30_000;
   while (!existsSync(path)) {
     if (Date.now() >= deadline) throw new Error(`timed out waiting for ${path}`);
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -337,6 +341,29 @@ describe("daemon runtime ownership", () => {
     });
   });
 
+  it("never auto-recovers an abandoned main-mutation fence", () => {
+    const home = join(root, "abandoned-recovery-fence");
+    const fencePath = recoveryFencePath(home);
+    const fence = {
+      lockVersion: 1,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:recovery-fence",
+      startedAt: new Date().toISOString(),
+    };
+    mkdirSync(dirname(fencePath), { recursive: true });
+    writeFileSync(fencePath, `${JSON.stringify(fence, null, 2)}\n`, "utf8");
+
+    expect(() => acquireDaemonRuntimeOwnership({ channel: "dev", mode: "foreground", version: "test", home })).toThrow(
+      /recovery fence .* requires manual remediation/u,
+    );
+    expect(JSON.parse(readFileSync(fencePath, "utf8"))).toEqual(fence);
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+      state: "untrusted",
+      reason: expect.stringContaining("requires manual remediation"),
+    });
+  });
+
   it("treats a live reused pid with a different start identity as stale", () => {
     const home = join(root, "pid-reuse");
     const original = acquire(home);
@@ -496,20 +523,18 @@ describe("daemon runtime ownership", () => {
       await waitForFile(join(barrierDir, "p1.guard-before-rename.ready"));
 
       const p2 = await spawnContender("p2");
-      await waitForFile(join(barrierDir, "p2.owner-before-rename.ready"));
-
       releaseBarrier(barrierDir, "p1", "guard-before-rename");
       await waitForFile(join(barrierDir, "p1.guard-after-rename.ready"));
 
       const p3 = await spawnContender("p3");
-      await waitForFile(join(barrierDir, "p3.owner-before-rename.ready"));
+      const p3Result = await p3.next();
+      expect(p3Result.event).toBe("rejected");
 
       releaseBarrier(barrierDir, "p1", "guard-after-rename");
       const p1Result = await p1.next();
+      await waitForFile(join(barrierDir, "p2.owner-before-rename.ready"));
       releaseBarrier(barrierDir, "p2", "owner-before-rename");
       const p2Result = await p2.next();
-      releaseBarrier(barrierDir, "p3", "owner-before-rename");
-      const p3Result = await p3.next();
       const results = [p1Result, p2Result, p3Result];
       const winners = results.filter((result) => result.event === "acquired");
 
@@ -522,10 +547,93 @@ describe("daemon runtime ownership", () => {
       expect(exits.filter((code) => code === 0)).toHaveLength(1);
       expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "absent" });
       expect(existsSync(recoveryGuardPath(home))).toBe(false);
+      expect(existsSync(recoveryFencePath(home))).toBe(false);
+      expect(readdirSync(dirname(original.lockPath)).some((name) => name.includes(".entrant."))).toBe(false);
     } finally {
       for (const child of children) {
         if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
       }
     }
-  });
+  }, 45_000);
+
+  it("fences the five-role handoff before a returned lease can be displaced", async () => {
+    const home = join(root, "five-role-recovery");
+    const barrierDir = join(root, "five-role-barriers");
+    mkdirSync(barrierDir, { recursive: true });
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:five-role-owner",
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+    writeRecoveryGuard(home, {
+      lockVersion: 1,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:five-role-guard",
+      startedAt: new Date().toISOString(),
+    });
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-race-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const children: ChildProcessWithoutNullStreams[] = [];
+    const spawnRole = async (role: "s" | "r" | "a" | "t" | "n") => {
+      const child = spawn(process.execPath, ["--import", "tsx", fixture, home, role, barrierDir], {
+        cwd: cliRoot,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      children.push(child);
+      const next = waitForChildMessage(child);
+      expect((await next()).event).toBe("ready");
+      child.stdin.write("go\n");
+      return { child, next };
+    };
+
+    try {
+      const s = await spawnRole("s");
+      await waitForFile(join(barrierDir, "s.guard-before-rename.ready"));
+
+      const r = await spawnRole("r");
+      releaseBarrier(barrierDir, "s", "guard-before-rename");
+      await waitForFile(join(barrierDir, "s.guard-after-rename.ready"));
+
+      const a = await spawnRole("a");
+      const aResult = await a.next();
+      expect(aResult.event).toBe("rejected");
+
+      releaseBarrier(barrierDir, "s", "guard-after-rename");
+      expect((await s.next()).event).toBe("rejected");
+      await waitForFile(join(barrierDir, "r.owner-before-rename.ready"));
+
+      const t = await spawnRole("t");
+      expect((await t.next()).event).toBe("rejected");
+
+      const n = await spawnRole("n");
+      const nResult = await n.next();
+      expect(nResult.event).toBe("rejected");
+
+      releaseBarrier(barrierDir, "r", "owner-before-rename");
+      await waitForFile(join(barrierDir, "r.owner-after-rename.ready"));
+      releaseBarrier(barrierDir, "r", "owner-after-rename");
+      const rResult = await r.next();
+      expect(rResult.event).toBe("acquired");
+      expect(r.child.exitCode).toBeNull();
+      expect([aResult, rResult, nResult].filter((result) => result.event === "acquired")).toHaveLength(1);
+
+      r.child.stdin.write("release\n");
+      const exits = await Promise.all(children.map((child) => waitForExit(child)));
+      expect(exits.filter((code) => code === 0)).toHaveLength(1);
+      expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "absent" });
+      expect(existsSync(recoveryGuardPath(home))).toBe(false);
+      expect(existsSync(recoveryFencePath(home))).toBe(false);
+      expect(readdirSync(dirname(original.lockPath)).some((name) => name.includes(".entrant."))).toBe(false);
+    } finally {
+      for (const child of children) {
+        if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      }
+    }
+  }, 45_000);
 });

--- a/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
+++ b/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
@@ -115,6 +115,18 @@ function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number | nu
   });
 }
 
+async function waitForFile(path: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${path}`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function releaseBarrier(barrierDir: string, role: string, name: string): void {
+  writeFileSync(join(barrierDir, `${role}.${name}.go`), "\n", "utf8");
+}
+
 describe("daemon runtime ownership", () => {
   it("records the authoritative owner fields and releases only its own instance", () => {
     const home = join(root, "home");
@@ -441,5 +453,79 @@ describe("daemon runtime ownership", () => {
       state: "absent",
     });
     expect(stateFiles.some((name) => name.includes(".recovery.stale."))).toBe(true);
+  });
+
+  it("keeps a three-contender stale-guard race to one exact owner", async () => {
+    const home = join(root, "three-contender-recovery");
+    const barrierDir = join(root, "barriers");
+    mkdirSync(barrierDir, { recursive: true });
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:three-contender-owner",
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+    writeRecoveryGuard(home, {
+      lockVersion: 1,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:three-contender-guard",
+      startedAt: new Date().toISOString(),
+    });
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-race-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const children: ChildProcessWithoutNullStreams[] = [];
+    const spawnContender = async (role: "p1" | "p2" | "p3") => {
+      const child = spawn(process.execPath, ["--import", "tsx", fixture, home, role, barrierDir], {
+        cwd: cliRoot,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      children.push(child);
+      const next = waitForChildMessage(child);
+      expect((await next()).event).toBe("ready");
+      child.stdin.write("go\n");
+      return { child, next };
+    };
+
+    try {
+      const p1 = await spawnContender("p1");
+      await waitForFile(join(barrierDir, "p1.guard-before-rename.ready"));
+
+      const p2 = await spawnContender("p2");
+      await waitForFile(join(barrierDir, "p2.owner-before-rename.ready"));
+
+      releaseBarrier(barrierDir, "p1", "guard-before-rename");
+      await waitForFile(join(barrierDir, "p1.guard-after-rename.ready"));
+
+      const p3 = await spawnContender("p3");
+      await waitForFile(join(barrierDir, "p3.owner-before-rename.ready"));
+
+      releaseBarrier(barrierDir, "p1", "guard-after-rename");
+      const p1Result = await p1.next();
+      releaseBarrier(barrierDir, "p2", "owner-before-rename");
+      const p2Result = await p2.next();
+      releaseBarrier(barrierDir, "p3", "owner-before-rename");
+      const p3Result = await p3.next();
+      const results = [p1Result, p2Result, p3Result];
+      const winners = results.filter((result) => result.event === "acquired");
+
+      expect(results.every((result) => result.event === "acquired" || result.event === "rejected")).toBe(true);
+      expect(winners, JSON.stringify(results, null, 2)).toHaveLength(1);
+      const winnerIndex = results.findIndex((result) => result.event === "acquired");
+      children[winnerIndex]?.stdin.write("release\n");
+
+      const exits = await Promise.all(children.map((child) => waitForExit(child)));
+      expect(exits.filter((code) => code === 0)).toHaveLength(1);
+      expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "absent" });
+      expect(existsSync(recoveryGuardPath(home))).toBe(false);
+    } finally {
+      for (const child of children) {
+        if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      }
+    }
   });
 });

--- a/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
+++ b/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
   existsSync,
+  linkSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -31,7 +32,7 @@ import {
 } from "../core/daemon-runtime-ownership.js";
 
 type ChildMessage = {
-  event: "ready" | "acquired" | "recovery-guard-created" | "rejected" | "error";
+  event: "ready" | "acquired" | "recovery-guard-created" | "repaired" | "no-repair" | "rejected" | "error";
   pid: number;
   mode?: "foreground" | "service";
   message?: string;
@@ -381,6 +382,42 @@ describe("daemon runtime ownership", () => {
     });
   });
 
+  it("classifies live, PID-reused, and malformed fences before repair", () => {
+    const liveHome = join(root, "repair-live-fence");
+    const liveProbe = acquire(liveHome);
+    expect(liveProbe.release()).toBe(true);
+    writeGuard(recoveryFencePath(liveHome), {
+      lockVersion: 1,
+      instanceId: randomUUID(),
+      pid: liveProbe.owner.pid,
+      processStartIdentity: liveProbe.owner.processStartIdentity,
+      startedAt: new Date().toISOString(),
+    });
+    expect(() => repairDaemonRuntimeOwnership(liveHome)).toThrow(/fence .* is live/u);
+    expect(existsSync(recoveryFencePath(liveHome))).toBe(true);
+
+    const reusedHome = join(root, "repair-reused-fence-pid");
+    writeGuard(recoveryFencePath(reusedHome), {
+      lockVersion: 1,
+      instanceId: randomUUID(),
+      pid: process.pid,
+      processStartIdentity: "test-reused-pid:older-repair",
+      startedAt: new Date().toISOString(),
+    });
+    expect(repairDaemonRuntimeOwnership(reusedHome)).toMatchObject({
+      repaired: true,
+      reconciledState: "empty",
+    });
+    expect(existsSync(recoveryFencePath(reusedHome))).toBe(false);
+
+    const malformedHome = join(root, "repair-malformed-fence");
+    const malformedPath = recoveryFencePath(malformedHome);
+    mkdirSync(dirname(malformedPath), { recursive: true });
+    writeFileSync(malformedPath, "{ not-complete", "utf8");
+    expect(() => repairDaemonRuntimeOwnership(malformedHome)).toThrow(/fence cannot be trusted: invalid JSON/u);
+    expect(readFileSync(malformedPath, "utf8")).toBe("{ not-complete");
+  });
+
   it.each([
     "canonical-old",
     "quarantined-old",
@@ -466,7 +503,7 @@ describe("daemon runtime ownership", () => {
     };
     expect(probe.release()).toBe(true);
     rewriteOwner(`${lockPath}.stale.one.${first.instanceId}.${fence.instanceId}`, first);
-    rewriteOwner(`${lockPath}.stale.two.${second.instanceId}.${fence.instanceId}`, second);
+    rewriteOwner(`${lockPath}.stale.historical.${second.instanceId}`, second);
     writeGuard(recoveryFencePath(home), fence);
     writeRecoveryGuard(home, fence);
 
@@ -474,6 +511,171 @@ describe("daemon runtime ownership", () => {
     expect(existsSync(recoveryFencePath(home))).toBe(true);
     expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "untrusted" });
   });
+
+  it("does not prove safe-empty while an unrelated owner candidate is live or untrusted", () => {
+    const liveHome = join(root, "repair-unrelated-live");
+    const probe = acquire(liveHome);
+    expect(probe.release()).toBe(true);
+    const liveCandidatePath = `${probe.lockPath}.stale.historical.${probe.owner.instanceId}`;
+    rewriteOwner(liveCandidatePath, probe.owner);
+    const liveFence = {
+      lockVersion: 1 as const,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:repair-unrelated-live-fence",
+      startedAt: new Date().toISOString(),
+    };
+    writeGuard(recoveryFencePath(liveHome), liveFence);
+
+    const restored = repairDaemonRuntimeOwnership(liveHome);
+    expect(restored).toMatchObject({
+      repaired: true,
+      reconciledState: "owner",
+      restoredFrom: liveCandidatePath,
+    });
+    expect(parseOwner(probe.lockPath)).toEqual(probe.owner);
+
+    const untrustedHome = join(root, "repair-unrelated-untrusted");
+    const untrustedLockPath = daemonRuntimeOwnershipPath(untrustedHome);
+    const untrustedCandidatePath = `${untrustedLockPath}.stale.historical.untrusted`;
+    mkdirSync(dirname(untrustedLockPath), { recursive: true });
+    writeFileSync(untrustedCandidatePath, "{ not-an-owner", "utf8");
+    writeGuard(recoveryFencePath(untrustedHome), {
+      ...liveFence,
+      instanceId: randomUUID(),
+      processStartIdentity: "test-dead-process:repair-unrelated-untrusted-fence",
+    });
+
+    expect(() => repairDaemonRuntimeOwnership(untrustedHome)).toThrow(/quarantine candidate .* is untrusted/u);
+    expect(existsSync(recoveryFencePath(untrustedHome))).toBe(true);
+  });
+
+  it("deduplicates hard-link aliases of one quarantine candidate by instance and inode", () => {
+    const home = join(root, "repair-hard-link-alias");
+    const lockPath = daemonRuntimeOwnershipPath(home);
+    const probe = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...probe.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:repair-hard-link-alias-owner",
+    };
+    const fence = {
+      lockVersion: 1 as const,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:repair-hard-link-alias-fence",
+      startedAt: new Date().toISOString(),
+    };
+    expect(probe.release()).toBe(true);
+    const firstPath = `${lockPath}.stale.one.${staleOwner.instanceId}.${fence.instanceId}`;
+    const aliasPath = `${lockPath}.stale.alias.${staleOwner.instanceId}.${fence.instanceId}`;
+    rewriteOwner(firstPath, staleOwner);
+    linkSync(firstPath, aliasPath);
+    writeGuard(recoveryFencePath(home), fence);
+    writeRecoveryGuard(home, fence);
+
+    const repaired = repairDaemonRuntimeOwnership(home);
+    expect(repaired).toMatchObject({ repaired: true, reconciledState: "owner" });
+    expect(parseOwner(lockPath)).toEqual(staleOwner);
+    expect(existsSync(recoveryFencePath(home))).toBe(false);
+  });
+
+  it("preserves a live canonical owner while clearing an exact stale fence", () => {
+    const home = join(root, "repair-live-canonical");
+    const live = acquire(home);
+    const fence = {
+      lockVersion: 1 as const,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:repair-live-canonical-fence",
+      startedAt: new Date().toISOString(),
+    };
+    writeGuard(recoveryFencePath(home), fence);
+
+    const repaired = repairDaemonRuntimeOwnership(home);
+    expect(repaired).toMatchObject({ repaired: true, reconciledState: "owner" });
+    expect(existsSync(recoveryFencePath(home))).toBe(false);
+    expect(parseOwner(live.lockPath).instanceId).toBe(live.owner.instanceId);
+    expect(live.release()).toBe(true);
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "absent" });
+  });
+
+  it.each([
+    {
+      role: "repair-crash-after-guard",
+      barrier: "repair-after-guard",
+      expectedRepaired: true,
+    },
+    {
+      role: "repair-crash-before-fence-remove",
+      barrier: "repair-before-fence-remove",
+      expectedRepaired: true,
+    },
+    {
+      role: "repair-crash-after-fence-remove",
+      barrier: "repair-after-fence-remove",
+      expectedRepaired: false,
+    },
+  ] as const)("continues an interrupted repair after $role without reopening main mutation", async ({
+    role,
+    barrier,
+    expectedRepaired,
+  }) => {
+    const home = join(root, role);
+    const barrierDir = join(root, `${role}-barriers`);
+    mkdirSync(barrierDir, { recursive: true });
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: `test-dead-process:${role}-owner`,
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+    const fence = {
+      lockVersion: 1 as const,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: `test-dead-process:${role}-fence`,
+      startedAt: new Date().toISOString(),
+    };
+    writeGuard(recoveryFencePath(home), fence);
+    writeRecoveryGuard(home, fence);
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-race-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const crashed = spawn(process.execPath, ["--import", "tsx", fixture, home, role, barrierDir], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const next = waitForChildMessage(crashed);
+
+    try {
+      expect((await next()).event).toBe("ready");
+      crashed.stdin.write("go\n");
+      await waitForFile(join(barrierDir, `${role}.${barrier}.ready`));
+      if (role === "repair-crash-after-fence-remove") expect(existsSync(recoveryFencePath(home))).toBe(false);
+      else expect(existsSync(recoveryFencePath(home))).toBe(true);
+
+      crashed.kill("SIGKILL");
+      expect(await waitForExit(crashed)).toBeNull();
+      const continued = repairDaemonRuntimeOwnership(home);
+      expect(continued.repaired).toBe(expectedRepaired);
+      expect(existsSync(recoveryFencePath(home))).toBe(false);
+      expect(existsSync(`${original.lockPath}.repair`)).toBe(false);
+      expect(parseOwner(original.lockPath)).toEqual(staleOwner);
+      const stateFiles = readdirSync(dirname(original.lockPath));
+      expect(stateFiles.some((name) => name.includes(".repair-slot."))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".repair-ticket."))).toBe(false);
+
+      const recovered = acquire(home, "dev", "service");
+      expect(recovered.owner.instanceId).not.toBe(staleOwner.instanceId);
+    } finally {
+      if (crashed.exitCode === null && crashed.signalCode === null) crashed.kill("SIGKILL");
+    }
+  }, 45_000);
 
   it("orders simultaneous ownership repairs through per-instance tickets", async () => {
     const home = join(root, "repair-concurrent");
@@ -686,9 +888,9 @@ describe("daemon runtime ownership", () => {
       await waitForFile(join(barrierDir, "e.entrant-before-publish.ready"));
       const prePublishFiles = readdirSync(dirname(original.lockPath));
       expect(prePublishFiles.some((name) => name.startsWith(`${basename(original.lockPath)}.entrant.`))).toBe(false);
-      expect(prePublishFiles.some((name) => name.startsWith(`${basename(original.lockPath)}.entrant-temp.`))).toBe(
-        true,
-      );
+      expect(
+        prePublishFiles.some((name) => name.startsWith(`${basename(original.lockPath)}.publish-temp.entrant.`)),
+      ).toBe(true);
 
       expect((await nextRecovery()).event).toBe("ready");
       recovery.stdin.write("go\n");
@@ -707,7 +909,7 @@ describe("daemon runtime ownership", () => {
       expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "absent" });
       expect(existsSync(recoveryFencePath(home))).toBe(false);
       expect(stateFiles.some((name) => name.includes(".entrant."))).toBe(false);
-      expect(stateFiles.some((name) => name.includes(".entrant-temp."))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".publish-temp.entrant."))).toBe(false);
     } finally {
       if (entrant.exitCode === null && entrant.signalCode === null) entrant.kill("SIGKILL");
       if (recovery.exitCode === null && recovery.signalCode === null) recovery.kill("SIGKILL");
@@ -754,11 +956,156 @@ describe("daemon runtime ownership", () => {
       const stateFiles = readdirSync(dirname(original.lockPath));
       expect(existsSync(recoveryFencePath(home))).toBe(false);
       expect(stateFiles.some((name) => name.includes(".entrant."))).toBe(false);
-      expect(stateFiles.some((name) => name.includes(".entrant-temp."))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".publish-temp.entrant."))).toBe(false);
     } finally {
       if (crashed.exitCode === null && crashed.signalCode === null) crashed.kill("SIGKILL");
     }
   });
+
+  it.each(
+    (["main", "recovery", "fence", "entrant"] as const).flatMap((kind) =>
+      (["open", "before", "after"] as const).map((phase) => ({ kind, phase })),
+    ),
+  )("never exposes a partial canonical $kind record after a kill at $phase", async ({ kind, phase }) => {
+    const home = join(root, `canonical-publication-${kind}-${phase}`);
+    const barrierDir = join(root, `canonical-publication-${kind}-${phase}-barriers`);
+    mkdirSync(barrierDir, { recursive: true });
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: `test-dead-process:canonical-publication-${kind}-${phase}`,
+    };
+    expect(original.release()).toBe(true);
+    if (kind !== "main") rewriteOwner(original.lockPath, staleOwner);
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-race-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const role = `publish-${kind}-${phase}`;
+    const barrier =
+      phase === "open"
+        ? `${kind}-temp-after-open`
+        : phase === "before"
+          ? `${kind}-before-publish`
+          : `${kind}-after-publish`;
+    const crashed = spawn(process.execPath, ["--import", "tsx", fixture, home, role, barrierDir], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const next = waitForChildMessage(crashed);
+
+    try {
+      expect((await next()).event).toBe("ready");
+      crashed.stdin.write("go\n");
+      await waitForFile(join(barrierDir, `${role}.${barrier}.ready`));
+
+      const canonicalPath =
+        kind === "main"
+          ? original.lockPath
+          : kind === "recovery"
+            ? recoveryGuardPath(home)
+            : kind === "fence"
+              ? recoveryFencePath(home)
+              : undefined;
+      if (phase === "open" || phase === "before") {
+        if (canonicalPath) expect(existsSync(canonicalPath)).toBe(false);
+        else {
+          expect(
+            readdirSync(dirname(original.lockPath)).some((name) =>
+              name.startsWith(`${basename(original.lockPath)}.entrant.`),
+            ),
+          ).toBe(false);
+        }
+        const publicationTemps = readdirSync(dirname(original.lockPath)).filter((name) =>
+          name.includes(`.publish-temp.${kind}.`),
+        );
+        expect(publicationTemps).toHaveLength(1);
+        const tempContents = readFileSync(join(dirname(original.lockPath), publicationTemps[0] ?? ""), "utf8");
+        if (phase === "open") expect(tempContents).toBe("");
+        else expect(() => JSON.parse(tempContents)).not.toThrow();
+      } else if (canonicalPath) {
+        expect(() => JSON.parse(readFileSync(canonicalPath, "utf8"))).not.toThrow();
+      } else {
+        const entrant = readdirSync(dirname(original.lockPath)).find((name) =>
+          name.startsWith(`${basename(original.lockPath)}.entrant.`),
+        );
+        expect(entrant).toBeTruthy();
+        expect(() => JSON.parse(readFileSync(join(dirname(original.lockPath), entrant ?? ""), "utf8"))).not.toThrow();
+      }
+
+      crashed.kill("SIGKILL");
+      expect(await waitForExit(crashed)).toBeNull();
+      if (kind === "fence" && phase === "after") {
+        expect(repairDaemonRuntimeOwnership(home)).toMatchObject({ repaired: true, reconciledState: "owner" });
+      }
+      const recovered = acquire(home, "dev", "service");
+      expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+        state: "live",
+        owner: { instanceId: recovered.owner.instanceId },
+      });
+      expect(recovered.release()).toBe(true);
+      expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "absent" });
+      if (phase !== "open") {
+        expect(readdirSync(dirname(original.lockPath)).some((name) => name.includes(`.publish-temp.${kind}.`))).toBe(
+          false,
+        );
+      }
+    } finally {
+      if (crashed.exitCode === null && crashed.signalCode === null) crashed.kill("SIGKILL");
+    }
+  }, 45_000);
+
+  it.each(
+    (["repair-slot", "repair-ticket", "repair-guard"] as const).flatMap((kind) =>
+      (["before", "after"] as const).map((phase) => ({ kind, phase })),
+    ),
+  )("cleans a stale $kind publication temp after a kill $phase publish", async ({ kind, phase }) => {
+    const home = join(root, `repair-publication-${kind}-${phase}`);
+    const barrierDir = join(root, `repair-publication-${kind}-${phase}-barriers`);
+    mkdirSync(barrierDir, { recursive: true });
+    const fence = {
+      lockVersion: 1 as const,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: `test-dead-process:repair-publication-${kind}-${phase}`,
+      startedAt: new Date().toISOString(),
+    };
+    writeGuard(recoveryFencePath(home), fence);
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-race-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const role = `publish-${kind}-${phase}`;
+    const barrier = `${kind}-${phase === "before" ? "before" : "after"}-publish`;
+    const crashed = spawn(process.execPath, ["--import", "tsx", fixture, home, role, barrierDir], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const next = waitForChildMessage(crashed);
+
+    try {
+      expect((await next()).event).toBe("ready");
+      crashed.stdin.write("go\n");
+      await waitForFile(join(barrierDir, `${role}.${barrier}.ready`));
+      expect(
+        readdirSync(dirname(daemonRuntimeOwnershipPath(home))).some((name) => name.includes(`.publish-temp.${kind}.`)),
+      ).toBe(true);
+
+      crashed.kill("SIGKILL");
+      expect(await waitForExit(crashed)).toBeNull();
+      expect(repairDaemonRuntimeOwnership(home)).toMatchObject({
+        repaired: true,
+        reconciledState: "empty",
+      });
+      const stateFiles = readdirSync(dirname(daemonRuntimeOwnershipPath(home)));
+      expect(stateFiles.some((name) => name.includes(".publish-temp."))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".repair-slot."))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".repair-ticket."))).toBe(false);
+      expect(stateFiles.some((name) => name === `${basename(daemonRuntimeOwnershipPath(home))}.repair`)).toBe(false);
+    } finally {
+      if (crashed.exitCode === null && crashed.signalCode === null) crashed.kill("SIGKILL");
+    }
+  }, 45_000);
 
   it("keeps a three-contender stale-guard race to one exact owner", async () => {
     const home = join(root, "three-contender-recovery");

--- a/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
+++ b/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
@@ -1,7 +1,16 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
@@ -18,7 +27,7 @@ import {
 } from "../core/daemon-runtime-ownership.js";
 
 type ChildMessage = {
-  event: "ready" | "acquired" | "rejected" | "error";
+  event: "ready" | "acquired" | "recovery-guard-created" | "rejected" | "error";
   pid: number;
   mode?: "foreground" | "service";
   message?: string;
@@ -55,6 +64,26 @@ function parseOwner(lockPath: string): DaemonRuntimeOwner {
   return JSON.parse(readFileSync(lockPath, "utf8")) as DaemonRuntimeOwner;
 }
 
+function recoveryGuardPath(home: string): string {
+  return `${daemonRuntimeOwnershipPath(home)}.recovery`;
+}
+
+function writeRecoveryGuard(
+  home: string,
+  guard: {
+    lockVersion: 1;
+    instanceId: string;
+    pid: number;
+    processStartIdentity: string;
+    startedAt: string;
+  },
+): string {
+  const path = recoveryGuardPath(home);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(guard, null, 2)}\n`, "utf8");
+  return path;
+}
+
 function waitForChildMessage(child: ChildProcessWithoutNullStreams): () => Promise<ChildMessage> {
   const queued: ChildMessage[] = [];
   const waiting: Array<(message: ChildMessage) => void> = [];
@@ -79,7 +108,7 @@ function waitForChildMessage(child: ChildProcessWithoutNullStreams): () => Promi
 }
 
 function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number | null> {
-  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(child.exitCode);
   return new Promise((resolve, reject) => {
     child.once("error", reject);
     child.once("exit", (code) => resolve(code));
@@ -175,7 +204,7 @@ describe("daemon runtime ownership", () => {
     const first = acquire(home);
     expect(first.release()).toBe(true);
     expect(first.release()).toBe(false);
-    expect(inspectDaemonRuntimeOwnership(home).state).toBe("absent");
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "absent" });
 
     const second = acquire(home, "dev", "service");
     expect(second.owner.instanceId).not.toBe(first.owner.instanceId);
@@ -200,6 +229,99 @@ describe("daemon runtime ownership", () => {
     expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
       state: "live",
       owner: { instanceId: recovered.owner.instanceId },
+    });
+  });
+
+  it("keeps a live recovery guard fail-closed with holder diagnostics", () => {
+    const home = join(root, "live-recovery");
+    const probe = acquire(home);
+    expect(probe.release()).toBe(true);
+    const recoveryPath = writeRecoveryGuard(home, {
+      lockVersion: 1,
+      instanceId: probe.owner.instanceId,
+      pid: probe.owner.pid,
+      processStartIdentity: probe.owner.processStartIdentity,
+      startedAt: probe.owner.startedAt,
+    });
+
+    try {
+      acquireDaemonRuntimeOwnership({ channel: "dev", mode: "foreground", version: "test", home });
+      throw new Error("expected live recovery guard rejection");
+    } catch (error) {
+      expect(isDaemonRuntimeOwnershipError(error)).toBe(true);
+      if (!isDaemonRuntimeOwnershipError(error)) return;
+      expect(error.code).toBe(DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy);
+      expect(error.message).toContain(`pid ${process.pid}`);
+      expect(error.message).toContain(recoveryPath);
+    }
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+      state: "untrusted",
+      reason: expect.stringContaining("recovery is in progress"),
+    });
+  });
+
+  it("recovers a guard abandoned by a process crash before stale-owner cleanup", async () => {
+    const home = join(root, "crashed-recovery");
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:recovery-owner",
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const crashed = spawn(process.execPath, ["--import", "tsx", fixture, home, "seed-recovery"], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const next = waitForChildMessage(crashed);
+
+    try {
+      expect((await next()).event).toBe("ready");
+      crashed.stdin.write("go\n");
+      const created = await next();
+      expect(created.event).toBe("recovery-guard-created");
+      crashed.kill("SIGKILL");
+      expect(await waitForExit(crashed)).toBeNull();
+
+      expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+        state: "untrusted",
+        reason: expect.stringContaining("is abandoned"),
+      });
+
+      const recovered = acquire(home, "dev", "service");
+      expect(recovered.quarantinedRecoveryGuardPath).toBeTruthy();
+      expect(existsSync(recovered.quarantinedRecoveryGuardPath ?? "")).toBe(true);
+      expect(JSON.parse(readFileSync(recovered.quarantinedRecoveryGuardPath ?? "", "utf8"))).toMatchObject({
+        pid: created.pid,
+      });
+      expect(recovered.quarantinedLockPath).toBeTruthy();
+      expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+        state: "live",
+        owner: { instanceId: recovered.owner.instanceId },
+      });
+    } finally {
+      if (crashed.exitCode === null && crashed.signalCode === null) crashed.kill("SIGKILL");
+    }
+  });
+
+  it("fails closed without changing a corrupted recovery guard", () => {
+    const home = join(root, "corrupt-recovery");
+    const recoveryPath = recoveryGuardPath(home);
+    mkdirSync(dirname(recoveryPath), { recursive: true });
+    writeFileSync(recoveryPath, "{ definitely-not-json", "utf8");
+
+    expect(() => acquireDaemonRuntimeOwnership({ channel: "dev", mode: "foreground", version: "test", home })).toThrow(
+      /recovery guard .* cannot be trusted: invalid JSON/u,
+    );
+    expect(readFileSync(recoveryPath, "utf8")).toBe("{ definitely-not-json");
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+      state: "untrusted",
+      reason: expect.stringContaining("recovery guard"),
     });
   });
 
@@ -265,5 +387,59 @@ describe("daemon runtime ownership", () => {
     expect(winnerExit).toBe(0);
     expect(loserExit).toBe(2);
     expect(inspectDaemonRuntimeOwnership(home).state).toBe("absent");
+  });
+
+  it("isolates one stale recovery guard under concurrent acquisition without admitting two owners", async () => {
+    const home = join(root, "concurrent-recovery");
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:concurrent-recovery",
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+    writeRecoveryGuard(home, {
+      lockVersion: 1,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:recovery-guard",
+      startedAt: new Date().toISOString(),
+    });
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const first = spawn(process.execPath, ["--import", "tsx", fixture, home, "service"], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const second = spawn(process.execPath, ["--import", "tsx", fixture, home, "foreground"], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const nextFirst = waitForChildMessage(first);
+    const nextSecond = waitForChildMessage(second);
+
+    expect((await nextFirst()).event).toBe("ready");
+    expect((await nextSecond()).event).toBe("ready");
+    first.stdin.write("go\n");
+    second.stdin.write("go\n");
+
+    const results = await Promise.all([nextFirst(), nextSecond()]);
+    expect(results.map((result) => result.event).sort()).toEqual(["acquired", "rejected"]);
+    const winner = results[0]?.event === "acquired" ? first : second;
+    const loser = winner === first ? second : first;
+    winner.stdin.write("release\n");
+
+    const [winnerExit, loserExit] = await Promise.all([waitForExit(winner), waitForExit(loser)]);
+    expect(winnerExit).toBe(0);
+    expect(loserExit).toBe(2);
+    const finalInspection = inspectDaemonRuntimeOwnership(home);
+    const stateFiles = readdirSync(dirname(original.lockPath));
+    expect(finalInspection, JSON.stringify({ finalInspection, stateFiles }, null, 2)).toMatchObject({
+      state: "absent",
+    });
+    expect(stateFiles.some((name) => name.includes(".recovery.stale."))).toBe(true);
   });
 });

--- a/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
+++ b/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
@@ -1,0 +1,269 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  acquireDaemonRuntimeOwnership,
+  DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES,
+  type DaemonRuntimeOwner,
+  type DaemonRuntimeOwnershipLease,
+  daemonRuntimeOwnershipPath,
+  inspectDaemonRuntimeOwnership,
+  isDaemonRuntimeOwnershipError,
+} from "../core/daemon-runtime-ownership.js";
+
+type ChildMessage = {
+  event: "ready" | "acquired" | "rejected" | "error";
+  pid: number;
+  mode?: "foreground" | "service";
+  message?: string;
+};
+
+let root: string;
+const leases: DaemonRuntimeOwnershipLease[] = [];
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ft-daemon-owner-"));
+});
+
+afterEach(() => {
+  for (const lease of leases.splice(0)) lease.release();
+  rmSync(root, { recursive: true, force: true });
+});
+
+function acquire(
+  home: string,
+  channel: "dev" | "staging" | "prod" = "dev",
+  mode: "foreground" | "service" = "foreground",
+): DaemonRuntimeOwnershipLease {
+  const lease = acquireDaemonRuntimeOwnership({ channel, mode, version: "0.0.0-test", home });
+  leases.push(lease);
+  return lease;
+}
+
+function rewriteOwner(lockPath: string, owner: DaemonRuntimeOwner): void {
+  mkdirSync(dirname(lockPath), { recursive: true });
+  writeFileSync(lockPath, `${JSON.stringify(owner, null, 2)}\n`, "utf8");
+}
+
+function parseOwner(lockPath: string): DaemonRuntimeOwner {
+  return JSON.parse(readFileSync(lockPath, "utf8")) as DaemonRuntimeOwner;
+}
+
+function waitForChildMessage(child: ChildProcessWithoutNullStreams): () => Promise<ChildMessage> {
+  const queued: ChildMessage[] = [];
+  const waiting: Array<(message: ChildMessage) => void> = [];
+  const lines = createInterface({ input: child.stdout });
+  lines.on("line", (line) => {
+    const message = JSON.parse(line) as ChildMessage;
+    const resolve = waiting.shift();
+    if (resolve) resolve(message);
+    else queued.push(message);
+  });
+  return () => {
+    const message = queued.shift();
+    if (message) return Promise.resolve(message);
+    return new Promise<ChildMessage>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("timed out waiting for daemon owner child")), 10_000);
+      waiting.push((next) => {
+        clearTimeout(timeout);
+        resolve(next);
+      });
+    });
+  };
+}
+
+function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number | null> {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code) => resolve(code));
+  });
+}
+
+describe("daemon runtime ownership", () => {
+  it("records the authoritative owner fields and releases only its own instance", () => {
+    const home = join(root, "home");
+    const lease = acquire(home, "staging", "service");
+    const owner = parseOwner(lease.lockPath);
+
+    expect(owner).toMatchObject({
+      lockVersion: 1,
+      instanceId: lease.owner.instanceId,
+      pid: process.pid,
+      processStartIdentity: expect.stringMatching(/:/u),
+      channel: "staging",
+      mode: "service",
+      version: "0.0.0-test",
+      home: realpathSync(home),
+    });
+    expect(Date.parse(owner.startedAt)).not.toBeNaN();
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "live", owner });
+
+    rewriteOwner(lease.lockPath, { ...owner, instanceId: randomUUID() });
+    expect(lease.release()).toBe(false);
+    expect(existsSync(lease.lockPath)).toBe(true);
+  });
+
+  it("lets the prod, staging, and dev default-home shapes run in parallel", () => {
+    const prod = acquire(join(root, ".first-tree"), "prod");
+    const staging = acquire(join(root, ".first-tree-staging"), "staging");
+    const dev = acquire(join(root, ".first-tree-dev"), "dev");
+
+    expect(new Set([prod.lockPath, staging.lockPath, dev.lockPath]).size).toBe(3);
+    expect([prod, staging, dev].map((lease) => inspectDaemonRuntimeOwnership(lease.owner.home).state)).toEqual([
+      "live",
+      "live",
+      "live",
+    ]);
+  });
+
+  it("rejects foreground/service competition for the same resolved home with holder diagnostics", () => {
+    const home = join(root, "shared");
+    const service = acquire(home, "prod", "service");
+
+    try {
+      acquireDaemonRuntimeOwnership({ channel: "prod", mode: "foreground", version: "next", home });
+      throw new Error("expected ownership collision");
+    } catch (error) {
+      expect(isDaemonRuntimeOwnershipError(error)).toBe(true);
+      if (!isDaemonRuntimeOwnershipError(error)) return;
+      expect(error.code).toBe(DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.alreadyRunning);
+      expect(error.owner).toEqual(service.owner);
+      expect(error.message).toContain(`pid ${process.pid}`);
+      expect(error.message).toContain("channel prod");
+      expect(error.message).toContain("mode service");
+    }
+  });
+
+  it("rejects different channels that explicitly share one home", () => {
+    const home = join(root, "shared-channel-home");
+    acquire(home, "dev");
+
+    expect(() =>
+      acquireDaemonRuntimeOwnership({ channel: "staging", mode: "service", version: "0.0.0-test", home }),
+    ).toThrow(/already held.*channel dev/u);
+  });
+
+  it("collapses lexical aliases onto the same resolved home key", () => {
+    const home = join(root, "resolved");
+    mkdirSync(join(root, "placeholder"), { recursive: true });
+    const alias = join(root, "placeholder", "..", "resolved");
+    acquire(home, "dev");
+
+    expect(() =>
+      acquireDaemonRuntimeOwnership({ channel: "dev", mode: "service", version: "0.0.0-test", home: alias }),
+    ).toThrow(/already held/u);
+  });
+
+  it("allows multiple dev runtimes when their explicit homes differ", () => {
+    const first = acquire(join(root, "dev-a"), "dev");
+    const second = acquire(join(root, "dev-b"), "dev");
+
+    expect(first.lockPath).not.toBe(second.lockPath);
+    expect(inspectDaemonRuntimeOwnership(first.owner.home).state).toBe("live");
+    expect(inspectDaemonRuntimeOwnership(second.owner.home).state).toBe("live");
+  });
+
+  it("releases normally so a later owner can acquire the same home", () => {
+    const home = join(root, "release");
+    const first = acquire(home);
+    expect(first.release()).toBe(true);
+    expect(first.release()).toBe(false);
+    expect(inspectDaemonRuntimeOwnership(home).state).toBe("absent");
+
+    const second = acquire(home, "dev", "service");
+    expect(second.owner.instanceId).not.toBe(first.owner.instanceId);
+  });
+
+  it("quarantines a crash-stale lock and retries acquisition exactly once", () => {
+    const home = join(root, "crash");
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:1",
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+
+    const recovered = acquire(home, "dev", "service");
+    expect(recovered.quarantinedLockPath).toBeTruthy();
+    expect(existsSync(recovered.quarantinedLockPath ?? "")).toBe(true);
+    expect(parseOwner(recovered.quarantinedLockPath ?? "")).toEqual(staleOwner);
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+      state: "live",
+      owner: { instanceId: recovered.owner.instanceId },
+    });
+  });
+
+  it("treats a live reused pid with a different start identity as stale", () => {
+    const home = join(root, "pid-reuse");
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      processStartIdentity: "test-reused-pid:older-process",
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+      state: "stale",
+      reason: expect.stringContaining("pid"),
+    });
+    const recovered = acquire(home);
+    expect(recovered.quarantinedLockPath).toBeTruthy();
+  });
+
+  it("fails closed without changing a corrupted lock", () => {
+    const home = join(root, "corrupt");
+    const lockPath = daemonRuntimeOwnershipPath(home);
+    mkdirSync(dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, "{ definitely-not-json", "utf8");
+
+    expect(() => acquireDaemonRuntimeOwnership({ channel: "dev", mode: "foreground", version: "test", home })).toThrow(
+      /cannot be trusted: invalid JSON/u,
+    );
+    expect(readFileSync(lockPath, "utf8")).toBe("{ definitely-not-json");
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "untrusted" });
+  });
+
+  it("allows only one concurrent process to enter runtime ownership for a shared home", async () => {
+    const home = join(root, "concurrent");
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const first = spawn(process.execPath, ["--import", "tsx", fixture, home, "service"], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const second = spawn(process.execPath, ["--import", "tsx", fixture, home, "foreground"], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const nextFirst = waitForChildMessage(first);
+    const nextSecond = waitForChildMessage(second);
+
+    expect((await nextFirst()).event).toBe("ready");
+    expect((await nextSecond()).event).toBe("ready");
+    first.stdin.write("go\n");
+    second.stdin.write("go\n");
+
+    const results = await Promise.all([nextFirst(), nextSecond()]);
+    expect(results.map((result) => result.event).sort()).toEqual(["acquired", "rejected"]);
+    const winner = results[0]?.event === "acquired" ? first : second;
+    const loser = winner === first ? second : first;
+    winner.stdin.write("release\n");
+
+    const [winnerExit, loserExit] = await Promise.all([waitForExit(winner), waitForExit(loser)]);
+    expect(winnerExit).toBe(0);
+    expect(loserExit).toBe(2);
+    expect(inspectDaemonRuntimeOwnership(home).state).toBe("absent");
+  });
+});

--- a/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
+++ b/apps/cli/src/__tests__/daemon-runtime-ownership.test.ts
@@ -8,11 +8,12 @@ import {
   readdirSync,
   readFileSync,
   realpathSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -22,8 +23,11 @@ import {
   type DaemonRuntimeOwner,
   type DaemonRuntimeOwnershipLease,
   daemonRuntimeOwnershipPath,
+  formatDaemonRuntimeRecoveryEvidence,
   inspectDaemonRuntimeOwnership,
+  inspectDaemonRuntimeRecoveryEvidence,
   isDaemonRuntimeOwnershipError,
+  repairDaemonRuntimeOwnership,
 } from "../core/daemon-runtime-ownership.js";
 
 type ChildMessage = {
@@ -83,9 +87,22 @@ function writeRecoveryGuard(
   },
 ): string {
   const path = recoveryGuardPath(home);
+  writeGuard(path, guard);
+  return path;
+}
+
+function writeGuard(
+  path: string,
+  guard: {
+    lockVersion: 1;
+    instanceId: string;
+    pid: number;
+    processStartIdentity: string;
+    startedAt: string;
+  },
+): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${JSON.stringify(guard, null, 2)}\n`, "utf8");
-  return path;
 }
 
 function waitForChildMessage(child: ChildProcessWithoutNullStreams): () => Promise<ChildMessage> {
@@ -355,14 +372,168 @@ describe("daemon runtime ownership", () => {
     writeFileSync(fencePath, `${JSON.stringify(fence, null, 2)}\n`, "utf8");
 
     expect(() => acquireDaemonRuntimeOwnership({ channel: "dev", mode: "foreground", version: "test", home })).toThrow(
-      /recovery fence .* requires manual remediation/u,
+      /recovery fence .* run daemon repair-ownership/u,
     );
     expect(JSON.parse(readFileSync(fencePath, "utf8"))).toEqual(fence);
     expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
       state: "untrusted",
-      reason: expect.stringContaining("requires manual remediation"),
+      reason: expect.stringContaining(`instance ${fence.instanceId}`),
     });
   });
+
+  it.each([
+    "canonical-old",
+    "quarantined-old",
+    "canonical-new",
+  ] as const)("repairs a hard-killed fenced mutation at the $state stage", (state) => {
+    const home = join(root, `repair-${state}`);
+    const original = acquire(home);
+    const owner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: `test-dead-process:repair-owner-${state}`,
+      version: state === "canonical-new" ? "test-new-owner" : "test-old-owner",
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, owner);
+
+    const fence = {
+      lockVersion: 1 as const,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: `test-dead-process:repair-fence-${state}`,
+      startedAt: new Date().toISOString(),
+    };
+    let quarantinePath: string | undefined;
+    if (state === "quarantined-old") {
+      quarantinePath = `${original.lockPath}.stale.test.${owner.instanceId}.${fence.instanceId}`;
+      renameSync(original.lockPath, quarantinePath);
+    }
+    writeGuard(recoveryFencePath(home), fence);
+    writeRecoveryGuard(home, fence);
+
+    const before = inspectDaemonRuntimeRecoveryEvidence(home);
+    const beforeText = formatDaemonRuntimeRecoveryEvidence(before).join("; ");
+    expect(beforeText).toContain(`instance ${fence.instanceId}`);
+    expect(beforeText).toContain(`pid ${fence.pid}`);
+    expect(beforeText).toContain(fence.processStartIdentity);
+    expect(beforeText).toContain(state === "quarantined-old" ? "main=absent" : "main=stale");
+    if (quarantinePath) expect(beforeText).toContain(quarantinePath);
+    expect(() =>
+      acquireDaemonRuntimeOwnership({ channel: "dev", mode: "foreground", version: "blocked", home }),
+    ).toThrow(/ownership recovery fence .* run daemon repair-ownership/u);
+
+    const repaired = repairDaemonRuntimeOwnership(home);
+    expect(repaired.repaired).toBe(true);
+    expect(repaired.restoredFrom).toBe(quarantinePath);
+    expect(existsSync(recoveryFencePath(home))).toBe(false);
+    expect(existsSync(recoveryGuardPath(home))).toBe(false);
+    expect(parseOwner(original.lockPath)).toEqual(owner);
+    expect(readdirSync(dirname(original.lockPath)).some((name) => name.includes(".repair-slot."))).toBe(false);
+    expect(readdirSync(dirname(original.lockPath)).some((name) => name.includes(".repair-ticket."))).toBe(false);
+
+    const recovered = acquire(home, "dev", "service");
+    expect(recovered.owner.instanceId).not.toBe(owner.instanceId);
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+      state: "live",
+      owner: { instanceId: recovered.owner.instanceId },
+    });
+  });
+
+  it("keeps ambiguous fenced repair evidence fail-closed", () => {
+    const home = join(root, "repair-ambiguous");
+    const lockPath = daemonRuntimeOwnershipPath(home);
+    mkdirSync(dirname(lockPath), { recursive: true });
+    const probe = acquire(home);
+    const first: DaemonRuntimeOwner = {
+      ...probe.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:repair-ambiguous-first",
+    };
+    const second: DaemonRuntimeOwner = {
+      ...first,
+      instanceId: randomUUID(),
+      processStartIdentity: "test-dead-process:repair-ambiguous-second",
+    };
+    const fence = {
+      lockVersion: 1 as const,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:repair-ambiguous-fence",
+      startedAt: new Date().toISOString(),
+    };
+    expect(probe.release()).toBe(true);
+    rewriteOwner(`${lockPath}.stale.one.${first.instanceId}.${fence.instanceId}`, first);
+    rewriteOwner(`${lockPath}.stale.two.${second.instanceId}.${fence.instanceId}`, second);
+    writeGuard(recoveryFencePath(home), fence);
+    writeRecoveryGuard(home, fence);
+
+    expect(() => repairDaemonRuntimeOwnership(home)).toThrow(/stale candidates are ambiguous/u);
+    expect(existsSync(recoveryFencePath(home))).toBe(true);
+    expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "untrusted" });
+  });
+
+  it("orders simultaneous ownership repairs through per-instance tickets", async () => {
+    const home = join(root, "repair-concurrent");
+    const barrierDir = join(root, "repair-concurrent-barriers");
+    mkdirSync(barrierDir, { recursive: true });
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:repair-concurrent-owner",
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+    const fence = {
+      lockVersion: 1 as const,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:repair-concurrent-fence",
+      startedAt: new Date().toISOString(),
+    };
+    writeGuard(recoveryFencePath(home), fence);
+    writeRecoveryGuard(home, fence);
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-race-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const spawnRepair = (role: "u" | "v") => {
+      const child = spawn(process.execPath, ["--import", "tsx", fixture, home, role, barrierDir], {
+        cwd: cliRoot,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return { child, next: waitForChildMessage(child), role };
+    };
+    const repairs = [spawnRepair("u"), spawnRepair("v")];
+
+    try {
+      for (const repair of repairs) {
+        expect((await repair.next()).event).toBe("ready");
+        repair.child.stdin.write("go\n");
+      }
+      await Promise.all(
+        repairs.map((repair) => waitForFile(join(barrierDir, `${repair.role}.repair-ticket-before-publish.ready`))),
+      );
+      for (const repair of repairs) releaseBarrier(barrierDir, repair.role, "repair-ticket-before-publish");
+
+      const outcomes = await Promise.all(repairs.map((repair) => repair.next()));
+      expect(outcomes.map((outcome) => outcome.event).sort()).toEqual(["no-repair", "repaired"]);
+      expect(await Promise.all(repairs.map((repair) => waitForExit(repair.child)))).toEqual([0, 0]);
+      expect(existsSync(recoveryFencePath(home))).toBe(false);
+      expect(existsSync(recoveryGuardPath(home))).toBe(false);
+      expect(parseOwner(original.lockPath)).toEqual(staleOwner);
+      const stateFiles = readdirSync(dirname(original.lockPath));
+      expect(stateFiles.some((name) => name.includes(".repair-slot."))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".repair-ticket."))).toBe(false);
+    } finally {
+      for (const repair of repairs) {
+        if (repair.child.exitCode === null && repair.child.signalCode === null) repair.child.kill("SIGKILL");
+      }
+    }
+  }, 45_000);
 
   it("treats a live reused pid with a different start identity as stale", () => {
     const home = join(root, "pid-reuse");
@@ -482,6 +653,113 @@ describe("daemon runtime ownership", () => {
     expect(stateFiles.some((name) => name.includes(".recovery.stale."))).toBe(true);
   });
 
+  it("ignores an unpublished entrant temp and rejects its late publish after recovery wins", async () => {
+    const home = join(root, "entrant-late-publish");
+    const barrierDir = join(root, "entrant-late-publish-barriers");
+    mkdirSync(barrierDir, { recursive: true });
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: "test-dead-process:entrant-late-publish",
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-race-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const entrant = spawn(process.execPath, ["--import", "tsx", fixture, home, "e", barrierDir], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const recovery = spawn(process.execPath, ["--import", "tsx", fixture, home, "recovery", barrierDir], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const nextEntrant = waitForChildMessage(entrant);
+    const nextRecovery = waitForChildMessage(recovery);
+
+    try {
+      expect((await nextEntrant()).event).toBe("ready");
+      entrant.stdin.write("go\n");
+      await waitForFile(join(barrierDir, "e.entrant-before-publish.ready"));
+      const prePublishFiles = readdirSync(dirname(original.lockPath));
+      expect(prePublishFiles.some((name) => name.startsWith(`${basename(original.lockPath)}.entrant.`))).toBe(false);
+      expect(prePublishFiles.some((name) => name.startsWith(`${basename(original.lockPath)}.entrant-temp.`))).toBe(
+        true,
+      );
+
+      expect((await nextRecovery()).event).toBe("ready");
+      recovery.stdin.write("go\n");
+      const recoveryResult = await nextRecovery();
+      expect(recoveryResult.event).toBe("acquired");
+      expect(recovery.exitCode).toBeNull();
+
+      releaseBarrier(barrierDir, "e", "entrant-before-publish");
+      expect((await nextEntrant()).event).toBe("rejected");
+      expect(recovery.exitCode).toBeNull();
+
+      recovery.stdin.write("release\n");
+      expect(await waitForExit(recovery)).toBe(0);
+      expect(await waitForExit(entrant)).toBe(2);
+      const stateFiles = readdirSync(dirname(original.lockPath));
+      expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({ state: "absent" });
+      expect(existsSync(recoveryFencePath(home))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".entrant."))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".entrant-temp."))).toBe(false);
+    } finally {
+      if (entrant.exitCode === null && entrant.signalCode === null) entrant.kill("SIGKILL");
+      if (recovery.exitCode === null && recovery.signalCode === null) recovery.kill("SIGKILL");
+    }
+  }, 45_000);
+
+  it.each([
+    { role: "e", barrier: "entrant-before-publish", label: "before publish" },
+    { role: "f", barrier: "entrant-after-publish", label: "after publish" },
+  ])("recovers after an entrant process crashes $label", async ({ role, barrier }) => {
+    const home = join(root, `entrant-crash-${role}`);
+    const barrierDir = join(root, `entrant-crash-${role}-barriers`);
+    mkdirSync(barrierDir, { recursive: true });
+    const original = acquire(home);
+    const staleOwner: DaemonRuntimeOwner = {
+      ...original.owner,
+      instanceId: randomUUID(),
+      pid: 999_999_999,
+      processStartIdentity: `test-dead-process:entrant-crash-${role}`,
+    };
+    expect(original.release()).toBe(true);
+    rewriteOwner(original.lockPath, staleOwner);
+
+    const fixture = fileURLToPath(new URL("./fixtures/daemon-runtime-owner-race-child.ts", import.meta.url));
+    const cliRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const crashed = spawn(process.execPath, ["--import", "tsx", fixture, home, role, barrierDir], {
+      cwd: cliRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const next = waitForChildMessage(crashed);
+
+    try {
+      expect((await next()).event).toBe("ready");
+      crashed.stdin.write("go\n");
+      await waitForFile(join(barrierDir, `${role}.${barrier}.ready`));
+      crashed.kill("SIGKILL");
+      expect(await waitForExit(crashed)).toBeNull();
+
+      const recovered = acquire(home, "dev", "service");
+      expect(inspectDaemonRuntimeOwnership(home)).toMatchObject({
+        state: "live",
+        owner: { instanceId: recovered.owner.instanceId },
+      });
+      const stateFiles = readdirSync(dirname(original.lockPath));
+      expect(existsSync(recoveryFencePath(home))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".entrant."))).toBe(false);
+      expect(stateFiles.some((name) => name.includes(".entrant-temp."))).toBe(false);
+    } finally {
+      if (crashed.exitCode === null && crashed.signalCode === null) crashed.kill("SIGKILL");
+    }
+  });
+
   it("keeps a three-contender stale-guard race to one exact owner", async () => {
     const home = join(root, "three-contender-recovery");
     const barrierDir = join(root, "barriers");
@@ -523,6 +801,7 @@ describe("daemon runtime ownership", () => {
       await waitForFile(join(barrierDir, "p1.guard-before-rename.ready"));
 
       const p2 = await spawnContender("p2");
+      await waitForFile(recoveryFencePath(home));
       releaseBarrier(barrierDir, "p1", "guard-before-rename");
       await waitForFile(join(barrierDir, "p1.guard-after-rename.ready"));
 
@@ -597,6 +876,7 @@ describe("daemon runtime ownership", () => {
       await waitForFile(join(barrierDir, "s.guard-before-rename.ready"));
 
       const r = await spawnRole("r");
+      await waitForFile(recoveryFencePath(home));
       releaseBarrier(barrierDir, "s", "guard-before-rename");
       await waitForFile(join(barrierDir, "s.guard-after-rename.ready"));
 

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -17,6 +17,7 @@ const clientMocks = vi.hoisted(() => ({
 }));
 
 const coreMocks = vi.hoisted(() => ({
+  acquireDaemonRuntimeOwnership: vi.fn(),
   CapabilityRefresher: vi.fn(),
   ClientRuntime: vi.fn(),
   createApiNameResolver: vi.fn(),
@@ -28,6 +29,7 @@ const coreMocks = vi.hoisted(() => ({
   getClientSwitchStartupBlock: vi.fn(),
   getClientServiceStatus: vi.fn(),
   handleClientOrgMismatch: vi.fn(),
+  isDaemonRuntimeOwnershipError: vi.fn(),
   isServiceSupported: vi.fn(),
   listPinnedAgents: vi.fn(),
   loadCredentials: vi.fn(),
@@ -90,6 +92,7 @@ const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | nu
 });
 
 let home: string;
+let runtimeOwnershipRelease: ReturnType<typeof vi.fn>;
 let runtimeInstance: {
   addAgent: ReturnType<typeof vi.fn>;
   start: ReturnType<typeof vi.fn>;
@@ -152,6 +155,15 @@ beforeEach(() => {
   coreMocks.loadCredentials.mockReturnValue({ refreshToken: "refresh" });
   coreMocks.loadDaemonEnv.mockReturnValue([]);
   coreMocks.getClientSwitchStartupBlock.mockReturnValue(null);
+  runtimeOwnershipRelease = vi.fn();
+  coreMocks.acquireDaemonRuntimeOwnership.mockReturnValue({
+    lockPath: join(home, "state", "daemon-runtime.lock"),
+    owner: { instanceId: "owner-test" },
+    release: runtimeOwnershipRelease,
+  });
+  coreMocks.isDaemonRuntimeOwnershipError.mockImplementation(
+    (error: unknown) => typeof error === "object" && error !== null && "daemonOwnership" in error,
+  );
   coreMocks.resolveClientRuntimeStopReason.mockReturnValue(undefined);
   coreMocks.isServiceSupported.mockReturnValue(false);
   coreMocks.getClientServiceStatus.mockReturnValue({
@@ -306,6 +318,8 @@ describe("daemon start command", () => {
 
     await expect(runStart()).resolves.toBeTruthy();
     expect(output()).toContain("Service is already running");
+    expect(output()).toContain("stop it before running `first-tree-dev daemon start --foreground`");
+    expect(coreMocks.acquireDaemonRuntimeOwnership).not.toHaveBeenCalled();
     expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
 
     stderrSpy.mockClear();
@@ -318,6 +332,25 @@ describe("daemon start command", () => {
 
     await expect(runStart()).resolves.toBeTruthy();
     expect(output()).toContain("Service is already running (systemd).");
+  });
+
+  it("preflights an active service before an explicit foreground start", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus.mockReturnValue({
+      platform: "launchd",
+      state: "active",
+      label: "first-tree-dev",
+      detail: "pid 123",
+      logDir: "/logs",
+    });
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(output()).toContain("Cannot start a foreground daemon while the launchd service is active (pid 123)");
+    expect(output()).toContain("`first-tree-dev daemon stop`");
+    expect(coreMocks.acquireDaemonRuntimeOwnership).not.toHaveBeenCalled();
+    expect(coreMocks.promptMissingFields).not.toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
   });
 
   it("starts an inactive service and prints log hints", async () => {
@@ -491,6 +524,15 @@ describe("daemon start command", () => {
   it("runs inline, reconciles local state, uploads capabilities and skills", async () => {
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
 
+    expect(coreMocks.acquireDaemonRuntimeOwnership).toHaveBeenCalledWith({
+      channel: "dev",
+      home,
+      mode: "foreground",
+      version: "0.0.0-test",
+    });
+    expect(coreMocks.acquireDaemonRuntimeOwnership.mock.invocationCallOrder[0]).toBeLessThan(
+      coreMocks.promptMissingFields.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(coreMocks.promptMissingFields).toHaveBeenCalledWith(expect.objectContaining({ noInteractive: false }));
     expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "info" });
     expect(coreMocks.migrateLocalAgentDirs).toHaveBeenCalled();
@@ -575,6 +617,7 @@ describe("daemon start command", () => {
       expect(runtimeInstance.unwatchAgentsDir).toHaveBeenCalled();
       expect(runtimeInstance.stop).toHaveBeenCalledWith(undefined);
       expect(coreMocks.registerClientRuntimeMarker.mock.results[0]?.value).toHaveBeenCalled();
+      expect(runtimeOwnershipRelease).toHaveBeenCalled();
       expect(clientMocks.flushClientSentry).toHaveBeenCalled();
       expect(exitSpy).toHaveBeenCalledWith(0);
     } finally {
@@ -729,6 +772,12 @@ describe("daemon start command", () => {
     expect(clientMocks.configureClientLoggerForService).toHaveBeenCalledWith(join(home, "logs"));
     expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "info" });
     expect(coreMocks.createLoggerRuntimeOutput).toHaveBeenCalledWith(expect.any(Object));
+    expect(coreMocks.acquireDaemonRuntimeOwnership).toHaveBeenCalledWith({
+      channel: "dev",
+      home,
+      mode: "service",
+      version: "0.0.0-test",
+    });
     expect(coreMocks.ClientRuntime).toHaveBeenCalledWith(
       "https://first-tree.example",
       "client_1234abcd",
@@ -738,6 +787,44 @@ describe("daemon start command", () => {
       }),
     );
     expect(output()).toBe("");
+  });
+
+  it("settles a supervisor ownership collision without a restart-triggering failure", async () => {
+    const daemonLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    clientMocks.createLogger.mockReturnValue(daemonLogger);
+    process.env.FIRST_TREE_SERVICE_MODE = "1";
+    coreMocks.acquireDaemonRuntimeOwnership.mockImplementationOnce(() => {
+      throw Object.assign(new Error("home is already held by pid 321 (foreground)"), { daemonOwnership: true });
+    });
+
+    await expect(runStart(["--no-interactive"])).resolves.toBeTruthy();
+
+    expect(daemonLogger.error).toHaveBeenCalledWith(
+      "✗ home is already held by pid 321 (foreground); supervisor child is stopping without restart.",
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(coreMocks.promptMissingFields).not.toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
+  });
+
+  it("fails a manual inline start with the live owner details", async () => {
+    coreMocks.acquireDaemonRuntimeOwnership.mockImplementationOnce(() => {
+      throw Object.assign(new Error("home is already held by pid 654 (service)"), {
+        code: "DAEMON_RUNTIME_ALREADY_RUNNING",
+        daemonOwnership: true,
+      });
+    });
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(failMock).toHaveBeenCalledWith(
+      "DAEMON_RUNTIME_ALREADY_RUNNING",
+      "home is already held by pid 654 (service)",
+      1,
+    );
+    expect(clientMocks.captureClientException).not.toHaveBeenCalled();
+    expect(coreMocks.promptMissingFields).not.toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
   });
 
   it("treats explicit foreground as foreground even when service-mode env is inherited", async () => {

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -23,6 +23,7 @@ const coreMocks = vi.hoisted(() => ({
   createApiNameResolver: vi.fn(),
   createExecuteUpdate: vi.fn(),
   createLoggerRuntimeOutput: vi.fn(),
+  daemonRuntimeHomesEqual: vi.fn(),
   declineUpdate: vi.fn(),
   ensureActiveRootClientIdPersisted: vi.fn(),
   ensureFreshAccessToken: vi.fn(),
@@ -164,6 +165,7 @@ beforeEach(() => {
   coreMocks.isDaemonRuntimeOwnershipError.mockImplementation(
     (error: unknown) => typeof error === "object" && error !== null && "daemonOwnership" in error,
   );
+  coreMocks.daemonRuntimeHomesEqual.mockImplementation((left: string, right: string) => left === right);
   coreMocks.resolveClientRuntimeStopReason.mockReturnValue(undefined);
   coreMocks.isServiceSupported.mockReturnValue(false);
   coreMocks.getClientServiceStatus.mockReturnValue({
@@ -342,6 +344,7 @@ describe("daemon start command", () => {
       label: "first-tree-dev",
       detail: "pid 123",
       logDir: "/logs",
+      configuredHome: home,
     });
 
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
@@ -351,6 +354,30 @@ describe("daemon start command", () => {
     expect(coreMocks.acquireDaemonRuntimeOwnership).not.toHaveBeenCalled();
     expect(coreMocks.promptMissingFields).not.toHaveBeenCalled();
     expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit foreground home run beside an active service for a different home", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus.mockReturnValue({
+      platform: "launchd",
+      state: "active",
+      label: "first-tree-dev",
+      detail: "pid 123",
+      logDir: "/logs",
+      configuredHome: join(home, "service-home"),
+    });
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(output()).not.toContain("Cannot start a foreground daemon while the launchd service is active");
+    expect(coreMocks.acquireDaemonRuntimeOwnership).toHaveBeenCalledWith({
+      channel: "dev",
+      home,
+      mode: "foreground",
+      version: "0.0.0-test",
+    });
+    expect(coreMocks.promptMissingFields).toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).toHaveBeenCalled();
   });
 
   it("starts an inactive service and prints log hints", async () => {

--- a/apps/cli/src/__tests__/doctor-core.test.ts
+++ b/apps/cli/src/__tests__/doctor-core.test.ts
@@ -47,6 +47,40 @@ afterEach(() => {
 });
 
 describe("doctor core checks", () => {
+  it("diagnoses absent, live, and untrusted daemon ownership", async () => {
+    const { checkDaemonRuntimeOwnership } = await import("../core/doctor.js");
+    const { acquireDaemonRuntimeOwnership, daemonRuntimeOwnershipPath } = await import(
+      "../core/daemon-runtime-ownership.js"
+    );
+
+    expect(checkDaemonRuntimeOwnership()).toEqual({
+      label: "Daemon owner",
+      ok: true,
+      detail: "lock not held",
+    });
+
+    const lease = acquireDaemonRuntimeOwnership({
+      channel: "dev",
+      home,
+      mode: "service",
+      version: "0.0.0-test",
+    });
+    expect(checkDaemonRuntimeOwnership()).toMatchObject({
+      label: "Daemon owner",
+      ok: true,
+      detail: expect.stringContaining(`pid ${process.pid}, dev/service`),
+    });
+    lease.release();
+
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeFileSync(daemonRuntimeOwnershipPath(home), "{broken", "utf8");
+    expect(checkDaemonRuntimeOwnership()).toMatchObject({
+      label: "Daemon owner",
+      ok: false,
+      detail: expect.stringContaining("untrusted lock"),
+    });
+  });
+
   it("checks config, server reachability, websocket reachability, and local agents", async () => {
     const {
       checkAgentConfigs,

--- a/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-child.ts
+++ b/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-child.ts
@@ -1,0 +1,42 @@
+import { createInterface } from "node:readline";
+import {
+  acquireDaemonRuntimeOwnership,
+  type DaemonRuntimeMode,
+  isDaemonRuntimeOwnershipError,
+} from "../../core/daemon-runtime-ownership.js";
+
+const [home, modeArg] = process.argv.slice(2);
+const mode: DaemonRuntimeMode = modeArg === "service" ? "service" : "foreground";
+
+if (!home) {
+  process.stderr.write("missing home\n");
+  process.exit(3);
+}
+
+const lines = createInterface({ input: process.stdin });
+process.stdout.write(`${JSON.stringify({ event: "ready", pid: process.pid })}\n`);
+
+lines.once("line", () => {
+  try {
+    const lease = acquireDaemonRuntimeOwnership({
+      channel: "dev",
+      mode,
+      version: "test-child",
+      home,
+    });
+    process.stdout.write(`${JSON.stringify({ event: "acquired", pid: process.pid, mode })}\n`);
+    lines.once("line", () => {
+      lease.release();
+      process.exit(0);
+    });
+  } catch (error) {
+    process.stdout.write(
+      `${JSON.stringify({
+        event: isDaemonRuntimeOwnershipError(error) ? "rejected" : "error",
+        pid: process.pid,
+        message: error instanceof Error ? error.message : String(error),
+      })}\n`,
+    );
+    process.exit(isDaemonRuntimeOwnershipError(error) ? 2 : 3);
+  }
+});

--- a/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-child.ts
+++ b/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-child.ts
@@ -1,12 +1,16 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { createInterface } from "node:readline";
 import {
   acquireDaemonRuntimeOwnership,
   type DaemonRuntimeMode,
+  daemonRuntimeOwnershipPath,
   isDaemonRuntimeOwnershipError,
 } from "../../core/daemon-runtime-ownership.js";
 
 const [home, modeArg] = process.argv.slice(2);
 const mode: DaemonRuntimeMode = modeArg === "service" ? "service" : "foreground";
+const seedRecoveryGuard = modeArg === "seed-recovery";
 
 if (!home) {
   process.stderr.write("missing home\n");
@@ -18,6 +22,35 @@ process.stdout.write(`${JSON.stringify({ event: "ready", pid: process.pid })}\n`
 
 lines.once("line", () => {
   try {
+    if (seedRecoveryGuard) {
+      const probe = acquireDaemonRuntimeOwnership({
+        channel: "dev",
+        mode: "foreground",
+        version: "test-recovery-seed",
+        home: `${home}.recovery-probe`,
+      });
+      const recoveryPath = `${daemonRuntimeOwnershipPath(home)}.recovery`;
+      mkdirSync(dirname(recoveryPath), { recursive: true });
+      writeFileSync(
+        recoveryPath,
+        `${JSON.stringify(
+          {
+            lockVersion: 1,
+            instanceId: probe.owner.instanceId,
+            pid: probe.owner.pid,
+            processStartIdentity: probe.owner.processStartIdentity,
+            startedAt: probe.owner.startedAt,
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      probe.release();
+      process.stdout.write(`${JSON.stringify({ event: "recovery-guard-created", pid: process.pid })}\n`);
+      return;
+    }
+
     const lease = acquireDaemonRuntimeOwnership({
       channel: "dev",
       mode,

--- a/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-race-child.ts
+++ b/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-race-child.ts
@@ -1,0 +1,83 @@
+import { createRequire, syncBuiltinESMExports } from "node:module";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+const [home, role, barrierDir] = process.argv.slice(2);
+
+if (!home || !role || !barrierDir) {
+  process.stderr.write("missing home, role, or barrier directory\n");
+  process.exit(3);
+}
+
+const require = createRequire(import.meta.url);
+const fs = require("node:fs") as typeof import("node:fs");
+const originalExistsSync = fs.existsSync.bind(fs);
+const originalMkdirSync = fs.mkdirSync.bind(fs);
+const originalRealpathSync = fs.realpathSync.bind(fs);
+const originalRenameSync = fs.renameSync.bind(fs);
+const originalWriteFileSync = fs.writeFileSync.bind(fs);
+
+originalMkdirSync(barrierDir, { recursive: true });
+const lockPath = join(originalRealpathSync(home), "state", "daemon-runtime.lock");
+const recoveryPath = `${lockPath}.recovery`;
+
+function waitAtBarrier(name: string): void {
+  originalWriteFileSync(join(barrierDir, `${role}.${name}.ready`), `${process.pid}\n`, "utf8");
+  const releasePath = join(barrierDir, `${role}.${name}.go`);
+  const deadline = Date.now() + 15_000;
+  while (!originalExistsSync(releasePath)) {
+    if (Date.now() >= deadline) throw new Error(`timed out at ${role}.${name}`);
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+  }
+}
+
+Object.defineProperty(fs, "renameSync", {
+  configurable: true,
+  value: (oldPath: import("node:fs").PathLike, newPath: import("node:fs").PathLike): void => {
+    const oldName = String(oldPath);
+    const newName = String(newPath);
+    if (role === "p1" && oldName === recoveryPath && newName.includes(".recovery.stale.")) {
+      waitAtBarrier("guard-before-rename");
+      originalRenameSync(oldPath, newPath);
+      waitAtBarrier("guard-after-rename");
+      return;
+    }
+    if ((role === "p2" || role === "p3") && oldName === lockPath && newName.includes(".lock.stale.")) {
+      waitAtBarrier("owner-before-rename");
+    }
+    originalRenameSync(oldPath, newPath);
+  },
+});
+syncBuiltinESMExports();
+
+const { acquireDaemonRuntimeOwnership, isDaemonRuntimeOwnershipError } = await import(
+  "../../core/daemon-runtime-ownership.js"
+);
+
+const lines = createInterface({ input: process.stdin });
+process.stdout.write(`${JSON.stringify({ event: "ready", pid: process.pid })}\n`);
+
+lines.once("line", () => {
+  try {
+    const lease = acquireDaemonRuntimeOwnership({
+      channel: "dev",
+      mode: "foreground",
+      version: `test-race-${role}`,
+      home,
+    });
+    process.stdout.write(`${JSON.stringify({ event: "acquired", pid: process.pid })}\n`);
+    lines.once("line", () => {
+      lease.release();
+      process.exit(0);
+    });
+  } catch (error) {
+    process.stdout.write(
+      `${JSON.stringify({
+        event: isDaemonRuntimeOwnershipError(error) ? "rejected" : "error",
+        pid: process.pid,
+        message: error instanceof Error ? error.message : String(error),
+      })}\n`,
+    );
+    process.exit(isDaemonRuntimeOwnershipError(error) ? 2 : 3);
+  }
+});

--- a/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-race-child.ts
+++ b/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-race-child.ts
@@ -12,7 +12,10 @@ if (!home || !role || !barrierDir) {
 const require = createRequire(import.meta.url);
 const fs = require("node:fs") as typeof import("node:fs");
 const originalExistsSync = fs.existsSync.bind(fs);
+const originalFsyncSync = fs.fsyncSync.bind(fs);
+const originalLinkSync = fs.linkSync.bind(fs);
 const originalMkdirSync = fs.mkdirSync.bind(fs);
+const originalOpenSync = fs.openSync.bind(fs);
 const originalRealpathSync = fs.realpathSync.bind(fs);
 const originalRenameSync = fs.renameSync.bind(fs);
 const originalWriteFileSync = fs.writeFileSync.bind(fs);
@@ -24,28 +27,82 @@ const recoveryPath = `${lockPath}.recovery`;
 function waitAtBarrier(name: string): void {
   originalWriteFileSync(join(barrierDir, `${role}.${name}.ready`), `${process.pid}\n`, "utf8");
   const releasePath = join(barrierDir, `${role}.${name}.go`);
-  const deadline = Date.now() + 15_000;
+  const deadline = Date.now() + 45_000;
   while (!originalExistsSync(releasePath)) {
     if (Date.now() >= deadline) throw new Error(`timed out at ${role}.${name}`);
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
   }
 }
 
+let ownerFd: number | undefined;
+let pausedAfterOwnerFsync = false;
+let pausedAfterRestoreCollision = false;
+
+Object.defineProperty(fs, "openSync", {
+  configurable: true,
+  value: (
+    path: import("node:fs").PathLike,
+    flags: import("node:fs").OpenMode,
+    mode?: import("node:fs").Mode,
+  ): number => {
+    const fd = originalOpenSync(path, flags, mode);
+    if (role === "t" && String(path) === lockPath && flags === "wx") ownerFd = fd;
+    return fd;
+  },
+});
+
+Object.defineProperty(fs, "fsyncSync", {
+  configurable: true,
+  value: (fd: number): void => {
+    originalFsyncSync(fd);
+    if (role === "t" && fd === ownerFd && !pausedAfterOwnerFsync) {
+      pausedAfterOwnerFsync = true;
+      waitAtBarrier("owner-after-fsync");
+    }
+  },
+});
+
 Object.defineProperty(fs, "renameSync", {
   configurable: true,
   value: (oldPath: import("node:fs").PathLike, newPath: import("node:fs").PathLike): void => {
     const oldName = String(oldPath);
     const newName = String(newPath);
-    if (role === "p1" && oldName === recoveryPath && newName.includes(".recovery.stale.")) {
+    if ((role === "p1" || role === "s") && oldName === recoveryPath && newName.includes(".recovery.stale.")) {
       waitAtBarrier("guard-before-rename");
       originalRenameSync(oldPath, newPath);
       waitAtBarrier("guard-after-rename");
       return;
     }
-    if ((role === "p2" || role === "p3") && oldName === lockPath && newName.includes(".lock.stale.")) {
+    if ((role === "p2" || role === "p3" || role === "r") && oldName === lockPath && newName.includes(".lock.stale.")) {
       waitAtBarrier("owner-before-rename");
+      originalRenameSync(oldPath, newPath);
+      if (role === "r") waitAtBarrier("owner-after-rename");
+      return;
+    }
+    if (role === "t" && oldName === lockPath && newName.includes(".lock.cleanup.")) {
+      waitAtBarrier("cleanup-before-rename");
     }
     originalRenameSync(oldPath, newPath);
+  },
+});
+
+Object.defineProperty(fs, "linkSync", {
+  configurable: true,
+  value: (existingPath: import("node:fs").PathLike, newPath: import("node:fs").PathLike): void => {
+    try {
+      originalLinkSync(existingPath, newPath);
+    } catch (error) {
+      if (
+        role === "r" &&
+        !pausedAfterRestoreCollision &&
+        String(existingPath).includes(".lock.stale.") &&
+        String(newPath) === lockPath
+      ) {
+        pausedAfterRestoreCollision = true;
+        waitAtBarrier("restore-after-link-failure");
+      }
+      throw error;
+    }
   },
 });
 syncBuiltinESMExports();

--- a/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-race-child.ts
+++ b/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-race-child.ts
@@ -89,14 +89,35 @@ Object.defineProperty(fs, "renameSync", {
 Object.defineProperty(fs, "linkSync", {
   configurable: true,
   value: (existingPath: import("node:fs").PathLike, newPath: import("node:fs").PathLike): void => {
+    const existingName = String(existingPath);
+    const newName = String(newPath);
+    if (
+      (role === "e" || role === "f") &&
+      existingName.includes(".lock.entrant-temp.") &&
+      newName.includes(".lock.entrant.")
+    ) {
+      if (role === "e") waitAtBarrier("entrant-before-publish");
+      originalLinkSync(existingPath, newPath);
+      if (role === "f") waitAtBarrier("entrant-after-publish");
+      return;
+    }
+    if (
+      (role === "u" || role === "v") &&
+      existingName.includes(".lock.repair-ticket-temp.") &&
+      newName.includes(".lock.repair-ticket.")
+    ) {
+      waitAtBarrier("repair-ticket-before-publish");
+      originalLinkSync(existingPath, newPath);
+      return;
+    }
     try {
       originalLinkSync(existingPath, newPath);
     } catch (error) {
       if (
         role === "r" &&
         !pausedAfterRestoreCollision &&
-        String(existingPath).includes(".lock.stale.") &&
-        String(newPath) === lockPath
+        existingName.includes(".lock.stale.") &&
+        newName === lockPath
       ) {
         pausedAfterRestoreCollision = true;
         waitAtBarrier("restore-after-link-failure");
@@ -107,7 +128,7 @@ Object.defineProperty(fs, "linkSync", {
 });
 syncBuiltinESMExports();
 
-const { acquireDaemonRuntimeOwnership, isDaemonRuntimeOwnershipError } = await import(
+const { acquireDaemonRuntimeOwnership, isDaemonRuntimeOwnershipError, repairDaemonRuntimeOwnership } = await import(
   "../../core/daemon-runtime-ownership.js"
 );
 
@@ -116,6 +137,13 @@ process.stdout.write(`${JSON.stringify({ event: "ready", pid: process.pid })}\n`
 
 lines.once("line", () => {
   try {
+    if (role === "u" || role === "v") {
+      const result = repairDaemonRuntimeOwnership(home);
+      process.stdout.write(
+        `${JSON.stringify({ event: result.repaired ? "repaired" : "no-repair", pid: process.pid })}\n`,
+      );
+      process.exit(0);
+    }
     const lease = acquireDaemonRuntimeOwnership({
       channel: "dev",
       mode: "foreground",

--- a/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-race-child.ts
+++ b/apps/cli/src/__tests__/fixtures/daemon-runtime-owner-race-child.ts
@@ -23,6 +23,8 @@ const originalWriteFileSync = fs.writeFileSync.bind(fs);
 originalMkdirSync(barrierDir, { recursive: true });
 const lockPath = join(originalRealpathSync(home), "state", "daemon-runtime.lock");
 const recoveryPath = `${lockPath}.recovery`;
+const fencePath = `${lockPath}.recovery-fence`;
+const repairPath = `${lockPath}.repair`;
 
 function waitAtBarrier(name: string): void {
   originalWriteFileSync(join(barrierDir, `${role}.${name}.ready`), `${process.pid}\n`, "utf8");
@@ -38,6 +40,27 @@ let ownerFd: number | undefined;
 let pausedAfterOwnerFsync = false;
 let pausedAfterRestoreCollision = false;
 
+function publicationKind(
+  path: string,
+): "main" | "recovery" | "fence" | "entrant" | "repair-slot" | "repair-ticket" | "repair-guard" | undefined {
+  for (const kind of [
+    "main",
+    "recovery",
+    "fence",
+    "entrant",
+    "repair-slot",
+    "repair-ticket",
+    "repair-guard",
+  ] as const) {
+    if (path.includes(`.lock.publish-temp.${kind}.`)) return kind;
+  }
+  return undefined;
+}
+
+function isRepairRole(value: string): boolean {
+  return value === "u" || value === "v" || value.startsWith("repair-crash-") || value.startsWith("publish-repair-");
+}
+
 Object.defineProperty(fs, "openSync", {
   configurable: true,
   value: (
@@ -46,6 +69,10 @@ Object.defineProperty(fs, "openSync", {
     mode?: import("node:fs").Mode,
   ): number => {
     const fd = originalOpenSync(path, flags, mode);
+    const kind = publicationKind(String(path));
+    if (flags === "wx" && role === `publish-${kind}-open`) {
+      waitAtBarrier(`${kind}-temp-after-open`);
+    }
     if (role === "t" && String(path) === lockPath && flags === "wx") ownerFd = fd;
     return fd;
   },
@@ -82,6 +109,16 @@ Object.defineProperty(fs, "renameSync", {
     if (role === "t" && oldName === lockPath && newName.includes(".lock.cleanup.")) {
       waitAtBarrier("cleanup-before-rename");
     }
+    if (
+      role === "repair-crash-before-fence-remove" &&
+      oldName === fencePath &&
+      newName.includes(".recovery-fence.cleanup.")
+    ) {
+      waitAtBarrier("repair-before-fence-remove");
+    }
+    if (role === "repair-crash-after-fence-remove" && oldName === repairPath && newName.includes(".repair.cleanup.")) {
+      waitAtBarrier("repair-after-fence-remove");
+    }
     originalRenameSync(oldPath, newPath);
   },
 });
@@ -91,9 +128,13 @@ Object.defineProperty(fs, "linkSync", {
   value: (existingPath: import("node:fs").PathLike, newPath: import("node:fs").PathLike): void => {
     const existingName = String(existingPath);
     const newName = String(newPath);
+    const kind = publicationKind(existingName);
+    if (kind && role === `publish-${kind}-before`) {
+      waitAtBarrier(`${kind}-before-publish`);
+    }
     if (
       (role === "e" || role === "f") &&
-      existingName.includes(".lock.entrant-temp.") &&
+      existingName.includes(".lock.publish-temp.entrant.") &&
       newName.includes(".lock.entrant.")
     ) {
       if (role === "e") waitAtBarrier("entrant-before-publish");
@@ -103,15 +144,23 @@ Object.defineProperty(fs, "linkSync", {
     }
     if (
       (role === "u" || role === "v") &&
-      existingName.includes(".lock.repair-ticket-temp.") &&
+      existingName.includes(".lock.publish-temp.repair-ticket.") &&
       newName.includes(".lock.repair-ticket.")
     ) {
       waitAtBarrier("repair-ticket-before-publish");
       originalLinkSync(existingPath, newPath);
       return;
     }
+    if (role === "repair-crash-after-guard" && newName === repairPath) {
+      originalLinkSync(existingPath, newPath);
+      waitAtBarrier("repair-after-guard");
+      return;
+    }
     try {
       originalLinkSync(existingPath, newPath);
+      if (kind && role === `publish-${kind}-after`) {
+        waitAtBarrier(`${kind}-after-publish`);
+      }
     } catch (error) {
       if (
         role === "r" &&
@@ -137,7 +186,7 @@ process.stdout.write(`${JSON.stringify({ event: "ready", pid: process.pid })}\n`
 
 lines.once("line", () => {
   try {
-    if (role === "u" || role === "v") {
+    if (isRepairRole(role)) {
       const result = repairDaemonRuntimeOwnership(home);
       process.stdout.write(
         `${JSON.stringify({ event: result.repaired ? "repaired" : "no-repair", pid: process.pid })}\n`,

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -315,7 +315,7 @@ describe("service install helpers", () => {
     setPlatform("darwin");
     const plistPath = join(home, "Library", "LaunchAgents", `${channelConfig.launchdLabel}.plist`);
     mkdirSync(dirname(plistPath), { recursive: true });
-    writeFileSync(plistPath, "plist");
+    writeFileSync(plistPath, renderPlist(join(home, "service-wrapper")));
 
     spawnSyncMock.mockReturnValueOnce({
       status: 0,
@@ -327,6 +327,7 @@ describe("service install helpers", () => {
       state: "active",
       pid: 123,
       detail: "pid 123",
+      configuredHome: process.env.FIRST_TREE_HOME,
     });
 
     spawnSyncMock.mockReturnValueOnce({ status: 3, stdout: "", stderr: "Could not find service" });
@@ -341,7 +342,7 @@ describe("service install helpers", () => {
     setPlatform("linux");
     const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
     mkdirSync(dirname(unitPath), { recursive: true });
-    writeFileSync(unitPath, "unit");
+    writeFileSync(unitPath, renderSystemdUnit({ kind: "bin", program: "/opt/first-tree" }));
     spawnSyncMock
       .mockReturnValueOnce({ status: 0, stdout: "active\n", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "456\n", stderr: "" });
@@ -351,6 +352,7 @@ describe("service install helpers", () => {
       state: "active",
       pid: 456,
       detail: "pid 456",
+      configuredHome: process.env.FIRST_TREE_HOME,
     });
 
     spawnSyncMock.mockReturnValueOnce({ status: 3, stdout: "inactive\n", stderr: "" });

--- a/apps/cli/src/__tests__/status-blocks.test.ts
+++ b/apps/cli/src/__tests__/status-blocks.test.ts
@@ -106,6 +106,34 @@ describe("status block renderers", () => {
     expect(output()).toContain("unknown (systemd, denied)");
   });
 
+  it("renders authoritative daemon owner lock states", async () => {
+    const { renderDaemonRuntimeOwnerBlock } = await import("../commands/_shared/status-blocks.js");
+    const { acquireDaemonRuntimeOwnership, daemonRuntimeOwnershipPath } = await import(
+      "../core/daemon-runtime-ownership.js"
+    );
+
+    renderDaemonRuntimeOwnerBlock();
+    expect(output()).toContain("Owner:    not held");
+
+    stderrSpy.mockClear();
+    const lease = acquireDaemonRuntimeOwnership({
+      channel: "dev",
+      home,
+      mode: "foreground",
+      version: "0.0.0-test",
+    });
+    renderDaemonRuntimeOwnerBlock();
+    expect(output()).toContain(`Owner:    ✓ pid ${process.pid}, dev/foreground`);
+    lease.release();
+
+    stderrSpy.mockClear();
+    const lockPath = daemonRuntimeOwnershipPath(home);
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeFileSync(lockPath, "{broken", "utf8");
+    renderDaemonRuntimeOwnerBlock();
+    expect(output()).toContain("Owner:    ✗ untrusted lock");
+  });
+
   it("renders server configuration states", async () => {
     const { renderHubBlock } = await import("../commands/_shared/status-blocks.js");
 

--- a/apps/cli/src/commands/_shared/doctor-checks.ts
+++ b/apps/cli/src/commands/_shared/doctor-checks.ts
@@ -6,6 +6,7 @@ import {
   checkAgentConfigs,
   checkBackgroundService,
   checkClientConfig,
+  checkDaemonRuntimeOwnership,
   checkNodeVersion,
   checkServerReachable,
   checkWebSocket,
@@ -70,6 +71,7 @@ export async function runDaemonChecks(): Promise<CheckResult[]> {
     agentCheck,
     await checkWebSocket(),
     checkBackgroundService(),
+    checkDaemonRuntimeOwnership(),
     ...(await checkRuntimeProviders()),
   ];
 }

--- a/apps/cli/src/commands/_shared/status-blocks.ts
+++ b/apps/cli/src/commands/_shared/status-blocks.ts
@@ -1,8 +1,15 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { agentConfigSchema, defaultConfigDir, loadAgents, readConfigFile } from "@first-tree/shared/config";
+import {
+  agentConfigSchema,
+  defaultConfigDir,
+  defaultHome,
+  loadAgents,
+  readConfigFile,
+} from "@first-tree/shared/config";
 import { loadCredentials } from "../../core/bootstrap.js";
 import { channelConfig } from "../../core/channel.js";
+import { formatDaemonRuntimeOwnerSummary, inspectDaemonRuntimeOwnership } from "../../core/daemon-runtime-ownership.js";
 import { print } from "../../core/output.js";
 import { getClientServiceStatus, isServiceSupported } from "../../core/service-install.js";
 import { COMMAND_VERSION } from "../../core/version.js";
@@ -35,6 +42,19 @@ export function renderServiceBlock(): void {
     print.line(`  Service:  not installed — run \`${channelConfig.binName} login <code>\`\n`);
   } else {
     print.line(`  Service:  unknown (${svc.platform}${svc.detail ? `, ${svc.detail}` : ""})\n`);
+  }
+}
+
+export function renderDaemonRuntimeOwnerBlock(): void {
+  const ownership = inspectDaemonRuntimeOwnership(defaultHome());
+  if (ownership.state === "absent") {
+    print.line("  Owner:    not held\n");
+  } else if (ownership.state === "live") {
+    print.line(`  Owner:    ✓ ${formatDaemonRuntimeOwnerSummary(ownership.owner)}\n`);
+  } else if (ownership.state === "stale") {
+    print.line(`  Owner:    ⚠ stale ${formatDaemonRuntimeOwnerSummary(ownership.owner)} (${ownership.reason})\n`);
+  } else {
+    print.line(`  Owner:    ✗ untrusted lock (${ownership.reason})\n`);
   }
 }
 

--- a/apps/cli/src/commands/_shared/status-blocks.ts
+++ b/apps/cli/src/commands/_shared/status-blocks.ts
@@ -9,7 +9,12 @@ import {
 } from "@first-tree/shared/config";
 import { loadCredentials } from "../../core/bootstrap.js";
 import { channelConfig } from "../../core/channel.js";
-import { formatDaemonRuntimeOwnerSummary, inspectDaemonRuntimeOwnership } from "../../core/daemon-runtime-ownership.js";
+import {
+  formatDaemonRuntimeOwnerSummary,
+  formatDaemonRuntimeRecoveryEvidence,
+  inspectDaemonRuntimeOwnership,
+  inspectDaemonRuntimeRecoveryEvidence,
+} from "../../core/daemon-runtime-ownership.js";
 import { print } from "../../core/output.js";
 import { getClientServiceStatus, isServiceSupported } from "../../core/service-install.js";
 import { COMMAND_VERSION } from "../../core/version.js";
@@ -55,6 +60,12 @@ export function renderDaemonRuntimeOwnerBlock(): void {
     print.line(`  Owner:    ⚠ stale ${formatDaemonRuntimeOwnerSummary(ownership.owner)} (${ownership.reason})\n`);
   } else {
     print.line(`  Owner:    ✗ untrusted lock (${ownership.reason})\n`);
+    const evidence = inspectDaemonRuntimeRecoveryEvidence(defaultHome());
+    if (evidence.fence.state !== "absent") {
+      for (const line of formatDaemonRuntimeRecoveryEvidence(evidence)) {
+        print.line(`            ${line}\n`);
+      }
+    }
   }
 }
 

--- a/apps/cli/src/commands/daemon/index.ts
+++ b/apps/cli/src/commands/daemon/index.ts
@@ -6,6 +6,7 @@ import { registerDaemonInstallClaudeCommand } from "./install-claude.js";
 import { registerDaemonInstallCodexCommand } from "./install-codex.js";
 import { registerDaemonProbeCommand } from "./probe.js";
 import { registerDaemonRefreshUnitCommand } from "./refresh-unit.js";
+import { registerDaemonRepairOwnershipCommand } from "./repair-ownership.js";
 import { registerDaemonRestartCommand } from "./restart.js";
 import { registerDaemonStartCommand } from "./start.js";
 import { registerDaemonStatusCommand } from "./status.js";
@@ -21,6 +22,7 @@ export function registerDaemonCommands(program: Command): void {
   registerDaemonRestartCommand(daemon);
   registerDaemonStatusCommand(daemon);
   registerDaemonDoctorCommand(daemon);
+  registerDaemonRepairOwnershipCommand(daemon);
   registerDaemonProbeCommand(daemon);
   registerDaemonInstallCodexCommand(daemon);
   registerDaemonInstallClaudeCommand(daemon);

--- a/apps/cli/src/commands/daemon/repair-ownership.ts
+++ b/apps/cli/src/commands/daemon/repair-ownership.ts
@@ -1,0 +1,32 @@
+import { defaultHome } from "@first-tree/shared/config";
+import type { Command } from "commander";
+import { fail } from "../../cli/output.js";
+import {
+  formatDaemonRuntimeRecoveryEvidence,
+  isDaemonRuntimeOwnershipError,
+  repairDaemonRuntimeOwnership,
+} from "../../core/daemon-runtime-ownership.js";
+import { print } from "../../core/output.js";
+
+export function registerDaemonRepairOwnershipCommand(daemon: Command): void {
+  daemon
+    .command("repair-ownership")
+    .description("Safely reconcile an interrupted daemon ownership recovery")
+    .action(() => {
+      try {
+        const result = repairDaemonRuntimeOwnership(defaultHome());
+        if (!result.repaired) {
+          print.line("  Ownership: no stale recovery fence needs repair\n");
+          return;
+        }
+        print.line(`  Ownership: repaired ${result.lockPath}\n`);
+        if (result.restoredFrom) print.line(`  Restored:  ${result.restoredFrom}\n`);
+        for (const line of formatDaemonRuntimeRecoveryEvidence(result.evidence)) {
+          print.line(`  Evidence:  ${line}\n`);
+        }
+      } catch (error) {
+        if (isDaemonRuntimeOwnershipError(error)) fail(error.code, error.message, 1);
+        throw error;
+      }
+    });
+}

--- a/apps/cli/src/commands/daemon/repair-ownership.ts
+++ b/apps/cli/src/commands/daemon/repair-ownership.ts
@@ -20,6 +20,9 @@ export function registerDaemonRepairOwnershipCommand(daemon: Command): void {
           return;
         }
         print.line(`  Ownership: repaired ${result.lockPath}\n`);
+        if (result.reconciledState) {
+          print.line(`  Reconciled: ${result.reconciledState === "empty" ? "safe empty" : "trusted owner"}\n`);
+        }
         if (result.restoredFrom) print.line(`  Restored:  ${result.restoredFrom}\n`);
         for (const line of formatDaemonRuntimeRecoveryEvidence(result.evidence)) {
           print.line(`  Evidence:  ${line}\n`);

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -35,6 +35,7 @@ import {
   createApiNameResolver,
   createExecuteUpdate,
   createLoggerRuntimeOutput,
+  daemonRuntimeHomesEqual,
   declineUpdate,
   ensureActiveRootClientIdPersisted,
   ensureFreshAccessToken,
@@ -131,7 +132,8 @@ export function registerDaemonStartCommand(daemon: Command): void {
         //   1. service active           → refuse, point at `daemon restart`
         //   2. service installed/inactive → systemctl/launchctl start
         //   3. service not installed    → fall through to inline run
-        //   4. --foreground             → always inline (debug / --no-start users)
+        //   4. --foreground             → inline unless the active service owns
+        //                                  the same canonical home
         // The supervisor itself reaches this code with --no-interactive and
         // FIRST_TREE_SERVICE_MODE=1 set; we treat that combo as "supervisor
         // invoking us, run inline" so we don't recursively call systemctl
@@ -146,7 +148,10 @@ export function registerDaemonStartCommand(daemon: Command): void {
             writeLine(`  Complete the root systemd migration out-of-service with \`${binName} login <code>\`.\n\n`);
             process.exit(1);
           }
-          if (svc.state === "active") {
+          const serviceOwnsCurrentHome =
+            svc.state === "active" &&
+            daemonRuntimeHomesEqual(svc.configuredHome ?? channelConfig.defaultHome, defaultHome());
+          if (serviceOwnsCurrentHome) {
             writeLine(
               `\n  Cannot start a foreground daemon while the ${svc.platform} service is active${
                 svc.detail ? ` (${svc.detail})` : ""

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -28,6 +28,7 @@ import { CLIENT_SENTRY_DSN, GIT_SHA } from "../../build-info.js";
 import { fail } from "../../cli/output.js";
 import { channelConfig } from "../../core/channel.js";
 import {
+  acquireDaemonRuntimeOwnership,
   CapabilityRefresher,
   ClientRuntime,
   COMMAND_VERSION,
@@ -40,6 +41,7 @@ import {
   getClientServiceStatus,
   getClientSwitchStartupBlock,
   handleClientOrgMismatch,
+  isDaemonRuntimeOwnershipError,
   isServiceSupported,
   listPinnedAgents,
   loadCredentials,
@@ -122,6 +124,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
       }
 
       let unregisterRuntimeMarker: (() => void) | null = null;
+      let releaseRuntimeOwnership: (() => void) | null = null;
       try {
         // Service-mode delegation. We split four cases so the user gets a
         // single coherent command:
@@ -143,13 +146,26 @@ export function registerDaemonStartCommand(daemon: Command): void {
             writeLine(`  Complete the root systemd migration out-of-service with \`${binName} login <code>\`.\n\n`);
             process.exit(1);
           }
+          if (svc.state === "active") {
+            writeLine(
+              `\n  Cannot start a foreground daemon while the ${svc.platform} service is active${
+                svc.detail ? ` (${svc.detail})` : ""
+              }.\n`,
+            );
+            writeLine(
+              `  Stop it with \`${binName} daemon stop\` before running \`${binName} daemon start --foreground\`.\n\n`,
+            );
+            process.exit(1);
+          }
         }
         if (!wantInline && isServiceSupported()) {
           const svc = getClientServiceStatus();
           if (svc.state === "active") {
             writeLine("\n");
             writeLine(`  Service is already running (${svc.platform}${svc.detail ? `, ${svc.detail}` : ""}).\n`);
-            writeLine(`  Use \`${binName} daemon restart\` to restart, or \`--foreground\` to run inline.\n\n`);
+            writeLine(
+              `  Use \`${binName} daemon restart\` to restart it, or stop it before running \`${binName} daemon start --foreground\`.\n\n`,
+            );
             return;
           }
           if (svc.state === "inactive") {
@@ -220,6 +236,35 @@ export function registerDaemonStartCommand(daemon: Command): void {
             process.exit(1);
           }
           // state === "not-installed" → fall through to inline run.
+        }
+
+        // The resolved channel home is the daemon's ownership boundary. Take
+        // the authoritative lock only after service delegation has decided
+        // this command will run inline, and before client.yaml or the
+        // WebSocket runtime can be opened.
+        try {
+          const ownership = acquireDaemonRuntimeOwnership({
+            channel: channelConfig.channel,
+            home: defaultHome(),
+            mode: isSupervisorChild ? "service" : "foreground",
+            version: COMMAND_VERSION,
+          });
+          const releaseOwnership = () => {
+            process.off("exit", releaseOwnership);
+            ownership.release();
+          };
+          process.once("exit", releaseOwnership);
+          releaseRuntimeOwnership = releaseOwnership;
+        } catch (error) {
+          if (isSupervisorChild && isDaemonRuntimeOwnershipError(error)) {
+            // systemd Restart=on-failure, launchd SuccessfulExit=false, and the
+            // Windows wrapper all treat exit 0 as a settled stop. Log the live
+            // holder once and return cleanly instead of creating a restart/log
+            // storm while another foreground/service owner holds this home.
+            writeStatus("✗", `${error.message}; supervisor child is stopping without restart.`);
+            return;
+          }
+          throw error;
         }
 
         // Schema-driven prompts for missing required fields
@@ -466,6 +511,8 @@ export function registerDaemonStartCommand(daemon: Command): void {
           await runtime.stop(resolveClientRuntimeStopReason());
           unregisterRuntimeMarker?.();
           unregisterRuntimeMarker = null;
+          releaseRuntimeOwnership?.();
+          releaseRuntimeOwnership = null;
           await flushClientSentry();
           process.exit(0);
         };
@@ -518,13 +565,19 @@ export function registerDaemonStartCommand(daemon: Command): void {
           });
         }
         const msg = error instanceof Error ? error.message : String(error);
-        captureClientException(error, { command: "daemon start" });
+        if (!isDaemonRuntimeOwnershipError(error)) {
+          captureClientException(error, { command: "daemon start" });
+        }
         unregisterRuntimeMarker?.();
         unregisterRuntimeMarker = null;
         await flushClientSentry();
+        if (isDaemonRuntimeOwnershipError(error)) {
+          fail(error.code, msg, 1);
+        }
         writeErrorAndExit(`Error: ${msg}`);
       } finally {
         unregisterRuntimeMarker?.();
+        releaseRuntimeOwnership?.();
         // Reset singleton so other commands can reinit
         resetConfig();
         resetConfigMeta();

--- a/apps/cli/src/commands/daemon/status.ts
+++ b/apps/cli/src/commands/daemon/status.ts
@@ -1,6 +1,11 @@
 import type { Command } from "commander";
 import { print } from "../../core/output.js";
-import { renderAuthBlock, renderHubBlock, renderServiceBlock } from "../_shared/status-blocks.js";
+import {
+  renderAuthBlock,
+  renderDaemonRuntimeOwnerBlock,
+  renderHubBlock,
+  renderServiceBlock,
+} from "../_shared/status-blocks.js";
 
 /**
  * `daemon status` — local daemon-only view (service state + server binding +
@@ -15,6 +20,7 @@ export function registerDaemonStatusCommand(daemon: Command): void {
     .action(() => {
       print.line("\n");
       renderServiceBlock();
+      renderDaemonRuntimeOwnerBlock();
       renderHubBlock();
       renderAuthBlock();
       print.line("\n");

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -4,6 +4,7 @@ import {
   renderAgentsBlock,
   renderAuthBlock,
   renderCliVersionBlock,
+  renderDaemonRuntimeOwnerBlock,
   renderHubBlock,
   renderServiceBlock,
 } from "./_shared/status-blocks.js";
@@ -22,6 +23,7 @@ export function registerStatusCommand(program: Command): void {
       print.line("\n");
       renderCliVersionBlock();
       renderServiceBlock();
+      renderDaemonRuntimeOwnerBlock();
       renderHubBlock();
       renderAuthBlock();
       renderAgentsBlock();

--- a/apps/cli/src/core/daemon-runtime-ownership.ts
+++ b/apps/cli/src/core/daemon-runtime-ownership.ts
@@ -7,19 +7,21 @@ import {
   linkSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import type { ChannelName } from "@first-tree/shared/channel";
 
 const LOCK_FORMAT_VERSION = 1;
 const PROCESS_QUERY_TIMEOUT_MS = 5_000;
 const RECOVERY_GUARD_CLEANUP_RETRIES = 50;
 const RECOVERY_GUARD_CLEANUP_RETRY_MS = 10;
+const RECOVERY_FENCE_DRAIN_RETRIES = 3_000;
 const INSTANCE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 
 export type DaemonRuntimeMode = "foreground" | "service";
@@ -109,6 +111,14 @@ export function daemonRuntimeHomesEqual(left: string, right: string): boolean {
 
 function recoveryGuardPath(lockPath: string): string {
   return `${lockPath}.recovery`;
+}
+
+function recoveryMutationFencePath(lockPath: string): string {
+  return `${lockPath}.recovery-fence`;
+}
+
+function ownershipEntrantPath(lockPath: string, instanceId: string): string {
+  return `${lockPath}.entrant.${instanceId}`;
 }
 
 function errorCode(error: unknown): string | undefined {
@@ -413,6 +423,17 @@ export function inspectDaemonRuntimeOwnership(home: string): DaemonRuntimeOwners
     throw error;
   }
   const lockPath = join(resolvedHome, "state", "daemon-runtime.lock");
+  const mutationFenceInspection = readRecoveryGuardInspection(recoveryMutationFencePath(lockPath));
+  if (mutationFenceInspection.state !== "absent") {
+    return {
+      state: "untrusted",
+      lockPath,
+      reason:
+        mutationFenceInspection.state === "live"
+          ? `main-lock recovery is fenced at ${mutationFenceInspection.recoveryPath} by pid ${mutationFenceInspection.guard.pid}`
+          : `daemon ownership recovery fence at ${mutationFenceInspection.recoveryPath} requires manual remediation`,
+    };
+  }
   const recoveryInspection = readRecoveryGuardInspection(recoveryGuardPath(lockPath));
   if (recoveryInspection.state === "live") {
     return {
@@ -502,6 +523,17 @@ function restoreQuarantinedFileIfAbsent(quarantinePath: string, path: string): b
   return true;
 }
 
+function restoreQuarantinedFileWithRetries(quarantinePath: string, path: string): boolean {
+  for (let attempt = 0; attempt < RECOVERY_GUARD_CLEANUP_RETRIES; attempt += 1) {
+    if (restoreQuarantinedFileIfAbsent(quarantinePath, path)) return true;
+    if (!existsSync(quarantinePath)) return false;
+    if (attempt + 1 < RECOVERY_GUARD_CLEANUP_RETRIES) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, RECOVERY_GUARD_CLEANUP_RETRY_MS);
+    }
+  }
+  return false;
+}
+
 function removeOwnedJson(path: string, instanceId: string): boolean {
   if (readInstanceId(path) !== instanceId) return false;
   const cleanupPath = `${path}.cleanup.${instanceId}.${randomUUID()}`;
@@ -581,6 +613,76 @@ function assertOwnedRecoveryGuard(recoveryPath: string, recovery: RecoveryGuard,
   throw new DaemonRuntimeOwnershipError(
     DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
     `Recovery guard ${recoveryPath} is no longer held by exact instance ${recovery.instanceId}; refusing daemon startup`,
+    lockPath,
+  );
+}
+
+function mutationFenceError(
+  inspection: Exclude<RecoveryGuardInspection, { state: "absent" }>,
+  lockPath: string,
+): DaemonRuntimeOwnershipError {
+  if (inspection.state === "live") {
+    return new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+      `Refusing daemon startup because pid ${inspection.guard.pid} is mutating ${lockPath} under fence ${inspection.recoveryPath}`,
+      lockPath,
+    );
+  }
+  return new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+    `Refusing daemon startup because ownership recovery fence ${inspection.recoveryPath} is present; the home requires manual remediation`,
+    lockPath,
+  );
+}
+
+function assertNoRecoveryMutationFence(fencePath: string, lockPath: string): void {
+  const inspection = readRecoveryGuardInspection(fencePath);
+  if (inspection.state !== "absent") throw mutationFenceError(inspection, lockPath);
+}
+
+function assertOwnedRecoveryMutationFence(fencePath: string, recovery: RecoveryGuard, lockPath: string): void {
+  const inspection = readRecoveryGuardInspection(fencePath);
+  if (inspection.state === "live" && inspection.guard.instanceId === recovery.instanceId) return;
+  if (inspection.state !== "absent") throw mutationFenceError(inspection, lockPath);
+  throw new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+    `Ownership recovery fence ${fencePath} disappeared during main-lock mutation; refusing daemon startup`,
+    lockPath,
+  );
+}
+
+function drainOwnershipEntrants(lockPath: string, ownEntrantPath: string): void {
+  const directory = dirname(lockPath);
+  const prefix = `${basename(lockPath)}.entrant.`;
+  for (let attempt = 0; attempt < RECOVERY_FENCE_DRAIN_RETRIES; attempt += 1) {
+    let blocked = false;
+    for (const name of readdirSync(directory)) {
+      if (!name.startsWith(prefix)) continue;
+      const entrantPath = join(directory, name);
+      if (entrantPath === ownEntrantPath) continue;
+      const inspection = readRecoveryGuardInspection(entrantPath);
+      if (inspection.state === "absent") continue;
+      if (inspection.state === "stale") {
+        removeOwnedJson(entrantPath, inspection.guard.instanceId);
+        continue;
+      }
+      if (inspection.state === "untrusted") {
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+          `Refusing daemon startup because ownership entrant ${entrantPath} cannot be trusted: ${inspection.reason}`,
+          lockPath,
+        );
+      }
+      blocked = true;
+    }
+    if (!blocked) return;
+    if (attempt + 1 < RECOVERY_FENCE_DRAIN_RETRIES) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, RECOVERY_GUARD_CLEANUP_RETRY_MS);
+    }
+  }
+  throw new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+    `Timed out draining in-flight daemon ownership entrants before recovering ${lockPath}`,
     lockPath,
   );
 }
@@ -704,116 +806,197 @@ export function acquireDaemonRuntimeOwnership(opts: {
     home,
   };
 
-  let quarantinedRecoveryGuardPath = quarantineStaleRecoveryGuard(recoveryPath, lockPath);
-
-  const firstAttempt = tryWriteExclusiveJson(lockPath, owner);
-  if (firstAttempt === "created") {
-    const racedRecovery = readRecoveryGuardInspection(recoveryPath);
-    if (racedRecovery.state !== "absent") {
-      removeOwnedJson(lockPath, owner.instanceId);
-      if (racedRecovery.state === "live" || racedRecovery.state === "untrusted") {
-        throw recoveryGuardErrorFromInspection(racedRecovery, lockPath);
-      }
-      throw new DaemonRuntimeOwnershipError(
-        DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
-        `Refusing daemon startup because abandoned stale-lock recovery raced this owner at ${recoveryPath}`,
-        lockPath,
-      );
-    }
-    return makeLease(lockPath, owner, undefined, quarantinedRecoveryGuardPath);
-  }
-
-  const firstInspection = readOwnerInspection(lockPath, home);
-  if (firstInspection.state === "live" || firstInspection.state === "untrusted") {
-    throw ownershipErrorFromInspection(firstInspection);
-  }
-
-  const recovery: RecoveryGuard = {
+  const entrant: RecoveryGuard = {
     lockVersion: LOCK_FORMAT_VERSION,
-    instanceId: randomUUID(),
+    instanceId: owner.instanceId,
     pid: process.pid,
     processStartIdentity: processStart.identity,
     startedAt: new Date().toISOString(),
   };
-  quarantinedRecoveryGuardPath = quarantineStaleRecoveryGuard(recoveryPath, lockPath) ?? quarantinedRecoveryGuardPath;
-  if (tryWriteExclusiveJson(recoveryPath, recovery) === "exists") {
-    const inspection = readRecoveryGuardInspection(recoveryPath);
-    if (inspection.state === "live" || inspection.state === "untrusted") {
-      throw recoveryGuardErrorFromInspection(inspection, lockPath);
-    }
+  const entrantPath = ownershipEntrantPath(lockPath, entrant.instanceId);
+  const fencePath = recoveryMutationFencePath(lockPath);
+  if (tryWriteExclusiveJson(entrantPath, entrant) === "exists") {
     throw new DaemonRuntimeOwnershipError(
-      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
-      `Refusing daemon startup because recovery ownership for ${lockPath} changed concurrently`,
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+      `Unable to create unique daemon ownership entrant ${entrantPath}`,
       lockPath,
     );
   }
 
-  let quarantinedLockPath: string | undefined;
-  let ownerCreated = false;
   try {
-    const guardedInspection = readOwnerInspection(lockPath, home);
-    if (guardedInspection.state === "live" || guardedInspection.state === "untrusted") {
-      throw ownershipErrorFromInspection(guardedInspection);
-    }
-    if (guardedInspection.state === "stale") {
-      quarantinedLockPath = `${lockPath}.stale.${Date.now()}.${guardedInspection.owner.instanceId}.${recovery.instanceId}`;
-      assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
-      try {
-        renameSync(lockPath, quarantinedLockPath);
-      } catch (error) {
+    assertNoRecoveryMutationFence(fencePath, lockPath);
+    let quarantinedRecoveryGuardPath = quarantineStaleRecoveryGuard(recoveryPath, lockPath);
+    assertNoRecoveryMutationFence(fencePath, lockPath);
+
+    const firstAttempt = tryWriteExclusiveJson(lockPath, owner);
+    if (firstAttempt === "created") {
+      const racedRecovery = readRecoveryGuardInspection(recoveryPath);
+      const racedFence = readRecoveryGuardInspection(fencePath);
+      if (racedRecovery.state !== "absent" || racedFence.state !== "absent") {
+        removeOwnedJson(lockPath, owner.instanceId);
+        if (racedFence.state !== "absent") throw mutationFenceError(racedFence, lockPath);
+        if (racedRecovery.state === "live" || racedRecovery.state === "untrusted") {
+          throw recoveryGuardErrorFromInspection(racedRecovery, lockPath);
+        }
         throw new DaemonRuntimeOwnershipError(
-          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
-          `Unable to quarantine stale daemon ownership file ${lockPath}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-          lockPath,
-          guardedInspection.owner,
-        );
-      }
-      const movedOwner = readInstanceId(quarantinedLockPath);
-      if (movedOwner !== guardedInspection.owner.instanceId) {
-        restoreQuarantinedFileIfAbsent(quarantinedLockPath, lockPath);
-        throw new DaemonRuntimeOwnershipError(
-          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
-          `Daemon ownership ${lockPath} changed while being quarantined; refusing daemon startup`,
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+          `Refusing daemon startup because abandoned stale-lock recovery raced this owner at ${recoveryPath}`,
           lockPath,
         );
       }
-      try {
-        assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
-      } catch (error) {
-        restoreQuarantinedFileIfAbsent(quarantinedLockPath, lockPath);
-        throw error;
-      }
+      return makeLease(lockPath, owner, undefined, quarantinedRecoveryGuardPath);
     }
 
-    // Exactly one retry is allowed after the stale owner has been isolated (or
-    // after a colliding owner released between the first read and the guard).
-    assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
-    if (tryWriteExclusiveJson(lockPath, owner) === "exists") {
-      const retryInspection = readOwnerInspection(lockPath, home);
-      if (retryInspection.state === "absent") {
+    const firstInspection = readOwnerInspection(lockPath, home);
+    if (firstInspection.state === "live" || firstInspection.state === "untrusted") {
+      throw ownershipErrorFromInspection(firstInspection);
+    }
+
+    const recovery: RecoveryGuard = {
+      lockVersion: LOCK_FORMAT_VERSION,
+      instanceId: randomUUID(),
+      pid: process.pid,
+      processStartIdentity: processStart.identity,
+      startedAt: new Date().toISOString(),
+    };
+    quarantinedRecoveryGuardPath = quarantineStaleRecoveryGuard(recoveryPath, lockPath) ?? quarantinedRecoveryGuardPath;
+    assertNoRecoveryMutationFence(fencePath, lockPath);
+    if (tryWriteExclusiveJson(recoveryPath, recovery) === "exists") {
+      const inspection = readRecoveryGuardInspection(recoveryPath);
+      if (inspection.state === "live" || inspection.state === "untrusted") {
+        throw recoveryGuardErrorFromInspection(inspection, lockPath);
+      }
+      throw new DaemonRuntimeOwnershipError(
+        DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+        `Refusing daemon startup because recovery ownership for ${lockPath} changed concurrently`,
+        lockPath,
+      );
+    }
+
+    let quarantinedLockPath: string | undefined;
+    let quarantinedOwnerInstanceId: string | undefined;
+    let ownerCreated = false;
+    let fenceOwned = false;
+    let safeToRemoveFence = false;
+    try {
+      assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+      if (tryWriteExclusiveJson(fencePath, recovery) === "exists") {
+        const inspection = readRecoveryGuardInspection(fencePath);
+        if (inspection.state !== "absent") throw mutationFenceError(inspection, lockPath);
         throw new DaemonRuntimeOwnershipError(
-          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
-          `Daemon ownership changed again while retrying ${lockPath}; refusing a second retry`,
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+          `Ownership recovery fence ${fencePath} changed while being acquired`,
           lockPath,
         );
       }
-      throw ownershipErrorFromInspection(retryInspection);
+      fenceOwned = true;
+      assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+      assertOwnedRecoveryMutationFence(fencePath, recovery, lockPath);
+
+      // Every acquisition publishes an entrant before checking the fence.
+      // Once the fence exists, draining all older entrants closes the gap
+      // between their last fence check and a possible main-lock write.
+      drainOwnershipEntrants(lockPath, entrantPath);
+      assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+      assertOwnedRecoveryMutationFence(fencePath, recovery, lockPath);
+
+      const guardedInspection = readOwnerInspection(lockPath, home);
+      if (guardedInspection.state === "live" || guardedInspection.state === "untrusted") {
+        safeToRemoveFence = true;
+        throw ownershipErrorFromInspection(guardedInspection);
+      }
+      if (guardedInspection.state === "stale") {
+        quarantinedOwnerInstanceId = guardedInspection.owner.instanceId;
+        quarantinedLockPath = `${lockPath}.stale.${Date.now()}.${guardedInspection.owner.instanceId}.${recovery.instanceId}`;
+        assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+        assertOwnedRecoveryMutationFence(fencePath, recovery, lockPath);
+        try {
+          renameSync(lockPath, quarantinedLockPath);
+        } catch (error) {
+          safeToRemoveFence = errorCode(error) === "ENOENT";
+          throw new DaemonRuntimeOwnershipError(
+            DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+            `Unable to quarantine stale daemon ownership file ${lockPath}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+            lockPath,
+            guardedInspection.owner,
+          );
+        }
+        const movedOwner = readInstanceId(quarantinedLockPath);
+        if (movedOwner !== guardedInspection.owner.instanceId) {
+          safeToRemoveFence = restoreQuarantinedFileWithRetries(quarantinedLockPath, lockPath);
+          throw new DaemonRuntimeOwnershipError(
+            DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+            `Daemon ownership ${lockPath} changed while being quarantined; refusing daemon startup`,
+            lockPath,
+          );
+        }
+        try {
+          assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+          assertOwnedRecoveryMutationFence(fencePath, recovery, lockPath);
+        } catch (error) {
+          safeToRemoveFence = restoreQuarantinedFileWithRetries(quarantinedLockPath, lockPath);
+          throw error;
+        }
+      } else {
+        safeToRemoveFence = true;
+      }
+
+      // Exactly one retry is allowed after the stale owner has been isolated
+      // (or after a colliding owner released while entrants were drained).
+      assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+      assertOwnedRecoveryMutationFence(fencePath, recovery, lockPath);
+      if (tryWriteExclusiveJson(lockPath, owner) === "exists") {
+        const retryInspection = readOwnerInspection(lockPath, home);
+        if (retryInspection.state === "absent") {
+          throw new DaemonRuntimeOwnershipError(
+            DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+            `Daemon ownership changed again while retrying ${lockPath}; refusing a second retry`,
+            lockPath,
+          );
+        }
+        throw ownershipErrorFromInspection(retryInspection);
+      }
+      ownerCreated = true;
+      assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+      assertOwnedRecoveryMutationFence(fencePath, recovery, lockPath);
+      assertOwnedMainLock(lockPath, home, owner);
+      safeToRemoveFence = true;
+      if (!removeOwnedRecoveryGuard(fencePath, recovery.instanceId)) {
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+          `Unable to release exact ownership recovery fence ${fencePath}; refusing daemon startup`,
+          lockPath,
+        );
+      }
+      fenceOwned = false;
+      assertOwnedMainLock(lockPath, home, owner);
+      assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+      return makeLease(lockPath, owner, quarantinedLockPath, quarantinedRecoveryGuardPath);
+    } catch (error) {
+      if (ownerCreated) removeOwnedJson(lockPath, owner.instanceId);
+      if (quarantinedLockPath && existsSync(quarantinedLockPath)) {
+        safeToRemoveFence =
+          restoreQuarantinedFileWithRetries(quarantinedLockPath, lockPath) &&
+          readInstanceId(lockPath) === quarantinedOwnerInstanceId;
+      }
+      if (fenceOwned && safeToRemoveFence && removeOwnedRecoveryGuard(fencePath, recovery.instanceId)) {
+        fenceOwned = false;
+      }
+      throw error;
+    } finally {
+      // A concurrent stale-guard inspector may have atomically moved this guard
+      // aside just before discovering the instance mismatch. Give that process
+      // a bounded window to restore our live guard, then remove only our instance.
+      removeOwnedRecoveryGuard(recoveryPath, recovery.instanceId);
+      // An unresolved main-lock mutation deliberately leaves this fence in
+      // place. It is never auto-recovered: manual remediation is safer than
+      // admitting a second lease after an interrupted quarantine/restore.
+      if (fenceOwned && safeToRemoveFence) removeOwnedRecoveryGuard(fencePath, recovery.instanceId);
     }
-    ownerCreated = true;
-    assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
-    assertOwnedMainLock(lockPath, home, owner);
-    assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
-    return makeLease(lockPath, owner, quarantinedLockPath, quarantinedRecoveryGuardPath);
-  } catch (error) {
-    if (ownerCreated) removeOwnedJson(lockPath, owner.instanceId);
-    throw error;
   } finally {
-    // A concurrent stale-guard inspector may have atomically moved this guard
-    // aside just before discovering the instance mismatch. Give that process a
-    // bounded window to restore our live guard, then remove only our instance.
-    removeOwnedRecoveryGuard(recoveryPath, recovery.instanceId);
+    removeOwnedJson(entrantPath, entrant.instanceId);
   }
 }
 

--- a/apps/cli/src/core/daemon-runtime-ownership.ts
+++ b/apps/cli/src/core/daemon-runtime-ownership.ts
@@ -17,6 +17,8 @@ import type { ChannelName } from "@first-tree/shared/channel";
 
 const LOCK_FORMAT_VERSION = 1;
 const PROCESS_QUERY_TIMEOUT_MS = 5_000;
+const RECOVERY_GUARD_CLEANUP_RETRIES = 50;
+const RECOVERY_GUARD_CLEANUP_RETRY_MS = 10;
 const INSTANCE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 
 export type DaemonRuntimeMode = "foreground" | "service";
@@ -43,6 +45,7 @@ export type DaemonRuntimeOwnershipLease = {
   lockPath: string;
   owner: DaemonRuntimeOwner;
   quarantinedLockPath?: string;
+  quarantinedRecoveryGuardPath?: string;
   release: () => boolean;
 };
 
@@ -87,8 +90,20 @@ type RecoveryGuard = {
   startedAt: string;
 };
 
+type ParsedRecoveryGuard = { ok: true; guard: RecoveryGuard } | { ok: false; reason: string };
+
+type RecoveryGuardInspection =
+  | { state: "absent"; recoveryPath: string }
+  | { state: "live"; recoveryPath: string; guard: RecoveryGuard }
+  | { state: "stale"; recoveryPath: string; guard: RecoveryGuard; reason: string }
+  | { state: "untrusted"; recoveryPath: string; guard?: RecoveryGuard; reason: string };
+
 export function daemonRuntimeOwnershipPath(home: string): string {
   return join(canonicalHome(home, false), "state", "daemon-runtime.lock");
+}
+
+export function daemonRuntimeHomesEqual(left: string, right: string): boolean {
+  return daemonRuntimeOwnershipPath(left) === daemonRuntimeOwnershipPath(right);
 }
 
 function recoveryGuardPath(lockPath: string): string {
@@ -177,6 +192,47 @@ function parseOwner(raw: string, expectedHome: string): ParsedOwner {
       version,
       startedAt,
       home,
+    },
+  };
+}
+
+function parseRecoveryGuard(raw: string): ParsedRecoveryGuard {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    return { ok: false, reason: `invalid JSON (${error instanceof Error ? error.message : String(error)})` };
+  }
+  if (!isRecord(value)) return { ok: false, reason: "recovery guard contents are not an object" };
+
+  const { lockVersion, instanceId, pid, processStartIdentity, startedAt } = value;
+  if (lockVersion !== LOCK_FORMAT_VERSION) {
+    return { ok: false, reason: `unsupported lockVersion ${String(lockVersion)}` };
+  }
+  if (typeof instanceId !== "string" || !INSTANCE_ID_PATTERN.test(instanceId)) {
+    return { ok: false, reason: "instanceId is missing or invalid" };
+  }
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+    return { ok: false, reason: "pid is missing or invalid" };
+  }
+  if (
+    typeof processStartIdentity !== "string" ||
+    processStartIdentity.length === 0 ||
+    processStartIdentity.length > 512
+  ) {
+    return { ok: false, reason: "processStartIdentity is missing or invalid" };
+  }
+  if (typeof startedAt !== "string" || !Number.isFinite(Date.parse(startedAt))) {
+    return { ok: false, reason: "startedAt is missing or invalid" };
+  }
+  return {
+    ok: true,
+    guard: {
+      lockVersion,
+      instanceId,
+      pid,
+      processStartIdentity,
+      startedAt,
     },
   };
 }
@@ -307,6 +363,44 @@ function readOwnerInspection(lockPath: string, home: string): DaemonRuntimeOwner
   return { state: "live", lockPath, owner: parsed.owner };
 }
 
+function readRecoveryGuardInspection(recoveryPath: string): RecoveryGuardInspection {
+  let raw: string;
+  try {
+    raw = readFileSync(recoveryPath, "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return { state: "absent", recoveryPath };
+    return {
+      state: "untrusted",
+      recoveryPath,
+      reason: `unable to read recovery guard: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const parsed = parseRecoveryGuard(raw);
+  if (!parsed.ok) return { state: "untrusted", recoveryPath, reason: parsed.reason };
+  const process = inspectProcessStart(parsed.guard.pid);
+  if (process.state === "gone") {
+    return {
+      state: "stale",
+      recoveryPath,
+      guard: parsed.guard,
+      reason: `pid ${parsed.guard.pid} no longer exists`,
+    };
+  }
+  if (process.state === "unknown") {
+    return { state: "untrusted", recoveryPath, guard: parsed.guard, reason: process.reason };
+  }
+  if (process.identity !== parsed.guard.processStartIdentity) {
+    return {
+      state: "stale",
+      recoveryPath,
+      guard: parsed.guard,
+      reason: `pid ${parsed.guard.pid} was reused with a different process start identity`,
+    };
+  }
+  return { state: "live", recoveryPath, guard: parsed.guard };
+}
+
 export function inspectDaemonRuntimeOwnership(home: string): DaemonRuntimeOwnershipInspection {
   let resolvedHome: string;
   try {
@@ -318,11 +412,26 @@ export function inspectDaemonRuntimeOwnership(home: string): DaemonRuntimeOwners
     throw error;
   }
   const lockPath = join(resolvedHome, "state", "daemon-runtime.lock");
-  if (existsSync(recoveryGuardPath(lockPath))) {
+  const recoveryInspection = readRecoveryGuardInspection(recoveryGuardPath(lockPath));
+  if (recoveryInspection.state === "live") {
     return {
       state: "untrusted",
       lockPath,
-      reason: `stale-lock recovery is in progress (${recoveryGuardPath(lockPath)})`,
+      reason: `stale-lock recovery is in progress at ${recoveryInspection.recoveryPath} by pid ${recoveryInspection.guard.pid}`,
+    };
+  }
+  if (recoveryInspection.state === "stale") {
+    return {
+      state: "untrusted",
+      lockPath,
+      reason: `stale-lock recovery guard at ${recoveryInspection.recoveryPath} is abandoned: ${recoveryInspection.reason}`,
+    };
+  }
+  if (recoveryInspection.state === "untrusted") {
+    return {
+      state: "untrusted",
+      lockPath,
+      reason: `recovery guard at ${recoveryInspection.recoveryPath} cannot be trusted: ${recoveryInspection.reason}`,
     };
   }
   return readOwnerInspection(lockPath, resolvedHome);
@@ -381,6 +490,17 @@ function removeOwnedJson(path: string, instanceId: string): boolean {
   }
 }
 
+function removeOwnedRecoveryGuard(path: string, instanceId: string): boolean {
+  for (let attempt = 0; attempt < RECOVERY_GUARD_CLEANUP_RETRIES; attempt += 1) {
+    if (removeOwnedJson(path, instanceId)) return true;
+    if (existsSync(path)) return false;
+    if (attempt + 1 < RECOVERY_GUARD_CLEANUP_RETRIES) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, RECOVERY_GUARD_CLEANUP_RETRY_MS);
+    }
+  }
+  return false;
+}
+
 function ownershipErrorFromInspection(inspection: Exclude<DaemonRuntimeOwnershipInspection, { state: "absent" }>) {
   if (inspection.state === "live") {
     return new DaemonRuntimeOwnershipError(
@@ -400,16 +520,103 @@ function ownershipErrorFromInspection(inspection: Exclude<DaemonRuntimeOwnership
   );
 }
 
+function recoveryGuardErrorFromInspection(
+  inspection: Exclude<RecoveryGuardInspection, { state: "absent" | "stale" }>,
+  lockPath: string,
+): DaemonRuntimeOwnershipError {
+  if (inspection.state === "live") {
+    return new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+      `Refusing daemon startup because pid ${inspection.guard.pid} is recovering ${lockPath} under guard ${inspection.recoveryPath}`,
+      lockPath,
+    );
+  }
+  return new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+    `Refusing daemon startup because recovery guard ${inspection.recoveryPath} cannot be trusted: ${inspection.reason}`,
+    lockPath,
+  );
+}
+
+function quarantineStaleRecoveryGuard(recoveryPath: string, lockPath: string): string | undefined {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const inspection = readRecoveryGuardInspection(recoveryPath);
+    if (inspection.state === "absent") return undefined;
+    if (inspection.state === "live" || inspection.state === "untrusted") {
+      throw recoveryGuardErrorFromInspection(inspection, lockPath);
+    }
+
+    // Re-read immediately before the atomic rename so a concurrent recovery
+    // that replaced this guard cannot be mistaken for the abandoned owner.
+    const current = readRecoveryGuardInspection(recoveryPath);
+    if (current.state === "absent") continue;
+    if (current.state === "live" || current.state === "untrusted") {
+      throw recoveryGuardErrorFromInspection(current, lockPath);
+    }
+    if (current.guard.instanceId !== inspection.guard.instanceId) continue;
+
+    const quarantinePath = `${recoveryPath}.stale.${Date.now()}.${current.guard.instanceId}.${randomUUID()}`;
+    try {
+      renameSync(recoveryPath, quarantinePath);
+    } catch (error) {
+      if (errorCode(error) === "ENOENT") continue;
+      throw new DaemonRuntimeOwnershipError(
+        DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+        `Unable to quarantine stale recovery guard ${recoveryPath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        lockPath,
+      );
+    }
+
+    const quarantined = readRecoveryGuardInspection(quarantinePath);
+    if (
+      quarantined.state !== "untrusted" &&
+      quarantined.state !== "absent" &&
+      quarantined.guard.instanceId === current.guard.instanceId
+    ) {
+      return quarantinePath;
+    }
+
+    if (!existsSync(recoveryPath)) {
+      try {
+        renameSync(quarantinePath, recoveryPath);
+      } catch (error) {
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+          `Recovery guard ${recoveryPath} changed while being quarantined and could not be restored: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          lockPath,
+        );
+      }
+    }
+    throw new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+      `Recovery guard ${recoveryPath} changed while being quarantined; refusing daemon startup`,
+      lockPath,
+    );
+  }
+
+  throw new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+    `Recovery guard ${recoveryPath} changed repeatedly while establishing ownership`,
+    lockPath,
+  );
+}
+
 function makeLease(
   lockPath: string,
   owner: DaemonRuntimeOwner,
   quarantinedLockPath?: string,
+  quarantinedRecoveryGuardPath?: string,
 ): DaemonRuntimeOwnershipLease {
   let released = false;
   return {
     lockPath,
     owner,
     quarantinedLockPath,
+    quarantinedRecoveryGuardPath,
     release: () => {
       if (released) return false;
       released = true;
@@ -449,25 +656,23 @@ export function acquireDaemonRuntimeOwnership(opts: {
     home,
   };
 
-  if (existsSync(recoveryPath)) {
-    throw new DaemonRuntimeOwnershipError(
-      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
-      `Refusing daemon startup while stale-lock recovery is in progress at ${recoveryPath}`,
-      lockPath,
-    );
-  }
+  let quarantinedRecoveryGuardPath = quarantineStaleRecoveryGuard(recoveryPath, lockPath);
 
   const firstAttempt = tryWriteExclusiveJson(lockPath, owner);
   if (firstAttempt === "created") {
-    if (existsSync(recoveryPath)) {
+    const racedRecovery = readRecoveryGuardInspection(recoveryPath);
+    if (racedRecovery.state !== "absent") {
       removeOwnedJson(lockPath, owner.instanceId);
+      if (racedRecovery.state === "live" || racedRecovery.state === "untrusted") {
+        throw recoveryGuardErrorFromInspection(racedRecovery, lockPath);
+      }
       throw new DaemonRuntimeOwnershipError(
         DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
-        `Refusing daemon startup because stale-lock recovery raced this owner at ${recoveryPath}`,
+        `Refusing daemon startup because abandoned stale-lock recovery raced this owner at ${recoveryPath}`,
         lockPath,
       );
     }
-    return makeLease(lockPath, owner);
+    return makeLease(lockPath, owner, undefined, quarantinedRecoveryGuardPath);
   }
 
   const firstInspection = readOwnerInspection(lockPath, home);
@@ -482,10 +687,15 @@ export function acquireDaemonRuntimeOwnership(opts: {
     processStartIdentity: processStart.identity,
     startedAt: new Date().toISOString(),
   };
+  quarantinedRecoveryGuardPath = quarantineStaleRecoveryGuard(recoveryPath, lockPath) ?? quarantinedRecoveryGuardPath;
   if (tryWriteExclusiveJson(recoveryPath, recovery) === "exists") {
+    const inspection = readRecoveryGuardInspection(recoveryPath);
+    if (inspection.state === "live" || inspection.state === "untrusted") {
+      throw recoveryGuardErrorFromInspection(inspection, lockPath);
+    }
     throw new DaemonRuntimeOwnershipError(
       DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
-      `Refusing daemon startup because another process is recovering ${lockPath}`,
+      `Refusing daemon startup because recovery ownership for ${lockPath} changed concurrently`,
       lockPath,
     );
   }
@@ -525,9 +735,12 @@ export function acquireDaemonRuntimeOwnership(opts: {
       }
       throw ownershipErrorFromInspection(retryInspection);
     }
-    return makeLease(lockPath, owner, quarantinedLockPath);
+    return makeLease(lockPath, owner, quarantinedLockPath, quarantinedRecoveryGuardPath);
   } finally {
-    removeOwnedJson(recoveryPath, recovery.instanceId);
+    // A concurrent stale-guard inspector may have atomically moved this guard
+    // aside just before discovering the instance mismatch. Give that process a
+    // bounded window to restore our live guard, then remove only our instance.
+    removeOwnedRecoveryGuard(recoveryPath, recovery.instanceId);
   }
 }
 

--- a/apps/cli/src/core/daemon-runtime-ownership.ts
+++ b/apps/cli/src/core/daemon-runtime-ownership.ts
@@ -85,7 +85,7 @@ type ProcessStartInspection =
 
 type ParsedOwner = { ok: true; owner: DaemonRuntimeOwner } | { ok: false; reason: string };
 
-type RecoveryGuard = {
+export type DaemonRuntimeRecoveryGuard = {
   lockVersion: 1;
   instanceId: string;
   pid: number;
@@ -93,13 +93,33 @@ type RecoveryGuard = {
   startedAt: string;
 };
 
+type RecoveryGuard = DaemonRuntimeRecoveryGuard;
+
 type ParsedRecoveryGuard = { ok: true; guard: RecoveryGuard } | { ok: false; reason: string };
 
-type RecoveryGuardInspection =
+export type DaemonRuntimeRecoveryGuardInspection =
   | { state: "absent"; recoveryPath: string }
   | { state: "live"; recoveryPath: string; guard: RecoveryGuard }
   | { state: "stale"; recoveryPath: string; guard: RecoveryGuard; reason: string }
   | { state: "untrusted"; recoveryPath: string; guard?: RecoveryGuard; reason: string };
+
+type RecoveryGuardInspection = DaemonRuntimeRecoveryGuardInspection;
+
+export type DaemonRuntimeRecoveryEvidence = {
+  lockPath: string;
+  fence: DaemonRuntimeRecoveryGuardInspection;
+  repairSlots: Array<{ path: string; inspection: DaemonRuntimeRecoveryGuardInspection; ticket?: string }>;
+  main: DaemonRuntimeOwnershipInspection;
+  quarantineCandidates: Array<{ path: string; inspection: DaemonRuntimeOwnershipInspection }>;
+  entrants: Array<{ path: string; inspection: DaemonRuntimeRecoveryGuardInspection }>;
+};
+
+export type DaemonRuntimeOwnershipRepairResult = {
+  repaired: boolean;
+  lockPath: string;
+  restoredFrom?: string;
+  evidence: DaemonRuntimeRecoveryEvidence;
+};
 
 export function daemonRuntimeOwnershipPath(home: string): string {
   return join(canonicalHome(home, false), "state", "daemon-runtime.lock");
@@ -119,6 +139,18 @@ function recoveryMutationFencePath(lockPath: string): string {
 
 function ownershipEntrantPath(lockPath: string, instanceId: string): string {
   return `${lockPath}.entrant.${instanceId}`;
+}
+
+function ownershipEntrantTempPath(lockPath: string, instanceId: string): string {
+  return `${lockPath}.entrant-temp.${instanceId}`;
+}
+
+function ownershipRepairSlotPath(lockPath: string, instanceId: string): string {
+  return `${lockPath}.repair-slot.${instanceId}`;
+}
+
+function ownershipRepairTicketPath(lockPath: string, instanceId: string): string {
+  return `${lockPath}.repair-ticket.${instanceId}`;
 }
 
 function errorCode(error: unknown): string | undefined {
@@ -412,6 +444,141 @@ function readRecoveryGuardInspection(recoveryPath: string): RecoveryGuardInspect
   return { state: "live", recoveryPath, guard: parsed.guard };
 }
 
+function listPathsWithPrefix(path: string, suffixPrefix: string): string[] {
+  const directory = dirname(path);
+  if (!existsSync(directory)) return [];
+  const prefix = `${basename(path)}${suffixPrefix}`;
+  return readdirSync(directory)
+    .filter((name) => name.startsWith(prefix))
+    .map((name) => join(directory, name))
+    .sort();
+}
+
+type RepairTicketInspection =
+  | { state: "absent"; path: string }
+  | { state: "valid"; path: string; guard: RecoveryGuard; ticket: string }
+  | { state: "untrusted"; path: string; reason: string };
+
+function readRepairTicketInspection(path: string): RepairTicketInspection {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return { state: "absent", path };
+    return {
+      state: "untrusted",
+      path,
+      reason: `unable to read repair ticket: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    return {
+      state: "untrusted",
+      path,
+      reason: `invalid JSON (${error instanceof Error ? error.message : String(error)})`,
+    };
+  }
+  if (!isRecord(value) || typeof value.ticket !== "string" || !/^[1-9]\d*$/u.test(value.ticket)) {
+    return { state: "untrusted", path, reason: "repair ticket is missing or invalid" };
+  }
+  const parsed = parseRecoveryGuard(raw);
+  if (!parsed.ok) return { state: "untrusted", path, reason: parsed.reason };
+  return { state: "valid", path, guard: parsed.guard, ticket: value.ticket };
+}
+
+function inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(
+  resolvedHome: string,
+  lockPath: string,
+): DaemonRuntimeRecoveryEvidence {
+  return {
+    lockPath,
+    fence: readRecoveryGuardInspection(recoveryMutationFencePath(lockPath)),
+    repairSlots: listPathsWithPrefix(lockPath, ".repair-slot.").map((path) => {
+      const inspection = readRecoveryGuardInspection(path);
+      const instanceId = inspection.state === "absent" ? undefined : inspection.guard?.instanceId;
+      const ticket = instanceId
+        ? readRepairTicketInspection(ownershipRepairTicketPath(lockPath, instanceId))
+        : undefined;
+      return {
+        path,
+        inspection,
+        ticket: ticket?.state === "valid" ? ticket.ticket : undefined,
+      };
+    }),
+    main: readOwnerInspection(lockPath, resolvedHome),
+    quarantineCandidates: listPathsWithPrefix(lockPath, ".stale.").map((path) => ({
+      path,
+      inspection: readOwnerInspection(path, resolvedHome),
+    })),
+    entrants: listPathsWithPrefix(lockPath, ".entrant.").map((path) => ({
+      path,
+      inspection: readRecoveryGuardInspection(path),
+    })),
+  };
+}
+
+export function inspectDaemonRuntimeRecoveryEvidence(home: string): DaemonRuntimeRecoveryEvidence {
+  const resolvedHome = canonicalHome(home, false);
+  const lockPath = join(resolvedHome, "state", "daemon-runtime.lock");
+  return inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(resolvedHome, lockPath);
+}
+
+function formatRecoveryGuardInspection(label: string, inspection: RecoveryGuardInspection): string {
+  if (inspection.state === "absent") return `${label}=absent`;
+  const holder = inspection.guard
+    ? `instance ${inspection.guard.instanceId}, pid ${inspection.guard.pid}, start ${inspection.guard.processStartIdentity}`
+    : "holder unavailable";
+  const reason = inspection.state === "stale" || inspection.state === "untrusted" ? `, ${inspection.reason}` : "";
+  return `${label}=${inspection.state} (${holder}${reason})`;
+}
+
+function formatOwnerInspection(label: string, inspection: DaemonRuntimeOwnershipInspection): string {
+  if (inspection.state === "absent") return `${label}=absent`;
+  if (inspection.state === "untrusted" && !inspection.owner) {
+    return `${label}=untrusted (${inspection.reason})`;
+  }
+  const owner = inspection.owner;
+  const reason = inspection.state === "stale" || inspection.state === "untrusted" ? `, ${inspection.reason}` : "";
+  return `${label}=${inspection.state} (instance ${owner?.instanceId ?? "unknown"}, pid ${
+    owner?.pid ?? "unknown"
+  }, start ${owner?.processStartIdentity ?? "unknown"}${reason})`;
+}
+
+export function formatDaemonRuntimeRecoveryEvidence(evidence: DaemonRuntimeRecoveryEvidence): string[] {
+  const lines = [formatRecoveryGuardInspection("fence", evidence.fence), formatOwnerInspection("main", evidence.main)];
+  if (evidence.repairSlots.length === 0) {
+    lines.push("repair=none");
+  } else {
+    for (const slot of evidence.repairSlots) {
+      lines.push(
+        `${formatRecoveryGuardInspection(`repair ${slot.path}`, slot.inspection)}, ticket=${slot.ticket ?? "none"}`,
+      );
+    }
+  }
+  if (evidence.quarantineCandidates.length === 0) {
+    lines.push("quarantine=none");
+  } else {
+    for (const candidate of evidence.quarantineCandidates) {
+      lines.push(formatOwnerInspection(`quarantine ${candidate.path}`, candidate.inspection));
+    }
+    const candidateInstances = new Set(
+      evidence.quarantineCandidates.flatMap((candidate) =>
+        candidate.inspection.state === "live" || candidate.inspection.state === "stale"
+          ? [candidate.inspection.owner.instanceId]
+          : [],
+      ),
+    );
+    if (candidateInstances.size > 1) {
+      lines.push(`quarantine-ambiguity=${[...candidateInstances].join(",")}`);
+    }
+  }
+  lines.push(`entrants=${evidence.entrants.length}`);
+  return lines;
+}
+
 export function inspectDaemonRuntimeOwnership(home: string): DaemonRuntimeOwnershipInspection {
   let resolvedHome: string;
   try {
@@ -423,15 +590,13 @@ export function inspectDaemonRuntimeOwnership(home: string): DaemonRuntimeOwners
     throw error;
   }
   const lockPath = join(resolvedHome, "state", "daemon-runtime.lock");
-  const mutationFenceInspection = readRecoveryGuardInspection(recoveryMutationFencePath(lockPath));
+  const recoveryEvidence = inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(resolvedHome, lockPath);
+  const mutationFenceInspection = recoveryEvidence.fence;
   if (mutationFenceInspection.state !== "absent") {
     return {
       state: "untrusted",
       lockPath,
-      reason:
-        mutationFenceInspection.state === "live"
-          ? `main-lock recovery is fenced at ${mutationFenceInspection.recoveryPath} by pid ${mutationFenceInspection.guard.pid}`
-          : `daemon ownership recovery fence at ${mutationFenceInspection.recoveryPath} requires manual remediation`,
+      reason: formatDaemonRuntimeRecoveryEvidence(recoveryEvidence).join("; "),
     };
   }
   const recoveryInspection = readRecoveryGuardInspection(recoveryGuardPath(lockPath));
@@ -534,6 +699,53 @@ function restoreQuarantinedFileWithRetries(quarantinePath: string, path: string)
   return false;
 }
 
+function cleanupStaleOwnershipEntrantTemps(lockPath: string): void {
+  const directory = dirname(lockPath);
+  if (!existsSync(directory)) return;
+  const prefix = `${basename(lockPath)}.entrant-temp.`;
+  for (const name of readdirSync(directory)) {
+    if (!name.startsWith(prefix)) continue;
+    const tempPath = join(directory, name);
+    const inspection = readRecoveryGuardInspection(tempPath);
+    if (inspection.state === "stale") removeOwnedJson(tempPath, inspection.guard.instanceId);
+  }
+}
+
+function publishCompleteJson<T extends { instanceId: string }>(
+  lockPath: string,
+  path: string,
+  tempPath: string,
+  value: T,
+): void {
+  if (tryWriteExclusiveJson(tempPath, value) === "exists") {
+    throw new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+      `Unable to create unique ownership publication temp ${tempPath}`,
+      lockPath,
+    );
+  }
+  try {
+    linkSync(tempPath, path);
+  } catch (error) {
+    throw new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+      `Unable to publish ownership record ${path}: ${error instanceof Error ? error.message : String(error)}`,
+      lockPath,
+    );
+  } finally {
+    removeOwnedJson(tempPath, value.instanceId);
+  }
+}
+
+function publishOwnershipEntrant(lockPath: string, entrant: RecoveryGuard): string {
+  const entrantPath = ownershipEntrantPath(lockPath, entrant.instanceId);
+  const tempPath = ownershipEntrantTempPath(lockPath, entrant.instanceId);
+  // The scanner ignores entrant-temp paths. The hard link publishes the
+  // already-fsynced inode atomically and cannot overwrite another path.
+  publishCompleteJson(lockPath, entrantPath, tempPath, entrant);
+  return entrantPath;
+}
+
 function removeOwnedJson(path: string, instanceId: string): boolean {
   if (readInstanceId(path) !== instanceId) return false;
   const cleanupPath = `${path}.cleanup.${instanceId}.${randomUUID()}`;
@@ -630,7 +842,7 @@ function mutationFenceError(
   }
   return new DaemonRuntimeOwnershipError(
     DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
-    `Refusing daemon startup because ownership recovery fence ${inspection.recoveryPath} is present; the home requires manual remediation`,
+    `Refusing daemon startup because ownership recovery fence ${inspection.recoveryPath} is present; inspect status or doctor, then run daemon repair-ownership`,
     lockPath,
   );
 }
@@ -685,6 +897,135 @@ function drainOwnershipEntrants(lockPath: string, ownEntrantPath: string): void 
     `Timed out draining in-flight daemon ownership entrants before recovering ${lockPath}`,
     lockPath,
   );
+}
+
+type OwnershipRepairLease = {
+  guard: RecoveryGuard;
+  release: () => void;
+};
+
+function repairOrderIsEarlier(leftTicket: string, leftId: string, rightTicket: string, rightId: string): boolean {
+  const left = BigInt(leftTicket);
+  const right = BigInt(rightTicket);
+  return left < right || (left === right && leftId < rightId);
+}
+
+function acquireOwnershipRepairLease(lockPath: string, processStartIdentity: string): OwnershipRepairLease {
+  const guard: RecoveryGuard = {
+    lockVersion: LOCK_FORMAT_VERSION,
+    instanceId: randomUUID(),
+    pid: process.pid,
+    processStartIdentity,
+    startedAt: new Date().toISOString(),
+  };
+  const slotPath = ownershipRepairSlotPath(lockPath, guard.instanceId);
+  const slotTempPath = `${lockPath}.repair-slot-temp.${guard.instanceId}`;
+  const ticketPath = ownershipRepairTicketPath(lockPath, guard.instanceId);
+  const ticketTempPath = `${lockPath}.repair-ticket-temp.${guard.instanceId}`;
+  publishCompleteJson(lockPath, slotPath, slotTempPath, guard);
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    removeOwnedJson(ticketPath, guard.instanceId);
+    removeOwnedJson(slotPath, guard.instanceId);
+  };
+
+  try {
+    let maxTicket = 0n;
+    for (const path of listPathsWithPrefix(lockPath, ".repair-slot.")) {
+      const inspection = readRecoveryGuardInspection(path);
+      if (inspection.state === "stale") {
+        removeOwnedJson(ownershipRepairTicketPath(lockPath, inspection.guard.instanceId), inspection.guard.instanceId);
+        removeOwnedJson(path, inspection.guard.instanceId);
+        continue;
+      }
+      if (inspection.state === "untrusted") {
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+          `Repair slot ${path} cannot be trusted: ${inspection.reason}`,
+          lockPath,
+        );
+      }
+      if (inspection.state === "absent") continue;
+      const ticket = readRepairTicketInspection(ownershipRepairTicketPath(lockPath, inspection.guard.instanceId));
+      if (ticket.state === "untrusted") {
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+          `Repair ticket ${ticket.path} cannot be trusted: ${ticket.reason}`,
+          lockPath,
+        );
+      }
+      if (ticket.state === "valid") {
+        if (ticket.guard.instanceId !== inspection.guard.instanceId) {
+          throw new DaemonRuntimeOwnershipError(
+            DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+            `Repair ticket ${ticket.path} does not match slot instance ${inspection.guard.instanceId}`,
+            lockPath,
+          );
+        }
+        const value = BigInt(ticket.ticket);
+        if (value > maxTicket) maxTicket = value;
+      }
+    }
+
+    const ownTicket = (maxTicket + 1n).toString();
+    publishCompleteJson(lockPath, ticketPath, ticketTempPath, { ...guard, ticket: ownTicket });
+
+    for (let attempt = 0; attempt < RECOVERY_FENCE_DRAIN_RETRIES; attempt += 1) {
+      let blocked = false;
+      for (const path of listPathsWithPrefix(lockPath, ".repair-slot.")) {
+        const inspection = readRecoveryGuardInspection(path);
+        if (inspection.state === "absent") continue;
+        if (inspection.state === "stale") {
+          removeOwnedJson(
+            ownershipRepairTicketPath(lockPath, inspection.guard.instanceId),
+            inspection.guard.instanceId,
+          );
+          removeOwnedJson(path, inspection.guard.instanceId);
+          continue;
+        }
+        if (inspection.state === "untrusted") {
+          throw new DaemonRuntimeOwnershipError(
+            DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+            `Repair slot ${path} cannot be trusted: ${inspection.reason}`,
+            lockPath,
+          );
+        }
+        if (inspection.guard.instanceId === guard.instanceId) continue;
+        const ticket = readRepairTicketInspection(ownershipRepairTicketPath(lockPath, inspection.guard.instanceId));
+        if (ticket.state === "absent") {
+          blocked = true;
+          continue;
+        }
+        if (ticket.state === "untrusted" || ticket.guard.instanceId !== inspection.guard.instanceId) {
+          throw new DaemonRuntimeOwnershipError(
+            DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+            `Repair ticket ${ticket.path} cannot be trusted${
+              ticket.state === "untrusted" ? `: ${ticket.reason}` : ": instance mismatch"
+            }`,
+            lockPath,
+          );
+        }
+        if (repairOrderIsEarlier(ticket.ticket, inspection.guard.instanceId, ownTicket, guard.instanceId)) {
+          blocked = true;
+        }
+      }
+      if (!blocked) return { guard, release };
+      if (attempt + 1 < RECOVERY_FENCE_DRAIN_RETRIES) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, RECOVERY_GUARD_CLEANUP_RETRY_MS);
+      }
+    }
+    throw new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+      `Timed out waiting for an earlier ownership repair for ${lockPath}`,
+      lockPath,
+    );
+  } catch (error) {
+    release();
+    throw error;
+  }
 }
 
 function assertOwnedMainLock(lockPath: string, home: string, owner: DaemonRuntimeOwner): void {
@@ -813,15 +1154,9 @@ export function acquireDaemonRuntimeOwnership(opts: {
     processStartIdentity: processStart.identity,
     startedAt: new Date().toISOString(),
   };
-  const entrantPath = ownershipEntrantPath(lockPath, entrant.instanceId);
   const fencePath = recoveryMutationFencePath(lockPath);
-  if (tryWriteExclusiveJson(entrantPath, entrant) === "exists") {
-    throw new DaemonRuntimeOwnershipError(
-      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
-      `Unable to create unique daemon ownership entrant ${entrantPath}`,
-      lockPath,
-    );
-  }
+  cleanupStaleOwnershipEntrantTemps(lockPath);
+  const entrantPath = publishOwnershipEntrant(lockPath, entrant);
 
   try {
     assertNoRecoveryMutationFence(fencePath, lockPath);
@@ -997,6 +1332,191 @@ export function acquireDaemonRuntimeOwnership(opts: {
     }
   } finally {
     removeOwnedJson(entrantPath, entrant.instanceId);
+  }
+}
+
+function ownershipRepairError(lockPath: string, message: string): DaemonRuntimeOwnershipError {
+  return new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+    `Refusing daemon ownership repair for ${lockPath}: ${message}`,
+    lockPath,
+  );
+}
+
+export function repairDaemonRuntimeOwnership(homeInput: string): DaemonRuntimeOwnershipRepairResult {
+  const home = canonicalHome(homeInput, true);
+  const lockPath = join(home, "state", "daemon-runtime.lock");
+  const fencePath = recoveryMutationFencePath(lockPath);
+  const recoveryPath = recoveryGuardPath(lockPath);
+  const processStart = inspectProcessStart(process.pid);
+  if (processStart.state !== "present") {
+    throw ownershipRepairError(
+      lockPath,
+      processStart.state === "gone" ? "current repair process disappeared" : processStart.reason,
+    );
+  }
+
+  const repair = acquireOwnershipRepairLease(lockPath, processStart.identity);
+  let restoredFrom: string | undefined;
+  try {
+    let evidence = inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(home, lockPath);
+    if (evidence.fence.state === "absent") {
+      repair.release();
+      evidence = inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(home, lockPath);
+      return { repaired: false, lockPath, evidence };
+    }
+    if (evidence.fence.state === "live") {
+      throw new DaemonRuntimeOwnershipError(
+        DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+        `Refusing repair because fence ${evidence.fence.recoveryPath} is live: instance ${
+          evidence.fence.guard.instanceId
+        }, pid ${evidence.fence.guard.pid}, start ${evidence.fence.guard.processStartIdentity}`,
+        lockPath,
+      );
+    }
+    if (evidence.fence.state === "untrusted") {
+      throw ownershipRepairError(lockPath, `fence cannot be trusted: ${evidence.fence.reason}`);
+    }
+    const fenceInstanceId = evidence.fence.guard.instanceId;
+
+    // The stale fence remains authoritative while repair waits out every
+    // startup that was published before it and every later startup rejects.
+    drainOwnershipEntrants(lockPath, "");
+    evidence = inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(home, lockPath);
+    if (evidence.fence.state !== "stale" || evidence.fence.guard.instanceId !== fenceInstanceId) {
+      throw ownershipRepairError(lockPath, "the exact stale fence changed while repair was acquiring ownership");
+    }
+    if (evidence.main.state === "untrusted") {
+      throw ownershipRepairError(lockPath, `canonical main owner is untrusted: ${evidence.main.reason}`);
+    }
+    const relatedCandidates = evidence.quarantineCandidates.filter((candidate) =>
+      candidate.path.endsWith(`.${fenceInstanceId}`),
+    );
+    const untrustedCandidate = relatedCandidates.find((candidate) => candidate.inspection.state === "untrusted");
+    if (untrustedCandidate?.inspection.state === "untrusted") {
+      throw ownershipRepairError(
+        lockPath,
+        `quarantine candidate ${untrustedCandidate.path} is untrusted: ${untrustedCandidate.inspection.reason}`,
+      );
+    }
+
+    const liveCandidates = relatedCandidates.filter(
+      (
+        candidate,
+      ): candidate is { path: string; inspection: Extract<DaemonRuntimeOwnershipInspection, { state: "live" }> } =>
+        candidate.inspection.state === "live",
+    );
+    const liveInstances = new Set(liveCandidates.map((candidate) => candidate.inspection.owner.instanceId));
+    if (evidence.main.state === "live") liveInstances.add(evidence.main.owner.instanceId);
+    if (liveInstances.size > 1) {
+      throw ownershipRepairError(
+        lockPath,
+        `multiple different live owner candidates exist: ${[...liveInstances].join(", ")}`,
+      );
+    }
+
+    const uniqueLiveCandidate =
+      liveCandidates.length > 0
+        ? liveCandidates.find(
+            (candidate) =>
+              evidence.main.state !== "live" ||
+              candidate.inspection.owner.instanceId !== evidence.main.owner.instanceId,
+          )
+        : undefined;
+
+    if (evidence.main.state === "absent") {
+      const staleCandidates = relatedCandidates.filter(
+        (
+          candidate,
+        ): candidate is { path: string; inspection: Extract<DaemonRuntimeOwnershipInspection, { state: "stale" }> } =>
+          candidate.inspection.state === "stale",
+      );
+      const staleInstances = new Set(staleCandidates.map((candidate) => candidate.inspection.owner.instanceId));
+      const candidate =
+        uniqueLiveCandidate ??
+        (liveInstances.size === 0 && staleInstances.size === 1
+          ? staleCandidates.find((item) => item.inspection.owner.instanceId === [...staleInstances][0])
+          : undefined);
+      if (!candidate) {
+        throw ownershipRepairError(
+          lockPath,
+          liveInstances.size === 0 && staleInstances.size > 1
+            ? `canonical main is absent and stale candidates are ambiguous: ${[...staleInstances].join(", ")}`
+            : "canonical main is absent and no unique trusted quarantine candidate can restore it",
+        );
+      }
+      if (!restoreQuarantinedFileWithRetries(candidate.path, lockPath)) {
+        throw ownershipRepairError(lockPath, `failed to restore candidate ${candidate.path} without overwriting main`);
+      }
+      restoredFrom = candidate.path;
+    } else if (evidence.main.state === "stale" && uniqueLiveCandidate) {
+      const displacedMainPath = `${lockPath}.repair-stale.${Date.now()}.${evidence.main.owner.instanceId}.${repair.guard.instanceId}`;
+      try {
+        renameSync(lockPath, displacedMainPath);
+      } catch (error) {
+        throw ownershipRepairError(
+          lockPath,
+          `failed to isolate stale canonical main: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      if (readInstanceId(displacedMainPath) !== evidence.main.owner.instanceId) {
+        restoreQuarantinedFileWithRetries(displacedMainPath, lockPath);
+        throw ownershipRepairError(lockPath, "canonical main changed while repair isolated it");
+      }
+      if (!restoreQuarantinedFileWithRetries(uniqueLiveCandidate.path, lockPath)) {
+        restoreQuarantinedFileWithRetries(displacedMainPath, lockPath);
+        throw ownershipRepairError(lockPath, `failed to restore live candidate ${uniqueLiveCandidate.path}`);
+      }
+      restoredFrom = uniqueLiveCandidate.path;
+    }
+
+    const reconciledMain = readOwnerInspection(lockPath, home);
+    if (reconciledMain.state !== "live" && reconciledMain.state !== "stale") {
+      throw ownershipRepairError(
+        lockPath,
+        reconciledMain.state === "untrusted"
+          ? `reconciled main is untrusted: ${reconciledMain.reason}`
+          : "reconciled main is absent",
+      );
+    }
+    const exactFence = readRecoveryGuardInspection(fencePath);
+    if (exactFence.state !== "stale" || exactFence.guard.instanceId !== fenceInstanceId) {
+      throw ownershipRepairError(lockPath, "exact stale fence changed before repair commit");
+    }
+
+    const legacyGuard = readRecoveryGuardInspection(recoveryPath);
+    if (legacyGuard.state === "live" || legacyGuard.state === "untrusted") {
+      throw ownershipRepairError(
+        lockPath,
+        legacyGuard.state === "live"
+          ? `legacy recovery guard is still live under instance ${legacyGuard.guard.instanceId}`
+          : `legacy recovery guard is untrusted: ${legacyGuard.reason}`,
+      );
+    }
+    if (legacyGuard.state === "stale") {
+      if (legacyGuard.guard.instanceId !== fenceInstanceId) {
+        throw ownershipRepairError(
+          lockPath,
+          `legacy recovery guard instance ${legacyGuard.guard.instanceId} does not match fence ${fenceInstanceId}`,
+        );
+      }
+      if (!removeOwnedRecoveryGuard(recoveryPath, fenceInstanceId) && existsSync(recoveryPath)) {
+        throw ownershipRepairError(lockPath, "failed to remove exact stale legacy recovery guard");
+      }
+    }
+    if (!removeOwnedRecoveryGuard(fencePath, fenceInstanceId)) {
+      throw ownershipRepairError(lockPath, "failed to remove exact stale recovery fence");
+    }
+
+    repair.release();
+    return {
+      repaired: true,
+      lockPath,
+      restoredFrom,
+      evidence: inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(home, lockPath),
+    };
+  } finally {
+    repair.release();
   }
 }
 

--- a/apps/cli/src/core/daemon-runtime-ownership.ts
+++ b/apps/cli/src/core/daemon-runtime-ownership.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   closeSync,
   existsSync,
@@ -12,6 +12,7 @@ import {
   realpathSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -108,15 +109,21 @@ type RecoveryGuardInspection = DaemonRuntimeRecoveryGuardInspection;
 export type DaemonRuntimeRecoveryEvidence = {
   lockPath: string;
   fence: DaemonRuntimeRecoveryGuardInspection;
+  repairGuard: DaemonRuntimeRecoveryGuardInspection;
   repairSlots: Array<{ path: string; inspection: DaemonRuntimeRecoveryGuardInspection; ticket?: string }>;
   main: DaemonRuntimeOwnershipInspection;
-  quarantineCandidates: Array<{ path: string; inspection: DaemonRuntimeOwnershipInspection }>;
+  quarantineCandidates: Array<{
+    path: string;
+    fileIdentity?: string;
+    inspection: DaemonRuntimeOwnershipInspection;
+  }>;
   entrants: Array<{ path: string; inspection: DaemonRuntimeRecoveryGuardInspection }>;
 };
 
 export type DaemonRuntimeOwnershipRepairResult = {
   repaired: boolean;
   lockPath: string;
+  reconciledState?: "owner" | "empty";
   restoredFrom?: string;
   evidence: DaemonRuntimeRecoveryEvidence;
 };
@@ -137,12 +144,12 @@ function recoveryMutationFencePath(lockPath: string): string {
   return `${lockPath}.recovery-fence`;
 }
 
-function ownershipEntrantPath(lockPath: string, instanceId: string): string {
-  return `${lockPath}.entrant.${instanceId}`;
+function ownershipRepairGuardPath(lockPath: string): string {
+  return `${lockPath}.repair`;
 }
 
-function ownershipEntrantTempPath(lockPath: string, instanceId: string): string {
-  return `${lockPath}.entrant-temp.${instanceId}`;
+function ownershipEntrantPath(lockPath: string, instanceId: string): string {
+  return `${lockPath}.entrant.${instanceId}`;
 }
 
 function ownershipRepairSlotPath(lockPath: string, instanceId: string): string {
@@ -496,6 +503,7 @@ function inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(
   return {
     lockPath,
     fence: readRecoveryGuardInspection(recoveryMutationFencePath(lockPath)),
+    repairGuard: readRecoveryGuardInspection(ownershipRepairGuardPath(lockPath)),
     repairSlots: listPathsWithPrefix(lockPath, ".repair-slot.").map((path) => {
       const inspection = readRecoveryGuardInspection(path);
       const instanceId = inspection.state === "absent" ? undefined : inspection.guard?.instanceId;
@@ -509,8 +517,12 @@ function inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(
       };
     }),
     main: readOwnerInspection(lockPath, resolvedHome),
-    quarantineCandidates: listPathsWithPrefix(lockPath, ".stale.").map((path) => ({
+    quarantineCandidates: [
+      ...listPathsWithPrefix(lockPath, ".stale."),
+      ...listPathsWithPrefix(lockPath, ".repair-stale."),
+    ].map((path) => ({
       path,
+      fileIdentity: publishedFileIdentity(path),
       inspection: readOwnerInspection(path, resolvedHome),
     })),
     entrants: listPathsWithPrefix(lockPath, ".entrant.").map((path) => ({
@@ -548,7 +560,11 @@ function formatOwnerInspection(label: string, inspection: DaemonRuntimeOwnership
 }
 
 export function formatDaemonRuntimeRecoveryEvidence(evidence: DaemonRuntimeRecoveryEvidence): string[] {
-  const lines = [formatRecoveryGuardInspection("fence", evidence.fence), formatOwnerInspection("main", evidence.main)];
+  const lines = [
+    formatRecoveryGuardInspection("fence", evidence.fence),
+    formatRecoveryGuardInspection("repair-guard", evidence.repairGuard),
+    formatOwnerInspection("main", evidence.main),
+  ];
   if (evidence.repairSlots.length === 0) {
     lines.push("repair=none");
   } else {
@@ -562,7 +578,11 @@ export function formatDaemonRuntimeRecoveryEvidence(evidence: DaemonRuntimeRecov
     lines.push("quarantine=none");
   } else {
     for (const candidate of evidence.quarantineCandidates) {
-      lines.push(formatOwnerInspection(`quarantine ${candidate.path}`, candidate.inspection));
+      lines.push(
+        `${formatOwnerInspection(`quarantine ${candidate.path}`, candidate.inspection)}, file=${
+          candidate.fileIdentity ?? "unavailable"
+        }`,
+      );
     }
     const candidateInstances = new Set(
       evidence.quarantineCandidates.flatMap((candidate) =>
@@ -624,7 +644,7 @@ export function inspectDaemonRuntimeOwnership(home: string): DaemonRuntimeOwners
   return readOwnerInspection(lockPath, resolvedHome);
 }
 
-function tryWriteExclusiveJson(path: string, value: unknown): "created" | "exists" {
+function tryWriteCompleteJsonTempExclusive(path: string, value: unknown): "created" | "exists" {
   let fd: number | null = null;
   let created = false;
   try {
@@ -653,7 +673,9 @@ function tryWriteExclusiveJson(path: string, value: unknown): "created" | "exist
     }
     throw new DaemonRuntimeOwnershipError(
       DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
-      `Unable to create daemon ownership file ${path}: ${error instanceof Error ? error.message : String(error)}`,
+      `Unable to create complete ownership publication temp ${path}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
       path,
     );
   } finally {
@@ -669,6 +691,45 @@ function readInstanceId(path: string): string | undefined {
     return undefined;
   }
   return isRecord(value) && typeof value.instanceId === "string" ? value.instanceId : undefined;
+}
+
+function publishedJsonFingerprint(path: string): string | undefined {
+  try {
+    return createHash("sha256").update(readFileSync(path)).digest("hex");
+  } catch {
+    return undefined;
+  }
+}
+
+function publishedFileIdentity(path: string): string | undefined {
+  try {
+    const stats = statSync(path, { bigint: true });
+    return `${stats.dev}:${stats.ino}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function assertExactStaleRecoveryRecord(
+  path: string,
+  instanceId: string,
+  fingerprint: string,
+  lockPath: string,
+  label: string,
+): RecoveryGuard {
+  const inspection = readRecoveryGuardInspection(path);
+  if (
+    inspection.state === "stale" &&
+    inspection.guard.instanceId === instanceId &&
+    publishedJsonFingerprint(path) === fingerprint
+  ) {
+    return inspection.guard;
+  }
+  throw new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+    `${label} ${path} changed from exact stale instance ${instanceId}`,
+    lockPath,
+  );
 }
 
 function restoreQuarantinedFileIfAbsent(quarantinePath: string, path: string): boolean {
@@ -699,10 +760,10 @@ function restoreQuarantinedFileWithRetries(quarantinePath: string, path: string)
   return false;
 }
 
-function cleanupStaleOwnershipEntrantTemps(lockPath: string): void {
+function cleanupStaleOwnershipPublicationTemps(lockPath: string): void {
   const directory = dirname(lockPath);
   if (!existsSync(directory)) return;
-  const prefix = `${basename(lockPath)}.entrant-temp.`;
+  const prefix = `${basename(lockPath)}.publish-temp.`;
   for (const name of readdirSync(directory)) {
     if (!name.startsWith(prefix)) continue;
     const tempPath = join(directory, name);
@@ -711,13 +772,23 @@ function cleanupStaleOwnershipEntrantTemps(lockPath: string): void {
   }
 }
 
-function publishCompleteJson<T extends { instanceId: string }>(
+type OwnershipPublicationKind =
+  | "main"
+  | "recovery"
+  | "fence"
+  | "entrant"
+  | "repair-guard"
+  | "repair-slot"
+  | "repair-ticket";
+
+function tryPublishCompleteJsonExclusive<T extends { instanceId: string }>(
   lockPath: string,
   path: string,
-  tempPath: string,
+  kind: OwnershipPublicationKind,
   value: T,
-): void {
-  if (tryWriteExclusiveJson(tempPath, value) === "exists") {
+): "created" | "exists" {
+  const tempPath = `${lockPath}.publish-temp.${kind}.${value.instanceId}.${randomUUID()}`;
+  if (tryWriteCompleteJsonTempExclusive(tempPath, value) === "exists") {
     throw new DaemonRuntimeOwnershipError(
       DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
       `Unable to create unique ownership publication temp ${tempPath}`,
@@ -727,6 +798,7 @@ function publishCompleteJson<T extends { instanceId: string }>(
   try {
     linkSync(tempPath, path);
   } catch (error) {
+    if (errorCode(error) === "EEXIST") return "exists";
     throw new DaemonRuntimeOwnershipError(
       DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
       `Unable to publish ownership record ${path}: ${error instanceof Error ? error.message : String(error)}`,
@@ -735,14 +807,28 @@ function publishCompleteJson<T extends { instanceId: string }>(
   } finally {
     removeOwnedJson(tempPath, value.instanceId);
   }
+  return "created";
+}
+
+function publishCompleteJson<T extends { instanceId: string }>(
+  lockPath: string,
+  path: string,
+  kind: OwnershipPublicationKind,
+  value: T,
+): void {
+  if (tryPublishCompleteJsonExclusive(lockPath, path, kind, value) === "created") return;
+  throw new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+    `Unable to publish unique ownership record ${path}: the path already exists`,
+    lockPath,
+  );
 }
 
 function publishOwnershipEntrant(lockPath: string, entrant: RecoveryGuard): string {
   const entrantPath = ownershipEntrantPath(lockPath, entrant.instanceId);
-  const tempPath = ownershipEntrantTempPath(lockPath, entrant.instanceId);
-  // The scanner ignores entrant-temp paths. The hard link publishes the
+  // The scanner ignores publish-temp paths. The hard link publishes the
   // already-fsynced inode atomically and cannot overwrite another path.
-  publishCompleteJson(lockPath, entrantPath, tempPath, entrant);
+  publishCompleteJson(lockPath, entrantPath, "entrant", entrant);
   return entrantPath;
 }
 
@@ -756,6 +842,27 @@ function removeOwnedJson(path: string, instanceId: string): boolean {
     return false;
   }
   if (readInstanceId(cleanupPath) !== instanceId) {
+    restoreQuarantinedFileIfAbsent(cleanupPath, path);
+    return false;
+  }
+  try {
+    rmSync(cleanupPath);
+    return true;
+  } catch {
+    restoreQuarantinedFileIfAbsent(cleanupPath, path);
+    return false;
+  }
+}
+
+function removeExactOwnedJson(path: string, instanceId: string, fingerprint: string): boolean {
+  if (readInstanceId(path) !== instanceId || publishedJsonFingerprint(path) !== fingerprint) return false;
+  const cleanupPath = `${path}.cleanup.${instanceId}.${randomUUID()}`;
+  try {
+    renameSync(path, cleanupPath);
+  } catch {
+    return false;
+  }
+  if (readInstanceId(cleanupPath) !== instanceId || publishedJsonFingerprint(cleanupPath) !== fingerprint) {
     restoreQuarantinedFileIfAbsent(cleanupPath, path);
     return false;
   }
@@ -901,6 +1008,9 @@ function drainOwnershipEntrants(lockPath: string, ownEntrantPath: string): void 
 
 type OwnershipRepairLease = {
   guard: RecoveryGuard;
+  repairPath: string;
+  repairFingerprint: string;
+  assertOwned: () => void;
   release: () => void;
 };
 
@@ -908,6 +1018,83 @@ function repairOrderIsEarlier(leftTicket: string, leftId: string, rightTicket: s
   const left = BigInt(leftTicket);
   const right = BigInt(rightTicket);
   return left < right || (left === right && leftId < rightId);
+}
+
+function assertOwnedOwnershipRepairGuard(
+  repairPath: string,
+  guard: RecoveryGuard,
+  repairFingerprint: string,
+  lockPath: string,
+): void {
+  const inspection = readRecoveryGuardInspection(repairPath);
+  if (
+    inspection.state === "live" &&
+    inspection.guard.instanceId === guard.instanceId &&
+    publishedJsonFingerprint(repairPath) === repairFingerprint
+  ) {
+    return;
+  }
+  throw new DaemonRuntimeOwnershipError(
+    inspection.state === "untrusted"
+      ? DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock
+      : DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+    `Ownership repair guard ${repairPath} is not held by exact instance ${guard.instanceId}${
+      inspection.state === "untrusted" ? `: ${inspection.reason}` : ""
+    }`,
+    lockPath,
+  );
+}
+
+function acquireCanonicalOwnershipRepairGuard(
+  lockPath: string,
+  guard: RecoveryGuard,
+): { repairPath: string; repairFingerprint: string } {
+  const repairPath = ownershipRepairGuardPath(lockPath);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const inspection = readRecoveryGuardInspection(repairPath);
+    if (inspection.state === "live") {
+      throw new DaemonRuntimeOwnershipError(
+        DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+        `Ownership repair is already active at ${repairPath} under instance ${inspection.guard.instanceId}, pid ${inspection.guard.pid}`,
+        lockPath,
+      );
+    }
+    if (inspection.state === "untrusted") {
+      throw new DaemonRuntimeOwnershipError(
+        DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+        `Ownership repair guard ${repairPath} cannot be trusted: ${inspection.reason}`,
+        lockPath,
+      );
+    }
+    if (inspection.state === "stale") {
+      const staleFingerprint = publishedJsonFingerprint(repairPath);
+      if (!staleFingerprint || !removeExactOwnedJson(repairPath, inspection.guard.instanceId, staleFingerprint)) {
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+          `Ownership repair guard ${repairPath} changed while reclaiming stale instance ${inspection.guard.instanceId}`,
+          lockPath,
+        );
+      }
+    }
+    if (inspection.state === "stale") continue;
+    if (tryPublishCompleteJsonExclusive(lockPath, repairPath, "repair-guard", guard) === "created") {
+      const repairFingerprint = publishedJsonFingerprint(repairPath);
+      if (!repairFingerprint) {
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+          `Ownership repair guard ${repairPath} could not be fingerprinted after publication`,
+          lockPath,
+        );
+      }
+      assertOwnedOwnershipRepairGuard(repairPath, guard, repairFingerprint, lockPath);
+      return { repairPath, repairFingerprint };
+    }
+  }
+  throw new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+    `Ownership repair guard ${repairPath} changed repeatedly`,
+    lockPath,
+  );
 }
 
 function acquireOwnershipRepairLease(lockPath: string, processStartIdentity: string): OwnershipRepairLease {
@@ -919,15 +1106,16 @@ function acquireOwnershipRepairLease(lockPath: string, processStartIdentity: str
     startedAt: new Date().toISOString(),
   };
   const slotPath = ownershipRepairSlotPath(lockPath, guard.instanceId);
-  const slotTempPath = `${lockPath}.repair-slot-temp.${guard.instanceId}`;
   const ticketPath = ownershipRepairTicketPath(lockPath, guard.instanceId);
-  const ticketTempPath = `${lockPath}.repair-ticket-temp.${guard.instanceId}`;
-  publishCompleteJson(lockPath, slotPath, slotTempPath, guard);
+  publishCompleteJson(lockPath, slotPath, "repair-slot", guard);
 
   let released = false;
+  let repairPath: string | undefined;
+  let repairFingerprint: string | undefined;
   const release = () => {
     if (released) return;
     released = true;
+    if (repairPath && repairFingerprint) removeExactOwnedJson(repairPath, guard.instanceId, repairFingerprint);
     removeOwnedJson(ticketPath, guard.instanceId);
     removeOwnedJson(slotPath, guard.instanceId);
   };
@@ -971,7 +1159,7 @@ function acquireOwnershipRepairLease(lockPath: string, processStartIdentity: str
     }
 
     const ownTicket = (maxTicket + 1n).toString();
-    publishCompleteJson(lockPath, ticketPath, ticketTempPath, { ...guard, ticket: ownTicket });
+    publishCompleteJson(lockPath, ticketPath, "repair-ticket", { ...guard, ticket: ownTicket });
 
     for (let attempt = 0; attempt < RECOVERY_FENCE_DRAIN_RETRIES; attempt += 1) {
       let blocked = false;
@@ -1012,7 +1200,19 @@ function acquireOwnershipRepairLease(lockPath: string, processStartIdentity: str
           blocked = true;
         }
       }
-      if (!blocked) return { guard, release };
+      if (!blocked) {
+        const acquired = acquireCanonicalOwnershipRepairGuard(lockPath, guard);
+        repairPath = acquired.repairPath;
+        repairFingerprint = acquired.repairFingerprint;
+        return {
+          guard,
+          repairPath: acquired.repairPath,
+          repairFingerprint: acquired.repairFingerprint,
+          assertOwned: () =>
+            assertOwnedOwnershipRepairGuard(acquired.repairPath, guard, acquired.repairFingerprint, lockPath),
+          release,
+        };
+      }
       if (attempt + 1 < RECOVERY_FENCE_DRAIN_RETRIES) {
         Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, RECOVERY_GUARD_CLEANUP_RETRY_MS);
       }
@@ -1155,7 +1355,7 @@ export function acquireDaemonRuntimeOwnership(opts: {
     startedAt: new Date().toISOString(),
   };
   const fencePath = recoveryMutationFencePath(lockPath);
-  cleanupStaleOwnershipEntrantTemps(lockPath);
+  cleanupStaleOwnershipPublicationTemps(lockPath);
   const entrantPath = publishOwnershipEntrant(lockPath, entrant);
 
   try {
@@ -1163,7 +1363,7 @@ export function acquireDaemonRuntimeOwnership(opts: {
     let quarantinedRecoveryGuardPath = quarantineStaleRecoveryGuard(recoveryPath, lockPath);
     assertNoRecoveryMutationFence(fencePath, lockPath);
 
-    const firstAttempt = tryWriteExclusiveJson(lockPath, owner);
+    const firstAttempt = tryPublishCompleteJsonExclusive(lockPath, lockPath, "main", owner);
     if (firstAttempt === "created") {
       const racedRecovery = readRecoveryGuardInspection(recoveryPath);
       const racedFence = readRecoveryGuardInspection(fencePath);
@@ -1196,7 +1396,7 @@ export function acquireDaemonRuntimeOwnership(opts: {
     };
     quarantinedRecoveryGuardPath = quarantineStaleRecoveryGuard(recoveryPath, lockPath) ?? quarantinedRecoveryGuardPath;
     assertNoRecoveryMutationFence(fencePath, lockPath);
-    if (tryWriteExclusiveJson(recoveryPath, recovery) === "exists") {
+    if (tryPublishCompleteJsonExclusive(lockPath, recoveryPath, "recovery", recovery) === "exists") {
       const inspection = readRecoveryGuardInspection(recoveryPath);
       if (inspection.state === "live" || inspection.state === "untrusted") {
         throw recoveryGuardErrorFromInspection(inspection, lockPath);
@@ -1215,7 +1415,7 @@ export function acquireDaemonRuntimeOwnership(opts: {
     let safeToRemoveFence = false;
     try {
       assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
-      if (tryWriteExclusiveJson(fencePath, recovery) === "exists") {
+      if (tryPublishCompleteJsonExclusive(lockPath, fencePath, "fence", recovery) === "exists") {
         const inspection = readRecoveryGuardInspection(fencePath);
         if (inspection.state !== "absent") throw mutationFenceError(inspection, lockPath);
         throw new DaemonRuntimeOwnershipError(
@@ -1282,7 +1482,7 @@ export function acquireDaemonRuntimeOwnership(opts: {
       // (or after a colliding owner released while entrants were drained).
       assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
       assertOwnedRecoveryMutationFence(fencePath, recovery, lockPath);
-      if (tryWriteExclusiveJson(lockPath, owner) === "exists") {
+      if (tryPublishCompleteJsonExclusive(lockPath, lockPath, "main", owner) === "exists") {
         const retryInspection = readOwnerInspection(lockPath, home);
         if (retryInspection.state === "absent") {
           throw new DaemonRuntimeOwnershipError(
@@ -1326,8 +1526,8 @@ export function acquireDaemonRuntimeOwnership(opts: {
       // a bounded window to restore our live guard, then remove only our instance.
       removeOwnedRecoveryGuard(recoveryPath, recovery.instanceId);
       // An unresolved main-lock mutation deliberately leaves this fence in
-      // place. It is never auto-recovered: manual remediation is safer than
-      // admitting a second lease after an interrupted quarantine/restore.
+      // place. Ordinary startup never auto-recovers it; the evidence-driven
+      // repair command must reconcile main ownership before removing it.
       if (fenceOwned && safeToRemoveFence) removeOwnedRecoveryGuard(fencePath, recovery.instanceId);
     }
   } finally {
@@ -1356,9 +1556,12 @@ export function repairDaemonRuntimeOwnership(homeInput: string): DaemonRuntimeOw
     );
   }
 
+  cleanupStaleOwnershipPublicationTemps(lockPath);
   const repair = acquireOwnershipRepairLease(lockPath, processStart.identity);
   let restoredFrom: string | undefined;
+  let reconciledState: "owner" | "empty" | undefined;
   try {
+    repair.assertOwned();
     let evidence = inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(home, lockPath);
     if (evidence.fence.state === "absent") {
       repair.release();
@@ -1378,21 +1581,23 @@ export function repairDaemonRuntimeOwnership(homeInput: string): DaemonRuntimeOw
       throw ownershipRepairError(lockPath, `fence cannot be trusted: ${evidence.fence.reason}`);
     }
     const fenceInstanceId = evidence.fence.guard.instanceId;
+    const fenceFingerprint = publishedJsonFingerprint(fencePath);
+    if (!fenceFingerprint) throw ownershipRepairError(lockPath, "exact stale fence content cannot be fingerprinted");
 
     // The stale fence remains authoritative while repair waits out every
     // startup that was published before it and every later startup rejects.
     drainOwnershipEntrants(lockPath, "");
+    repair.assertOwned();
+    assertExactStaleRecoveryRecord(fencePath, fenceInstanceId, fenceFingerprint, lockPath, "Recovery fence");
     evidence = inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(home, lockPath);
-    if (evidence.fence.state !== "stale" || evidence.fence.guard.instanceId !== fenceInstanceId) {
-      throw ownershipRepairError(lockPath, "the exact stale fence changed while repair was acquiring ownership");
-    }
     if (evidence.main.state === "untrusted") {
       throw ownershipRepairError(lockPath, `canonical main owner is untrusted: ${evidence.main.reason}`);
     }
-    const relatedCandidates = evidence.quarantineCandidates.filter((candidate) =>
-      candidate.path.endsWith(`.${fenceInstanceId}`),
-    );
-    const untrustedCandidate = relatedCandidates.find((candidate) => candidate.inspection.state === "untrusted");
+    // A historical quarantine need not carry the current fence suffix. Any
+    // candidate can represent a previously returned lease, so repair scans
+    // every owner quarantine before proving a canonical or safe-empty state.
+    const ownerCandidates = evidence.quarantineCandidates;
+    const untrustedCandidate = ownerCandidates.find((candidate) => candidate.inspection.state === "untrusted");
     if (untrustedCandidate?.inspection.state === "untrusted") {
       throw ownershipRepairError(
         lockPath,
@@ -1400,57 +1605,90 @@ export function repairDaemonRuntimeOwnership(homeInput: string): DaemonRuntimeOw
       );
     }
 
-    const liveCandidates = relatedCandidates.filter(
+    const liveCandidates = ownerCandidates.filter(
       (
         candidate,
-      ): candidate is { path: string; inspection: Extract<DaemonRuntimeOwnershipInspection, { state: "live" }> } =>
-        candidate.inspection.state === "live",
+      ): candidate is {
+        path: string;
+        fileIdentity?: string;
+        inspection: Extract<DaemonRuntimeOwnershipInspection, { state: "live" }>;
+      } => candidate.inspection.state === "live",
     );
-    const liveInstances = new Set(liveCandidates.map((candidate) => candidate.inspection.owner.instanceId));
-    if (evidence.main.state === "live") liveInstances.add(evidence.main.owner.instanceId);
-    if (liveInstances.size > 1) {
+    const candidateKey = (candidate: {
+      path: string;
+      fileIdentity?: string;
+      inspection: Extract<DaemonRuntimeOwnershipInspection, { state: "live" | "stale" }>;
+    }): string => {
+      if (!candidate.fileIdentity) {
+        throw ownershipRepairError(lockPath, `candidate ${candidate.path} changed before its file identity was read`);
+      }
+      return `${candidate.inspection.owner.instanceId}:${candidate.fileIdentity}`;
+    };
+    const uniqueLiveCandidates = new Map(liveCandidates.map((candidate) => [candidateKey(candidate), candidate]));
+    let canonicalLiveKey: string | undefined;
+    if (evidence.main.state === "live") {
+      const mainFileIdentity = publishedFileIdentity(lockPath);
+      if (!mainFileIdentity) throw ownershipRepairError(lockPath, "live canonical main file identity is unavailable");
+      canonicalLiveKey = `${evidence.main.owner.instanceId}:${mainFileIdentity}`;
+      uniqueLiveCandidates.delete(canonicalLiveKey);
+    }
+    if (uniqueLiveCandidates.size + (canonicalLiveKey ? 1 : 0) > 1) {
       throw ownershipRepairError(
         lockPath,
-        `multiple different live owner candidates exist: ${[...liveInstances].join(", ")}`,
+        `multiple different live owner candidates exist: ${[
+          ...(canonicalLiveKey ? [canonicalLiveKey] : []),
+          ...uniqueLiveCandidates.keys(),
+        ].join(", ")}`,
       );
     }
 
-    const uniqueLiveCandidate =
-      liveCandidates.length > 0
-        ? liveCandidates.find(
-            (candidate) =>
-              evidence.main.state !== "live" ||
-              candidate.inspection.owner.instanceId !== evidence.main.owner.instanceId,
-          )
-        : undefined;
+    const uniqueLiveCandidate = canonicalLiveKey ? undefined : uniqueLiveCandidates.values().next().value;
 
+    let safeEmpty = false;
     if (evidence.main.state === "absent") {
-      const staleCandidates = relatedCandidates.filter(
+      const staleCandidates = ownerCandidates.filter(
         (
           candidate,
-        ): candidate is { path: string; inspection: Extract<DaemonRuntimeOwnershipInspection, { state: "stale" }> } =>
-          candidate.inspection.state === "stale",
+        ): candidate is {
+          path: string;
+          fileIdentity?: string;
+          inspection: Extract<DaemonRuntimeOwnershipInspection, { state: "stale" }>;
+        } => candidate.inspection.state === "stale",
       );
-      const staleInstances = new Set(staleCandidates.map((candidate) => candidate.inspection.owner.instanceId));
+      const uniqueStaleCandidates = new Map(staleCandidates.map((candidate) => [candidateKey(candidate), candidate]));
       const candidate =
         uniqueLiveCandidate ??
-        (liveInstances.size === 0 && staleInstances.size === 1
-          ? staleCandidates.find((item) => item.inspection.owner.instanceId === [...staleInstances][0])
+        (uniqueLiveCandidates.size === 0 && uniqueStaleCandidates.size === 1
+          ? uniqueStaleCandidates.values().next().value
           : undefined);
       if (!candidate) {
-        throw ownershipRepairError(
-          lockPath,
-          liveInstances.size === 0 && staleInstances.size > 1
-            ? `canonical main is absent and stale candidates are ambiguous: ${[...staleInstances].join(", ")}`
-            : "canonical main is absent and no unique trusted quarantine candidate can restore it",
-        );
+        if (ownerCandidates.length === 0) {
+          safeEmpty = true;
+        } else {
+          throw ownershipRepairError(
+            lockPath,
+            uniqueLiveCandidates.size === 0 && uniqueStaleCandidates.size > 1
+              ? `canonical main is absent and stale candidates are ambiguous: ${[...uniqueStaleCandidates.keys()].join(
+                  ", ",
+                )}`
+              : "canonical main is absent and no unique trusted quarantine candidate can restore it",
+          );
+        }
+      } else {
+        repair.assertOwned();
+        assertExactStaleRecoveryRecord(fencePath, fenceInstanceId, fenceFingerprint, lockPath, "Recovery fence");
+        if (!restoreQuarantinedFileWithRetries(candidate.path, lockPath)) {
+          throw ownershipRepairError(
+            lockPath,
+            `failed to restore candidate ${candidate.path} without overwriting main`,
+          );
+        }
+        restoredFrom = candidate.path;
       }
-      if (!restoreQuarantinedFileWithRetries(candidate.path, lockPath)) {
-        throw ownershipRepairError(lockPath, `failed to restore candidate ${candidate.path} without overwriting main`);
-      }
-      restoredFrom = candidate.path;
     } else if (evidence.main.state === "stale" && uniqueLiveCandidate) {
       const displacedMainPath = `${lockPath}.repair-stale.${Date.now()}.${evidence.main.owner.instanceId}.${repair.guard.instanceId}`;
+      repair.assertOwned();
+      assertExactStaleRecoveryRecord(fencePath, fenceInstanceId, fenceFingerprint, lockPath, "Recovery fence");
       try {
         renameSync(lockPath, displacedMainPath);
       } catch (error) {
@@ -1463,6 +1701,8 @@ export function repairDaemonRuntimeOwnership(homeInput: string): DaemonRuntimeOw
         restoreQuarantinedFileWithRetries(displacedMainPath, lockPath);
         throw ownershipRepairError(lockPath, "canonical main changed while repair isolated it");
       }
+      repair.assertOwned();
+      assertExactStaleRecoveryRecord(fencePath, fenceInstanceId, fenceFingerprint, lockPath, "Recovery fence");
       if (!restoreQuarantinedFileWithRetries(uniqueLiveCandidate.path, lockPath)) {
         restoreQuarantinedFileWithRetries(displacedMainPath, lockPath);
         throw ownershipRepairError(lockPath, `failed to restore live candidate ${uniqueLiveCandidate.path}`);
@@ -1471,7 +1711,11 @@ export function repairDaemonRuntimeOwnership(homeInput: string): DaemonRuntimeOw
     }
 
     const reconciledMain = readOwnerInspection(lockPath, home);
-    if (reconciledMain.state !== "live" && reconciledMain.state !== "stale") {
+    if (reconciledMain.state === "live" || reconciledMain.state === "stale") {
+      reconciledState = "owner";
+    } else if (reconciledMain.state === "absent" && safeEmpty) {
+      reconciledState = "empty";
+    } else {
       throw ownershipRepairError(
         lockPath,
         reconciledMain.state === "untrusted"
@@ -1479,10 +1723,8 @@ export function repairDaemonRuntimeOwnership(homeInput: string): DaemonRuntimeOw
           : "reconciled main is absent",
       );
     }
-    const exactFence = readRecoveryGuardInspection(fencePath);
-    if (exactFence.state !== "stale" || exactFence.guard.instanceId !== fenceInstanceId) {
-      throw ownershipRepairError(lockPath, "exact stale fence changed before repair commit");
-    }
+    repair.assertOwned();
+    assertExactStaleRecoveryRecord(fencePath, fenceInstanceId, fenceFingerprint, lockPath, "Recovery fence");
 
     const legacyGuard = readRecoveryGuardInspection(recoveryPath);
     if (legacyGuard.state === "live" || legacyGuard.state === "untrusted") {
@@ -1504,14 +1746,20 @@ export function repairDaemonRuntimeOwnership(homeInput: string): DaemonRuntimeOw
         throw ownershipRepairError(lockPath, "failed to remove exact stale legacy recovery guard");
       }
     }
-    if (!removeOwnedRecoveryGuard(fencePath, fenceInstanceId)) {
+    repair.assertOwned();
+    assertExactStaleRecoveryRecord(fencePath, fenceInstanceId, fenceFingerprint, lockPath, "Recovery fence");
+    if (!removeExactOwnedJson(fencePath, fenceInstanceId, fenceFingerprint)) {
       throw ownershipRepairError(lockPath, "failed to remove exact stale recovery fence");
     }
 
+    // Fence deletion is the repair linearization point. Main ownership is
+    // immutable after this line; only the exact repair guard/election records
+    // are released.
     repair.release();
     return {
       repaired: true,
       lockPath,
+      reconciledState,
       restoredFrom,
       evidence: inspectDaemonRuntimeRecoveryEvidenceForResolvedHome(home, lockPath),
     };

--- a/apps/cli/src/core/daemon-runtime-ownership.ts
+++ b/apps/cli/src/core/daemon-runtime-ownership.ts
@@ -1,0 +1,540 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import type { ChannelName } from "@first-tree/shared/channel";
+
+const LOCK_FORMAT_VERSION = 1;
+const PROCESS_QUERY_TIMEOUT_MS = 5_000;
+const INSTANCE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
+export type DaemonRuntimeMode = "foreground" | "service";
+
+export type DaemonRuntimeOwner = {
+  lockVersion: 1;
+  instanceId: string;
+  pid: number;
+  processStartIdentity: string;
+  channel: ChannelName;
+  mode: DaemonRuntimeMode;
+  version: string;
+  startedAt: string;
+  home: string;
+};
+
+export type DaemonRuntimeOwnershipInspection =
+  | { state: "absent"; lockPath: string }
+  | { state: "live"; lockPath: string; owner: DaemonRuntimeOwner }
+  | { state: "stale"; lockPath: string; owner: DaemonRuntimeOwner; reason: string }
+  | { state: "untrusted"; lockPath: string; owner?: DaemonRuntimeOwner; reason: string };
+
+export type DaemonRuntimeOwnershipLease = {
+  lockPath: string;
+  owner: DaemonRuntimeOwner;
+  quarantinedLockPath?: string;
+  release: () => boolean;
+};
+
+export const DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES = {
+  alreadyRunning: "DAEMON_RUNTIME_ALREADY_RUNNING",
+  untrustedLock: "DAEMON_RUNTIME_LOCK_UNTRUSTED",
+  recoveryBusy: "DAEMON_RUNTIME_LOCK_RECOVERY_BUSY",
+  io: "DAEMON_RUNTIME_LOCK_IO",
+} as const;
+
+export type DaemonRuntimeOwnershipErrorCode =
+  (typeof DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES)[keyof typeof DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES];
+
+export class DaemonRuntimeOwnershipError extends Error {
+  constructor(
+    readonly code: DaemonRuntimeOwnershipErrorCode,
+    message: string,
+    readonly lockPath: string,
+    readonly owner?: DaemonRuntimeOwner,
+  ) {
+    super(message);
+    this.name = "DaemonRuntimeOwnershipError";
+  }
+}
+
+export function isDaemonRuntimeOwnershipError(error: unknown): error is DaemonRuntimeOwnershipError {
+  return error instanceof DaemonRuntimeOwnershipError;
+}
+
+type ProcessStartInspection =
+  | { state: "present"; identity: string }
+  | { state: "gone" }
+  | { state: "unknown"; reason: string };
+
+type ParsedOwner = { ok: true; owner: DaemonRuntimeOwner } | { ok: false; reason: string };
+
+type RecoveryGuard = {
+  lockVersion: 1;
+  instanceId: string;
+  pid: number;
+  processStartIdentity: string;
+  startedAt: string;
+};
+
+export function daemonRuntimeOwnershipPath(home: string): string {
+  return join(canonicalHome(home, false), "state", "daemon-runtime.lock");
+}
+
+function recoveryGuardPath(lockPath: string): string {
+  return `${lockPath}.recovery`;
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+  return typeof error.code === "string" ? error.code : undefined;
+}
+
+function canonicalHome(home: string, create: boolean): string {
+  const absolute = resolve(home);
+  if (!create && !existsSync(absolute)) return absolute;
+  try {
+    if (create) mkdirSync(absolute, { recursive: true, mode: 0o700 });
+    return realpathSync.native(absolute);
+  } catch (error) {
+    throw new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+      `Unable to resolve daemon home ${absolute}: ${error instanceof Error ? error.message : String(error)}`,
+      join(absolute, "state", "daemon-runtime.lock"),
+    );
+  }
+}
+
+function isChannelName(value: unknown): value is ChannelName {
+  return value === "dev" || value === "staging" || value === "prod";
+}
+
+function isDaemonRuntimeMode(value: unknown): value is DaemonRuntimeMode {
+  return value === "foreground" || value === "service";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseOwner(raw: string, expectedHome: string): ParsedOwner {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    return { ok: false, reason: `invalid JSON (${error instanceof Error ? error.message : String(error)})` };
+  }
+  if (!isRecord(value)) return { ok: false, reason: "lock contents are not an object" };
+
+  const { lockVersion, instanceId, pid, processStartIdentity, channel, mode, version, startedAt, home } = value;
+  if (lockVersion !== LOCK_FORMAT_VERSION) {
+    return { ok: false, reason: `unsupported lockVersion ${String(lockVersion)}` };
+  }
+  if (typeof instanceId !== "string" || !INSTANCE_ID_PATTERN.test(instanceId)) {
+    return { ok: false, reason: "instanceId is missing or invalid" };
+  }
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+    return { ok: false, reason: "pid is missing or invalid" };
+  }
+  if (
+    typeof processStartIdentity !== "string" ||
+    processStartIdentity.length === 0 ||
+    processStartIdentity.length > 512
+  ) {
+    return { ok: false, reason: "processStartIdentity is missing or invalid" };
+  }
+  if (!isChannelName(channel)) return { ok: false, reason: "channel is missing or invalid" };
+  if (!isDaemonRuntimeMode(mode)) return { ok: false, reason: "mode is missing or invalid" };
+  if (typeof version !== "string" || version.length === 0 || version.length > 128) {
+    return { ok: false, reason: "version is missing or invalid" };
+  }
+  if (typeof startedAt !== "string" || !Number.isFinite(Date.parse(startedAt))) {
+    return { ok: false, reason: "startedAt is missing or invalid" };
+  }
+  if (home !== expectedHome) {
+    return { ok: false, reason: `lock home ${String(home)} does not match resolved home ${expectedHome}` };
+  }
+
+  return {
+    ok: true,
+    owner: {
+      lockVersion,
+      instanceId,
+      pid,
+      processStartIdentity,
+      channel,
+      mode,
+      version,
+      startedAt,
+      home,
+    },
+  };
+}
+
+function inspectPidExistence(pid: number): "present" | "gone" | "unknown" {
+  try {
+    process.kill(pid, 0);
+    return "present";
+  } catch (error) {
+    const code = errorCode(error);
+    if (code === "ESRCH") return "gone";
+    if (code === "EPERM") return "present";
+    return "unknown";
+  }
+}
+
+function inspectLinuxProcessStart(pid: number): ProcessStartInspection {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const commandEnd = stat.lastIndexOf(")");
+    if (commandEnd < 0) return { state: "unknown", reason: `/proc/${pid}/stat has no command terminator` };
+    const fieldsAfterCommand = stat
+      .slice(commandEnd + 1)
+      .trim()
+      .split(/\s+/u);
+    const startTicks = fieldsAfterCommand[19];
+    if (!startTicks || !/^\d+$/u.test(startTicks)) {
+      return { state: "unknown", reason: `/proc/${pid}/stat has no valid process start ticks` };
+    }
+    return { state: "present", identity: `linux-proc-start-ticks:${startTicks}` };
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return { state: "gone" };
+    return {
+      state: "unknown",
+      reason: `unable to read /proc/${pid}/stat: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+function inspectDarwinProcessStart(pid: number): ProcessStartInspection {
+  const result = spawnSync("ps", ["-p", String(pid), "-o", "lstart="], {
+    encoding: "utf8",
+    env: { ...process.env, LANG: "C", LC_ALL: "C" },
+    timeout: PROCESS_QUERY_TIMEOUT_MS,
+  });
+  if (result.error) {
+    return { state: "unknown", reason: `unable to run ps: ${result.error.message}` };
+  }
+  const startedAt = result.stdout.trim();
+  if (result.status === 0 && startedAt) {
+    return { state: "present", identity: `darwin-ps-lstart:${startedAt}` };
+  }
+  const existence = inspectPidExistence(pid);
+  if (existence === "gone") return { state: "gone" };
+  return {
+    state: "unknown",
+    reason: result.stderr.trim() || `ps did not return a start identity for pid ${pid}`,
+  };
+}
+
+function inspectWindowsProcessStart(pid: number): ProcessStartInspection {
+  const script = [
+    "$ErrorActionPreference = 'Stop'",
+    `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction SilentlyContinue`,
+    "if ($null -eq $p) { exit 3 }",
+    "$creation = if ($null -eq $p.CreationDate) { '' } else { $p.CreationDate.ToUniversalTime().ToString('o') }",
+    "[Console]::Out.Write($creation)",
+  ].join("; ");
+  const result = spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
+    { encoding: "utf8", timeout: PROCESS_QUERY_TIMEOUT_MS },
+  );
+  if (result.status === 3) return { state: "gone" };
+  if (result.error) {
+    return { state: "unknown", reason: `unable to run PowerShell: ${result.error.message}` };
+  }
+  const creationTime = result.stdout.trim();
+  if (result.status === 0 && creationTime) {
+    return { state: "present", identity: `windows-cim-creation-time:${creationTime}` };
+  }
+  return {
+    state: "unknown",
+    reason: result.stderr.trim() || `PowerShell did not return a creation time for pid ${pid}`,
+  };
+}
+
+function inspectProcessStart(pid: number): ProcessStartInspection {
+  const existence = inspectPidExistence(pid);
+  if (existence === "gone") return { state: "gone" };
+  if (existence === "unknown") return { state: "unknown", reason: `unable to determine whether pid ${pid} exists` };
+  if (process.platform === "linux") return inspectLinuxProcessStart(pid);
+  if (process.platform === "darwin") return inspectDarwinProcessStart(pid);
+  if (process.platform === "win32") return inspectWindowsProcessStart(pid);
+  return { state: "unknown", reason: `process start identity is unsupported on ${process.platform}` };
+}
+
+function readOwnerInspection(lockPath: string, home: string): DaemonRuntimeOwnershipInspection {
+  let raw: string;
+  try {
+    raw = readFileSync(lockPath, "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return { state: "absent", lockPath };
+    return {
+      state: "untrusted",
+      lockPath,
+      reason: `unable to read lock: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const parsed = parseOwner(raw, home);
+  if (!parsed.ok) return { state: "untrusted", lockPath, reason: parsed.reason };
+  const process = inspectProcessStart(parsed.owner.pid);
+  if (process.state === "gone") {
+    return { state: "stale", lockPath, owner: parsed.owner, reason: `pid ${parsed.owner.pid} no longer exists` };
+  }
+  if (process.state === "unknown") {
+    return { state: "untrusted", lockPath, owner: parsed.owner, reason: process.reason };
+  }
+  if (process.identity !== parsed.owner.processStartIdentity) {
+    return {
+      state: "stale",
+      lockPath,
+      owner: parsed.owner,
+      reason: `pid ${parsed.owner.pid} was reused with a different process start identity`,
+    };
+  }
+  return { state: "live", lockPath, owner: parsed.owner };
+}
+
+export function inspectDaemonRuntimeOwnership(home: string): DaemonRuntimeOwnershipInspection {
+  let resolvedHome: string;
+  try {
+    resolvedHome = canonicalHome(home, false);
+  } catch (error) {
+    if (isDaemonRuntimeOwnershipError(error)) {
+      return { state: "untrusted", lockPath: error.lockPath, reason: error.message };
+    }
+    throw error;
+  }
+  const lockPath = join(resolvedHome, "state", "daemon-runtime.lock");
+  if (existsSync(recoveryGuardPath(lockPath))) {
+    return {
+      state: "untrusted",
+      lockPath,
+      reason: `stale-lock recovery is in progress (${recoveryGuardPath(lockPath)})`,
+    };
+  }
+  return readOwnerInspection(lockPath, resolvedHome);
+}
+
+function tryWriteExclusiveJson(path: string, value: unknown): "created" | "exists" {
+  let fd: number | null = null;
+  let created = false;
+  try {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    fd = openSync(path, "wx", 0o600);
+    created = true;
+    writeFileSync(fd, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+    fsyncSync(fd);
+    return "created";
+  } catch (error) {
+    if (!created && errorCode(error) === "EEXIST") return "exists";
+    if (created) {
+      if (fd !== null) {
+        try {
+          closeSync(fd);
+        } catch {
+          // Preserve the original write/fsync error below.
+        }
+        fd = null;
+      }
+      try {
+        rmSync(path, { force: true });
+      } catch {
+        // A handled write failure should not leave a partial lock when cleanup is possible.
+      }
+    }
+    throw new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+      `Unable to create daemon ownership file ${path}: ${error instanceof Error ? error.message : String(error)}`,
+      path,
+    );
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+function removeOwnedJson(path: string, instanceId: string): boolean {
+  let value: unknown;
+  try {
+    value = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return false;
+  }
+  if (!isRecord(value) || value.instanceId !== instanceId) return false;
+  try {
+    rmSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ownershipErrorFromInspection(inspection: Exclude<DaemonRuntimeOwnershipInspection, { state: "absent" }>) {
+  if (inspection.state === "live") {
+    return new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.alreadyRunning,
+      `Daemon runtime ownership for ${inspection.owner.home} is already held by ${formatDaemonRuntimeOwner(
+        inspection.owner,
+      )}. Lock: ${inspection.lockPath}`,
+      inspection.lockPath,
+      inspection.owner,
+    );
+  }
+  return new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+    `Refusing daemon startup because ${inspection.lockPath} cannot be trusted: ${inspection.reason}`,
+    inspection.lockPath,
+    inspection.owner,
+  );
+}
+
+function makeLease(
+  lockPath: string,
+  owner: DaemonRuntimeOwner,
+  quarantinedLockPath?: string,
+): DaemonRuntimeOwnershipLease {
+  let released = false;
+  return {
+    lockPath,
+    owner,
+    quarantinedLockPath,
+    release: () => {
+      if (released) return false;
+      released = true;
+      return removeOwnedJson(lockPath, owner.instanceId);
+    },
+  };
+}
+
+export function acquireDaemonRuntimeOwnership(opts: {
+  channel: ChannelName;
+  mode: DaemonRuntimeMode;
+  version: string;
+  home: string;
+}): DaemonRuntimeOwnershipLease {
+  const home = canonicalHome(opts.home, true);
+  const lockPath = join(home, "state", "daemon-runtime.lock");
+  const recoveryPath = recoveryGuardPath(lockPath);
+  const processStart = inspectProcessStart(process.pid);
+  if (processStart.state !== "present") {
+    const reason = processStart.state === "gone" ? "current process disappeared during startup" : processStart.reason;
+    throw new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+      `Cannot establish the current daemon process start identity: ${reason}`,
+      lockPath,
+    );
+  }
+
+  const owner: DaemonRuntimeOwner = {
+    lockVersion: LOCK_FORMAT_VERSION,
+    instanceId: randomUUID(),
+    pid: process.pid,
+    processStartIdentity: processStart.identity,
+    channel: opts.channel,
+    mode: opts.mode,
+    version: opts.version,
+    startedAt: new Date().toISOString(),
+    home,
+  };
+
+  if (existsSync(recoveryPath)) {
+    throw new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+      `Refusing daemon startup while stale-lock recovery is in progress at ${recoveryPath}`,
+      lockPath,
+    );
+  }
+
+  const firstAttempt = tryWriteExclusiveJson(lockPath, owner);
+  if (firstAttempt === "created") {
+    if (existsSync(recoveryPath)) {
+      removeOwnedJson(lockPath, owner.instanceId);
+      throw new DaemonRuntimeOwnershipError(
+        DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+        `Refusing daemon startup because stale-lock recovery raced this owner at ${recoveryPath}`,
+        lockPath,
+      );
+    }
+    return makeLease(lockPath, owner);
+  }
+
+  const firstInspection = readOwnerInspection(lockPath, home);
+  if (firstInspection.state === "live" || firstInspection.state === "untrusted") {
+    throw ownershipErrorFromInspection(firstInspection);
+  }
+
+  const recovery: RecoveryGuard = {
+    lockVersion: LOCK_FORMAT_VERSION,
+    instanceId: randomUUID(),
+    pid: process.pid,
+    processStartIdentity: processStart.identity,
+    startedAt: new Date().toISOString(),
+  };
+  if (tryWriteExclusiveJson(recoveryPath, recovery) === "exists") {
+    throw new DaemonRuntimeOwnershipError(
+      DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+      `Refusing daemon startup because another process is recovering ${lockPath}`,
+      lockPath,
+    );
+  }
+
+  let quarantinedLockPath: string | undefined;
+  try {
+    const guardedInspection = readOwnerInspection(lockPath, home);
+    if (guardedInspection.state === "live" || guardedInspection.state === "untrusted") {
+      throw ownershipErrorFromInspection(guardedInspection);
+    }
+    if (guardedInspection.state === "stale") {
+      quarantinedLockPath = `${lockPath}.stale.${Date.now()}.${guardedInspection.owner.instanceId}.${recovery.instanceId}`;
+      try {
+        renameSync(lockPath, quarantinedLockPath);
+      } catch (error) {
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+          `Unable to quarantine stale daemon ownership file ${lockPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          lockPath,
+          guardedInspection.owner,
+        );
+      }
+    }
+
+    // Exactly one retry is allowed after the stale owner has been isolated (or
+    // after a colliding owner released between the first read and the guard).
+    if (tryWriteExclusiveJson(lockPath, owner) === "exists") {
+      const retryInspection = readOwnerInspection(lockPath, home);
+      if (retryInspection.state === "absent") {
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
+          `Daemon ownership changed again while retrying ${lockPath}; refusing a second retry`,
+          lockPath,
+        );
+      }
+      throw ownershipErrorFromInspection(retryInspection);
+    }
+    return makeLease(lockPath, owner, quarantinedLockPath);
+  } finally {
+    removeOwnedJson(recoveryPath, recovery.instanceId);
+  }
+}
+
+export function formatDaemonRuntimeOwner(owner: DaemonRuntimeOwner): string {
+  return `instance ${owner.instanceId} (pid ${owner.pid}, start ${owner.processStartIdentity}, channel ${owner.channel}, mode ${owner.mode}, version ${owner.version}, since ${owner.startedAt})`;
+}
+
+export function formatDaemonRuntimeOwnerSummary(owner: DaemonRuntimeOwner): string {
+  return `pid ${owner.pid}, ${owner.channel}/${owner.mode}, v${owner.version}, since ${owner.startedAt}`;
+}

--- a/apps/cli/src/core/daemon-runtime-ownership.ts
+++ b/apps/cli/src/core/daemon-runtime-ownership.ts
@@ -4,6 +4,7 @@ import {
   closeSync,
   existsSync,
   fsyncSync,
+  linkSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -474,18 +475,51 @@ function tryWriteExclusiveJson(path: string, value: unknown): "created" | "exist
   }
 }
 
-function removeOwnedJson(path: string, instanceId: string): boolean {
+function readInstanceId(path: string): string | undefined {
   let value: unknown;
   try {
     value = JSON.parse(readFileSync(path, "utf8"));
   } catch {
+    return undefined;
+  }
+  return isRecord(value) && typeof value.instanceId === "string" ? value.instanceId : undefined;
+}
+
+function restoreQuarantinedFileIfAbsent(quarantinePath: string, path: string): boolean {
+  try {
+    // A hard link is an exclusive, non-overwriting restore: unlike rename on
+    // POSIX it cannot replace a contender that claimed the canonical path.
+    linkSync(quarantinePath, path);
+  } catch (error) {
+    if (errorCode(error) === "EEXIST") return false;
     return false;
   }
-  if (!isRecord(value) || value.instanceId !== instanceId) return false;
   try {
-    rmSync(path);
+    rmSync(quarantinePath);
+  } catch {
+    // The canonical link is authoritative even if the quarantine alias remains.
+  }
+  return true;
+}
+
+function removeOwnedJson(path: string, instanceId: string): boolean {
+  if (readInstanceId(path) !== instanceId) return false;
+  const cleanupPath = `${path}.cleanup.${instanceId}.${randomUUID()}`;
+  try {
+    renameSync(path, cleanupPath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return false;
+    return false;
+  }
+  if (readInstanceId(cleanupPath) !== instanceId) {
+    restoreQuarantinedFileIfAbsent(cleanupPath, path);
+    return false;
+  }
+  try {
+    rmSync(cleanupPath);
     return true;
   } catch {
+    restoreQuarantinedFileIfAbsent(cleanupPath, path);
     return false;
   }
 }
@@ -538,6 +572,32 @@ function recoveryGuardErrorFromInspection(
   );
 }
 
+function assertOwnedRecoveryGuard(recoveryPath: string, recovery: RecoveryGuard, lockPath: string): void {
+  const inspection = readRecoveryGuardInspection(recoveryPath);
+  if (inspection.state === "live" && inspection.guard.instanceId === recovery.instanceId) return;
+  if (inspection.state === "untrusted") {
+    throw recoveryGuardErrorFromInspection(inspection, lockPath);
+  }
+  throw new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+    `Recovery guard ${recoveryPath} is no longer held by exact instance ${recovery.instanceId}; refusing daemon startup`,
+    lockPath,
+  );
+}
+
+function assertOwnedMainLock(lockPath: string, home: string, owner: DaemonRuntimeOwner): void {
+  const inspection = readOwnerInspection(lockPath, home);
+  if (inspection.state === "live" && inspection.owner.instanceId === owner.instanceId) return;
+  if (inspection.state === "live" || inspection.state === "untrusted") {
+    throw ownershipErrorFromInspection(inspection);
+  }
+  throw new DaemonRuntimeOwnershipError(
+    DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.recoveryBusy,
+    `Daemon ownership ${lockPath} is no longer held by exact instance ${owner.instanceId}; refusing daemon startup`,
+    lockPath,
+  );
+}
+
 function quarantineStaleRecoveryGuard(recoveryPath: string, lockPath: string): string | undefined {
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const inspection = readRecoveryGuardInspection(recoveryPath);
@@ -578,19 +638,7 @@ function quarantineStaleRecoveryGuard(recoveryPath: string, lockPath: string): s
       return quarantinePath;
     }
 
-    if (!existsSync(recoveryPath)) {
-      try {
-        renameSync(quarantinePath, recoveryPath);
-      } catch (error) {
-        throw new DaemonRuntimeOwnershipError(
-          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.io,
-          `Recovery guard ${recoveryPath} changed while being quarantined and could not be restored: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-          lockPath,
-        );
-      }
-    }
+    restoreQuarantinedFileIfAbsent(quarantinePath, recoveryPath);
     throw new DaemonRuntimeOwnershipError(
       DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
       `Recovery guard ${recoveryPath} changed while being quarantined; refusing daemon startup`,
@@ -701,6 +749,7 @@ export function acquireDaemonRuntimeOwnership(opts: {
   }
 
   let quarantinedLockPath: string | undefined;
+  let ownerCreated = false;
   try {
     const guardedInspection = readOwnerInspection(lockPath, home);
     if (guardedInspection.state === "live" || guardedInspection.state === "untrusted") {
@@ -708,6 +757,7 @@ export function acquireDaemonRuntimeOwnership(opts: {
     }
     if (guardedInspection.state === "stale") {
       quarantinedLockPath = `${lockPath}.stale.${Date.now()}.${guardedInspection.owner.instanceId}.${recovery.instanceId}`;
+      assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
       try {
         renameSync(lockPath, quarantinedLockPath);
       } catch (error) {
@@ -720,10 +770,26 @@ export function acquireDaemonRuntimeOwnership(opts: {
           guardedInspection.owner,
         );
       }
+      const movedOwner = readInstanceId(quarantinedLockPath);
+      if (movedOwner !== guardedInspection.owner.instanceId) {
+        restoreQuarantinedFileIfAbsent(quarantinedLockPath, lockPath);
+        throw new DaemonRuntimeOwnershipError(
+          DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES.untrustedLock,
+          `Daemon ownership ${lockPath} changed while being quarantined; refusing daemon startup`,
+          lockPath,
+        );
+      }
+      try {
+        assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+      } catch (error) {
+        restoreQuarantinedFileIfAbsent(quarantinedLockPath, lockPath);
+        throw error;
+      }
     }
 
     // Exactly one retry is allowed after the stale owner has been isolated (or
     // after a colliding owner released between the first read and the guard).
+    assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
     if (tryWriteExclusiveJson(lockPath, owner) === "exists") {
       const retryInspection = readOwnerInspection(lockPath, home);
       if (retryInspection.state === "absent") {
@@ -735,7 +801,14 @@ export function acquireDaemonRuntimeOwnership(opts: {
       }
       throw ownershipErrorFromInspection(retryInspection);
     }
+    ownerCreated = true;
+    assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
+    assertOwnedMainLock(lockPath, home, owner);
+    assertOwnedRecoveryGuard(recoveryPath, recovery, lockPath);
     return makeLease(lockPath, owner, quarantinedLockPath, quarantinedRecoveryGuardPath);
+  } catch (error) {
+    if (ownerCreated) removeOwnedJson(lockPath, owner.instanceId);
+    throw error;
   } finally {
     // A concurrent stale-guard inspector may have atomically moved this guard
     // aside just before discovering the instance mismatch. Give that process a

--- a/apps/cli/src/core/doctor.ts
+++ b/apps/cli/src/core/doctor.ts
@@ -13,7 +13,12 @@ import { parse as parseYaml } from "yaml";
 import { findStaleAliases, formatStaleReason, type PinnedAgent, type StaleAlias } from "./agent-prune.js";
 import { channelConfig } from "./channel.js";
 import { cliFetch } from "./cli-fetch.js";
-import { formatDaemonRuntimeOwnerSummary, inspectDaemonRuntimeOwnership } from "./daemon-runtime-ownership.js";
+import {
+  formatDaemonRuntimeOwnerSummary,
+  formatDaemonRuntimeRecoveryEvidence,
+  inspectDaemonRuntimeOwnership,
+  inspectDaemonRuntimeRecoveryEvidence,
+} from "./daemon-runtime-ownership.js";
 import { blank, print } from "./output.js";
 import { getClientServiceStatus } from "./service-install.js";
 
@@ -296,10 +301,14 @@ export function checkDaemonRuntimeOwnership(): CheckResult {
       detail: `stale ${formatDaemonRuntimeOwnerSummary(ownership.owner)} — ${ownership.reason}`,
     };
   }
+  const evidence = inspectDaemonRuntimeRecoveryEvidence(defaultHome());
   return {
     label: "Daemon owner",
     ok: false,
-    detail: `untrusted lock — ${ownership.reason}`,
+    detail:
+      evidence.fence.state === "absent"
+        ? `untrusted lock — ${ownership.reason}`
+        : `untrusted lock — ${formatDaemonRuntimeRecoveryEvidence(evidence).join("; ")}`,
   };
 }
 

--- a/apps/cli/src/core/doctor.ts
+++ b/apps/cli/src/core/doctor.ts
@@ -5,6 +5,7 @@ import {
   agentConfigSchema,
   clientConfigSchema,
   defaultConfigDir,
+  defaultHome,
   loadAgents,
   resolveConfigReadonly,
 } from "@first-tree/shared/config";
@@ -12,6 +13,7 @@ import { parse as parseYaml } from "yaml";
 import { findStaleAliases, formatStaleReason, type PinnedAgent, type StaleAlias } from "./agent-prune.js";
 import { channelConfig } from "./channel.js";
 import { cliFetch } from "./cli-fetch.js";
+import { formatDaemonRuntimeOwnerSummary, inspectDaemonRuntimeOwnership } from "./daemon-runtime-ownership.js";
 import { blank, print } from "./output.js";
 import { getClientServiceStatus } from "./service-install.js";
 
@@ -272,6 +274,32 @@ export function checkBackgroundService(): CheckResult {
     label: "Background service",
     ok: false,
     detail: `not installed — re-run \`${channelConfig.binName} login <code>\` to install`,
+  };
+}
+
+export function checkDaemonRuntimeOwnership(): CheckResult {
+  const ownership = inspectDaemonRuntimeOwnership(defaultHome());
+  if (ownership.state === "absent") {
+    return { label: "Daemon owner", ok: true, detail: "lock not held" };
+  }
+  if (ownership.state === "live") {
+    return {
+      label: "Daemon owner",
+      ok: true,
+      detail: formatDaemonRuntimeOwnerSummary(ownership.owner),
+    };
+  }
+  if (ownership.state === "stale") {
+    return {
+      label: "Daemon owner",
+      ok: false,
+      detail: `stale ${formatDaemonRuntimeOwnerSummary(ownership.owner)} — ${ownership.reason}`,
+    };
+  }
+  return {
+    label: "Daemon owner",
+    ok: false,
+    detail: `untrusted lock — ${ownership.reason}`,
   };
 }
 

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -130,6 +130,10 @@ export type {
   DaemonRuntimeOwnershipErrorCode,
   DaemonRuntimeOwnershipInspection,
   DaemonRuntimeOwnershipLease,
+  DaemonRuntimeOwnershipRepairResult,
+  DaemonRuntimeRecoveryEvidence,
+  DaemonRuntimeRecoveryGuard,
+  DaemonRuntimeRecoveryGuardInspection,
 } from "./daemon-runtime-ownership.js";
 // Authoritative per-home daemon runtime ownership. Runtime markers remain
 // lifecycle diagnostics; they are not a mutual-exclusion primitive.
@@ -141,8 +145,11 @@ export {
   daemonRuntimeOwnershipPath,
   formatDaemonRuntimeOwner,
   formatDaemonRuntimeOwnerSummary,
+  formatDaemonRuntimeRecoveryEvidence,
   inspectDaemonRuntimeOwnership,
+  inspectDaemonRuntimeRecoveryEvidence,
   isDaemonRuntimeOwnershipError,
+  repairDaemonRuntimeOwnership,
 } from "./daemon-runtime-ownership.js";
 // Document review (docloop) CLI helpers
 export { slugFromFilename, titleFromMarkdown } from "./doc-review.js";

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -124,6 +124,25 @@ export type {
 export { ContextTreeWritePreflightCliError, preflightContextTreeWrite } from "./context-tree-write.js";
 // User-owned daemon environment (proxy etc.) — read, never written by us
 export { daemonEnvPath, loadDaemonEnv, parseDaemonEnv } from "./daemon-env.js";
+export type {
+  DaemonRuntimeMode,
+  DaemonRuntimeOwner,
+  DaemonRuntimeOwnershipErrorCode,
+  DaemonRuntimeOwnershipInspection,
+  DaemonRuntimeOwnershipLease,
+} from "./daemon-runtime-ownership.js";
+// Authoritative per-home daemon runtime ownership. Runtime markers remain
+// lifecycle diagnostics; they are not a mutual-exclusion primitive.
+export {
+  acquireDaemonRuntimeOwnership,
+  DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES,
+  DaemonRuntimeOwnershipError,
+  daemonRuntimeOwnershipPath,
+  formatDaemonRuntimeOwner,
+  formatDaemonRuntimeOwnerSummary,
+  inspectDaemonRuntimeOwnership,
+  isDaemonRuntimeOwnershipError,
+} from "./daemon-runtime-ownership.js";
 // Document review (docloop) CLI helpers
 export { slugFromFilename, titleFromMarkdown } from "./doc-review.js";
 // Diagnostics (doctor)
@@ -132,6 +151,7 @@ export {
   checkAgentConfigs,
   checkBackgroundService,
   checkClientConfig,
+  checkDaemonRuntimeOwnership,
   checkNodeVersion,
   checkServerReachable,
   checkWebSocket,

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -137,6 +137,7 @@ export {
   acquireDaemonRuntimeOwnership,
   DAEMON_RUNTIME_OWNERSHIP_ERROR_CODES,
   DaemonRuntimeOwnershipError,
+  daemonRuntimeHomesEqual,
   daemonRuntimeOwnershipPath,
   formatDaemonRuntimeOwner,
   formatDaemonRuntimeOwnerSummary,

--- a/apps/cli/src/core/supervisor/launchd.ts
+++ b/apps/cli/src/core/supervisor/launchd.ts
@@ -7,6 +7,7 @@ import { channelConfig } from "../channel.js";
 import { print } from "../output.js";
 import {
   ensureLogDir,
+  extractFirstTreeHomeFromPlist,
   extractProxyFromPlist,
   launchdPathEnv,
   logDir,
@@ -330,12 +331,22 @@ function getLaunchdServiceStatus(): ServiceInfo {
 }
 
 function launchdInfo(unitPath: string, state: ServiceState, pid?: number, detail?: string): ServiceInfo {
+  let configuredHome: string | undefined;
+  if (existsSync(unitPath)) {
+    try {
+      configuredHome = extractFirstTreeHomeFromPlist(readFileSync(unitPath, "utf8")) ?? channelConfig.defaultHome;
+    } catch {
+      // An unreadable definition cannot prove which home the service owns.
+      configuredHome = undefined;
+    }
+  }
   return {
     platform: "launchd",
     label: LAUNCHD_LABEL,
     unitPath,
     logDir: logDir(),
     state,
+    configuredHome,
     pid,
     detail,
   };

--- a/apps/cli/src/core/supervisor/shared.ts
+++ b/apps/cli/src/core/supervisor/shared.ts
@@ -109,6 +109,12 @@ function unescapeXml(value: string): string {
     .replace(/&amp;/g, "&");
 }
 
+/** Read the home pinned into a generated launchd plist. */
+export function extractFirstTreeHomeFromPlist(xml: string): string | undefined {
+  const match = xml.match(/<key>FIRST_TREE_HOME<\/key>\s*<string>([^<]*)<\/string>/u);
+  return match?.[1] ? unescapeXml(match[1]) : undefined;
+}
+
 /** Lift proxy env vars baked into a previous launchd plist (pre-compat units). */
 export function extractProxyFromPlist(xml: string): Record<string, string> {
   const out: Record<string, string> = {};
@@ -119,16 +125,27 @@ export function extractProxyFromPlist(xml: string): Record<string, string> {
   return out;
 }
 
+function unquoteSystemdEnvironmentValue(raw: string): string {
+  let value = raw.trim();
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+  return value;
+}
+
+/** Read the home pinned into a generated systemd unit. */
+export function extractFirstTreeHomeFromSystemd(text: string): string | undefined {
+  const match = text.match(/^Environment=FIRST_TREE_HOME=(.*)$/mu);
+  return match ? unquoteSystemdEnvironmentValue(match[1]) : undefined;
+}
+
 /** Lift proxy env vars baked into a previous systemd unit (pre-compat units). */
 export function extractProxyFromSystemd(text: string): Record<string, string> {
   const out: Record<string, string> = {};
   for (const key of PROXY_ENV_KEYS) {
     const match = text.match(new RegExp(`^Environment=${key}=(.*)$`, "m"));
     if (!match) continue;
-    let value = match[1].trim();
-    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
-      value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
-    }
+    const value = unquoteSystemdEnvironmentValue(match[1]);
     if (value.length > 0) out[key] = value;
   }
   return out;

--- a/apps/cli/src/core/supervisor/systemd.ts
+++ b/apps/cli/src/core/supervisor/systemd.ts
@@ -7,6 +7,7 @@ import { channelConfig } from "../channel.js";
 import { print } from "../output.js";
 import {
   ensureLogDir,
+  extractFirstTreeHomeFromSystemd,
   extractProxyFromSystemd,
   logDir,
   migrateBakedProxyEnv,
@@ -378,12 +379,22 @@ function systemdInfo(
   detail?: string,
   migrationRequired?: ServiceInfo["migrationRequired"],
 ): ServiceInfo {
+  let configuredHome: string | undefined;
+  if (existsSync(unitPath)) {
+    try {
+      configuredHome = extractFirstTreeHomeFromSystemd(readFileSync(unitPath, "utf8")) ?? channelConfig.defaultHome;
+    } catch {
+      // An unreadable definition cannot prove which home the service owns.
+      configuredHome = undefined;
+    }
+  }
   return {
     platform: "systemd",
     label: SYSTEMD_UNIT,
     unitPath,
     logDir: logDir(),
     state,
+    configuredHome,
     managerScope,
     migrationRequired,
     pid,

--- a/apps/cli/src/core/supervisor/task-scheduler.ts
+++ b/apps/cli/src/core/supervisor/task-scheduler.ts
@@ -80,6 +80,7 @@ function windowsInfo(state: ServiceState, pid?: number, detail?: string): Servic
     unitPath: windowsTaskXmlPath(),
     logDir: join(defaultHome(), "logs"),
     state,
+    configuredHome: defaultHome(),
     pid,
     detail,
   };

--- a/apps/cli/src/core/supervisor/types.ts
+++ b/apps/cli/src/core/supervisor/types.ts
@@ -6,6 +6,8 @@ export type ServiceInfo = {
   unitPath: string;
   logDir: string;
   state: ServiceState;
+  /** Home pinned into the installed supervisor definition, when readable. */
+  configuredHome?: string;
   /** PID of the active service process, if running. */
   pid?: number;
   /** systemd manager scope when platform === "systemd". */

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -970,6 +970,7 @@ first-tree daemon
 ├── restart
 ├── status
 ├── doctor
+├── repair-ownership
 ├── probe [--no-upload] [--json]
 ├── install-codex [--spec <spec>] [--json]
 └── install-claude [--spec <spec>] [--json]
@@ -982,6 +983,7 @@ first-tree daemon
 | `restart` | Restart the service. |
 | `status` | Local service state + authoritative daemon owner + server binding + auth health. Runs in well under a second. |
 | `doctor` | Walk Node version, config, server reachability, WS, agent registrations, the installed service file, the authoritative daemon owner lock, **and the runtime providers** — each step reported. The runtime-provider rows run the real launch-verified probe (a 1-turn model call for `claude-code`, a `codex doctor` handshake for `codex`), so `doctor` makes live provider calls; it is a deliberate diagnostic, not a hot path. |
+| `repair-ownership` | Reconcile an interrupted fenced ownership mutation. The command elects one repair process through per-instance ticket slots, requires strict PID/start-identity proof that the fence owner is gone or reused, drains published startup entrants, and refuses live, malformed, unverifiable, or ambiguous evidence. It never blindly deletes a fence. |
 | `probe` | Launch-probe the local runtime providers on demand and upload the result to the server (`PATCH /clients/:id/capabilities`). This is the manual refresh for a client's advertised capabilities after a provider is installed / logged in. Each probe really launches its provider. `--no-upload` runs a **credentials-free local-only** diagnostic (probe + print, no server auth needed). `--json` (or the global `--json`) emits the capability snapshot as the machine-readable `{ ok, data }` envelope on stdout. |
 | `install-codex` | Install the native Codex runtime engine on this machine (`npm install -g @openai/codex`). First Tree does not bundle the ~225MB native `codex` binary by default — the runtime resolves an external `codex` from PATH, known install locations, or the macOS ChatGPT/Codex desktop app — so this is the on-demand remediation when the `codex` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
 | `install-claude` | Install the native Claude Code runtime engine on this machine (`npm install -g @anthropic-ai/claude-code`). First Tree does not bundle the ~210MB native `claude` binary by default — the runtime resolves a system `claude` (env override / PATH / well-known install dirs) — so this is the on-demand remediation when the `claude-code` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
@@ -1023,10 +1025,32 @@ deleted automatically. Normal cleanup removes the lock or guard only when its
 Before changing the main lock, recovery also publishes a
 `.recovery-fence` and drains startup attempts that began before that fence.
 The fence stays authoritative across quarantine and restore, so no process can
-return a new lease through a temporarily empty main-lock path. An interrupted
-or unresolved fenced mutation is deliberately not auto-recovered: `status` and
-`doctor` report the home as untrusted and require manual remediation rather
-than risk admitting a second runtime.
+return a new lease through a temporarily empty main-lock path. Every startup
+publishes a complete per-instance entrant atomically before checking the fence;
+an incomplete temporary record is never visible to the drain protocol.
+
+An interrupted or unresolved fenced mutation is deliberately not recovered by
+ordinary startup. `status` and `doctor` report the exact fence instance,
+PID/start identity, canonical main state, quarantine candidates, repair slots,
+and entrant count. Run `first-tree daemon repair-ownership` to perform the
+supported repair. The command:
+
+1. elects one repair owner with non-destructive per-instance intent/ticket
+   slots, so simultaneous repairs have one ordered winner and stale unique
+   slots are removable only after PID/start-identity proof;
+2. refuses a live or unverifiable fence, drains pre-fence entrants, and
+   revalidates the exact stale fence;
+3. keeps a trusted canonical owner, or, when canonical is absent, restores the
+   unique trusted live quarantine candidate (preferred) or unique trusted
+   stale placeholder without overwriting another claimant;
+4. refuses malformed/unreadable evidence, different multiple live candidates,
+   or ambiguous stale candidates; and
+5. removes the matching stale recovery guard and exact fence only after one
+   trusted canonical owner record is established.
+
+The repair command therefore fails closed when evidence cannot prove a unique
+safe state. Do not manually delete `.recovery-fence`, `.recovery`, entrant,
+repair-slot, or owner/quarantine files.
 
 Files under `<home>/state/client-runtimes/` remain runtime markers for
 diagnostics, account-switch drain checks, and Windows supervisor lifecycle

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1020,6 +1020,14 @@ unreadable, or unverifiable locks and recovery guards fail closed and are never
 deleted automatically. Normal cleanup removes the lock or guard only when its
 `instanceId` still belongs to the exiting process.
 
+Before changing the main lock, recovery also publishes a
+`.recovery-fence` and drains startup attempts that began before that fence.
+The fence stays authoritative across quarantine and restore, so no process can
+return a new lease through a temporarily empty main-lock path. An interrupted
+or unresolved fenced mutation is deliberately not auto-recovered: `status` and
+`doctor` report the home as untrusted and require manual remediation rather
+than risk admitting a second runtime.
+
 Files under `<home>/state/client-runtimes/` remain runtime markers for
 diagnostics, account-switch drain checks, and Windows supervisor lifecycle
 reporting. They are not daemon ownership or mutual-exclusion authority.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -983,7 +983,7 @@ first-tree daemon
 | `restart` | Restart the service. |
 | `status` | Local service state + authoritative daemon owner + server binding + auth health. Runs in well under a second. |
 | `doctor` | Walk Node version, config, server reachability, WS, agent registrations, the installed service file, the authoritative daemon owner lock, **and the runtime providers** — each step reported. The runtime-provider rows run the real launch-verified probe (a 1-turn model call for `claude-code`, a `codex doctor` handshake for `codex`), so `doctor` makes live provider calls; it is a deliberate diagnostic, not a hot path. |
-| `repair-ownership` | Reconcile an interrupted fenced ownership mutation. The command elects one repair process through per-instance ticket slots, requires strict PID/start-identity proof that the fence owner is gone or reused, drains published startup entrants, and refuses live, malformed, unverifiable, or ambiguous evidence. It never blindly deletes a fence. |
+| `repair-ownership` | Reconcile an interrupted fenced ownership mutation. The command elects one repair process through per-instance ticket slots, atomically acquires a canonical repair guard, requires strict PID/start-identity proof that the exact fence owner is gone or reused, drains published startup entrants, and refuses live, malformed, unverifiable, changed, or ambiguous evidence. It never blindly deletes a fence. |
 | `probe` | Launch-probe the local runtime providers on demand and upload the result to the server (`PATCH /clients/:id/capabilities`). This is the manual refresh for a client's advertised capabilities after a provider is installed / logged in. Each probe really launches its provider. `--no-upload` runs a **credentials-free local-only** diagnostic (probe + print, no server auth needed). `--json` (or the global `--json`) emits the capability snapshot as the machine-readable `{ ok, data }` envelope on stdout. |
 | `install-codex` | Install the native Codex runtime engine on this machine (`npm install -g @openai/codex`). First Tree does not bundle the ~225MB native `codex` binary by default — the runtime resolves an external `codex` from PATH, known install locations, or the macOS ChatGPT/Codex desktop app — so this is the on-demand remediation when the `codex` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
 | `install-claude` | Install the native Claude Code runtime engine on this machine (`npm install -g @anthropic-ai/claude-code`). First Tree does not bundle the ~210MB native `claude` binary by default — the runtime resolves a system `claude` (env override / PATH / well-known install dirs) — so this is the on-demand remediation when the `claude-code` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
@@ -1028,6 +1028,12 @@ The fence stays authoritative across quarantine and restore, so no process can
 return a new lease through a temporarily empty main-lock path. Every startup
 publishes a complete per-instance entrant atomically before checking the fence;
 an incomplete temporary record is never visible to the drain protocol.
+The main owner, recovery guard, mutation fence, entrant, canonical repair guard,
+and repair election slot/ticket all use the same complete-publication rule:
+write and fsync a unique ignored same-directory temporary inode, close it, then
+hard-link it without overwriting the canonical path. A crash before that link
+cannot expose a partial canonical record; after the link, the canonical record
+is already complete. Publication temporaries are never ownership evidence.
 
 An interrupted or unresolved fenced mutation is deliberately not recovered by
 ordinary startup. `status` and `doctor` report the exact fence instance,
@@ -1036,21 +1042,34 @@ and entrant count. Run `first-tree daemon repair-ownership` to perform the
 supported repair. The command:
 
 1. elects one repair owner with non-destructive per-instance intent/ticket
-   slots, so simultaneous repairs have one ordered winner and stale unique
-   slots are removable only after PID/start-identity proof;
-2. refuses a live or unverifiable fence, drains pre-fence entrants, and
-   revalidates the exact stale fence;
-3. keeps a trusted canonical owner, or, when canonical is absent, restores the
-   unique trusted live quarantine candidate (preferred) or unique trusted
-   stale placeholder without overwriting another claimant;
-4. refuses malformed/unreadable evidence, different multiple live candidates,
-   or ambiguous stale candidates; and
-5. removes the matching stale recovery guard and exact fence only after one
-   trusted canonical owner record is established.
+   slots, then acquires a separate canonical repair guard; simultaneous repairs
+   therefore have one mutation owner, and stale unique records are removable
+   only after PID/start-identity proof;
+2. refuses a live, malformed, or process-identity-unverifiable fence, fixes the
+   target as an exact instance plus content fingerprint, drains pre-fence
+   entrants, and revalidates that exact stale fence before every main mutation;
+3. keeps a trusted canonical live or stale owner; when canonical is absent,
+   restores the unique trusted live quarantine candidate (preferred) or unique
+   trusted stale placeholder without overwriting another claimant; when no
+   candidate exists at all, records an explicit safe-empty reconciliation
+   without inventing a live owner;
+4. treats hard-link aliases as one candidate only when both instance and inode
+   match, and refuses unreadable evidence, changed file identity, different
+   live candidates, copied duplicates, or ambiguous stale candidates; and
+5. removes the matching stale recovery guard, revalidates the repair guard and
+   exact fence, then removes that fence. Fence removal is the repair opening
+   point: repair never changes main ownership afterward and only releases its
+   own repair records.
 
-The repair command therefore fails closed when evidence cannot prove a unique
-safe state. Do not manually delete `.recovery-fence`, `.recovery`, entrant,
-repair-slot, or owner/quarantine files.
+The repair command automatically handles a strictly stale fence with a trusted
+canonical owner, a unique trusted quarantine candidate, or a provably empty
+candidate set. It fails closed with the exact evidence when the fence/repair
+holder is live or unverifiable, any authoritative record is malformed or
+unreadable, the target fence changes, or candidates are ambiguous. An
+interrupted repair remains fenced and can be rerun: the next repair proves the
+old repair guard stale and resumes idempotently. Do not manually delete
+`.recovery-fence`, `.recovery`, `.repair`, entrant, repair-slot/ticket, owner,
+or quarantine files.
 
 Files under `<home>/state/client-runtimes/` remain runtime markers for
 diagnostics, account-switch drain checks, and Windows supervisor lifecycle

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1013,8 +1013,11 @@ another process owns stale-lock recovery.
 After a crash, a later start only recovers the lock when OS process inspection
 strictly proves the PID is gone or has a different process-start identity. The
 old record is renamed beside the lock as a `.stale.*` diagnostic and creation
-is retried once. Malformed, unreadable, or unverifiable locks fail closed and
-are never deleted automatically. Normal cleanup removes the lock only when its
+is retried once. The same evidence rule applies to the recovery guard: a live
+guard blocks startup, while a guard whose PID/start identity is strictly stale
+is quarantined as `.recovery.stale.*` before recovery continues. Malformed,
+unreadable, or unverifiable locks and recovery guards fail closed and are never
+deleted automatically. Normal cleanup removes the lock or guard only when its
 `instanceId` still belongs to the exiting process.
 
 Files under `<home>/state/client-runtimes/` remain runtime markers for

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -977,14 +977,49 @@ first-tree daemon
 
 | Subcommand | Purpose |
 |---|---|
-| `start` | Start the daemon and connect every configured agent to the server. **Fail-closed**: exits 1 with `NO_CREDENTIALS` if no `credentials.json` exists; run `login` first. `--foreground` runs in the current shell (for debugging); the default installs/starts the service. |
+| `start` | Start the daemon and connect every configured agent to the server. **Fail-closed**: exits 1 with `NO_CREDENTIALS` if no `credentials.json` exists; run `login` first. `--foreground` runs in the current shell (for debugging), but refuses when that home's background service is already active; stop the service first. The default delegates to the service manager. Every inline runtime must acquire the resolved home owner lock before reading `client.yaml` or opening the WebSocket. |
 | `stop` | Stop the service (preserves auto-start; bring it back with `start`). |
 | `restart` | Restart the service. |
-| `status` | Local service state + server binding + auth health. Runs in well under a second. |
-| `doctor` | Walk Node version, config, server reachability, WS, agent registrations, the installed service file, **and the runtime providers** — each step reported. The runtime-provider rows run the real launch-verified probe (a 1-turn model call for `claude-code`, a `codex doctor` handshake for `codex`), so `doctor` makes live provider calls; it is a deliberate diagnostic, not a hot path. |
+| `status` | Local service state + authoritative daemon owner + server binding + auth health. Runs in well under a second. |
+| `doctor` | Walk Node version, config, server reachability, WS, agent registrations, the installed service file, the authoritative daemon owner lock, **and the runtime providers** — each step reported. The runtime-provider rows run the real launch-verified probe (a 1-turn model call for `claude-code`, a `codex doctor` handshake for `codex`), so `doctor` makes live provider calls; it is a deliberate diagnostic, not a hot path. |
 | `probe` | Launch-probe the local runtime providers on demand and upload the result to the server (`PATCH /clients/:id/capabilities`). This is the manual refresh for a client's advertised capabilities after a provider is installed / logged in. Each probe really launches its provider. `--no-upload` runs a **credentials-free local-only** diagnostic (probe + print, no server auth needed). `--json` (or the global `--json`) emits the capability snapshot as the machine-readable `{ ok, data }` envelope on stdout. |
 | `install-codex` | Install the native Codex runtime engine on this machine (`npm install -g @openai/codex`). First Tree does not bundle the ~225MB native `codex` binary by default — the runtime resolves an external `codex` from PATH, known install locations, or the macOS ChatGPT/Codex desktop app — so this is the on-demand remediation when the `codex` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
 | `install-claude` | Install the native Claude Code runtime engine on this machine (`npm install -g @anthropic-ai/claude-code`). First Tree does not bundle the ~210MB native `claude` binary by default — the runtime resolves a system `claude` (env override / PATH / well-known install dirs) — so this is the on-demand remediation when the `claude-code` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
+
+### Single runtime owner per home
+
+The resolved `FIRST_TREE_HOME` is the daemon's complete ownership key. An
+inline foreground or supervisor child atomically creates
+`<home>/state/daemon-runtime.lock` before reading the active client config or
+opening a WebSocket. The record includes an instance id, PID, OS process-start
+identity, channel, mode, CLI version, and start time. Client id, server URL, and
+release channel never subdivide the lock: channel, mode, and version are
+recorded only as holder diagnostics, while client id and server URL are not
+part of the ownership record at all.
+
+Consequently, prod, staging, and dev can run together under their distinct
+default homes. If two binaries — including binaries from different channels —
+are pointed at one explicit `FIRST_TREE_HOME`, the second runtime is refused
+and reports the live holder. Service delegation commands do not acquire the
+lock themselves; the supervisor child acquires it when it actually enters the
+runtime. A colliding supervisor child logs the holder once and exits cleanly so
+the service manager does not create a restart/log storm.
+
+Script-facing failures use `DAEMON_RUNTIME_ALREADY_RUNNING` for a verified live
+holder, `DAEMON_RUNTIME_LOCK_UNTRUSTED` when the existing record or process
+identity cannot be trusted, and `DAEMON_RUNTIME_LOCK_RECOVERY_BUSY` while
+another process owns stale-lock recovery.
+
+After a crash, a later start only recovers the lock when OS process inspection
+strictly proves the PID is gone or has a different process-start identity. The
+old record is renamed beside the lock as a `.stale.*` diagnostic and creation
+is retried once. Malformed, unreadable, or unverifiable locks fail closed and
+are never deleted automatically. Normal cleanup removes the lock only when its
+`instanceId` still belongs to the exiting process.
+
+Files under `<home>/state/client-runtimes/` remain runtime markers for
+diagnostics, account-switch drain checks, and Windows supervisor lifecycle
+reporting. They are not daemon ownership or mutual-exclusion authority.
 
 **Capability refresh timing.** The daemon launch-probes runtime providers at
 startup and re-probes automatically on every WebSocket reconnect. A full real
@@ -1583,7 +1618,7 @@ Most environment variables use the `FIRST_TREE_` prefix.
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `FIRST_TREE_HOME` | Override the CLI home directory for config, data, and agent workspaces. | Channel-dependent: `~/.first-tree` (prod), `~/.first-tree-staging` (staging), `~/.first-tree-dev` (dev). |
+| `FIRST_TREE_HOME` | Override the CLI home directory for config, data, agent workspaces, and daemon ownership. Binaries that explicitly share one resolved home are mutually exclusive even when their channels, client ids, or server URLs differ. | Channel-dependent: `~/.first-tree` (prod), `~/.first-tree-staging` (staging), `~/.first-tree-dev` (dev). |
 | `FIRST_TREE_SERVER_URL` | Server URL override for `login <code>` and fallback for other commands; otherwise `login` uses the CLI channel default. | — |
 | `FIRST_TREE_LOG_LEVEL` | Log level (`trace` / `debug` / `info` / `warn` / `error` / `fatal`). | `info` |
 | `FIRST_TREE_JSON` | JSON output mode (equivalent to `--json`). | — |
@@ -1857,6 +1892,9 @@ See [observability.md](observability.md) for the full config reference, backend 
 │       └── <agent-name>/                          # per-agent home (cwd is shared across chats)
 │           ├── context-tree/                      # agent-managed Context Tree clone (agent clones/pulls it per its briefing)
 │           └── worktrees/                         # per-task worktrees the agent creates and cleans up
+├── state/
+│   ├── daemon-runtime.lock                        # authoritative single runtime owner for this resolved home
+│   └── client-runtimes/                           # non-authoritative runtime markers used by diagnostics/lifecycle checks
 └── logs/                                          # daemon stderr / stdout (macOS)
 ```
 

--- a/docs/development/local-dev-isolation.md
+++ b/docs/development/local-dev-isolation.md
@@ -56,7 +56,21 @@ $ systemctl --user list-units 'first-tree*'
 ```
 
 Three independent unit files, three PIDs, three journald identifiers,
-three home dirs. No cross-contamination.
+three home dirs. No cross-contamination. Each daemon takes an atomic owner lock
+at `<resolved-home>/state/daemon-runtime.lock`; the home, rather than the
+channel/client/server tuple, is the mutual-exclusion boundary.
+
+Do not point a dev command at a live prod or staging home to test another
+channel. An explicit shared `FIRST_TREE_HOME` intentionally collapses the
+isolation boundary, so the second foreground or service runtime is refused even
+when its channel, client id, or server URL differs. Use another temporary dev
+home instead:
+
+```bash
+FIRST_TREE_HOME="$(mktemp -d)" first-tree-dev daemon start --foreground
+```
+
+Distinct temporary dev homes can run concurrently.
 
 ## How channel identity is wired
 
@@ -70,9 +84,9 @@ from this single value via `getChannelConfig` in
 `apps/cli/src/core/channel-env.ts` runs as the very first import in the
 CLI entry. It sets `process.env.FIRST_TREE_HOME` from the channel's
 default home (unless the operator already set the env explicitly),
-which the `@first-tree/shared/config` module then reads at load time.
-That's how every const-import of `DEFAULT_HOME_DIR` automatically picks
-up the right channel-aware path with zero refactoring at call sites.
+which the `@first-tree/shared/config` resolver reads lazily at each call.
+That keeps bundled ESM evaluation from freezing a staging/dev process onto the
+production fallback before channel initialization.
 
 The published-package `name` and `bin` get rewritten by the CI publish
 job alongside `CHANNEL` — the source-tree `apps/cli/package.json`

--- a/docs/development/local-dev-isolation.md
+++ b/docs/development/local-dev-isolation.md
@@ -70,7 +70,11 @@ home instead:
 FIRST_TREE_HOME="$(mktemp -d)" first-tree-dev daemon start --foreground
 ```
 
-Distinct temporary dev homes can run concurrently.
+Distinct temporary dev homes can run concurrently, including while the ordinary
+dev background service remains active under its separately configured home.
+Foreground preflight compares the canonical current home with the home pinned
+into the installed supervisor definition before asking the operator to stop the
+service; the per-home owner lock remains the final authority.
 
 ## How channel identity is wired
 

--- a/packages/qa/cases/runtime/daemon-single-home-ownership.md
+++ b/packages/qa/cases/runtime/daemon-single-home-ownership.md
@@ -82,13 +82,21 @@ Exercise the following branches, resetting only run-cell state between them:
 - Pause one startup after its complete entrant temp is fsynced but before the
   non-overwriting publish. Let another process recover and acquire, then
   release the late publisher: it must reject against the fence or live owner.
-  Also hard-kill before and after entrant publish; later recovery must never
-  treat an incomplete temp as an authoritative entrant and must leave no
-  active fence, entrant, or repair slot.
+  For main owner, recovery guard, mutation fence, and entrant publication,
+  hard-kill once after the unique temp inode is opened but before JSON is
+  written, and once immediately after the hard-link publish. Before publish,
+  no canonical coordination record may exist; after publish, the canonical
+  record must already be complete. Later startup or supported repair must
+  recover without treating an incomplete `.publish-temp.*` file as authority.
 - Start two `daemon repair-ownership` processes together. The per-instance
-  repair ticket order must admit only one mutation owner; crashing a repair
-  before and after ticket publication must be evidence-recoverable, and an old
-  cleanup must never remove a newer instance's slot.
+  repair ticket order plus canonical repair guard must admit only one mutation
+  owner; crashing a repair after the guard publish, before exact fence removal,
+  and after fence removal must be evidence-recoverable and idempotent. Confirm
+  the post-fence crash cannot mutate main on retry, an old cleanup never removes
+  a newer instance's records, and no active fence, repair guard, entrant, slot,
+  or ticket leaks. Include a live canonical owner with a stale fence, PID reuse,
+  malformed/unverifiable fence evidence, hard-link aliases of one quarantine
+  inode, and copied or otherwise ambiguous quarantine candidates.
 - Replace the lock with malformed or incomplete content after proving no
   daemon owns the test home. Startup must refuse without deleting or rewriting
   the damaged file, and `daemon status` / `daemon doctor` must identify the

--- a/packages/qa/cases/runtime/daemon-single-home-ownership.md
+++ b/packages/qa/cases/runtime/daemon-single-home-ownership.md
@@ -52,8 +52,11 @@ Exercise the following branches, resetting only run-cell state between them:
   time.
 - Start the real background service, then attempt `daemon start --foreground`
   for the same home. Confirm the foreground preflight gives actionable stop
-  guidance. Also arrange a race where service-state observation alone is
-  insufficient and verify the atomic home lock is still the final decision.
+  guidance. While that service remains active, start foreground with a
+  different explicit home and confirm it is allowed to reach its own owner
+  lock and WebSocket runtime. Also arrange a race where service-state
+  observation alone is insufficient and verify the atomic home lock is still
+  the final decision.
 - Compete a foreground owner with a supervisor child. The child must log one
   holder summary and settle without repeated child restarts or repeated
   collision log lines.
@@ -62,6 +65,10 @@ Exercise the following branches, resetting only run-cell state between them:
 - Hard-kill a winning process without cleanup. The next start must prove the
   old PID/start identity stale, rename the old lock to a `.stale.*` diagnostic,
   retry once, and become the sole owner.
+- Hard-kill a process after it creates the stale-lock `.recovery` guard but
+  before cleanup. Race two later starts against that home. They must prove and
+  quarantine the abandoned guard, and exactly one may become the owner; a live
+  or unverifiable recovery guard must remain fail-closed.
 - Replace the lock with malformed or incomplete content after proving no
   daemon owns the test home. Startup must refuse without deleting or rewriting
   the damaged file, and `daemon status` / `daemon doctor` must identify the

--- a/packages/qa/cases/runtime/daemon-single-home-ownership.md
+++ b/packages/qa/cases/runtime/daemon-single-home-ownership.md
@@ -1,0 +1,101 @@
+---
+id: daemon-single-home-ownership
+description: Validate that one resolved First Tree home admits exactly one live daemon runtime while isolated channel and dev homes remain parallel.
+areas: [runtime]
+surfaces: [cli, client]
+---
+
+# Daemon Single-Home Ownership
+
+## Goal
+
+Verify the real process and supervisor boundary behind daemon ownership: one
+resolved `FIRST_TREE_HOME` admits exactly one runtime before client config or
+WebSocket startup, while prod, staging, dev, and separate explicit dev homes
+remain independent.
+
+Use this case for changes to daemon startup, service delegation, foreground
+mode, process identity, stale-lock recovery, or channel-home isolation. Stable
+record parsing and filesystem edge cases belong in product tests; this case
+owns the live multi-process and supervisor behavior those tests cannot fully
+prove.
+
+## Preconditions
+
+- Run only inside the complete isolated QA cell selected by the plan. Never
+  reuse, stop, restart, inspect, or write the operator host's real prod,
+  staging, or dev daemon homes.
+- Build or install the exact candidate CLI variants needed for the channel
+  matrix. Give every variant isolated run-cell credentials and client config
+  against the run-cell server so a winning process can reach and hold its real
+  WebSocket runtime.
+- For service/foreground competition, provide a real supported supervisor
+  boundary (launchd, systemd, or Windows Task Scheduler plus the First Tree
+  wrapper). If the run cell cannot provide one, report that branch `BLOCKED`;
+  do not replace it with a mocked service manager.
+- Record every binary version, channel, resolved home, service identifier, PID,
+  and test-only client id. Keep all temporary homes outside the source
+  worktree.
+
+## Operate And Observe
+
+Exercise the following branches, resetting only run-cell state between them:
+
+- Start prod, staging, and dev with their distinct channel-default home shapes.
+  Confirm all three runtimes coexist, each owns
+  `<home>/state/daemon-runtime.lock`, and each connects using only its own
+  config.
+- Gate two foreground processes on a common start barrier and release them
+  concurrently against one explicit home. Exactly one process may progress to
+  config/WebSocket startup; the other must fail closed with the live holder's
+  instance id, PID, process-start identity, channel, mode, version, and start
+  time.
+- Start the real background service, then attempt `daemon start --foreground`
+  for the same home. Confirm the foreground preflight gives actionable stop
+  guidance. Also arrange a race where service-state observation alone is
+  insufficient and verify the atomic home lock is still the final decision.
+- Compete a foreground owner with a supervisor child. The child must log one
+  holder summary and settle without repeated child restarts or repeated
+  collision log lines.
+- Stop a winning runtime normally and confirm its lock disappears. Start again
+  and confirm a new instance id owns the home.
+- Hard-kill a winning process without cleanup. The next start must prove the
+  old PID/start identity stale, rename the old lock to a `.stale.*` diagnostic,
+  retry once, and become the sole owner.
+- Replace the lock with malformed or incomplete content after proving no
+  daemon owns the test home. Startup must refuse without deleting or rewriting
+  the damaged file, and `daemon status` / `daemon doctor` must identify the
+  untrusted lock.
+- Point two different channel binaries at one explicit home. The second must be
+  rejected even if its client id and server URL differ. Then point two dev
+  binaries at two explicit homes and confirm they run in parallel.
+
+Runtime marker files under `state/client-runtimes/` may support lifecycle
+diagnosis, but their presence or absence must never allow a second runtime to
+bypass the authoritative home lock.
+
+## Expected Result
+
+`PASS` means every available branch demonstrates one authoritative owner per
+resolved home, independent homes remain parallel, foreground/service races are
+closed by the atomic lock, stale recovery is evidence-based and bounded, and a
+supervisor collision settles without a restart/log storm.
+
+`FAIL` means two live runtimes enter config/WebSocket startup for one home, an
+unverified or malformed lock is removed automatically, one owner releases a
+different instance's lock, distinct default homes interfere, or a colliding
+supervisor repeatedly restarts.
+
+`BLOCKED` means the isolated cell cannot provide the required channel binary,
+authenticated runtime, or real supervisor boundary. `INCONCLUSIVE` means the
+process, lock, service, or WebSocket evidence cannot be attributed to the
+candidate build.
+
+## Evidence
+
+Keep the exact commands and exit statuses; resolved home and service paths;
+redacted owner records; process listings with start identities; service status
+and bounded logs; WebSocket/client-registration evidence showing which process
+entered the runtime; quarantine filenames; and before/after hashes of damaged
+locks. Redact credentials, tokens, private user paths, and unrelated host
+processes.

--- a/packages/qa/cases/runtime/daemon-single-home-ownership.md
+++ b/packages/qa/cases/runtime/daemon-single-home-ownership.md
@@ -69,6 +69,26 @@ Exercise the following branches, resetting only run-cell state between them:
   before cleanup. Race two later starts against that home. They must prove and
   quarantine the abandoned guard, and exactly one may become the owner; a live
   or unverifiable recovery guard must remain fail-closed.
+- Hard-kill recovery at three fenced stages: while the old main remains
+  canonical, after the old main is quarantined and canonical is empty, and
+  after a replacement main is created but before the fence is cleared. In each
+  state, verify normal startup fails closed and `daemon status` / `daemon
+  doctor` expose the exact fence holder, PID/start identity, canonical main
+  state, quarantine candidates/ambiguity, repair slots, and entrant count.
+  Run `daemon repair-ownership`; it must reject live/unverifiable or ambiguous
+  evidence, but for a unique trusted state it must restore/retain one
+  canonical owner, remove only the matching stale guard/fence, and allow
+  exactly one later runtime.
+- Pause one startup after its complete entrant temp is fsynced but before the
+  non-overwriting publish. Let another process recover and acquire, then
+  release the late publisher: it must reject against the fence or live owner.
+  Also hard-kill before and after entrant publish; later recovery must never
+  treat an incomplete temp as an authoritative entrant and must leave no
+  active fence, entrant, or repair slot.
+- Start two `daemon repair-ownership` processes together. The per-instance
+  repair ticket order must admit only one mutation owner; crashing a repair
+  before and after ticket publication must be evidence-recoverable, and an old
+  cleanup must never remove a newer instance's slot.
 - Replace the lock with malformed or incomplete content after proving no
   daemon owns the test home. Startup must refuse without deleting or rewriting
   the damaged file, and `daemon status` / `daemon doctor` must identify the


### PR DESCRIPTION
## Summary

- enforce one live inline daemon owner for each canonical resolved `FIRST_TREE_HOME` before client config or WebSocket startup
- publish every authoritative ownership/coordinator record as a complete inode (`write + fsync + close`, then non-overwriting hard link), so readers never observe a canonical zero-byte or partial JSON record
- make every acquisition publish a unique entrant before its first fence check; stale-owner recovery holds an exact mutation fence, drains all pre-fence entrants, then re-inspects and reconciles the canonical owner
- keep interrupted mutation fences fail-closed for ordinary startup and provide evidence-driven `daemon repair-ownership` recovery
- scope supervisor preflight to the installed service's canonical home, allowing distinct explicit homes to run concurrently while same-home collisions settle without restart storms
- expose owner, fence, entrant, quarantine, and repair evidence through `status` and `doctor`, document the operator contract, and extend the reusable live QA case

## Ownership protocol

The ownership key is only the canonical resolved home. Channel, client id, server URL, runtime mode, and service label do not partition it: channel-default homes remain independent, while any processes resolving to the same explicit home are mutually exclusive.

Owner, recovery guard, mutation fence, entrant, repair guard, repair slot, and repair ticket records are first written completely to same-directory publication-temp paths that are outside authoritative scans. A non-overwriting hard link is the publication linearization point. Cleanup remains exact-instance scoped, and abandoned complete temps are removed only when PID/process-start evidence proves their publisher stale.

Every acquisition publishes its entrant before checking the mutation fence. Recovery publishes an exact fence before any main-owner mutation, waits for every pre-fence entrant to drain, then performs a fresh main inspection. Late entrants see the fence and fail closed. The fence remains authoritative across quarantine, moved-instance validation, restore, and replacement-owner creation, so a process armed from a stale observation cannot reopen a temporarily empty canonical path.

Live, malformed, unverifiable, duplicated, or ambiguous ownership evidence fails closed. Ordinary startup never auto-recovers an interrupted mutation fence.

## Supported interrupted-fence repair

`daemon repair-ownership` is the only supported path that may reconcile and clear an interrupted mutation fence. Concurrent repairs are serialized by per-instance tickets plus an exact canonical repair guard. The selected repair:

1. proves the exact fence holder stale by PID and process-start identity;
2. drains entrants and revalidates the exact repair guard and fence;
3. scans the canonical owner and all related quarantine candidates;
4. preserves a trusted canonical owner, restores only a unique trusted candidate when canonical is absent, or records an explicitly proven safe-empty state;
5. rejects live, unverifiable, malformed, duplicated, or ambiguous evidence without clearing the fence;
6. removes only the exact stale fence after reconciliation, then performs no further main-owner mutation.

If repair is interrupted, the fence or stale repair guard remains fail-closed and a later repair can resume from evidence. `status` and `doctor` report the exact fence identity, canonical-main classification, quarantine candidates, repair records, and entrant count; operators are not instructed to delete authoritative files manually.

## Supervisor behavior

Foreground preflight reads the canonical home pinned into the installed launchd/systemd definition. An active service blocks only the same home; a different explicit home may run in parallel. The per-home owner protocol remains the final authority for service-state races, and a supervisor child that loses ownership exits successfully so the service manager does not restart-loop.

## Paired Context Tree

- Draft durable-contract PR: https://github.com/agent-team-foundation/first-tree-context/pull/846

The draft records complete atomic publication, entrant-before-fence participation, pre-fence drain, non-auto-recoverable interrupted mutation fences, evidence-driven exact-fence repair, and instance-scoped cleanup. `first-tree-staging tree verify --json` passes on its exact head. Context Reviewer found no content issue and correctly deferred approval until this implementation merges; the draft will then be reconciled against merged source and marked ready.

## Validation — exact head `3f9b6b963cd72c2acbc3a2408e82a775a0014f0a`

Independent isolated QA: **PASS**.

- real CLI/portable/WebSocket ownership journeys: `9/9`
- real recovery-guard live/crash/corrupt branches: `3/3`
- real SIGKILL after each of three fenced-mutation stages: ordinary startup stayed fail-closed, `status`/`doctor` exposed exact evidence, supported repair succeeded, and only one later runtime registered
- real systemd PID-1 coverage: same-home rejection, different-home parallel runtime, collision settlement with `NRestarts=0`, and unverifiable `/proc` evidence fail-closed
- deterministic ownership suite: `51/51`
- all nine changed CLI suites: `163/163`
- reviewer five-role late-handoff schedule: `20/20` consecutive runs
- three-contender stale-guard schedule: `20/20` consecutive runs
- full CLI runner: `23/23` batches
- `pnpm check`: pass (16 existing warnings and 1 existing info)
- `pnpm typecheck`: `11/11` tasks
- full repository `pnpm test`: `12/12` tasks on container-native exact-head Linux source; server suite `2699/2699`
- `git diff --check`: pass; exact source clean
- exact-head GitHub CI and CodeQL: all successful

The independent run retained failed harness attempts instead of masking them: Docker Desktop bind-mount permission/`chmod(0)` semantics were isolated, the affected CLI test passed `10/10`, and the final complete CLI and repository runs passed on native Linux storage. No candidate defect was found.

## Scope and isolation

The operator's live staging daemon, launchd registration, homes, wrappers, and provider credentials were not used or modified. Protected host wrapper/plist snapshots were byte-for-byte unchanged after QA, and all run-created containers, volumes, images, worktrees, homes, credentials, portable installs, and caches were removed.

This change intentionally excludes runtime-session token generation and Inbox recovery.
