### PR TITLE
fix(server): add app-wide browser security headers

### DIFF
--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -219,6 +219,51 @@ describe("buildApp — retired feedback route boundary", () => {
   });
 });
 
+describe("buildApp — browser security headers", () => {
+  it("enforces the policy on API, static, SPA, error, and HEAD responses", async () => {
+    const webRoot = await mkdtemp(join(tmpdir(), "first-tree-security-headers-"));
+    await writeFile(join(webRoot, "index.html"), "<!doctype html><html><body>App shell</body></html>", "utf8");
+    await writeFile(join(webRoot, "app.js"), "globalThis.firstTreeLoaded = true;", "utf8");
+
+    let app: FastifyInstance | undefined;
+    try {
+      app = await buildApp({ ...baseConfig, webDistPath: webRoot });
+
+      const responses = await Promise.all([
+        app.inject({ method: "GET", url: "/healthz" }),
+        app.inject({ method: "GET", url: "/app.js" }),
+        app.inject({ method: "GET", url: "/workspace/deep-link" }),
+        app.inject({ method: "GET", url: "/api/missing" }),
+        app.inject({ method: "HEAD", url: "/" }),
+      ]);
+
+      expect(responses.map((response) => response.statusCode)).toEqual([200, 200, 200, 404, 200]);
+      for (const response of responses) {
+        expect(response.headers["content-security-policy-report-only"]).toBeUndefined();
+        expect(response.headers["content-security-policy"]).toContain("default-src 'self'");
+        expect(response.headers["content-security-policy"]).toContain("frame-ancestors 'none'");
+        expect(response.headers["strict-transport-security"]).toBe("max-age=31536000; includeSubDomains");
+        expect(response.headers["x-content-type-options"]).toBe("nosniff");
+        expect(response.headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+        expect(response.headers["x-frame-options"]).toBe("DENY");
+        expect(response.headers["permissions-policy"]).toBe(
+          "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
+        );
+      }
+
+      const csp = responses[0]?.headers["content-security-policy"];
+      expect(csp).toBeTypeOf("string");
+      const scriptDirective = csp?.split("; ").find((directive) => directive.startsWith("script-src "));
+      expect(scriptDirective).toBe("script-src 'self' https://*.googletagmanager.com https://*.clarity.ms");
+      expect(scriptDirective).not.toContain("'unsafe-inline'");
+      expect(scriptDirective).not.toContain("'unsafe-eval'");
+    } finally {
+      await safeClose(app);
+      await rm(webRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("buildApp — boot-time edge branches", () => {
   it("boots with package-version fallback, trusted proxy logging, trace attrs, and backfill failure tolerance", async () => {
     const backfill = vi.spyOn(resourcesMigration, "backfillResourcesPhase1").mockRejectedValueOnce(new Error("down"));

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -94,6 +94,7 @@ import {
   reportErrorToRoot,
   rootLogger,
 } from "./observability/index.js";
+import { registerBrowserSecurityHeaders } from "./security/browser-security-headers.js";
 import { broadcastToAdmins } from "./services/admin-broadcast.js";
 import { expiryToSeconds } from "./services/auth.js";
 import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
@@ -197,6 +198,10 @@ export async function buildApp(config: Config) {
     // upstream proxy chain.
     trustProxy: config.trustProxy,
   });
+
+  // Establish one enforceable browser-security contract for API responses,
+  // static assets, SPA fallbacks, and errors before any route is registered.
+  registerBrowserSecurityHeaders(app);
 
   // Loud security reminder: trustProxy=true makes Fastify trust ANY upstream's
   // x-forwarded-for header. Safe iff the First Tree container only receives traffic

--- a/packages/server/src/security/browser-security-headers.ts
+++ b/packages/server/src/security/browser-security-headers.ts
@@ -1,0 +1,44 @@
+import type { FastifyInstance } from "fastify";
+
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "base-uri 'none'",
+  "connect-src 'self' ws: wss: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.clarity.ms https://c.bing.com https://*.ingest.sentry.io",
+  "font-src 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "frame-src 'none'",
+  "img-src 'self' data: blob: https:",
+  "manifest-src 'self'",
+  "media-src 'self' data: blob:",
+  "object-src 'none'",
+  "script-src 'self' https://*.googletagmanager.com https://*.clarity.ms",
+  "script-src-attr 'none'",
+  "style-src 'self' 'unsafe-inline'",
+  "worker-src 'self' blob:",
+].join("; ");
+
+export const BROWSER_SECURITY_HEADERS = {
+  "Content-Security-Policy": CONTENT_SECURITY_POLICY,
+  "Permissions-Policy": "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+} as const;
+
+const BROWSER_SECURITY_HEADER_ENTRIES = Object.entries(BROWSER_SECURITY_HEADERS);
+
+/**
+ * Apply the browser security contract before any API or static-file route runs.
+ * HSTS is sent on every response because browsers ignore it over plain HTTP;
+ * this keeps the policy effective behind a TLS-terminating reverse proxy.
+ */
+export function registerBrowserSecurityHeaders(app: FastifyInstance): void {
+  app.addHook("onRequest", (_request, reply, done) => {
+    for (const [name, value] of BROWSER_SECURITY_HEADER_ENTRIES) {
+      reply.header(name, value);
+    }
+    done();
+  });
+}

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -9,72 +9,12 @@
     <link rel="preload" href="/fonts/jetbrains-mono-latin.woff2" as="font" type="font/woff2" crossorigin />
     <title>First Tree</title>
     <!--
-      Google Analytics 4 — same property (G-BHG918MZ02) as first-tree.ai, with
-      cross-domain linking so a visitor who goes marketing-site -> cloud is
-      stitched into one user (that's what makes "click_app -> signup"
-      attributable per repo/campaign). send_page_view is off: this is a
-      react-router SPA, so RouteTracker (src/analytics.tsx) reports page_view on
-      every route change — leaving it on would double-count the first screen.
-
-      PRODUCTION ONLY: the Docker build produces one web dist for every channel,
-      so we gate here on hostname. Without this, dev (127.0.0.1) and staging
-      (dev.cloud.first-tree.ai) would load gtag and write into the shared
-      production property, polluting the attribution dataset. gtag is neither
-      fetched nor configured off the production host. analytics.tsx applies the
-      same host gate before sending, as defense in depth.
+      The external bootstrap applies the saved theme and initializes GA4 and
+      Microsoft Clarity only on cloud.first-tree.ai. Keeping executable code
+      out of index.html lets the server enforce script-src without
+      'unsafe-inline'. The React app root remains masked from Clarity below.
     -->
-    <script>
-      (() => {
-        if (window.location.hostname !== "cloud.first-tree.ai") return;
-        window.dataLayer = window.dataLayer || [];
-        // Keep the official gtag queue shape. gtag.js consumes the function's
-        // Arguments object; pushing the rest-parameter Array leaves commands
-        // queued without producing GA collect requests in production.
-        window.gtag = function gtag() {
-          // biome-ignore lint/complexity/noArguments: the official gtag.js queue contract uses Arguments.
-          window.dataLayer.push(arguments);
-        };
-        const tag = document.createElement("script");
-        tag.async = true;
-        tag.src = "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02";
-        document.head.appendChild(tag);
-        window.gtag("js", new Date());
-        window.gtag("config", "G-BHG918MZ02", {
-          send_page_view: false,
-          linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
-        });
-      })();
-    </script>
-    <!--
-      Microsoft Clarity — session insights for the production Web Console.
-      Like GA4, this is hostname-gated because the Docker build ships one dist
-      across channels; staging/local must not write into the production project.
-      The React app root is masked below so customer/workspace text is not
-      uploaded in Clarity recordings by default.
-    -->
-    <script>
-      (() => {
-        if (window.location.hostname !== "cloud.first-tree.ai") return;
-        window.clarity =
-          window.clarity ||
-          ((...args) => {
-            const queue = window.clarity.q || [];
-            window.clarity.q = queue;
-            queue.push(args);
-          });
-        const tag = document.createElement("script");
-        tag.async = true;
-        tag.src = "https://www.clarity.ms/tag/xj2f9syfng";
-        document.head.appendChild(tag);
-      })();
-    </script>
-    <script>
-      (() => {
-        const t = localStorage.getItem("theme");
-        const m = window.matchMedia("(prefers-color-scheme: dark)").matches;
-        if (t === "dark" || (!t && m)) document.documentElement.classList.add("dark");
-      })();
-    </script>
+    <script src="/browser-bootstrap.js"></script>
   </head>
   <body>
     <div id="root" data-clarity-mask="true"></div>

--- a/packages/web/public/browser-bootstrap.js
+++ b/packages/web/public/browser-bootstrap.js
@@ -1,0 +1,40 @@
+(() => {
+  if (window.location.hostname !== "cloud.first-tree.ai") return;
+  window.dataLayer = window.dataLayer || [];
+  // Keep the official gtag queue shape. gtag.js consumes the function's
+  // Arguments object; pushing a rest-parameter Array leaves commands queued.
+  window.gtag = function gtag() {
+    // biome-ignore lint/complexity/noArguments: the official gtag.js queue contract uses Arguments.
+    window.dataLayer.push(arguments);
+  };
+  const tag = document.createElement("script");
+  tag.async = true;
+  tag.src = "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02";
+  document.head.appendChild(tag);
+  window.gtag("js", new Date());
+  window.gtag("config", "G-BHG918MZ02", {
+    send_page_view: false,
+    linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
+  });
+})();
+
+(() => {
+  if (window.location.hostname !== "cloud.first-tree.ai") return;
+  window.clarity =
+    window.clarity ||
+    ((...args) => {
+      const queue = window.clarity.q || [];
+      window.clarity.q = queue;
+      queue.push(args);
+    });
+  const tag = document.createElement("script");
+  tag.async = true;
+  tag.src = "https://www.clarity.ms/tag/xj2f9syfng";
+  document.head.appendChild(tag);
+})();
+
+(() => {
+  const theme = localStorage.getItem("theme");
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  if (theme === "dark" || (!theme && prefersDark)) document.documentElement.classList.add("dark");
+})();

--- a/packages/web/src/__tests__/analytics.test.ts
+++ b/packages/web/src/__tests__/analytics.test.ts
@@ -2,12 +2,12 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { sanitizePath } from "../analytics.js";
 
-const indexHtml = readFileSync(new URL("../../index.html", import.meta.url), "utf8");
+const browserBootstrap = readFileSync(new URL("../../public/browser-bootstrap.js", import.meta.url), "utf8");
 
 describe("production gtag bootstrap", () => {
   it("queues the official Arguments object so gtag.js processes commands", () => {
-    expect(indexHtml).toContain("window.dataLayer.push(arguments)");
-    expect(indexHtml).not.toContain("window.dataLayer.push(args)");
+    expect(browserBootstrap).toContain("window.dataLayer.push(arguments)");
+    expect(browserBootstrap).not.toContain("window.dataLayer.push(args)");
   });
 });
 

--- a/packages/web/src/__tests__/browser-bootstrap.test.ts
+++ b/packages/web/src/__tests__/browser-bootstrap.test.ts
@@ -1,0 +1,83 @@
+import { readFile } from "node:fs/promises";
+import { runInNewContext } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+const indexHtmlUrl = new URL("../../index.html", import.meta.url);
+const bootstrapUrl = new URL("../../public/browser-bootstrap.js", import.meta.url);
+
+type BootstrapResult = {
+  appendedScriptSources: string[];
+  darkClassAdded: ReturnType<typeof vi.fn>;
+  windowObject: Record<string, unknown>;
+};
+
+async function runBootstrap(options: {
+  hostname: string;
+  theme: string | null;
+  prefersDark: boolean;
+}): Promise<BootstrapResult> {
+  const source = await readFile(bootstrapUrl, "utf8");
+  const appendedScriptSources: string[] = [];
+  const darkClassAdded = vi.fn();
+  const windowObject: Record<string, unknown> = {
+    location: { hostname: options.hostname },
+    matchMedia: vi.fn(() => ({ matches: options.prefersDark })),
+  };
+  const documentObject = {
+    createElement: vi.fn(() => ({ async: false, src: "" })),
+    documentElement: { classList: { add: darkClassAdded } },
+    head: {
+      appendChild: vi.fn((tag: { src: string }) => {
+        appendedScriptSources.push(tag.src);
+      }),
+    },
+  };
+  const localStorageObject = { getItem: vi.fn(() => options.theme) };
+
+  runInNewContext(source, {
+    document: documentObject,
+    localStorage: localStorageObject,
+    window: windowObject,
+  });
+
+  return { appendedScriptSources, darkClassAdded, windowObject };
+}
+
+describe("browser bootstrap", () => {
+  it("keeps index.html free of inline executable scripts", async () => {
+    const indexHtml = await readFile(indexHtmlUrl, "utf8");
+    const scripts = Array.from(indexHtml.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gu)).map((match) => ({
+      attributes: match[1] ?? "",
+      body: match[2] ?? "",
+    }));
+
+    expect(scripts.map((script) => script.attributes.match(/\bsrc="([^"]+)"/u)?.[1])).toEqual([
+      "/browser-bootstrap.js",
+      "/src/main.tsx",
+    ]);
+    expect(scripts.every((script) => script.body.trim().length === 0)).toBe(true);
+  });
+
+  it("loads production analytics and preserves the gtag queue contract", async () => {
+    const result = await runBootstrap({ hostname: "cloud.first-tree.ai", theme: "dark", prefersDark: false });
+
+    expect(result.appendedScriptSources).toEqual([
+      "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02",
+      "https://www.clarity.ms/tag/xj2f9syfng",
+    ]);
+    expect(result.windowObject.dataLayer).toHaveLength(2);
+    expect(result.windowObject.gtag).toBeTypeOf("function");
+    expect(result.windowObject.clarity).toBeTypeOf("function");
+    expect(result.darkClassAdded).toHaveBeenCalledWith("dark");
+  });
+
+  it("does not initialize production analytics on staging or local hosts", async () => {
+    const result = await runBootstrap({ hostname: "dev.cloud.first-tree.ai", theme: null, prefersDark: true });
+
+    expect(result.appendedScriptSources).toEqual([]);
+    expect(result.windowObject.dataLayer).toBeUndefined();
+    expect(result.windowObject.gtag).toBeUndefined();
+    expect(result.windowObject.clarity).toBeUndefined();
+    expect(result.darkClassAdded).toHaveBeenCalledWith("dark");
+  });
+});

--- a/packages/web/src/__tests__/browser-bootstrap.test.ts
+++ b/packages/web/src/__tests__/browser-bootstrap.test.ts
@@ -46,7 +46,7 @@ async function runBootstrap(options: {
 describe("browser bootstrap", () => {
   it("keeps index.html free of inline executable scripts", async () => {
     const indexHtml = await readFile(indexHtmlUrl, "utf8");
-    const scripts = Array.from(indexHtml.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gu)).map((match) => ({
+    const scripts = Array.from(indexHtml.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/giu)).map((match) => ({
       attributes: match[1] ?? "",
       body: match[2] ?? "",
     }));

--- a/packages/web/src/analytics.tsx
+++ b/packages/web/src/analytics.tsx
@@ -2,9 +2,10 @@ import { useEffect } from "react";
 import { useLocation } from "react-router";
 
 /**
- * GA4 analytics for the cloud SPA. The gtag snippet + config live in
- * index.html (property G-BHG918MZ02, cross-domain linker, send_page_view off).
- * This module reports SPA navigations and exposes a typed event helper.
+ * GA4 analytics for the cloud SPA. The gtag bootstrap + config live in
+ * public/browser-bootstrap.js (property G-BHG918MZ02, cross-domain linker,
+ * send_page_view off). This module reports SPA navigations and exposes a typed
+ * event helper.
  *
  * Why manual page_view: gtag fires page_view once on initial load. A
  * react-router app changes the URL without a full load, so without this every
@@ -53,7 +54,7 @@ type GtagArgs =
 function gtag(...args: GtagArgs): void {
   if (!analyticsEnabled()) return;
   const w = window as unknown as { gtag?: (...a: GtagArgs) => void };
-  // gtag is defined inline in index.html; guard in case the snippet is absent
+  // gtag is defined by browser-bootstrap.js; guard in case the script is absent
   // (e.g. an ad-blocker removed it) so analytics never breaks the app.
   w.gtag?.(...args);
 }


### PR DESCRIPTION
## Summary

- Enforce app-wide CSP, HSTS, nosniff, referrer, frame, and permissions headers before all Fastify API and SPA routes.
- Keep the policy compatible with the current same-origin API and WebSocket flow and the production GA4, Clarity, and Sentry endpoints.
- Move inline theme and analytics bootstrap code into a same-origin static asset so the CSP can reject inline scripts.
- Add integration coverage for API, static asset, SPA fallback, error, and HEAD responses, plus bootstrap regression coverage.

## Verification

- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `GIT_CONFIG_GLOBAL=<clean config> TMPDIR=/private/tmp pnpm exec turbo run test --env-mode=loose` (12/12 tasks passed under Node.js 24)

## QA

Formal QA was not run. This change affects server and web response behavior. A production browser pass should check the CSP console, GA4, Clarity, Sentry, same-origin API calls, and WebSocket reconnects.

Closes #1541