### PR TITLE
fix(cli): report external context hook and activation state

### DIFF
--- a/apps/cli/src/__tests__/context-account-state-guard.test.ts
+++ b/apps/cli/src/__tests__/context-account-state-guard.test.ts
@@ -58,6 +58,9 @@ describe("Context/client-switch account-state interlock", () => {
       probe: () => {
         throw new Error("must not probe");
       },
+      inspectHook: async () => {
+        throw new Error("must not inspect");
+      },
       validateMarketplace: () => undefined,
       install: () => {
         throw new Error("must not install");

--- a/apps/cli/src/__tests__/context-bundle-manifest.test.ts
+++ b/apps/cli/src/__tests__/context-bundle-manifest.test.ts
@@ -166,7 +166,6 @@ describe("context integration bundle", () => {
       installed: true,
       enabled: true,
       installedPath,
-      hookTrust: "provider_managed",
       issues: [],
     };
     const installedMarketplaces: string[] = [];
@@ -175,6 +174,7 @@ describe("context integration bundle", () => {
       executable: "codex",
       minimumVersion: "0.144.1",
       probe: () => probe,
+      inspectHook: async () => ({ trust: "trusted", enabled: true, source: "provider_api", issues: [] }),
       validateMarketplace: () => undefined,
       install: ({ marketplaceRoot }) => {
         installedMarketplaces.push(marketplaceRoot);
@@ -213,9 +213,9 @@ describe("context integration bundle", () => {
         installed: true,
         enabled: true,
         installedPath: "/provider/cache/first-tree-context",
-        hookTrust: "review_required",
         issues: [],
       }),
+      inspectHook: async () => ({ trust: "trusted", enabled: true, source: "provider_api", issues: [] }),
       validateMarketplace: () => undefined,
       install: () => {
         throw new Error("not used");
@@ -260,7 +260,6 @@ describe("context integration bundle", () => {
       installed: false,
       enabled: false,
       installedPath: null,
-      hookTrust: "provider_managed",
       issues: [],
     };
     const driver: ContextIntegrationProviderDriver = {
@@ -268,6 +267,7 @@ describe("context integration bundle", () => {
       executable: "codex",
       minimumVersion: "0.144.0",
       probe: () => probe,
+      inspectHook: async () => ({ trust: "unknown", enabled: null, source: "unavailable", issues: [] }),
       validateMarketplace: () => undefined,
       install: ({ marketplaceRoot }) => {
         expect(marketplaceRoot).toBe(contextIntegrationMarketplaceSourcePath("codex"));
@@ -316,7 +316,6 @@ describe("context integration bundle", () => {
       installed: false,
       enabled: false,
       installedPath: null,
-      hookTrust: "provider_managed",
       issues: [],
     };
     const driver: ContextIntegrationProviderDriver = {
@@ -324,6 +323,7 @@ describe("context integration bundle", () => {
       executable: "codex",
       minimumVersion: "0.144.0",
       probe: () => initialProbe,
+      inspectHook: async () => ({ trust: "unknown", enabled: null, source: "unavailable", issues: [] }),
       validateMarketplace: () => undefined,
       install: ({ marketplaceRoot }) => {
         cpSync(join(marketplaceRoot, "plugins", "first-tree-context"), installedPath, { recursive: true });
@@ -373,9 +373,9 @@ describe("context integration bundle", () => {
         installed: probeCount++ > 0,
         enabled: true,
         installedPath: null,
-        hookTrust: "review_required",
         issues: [],
       }),
+      inspectHook: async () => ({ trust: "trusted", enabled: true, source: "provider_api", issues: [] }),
       validateMarketplace: () => undefined,
       install,
       uninstall: () => undefined,
@@ -421,9 +421,9 @@ describe("context integration bundle", () => {
         installed: false,
         enabled: false,
         installedPath: null,
-        hookTrust: "unknown",
         issues: ["Codex 0.100.0 is older than the required 0.144.0."],
       }),
+      inspectHook: async () => ({ trust: "unknown", enabled: null, source: "unavailable", issues: [] }),
       validateMarketplace: () => undefined,
       install,
       uninstall: () => undefined,
@@ -465,9 +465,9 @@ describe("context integration bundle", () => {
         installed: true,
         enabled: false,
         installedPath: "/provider/cache/first-tree-context",
-        hookTrust: "review_required",
         issues: [],
       }),
+      inspectHook: async () => ({ trust: "trusted", enabled: false, source: "provider_api", issues: [] }),
       validateMarketplace: () => undefined,
       install,
       uninstall: () => undefined,
@@ -501,6 +501,9 @@ describe("context integration bundle", () => {
       minimumVersion: "0.144.0",
       probe: () => {
         throw new Error("must not probe");
+      },
+      inspectHook: async () => {
+        throw new Error("must not inspect");
       },
       validateMarketplace: () => undefined,
       install: () => {

--- a/apps/cli/src/__tests__/context-integration-providers.test.ts
+++ b/apps/cli/src/__tests__/context-integration-providers.test.ts
@@ -93,7 +93,7 @@ describe("Context provider drivers", () => {
     ]);
   });
 
-  it("uses Codex JSON Plugin lifecycle and preserves native hook trust", () => {
+  it("uses Codex JSON Plugin lifecycle without bypassing native Hook trust", () => {
     const fake = fakeRunner("codex");
     const driver = new CodexContextIntegrationDriver(fake.run);
     const probe = driver.install({
@@ -105,7 +105,6 @@ describe("Context provider drivers", () => {
       installed: true,
       enabled: true,
       compatible: true,
-      hookTrust: "review_required",
     });
     expect(fake.calls.map((call) => call.args)).toContainEqual([
       "plugin",
@@ -114,6 +113,80 @@ describe("Context provider drivers", () => {
       "--json",
     ]);
     expect(fake.calls.flatMap((call) => call.args)).not.toContain("--dangerously-bypass-hook-trust");
+  });
+
+  it("reads trusted and enabled Codex SessionStart state from the provider API", async () => {
+    const fake = fakeRunner("codex");
+    const driver = new CodexContextIntegrationDriver(fake.run, {
+      readHookState: async () => ({
+        data: [
+          {
+            cwd: "/work/repo",
+            hooks: [
+              {
+                pluginId: "first-tree-context@first-tree-dev",
+                eventName: "sessionStart",
+                handlerType: "command",
+                trustStatus: "trusted",
+                enabled: true,
+              },
+            ],
+            warnings: [],
+            errors: [],
+          },
+        ],
+      }),
+    });
+
+    await expect(
+      driver.inspectHook({
+        marketplaceName: "first-tree-dev",
+        pluginName: "first-tree-context",
+        cwd: "/work/repo",
+        plugin: { installed: true, enabled: true },
+      }),
+    ).resolves.toEqual({
+      trust: "trusted",
+      enabled: true,
+      source: "provider_api",
+      issues: [],
+    });
+  });
+
+  it("distinguishes modified trust from a disabled Codex Hook", async () => {
+    const fake = fakeRunner("codex");
+    const driver = new CodexContextIntegrationDriver(fake.run, {
+      readHookState: async () => ({
+        data: [
+          {
+            cwd: "/work/repo",
+            hooks: [
+              {
+                pluginId: "first-tree-context@first-tree-dev",
+                eventName: "sessionStart",
+                handlerType: "command",
+                trustStatus: "modified",
+                enabled: false,
+              },
+            ],
+            warnings: [],
+            errors: [],
+          },
+        ],
+      }),
+    });
+
+    await expect(
+      driver.inspectHook({
+        marketplaceName: "first-tree-dev",
+        pluginName: "first-tree-context",
+        cwd: "/work/repo",
+        plugin: { installed: true, enabled: true },
+      }),
+    ).resolves.toMatchObject({
+      trust: "modified",
+      enabled: false,
+    });
   });
 
   it("resolves Codex's provider-owned cache path for safe update rollback", () => {

--- a/apps/cli/src/__tests__/context-integration-providers.test.ts
+++ b/apps/cli/src/__tests__/context-integration-providers.test.ts
@@ -93,6 +93,37 @@ describe("Context provider drivers", () => {
     ]);
   });
 
+  it("reports Claude Hook state only when the provider-managed Plugin exists", async () => {
+    const driver = new ClaudeCodeContextIntegrationDriver(fakeRunner("claude").run);
+
+    await expect(
+      driver.inspectHook({
+        marketplaceName: "first-tree-dev",
+        pluginName: "first-tree-context",
+        cwd: "/work/repo",
+        plugin: { installed: false, enabled: false },
+      }),
+    ).resolves.toEqual({
+      trust: "unknown",
+      enabled: null,
+      source: "unavailable",
+      issues: [],
+    });
+    await expect(
+      driver.inspectHook({
+        marketplaceName: "first-tree-dev",
+        pluginName: "first-tree-context",
+        cwd: "/work/repo",
+        plugin: { installed: true, enabled: false },
+      }),
+    ).resolves.toEqual({
+      trust: "provider_managed",
+      enabled: false,
+      source: "provider_managed",
+      issues: [],
+    });
+  });
+
   it("uses Codex JSON Plugin lifecycle without bypassing native Hook trust", () => {
     const fake = fakeRunner("codex");
     const driver = new CodexContextIntegrationDriver(fake.run);

--- a/apps/cli/src/__tests__/context-operation.test.ts
+++ b/apps/cli/src/__tests__/context-operation.test.ts
@@ -56,7 +56,6 @@ function probe(installed: boolean): ProviderPluginProbe {
     installed,
     enabled: installed,
     installedPath: installed ? "/provider/cache/first-tree-context" : null,
-    hookTrust: installed ? "review_required" : "unknown",
     issues: [],
   };
 }
@@ -74,6 +73,12 @@ function driver(installed: boolean) {
     executable: "codex",
     minimumVersion: "0.144.0",
     probe: () => probe(installed),
+    inspectHook: async () => ({
+      trust: installed ? "trusted" : "unknown",
+      enabled: installed ? true : null,
+      source: installed ? "provider_api" : "unavailable",
+      issues: [],
+    }),
     validateMarketplace: () => undefined,
     install,
     uninstall,
@@ -111,6 +116,7 @@ describe("Context integration cross-resource operation", () => {
       executable: "codex",
       minimumVersion: "0.144.0",
       probe: () => ({ ...probe(true), enabled: false }),
+      inspectHook: async () => ({ trust: "trusted", enabled: false, source: "provider_api", issues: [] }),
       validateMarketplace: () => undefined,
       install,
       uninstall,

--- a/apps/cli/src/__tests__/context-runtime-health.test.ts
+++ b/apps/cli/src/__tests__/context-runtime-health.test.ts
@@ -54,7 +54,6 @@ function providerProbe(overrides: Partial<ProviderPluginProbe> = {}): ProviderPl
     installed: true,
     enabled: true,
     installedPath: "/provider/cache/first-tree-context",
-    hookTrust: "review_required",
     issues: [],
     ...overrides,
   };
@@ -66,6 +65,7 @@ function driver(probe: ProviderPluginProbe): ContextIntegrationProviderDriver {
     executable: "codex",
     minimumVersion: "0.144.0",
     probe: () => probe,
+    inspectHook: async () => ({ trust: "trusted", enabled: true, source: "provider_api", issues: [] }),
     validateMarketplace: () => undefined,
     install: () => probe,
     uninstall: () => undefined,

--- a/apps/cli/src/__tests__/context-status.test.ts
+++ b/apps/cli/src/__tests__/context-status.test.ts
@@ -1,0 +1,221 @@
+import type { ContextActivationResponse } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import { buildContextEnableNextActions } from "../commands/context/enable.js";
+import { renderHookEnabled, renderHookTrust } from "../commands/context/status.js";
+import type { ContextActivationValidator } from "../core/context-integration/activation.js";
+import {
+  ContextClientPreflightError,
+  contextClientPreflightErrorCode,
+} from "../core/context-integration/client-preflight.js";
+import type {
+  ContextIntegrationProviderDriver,
+  ProviderPluginProbe,
+} from "../core/context-integration/provider-driver.js";
+import { inspectContextIntegrationStatus } from "../core/context-integration/status.js";
+
+function pluginProbe(overrides: Partial<ProviderPluginProbe> = {}): ProviderPluginProbe {
+  return {
+    provider: "codex",
+    binaryAvailable: true,
+    version: "0.146.0",
+    compatible: true,
+    installed: true,
+    enabled: true,
+    installedPath: "/provider/cache/first-tree-context",
+    issues: [],
+    ...overrides,
+  };
+}
+
+function driver(probe = pluginProbe()): ContextIntegrationProviderDriver {
+  return {
+    provider: "codex",
+    executable: "codex",
+    minimumVersion: "0.144.0",
+    probe: () => probe,
+    inspectHook: async () => ({
+      trust: "trusted",
+      enabled: true,
+      source: "provider_api",
+      issues: [],
+    }),
+    validateMarketplace: () => undefined,
+    install: () => probe,
+    uninstall: () => undefined,
+  };
+}
+
+function validator(response: ContextActivationResponse): ContextActivationValidator {
+  return {
+    validateMemberContextActivation: vi.fn(async () => response),
+  };
+}
+
+describe("Context integration layered status", () => {
+  it("reports provider, Plugin, Hook, checkout, exact binding, and live activation independently", async () => {
+    const value = await inspectContextIntegrationStatus(
+      driver(),
+      validator({
+        schemaVersion: 1,
+        outcome: "connected",
+        team: {
+          organizationId: "org_acme",
+          displayName: "Acme",
+          role: "admin",
+        },
+      }),
+      "/work/repo",
+      {
+        inspectRuntime: (runtimeDriver) => ({
+          provider: "codex",
+          healthy: true,
+          issues: [],
+          install: null,
+          release: null,
+          probe: runtimeDriver.probe("first-tree-dev", "first-tree-context"),
+        }),
+        inspectPreflight: () => ({
+          checkoutRoot: "/work/repo",
+          repositoryKey: "github.com/acme/repo",
+          originUrl: "git@github.com:acme/repo.git",
+        }),
+        findBinding: () => ({
+          provider: "codex",
+          checkoutRoot: "/work/repo",
+          repositoryKey: "github.com/acme/repo",
+          organizationId: "org_acme",
+        }),
+      },
+    );
+
+    expect(value).toMatchObject({
+      provider: { available: true, compatible: true, version: "0.146.0" },
+      plugin: { installed: true, enabled: true },
+      hook: { trust: "trusted", enabled: true },
+      checkout: { state: "ready", root: "/work/repo" },
+      binding: { state: "exact", organizationId: "org_acme" },
+      activation: { state: "connected", team: { displayName: "Acme" } },
+    });
+  });
+
+  it.each([
+    [contextClientPreflightErrorCode.notSignedIn, "First Tree is not signed in.", "Run `first-tree login <code>`."],
+    [
+      contextClientPreflightErrorCode.notGitCheckout,
+      "The current directory is not a Git checkout.",
+      "Run this command inside the target Git checkout.",
+    ],
+    [
+      contextClientPreflightErrorCode.originUnreadable,
+      "The current Git checkout has no readable `origin` remote.",
+      "Add or repair `origin`.",
+    ],
+  ])("preserves the %s checkout failure and repair action", async (code, message, nextAction) => {
+    const value = await inspectContextIntegrationStatus(
+      driver(),
+      validator({
+        schemaVersion: 1,
+        outcome: "connected",
+        team: {
+          organizationId: "org_acme",
+          displayName: "Acme",
+          role: "member",
+        },
+      }),
+      "/work/repo",
+      {
+        inspectRuntime: (runtimeDriver) => ({
+          provider: "codex",
+          healthy: true,
+          issues: [],
+          install: null,
+          release: null,
+          probe: runtimeDriver.probe("first-tree-dev", "first-tree-context"),
+        }),
+        inspectPreflight: () => {
+          throw new ContextClientPreflightError(code, message, nextAction);
+        },
+      },
+    );
+
+    expect(value.checkout).toEqual({
+      state: "unavailable",
+      reason: code,
+      message,
+      nextAction,
+    });
+    expect(value.binding.state).toBe("not_checked");
+    expect(value.activation.state).toBe("not_checked");
+  });
+
+  it("keeps exact binding visible when live activation is unavailable", async () => {
+    const unavailable: ContextActivationValidator = {
+      validateMemberContextActivation: vi.fn(async () => {
+        throw new Error("network timeout");
+      }),
+    };
+    const value = await inspectContextIntegrationStatus(driver(), unavailable, "/work/repo", {
+      inspectRuntime: (runtimeDriver) => ({
+        provider: "codex",
+        healthy: true,
+        issues: [],
+        install: null,
+        release: null,
+        probe: runtimeDriver.probe("first-tree-dev", "first-tree-context"),
+      }),
+      inspectPreflight: () => ({
+        checkoutRoot: "/work/repo",
+        repositoryKey: "github.com/acme/repo",
+        originUrl: "https://github.com/acme/repo.git",
+      }),
+      findBinding: () => ({
+        provider: "codex",
+        checkoutRoot: "/work/repo",
+        repositoryKey: "github.com/acme/repo",
+        organizationId: "org_acme",
+      }),
+    });
+
+    expect(value.binding).toMatchObject({ state: "exact", organizationId: "org_acme" });
+    expect(value.activation).toMatchObject({
+      state: "unavailable",
+      message: expect.stringContaining("network timeout"),
+    });
+  });
+});
+
+describe("Context enable Hook guidance", () => {
+  it("guides pending Codex consent through every verifiable step", () => {
+    const actions = buildContextEnableNextActions(
+      "codex",
+      {
+        trust: "review_required",
+        enabled: false,
+      },
+      "first-tree-staging",
+    );
+
+    expect(actions).toEqual([
+      "Open Codex in this checkout.",
+      "Run `/hooks`.",
+      "Find First Tree Context → SessionStart, enable its checkbox, and choose Trust.",
+      "Exit and start a new Codex session in this checkout.",
+      "Run `first-tree-staging context status --provider codex`; confirm Hook trusted/enabled are Yes and Live activation is Connected.",
+    ]);
+  });
+
+  it("does not ask for another review after Codex reports trusted and enabled", () => {
+    const actions = buildContextEnableNextActions(
+      "codex",
+      {
+        trust: "trusted",
+        enabled: true,
+      },
+      "first-tree-staging",
+    );
+
+    expect(actions.join(" ")).not.toContain("/hooks");
+    expect(renderHookTrust({ trust: "trusted", enabled: true, source: "provider_api", issues: [] })).toBe("Yes");
+    expect(renderHookEnabled({ trust: "trusted", enabled: true, source: "provider_api", issues: [] })).toBe("Yes");
+  });
+});

--- a/apps/cli/src/__tests__/context-status.test.ts
+++ b/apps/cli/src/__tests__/context-status.test.ts
@@ -11,6 +11,7 @@ import type {
   ContextIntegrationProviderDriver,
   ProviderPluginProbe,
 } from "../core/context-integration/provider-driver.js";
+import { ClaudeCodeContextIntegrationDriver } from "../core/context-integration/providers/claude-code.js";
 import { inspectContextIntegrationStatus } from "../core/context-integration/status.js";
 
 function pluginProbe(overrides: Partial<ProviderPluginProbe> = {}): ProviderPluginProbe {
@@ -95,6 +96,64 @@ describe("Context integration layered status", () => {
       checkout: { state: "ready", root: "/work/repo" },
       binding: { state: "exact", organizationId: "org_acme" },
       activation: { state: "connected", team: { displayName: "Acme" } },
+    });
+  });
+
+  it("uses the release manifest minimum when computing provider compatibility", async () => {
+    const value = await inspectContextIntegrationStatus(
+      driver(),
+      validator({
+        schemaVersion: 1,
+        outcome: "connected",
+        team: {
+          organizationId: "org_acme",
+          displayName: "Acme",
+          role: "admin",
+        },
+      }),
+      "/work/repo",
+      {
+        inspectRuntime: (runtimeDriver) => ({
+          provider: "codex",
+          healthy: false,
+          issues: ["codex 0.146.0 must be upgraded to 0.147.0 or newer."],
+          install: null,
+          release: {
+            root: "/release",
+            manifest: {
+              schemaVersion: 1,
+              version: "0.5.18",
+              channel: "dev",
+              bundleDigest: `sha256:${"1".repeat(64)}`,
+              policyDigest: `sha256:${"2".repeat(64)}`,
+              providers: {
+                "claude-code": {
+                  adapterDigest: `sha256:${"3".repeat(64)}`,
+                  minimumVersion: "2.1.121",
+                },
+                codex: {
+                  adapterDigest: `sha256:${"4".repeat(64)}`,
+                  minimumVersion: "0.147.0",
+                },
+              },
+            },
+          },
+          probe: runtimeDriver.probe("first-tree-dev", "first-tree-context"),
+        }),
+        inspectPreflight: () => {
+          throw new ContextClientPreflightError(
+            contextClientPreflightErrorCode.notGitCheckout,
+            "The current directory is not a Git checkout.",
+            "Run this command inside the target Git checkout.",
+          );
+        },
+      },
+    );
+
+    expect(value.provider).toMatchObject({
+      version: "0.146.0",
+      minimumVersion: "0.147.0",
+      compatible: false,
     });
   });
 
@@ -217,5 +276,52 @@ describe("Context enable Hook guidance", () => {
     expect(actions.join(" ")).not.toContain("/hooks");
     expect(renderHookTrust({ trust: "trusted", enabled: true, source: "provider_api", issues: [] })).toBe("Yes");
     expect(renderHookEnabled({ trust: "trusted", enabled: true, source: "provider_api", issues: [] })).toBe("Yes");
+  });
+
+  it("asks only for enablement when the Codex Hook is already trusted", () => {
+    const actions = buildContextEnableNextActions(
+      "codex",
+      {
+        trust: "trusted",
+        enabled: false,
+      },
+      "first-tree-staging",
+    );
+
+    expect(actions.join(" ")).toContain("enable its checkbox");
+    expect(actions.join(" ")).not.toContain("choose Trust");
+  });
+});
+
+describe("provider-aware Hook rendering", () => {
+  it("renders a disabled Claude Hook as Plugin-managed", () => {
+    const hook = {
+      trust: "provider_managed" as const,
+      enabled: false,
+      source: "provider_managed" as const,
+      issues: [],
+    };
+
+    expect(renderHookTrust(hook)).toBe("Managed by provider");
+    expect(renderHookEnabled(hook)).toBe("No — enable the First Tree Context Plugin in Claude Code");
+  });
+
+  it("does not claim a provider-managed Hook when the Claude Plugin is absent", async () => {
+    const claudeDriver = new ClaudeCodeContextIntegrationDriver(() => ({ stdout: "", stderr: "" }));
+    const hook = await claudeDriver.inspectHook({
+      marketplaceName: "first-tree-dev",
+      pluginName: "first-tree-context",
+      cwd: "/work/repo",
+      plugin: { installed: false, enabled: false },
+    });
+
+    expect(hook).toEqual({
+      trust: "unknown",
+      enabled: null,
+      source: "unavailable",
+      issues: [],
+    });
+    expect(renderHookTrust(hook)).toBe("Not available");
+    expect(renderHookEnabled(hook)).toBe("Not available");
   });
 });

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -1,5 +1,6 @@
 import { confirm } from "@inquirer/prompts";
 import type { Command } from "commander";
+import { channelConfig } from "../../core/channel.js";
 import { readActiveContextAccountClientId } from "../../core/context-integration/account-state-guard.js";
 import { inspectContextClientPreflight } from "../../core/context-integration/client-preflight.js";
 import {
@@ -8,10 +9,13 @@ import {
 } from "../../core/context-integration/context-binding-store.js";
 import { planContextIntegrationInstall } from "../../core/context-integration/installer.js";
 import { enableContextIntegrationOperation } from "../../core/context-integration/operation.js";
+import type { ProviderHookProbe } from "../../core/context-integration/provider-driver.js";
+import { inspectContextIntegrationStatus } from "../../core/context-integration/status.js";
 import { print } from "../../core/output.js";
 import { createMemberSdk } from "../_shared/member.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
 import { createContextIntegrationDriver, parseContextProvider } from "./shared.js";
+import { renderHookEnabled, renderHookTrust } from "./status.js";
 
 type EnableOptions = {
   provider?: string;
@@ -35,7 +39,8 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
   }
   const expectedAccountClientId = readActiveContextAccountClientId();
   const preflight = inspectContextClientPreflight();
-  const activation = await createMemberSdk().validateMemberContextActivation(
+  const sdk = createMemberSdk();
+  const activation = await sdk.validateMemberContextActivation(
     teamId,
     {
       schemaVersion: 1,
@@ -83,22 +88,63 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
     expectedAccountClientId,
   );
 
+  const verification = await inspectContextIntegrationStatus(driver, sdk, preflight.checkoutRoot);
+  const nextActions = buildContextEnableNextActions(provider, verification.hook);
   const result = {
     provider,
     team: activation.team,
     checkoutRoot: preflight.checkoutRoot,
     repositoryKey: preflight.repositoryKey,
     plugin: installPlan.operation,
-    nextAction:
-      provider === "codex"
-        ? "Open Codex, review the First Tree hook in `/hooks`, then start a new session."
-        : "Start a new Claude Code local session in this repository.",
+    verification,
+    nextActions,
   };
   if (context.options.json) print.result(result);
   else {
     print.status("Context", `Enabled for ${activation.team.displayName}`);
-    print.status("Next", result.nextAction);
+    print.status("Plugin installed", verification.plugin.installed ? "Yes" : "No");
+    print.status("Plugin enabled", verification.plugin.enabled ? "Yes" : "No");
+    print.status("Hook trusted", renderHookTrust(verification.hook));
+    print.status("Hook enabled", renderHookEnabled(verification.hook));
+    print.status(
+      "Exact binding",
+      verification.binding.state === "exact"
+        ? `Yes — Team ${verification.binding.organizationId}`
+        : `No — ${verification.binding.state}`,
+    );
+    print.status(
+      "Live activation",
+      verification.activation.state === "connected"
+        ? `Connected — ${verification.activation.team.displayName}`
+        : verification.activation.state,
+    );
+    nextActions.forEach((action, index) => {
+      print.status(`Next ${index + 1}`, action);
+    });
   }
+}
+
+export function buildContextEnableNextActions(
+  provider: "claude-code" | "codex",
+  hook: Pick<ProviderHookProbe, "trust" | "enabled">,
+  binName = channelConfig.binName,
+): string[] {
+  if (provider === "claude-code") {
+    return ["Start a new Claude Code local session in this repository."];
+  }
+  if (hook.trust === "trusted" && hook.enabled === true) {
+    return [
+      "Start a new Codex session in this checkout so SessionStart can connect Context.",
+      `Run \`${binName} context status --provider codex\` to verify every layer remains connected.`,
+    ];
+  }
+  return [
+    "Open Codex in this checkout.",
+    "Run `/hooks`.",
+    "Find First Tree Context → SessionStart, enable its checkbox, and choose Trust.",
+    "Exit and start a new Codex session in this checkout.",
+    `Run \`${binName} context status --provider codex\`; confirm Hook trusted/enabled are Yes and Live activation is Connected.`,
+  ];
 }
 
 export const contextEnableCommand: SubcommandModule = {

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -138,6 +138,15 @@ export function buildContextEnableNextActions(
       `Run \`${binName} context status --provider codex\` to verify every layer remains connected.`,
     ];
   }
+  if (hook.trust === "trusted" && hook.enabled === false) {
+    return [
+      "Open Codex in this checkout.",
+      "Run `/hooks`.",
+      "Find First Tree Context → SessionStart and enable its checkbox.",
+      "Exit and start a new Codex session in this checkout.",
+      `Run \`${binName} context status --provider codex\`; confirm Hook trusted/enabled are Yes and Live activation is Connected.`,
+    ];
+  }
   return [
     "Open Codex in this checkout.",
     "Run `/hooks`.",

--- a/apps/cli/src/commands/context/status.ts
+++ b/apps/cli/src/commands/context/status.ts
@@ -64,12 +64,17 @@ export function renderHookTrust(hook: ProviderHookProbe): string {
   if (hook.trust === "review_required") {
     return "No — review First Tree SessionStart in Codex `/hooks`";
   }
-  return "Unknown";
+  return hook.source === "unavailable" ? "Not available" : "Unknown";
 }
 
 export function renderHookEnabled(hook: ProviderHookProbe): string {
   if (hook.enabled === true) return "Yes";
-  if (hook.enabled === false) return "No — enable First Tree SessionStart in Codex `/hooks`";
+  if (hook.enabled === false) {
+    return hook.source === "provider_managed"
+      ? "No — enable the First Tree Context Plugin in Claude Code"
+      : "No — enable First Tree SessionStart in Codex `/hooks`";
+  }
+  if (hook.source === "unavailable") return "Not available";
   return hook.source === "provider_managed" ? "Managed by provider" : "Unknown";
 }
 

--- a/apps/cli/src/commands/context/status.ts
+++ b/apps/cli/src/commands/context/status.ts
@@ -1,9 +1,11 @@
 import type { Command } from "commander";
-import { inspectContextClientPreflight } from "../../core/context-integration/client-preflight.js";
-import { findContextBinding } from "../../core/context-integration/context-binding-store.js";
 import { readContextIntegrationInstallJournal } from "../../core/context-integration/installer.js";
 import { inspectContextIntegrationOperation } from "../../core/context-integration/operation.js";
-import { inspectContextIntegrationRuntime } from "../../core/context-integration/runtime-health.js";
+import type { ProviderHookProbe } from "../../core/context-integration/provider-driver.js";
+import {
+  type ContextIntegrationStatus,
+  inspectContextIntegrationStatus,
+} from "../../core/context-integration/status.js";
 import { print } from "../../core/output.js";
 import { createMemberSdk } from "../_shared/member.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
@@ -16,62 +18,111 @@ function configure(command: Command): void {
 export async function runContextStatus(context: CommandContext): Promise<void> {
   const provider = parseContextProvider(context.command.opts<{ provider?: string }>().provider ?? "");
   const driver = createContextIntegrationDriver(provider);
-  const health = inspectContextIntegrationRuntime(driver);
-  const install = health.install;
+  const status = await inspectContextIntegrationStatus(driver, createMemberSdk());
   const incompleteInstall = readContextIntegrationInstallJournal();
   const incompleteOperation = inspectContextIntegrationOperation();
-  const probe = health.probe;
-  let checkout:
-    | {
-        root: string;
-        repositoryKey: string;
-        binding: ReturnType<typeof findContextBinding>;
-        activation?: unknown;
-      }
-    | undefined;
-  try {
-    const preflight = inspectContextClientPreflight();
-    const binding = findContextBinding(provider, preflight.checkoutRoot);
-    checkout = {
-      root: preflight.checkoutRoot,
-      repositoryKey: preflight.repositoryKey,
-      binding,
-    };
-    if (health.healthy && binding && binding.repositoryKey === preflight.repositoryKey) {
-      checkout.activation = await createMemberSdk().validateMemberContextActivation(
-        binding.organizationId,
-        {
-          schemaVersion: 1,
-          repositoryKey: binding.repositoryKey,
-        },
-        { retry: false, timeoutMs: 2_000 },
-      );
-    }
-  } catch {
-    // Provider status remains useful outside a Git checkout or while signed out.
+  const recovery = [
+    ...(incompleteInstall?.provider === provider ? [`Incomplete ${incompleteInstall.phase}; run context repair`] : []),
+    ...(incompleteOperation?.provider === provider
+      ? [`Incomplete ${incompleteOperation.operation}/${incompleteOperation.phase}; run context repair`]
+      : []),
+  ];
+  const result = { ...status, recovery };
+  if (context.options.json) {
+    print.result(result);
+    return;
   }
-  const result = { provider, health, install, incompleteInstall, incompleteOperation, probe, checkout };
-  if (context.options.json) print.result(result);
-  else {
-    print.status("Provider", probe.binaryAvailable ? (probe.version ?? "Available") : "Missing");
-    print.status("Plugin", probe.installed ? (probe.enabled ? "Enabled" : "Disabled") : "Not installed");
-    print.status("Release", health.healthy ? "Healthy" : "Repair required");
-    for (const issue of health.issues) print.status("Issue", issue);
-    if (incompleteInstall?.provider === provider) {
-      print.status("Recovery", `Incomplete ${incompleteInstall.phase}; run context repair`);
-    }
-    if (incompleteOperation?.provider === provider) {
-      print.status(
-        "Recovery",
-        `Incomplete ${incompleteOperation.operation}/${incompleteOperation.phase}; run context repair`,
-      );
-    }
-    print.status("Checkout", checkout?.root ?? "Not a signed-in Git checkout");
-    print.status("Team binding", checkout?.binding?.organizationId ?? "None");
-    if (probe.hookTrust === "review_required") {
-      print.status("Hook trust", "Review in Codex `/hooks`");
-    }
+
+  print.status("Provider compatible", renderProvider(status));
+  print.status("Plugin installed", status.plugin.installed ? "Yes" : "No");
+  print.status("Plugin enabled", status.plugin.installed ? (status.plugin.enabled ? "Yes" : "No") : "Not installed");
+  print.status("Plugin payload", status.runtime.healthy ? "Healthy" : "Repair required");
+  print.status("Hook trusted", renderHookTrust(status.hook));
+  print.status("Hook enabled", renderHookEnabled(status.hook));
+  renderCheckout(status);
+  renderBinding(status);
+  renderActivation(status);
+  for (const issue of status.hook.issues) print.status("Hook issue", issue);
+  for (const issue of status.runtime.issues) print.status("Issue", issue);
+  for (const item of recovery) print.status("Recovery", item);
+}
+
+function renderProvider(status: ContextIntegrationStatus): string {
+  if (!status.provider.available) return "No — provider executable is missing";
+  const version = status.provider.version ?? "unknown version";
+  return status.provider.compatible
+    ? `Yes — ${version} (requires ${status.provider.minimumVersion}+)`
+    : `No — ${version} (requires ${status.provider.minimumVersion}+)`;
+}
+
+export function renderHookTrust(hook: ProviderHookProbe): string {
+  if (hook.trust === "trusted") return "Yes";
+  if (hook.trust === "provider_managed") return "Managed by provider";
+  if (hook.trust === "modified") {
+    return "No — Hook changed since approval; review First Tree SessionStart in Codex `/hooks`";
   }
+  if (hook.trust === "review_required") {
+    return "No — review First Tree SessionStart in Codex `/hooks`";
+  }
+  return "Unknown";
+}
+
+export function renderHookEnabled(hook: ProviderHookProbe): string {
+  if (hook.enabled === true) return "Yes";
+  if (hook.enabled === false) return "No — enable First Tree SessionStart in Codex `/hooks`";
+  return hook.source === "provider_managed" ? "Managed by provider" : "Unknown";
+}
+
+function renderCheckout(status: ContextIntegrationStatus): void {
+  if (status.checkout.state === "ready") {
+    print.status("Checkout", status.checkout.root);
+    print.status("Repository", status.checkout.repositoryKey);
+    return;
+  }
+  print.status("Checkout", `Unavailable — ${status.checkout.message}`);
+  print.status("Checkout action", status.checkout.nextAction);
+}
+
+function renderBinding(status: ContextIntegrationStatus): void {
+  if (status.binding.state === "exact") {
+    print.status("Exact binding", `Yes — Team ${status.binding.organizationId}`);
+    return;
+  }
+  if (status.binding.state === "missing") {
+    print.status("Exact binding", "No");
+    print.status("Binding action", status.binding.nextAction);
+    return;
+  }
+  if (status.binding.state === "repository_mismatch") {
+    print.status(
+      "Exact binding",
+      `No — Team ${status.binding.organizationId} is bound to ${status.binding.boundRepositoryKey}`,
+    );
+    print.status("Binding action", status.binding.nextAction);
+    return;
+  }
+  print.status("Exact binding", `Not checked — ${status.binding.reason}`);
+}
+
+function renderActivation(status: ContextIntegrationStatus): void {
+  if (status.activation.state === "connected") {
+    print.status(
+      "Live activation",
+      `Connected — ${status.activation.team.displayName} (${status.activation.team.role})`,
+    );
+    return;
+  }
+  if (status.activation.state === "disabled" || status.activation.state === "needs_admin") {
+    print.status("Live activation", `${status.activation.state} — ${status.activation.message}`);
+    if (status.activation.settingsUrl) print.status("Activation action", status.activation.settingsUrl);
+    return;
+  }
+  if (status.activation.state === "unavailable") {
+    print.status("Live activation", `Unavailable — ${status.activation.message}`);
+    print.status("Activation action", status.activation.nextAction);
+    return;
+  }
+  print.status("Live activation", `Not checked — ${status.activation.reason}`);
 }
 
 export const contextStatusCommand: SubcommandModule = {

--- a/apps/cli/src/core/context-integration/client-preflight.ts
+++ b/apps/cli/src/core/context-integration/client-preflight.ts
@@ -3,6 +3,7 @@ import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { type CanonicalResourceRepoKey, canonicalizeResourceRepoUrl, repoUrlSchema } from "@first-tree/shared";
 import { loadCredentials } from "../bootstrap.js";
+import { channelConfig } from "../channel.js";
 
 export type ContextClientPreflight = {
   checkoutRoot: string;
@@ -10,16 +11,69 @@ export type ContextClientPreflight = {
   originUrl: string;
 };
 
+export const contextClientPreflightErrorCode = {
+  notSignedIn: "not_signed_in",
+  notGitCheckout: "not_git_checkout",
+  originUnreadable: "origin_unreadable",
+  originInvalid: "origin_invalid",
+} as const;
+
+export type ContextClientPreflightErrorCode =
+  (typeof contextClientPreflightErrorCode)[keyof typeof contextClientPreflightErrorCode];
+
+export class ContextClientPreflightError extends Error {
+  constructor(
+    readonly code: ContextClientPreflightErrorCode,
+    message: string,
+    readonly nextAction: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "ContextClientPreflightError";
+  }
+}
+
 export function inspectContextClientPreflight(cwd = process.cwd()): ContextClientPreflight {
   if (!loadCredentials()) {
-    throw new Error("First Tree is not signed in. Run `first-tree login <code>` first.");
+    throw new ContextClientPreflightError(
+      contextClientPreflightErrorCode.notSignedIn,
+      "First Tree is not signed in.",
+      `Run \`${channelConfig.binName} login <code>\`, then rerun this command.`,
+    );
   }
 
-  const absoluteCwd = realpathSync(resolve(cwd));
-  const checkoutRoot = runGit(absoluteCwd, ["rev-parse", "--show-toplevel"]);
+  let absoluteCwd: string;
+  try {
+    absoluteCwd = realpathSync(resolve(cwd));
+  } catch (error) {
+    throw new ContextClientPreflightError(
+      contextClientPreflightErrorCode.notGitCheckout,
+      "The current directory is not a readable Git checkout.",
+      "Run this command inside the target Git checkout.",
+      { cause: error },
+    );
+  }
+  const checkoutRoot = runGit(
+    absoluteCwd,
+    ["rev-parse", "--show-toplevel"],
+    contextClientPreflightErrorCode.notGitCheckout,
+  );
   const normalizedCheckoutRoot = realpathSync(checkoutRoot);
-  const originUrl = runGit(normalizedCheckoutRoot, ["remote", "get-url", "origin"]);
-  repoUrlSchema.parse(originUrl);
+  const originUrl = runGit(
+    normalizedCheckoutRoot,
+    ["remote", "get-url", "origin"],
+    contextClientPreflightErrorCode.originUnreadable,
+  );
+  try {
+    repoUrlSchema.parse(originUrl);
+  } catch (error) {
+    throw new ContextClientPreflightError(
+      contextClientPreflightErrorCode.originInvalid,
+      "The current Git checkout's `origin` is not a supported repository URL.",
+      "Set `origin` to a readable GitHub or GitLab repository URL, then rerun this command.",
+      { cause: error },
+    );
+  }
 
   return {
     checkoutRoot: normalizedCheckoutRoot,
@@ -28,18 +82,27 @@ export function inspectContextClientPreflight(cwd = process.cwd()): ContextClien
   };
 }
 
-function runGit(cwd: string, args: readonly string[]): string {
+function runGit(
+  cwd: string,
+  args: readonly string[],
+  code: typeof contextClientPreflightErrorCode.notGitCheckout | typeof contextClientPreflightErrorCode.originUnreadable,
+): string {
   try {
     return execFileSync("git", ["-C", cwd, ...args], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
     }).trim();
-  } catch {
-    throw new Error(
-      args[0] === "remote"
+  } catch (error) {
+    throw new ContextClientPreflightError(
+      code,
+      code === contextClientPreflightErrorCode.originUnreadable
         ? "The current Git checkout has no readable `origin` remote."
+        : "The current directory is not a Git checkout.",
+      code === contextClientPreflightErrorCode.originUnreadable
+        ? "Add or repair `origin` with `git remote add origin <repository-url>` (or `git remote set-url origin <repository-url>`), then rerun this command."
         : "Run this command inside the target Git checkout.",
+      { cause: error },
     );
   }
 }

--- a/apps/cli/src/core/context-integration/installer.ts
+++ b/apps/cli/src/core/context-integration/installer.ts
@@ -390,8 +390,7 @@ function sameProviderProbe(left: ProviderPluginProbe, right: ProviderPluginProbe
     left.compatible === right.compatible &&
     left.installed === right.installed &&
     left.enabled === right.enabled &&
-    left.installedPath === right.installedPath &&
-    left.hookTrust === right.hookTrust
+    left.installedPath === right.installedPath
   );
 }
 

--- a/apps/cli/src/core/context-integration/provider-driver.ts
+++ b/apps/cli/src/core/context-integration/provider-driver.ts
@@ -8,8 +8,23 @@ export type ProviderPluginProbe = {
   installed: boolean;
   enabled: boolean;
   installedPath: string | null;
-  hookTrust: "provider_managed" | "review_required" | "unknown";
   issues: string[];
+};
+
+export type ProviderHookTrust = "trusted" | "review_required" | "modified" | "provider_managed" | "unknown";
+
+export type ProviderHookProbe = {
+  trust: ProviderHookTrust;
+  enabled: boolean | null;
+  source: "provider_api" | "provider_managed" | "unavailable";
+  issues: string[];
+};
+
+export type ProviderHookInspectRequest = {
+  marketplaceName: string;
+  pluginName: string;
+  cwd: string;
+  plugin: Pick<ProviderPluginProbe, "installed" | "enabled">;
 };
 
 export type ProviderInstallRequest = {
@@ -30,6 +45,7 @@ export interface ContextIntegrationProviderDriver {
   readonly executable: string;
   readonly minimumVersion: string;
   probe(marketplaceName: string, pluginName: string): ProviderPluginProbe;
+  inspectHook(request: ProviderHookInspectRequest): Promise<ProviderHookProbe>;
   validateMarketplace(marketplaceRoot: string): void;
   install(request: ProviderInstallRequest): ProviderPluginProbe;
   uninstall(request: Omit<ProviderInstallRequest, "marketplaceRoot">): void;

--- a/apps/cli/src/core/context-integration/providers/claude-code.ts
+++ b/apps/cli/src/core/context-integration/providers/claude-code.ts
@@ -5,6 +5,8 @@ import semver from "semver";
 import type {
   ContextIntegrationProviderDriver,
   ProviderCommandRunner,
+  ProviderHookInspectRequest,
+  ProviderHookProbe,
   ProviderPluginProbe,
 } from "../provider-driver.js";
 import { parseProviderVersion, pluginIdentity } from "../provider-driver.js";
@@ -49,8 +51,16 @@ export class ClaudeCodeContextIntegrationDriver implements ContextIntegrationPro
       version,
       compatible: version !== null && semver.gte(version, this.minimumVersion),
       ...plugin,
-      hookTrust: "provider_managed",
       issues,
+    };
+  }
+
+  async inspectHook(request: ProviderHookInspectRequest): Promise<ProviderHookProbe> {
+    return {
+      trust: "provider_managed",
+      enabled: request.plugin.installed ? request.plugin.enabled : null,
+      source: "provider_managed",
+      issues: [],
     };
   }
 

--- a/apps/cli/src/core/context-integration/providers/claude-code.ts
+++ b/apps/cli/src/core/context-integration/providers/claude-code.ts
@@ -56,9 +56,17 @@ export class ClaudeCodeContextIntegrationDriver implements ContextIntegrationPro
   }
 
   async inspectHook(request: ProviderHookInspectRequest): Promise<ProviderHookProbe> {
+    if (!request.plugin.installed) {
+      return {
+        trust: "unknown",
+        enabled: null,
+        source: "unavailable",
+        issues: [],
+      };
+    }
     return {
       trust: "provider_managed",
-      enabled: request.plugin.installed ? request.plugin.enabled : null,
+      enabled: request.plugin.enabled,
       source: "provider_managed",
       issues: [],
     };

--- a/apps/cli/src/core/context-integration/providers/codex.ts
+++ b/apps/cli/src/core/context-integration/providers/codex.ts
@@ -1,26 +1,34 @@
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { createInterface } from "node:readline";
 import semver from "semver";
 import type {
   ContextIntegrationProviderDriver,
   ProviderCommandRunner,
+  ProviderHookInspectRequest,
+  ProviderHookProbe,
   ProviderPluginProbe,
 } from "../provider-driver.js";
 import { parseProviderVersion, pluginIdentity } from "../provider-driver.js";
 import { containsPlugin, defaultProviderCommandRunner, safeProviderProbe } from "./shared.js";
 
+export type CodexHookStateReader = (executable: string, cwd: string) => Promise<unknown>;
+
 export class CodexContextIntegrationDriver implements ContextIntegrationProviderDriver {
   readonly provider = "codex" as const;
   readonly executable: string;
   readonly minimumVersion: string;
+  private readonly readHookState: CodexHookStateReader;
 
   constructor(
     private readonly run: ProviderCommandRunner = defaultProviderCommandRunner,
-    options: { executable?: string; minimumVersion?: string } = {},
+    options: { executable?: string; minimumVersion?: string; readHookState?: CodexHookStateReader } = {},
   ) {
     this.executable = options.executable ?? "codex";
     this.minimumVersion = options.minimumVersion ?? "0.144.0";
+    this.readHookState = options.readHookState ?? readCodexHookState;
   }
 
   probe(marketplaceName: string, pluginName: string): ProviderPluginProbe {
@@ -49,9 +57,30 @@ export class CodexContextIntegrationDriver implements ContextIntegrationProvider
       version,
       compatible: version !== null && semver.gte(version, this.minimumVersion),
       ...plugin,
-      hookTrust: plugin.installed ? "review_required" : "unknown",
       issues,
     };
+  }
+
+  async inspectHook(request: ProviderHookInspectRequest): Promise<ProviderHookProbe> {
+    if (!request.plugin.installed) {
+      return {
+        trust: "unknown",
+        enabled: null,
+        source: "unavailable",
+        issues: [],
+      };
+    }
+    try {
+      const response = await this.readHookState(this.executable, request.cwd);
+      return parseCodexHookState(response, pluginIdentity(request.pluginName, request.marketplaceName));
+    } catch (error) {
+      return {
+        trust: "unknown",
+        enabled: null,
+        source: "unavailable",
+        issues: [`Codex Hook state could not be inspected: ${message(error)}`],
+      };
+    }
   }
 
   validateMarketplace(_marketplaceRoot: string): void {
@@ -103,4 +132,203 @@ function resolveCodexInstalledPluginPath(
     version,
   );
   return existsSync(path) ? path : null;
+}
+
+export function parseCodexHookState(value: unknown, targetPluginId: string): ProviderHookProbe {
+  const hooks = collectHookRows(value).filter(
+    (row) =>
+      Reflect.get(row, "pluginId") === targetPluginId &&
+      Reflect.get(row, "eventName") === "sessionStart" &&
+      Reflect.get(row, "handlerType") === "command",
+  );
+  if (hooks.length === 0) {
+    return {
+      trust: "unknown",
+      enabled: null,
+      source: "provider_api",
+      issues: ["Codex did not discover the First Tree SessionStart Hook."],
+    };
+  }
+
+  const trustStatuses = hooks.map((hook) => Reflect.get(hook, "trustStatus"));
+  const trust = trustStatuses.includes("modified")
+    ? "modified"
+    : trustStatuses.includes("untrusted")
+      ? "review_required"
+      : trustStatuses.every((status) => status === "managed")
+        ? "provider_managed"
+        : trustStatuses.every((status) => status === "trusted" || status === "managed")
+          ? "trusted"
+          : "unknown";
+  const enabledValues = hooks.map((hook) => Reflect.get(hook, "enabled"));
+  const enabled = enabledValues.every((item) => item === true)
+    ? true
+    : enabledValues.some((item) => item === false)
+      ? false
+      : null;
+
+  return {
+    trust,
+    enabled,
+    source: "provider_api",
+    issues: collectHookInspectionIssues(value),
+  };
+}
+
+function collectHookRows(value: unknown): Array<Record<string, unknown>> {
+  if (!isRecord(value)) return [];
+  const data = Reflect.get(value, "data");
+  if (!Array.isArray(data)) return [];
+  const hooks: Array<Record<string, unknown>> = [];
+  for (const entry of data) {
+    if (!isRecord(entry)) continue;
+    const entryHooks = Reflect.get(entry, "hooks");
+    if (!Array.isArray(entryHooks)) continue;
+    for (const hook of entryHooks) {
+      if (isRecord(hook)) hooks.push(hook);
+    }
+  }
+  return hooks;
+}
+
+function collectHookInspectionIssues(value: unknown): string[] {
+  if (!isRecord(value)) return [];
+  const data = Reflect.get(value, "data");
+  if (!Array.isArray(data)) return [];
+  const issues: string[] = [];
+  for (const entry of data) {
+    if (!isRecord(entry)) continue;
+    const warnings = Reflect.get(entry, "warnings");
+    if (Array.isArray(warnings)) {
+      for (const warning of warnings) {
+        if (typeof warning === "string") issues.push(warning);
+      }
+    }
+    const errors = Reflect.get(entry, "errors");
+    if (Array.isArray(errors)) {
+      for (const error of errors) {
+        if (!isRecord(error)) continue;
+        const errorMessage = Reflect.get(error, "message");
+        if (typeof errorMessage === "string") issues.push(errorMessage);
+      }
+    }
+  }
+  return issues;
+}
+
+function readCodexHookState(executable: string, cwd: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, ["app-server", "--stdio"], {
+      cwd,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const output = createInterface({ input: child.stdout });
+    let stderr = "";
+    let settled = false;
+    const timeout = setTimeout(() => finish(new Error("Codex app-server Hook inspection timed out.")), 5_000);
+
+    const finish = (error?: Error, result?: unknown): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      output.close();
+      child.stdin.end();
+      child.kill("SIGTERM");
+      if (error) reject(error);
+      else resolve(result);
+    };
+
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr = `${stderr}${chunk.toString()}`.slice(-8_000);
+    });
+    child.on("error", (error) => finish(error));
+    child.on("exit", (code, signal) => {
+      if (!settled) {
+        const detail = stderr.trim();
+        finish(
+          new Error(
+            `Codex app-server exited before returning Hook state (code ${code ?? "none"}, signal ${
+              signal ?? "none"
+            })${detail ? `: ${detail}` : "."}`,
+          ),
+        );
+      }
+    });
+    output.on("line", (line) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (!isRecord(parsed)) return;
+      const id = Reflect.get(parsed, "id");
+      if (id === 1) {
+        const rpcError = rpcErrorMessage(parsed);
+        if (rpcError) {
+          finish(new Error(rpcError));
+          return;
+        }
+        child.stdin.write(`${JSON.stringify({ method: "initialized" })}\n`);
+        child.stdin.write(
+          `${JSON.stringify({
+            id: 2,
+            method: "hooks/list",
+            params: { cwds: [cwd] },
+          })}\n`,
+        );
+        return;
+      }
+      if (id === 2) {
+        const rpcError = rpcErrorMessage(parsed);
+        if (rpcError) finish(new Error(rpcError));
+        else finish(undefined, Reflect.get(parsed, "result"));
+        return;
+      }
+      const method = Reflect.get(parsed, "method");
+      if ((typeof id === "string" || typeof id === "number") && typeof method === "string") {
+        child.stdin.write(
+          `${JSON.stringify({
+            id,
+            error: { code: -32601, message: `First Tree does not handle app-server request ${method}` },
+          })}\n`,
+        );
+      }
+    });
+
+    child.stdin.write(
+      `${JSON.stringify({
+        id: 1,
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "first-tree",
+            title: "First Tree",
+            version: "0.0.0",
+          },
+          capabilities: {
+            experimentalApi: true,
+            requestAttestation: false,
+          },
+        },
+      })}\n`,
+    );
+  });
+}
+
+function rpcErrorMessage(value: Record<string, unknown>): string | null {
+  const error = Reflect.get(value, "error");
+  if (!isRecord(error)) return null;
+  const errorMessage = Reflect.get(error, "message");
+  return typeof errorMessage === "string" ? errorMessage : "Codex app-server Hook inspection failed.";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/cli/src/core/context-integration/status.ts
+++ b/apps/cli/src/core/context-integration/status.ts
@@ -3,6 +3,7 @@ import type {
   ContextIntegrationBinding,
   ContextIntegrationProvider,
 } from "@first-tree/shared";
+import semver from "semver";
 import { channelConfig } from "../channel.js";
 import type { ContextActivationValidator } from "./activation.js";
 import {
@@ -124,13 +125,18 @@ export async function inspectContextIntegrationStatus(
     pluginName,
     cwd,
   });
+  const minimumVersion = health.release?.manifest.providers[driver.provider].minimumVersion ?? driver.minimumVersion;
 
   const providerStatus = {
     name: driver.provider,
     available: plugin.binaryAvailable,
     version: plugin.version,
-    minimumVersion: health.release?.manifest.providers[driver.provider].minimumVersion ?? driver.minimumVersion,
-    compatible: plugin.compatible,
+    minimumVersion,
+    compatible:
+      plugin.binaryAvailable &&
+      plugin.version !== null &&
+      semver.valid(plugin.version) !== null &&
+      semver.gte(plugin.version, minimumVersion),
   };
   const pluginStatus = {
     installed: plugin.installed,

--- a/apps/cli/src/core/context-integration/status.ts
+++ b/apps/cli/src/core/context-integration/status.ts
@@ -1,0 +1,317 @@
+import type {
+  ContextActivationResponse,
+  ContextIntegrationBinding,
+  ContextIntegrationProvider,
+} from "@first-tree/shared";
+import { channelConfig } from "../channel.js";
+import type { ContextActivationValidator } from "./activation.js";
+import {
+  ContextClientPreflightError,
+  type ContextClientPreflightErrorCode,
+  inspectContextClientPreflight,
+} from "./client-preflight.js";
+import { findContextBinding } from "./context-binding-store.js";
+import { contextIntegrationMarketplaceName } from "./installer.js";
+import type { ContextIntegrationProviderDriver, ProviderHookProbe, ProviderPluginProbe } from "./provider-driver.js";
+import { type ContextIntegrationRuntimeHealth, inspectContextIntegrationRuntime } from "./runtime-health.js";
+
+type CheckoutStatus =
+  | {
+      state: "ready";
+      root: string;
+      repositoryKey: string;
+    }
+  | {
+      state: "unavailable";
+      reason: ContextClientPreflightErrorCode | "unknown";
+      message: string;
+      nextAction: string;
+    };
+
+type BindingStatus =
+  | {
+      state: "exact";
+      organizationId: string;
+      repositoryKey: string;
+    }
+  | {
+      state: "missing";
+      nextAction: string;
+    }
+  | {
+      state: "repository_mismatch";
+      organizationId: string;
+      boundRepositoryKey: string;
+      currentRepositoryKey: string;
+      nextAction: string;
+    }
+  | {
+      state: "not_checked";
+      reason: string;
+    };
+
+type LiveActivationStatus =
+  | {
+      state: "connected";
+      team: Extract<ContextActivationResponse, { outcome: "connected" }>["team"];
+    }
+  | {
+      state: "disabled";
+      reasonCode: string;
+      message: string;
+      settingsUrl: string | null;
+    }
+  | {
+      state: "needs_admin";
+      reasonCode: string;
+      message: string;
+      settingsUrl: string | null;
+    }
+  | {
+      state: "unavailable";
+      message: string;
+      nextAction: string;
+    }
+  | {
+      state: "not_checked";
+      reason: string;
+    };
+
+export type ContextIntegrationStatus = {
+  provider: {
+    name: ContextIntegrationProvider;
+    available: boolean;
+    version: string | null;
+    minimumVersion: string;
+    compatible: boolean;
+  };
+  plugin: {
+    installed: boolean;
+    enabled: boolean;
+    installedPath: string | null;
+  };
+  hook: ProviderHookProbe;
+  runtime: {
+    healthy: boolean;
+    issues: string[];
+  };
+  checkout: CheckoutStatus;
+  binding: BindingStatus;
+  activation: LiveActivationStatus;
+};
+
+type StatusDependencies = {
+  inspectRuntime?: (driver: ContextIntegrationProviderDriver) => ContextIntegrationRuntimeHealth;
+  inspectPreflight?: typeof inspectContextClientPreflight;
+  findBinding?: (provider: ContextIntegrationProvider, checkoutRoot: string) => ContextIntegrationBinding | null;
+};
+
+export async function inspectContextIntegrationStatus(
+  driver: ContextIntegrationProviderDriver,
+  validator: ContextActivationValidator,
+  cwd = process.cwd(),
+  dependencies: StatusDependencies = {},
+): Promise<ContextIntegrationStatus> {
+  const inspectRuntime = dependencies.inspectRuntime ?? inspectContextIntegrationRuntime;
+  const inspectPreflight = dependencies.inspectPreflight ?? inspectContextClientPreflight;
+  const resolveBinding = dependencies.findBinding ?? findContextBinding;
+  const health = inspectRuntime(driver);
+  const plugin = health.probe;
+  const marketplaceName = health.install?.marketplaceName ?? contextIntegrationMarketplaceName();
+  const pluginName = health.install?.pluginName ?? "first-tree-context";
+  const hook = await inspectProviderHook(driver, plugin, {
+    marketplaceName,
+    pluginName,
+    cwd,
+  });
+
+  const providerStatus = {
+    name: driver.provider,
+    available: plugin.binaryAvailable,
+    version: plugin.version,
+    minimumVersion: health.release?.manifest.providers[driver.provider].minimumVersion ?? driver.minimumVersion,
+    compatible: plugin.compatible,
+  };
+  const pluginStatus = {
+    installed: plugin.installed,
+    enabled: plugin.enabled,
+    installedPath: plugin.installedPath,
+  };
+  const runtime = {
+    healthy: health.healthy,
+    issues: health.issues,
+  };
+
+  let preflight: ReturnType<typeof inspectContextClientPreflight>;
+  try {
+    preflight = inspectPreflight(cwd);
+  } catch (error) {
+    const checkout = checkoutFailure(error);
+    return {
+      provider: providerStatus,
+      plugin: pluginStatus,
+      hook,
+      runtime,
+      checkout,
+      binding: {
+        state: "not_checked",
+        reason: checkout.message,
+      },
+      activation: {
+        state: "not_checked",
+        reason: checkout.message,
+      },
+    };
+  }
+
+  const checkout: CheckoutStatus = {
+    state: "ready",
+    root: preflight.checkoutRoot,
+    repositoryKey: preflight.repositoryKey,
+  };
+  let binding: ContextIntegrationBinding | null;
+  try {
+    binding = resolveBinding(driver.provider, preflight.checkoutRoot);
+  } catch (error) {
+    const reason = `The exact checkout binding could not be read: ${message(error)}`;
+    return {
+      provider: providerStatus,
+      plugin: pluginStatus,
+      hook,
+      runtime,
+      checkout,
+      binding: { state: "not_checked", reason },
+      activation: { state: "not_checked", reason },
+    };
+  }
+  if (!binding) {
+    return {
+      provider: providerStatus,
+      plugin: pluginStatus,
+      hook,
+      runtime,
+      checkout,
+      binding: {
+        state: "missing",
+        nextAction: `Run the target Team's \`${channelConfig.binName} context enable\` handoff in this checkout.`,
+      },
+      activation: {
+        state: "not_checked",
+        reason: "No exact provider + checkout binding exists.",
+      },
+    };
+  }
+  if (binding.repositoryKey !== preflight.repositoryKey) {
+    return {
+      provider: providerStatus,
+      plugin: pluginStatus,
+      hook,
+      runtime,
+      checkout,
+      binding: {
+        state: "repository_mismatch",
+        organizationId: binding.organizationId,
+        boundRepositoryKey: binding.repositoryKey,
+        currentRepositoryKey: preflight.repositoryKey,
+        nextAction: "Restore the bound `origin` or rerun the target Team's enable handoff.",
+      },
+      activation: {
+        state: "not_checked",
+        reason: "The checkout `origin` no longer matches its exact binding.",
+      },
+    };
+  }
+
+  const bindingStatus: BindingStatus = {
+    state: "exact",
+    organizationId: binding.organizationId,
+    repositoryKey: binding.repositoryKey,
+  };
+  try {
+    const response = await validator.validateMemberContextActivation(
+      binding.organizationId,
+      {
+        schemaVersion: 1,
+        repositoryKey: binding.repositoryKey,
+      },
+      { retry: false, timeoutMs: 2_000 },
+    );
+    return {
+      provider: providerStatus,
+      plugin: pluginStatus,
+      hook,
+      runtime,
+      checkout,
+      binding: bindingStatus,
+      activation: activationStatus(response),
+    };
+  } catch (error) {
+    return {
+      provider: providerStatus,
+      plugin: pluginStatus,
+      hook,
+      runtime,
+      checkout,
+      binding: bindingStatus,
+      activation: {
+        state: "unavailable",
+        message: `First Tree live activation could not be checked: ${message(error)}`,
+        nextAction: `Check the First Tree connection and rerun \`${channelConfig.binName} context status --provider ${driver.provider}\`.`,
+      },
+    };
+  }
+}
+
+function inspectProviderHook(
+  driver: ContextIntegrationProviderDriver,
+  plugin: ProviderPluginProbe,
+  input: {
+    marketplaceName: string;
+    pluginName: string;
+    cwd: string;
+  },
+): Promise<ProviderHookProbe> {
+  return driver.inspectHook({
+    ...input,
+    plugin: {
+      installed: plugin.installed,
+      enabled: plugin.enabled,
+    },
+  });
+}
+
+function checkoutFailure(error: unknown): Extract<CheckoutStatus, { state: "unavailable" }> {
+  if (error instanceof ContextClientPreflightError) {
+    return {
+      state: "unavailable",
+      reason: error.code,
+      message: error.message,
+      nextAction: error.nextAction,
+    };
+  }
+  return {
+    state: "unavailable",
+    reason: "unknown",
+    message: `The current checkout could not be inspected: ${message(error)}`,
+    nextAction: `Fix the reported checkout error, then rerun \`${channelConfig.binName} context status\`.`,
+  };
+}
+
+function activationStatus(response: ContextActivationResponse): LiveActivationStatus {
+  if (response.outcome === "connected") {
+    return {
+      state: "connected",
+      team: response.team,
+    };
+  }
+  return {
+    state: response.outcome,
+    reasonCode: response.reasonCode,
+    message: response.nextAction.message,
+    settingsUrl: response.nextAction.settingsUrl ?? null,
+  };
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1054,9 +1054,19 @@ exact provider + checkout/repository → Team binding in
 Chat, Computer, or runtime session; normal `login` and the existing daemon own
 the Computer connection.
 
-`context status` checks the local provider/version/Plugin manifest, the actual
-provider-installed Skill/Policy/hook bytes, and the current checkout's live
-Team activation. `context repair` revalidates and reinstalls only First Tree's
+For Codex, installation does not grant Hook consent. After the first enable,
+open Codex in the checkout, run `/hooks`, find **First Tree Context →
+SessionStart**, enable its checkbox, choose **Trust**, and start a new session.
+Then run `context status --provider codex` to verify the result.
+
+`context status` reports provider compatibility, Plugin installed/enabled,
+Hook trusted/enabled, current checkout, exact binding, and live Team activation
+as separate layers. It reads Codex Hook state from the provider-owned
+`hooks/list` API and distinguishes trusted, changed, review-required, and
+disabled states. A checkout failure states whether First Tree is signed out,
+the directory is not a Git checkout, or `origin` is unreadable/invalid, with a
+specific repair action. It also checks the Plugin manifest and the actual
+provider-installed Skill/Policy/hook bytes. `context repair` revalidates and reinstalls only First Tree's
 Plugin through the same durable operation journal used by enable/disable, with
 rollback to the prior provider cache on failure. Context mutations and local
 Client account switching are mutually exclusive; incomplete operations retain

--- a/docs/context-integration.md
+++ b/docs/context-integration.md
@@ -46,6 +46,32 @@ manifest also records both adapter digests and the canonical Policy digest.
   remote mutation when Automatic Review is absent, disabled, structurally
   incomplete, or offline.
 
+## Codex Hook consent and verification
+
+Codex owns Hook consent. First Tree installs the Plugin but never bypasses,
+pre-approves, or silently enables the SessionStart Hook. After the first
+`context enable --provider codex`:
+
+1. open Codex in the enabled checkout;
+2. run `/hooks`;
+3. find **First Tree Context → SessionStart**, enable its checkbox, and choose
+   **Trust**;
+4. exit and start a new Codex session in that checkout;
+5. run `first-tree context status --provider codex` and confirm **Hook trusted**
+   and **Hook enabled** are `Yes`, and **Live activation** is `Connected`.
+
+Both `context enable` and `context status` query Codex's provider-owned
+`hooks/list` API after installation. They report trust and enablement
+separately, including a Hook that changed after approval. A previously trusted
+and enabled Hook therefore does not receive another review prompt.
+
+Status output also keeps machine/user/provider and repository authority
+separate: provider compatibility, Plugin installation, Plugin enablement,
+Hook trust, Hook enablement, current checkout, exact binding, and live Team
+activation each have their own row. Checkout failures preserve their actual
+cause and repair action: signed out, outside a Git checkout, or missing/invalid
+`origin`.
+
 ## Upgrade, rollback, and disable
 
 `first-tree context repair --provider <provider>` validates the embedded

--- a/packages/qa/cases/cross-surface/external-context-hook-status.md
+++ b/packages/qa/cases/cross-surface/external-context-hook-status.md
@@ -1,0 +1,87 @@
+---
+id: external-context-hook-status
+description: Validate Codex Context enable consent guidance and layered status across provider, Plugin, Hook, checkout, binding, and live Team activation.
+areas: [cross-surface]
+surfaces: [cli, codex, server]
+---
+
+# External Context Hook Consent And Layered Status
+
+## Goal
+
+Confirm that the shipped CLI never bypasses Codex Hook consent, guides a person
+through the first enable flow, then reads the provider's real SessionStart
+trust and enabled state without conflating machine Plugin state with
+repository/Team activation.
+
+## Preconditions
+
+- Use the formal isolated QA run cell and a disposable ordinary Git repository
+  with a readable GitHub `origin`; do not use the product checkout as the
+  experience fixture.
+- Bridge to a supported host Codex installation using a throwaway
+  `CODEX_HOME`. The run must exercise the real Codex Plugin lifecycle,
+  interactive `/hooks` surface, and app-server `hooks/list` response.
+- Use a staging First Tree account and disposable Team/repository scope. Keep
+  credentials outside committed artifacts and redact the Team id if the
+  evidence leaves the QA environment.
+- Begin once with no Hook trust state and once with an already trusted and
+  enabled First Tree SessionStart Hook.
+
+## Operate
+
+- Run the Team-authored `context enable --provider codex` handoff from the
+  disposable checkout.
+- Follow only the displayed consent steps: open Codex, run `/hooks`, find First
+  Tree Context → SessionStart, enable it, trust it, and start a new session.
+- Run `context status --provider codex` in human and JSON modes before consent,
+  after enabling without trust, after trust, and after starting the new
+  session.
+- Disable the Hook while retaining trust, then change the installed Hook
+  definition so Codex reports modified trust; inspect status after each state.
+- Repeat enable with the already trusted and enabled Hook.
+- Separately inspect status while signed out, outside any Git repository, and
+  inside a signed-in Git repository with no readable `origin`.
+
+## Observe
+
+- Enable never passes a trust-bypass flag or writes trusted Hook state. Its
+  output gives the `/hooks` path as ordered, verifiable steps.
+- Provider compatibility, Plugin installed, Plugin enabled, Hook trusted, Hook
+  enabled, checkout, exact binding, and live activation are separate fields in
+  human and JSON output.
+- Codex `trusted + enabled` renders Hook trusted/enabled as `Yes`; repeating
+  enable does not incorrectly ask for another review.
+- Trusted but disabled, untrusted, and modified Hook states remain distinct and
+  include the correct `/hooks` repair action.
+- The exact checkout binding remains visible when live activation is
+  temporarily unavailable; no cached Team authority is presented as
+  connected.
+- Signed out, non-Git directory, and missing `origin` each retain their actual
+  cause and a specific repair action.
+- A new Codex session runs SessionStart and reports live activation connected
+  only for the exact disposable checkout binding.
+
+## Expected Result
+
+`PASS`: all state transitions are read from real provider/server surfaces,
+consent remains provider-owned, trusted/enabled state is reported accurately,
+and every status layer and checkout failure stays distinct.
+
+`FAIL`: status claims review is required after Codex reports trusted, conflates
+Hook enablement with Plugin enablement, hides the exact binding when the server
+is unavailable, merges checkout failures, bypasses consent, or reports live
+activation for another checkout/Team.
+
+`BLOCKED`: the isolated Codex bridge, staging account, disposable Team scope, or
+ordinary repository fixture cannot be prepared.
+
+`INCONCLUSIVE`: only source/tests/mocks were observed, the provider state could
+not be captured, or the state transition evidence is incomplete.
+
+## Evidence
+
+Keep the enable/status human output, redacted JSON envelopes, Codex `/hooks`
+screenshots for each state, the matching `hooks/list` rows, SessionStart output,
+and server activation response/log correlation. Record provider and CLI
+versions and the disposable checkout commit.


### PR DESCRIPTION
## Summary

- read Codex SessionStart Hook trust and enabled state from the provider instead of always reporting review required
- add step-by-step, post-install Hook consent guidance with a reliable status reread
- separate provider, Plugin, Hook, exact checkout binding, and live activation status
- distinguish signed-out, non-Git, unreadable origin, and unsupported origin checkout failures with channel-aware recovery commands
- document the flow and add deterministic tests plus a cross-surface QA case

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] real Codex app-server Hook smoke check returned trusted + enabled
- [x] `first-tree-staging` exact Context activation and relevant Context Tree read

## Change Surface

- [x] `apps/cli` public CLI or help output
- [x] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [x] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: no consent bypass; Codex still owns Hook trust and enablement
- docs or tests updated to match: CLI reference, integration guide, provider/status tests, and a QA case
- follow-up work: formal QA is warranted for clean-repo comparison, Claude Code, Write/PR, and cross-OS release qualification; the earlier GitLab SSH port 22 timeout is not treated as a generic Read defect
