### PR TITLE
docs(runtime): explain chat send attachment capture

### DIFF
--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -133,6 +133,35 @@ afterEach(() => {
 });
 
 describe("chat command behavior", () => {
+  it("keeps outbound attachment capture discoverable in `chat send --help`", async () => {
+    const { registerChatCommands } = await import("../commands/chat/index.js");
+    const program = new Command();
+    registerChatCommands(program);
+    const chat = program.commands.find((command) => command.name() === "chat");
+    const send = chat?.commands.find((command) => command.name() === "send");
+    let output = "";
+    send?.configureOutput({
+      writeOut: (text) => {
+        output += text;
+      },
+      writeErr: (text) => {
+        output += text;
+      },
+    });
+    send?.outputHelp();
+    const help = output.replace(/\s+/gu, " ");
+
+    expect(help).toContain("This reads only the message body; it does not attach <path>");
+    expect(help).toContain("Attachment capture (agent sessions; best-effort and body-reference based)");
+    expect(help).toContain("best-effort and body-reference based");
+    expect(help).toContain("PNG/JPEG/GIF/WebP");
+    expect(help).toContain("sending agent's own workspace");
+    expect(help).toContain("10 MiB each, up to 20 images per message");
+    expect(help).toContain("workspace `.md` path");
+    expect(help).toContain("10 MiB each, up to 10 documents per message");
+    expect(help).toContain("Other outbound file types are not captured");
+  });
+
   it("sends messages with metadata, stdin fallback, document context, and validation errors", async () => {
     docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({
       content: "see docs/plan.md",

--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -40,7 +40,19 @@ export function registerChatSendCommand(chat: Command): void {
       "-F, --message-file <path>",
       "Read the message body from <path> (or `-` for stdin) instead of the [message] argument. Preferred for any " +
         "rich or multi-line body: the content never passes through the shell, so backticks, quotes, and newlines " +
-        "are sent verbatim.",
+        "are sent verbatim. This reads only the message body; it does not attach <path>.",
+    )
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Attachment capture (agent sessions; best-effort and body-reference based):",
+        "  Images      Embed `![alt](path)` for PNG/JPEG/GIF/WebP files inside the sending agent's own workspace",
+        "              (10 MiB each, up to 20 images per message).",
+        "  Documents   Reference a workspace `.md` path (10 MiB each, up to 10 documents per message).",
+        "  Other       Other outbound file types are not captured by `chat send`.",
+        "",
+      ].join("\n"),
     )
     .action(async (name: string | undefined, message: string | undefined, options: SendOptions) => {
       try {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -345,7 +345,7 @@ first-tree chat
 │     --options <json> / --multi-select            #   (with --request) 2–4 options {label,description,preview?}; allow multi-pick
 ├── send <name> [message]                            # wake a participant — agent or human (a send to a human is informational only; a question the next step depends on goes through `chat ask`)
 │     # body: [message] arg, or stdin (omit [message]), or -F <path>; prefer stdin/-F for rich bodies (shell-safe)
-│     -F, --message-file <path>                      #   read the body from <path> (`-` = stdin); content never hits the shell
+│     -F, --message-file <path>                      #   read only the body from <path> (`-` = stdin); this does not attach <path>
 │     --reply-to <messageId>                         #   thread a reply under a message (pure threading)
 ├── ask <name> [message]                             # ask a HUMAN a tracked question; the body IS the ask, decision-self-sufficient (why it exists + recent-context recap + question + recommendation)
 │     # body: [message] arg, or stdin (omit [message]), or -F <path>; prefer stdin/-F for rich bodies (shell-safe)
@@ -403,10 +403,11 @@ first-tree chat send code-agent "ship the PR"
 echo "long body" | first-tree chat send code-agent -f markdown
 
 # Rich / multi-line bodies: write to a file, then read it with --message-file
-# (or `-F`). This is the most robust form — the body never passes through the
-# shell, so backticks (`code`), quotes, apostrophes, and newlines are sent
-# byte-for-byte. Inlining such a body lets the shell run backticks as command
-# substitution and break on quotes, silently mangling the message.
+# (or `-F`). This supplies only the message body; it does not attach that file.
+# It is the most robust form — the body never passes through the shell, so
+# backticks (`code`), quotes, apostrophes, and newlines are sent byte-for-byte.
+# Inlining such a body lets the shell run backticks as command substitution and
+# break on quotes, silently mangling the message.
 first-tree chat send code-agent -f markdown --message-file reply.md
 first-tree chat send code-agent -f markdown -F -   < reply.md   # `-` = stdin
 
@@ -435,13 +436,21 @@ EOF
 # literal sample (an image written inside inline `code` is treated as a live
 # embed). Capture is best-effort and never blocks the send, and is skipped
 # entirely for a body longer than ~1 million characters (then sent verbatim). An image
-# that is too large (>10 MB), unreadable, or beyond the 20-per-message cap is
+# that is too large (>10 MiB), unreadable, or beyond the 20-per-message cap is
 # skipped: if no image in the message captured, the body is sent unchanged (the
 # skipped embed stays as text); if at least one sibling image did capture — so
 # the message becomes an image send — every workspace-image embed is removed
 # from the caption, so a skipped one is dropped rather than left as a path that
 # would render broken.
 echo 'Latest run: ![chart](reports/latency.png)' | first-tree chat send code-agent -f markdown
+
+# Reference a workspace Markdown document by its `.md` path in the body. During
+# an agent session, `chat send` best-effort captures eligible documents inside
+# the sending agent's own workspace and replaces each captured mention with an
+# attachment link. Capture never blocks the send; the limit is 10 MiB per
+# document and 10 documents per message. Other outbound file types are not
+# captured by `chat send`.
+echo 'Full report: reports/latest-run.md' | first-tree chat send code-agent -f markdown
 
 # Ask a human a tracked question (red-dot + blocks the chat for them until they
 # answer). `chat ask` targets a single human; the message body IS the ask and

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -187,12 +187,12 @@ describe("buildAgentBriefing — generated skeleton", () => {
     );
 
     expect(lineCount(topLevelSection(briefing, "# Working in First Tree (First Tree Managed)"))).toBeLessThanOrEqual(
-      220,
+      230,
     );
     expect(briefing).not.toContain("# Required Reading (First Tree Managed)");
     expect(lineCount(topLevelSection(briefing, "# Context Tree (First Tree Managed)"))).toBeLessThanOrEqual(210);
     expect(lineCount(topLevelSection(briefing, "# Skills (First Tree Managed)"))).toBeLessThanOrEqual(20);
-    expect(lineCount(briefing)).toBeLessThanOrEqual(580);
+    expect(lineCount(briefing)).toBeLessThanOrEqual(590);
   });
 
   it("renders identity from visibility", () => {
@@ -506,6 +506,21 @@ describe("buildAgentBriefing — Working in First Tree hard rules", () => {
     expect(communication).toContain("@EOF");
     expect(communication).toContain("Issue #389");
     expect(communication).toMatch(/Use\s+`-f markdown`/);
+  });
+
+  it("explains agent-owned chat attachment capture and its format boundary", () => {
+    const briefing = buildAgentBriefing(makeOpts());
+    const communication = briefing.slice(briefing.indexOf("## Communication"));
+
+    expect(communication).toContain("Attachments are body references, not `-F` uploads");
+    expect(communication).toContain("it does not attach that file");
+    expect(communication).toContain("![result](artifacts/result.png)");
+    expect(communication).toContain("PNG, JPEG, GIF, or WebP files only from this agent's own workspace");
+    expect(communication).toContain("10 MiB each, up to 20 per message");
+    expect(communication).toContain("sender identity and CLI provenance");
+    expect(communication).toContain("referenced workspace `.md` path");
+    expect(communication).toContain("Other outbound file types are not captured");
+    expect(communication).toContain("never use a\nhuman's Web/browser session as a workaround");
   });
 
   it("uses one channel-resolved binary name across prompt, chat, GitHub, and tree commands", () => {

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -187,12 +187,12 @@ describe("buildAgentBriefing — generated skeleton", () => {
     );
 
     expect(lineCount(topLevelSection(briefing, "# Working in First Tree (First Tree Managed)"))).toBeLessThanOrEqual(
-      230,
+      220,
     );
     expect(briefing).not.toContain("# Required Reading (First Tree Managed)");
     expect(lineCount(topLevelSection(briefing, "# Context Tree (First Tree Managed)"))).toBeLessThanOrEqual(210);
     expect(lineCount(topLevelSection(briefing, "# Skills (First Tree Managed)"))).toBeLessThanOrEqual(20);
-    expect(lineCount(briefing)).toBeLessThanOrEqual(590);
+    expect(lineCount(briefing)).toBeLessThanOrEqual(580);
   });
 
   it("renders identity from visibility", () => {
@@ -506,21 +506,9 @@ describe("buildAgentBriefing — Working in First Tree hard rules", () => {
     expect(communication).toContain("@EOF");
     expect(communication).toContain("Issue #389");
     expect(communication).toMatch(/Use\s+`-f markdown`/);
-  });
-
-  it("explains agent-owned chat attachment capture and its format boundary", () => {
-    const briefing = buildAgentBriefing(makeOpts());
-    const communication = briefing.slice(briefing.indexOf("## Communication"));
-
-    expect(communication).toContain("Attachments are body references, not `-F` uploads");
-    expect(communication).toContain("it does not attach that file");
-    expect(communication).toContain("![result](artifacts/result.png)");
-    expect(communication).toContain("PNG, JPEG, GIF, or WebP files only from this agent's own workspace");
-    expect(communication).toContain("10 MiB each, up to 20 per message");
-    expect(communication).toContain("sender identity and CLI provenance");
-    expect(communication).toContain("referenced workspace `.md` path");
-    expect(communication).toContain("Other outbound file types are not captured");
-    expect(communication).toContain("never use a\nhuman's Web/browser session as a workaround");
+    expect(communication).toMatch(/`-F` supplies only\s+the body/);
+    expect(communication).toContain("chat send --help");
+    expect(communication).toContain("never borrow a human Web/browser session");
   });
 
   it("uses one channel-resolved binary name across prompt, chat, GitHub, and tree commands", () => {

--- a/packages/client/src/runtime/templates/agent-briefing.ejs
+++ b/packages/client/src/runtime/templates/agent-briefing.ejs
@@ -173,18 +173,11 @@ work needs its own task boundary. After an agent handoff, continue only
 independent work; do not poll solely because that agent has not replied.
 
 **Rich bodies use files or stdin.** Inline `"..."` is parsed by the shell:
-backticks and `$(...)` execute, `$VAR` expands, quotes can end the string,
-and broken heredocs leave `@EOF`. A file/stdin preserves Markdown, code,
-quotes, dollars, and newlines. Pass raw strings, never `JSON.stringify`;
-escaped `\n` rows caused the Issue #389 double-encode failure. Use
-`-f markdown` when you want Markdown rendering.
-
-**Attachments are body references, not `-F` uploads.** `-F` reads the message body; it does not attach that file.
-To attach an image, put an explicit embed such as `![result](artifacts/result.png)` in a text/markdown body:
-`chat send` best-effort captures PNG, JPEG, GIF, or WebP files only from this agent's own workspace
-(10 MiB each, up to 20 per message) and preserves this agent's sender identity and CLI provenance. A referenced workspace `.md` path is likewise captured
-as a document attachment (10 MiB each). Other outbound file types are not captured by agent `chat send`; never use a
-human's Web/browser session as a workaround. Report the limitation or share a supported artifact/link.
+backticks and `$(...)` execute, `$VAR` expands, quotes can end the string, and
+broken heredocs leave `@EOF`. A file/stdin preserves Markdown and newlines.
+Pass raw strings, never `JSON.stringify`; Issue #389 showed escaped `\n` rows can
+double-encode. Use `-f markdown`; `-F` supplies only the body. Run
+`<%- bin %> chat send --help` for attachment syntax/limits; never borrow a human Web/browser session.
 
 ## Workspace Collaboration
 

--- a/packages/client/src/runtime/templates/agent-briefing.ejs
+++ b/packages/client/src/runtime/templates/agent-briefing.ejs
@@ -179,6 +179,13 @@ quotes, dollars, and newlines. Pass raw strings, never `JSON.stringify`;
 escaped `\n` rows caused the Issue #389 double-encode failure. Use
 `-f markdown` when you want Markdown rendering.
 
+**Attachments are body references, not `-F` uploads.** `-F` reads the message body; it does not attach that file.
+To attach an image, put an explicit embed such as `![result](artifacts/result.png)` in a text/markdown body:
+`chat send` best-effort captures PNG, JPEG, GIF, or WebP files only from this agent's own workspace
+(10 MiB each, up to 20 per message) and preserves this agent's sender identity and CLI provenance. A referenced workspace `.md` path is likewise captured
+as a document attachment (10 MiB each). Other outbound file types are not captured by agent `chat send`; never use a
+human's Web/browser session as a workaround. Report the limitation or share a supported artifact/link.
+
 ## Workspace Collaboration
 
 Communication matrix: `chat send` / `chat ask` / `chat update --description`; agent


### PR DESCRIPTION
## Summary

- keep the generated briefing compact by folding a hard attachment boundary and a `chat send --help` discovery pointer into the existing rich-body guidance
- clarify in CLI help and the canonical CLI reference that `-F` supplies message body text rather than attaching the referenced file
- document image and Markdown capture formats and limits in the on-demand help and CLI reference
- guard the generated briefing and CLI help surfaces with contract tests

## Why

The capability existed but was not discoverable. A previous agent borrowed the operator's authenticated Web composer. Detailed command material belongs in CLI help and the canonical CLI reference; the always-present briefing only needs the protocol boundary and discovery pointer.

## Validation

- targeted briefing tests: 35 passed
- targeted CLI help/behavior tests: 32 passed
- `pnpm check` (rerun after the CLI reference correction; passes with 16 pre-existing warnings and 1 info in unrelated files)
- `pnpm typecheck`
- `pnpm test` (12/12 tasks)
- `git diff --check`
- built `chat send --help` readback
