### PR TITLE
fix(client): prevent stale slots from deleting rebound runtime tokens

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -1,9 +1,12 @@
 import { EventEmitter } from "node:events";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ClientConnection, SessionReconcileResult } from "../client-connection.js";
 import type { AgentSlotConfig } from "../runtime/agent-slot.js";
 import type { HandlerConfig } from "../runtime/handler.js";
+import { RuntimeSessionTokenFile } from "../runtime/runtime-session-token-file.js";
 import { type FirstTreeHubSDK, type RegisterResult, SdkError } from "../sdk.js";
 
 type FakeLogger = {
@@ -178,7 +181,12 @@ function makeFrame(overrides: Record<string, unknown> = {}) {
 }
 
 function installMocks(
-  options: { syncResult?: MockState["syncResult"]; syncDelayMs?: number; dispatchRejectEntryId?: number } = {},
+  options: {
+    syncResult?: MockState["syncResult"];
+    syncDelayMs?: number;
+    dispatchRejectEntryId?: number;
+    dataDir?: string;
+  } = {},
 ): MockState {
   vi.resetModules();
   const state: MockState = {
@@ -193,7 +201,7 @@ function installMocks(
   };
 
   vi.doMock("@first-tree/shared/config", () => ({
-    defaultDataDir: () => "/tmp/first-tree-test-data",
+    defaultDataDir: () => options.dataDir ?? "/tmp/first-tree-test-data",
   }));
   vi.doMock("../observability/logger.js", () => ({
     createLogger: () => state.logger,
@@ -312,6 +320,7 @@ async function makeSlot(options?: {
   dispatchRejectEntryId?: number;
   omitReconcileInterval?: boolean;
   deferSuspendOnSubprocess?: boolean;
+  dataDir?: string;
 }): Promise<{
   slot: import("../runtime/agent-slot.js").AgentSlot;
   connection: FakeClientConnection;
@@ -322,6 +331,7 @@ async function makeSlot(options?: {
     syncResult: options?.syncResult,
     syncDelayMs: options?.syncDelayMs,
     dispatchRejectEntryId: options?.dispatchRejectEntryId,
+    dataDir: options?.dataDir,
   });
   const sdk = makeSdk({
     agent: options?.agent,
@@ -784,6 +794,7 @@ describe("AgentSlot", () => {
       await Promise.resolve();
 
       expect(readFileSync(tokenFile, "utf8").trim()).toBe("runtime-token-2");
+      expect(connection.tokenProviders.get("agent-1")?.()).toBe("runtime-token-2");
     } finally {
       await slot.stop();
     }
@@ -791,6 +802,161 @@ describe("AgentSlot", () => {
     expect(existsSync(tokenFile)).toBe(false);
     expect(connection.clearRuntimeSessionTokenProvider).toHaveBeenCalledWith("agent-1", expect.any(Function));
     expect(connection.tokenProviders.has("agent-1")).toBe(false);
+  });
+
+  it("does not delete a newer token generation written by a replacement slot", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "first-tree-agent-slot-owner-"));
+    const tokenFile = join(dataDir, "runtime-session-tokens", "agent-1.token");
+    const { slot, connection } = await makeSlot({
+      dataDir,
+      activeRuntimeChatIds: ["chat-1"],
+      runtimeSessionToken: "runtime-token-A",
+    });
+    const replacementStore = new RuntimeSessionTokenFile(tokenFile);
+
+    try {
+      await slot.start();
+      replacementStore.persist("runtime-token-B");
+
+      expect(connection.tokenProviders.get("agent-1")?.()).toBe("runtime-token-B");
+      await slot.stop();
+
+      expect(replacementStore.read()).toBe("runtime-token-B");
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a slot unavailable when the per-agent mutation lock cannot be acquired", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "first-tree-agent-slot-lock-"));
+    const tokenFile = join(dataDir, "runtime-session-tokens", "agent-1.token");
+    mkdirSync(join(dataDir, "runtime-session-tokens"), { recursive: true, mode: 0o700 });
+    writeFileSync(`${tokenFile}.lock`, `${process.pid}\n`, { mode: 0o600 });
+    const { slot, connection, sdk, state } = await makeSlot({
+      dataDir,
+      runtimeSessionToken: "runtime-token-A",
+    });
+    const tokenStore = Reflect.get(slot, "runtimeSessionTokenStore");
+    if (typeof tokenStore !== "object" || tokenStore === null) throw new Error("runtime token store missing");
+    Reflect.set(tokenStore, "lockAcquireTimeoutMs", 20);
+    Reflect.set(tokenStore, "lockRetryDelayMs", 2);
+
+    try {
+      await expect(slot.start()).rejects.toThrow(/cannot become healthy/);
+
+      expect(connection.unbindAgent).toHaveBeenCalledWith("agent-1");
+      expect(vi.mocked(sdk.register)).not.toHaveBeenCalled();
+      expect(state.sessions).toHaveLength(0);
+      expect(existsSync(tokenFile)).toBe(false);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a slot unavailable when atomic token replacement fails", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "first-tree-agent-slot-write-"));
+    const tokenFile = join(dataDir, "runtime-session-tokens", "agent-1.token");
+    mkdirSync(tokenFile, { recursive: true });
+    const { slot, connection, sdk, state } = await makeSlot({
+      dataDir,
+      runtimeSessionToken: "runtime-token-A",
+    });
+
+    try {
+      await expect(slot.start()).rejects.toThrow(/cannot become healthy/);
+
+      expect(connection.unbindAgent).toHaveBeenCalledWith("agent-1");
+      expect(vi.mocked(sdk.register)).not.toHaveBeenCalled();
+      expect(state.sessions).toHaveLength(0);
+      expect(existsSync(`${tokenFile}.lock`)).toBe(false);
+      expect(statSync(tokenFile).isDirectory()).toBe(true);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("failed-start cleanup preserves a generation written by a later bind", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "first-tree-agent-slot-failed-start-"));
+    const tokenFile = join(dataDir, "runtime-session-tokens", "agent-1.token");
+    const { slot, sdk } = await makeSlot({
+      dataDir,
+      runtimeSessionToken: "runtime-token-A",
+    });
+    const configFetch = deferred<never>();
+    vi.mocked(sdk.fetchAgentConfig).mockImplementationOnce(() => configFetch.promise);
+    const replacementStore = new RuntimeSessionTokenFile(tokenFile);
+
+    try {
+      const startPromise = slot.start();
+      await vi.waitFor(() => expect(readFileSync(tokenFile, "utf8").trim()).toBe("runtime-token-A"));
+      replacementStore.persist("runtime-token-B");
+      configFetch.reject(new SdkError(403, "config rejected"));
+
+      await expect(startPromise).rejects.toThrow(/rejected agent config/);
+      expect(replacementStore.read()).toBe("runtime-token-B");
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("failed-start cleanup removes the generation written by that slot", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "first-tree-agent-slot-owned-failed-start-"));
+    const tokenFile = join(dataDir, "runtime-session-tokens", "agent-1.token");
+    const { slot } = await makeSlot({
+      dataDir,
+      runtimeSessionToken: "runtime-token-A",
+      configError: new SdkError(403, "config rejected"),
+    });
+
+    try {
+      await expect(slot.start()).rejects.toThrow(/rejected agent config/);
+      expect(existsSync(tokenFile)).toBe(false);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stops a healthy slot and preserves the file when reconnect persistence cannot lock", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "first-tree-agent-slot-rebind-lock-"));
+    const tokenFile = join(dataDir, "runtime-session-tokens", "agent-1.token");
+    const { slot, connection, state } = await makeSlot({
+      dataDir,
+      activeRuntimeChatIds: ["chat-1"],
+      runtimeSessionToken: "runtime-token-A",
+    });
+
+    try {
+      await slot.start();
+      const session = state.sessions[0];
+      if (!session) throw new Error("session missing");
+      const tokenStore = Reflect.get(slot, "runtimeSessionTokenStore");
+      if (typeof tokenStore !== "object" || tokenStore === null) throw new Error("runtime token store missing");
+      Reflect.set(tokenStore, "lockAcquireTimeoutMs", 20);
+      Reflect.set(tokenStore, "lockRetryDelayMs", 2);
+      writeFileSync(`${tokenFile}.lock`, `${process.pid}\n`, { mode: 0o600 });
+      connection.unbindAgent.mockClear();
+      session.noteBindRecoveryComplete.mockClear();
+
+      connection.emit("agent:bound", {
+        agentId: "agent-1",
+        displayName: "Agent One",
+        agentType: "agent",
+        sdk: makeSdk({ runtimeSessionToken: "runtime-token-B" }),
+        runtimeSessionToken: "runtime-token-B",
+      });
+
+      await vi.waitFor(() => expect(connection.unbindAgent).toHaveBeenCalledWith("agent-1"));
+      await vi.waitFor(() => expect(state.logger.info).toHaveBeenCalledWith("stopped"));
+      expect(session.noteBindRecoveryComplete).not.toHaveBeenCalled();
+      expect(connection.tokenProviders.has("agent-1")).toBe(false);
+      expect(readFileSync(tokenFile, "utf8").trim()).toBe("runtime-token-A");
+      expect(state.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error) }),
+        "runtime session token cleanup failed; leaving any remaining file untouched",
+      );
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 
   it("starts a fresh active-runtime-chat refresh after rebind even when the old refresh is in flight", async () => {

--- a/packages/client/src/__tests__/runtime-session-token-file.test.ts
+++ b/packages/client/src/__tests__/runtime-session-token-file.test.ts
@@ -1,0 +1,195 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { digestRuntimeSessionToken, RuntimeSessionTokenFile } from "../runtime/runtime-session-token-file.js";
+
+const roots: string[] = [];
+
+function makeTokenPath(): string {
+  const root = mkdtempSync(join(tmpdir(), "first-tree-runtime-token-"));
+  roots.push(root);
+  return join(root, "runtime-session-tokens", "agent-1.token");
+}
+
+describe("RuntimeSessionTokenFile", () => {
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("atomically writes pure token text at the stable path with private modes", () => {
+    const tokenPath = makeTokenPath();
+    const store = new RuntimeSessionTokenFile(tokenPath);
+
+    const digest = store.persist("runtime-token-A");
+
+    expect(digest).toBe(digestRuntimeSessionToken("runtime-token-A"));
+    expect(readFileSync(tokenPath, "utf8")).toBe("runtime-token-A\n");
+    expect(store.read()).toBe("runtime-token-A");
+    expect(readdirSync(join(tokenPath, "..")).sort()).toEqual(["agent-1.token"]);
+    if (process.platform !== "win32") {
+      expect(statSync(join(tokenPath, "..")).mode & 0o777).toBe(0o700);
+      expect(statSync(tokenPath).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("preserves B when B replaces A before A cleanup acquires the mutation lock", () => {
+    const tokenPath = makeTokenPath();
+    const slotA = new RuntimeSessionTokenFile(tokenPath);
+    const slotB = new RuntimeSessionTokenFile(tokenPath);
+    const digestA = slotA.persist("runtime-token-A");
+
+    const digestB = slotB.persist("runtime-token-B");
+
+    expect(slotA.removeIfOwned(digestA)).toBe("mismatch");
+    expect(slotB.read()).toBe("runtime-token-B");
+    expect(slotB.removeIfOwned(digestB)).toBe("removed");
+    expect(existsSync(tokenPath)).toBe(false);
+  });
+
+  it("waits for a cross-process A cleanup before writing B as the final generation", async () => {
+    const tokenPath = makeTokenPath();
+    const slotA = new RuntimeSessionTokenFile(tokenPath);
+    slotA.persist("runtime-token-A");
+    const lockPath = `${tokenPath}.lock`;
+    const script = [
+      'import { closeSync, openSync, rmSync, writeFileSync } from "node:fs";',
+      "const [lockPath, tokenPath] = process.argv.slice(1);",
+      'const descriptor = openSync(lockPath, "wx", 0o600);',
+      'writeFileSync(descriptor, String(process.pid) + "\\n", "utf8");',
+      'process.stdout.write("locked\\n");',
+      "setTimeout(() => {",
+      "  rmSync(tokenPath);",
+      "  closeSync(descriptor);",
+      "  rmSync(lockPath);",
+      "}, 75);",
+    ].join("\n");
+    const child = spawn(process.execPath, ["--input-type=module", "-e", script, lockPath, tokenPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await once(child.stdout, "data");
+    const slotB = new RuntimeSessionTokenFile(tokenPath, {
+      lockAcquireTimeoutMs: 1_000,
+      lockRetryDelayMs: 2,
+    });
+
+    slotB.persist("runtime-token-B");
+
+    expect(slotB.read()).toBe("runtime-token-B");
+    const [exitCode] = await once(child, "exit");
+    expect(exitCode).toBe(0);
+  });
+
+  it("waits for a cross-process B mutation before comparing A ownership", async () => {
+    const tokenPath = makeTokenPath();
+    const slotA = new RuntimeSessionTokenFile(tokenPath, {
+      lockAcquireTimeoutMs: 1_000,
+      lockRetryDelayMs: 2,
+    });
+    const digestA = slotA.persist("runtime-token-A");
+    const lockPath = `${tokenPath}.lock`;
+    const script = [
+      'import { closeSync, openSync, renameSync, rmSync, writeFileSync } from "node:fs";',
+      "const [lockPath, tokenPath] = process.argv.slice(1);",
+      'const descriptor = openSync(lockPath, "wx", 0o600);',
+      'writeFileSync(descriptor, String(process.pid) + "\\n", "utf8");',
+      'process.stdout.write("locked\\n");',
+      "setTimeout(() => {",
+      '  const temporaryPath = tokenPath + ".child-tmp";',
+      '  writeFileSync(temporaryPath, "runtime-token-B\\n", { mode: 0o600 });',
+      "  renameSync(temporaryPath, tokenPath);",
+      "  closeSync(descriptor);",
+      "  rmSync(lockPath);",
+      "}, 75);",
+    ].join("\n");
+    const child = spawn(process.execPath, ["--input-type=module", "-e", script, lockPath, tokenPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await once(child.stdout, "data");
+
+    expect(slotA.removeIfOwned(digestA)).toBe("mismatch");
+    expect(slotA.read()).toBe("runtime-token-B");
+
+    const [exitCode] = await once(child, "exit");
+    expect(exitCode).toBe(0);
+  });
+
+  it("fails closed while another process holds the mutation lock", async () => {
+    const tokenPath = makeTokenPath();
+    mkdirSync(join(tokenPath, ".."), { recursive: true, mode: 0o700 });
+    const lockPath = `${tokenPath}.lock`;
+    const script = [
+      'import { closeSync, openSync, rmSync, writeFileSync } from "node:fs";',
+      "const lockPath = process.argv[1];",
+      'const descriptor = openSync(lockPath, "wx", 0o600);',
+      'writeFileSync(descriptor, String(process.pid) + "\\n", "utf8");',
+      'process.stdout.write("locked\\n");',
+      "setTimeout(() => {",
+      "  closeSync(descriptor);",
+      "  rmSync(lockPath);",
+      "}, 150);",
+    ].join("\n");
+    const child = spawn(process.execPath, ["--input-type=module", "-e", script, lockPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await once(child.stdout, "data");
+    const store = new RuntimeSessionTokenFile(tokenPath, {
+      lockAcquireTimeoutMs: 20,
+      lockRetryDelayMs: 2,
+    });
+
+    expect(() => store.persist("runtime-token-A")).toThrow(/Timed out acquiring/);
+    expect(existsSync(tokenPath)).toBe(false);
+
+    const [exitCode] = await once(child, "exit");
+    expect(exitCode).toBe(0);
+  });
+
+  it("removes only a readable, non-empty matching generation", () => {
+    const tokenPath = makeTokenPath();
+    const store = new RuntimeSessionTokenFile(tokenPath);
+    const digestA = store.persist("runtime-token-A");
+
+    rmSync(tokenPath);
+    expect(store.removeIfOwned(digestA)).toBe("missing");
+
+    writeFileSync(tokenPath, "\n", { mode: 0o600 });
+    expect(store.removeIfOwned(digestA)).toBe("empty");
+    expect(existsSync(tokenPath)).toBe(true);
+
+    writeFileSync(tokenPath, "runtime-token-B\n", { mode: 0o600 });
+    expect(store.removeIfOwned(digestA)).toBe("mismatch");
+    expect(store.read()).toBe("runtime-token-B");
+
+    rmSync(tokenPath);
+    mkdirSync(tokenPath);
+    expect(() => store.removeIfOwned(digestA)).toThrow(/Failed to read/);
+    expect(statSync(tokenPath).isDirectory()).toBe(true);
+  });
+
+  it("preserves the target and removes temporary files when atomic replacement fails", () => {
+    const tokenPath = makeTokenPath();
+    mkdirSync(tokenPath, { recursive: true });
+    const failingStore = new RuntimeSessionTokenFile(tokenPath);
+
+    expect(() => failingStore.persist("runtime-token-B")).toThrow();
+
+    expect(statSync(tokenPath).isDirectory()).toBe(true);
+    expect(
+      readdirSync(join(tokenPath, "..")).filter((entry) => entry.includes(".tmp.") || entry.endsWith(".lock")),
+    ).toEqual([]);
+  });
+});

--- a/packages/client/src/__tests__/runtime-session-token-file.test.ts
+++ b/packages/client/src/__tests__/runtime-session-token-file.test.ts
@@ -158,6 +158,58 @@ describe("RuntimeSessionTokenFile", () => {
     expect(exitCode).toBe(0);
   });
 
+  it("fails both contenders closed when they race over the same stale lock", async () => {
+    const tokenPath = makeTokenPath();
+    mkdirSync(join(tokenPath, ".."), { recursive: true, mode: 0o700 });
+    const lockPath = `${tokenPath}.lock`;
+    writeFileSync(lockPath, "99999999\n", { mode: 0o600 });
+    const moduleUrl = new URL("../runtime/runtime-session-token-file.ts", import.meta.url).href;
+    const script = [
+      "const [moduleUrl, tokenPath, token] = process.argv.slice(1);",
+      "const { RuntimeSessionTokenFile } = await import(moduleUrl);",
+      "const store = new RuntimeSessionTokenFile(tokenPath, {",
+      "  lockAcquireTimeoutMs: 50,",
+      "  lockRetryDelayMs: 2,",
+      "});",
+      "try {",
+      "  store.persist(token);",
+      '  process.stdout.write("acquired\\n");',
+      "} catch {",
+      '  process.stdout.write("blocked\\n");',
+      "}",
+    ].join("\n");
+    const spawnContender = (token: string) =>
+      spawn(
+        process.execPath,
+        [
+          "--no-warnings",
+          "--experimental-strip-types",
+          "--input-type=module",
+          "-e",
+          script,
+          moduleUrl,
+          tokenPath,
+          token,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+    const contenderB = spawnContender("runtime-token-B");
+    const contenderC = spawnContender("runtime-token-C");
+    const outputB = once(contenderB.stdout, "data");
+    const outputC = once(contenderC.stdout, "data");
+    const exitB = once(contenderB, "exit");
+    const exitC = once(contenderC, "exit");
+
+    const [[chunkB], [chunkC], [exitCodeB], [exitCodeC]] = await Promise.all([outputB, outputC, exitB, exitC]);
+
+    expect(exitCodeB).toBe(0);
+    expect(exitCodeC).toBe(0);
+    expect(String(chunkB).trim()).toBe("blocked");
+    expect(String(chunkC).trim()).toBe("blocked");
+    expect(readFileSync(lockPath, "utf8")).toBe("99999999\n");
+    expect(existsSync(tokenPath)).toBe(false);
+  });
+
   it("removes only a readable, non-empty matching generation", () => {
     const tokenPath = makeTokenPath();
     const store = new RuntimeSessionTokenFile(tokenPath);

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -1,5 +1,4 @@
-import { chmodSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import type {
   AgentRuntimeConfig,
   InboxDeliverFrame,
@@ -19,6 +18,7 @@ import type { SessionConfig } from "./config.js";
 import { clampRetryAttempt, classify, ERROR_KINDS, nextRetryDelayMs } from "./error-taxonomy.js";
 import type { HandlerFactory } from "./handler.js";
 import { PsSubprocessProbe } from "./process-tree-probe.js";
+import { RuntimeSessionTokenFile } from "./runtime-session-token-file.js";
 import { SessionManager, type SessionManagerShutdownOptions } from "./session-manager.js";
 
 /**
@@ -105,6 +105,12 @@ export class AgentSlot {
   private sessionManager: SessionManager | null = null;
   private readonly config: AgentSlotConfig;
   private readonly runtimeSessionTokenFile: string;
+  private readonly runtimeSessionTokenStore: RuntimeSessionTokenFile;
+  private runtimeSessionTokenDigest: string | null = null;
+  private runtimeSessionTokenMutationError: unknown = null;
+  /** ClientConnection emits and resolves the same BoundAgent object for the initial bind. */
+  private readonly persistedBoundAgents = new WeakSet<BoundAgent>();
+  private started = false;
   private logger: pino.Logger;
   private agentConfigCache: AgentConfigCache | null = null;
   private sdk: FirstTreeHubSDK | null = null;
@@ -116,7 +122,7 @@ export class AgentSlot {
   private postBindReconcileTimer: ReturnType<typeof setTimeout> | null = null;
   private listeners: ConnectionListener[] = [];
   private stopping: Promise<void> | null = null;
-  private readonly runtimeSessionTokenProvider = (): string | undefined => this.readRuntimeSessionToken();
+  private readonly runtimeSessionTokenProvider = (): string | undefined => this.runtimeSessionTokenStore.read();
   /**
    * Aborts an in-flight bring-up config-fetch retry (see
    * {@link loadAgentConfigWithRetry}) so a stop()/unbind during the backoff
@@ -133,6 +139,7 @@ export class AgentSlot {
   constructor(config: AgentSlotConfig) {
     this.config = config;
     this.runtimeSessionTokenFile = join(defaultDataDir(), "runtime-session-tokens", `${config.agentId}.token`);
+    this.runtimeSessionTokenStore = new RuntimeSessionTokenFile(this.runtimeSessionTokenFile);
     this.logger = createLogger("slot").child({ agentName: config.name, agentId: config.agentId });
   }
 
@@ -158,6 +165,8 @@ export class AgentSlot {
   }
 
   async start(): Promise<RegisterResult> {
+    this.started = false;
+    this.runtimeSessionTokenMutationError = null;
     this.bringupAbort = new AbortController();
     this.clientConnection.setRuntimeSessionTokenProvider(this.config.agentId, this.runtimeSessionTokenProvider);
     // Attach listeners BEFORE `bindAgent` so the server's bind-time
@@ -196,7 +205,14 @@ export class AgentSlot {
     const onBound = (boundAgent: BoundAgent) => {
       if (boundAgent.agentId === this.config.agentId) {
         if (boundAgent.runtimeSessionToken) {
-          this.persistRuntimeSessionToken(boundAgent.runtimeSessionToken);
+          if (!this.persistBoundRuntimeSessionToken(boundAgent)) {
+            if (this.started) {
+              void this.stop("runtime session token persistence failed").catch((err) => {
+                this.logger.error({ err }, "failed to stop slot after runtime session token persistence failure");
+              });
+            }
+            return;
+          }
           if (boundAgent.sdk) this.adoptRuntimeTransport(boundAgent.sdk);
         }
         if (typeof this.sessionManager?.noteBindRecoveryComplete === "function") {
@@ -248,8 +264,12 @@ export class AgentSlot {
       const runtimeType = this.config.runtimeType ?? this.config.type;
       const bound = await this.clientConnection.bindAgent(this.config.agentId, runtimeType, this.config.runtimeVersion);
       bindSucceeded = true;
+      this.throwIfRuntimeSessionTokenMutationFailed();
       const sdk = bound.sdk;
-      if (bound.runtimeSessionToken) this.persistRuntimeSessionToken(bound.runtimeSessionToken);
+      if (bound.runtimeSessionToken && !this.persistedBoundAgents.has(bound)) {
+        this.persistBoundRuntimeSessionToken(bound);
+        this.throwIfRuntimeSessionTokenMutationFailed();
+      }
       this.adoptRuntimeTransport(sdk);
       const agent = await sdk.register();
 
@@ -257,6 +277,8 @@ export class AgentSlot {
 
       if (agent.type === "human") {
         this.logger.info("server reports type=human — message processing disabled");
+        this.throwIfRuntimeSessionTokenMutationFailed();
+        this.started = true;
         return agent;
       }
 
@@ -279,6 +301,7 @@ export class AgentSlot {
           "context tree not configured or binding unresolved — agent will start without organizational context",
         );
       }
+      this.throwIfRuntimeSessionTokenMutationFailed();
 
       const registryPath = join(defaultDataDir(), "sessions", `${this.config.name}.json`);
 
@@ -383,6 +406,8 @@ export class AgentSlot {
       this.scheduleActiveRuntimeChatIdsRefresh();
       this.startReconcileLoop();
 
+      this.throwIfRuntimeSessionTokenMutationFailed();
+      this.started = true;
       return agent;
     } catch (err) {
       await this.cleanupFailedStart({ unbind: bindSucceeded });
@@ -464,34 +489,35 @@ export class AgentSlot {
     this.sessionManager?.updateTransport(sdk, this.agentConfigCache ?? undefined);
   }
 
-  private persistRuntimeSessionToken(token: string | undefined): void {
-    let tmpFile: string | null = null;
+  private persistBoundRuntimeSessionToken(boundAgent: BoundAgent): boolean {
+    if (!boundAgent.runtimeSessionToken || this.persistedBoundAgents.has(boundAgent)) return true;
     try {
-      if (!token) {
-        rmSync(this.runtimeSessionTokenFile, { force: true });
-        return;
-      }
-      mkdirSync(dirname(this.runtimeSessionTokenFile), { recursive: true, mode: 0o700 });
-      tmpFile = `${this.runtimeSessionTokenFile}.tmp.${process.pid}.${Date.now()}.${Math.random()
-        .toString(36)
-        .slice(2)}`;
-      writeFileSync(tmpFile, `${token}\n`, { encoding: "utf8", mode: 0o600 });
-      chmodSync(tmpFile, 0o600);
-      renameSync(tmpFile, this.runtimeSessionTokenFile);
-      tmpFile = null;
-      chmodSync(this.runtimeSessionTokenFile, 0o600);
+      const digest = this.runtimeSessionTokenStore.persist(boundAgent.runtimeSessionToken);
+      this.runtimeSessionTokenDigest = digest;
+      this.persistedBoundAgents.add(boundAgent);
+      return true;
     } catch (err) {
-      if (tmpFile) rmSync(tmpFile, { force: true });
-      this.logger.warn({ err }, "failed to persist runtime session token");
+      this.runtimeSessionTokenMutationError = err;
+      this.logger.error({ err }, "failed to persist runtime session token — slot unavailable");
+      return false;
     }
   }
 
-  private readRuntimeSessionToken(): string | undefined {
+  private throwIfRuntimeSessionTokenMutationFailed(): void {
+    if (!this.runtimeSessionTokenMutationError) return;
+    throw new Error("Runtime session token persistence failed; the agent slot cannot become healthy.", {
+      cause: this.runtimeSessionTokenMutationError,
+    });
+  }
+
+  private cleanupOwnedRuntimeSessionToken(): void {
+    const digest = this.runtimeSessionTokenDigest;
+    this.runtimeSessionTokenDigest = null;
+    if (!digest) return;
     try {
-      const token = readFileSync(this.runtimeSessionTokenFile, "utf8").trim();
-      return token || undefined;
-    } catch {
-      return undefined;
+      this.runtimeSessionTokenStore.removeIfOwned(digest);
+    } catch (err) {
+      this.logger.warn({ err }, "runtime session token cleanup failed; leaving any remaining file untouched");
     }
   }
 
@@ -506,6 +532,7 @@ export class AgentSlot {
   }
 
   private async stopOnce(reason?: string, opts: AgentSlotStopOptions = {}): Promise<void> {
+    this.started = false;
     this.bringupAbort?.abort();
     this.activeRuntimeChatIdsRefreshGeneration++;
     if (this.reconcileTimer) {
@@ -538,7 +565,7 @@ export class AgentSlot {
       firstError ??= err;
       this.logger.warn({ err }, "failed to shut down sessions while stopping");
     }
-    this.persistRuntimeSessionToken(undefined);
+    this.cleanupOwnedRuntimeSessionToken();
     this.sessionManager = null;
     this.agentConfigCache = null;
     this.sdk = null;
@@ -550,6 +577,7 @@ export class AgentSlot {
   }
 
   private async cleanupFailedStart(opts: { unbind: boolean }): Promise<void> {
+    this.started = false;
     this.bringupAbort?.abort();
     this.activeRuntimeChatIdsRefreshGeneration++;
     if (this.reconcileTimer) {
@@ -576,14 +604,19 @@ export class AgentSlot {
         this.logger.warn({ err }, "failed to unbind after aborted agent start");
       }
     }
-    await this.sessionManager?.shutdown();
-    this.persistRuntimeSessionToken(undefined);
+    try {
+      await this.sessionManager?.shutdown();
+    } catch (err) {
+      this.logger.warn({ err }, "failed to shut down sessions after aborted agent start");
+    }
+    this.cleanupOwnedRuntimeSessionToken();
     this.sessionManager = null;
     this.agentConfigCache = null;
     this.sdk = null;
     this.activeRuntimeChatIds = null;
     this.activeRuntimeChatIdsRefreshInFlight = null;
     this.inboxId = null;
+    this.runtimeSessionTokenMutationError = null;
   }
 
   private reportSessionState(chatId: string, state: SessionState): void {

--- a/packages/client/src/runtime/runtime-session-token-file.ts
+++ b/packages/client/src/runtime/runtime-session-token-file.ts
@@ -1,0 +1,223 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+const DEFAULT_LOCK_ACQUIRE_TIMEOUT_MS = 5_000;
+const DEFAULT_LOCK_RETRY_DELAY_MS = 10;
+const DEFAULT_UNREADABLE_LOCK_STALE_MS = 5 * 60_000;
+const LOCK_WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+
+export type RuntimeSessionTokenCleanupResult = "removed" | "missing" | "empty" | "mismatch";
+
+export type RuntimeSessionTokenFileOptions = {
+  lockAcquireTimeoutMs?: number;
+  lockRetryDelayMs?: number;
+  unreadableLockStaleMs?: number;
+};
+
+/**
+ * Owns the stable per-agent runtime-session token file.
+ *
+ * The token itself is the generation identity: a successful write returns its
+ * SHA-256 digest for the owning AgentSlot to keep in memory. Both replacement
+ * and compare-and-delete run under the same cross-process per-agent lock.
+ */
+export class RuntimeSessionTokenFile {
+  readonly path: string;
+  readonly lockPath: string;
+  private readonly lockAcquireTimeoutMs: number;
+  private readonly lockRetryDelayMs: number;
+  private readonly unreadableLockStaleMs: number;
+
+  constructor(path: string, options: RuntimeSessionTokenFileOptions = {}) {
+    this.path = path;
+    this.lockPath = `${path}.lock`;
+    this.lockAcquireTimeoutMs = options.lockAcquireTimeoutMs ?? DEFAULT_LOCK_ACQUIRE_TIMEOUT_MS;
+    this.lockRetryDelayMs = options.lockRetryDelayMs ?? DEFAULT_LOCK_RETRY_DELAY_MS;
+    this.unreadableLockStaleMs = options.unreadableLockStaleMs ?? DEFAULT_UNREADABLE_LOCK_STALE_MS;
+  }
+
+  persist(token: string): string {
+    const normalizedToken = token.trim();
+    if (!normalizedToken) {
+      throw new Error("Cannot persist an empty runtime session token.");
+    }
+
+    return this.withMutationLock(() => {
+      this.writeAtomically(normalizedToken);
+      return digestRuntimeSessionToken(normalizedToken);
+    });
+  }
+
+  read(): string | undefined {
+    try {
+      const token = readFileSync(this.path, "utf8").trim();
+      return token || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  removeIfOwned(expectedDigest: string): RuntimeSessionTokenCleanupResult {
+    return this.withMutationLock(() => {
+      let token: string;
+      try {
+        token = readFileSync(this.path, "utf8").trim();
+      } catch (error) {
+        if (errorCode(error) === "ENOENT") return "missing";
+        throw new Error("Failed to read the runtime session token during owned cleanup.", { cause: error });
+      }
+
+      if (!token) return "empty";
+      if (digestRuntimeSessionToken(token) !== expectedDigest) return "mismatch";
+
+      rmSync(this.path);
+      return "removed";
+    });
+  }
+
+  private withMutationLock<T>(action: () => T): T {
+    this.ensurePrivateDirectory();
+    const descriptor = this.acquireMutationLock();
+
+    let outcome: { ok: true; value: T } | { ok: false; error: unknown };
+    try {
+      outcome = { ok: true, value: action() };
+    } catch (error) {
+      outcome = { ok: false, error };
+    }
+
+    let releaseError: unknown;
+    try {
+      closeSync(descriptor);
+      rmSync(this.lockPath);
+    } catch (error) {
+      releaseError = error;
+    }
+
+    if (!outcome.ok) {
+      if (releaseError) {
+        throw new AggregateError(
+          [outcome.error, releaseError],
+          "Runtime session token mutation and lock release both failed.",
+        );
+      }
+      throw outcome.error;
+    }
+    if (releaseError) {
+      throw new Error("Failed to release the runtime session token mutation lock.", { cause: releaseError });
+    }
+    return outcome.value;
+  }
+
+  private ensurePrivateDirectory(): void {
+    const directory = dirname(this.path);
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    chmodSync(directory, 0o700);
+  }
+
+  private acquireMutationLock(): number {
+    const deadline = Date.now() + Math.max(0, this.lockAcquireTimeoutMs);
+
+    while (true) {
+      try {
+        const descriptor = openSync(this.lockPath, "wx", 0o600);
+        try {
+          writeFileSync(descriptor, `${process.pid}\n`, "utf8");
+        } catch (error) {
+          closeSync(descriptor);
+          rmSync(this.lockPath, { force: true });
+          throw error;
+        }
+        return descriptor;
+      } catch (error) {
+        if (errorCode(error) !== "EEXIST") {
+          throw new Error("Failed to acquire the runtime session token mutation lock.", { cause: error });
+        }
+
+        if (this.removeStaleMutationLock()) continue;
+
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw new Error("Timed out acquiring the runtime session token mutation lock.", { cause: error });
+        }
+        sleepSync(Math.min(Math.max(1, this.lockRetryDelayMs), remainingMs));
+      }
+    }
+  }
+
+  /**
+   * Returns true when the contender should retry immediately. Unknown or
+   * unreadable ownership always stays in place: mutation then times out rather
+   * than risking two owners.
+   */
+  private removeStaleMutationLock(): boolean {
+    let ownerText: string;
+    try {
+      ownerText = readFileSync(this.lockPath, "utf8").trim();
+    } catch (error) {
+      return errorCode(error) === "ENOENT";
+    }
+
+    const owner = Number(ownerText);
+    if (Number.isInteger(owner) && owner > 0) {
+      try {
+        process.kill(owner, 0);
+        return false;
+      } catch (error) {
+        const code = errorCode(error);
+        if (code === "EPERM") return false;
+        if (code !== "ESRCH") return false;
+        try {
+          rmSync(this.lockPath);
+          return true;
+        } catch (removeError) {
+          return errorCode(removeError) === "ENOENT";
+        }
+      }
+    }
+
+    try {
+      if (Date.now() - statSync(this.lockPath).mtimeMs <= this.unreadableLockStaleMs) return false;
+      rmSync(this.lockPath);
+      return true;
+    } catch (error) {
+      return errorCode(error) === "ENOENT";
+    }
+  }
+
+  private writeAtomically(token: string): void {
+    let temporaryPath: string | null = `${this.path}.tmp.${process.pid}.${randomUUID()}`;
+    try {
+      writeFileSync(temporaryPath, `${token}\n`, { encoding: "utf8", mode: 0o600 });
+      chmodSync(temporaryPath, 0o600);
+      renameSync(temporaryPath, this.path);
+      temporaryPath = null;
+      chmodSync(this.path, 0o600);
+    } finally {
+      if (temporaryPath) rmSync(temporaryPath, { force: true });
+    }
+  }
+}
+
+export function digestRuntimeSessionToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(LOCK_WAIT_BUFFER, 0, 0, ms);
+}
+
+function errorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? Reflect.get(error, "code") : undefined;
+}

--- a/packages/client/src/runtime/runtime-session-token-file.ts
+++ b/packages/client/src/runtime/runtime-session-token-file.ts
@@ -1,20 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
-import {
-  chmodSync,
-  closeSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { chmodSync, closeSync, mkdirSync, openSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 const DEFAULT_LOCK_ACQUIRE_TIMEOUT_MS = 5_000;
 const DEFAULT_LOCK_RETRY_DELAY_MS = 10;
-const DEFAULT_UNREADABLE_LOCK_STALE_MS = 5 * 60_000;
 const LOCK_WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 
 export type RuntimeSessionTokenCleanupResult = "removed" | "missing" | "empty" | "mismatch";
@@ -22,7 +11,6 @@ export type RuntimeSessionTokenCleanupResult = "removed" | "missing" | "empty" |
 export type RuntimeSessionTokenFileOptions = {
   lockAcquireTimeoutMs?: number;
   lockRetryDelayMs?: number;
-  unreadableLockStaleMs?: number;
 };
 
 /**
@@ -37,14 +25,12 @@ export class RuntimeSessionTokenFile {
   readonly lockPath: string;
   private readonly lockAcquireTimeoutMs: number;
   private readonly lockRetryDelayMs: number;
-  private readonly unreadableLockStaleMs: number;
 
   constructor(path: string, options: RuntimeSessionTokenFileOptions = {}) {
     this.path = path;
     this.lockPath = `${path}.lock`;
     this.lockAcquireTimeoutMs = options.lockAcquireTimeoutMs ?? DEFAULT_LOCK_ACQUIRE_TIMEOUT_MS;
     this.lockRetryDelayMs = options.lockRetryDelayMs ?? DEFAULT_LOCK_RETRY_DELAY_MS;
-    this.unreadableLockStaleMs = options.unreadableLockStaleMs ?? DEFAULT_UNREADABLE_LOCK_STALE_MS;
   }
 
   persist(token: string): string {
@@ -145,54 +131,15 @@ export class RuntimeSessionTokenFile {
           throw new Error("Failed to acquire the runtime session token mutation lock.", { cause: error });
         }
 
-        if (this.removeStaleMutationLock()) continue;
-
+        // A pathname-only stale-lock delete cannot prove that the path still
+        // names the lock it inspected. Leave every existing lock untouched;
+        // bind fails unavailable and cleanup preserves the token on timeout.
         const remainingMs = deadline - Date.now();
         if (remainingMs <= 0) {
           throw new Error("Timed out acquiring the runtime session token mutation lock.", { cause: error });
         }
         sleepSync(Math.min(Math.max(1, this.lockRetryDelayMs), remainingMs));
       }
-    }
-  }
-
-  /**
-   * Returns true when the contender should retry immediately. Unknown or
-   * unreadable ownership always stays in place: mutation then times out rather
-   * than risking two owners.
-   */
-  private removeStaleMutationLock(): boolean {
-    let ownerText: string;
-    try {
-      ownerText = readFileSync(this.lockPath, "utf8").trim();
-    } catch (error) {
-      return errorCode(error) === "ENOENT";
-    }
-
-    const owner = Number(ownerText);
-    if (Number.isInteger(owner) && owner > 0) {
-      try {
-        process.kill(owner, 0);
-        return false;
-      } catch (error) {
-        const code = errorCode(error);
-        if (code === "EPERM") return false;
-        if (code !== "ESRCH") return false;
-        try {
-          rmSync(this.lockPath);
-          return true;
-        } catch (removeError) {
-          return errorCode(removeError) === "ENOENT";
-        }
-      }
-    }
-
-    try {
-      if (Date.now() - statSync(this.lockPath).mtimeMs <= this.unreadableLockStaleMs) return false;
-      rmSync(this.lockPath);
-      return true;
-    } catch (error) {
-      return errorCode(error) === "ENOENT";
     }
   }
 


### PR DESCRIPTION
## Summary

- serialize each agent's runtime-session token replacement and owned cleanup with a short-lived cross-process mutation lock
- treat the SHA-256 digest of the successfully persisted token as the in-memory generation owned by an `AgentSlot`
- compare and delete only while holding the same lock, preserving a newer bind's token when an older slot stops or cleans up a failed start
- leave every pre-existing lock untouched; bind becomes unavailable and cleanup preserves the token if lock acquisition times out
- keep the stable plain-text token path, atomic replacement, `0700` directory / `0600` file modes, request-time rereads, and no inherited-token fallback
- fail slot startup/rebind closed when the mutation lock or atomic persistence fails; cleanup failures preserve the current file

## Root cause and impact

Cleanup previously deleted the stable per-agent token path unconditionally. If a replacement daemon bound the same agent and atomically wrote a newly issued token before the old `AgentSlot` stopped, the old slot could remove the replacement generation. Long-lived provider children then kept the right path but found no proof on their next request.

The token content now identifies its generation. A slot remembers only the digest of its last successful write, so a stale slot cannot delete a later bind's token.

## Review follow-up

The initial implementation attempted to reclaim a lock after reading a dead PID. That pathname-only delete was not CAS-safe: another contender could acquire a new lock at the same path before the stale reclaimer removed it.

Head `4ad440666731348f692966f32ba4ee991e3247e4` removes stale-lock reclamation entirely. An existing lock is never deleted by a contender; all contenders wait and then fail closed. A regression starts two independent Node processes using the real `RuntimeSessionTokenFile` against the same dead-PID lock and proves that both remain blocked while the lock and token state stay unchanged.

## Validation

- `pnpm exec biome check packages/client/src/runtime/runtime-session-token-file.ts packages/client/src/runtime/agent-slot.ts packages/client/src/__tests__/runtime-session-token-file.test.ts packages/client/src/__tests__/agent-slot.test.ts`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/runtime-session-token-file.test.ts src/__tests__/agent-slot.test.ts` — 41 passed
- `pnpm --filter @first-tree/client test` — 1,731 passed, 3 skipped
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/local-agent-runtime-token-request.test.ts src/__tests__/agent-shared-helpers-extra.test.ts src/__tests__/tree-review.test.ts` — 21 passed
- `pnpm check` — passed; unchanged files continue to report the repository's existing warnings
- `pnpm typecheck` — 11/11 tasks passed
- `pnpm test` — 12/12 workspace tasks passed

The regression coverage includes both cross-process lock orderings, two contenders racing over one stale lock, A/B replacement ownership, same-slot rebind cleanup, failed-start cleanup, lock and atomic-write failures, missing/empty/unreadable/mismatched files, stable-path rereads, and private file modes.

## QA and task isolation

Independent live QA passed exact head `4ad440666731348f692966f32ba4ee991e3247e4`:

- four stale-lock race variants and eight independent contenders all timed out fail-closed at the product's default timeout; no contender entered the critical section, 9,102 observer samples saw no mutation, and the lock/token metadata and contents remained unchanged with no temp residue
- A→B replacement rotated the generation at the same private stable path; one unchanged child PID received HTTP 200 before and after replacement and after A's stale stop, while the file retained B's digest
- B's owned stop removed B's generation and left no token, lock, or temp residue
- targeted ownership/token tests passed 41/41; the full Client suite passed 1,731 with 3 skipped; CLI token reread/no-fallback tests passed 11/11; workspace typecheck passed 11/11; and every applicable exact-head GitHub CI/CodeQL check is green

QA classified the existing live token-delivery case as `candidate-case-update`; deterministic stale-lock contention remains at the product-test layer.

The existing reusable case `packages/qa/cases/cross-surface/agent-runtime-session-token-delivery.md` covers the stable-path, next-request reread, and no-fallback contracts; deterministic ownership and interleaving coverage lives in the client tests added here.

This branch was created directly from `origin/main` and does not include Issue 1's daemon single-instance ownership changes from `fix/daemon-home-owner-lock`. The two changes have zero file-path overlap, so there is no required merge order.
