### PR TITLE
fix(web): hide non-actionable Context preview status

### DIFF
--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -464,11 +464,12 @@ describe("ContextPage DOM behavior", () => {
       authMock.value = { organizationId: "org-1", role };
       const { container, root } = await renderDom(<ContextPage />);
 
-      await waitForText(container, "GitLab Web Context isn’t available for this repository");
-      expect(container.textContent).toContain(
-        "First Tree can’t display this Context Tree in the web app. Agents and Context Reviewer with repository access can continue using it as usual.",
-      );
+      await waitForText(container, "Web preview isn’t available for this repository");
+      expect(container.textContent).toContain("Agent access and Automatic Review are unaffected.");
       expect(container.textContent).not.toContain(serverDetail);
+      expect(container.querySelector('[data-context-availability-tone="neutral"]')).not.toBeNull();
+      expect(container.querySelector(".lucide-info")).not.toBeNull();
+      expect(container.querySelector(".lucide-triangle-alert")).toBeNull();
       expect(container.textContent).toContain(
         "Repo: https://[redacted]@gitlab.example/acme/private-context.git · Branch: main",
       );

--- a/packages/web/src/pages/context-tree-availability.ts
+++ b/packages/web/src/pages/context-tree-availability.ts
@@ -15,10 +15,9 @@ const TEAM_NON_ACTIONABLE_GITLAB_REASONS = new Set<ContextTreeUnavailableReason>
   "gitlab_egress_denied",
 ]);
 
-export const GITLAB_WEB_CONTEXT_UNAVAILABLE_TITLE = "GitLab Web Context isn’t available for this repository";
+export const GITLAB_WEB_CONTEXT_UNAVAILABLE_TITLE = "Web preview isn’t available for this repository";
 
-export const GITLAB_WEB_CONTEXT_UNAVAILABLE_DETAIL =
-  "First Tree can’t display this Context Tree in the web app. Agents and Context Reviewer with repository access can continue using it as usual.";
+export const GITLAB_WEB_CONTEXT_UNAVAILABLE_DETAIL = "Agent access and Automatic Review are unaffected.";
 
 export function isTeamNonActionableGitlabWebContext(
   snapshot: ContextTreeSnapshotAvailability | null | undefined,

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -7,7 +7,7 @@ import type {
 } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
 import { stratify, tree } from "d3-hierarchy";
-import { AlertTriangle, Network, RefreshCw } from "lucide-react";
+import { AlertTriangle, Info, Network, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { getContextTreeSnapshot } from "../api/context-tree.js";
@@ -679,11 +679,20 @@ function UnavailableState({
       : "Ask an admin to set up your team's Context Tree.";
   const syncDetail = teamNonActionableGitlabWebContext ? null : snapshot.contextStatus.detail;
   const repoLabel = snapshot.repo ? redactRepoForDisplay(snapshot.repo) : null;
+  const AvailabilityIcon = teamNonActionableGitlabWebContext ? Info : AlertTriangle;
   return (
     <Panel>
       <PanelBody>
-        <div className="flex items-start text-body" style={{ color: "var(--fg-2)", gap: "var(--sp-2)" }}>
-          <AlertTriangle size={18} style={{ color: "var(--warning)" }} />
+        <div
+          className="flex items-start text-body"
+          data-context-availability-tone={teamNonActionableGitlabWebContext ? "neutral" : "warning"}
+          style={{ color: "var(--fg-2)", gap: "var(--sp-2)" }}
+        >
+          <AvailabilityIcon
+            aria-hidden
+            size={18}
+            style={{ color: teamNonActionableGitlabWebContext ? "var(--fg-3)" : "var(--warning)" }}
+          />
           <div>
             <div className="font-semibold" style={{ color: "var(--fg)" }}>
               {title}

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -665,7 +665,7 @@ describe("Settings Setup overview", () => {
     "gitlab_dns_unavailable",
     "gitlab_address_not_authorized",
     "gitlab_egress_denied",
-  ] as const)("keeps non-actionable GitLab Web Context neutral and role-consistent for %s", (reason) => {
+  ] as const)("keeps non-actionable GitLab preview status out of Setup for %s", (reason) => {
     const capabilities = capabilityFixture({
       binding: {
         state: "bound",
@@ -700,10 +700,11 @@ describe("Settings Setup overview", () => {
     );
 
     for (const row of [admin, member]) {
-      expect(row.status).toMatchObject({ label: "Web Context unavailable", kind: "neutral" });
-      expect(row.status.detail).toContain("First Tree can’t display this Context Tree in the web app");
-      expect(row.status.detail).toContain("Agents and Context Reviewer");
-      expect(row.status.detail).not.toContain("recover");
+      expect(row.status).toEqual({
+        label: "Connected",
+        kind: "ready",
+        detail: "acme/context-tree · Review on",
+      });
     }
     expect(admin.action?.label).toBe("Manage");
     expect(member.action).toEqual({ label: "View", to: "/context" });
@@ -1364,16 +1365,17 @@ describe("Settings Setup overview", () => {
     });
 
     const view = await renderSettingsSetupPage();
-    const row = await waitForRowText(view.host, "context-tree", "Web Context unavailable");
+    const row = await waitForRowText(view.host, "context-tree", "Connected");
     const manage = [...row.querySelectorAll<HTMLButtonElement>("button")].find(
       (button) => button.textContent === "Manage",
     );
 
     expect(row.textContent).not.toContain("Needs recovery");
+    expect(row.textContent).not.toContain("Web Context unavailable");
     expect(row.textContent).not.toContain("GitLab deployment allowlist diagnostic");
     await act(async () => manage?.click());
     const controls = await waitForSelector<HTMLElement>(row, '[data-setup-owner-controls="context-tree"]');
-    expect(controls.textContent).toContain("Open Context");
+    expect(controls.textContent).not.toContain("Open Context");
     expect(controls.textContent).toContain("Automatic review");
     expect(controls.textContent).not.toContain("Work on this in chat");
     await act(async () => view.root.unmount());

--- a/packages/web/src/pages/settings/setup-context-tree-controls.tsx
+++ b/packages/web/src/pages/settings/setup-context-tree-controls.tsx
@@ -120,10 +120,12 @@ export function SetupContextTreeControls({
           <span className="text-label min-w-0" style={{ color: "var(--fg-3)", overflowWrap: "anywhere" }}>
             {bindingSummary}
           </span>
-          <Button type="button" variant="link" className="h-auto shrink-0 p-0" onClick={() => navigate("/context")}>
-            <span>Open Context</span>
-            <ArrowRight className="h-4 w-4" />
-          </Button>
+          {!teamNonActionableGitlabWebContext ? (
+            <Button type="button" variant="link" className="h-auto shrink-0 p-0" onClick={() => navigate("/context")}>
+              <span>Open Context</span>
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          ) : null}
         </div>
       ) : null}
 

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -36,10 +36,7 @@ import { getTeamSetupCapabilitiesAt, setupCapabilitiesQueryKey } from "../../api
 import { useAuth } from "../../auth/auth-context.js";
 import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { cn } from "../../lib/utils.js";
-import {
-  GITLAB_WEB_CONTEXT_UNAVAILABLE_DETAIL,
-  isTeamNonActionableGitlabWebContext,
-} from "../context-tree-availability.js";
+import { isTeamNonActionableGitlabWebContext } from "../context-tree-availability.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { ContextEnablement } from "./context-enablement.js";
 import { setupBlockerCopy } from "./setup-blocker-copy.js";
@@ -358,9 +355,9 @@ function contextTreeStatus(
   const detail = [bindingDetail, issueDetail].filter((item): item is string => Boolean(item)).join(" · ");
   if (teamNonActionableGitlabWebContext) {
     return {
-      label: "Web Context unavailable",
-      detail: `${bindingDetail} · ${GITLAB_WEB_CONTEXT_UNAVAILABLE_DETAIL}`,
-      kind: "neutral",
+      label: "Connected",
+      detail: bindingDetail,
+      kind: "ready",
     };
   }
   if (availability === "active") return { label: "Available", detail, kind: "ready" };


### PR DESCRIPTION
## Summary

- present a valid private/self-managed GitLab Context Tree binding as `Connected` in Settings Setup instead of surfacing Web preview availability as setup debt
- hide the expanded `Open Context` shortcut when that Web preview is known to be unavailable while preserving binding and Automatic Review controls
- keep the availability explanation on the Context consumption surface, with neutral presentation and concise copy that Agent access and Automatic Review are unaffected

## Product boundary

Settings communicates configuration validity and user-actionable recovery. Web preview availability is independent from the Context Tree binding and Automatic Review, so the non-actionable GitLab authentication/operator-network states now stay out of Setup.

## Paired Context Tree decision

- https://github.com/agent-team-foundation/first-tree-context/pull/843

The Tree PR updates the Context Tab, onboarding, and GitLab integration contracts to scope `Connected` to binding validity and keep Web preview availability on the consumption surface. It remains draft until this implementation merges, then will be reconciled against the final merged commit and submitted for Context Reviewer review.

## Verification

- `pnpm exec vitest run src/pages/settings/__tests__/setup-dom.test.tsx src/pages/__tests__/context-page-dom.test.tsx --maxWorkers=2` (78 tests)
- `pnpm --filter @first-tree/web typecheck`
- focused Biome check on all six changed files
- `git diff --check`
