### PR TITLE
docs(qa): use isolated agent-browser for web checks

### DIFF
--- a/packages/qa/__tests__/lifecycle-contract.test.ts
+++ b/packages/qa/__tests__/lifecycle-contract.test.ts
@@ -53,6 +53,19 @@ describe("first-tree-qa lifecycle contract", () => {
     expect(planTemplate).toContain("Create only after the complete harness is `QA READY`.");
   });
 
+  it("keeps ordinary Web QA on an isolated headless agent-browser session", () => {
+    const setupBriefing = readRepoFile("packages/qa/briefings/setup.md");
+    const executeBriefing = readRepoFile("packages/qa/briefings/execute.md");
+
+    expect(setupBriefing).toContain("agent-browser skills get core --full");
+    expect(setupBriefing).toContain("agent-browser session id --scope worktree --prefix first-tree-qa");
+    expect(setupBriefing).toContain("explicit `--headed false`");
+    expect(setupBriefing).toContain("operator's foreground browser");
+    expect(setupBriefing).toContain("`agent-browser --auto-connect`");
+    expect(executeBriefing).toContain("run-scoped, headless `agent-browser` session");
+    expect(executeBriefing).toContain("Never use an operator Web session");
+  });
+
   it("keeps every case disposition aligned in the skill and report template", () => {
     const skill = readRepoFile("skills/first-tree-qa/SKILL.md");
     const reportTemplate = readRepoFile("packages/qa/templates/qa-report.md");

--- a/packages/qa/briefings/execute.md
+++ b/packages/qa/briefings/execute.md
@@ -7,6 +7,12 @@ Use this briefing after `QA READY` and a run-local plan exist.
 - Confirm the relevant harness capabilities and reset paths remain ready.
 - Exercise final artifacts through CLI, HTTP, Web, SDK/client, daemon/runtime, provider, installer, and persisted-state
   boundaries selected by the plan.
+- Drive ordinary Web scenarios through the run-scoped, headless `agent-browser` session established during setup. Take a
+  fresh interactive snapshot before acting and reacquire refs after navigation, reload, upload/download, or rerender;
+  save relevant screenshots, console/network evidence, and traces under the run artifact directory.
+- Treat the browser only as a driver for the isolated product under test. Never use an operator Web session to deliver
+  reports, attachments, or chat messages, and never switch to the foreground browser when the isolated session is
+  missing state; deliver QA results through the QA agent's own First Tree chat command.
 - Use source and internal logs for risk discovery and diagnosis, not as the only evidence for product behavior.
 - Verify meaningful preconditions and use independent readback or restart boundaries when needed.
 - Save evidence and record findings as they occur; do not reconstruct the run from memory at the end.

--- a/packages/qa/briefings/setup.md
+++ b/packages/qa/briefings/setup.md
@@ -20,6 +20,26 @@ A formal run has a temporary run root, run-local bare clone and detached worktre
 networks/volumes/homes, and an external artifact directory. Build and start all formal surfaces, not only those suggested
 by the eventual task scope. Use native, device, or provider bridges where Docker cannot credibly host a surface.
 
+## Web Browser Drive
+
+Use the installed `agent-browser` CLI as the default driver for First Tree Web surfaces. Before driving the page, read
+its version-matched core guide with `agent-browser skills get core --full`, verify the binary/version, and establish a
+run-scoped wrapper modeled on:
+
+- a stable session from `agent-browser session id --scope worktree --prefix first-tree-qa`;
+- a disposable profile, download directory, screenshot directory, and any restored state inside the run root;
+- `--content-boundaries` plus explicit `--headed false`, so host config cannot open a visible browser window; and
+- the candidate Web loopback URL and run-local test identities, never operator credentials or production browser state.
+
+The operator's foreground browser, existing Chrome tabs/profiles, Codex in-app Browser, Chrome control, CDP attachment
+to an existing browser, and `agent-browser --auto-connect` are not QA harness resources. Do not switch to one of them to
+work around missing selectors, authentication, or state. If a surface genuinely requires a visible native browser,
+extension, PWA, OAuth, or device interaction, record it as a separate explicit bridge; use a disposable QA-only profile
+when authorized, otherwise report that capability `BLOCKED` rather than opening or claiming the operator's browser.
+
+Define browser cleanup before readiness and close the run-scoped `agent-browser` session after evidence capture. Retain
+only the redacted run artifacts required by the report.
+
 ## Setup Rules
 
 - Resolve the run root with `realpath` before sharing paths with Docker.


### PR DESCRIPTION
## Summary

- make the installed `agent-browser` CLI the default driver for ordinary First Tree Web QA
- require worktree-scoped, headless sessions with run-local browser state and artifacts
- prohibit using an operator's foreground browser, existing Chrome state, CDP auto-connect, or Web session for QA/report delivery
- add a lifecycle contract test for the browser isolation rules

## Why

QA browser validation must stay inside the isolated run harness and preserve agent/human provenance. Foreground operator browser state is not a QA resource; when a scenario genuinely requires a visible/native browser, it must use an explicitly authorized disposable QA profile or be reported as blocked.

## Validation

- `pnpm --filter @first-tree/qa test`
- `pnpm check` (passes; 16 pre-existing warnings and 1 informational diagnostic in unrelated files)
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`