### PR TITLE
Harden BYO Context activation resilience

### DIFF
--- a/apps/cli/src/__tests__/context-activation.test.ts
+++ b/apps/cli/src/__tests__/context-activation.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { FirstTreeHubSDK } from "@first-tree/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   activateExternalContext,
   ExternalContextActivationRequiredError,
@@ -12,28 +13,47 @@ const preflight = {
   originUrl: "git@github.com:acme/payments.git",
 } as const;
 
+const binding = {
+  provider: "codex" as const,
+  checkoutRoot: preflight.checkoutRoot,
+  repositoryKey: preflight.repositoryKey,
+  organizationId: "org_acme",
+};
+
+const connected = {
+  schemaVersion: 1 as const,
+  outcome: "connected" as const,
+  team: {
+    organizationId: "org_acme",
+    displayName: "Acme",
+    role: "member" as const,
+  },
+};
+
+function timeoutError(): Error {
+  const error = new Error("request timed out");
+  error.name = "TimeoutError";
+  return error;
+}
+
+function httpError(statusCode: number): Error & { statusCode: number } {
+  return Object.assign(new Error(`HTTP ${statusCode}`), { statusCode });
+}
+
 describe("external Context activation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it("uses only the exact local Team binding and returns a short connected envelope", async () => {
-    const validate = vi.fn(async () => ({
-      schemaVersion: 1 as const,
-      outcome: "connected" as const,
-      team: {
-        organizationId: "org_acme",
-        displayName: "Acme",
-        role: "member" as const,
-      },
-    }));
+    const validate = vi.fn(async () => connected);
     const result = await activateExternalContext(
       { validateMemberContextActivation: validate },
       { provider: "codex", cwd: "/work/payments/src" },
       {
         inspect: () => preflight,
-        findBinding: () => ({
-          provider: "codex",
-          checkoutRoot: preflight.checkoutRoot,
-          repositoryKey: preflight.repositoryKey,
-          organizationId: "org_acme",
-        }),
+        findBinding: () => binding,
       },
     );
 
@@ -70,7 +90,7 @@ describe("external Context activation", () => {
     ).rejects.toBeInstanceOf(ExternalContextActivationRequiredError);
   });
 
-  it("fails closed on repository drift and authority timeout without blocking coding", async () => {
+  it("fails closed on repository drift and SessionStart timeout without retrying or blocking coding", async () => {
     const drift = await activateExternalContext(
       { validateMemberContextActivation: vi.fn() },
       { provider: "codex", cwd: "/work/payments" },
@@ -89,27 +109,290 @@ describe("external Context activation", () => {
       reasonCode: "binding_repository_drift",
     });
 
+    const validate = vi.fn(async () => {
+      throw timeoutError();
+    });
     const unavailable = await activateExternalContext(
-      {
-        validateMemberContextActivation: async () => {
-          throw new Error("timeout");
-        },
-      },
+      { validateMemberContextActivation: validate },
       { provider: "codex", cwd: "/work/payments" },
       {
         inspect: () => preflight,
-        findBinding: () => ({
-          provider: "codex",
-          checkoutRoot: preflight.checkoutRoot,
-          repositoryKey: preflight.repositoryKey,
-          organizationId: "org_acme",
-        }),
+        findBinding: () => binding,
       },
     );
     expect(unavailable).toMatchObject({
       outcome: "unavailable",
-      reasonCode: "authority_unavailable",
+      reasonCode: "authority_timeout",
     });
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(validate).toHaveBeenCalledWith(
+      "org_acme",
+      { schemaVersion: 1, repositoryKey: preflight.repositoryKey },
+      { retry: false, timeoutMs: 2_000 },
+    );
     expect(renderProviderSessionStartResponse(unavailable)).toMatchObject({ continue: true });
+  });
+
+  it("retries one transient explicit activation against the same Team and repository", async () => {
+    const validate = vi.fn().mockRejectedValueOnce(timeoutError()).mockResolvedValueOnce(connected);
+
+    await expect(
+      requireConnectedExternalContext(
+        { validateMemberContextActivation: validate },
+        { provider: "codex", cwd: "/work/payments" },
+        {
+          inspect: () => preflight,
+          findBinding: () => binding,
+        },
+      ),
+    ).resolves.toMatchObject({
+      team: connected.team,
+      binding,
+    });
+    expect(validate).toHaveBeenCalledTimes(2);
+    expect(validate).toHaveBeenNthCalledWith(
+      1,
+      "org_acme",
+      { schemaVersion: 1, repositoryKey: preflight.repositoryKey },
+      { retry: false, timeoutMs: 5_000 },
+    );
+    expect(validate).toHaveBeenNthCalledWith(
+      2,
+      "org_acme",
+      { schemaVersion: 1, repositoryKey: preflight.repositoryKey },
+      { retry: false, timeoutMs: 5_000 },
+    );
+  });
+
+  it("bounds a stale-token refresh inside the SessionStart attempt signal", async () => {
+    let timeoutController: AbortController | undefined;
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((timeoutMs) => {
+      expect(timeoutMs).toBe(2_000);
+      timeoutController = new AbortController();
+      return timeoutController.signal;
+    });
+    const getAccessToken = vi.fn(
+      (options?: { signal?: AbortSignal }) =>
+        new Promise<string>((_resolve, reject) => {
+          const signal = options?.signal;
+          expect(signal).toBeDefined();
+          signal?.addEventListener(
+            "abort",
+            () => reject(signal.reason ?? new DOMException("This operation was aborted", "AbortError")),
+            { once: true },
+          );
+          timeoutController?.abort(timeoutError());
+        }),
+    );
+    const sdk = new FirstTreeHubSDK({
+      serverUrl: "https://first-tree.example",
+      getAccessToken,
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      activateExternalContext(
+        sdk,
+        { provider: "codex", cwd: "/work/payments" },
+        {
+          inspect: () => preflight,
+          findBinding: () => binding,
+        },
+      ),
+    ).resolves.toMatchObject({
+      outcome: "unavailable",
+      reasonCode: "authority_timeout",
+    });
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["refresh timeout", timeoutError(), "authority_timeout"],
+    [
+      "refresh network failure",
+      Object.assign(new Error("temporary DNS failure"), { code: "EAI_AGAIN" }),
+      "authority_network_error",
+    ],
+    ["refresh HTTP 5xx", httpError(503), "authority_server_error"],
+  ])("retries one explicit token-stage %s against the same target", async (_label, error, reasonCode) => {
+    const getAccessToken = vi.fn(async () => {
+      throw error;
+    });
+    const sdk = new FirstTreeHubSDK({
+      serverUrl: "https://first-tree.example",
+      getAccessToken,
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      requireConnectedExternalContext(
+        sdk,
+        { provider: "codex", cwd: "/work/payments" },
+        {
+          inspect: () => preflight,
+          findBinding: () => binding,
+        },
+      ),
+    ).rejects.toMatchObject({
+      outcome: "unavailable",
+      reasonCode,
+    });
+    expect(getAccessToken).toHaveBeenCalledTimes(2);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a bare EAI_AGAIN token-stage failure during SessionStart", async () => {
+    const getAccessToken = vi.fn(async () => {
+      throw Object.assign(new Error("temporary DNS failure"), { code: "EAI_AGAIN" });
+    });
+    const sdk = new FirstTreeHubSDK({
+      serverUrl: "https://first-tree.example",
+      getAccessToken,
+    });
+
+    await expect(
+      activateExternalContext(
+        sdk,
+        { provider: "codex", cwd: "/work/payments" },
+        {
+          inspect: () => preflight,
+          findBinding: () => binding,
+        },
+      ),
+    ).resolves.toMatchObject({
+      outcome: "unavailable",
+      reasonCode: "authority_network_error",
+    });
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["timeout", timeoutError(), "authority_timeout"],
+    [
+      "network failure",
+      Object.assign(new Error("fetch failed"), { cause: Object.assign(new Error("reset"), { code: "ECONNRESET" }) }),
+      "authority_network_error",
+    ],
+    ["server failure", httpError(503), "authority_server_error"],
+  ])("classifies and bounds explicit %s retries", async (_label, error, reasonCode) => {
+    const validate = vi.fn(async () => {
+      throw error;
+    });
+
+    await expect(
+      requireConnectedExternalContext(
+        { validateMemberContextActivation: validate },
+        { provider: "codex", cwd: "/work/payments" },
+        {
+          inspect: () => preflight,
+          findBinding: () => binding,
+        },
+      ),
+    ).rejects.toMatchObject({
+      outcome: "unavailable",
+      reasonCode,
+    });
+    expect(validate).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [401, "authority_authentication_required"],
+    [403, "authority_forbidden"],
+    [409, "authority_request_rejected"],
+  ])("does not retry deterministic HTTP %i authority failures", async (statusCode, reasonCode) => {
+    const validate = vi.fn(async () => {
+      throw httpError(statusCode);
+    });
+
+    await expect(
+      requireConnectedExternalContext(
+        { validateMemberContextActivation: validate },
+        { provider: "codex", cwd: "/work/payments" },
+        {
+          inspect: () => preflight,
+          findBinding: () => binding,
+        },
+      ),
+    ).rejects.toMatchObject({
+      outcome: "unavailable",
+      reasonCode,
+    });
+    expect(validate).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps HTTP 403 terminal even when the response message contains timeout text", async () => {
+    const validate = vi.fn(async () => {
+      throw Object.assign(new Error("request timed out"), { statusCode: 403 });
+    });
+
+    await expect(
+      requireConnectedExternalContext(
+        { validateMemberContextActivation: validate },
+        { provider: "codex", cwd: "/work/payments" },
+        {
+          inspect: () => preflight,
+          findBinding: () => binding,
+        },
+      ),
+    ).rejects.toMatchObject({
+      outcome: "unavailable",
+      reasonCode: "authority_forbidden",
+    });
+    expect(validate).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies HTTP 504 as a retryable server failure before inspecting timeout text", async () => {
+    const validate = vi.fn(async () => {
+      throw Object.assign(new Error("Gateway Timeout"), { statusCode: 504 });
+    });
+
+    await expect(
+      requireConnectedExternalContext(
+        { validateMemberContextActivation: validate },
+        { provider: "codex", cwd: "/work/payments" },
+        {
+          inspect: () => preflight,
+          findBinding: () => binding,
+        },
+      ),
+    ).rejects.toMatchObject({
+      outcome: "unavailable",
+      reasonCode: "authority_server_error",
+    });
+    expect(validate).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a typed Team scope denial", async () => {
+    const validate = vi.fn(async () => ({
+      schemaVersion: 1 as const,
+      outcome: "disabled" as const,
+      team: {
+        organizationId: "org_acme",
+        displayName: "Acme",
+      },
+      reasonCode: "repository_not_in_selected_team_scope" as const,
+      nextAction: {
+        message: "Ask a Team Admin to add this repository.",
+        settingsUrl: "https://first-tree.example/settings",
+      },
+    }));
+
+    await expect(
+      requireConnectedExternalContext(
+        { validateMemberContextActivation: validate },
+        { provider: "codex", cwd: "/work/payments" },
+        {
+          inspect: () => preflight,
+          findBinding: () => binding,
+        },
+      ),
+    ).rejects.toMatchObject({
+      outcome: "disabled",
+      reasonCode: "repository_not_in_selected_team_scope",
+    });
+    expect(validate).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/cli/src/__tests__/context-bundle-manifest.test.ts
+++ b/apps/cli/src/__tests__/context-bundle-manifest.test.ts
@@ -64,9 +64,13 @@ describe("context integration bundle", () => {
     const projectedSkills = new Map<string, { read: string; write: string }>();
     for (const provider of ["claude-code", "codex"]) {
       const pluginRoot = join(root, provider, "plugins", "first-tree-context");
+      const hook = readFileSync(join(pluginRoot, "hooks", "hooks.json"), "utf8");
       const readSkill = readFileSync(join(pluginRoot, "skills", "first-tree-read", "SKILL.md"), "utf8");
       const writeSkill = readFileSync(join(pluginRoot, "skills", "first-tree-write", "SKILL.md"), "utf8");
       projectedSkills.set(provider, { read: readSkill, write: writeSkill });
+      expect(hook).toContain('"timeout": 5');
+      expect(hook).not.toContain('"timeout": 3');
+      expect(hook).toContain('"matcher": "startup|resume|clear|compact"');
       expect(readSkill).toContain(`context read --provider ${provider}`);
       expect(writeSkill).toContain(`context write --provider ${provider}`);
       expect(readSkill).toContain("read\n`references/context-tree-policy.md` completely");

--- a/apps/cli/src/__tests__/context-status.test.ts
+++ b/apps/cli/src/__tests__/context-status.test.ts
@@ -208,10 +208,11 @@ describe("Context integration layered status", () => {
   });
 
   it("keeps exact binding visible when live activation is unavailable", async () => {
+    const validate = vi.fn(async () => {
+      throw new Error("network timeout");
+    });
     const unavailable: ContextActivationValidator = {
-      validateMemberContextActivation: vi.fn(async () => {
-        throw new Error("network timeout");
-      }),
+      validateMemberContextActivation: validate,
     };
     const value = await inspectContextIntegrationStatus(driver(), unavailable, "/work/repo", {
       inspectRuntime: (runtimeDriver) => ({
@@ -238,8 +239,28 @@ describe("Context integration layered status", () => {
     expect(value.binding).toMatchObject({ state: "exact", organizationId: "org_acme" });
     expect(value.activation).toMatchObject({
       state: "unavailable",
-      message: expect.stringContaining("network timeout"),
+      reasonCode: "authority_timeout",
+      message: expect.stringContaining("timed out"),
     });
+    expect(validate).toHaveBeenCalledTimes(2);
+    expect(validate).toHaveBeenNthCalledWith(
+      1,
+      "org_acme",
+      {
+        schemaVersion: 1,
+        repositoryKey: "github.com/acme/repo",
+      },
+      { retry: false, timeoutMs: 5_000 },
+    );
+    expect(validate).toHaveBeenNthCalledWith(
+      2,
+      "org_acme",
+      {
+        schemaVersion: 1,
+        repositoryKey: "github.com/acme/repo",
+      },
+      { retry: false, timeoutMs: 5_000 },
+    );
   });
 });
 

--- a/apps/cli/src/__tests__/ensure-fresh-access-token.test.ts
+++ b/apps/cli/src/__tests__/ensure-fresh-access-token.test.ts
@@ -130,14 +130,83 @@ describe("ensureFreshAccessToken — safety margin", () => {
     await expect(ensureFreshAccessToken()).rejects.toThrow(/Re-run `first-tree-dev login/);
   });
 
-  it("throws a generic Error (not AuthRefreshFailedError) on non-401 failures so transient outages still retry", async () => {
+  it("preserves the refresh HTTP status on non-401 failures so callers can classify transient 5xx", async () => {
     const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
     await writeCredentials(stale);
 
     fetchMock.mockResolvedValue(new Response(null, { status: 503 }));
 
     const { ensureFreshAccessToken, AuthRefreshFailedError } = await import("../core/bootstrap.js");
-    await expect(ensureFreshAccessToken()).rejects.not.toThrow(AuthRefreshFailedError);
+    const error = await ensureFreshAccessToken().catch((caught) => caught);
+    expect(error).not.toBeInstanceOf(AuthRefreshFailedError);
+    expect(error).toMatchObject({ name: "AuthRefreshHttpError", statusCode: 503 });
+  });
+
+  it("propagates a caller deadline into refresh fetch and aborts the underlying request", async () => {
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
+    await writeCredentials(stale);
+    let refreshSignal: AbortSignal | undefined;
+    fetchMock.mockImplementation(
+      (_input: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          refreshSignal = init?.signal ?? undefined;
+          const rejectForAbort = () => {
+            reject(refreshSignal?.reason ?? new DOMException("This operation was aborted", "AbortError"));
+          };
+          if (refreshSignal?.aborted) rejectForAbort();
+          else refreshSignal?.addEventListener("abort", rejectForAbort, { once: true });
+        }),
+    );
+
+    const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
+    const caller = new AbortController();
+    const result = ensureFreshAccessToken({ signal: caller.signal });
+    await vi.waitFor(() => {
+      expect(refreshSignal).toBeDefined();
+    });
+
+    caller.abort(new DOMException("The operation timed out", "TimeoutError"));
+    await expect(result).rejects.toMatchObject({ name: "TimeoutError" });
+    await vi.waitFor(() => {
+      expect(refreshSignal?.aborted).toBe(true);
+    });
+  });
+
+  it("keeps a shared refresh alive while another deadline-bound caller still waits", async () => {
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
+    const refreshed = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+    let refreshSignal: AbortSignal | undefined;
+    let finishRefresh: (response: Response) => void = () => {};
+    fetchMock.mockImplementation(
+      (_input: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((resolve, reject) => {
+          refreshSignal = init?.signal ?? undefined;
+          finishRefresh = resolve;
+          refreshSignal?.addEventListener(
+            "abort",
+            () => reject(refreshSignal?.reason ?? new DOMException("This operation was aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+
+    const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
+    const firstCaller = new AbortController();
+    const secondCaller = new AbortController();
+    const first = ensureFreshAccessToken({ signal: firstCaller.signal });
+    const second = ensureFreshAccessToken({ signal: secondCaller.signal });
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    firstCaller.abort(new DOMException("The operation timed out", "TimeoutError"));
+    await expect(first).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(refreshSignal?.aborted).toBe(false);
+
+    finishRefresh(new Response(JSON.stringify({ accessToken: refreshed })));
+    await expect(second).resolves.toBe(refreshed);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("throws AuthRefreshRateLimitedError carrying server's Retry-After on 429", async () => {

--- a/apps/cli/src/core/bootstrap.ts
+++ b/apps/cli/src/core/bootstrap.ts
@@ -95,6 +95,16 @@ export class AuthRefreshRateLimitedError extends Error {
   }
 }
 
+class AuthRefreshHttpError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number) {
+    super(`Refresh request failed with status ${statusCode}.`);
+    this.name = "AuthRefreshHttpError";
+    this.statusCode = statusCode;
+  }
+}
+
 /**
  * Parse an HTTP `Retry-After` header. Accepts either an integer seconds
  * value (the form fastify-rate-limit emits) or an RFC 7231 HTTP-date.
@@ -114,13 +124,24 @@ function parseRetryAfterMs(header: string | null): number | null {
 }
 
 /**
- * In-flight refresh promise. Multiple callers (WS handshake, proactive
+ * In-flight refresh operation. Multiple callers (WS handshake, proactive
  * refresh timer, every SDK request) can see an expired token within the same
  * millisecond — without dedupe each would fire an independent `/auth/refresh`
  * round-trip and race to write `credentials.json`. Share one in-flight
- * promise so N concurrent callers resolve from a single HTTP call.
+ * request so N concurrent callers resolve from a single HTTP call.
+ *
+ * Each caller can still carry its own deadline. The underlying request is
+ * aborted once every waiter has abandoned it; one short-lived caller never
+ * aborts a refresh that another live caller still needs.
  */
-let inflightRefresh: Promise<string> | null = null;
+type InflightRefresh = {
+  controller: AbortController;
+  promise: Promise<string>;
+  settled: boolean;
+  waiters: number;
+};
+
+let inflightRefresh: InflightRefresh | null = null;
 
 /** Default freshness window for HTTP callers: refresh if token expires within 30s. */
 const DEFAULT_MIN_VALIDITY_MS = 30_000;
@@ -143,7 +164,8 @@ const DEFAULT_MIN_VALIDITY_MS = 30_000;
  * losing the sliding behaviour against that backend, not a correctness
  * regression.
  */
-export async function ensureFreshAccessToken(opts?: { minValidityMs?: number }): Promise<string> {
+export async function ensureFreshAccessToken(opts?: { minValidityMs?: number; signal?: AbortSignal }): Promise<string> {
+  opts?.signal?.throwIfAborted();
   const minValidityMs = opts?.minValidityMs ?? DEFAULT_MIN_VALIDITY_MS;
   const creds = loadCredentials();
   if (!creds) {
@@ -151,50 +173,110 @@ export async function ensureFreshAccessToken(opts?: { minValidityMs?: number }):
   }
 
   if (!isTokenStale(creds.accessToken, minValidityMs)) {
+    opts?.signal?.throwIfAborted();
     return creds.accessToken;
   }
 
-  if (inflightRefresh) {
-    return inflightRefresh;
+  if (!inflightRefresh) {
+    inflightRefresh = startRefresh(creds);
+  }
+  return waitForRefresh(inflightRefresh, opts?.signal);
+}
+
+function startRefresh(creds: StoredCredentials): InflightRefresh {
+  const controller = new AbortController();
+  const refresh: InflightRefresh = {
+    controller,
+    promise: Promise.resolve(""),
+    settled: false,
+    waiters: 0,
+  };
+
+  refresh.promise = performRefresh(creds, controller.signal).finally(() => {
+    refresh.settled = true;
+    if (inflightRefresh === refresh) {
+      inflightRefresh = null;
+    }
+  });
+  return refresh;
+}
+
+async function performRefresh(creds: StoredCredentials, cancellation: AbortSignal): Promise<string> {
+  const signal = AbortSignal.any([cancellation, AbortSignal.timeout(10_000)]);
+  const res = await cliFetch(`${creds.serverUrl}/api/v1/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken: creds.refreshToken }),
+    signal,
+  });
+
+  if (res.status === 401) {
+    throw new AuthRefreshFailedError(
+      `Refresh token rejected by server. Re-run \`${channelConfig.binName} login <code>\` ` +
+        "(get a fresh token from the Web Computers page → New Connection).",
+    );
+  }
+  if (res.status === 429) {
+    const retryAfterMs = parseRetryAfterMs(res.headers.get("retry-after")) ?? 30_000;
+    throw new AuthRefreshRateLimitedError(retryAfterMs);
+  }
+  if (!res.ok) {
+    throw new AuthRefreshHttpError(res.status);
   }
 
-  inflightRefresh = (async () => {
-    const res = await cliFetch(`${creds.serverUrl}/api/v1/auth/refresh`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ refreshToken: creds.refreshToken }),
-      signal: AbortSignal.timeout(10_000),
-    });
+  const data = (await res.json()) as { accessToken: string; refreshToken?: string };
+  saveCredentials({
+    ...creds,
+    accessToken: data.accessToken,
+    // Older servers won't echo a rotated refreshToken back — keep the existing one.
+    refreshToken: data.refreshToken ?? creds.refreshToken,
+  });
+  return data.accessToken;
+}
 
-    if (res.status === 401) {
-      throw new AuthRefreshFailedError(
-        `Refresh token rejected by server. Re-run \`${channelConfig.binName} login <code>\` ` +
-          "(get a fresh token from the Web Computers page → New Connection).",
-      );
-    }
-    if (res.status === 429) {
-      const retryAfterMs = parseRetryAfterMs(res.headers.get("retry-after")) ?? 30_000;
-      throw new AuthRefreshRateLimitedError(retryAfterMs);
-    }
-    if (!res.ok) {
-      throw new Error(`Refresh request failed with status ${res.status}.`);
-    }
-
-    const data = (await res.json()) as { accessToken: string; refreshToken?: string };
-    saveCredentials({
-      ...creds,
-      accessToken: data.accessToken,
-      // Older servers won't echo a rotated refreshToken back — keep the existing one.
-      refreshToken: data.refreshToken ?? creds.refreshToken,
-    });
-    return data.accessToken;
-  })();
-
+async function waitForRefresh(refresh: InflightRefresh, signal: AbortSignal | undefined): Promise<string> {
+  refresh.waiters++;
   try {
-    return await inflightRefresh;
+    if (!signal) return await refresh.promise;
+    signal.throwIfAborted();
+    return await waitForPromiseWithSignal(refresh.promise, signal);
   } finally {
-    inflightRefresh = null;
+    refresh.waiters--;
+    if (signal?.aborted && refresh.waiters === 0 && !refresh.settled) {
+      if (inflightRefresh === refresh) {
+        inflightRefresh = null;
+      }
+      refresh.controller.abort(signal.reason);
+    }
   }
+}
+
+function waitForPromiseWithSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+    const onAbort = () => {
+      finish(() => reject(signal.reason ?? new DOMException("This operation was aborted", "AbortError")));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        finish(() => resolve(value));
+      },
+      (error: unknown) => {
+        finish(() => reject(error));
+      },
+    );
+    if (signal.aborted) onAbort();
+  });
 }
 
 /** Back-compat alias retained so existing call sites keep compiling. */

--- a/apps/cli/src/core/context-integration/activation.ts
+++ b/apps/cli/src/core/context-integration/activation.ts
@@ -3,19 +3,15 @@ import type {
   ContextIntegrationBinding,
   ContextIntegrationProvider,
 } from "@first-tree/shared";
+import {
+  type ContextActivationValidator,
+  type ExternalContextAuthorityMode,
+  validateExternalContextAuthority,
+} from "./authority.js";
 import { inspectContextClientPreflight } from "./client-preflight.js";
 import { findContextBinding } from "./context-binding-store.js";
 
-export type ContextActivationValidator = {
-  validateMemberContextActivation(
-    organizationId: string,
-    data: {
-      schemaVersion: 1;
-      repositoryKey: string;
-    },
-    options: { retry: false; timeoutMs: number },
-  ): Promise<ContextActivationResponse>;
-};
+export type { ContextActivationValidator } from "./authority.js";
 
 type ConnectedContextActivationResponse = Extract<ContextActivationResponse, { outcome: "connected" }>;
 
@@ -37,6 +33,9 @@ export async function activateExternalContext(
   dependencies: {
     inspect?: typeof inspectContextClientPreflight;
     findBinding?: typeof findContextBinding;
+  } = {},
+  options: {
+    authorityMode?: ExternalContextAuthorityMode;
   } = {},
 ): Promise<ExternalContextActivation> {
   const inspect = dependencies.inspect ?? inspectContextClientPreflight;
@@ -73,24 +72,16 @@ export async function activateExternalContext(
     };
   }
 
-  let response: ContextActivationResponse;
-  try {
-    response = await validator.validateMemberContextActivation(
-      binding.organizationId,
-      {
-        schemaVersion: 1,
-        repositoryKey: binding.repositoryKey,
-      },
-      { retry: false, timeoutMs: 2_000 },
-    );
-  } catch {
-    return {
-      outcome: "unavailable",
-      reasonCode: "authority_unavailable",
-      systemMessage:
-        "First Tree Context is temporarily unavailable. Normal coding can continue; no cached Team authority was used.",
-    };
+  const authority = await validateExternalContextAuthority(
+    validator,
+    binding.organizationId,
+    binding.repositoryKey,
+    options.authorityMode ?? "session-start",
+  );
+  if (authority.outcome === "unavailable") {
+    return authority;
   }
+  const response = authority.response;
 
   if (response.outcome === "disabled") {
     return {
@@ -159,7 +150,9 @@ export async function requireConnectedExternalContext(
   team: ConnectedContextActivationResponse["team"];
   binding: ContextIntegrationBinding;
 }> {
-  const activation = await activateExternalContext(validator, input, dependencies);
+  const activation = await activateExternalContext(validator, input, dependencies, {
+    authorityMode: "explicit",
+  });
   if (activation.outcome !== "connected") {
     throw new ExternalContextActivationRequiredError(
       activation.outcome,

--- a/apps/cli/src/core/context-integration/authority.ts
+++ b/apps/cli/src/core/context-integration/authority.ts
@@ -1,0 +1,181 @@
+import type { ContextActivationResponse } from "@first-tree/shared";
+import { classifyCliTransportError } from "../transport-error.js";
+
+export type ContextActivationValidator = {
+  validateMemberContextActivation(
+    organizationId: string,
+    data: {
+      schemaVersion: 1;
+      repositoryKey: string;
+    },
+    options: { retry: false; timeoutMs: number },
+  ): Promise<ContextActivationResponse>;
+};
+
+export type ExternalContextAuthorityMode = "session-start" | "explicit";
+
+export type ExternalContextAuthorityUnavailable = {
+  outcome: "unavailable";
+  reasonCode:
+    | "authority_authentication_required"
+    | "authority_forbidden"
+    | "authority_network_error"
+    | "authority_request_rejected"
+    | "authority_server_error"
+    | "authority_timeout"
+    | "authority_unavailable";
+  systemMessage: string;
+};
+
+export type ExternalContextAuthorityResult =
+  | {
+      outcome: "validated";
+      response: ContextActivationResponse;
+    }
+  | ExternalContextAuthorityUnavailable;
+
+const AUTHORITY_POLICIES: Record<
+  ExternalContextAuthorityMode,
+  {
+    attempts: 1 | 2;
+    timeoutMs: number;
+  }
+> = {
+  "session-start": {
+    attempts: 1,
+    timeoutMs: 2_000,
+  },
+  explicit: {
+    attempts: 2,
+    timeoutMs: 5_000,
+  },
+};
+
+/**
+ * Perform one logical live-authority check.
+ *
+ * SessionStart stays latency-bounded and never retries. Explicit user/Skill
+ * operations get one retry against the same exact Team + repository only for
+ * transport timeouts, network failures, and HTTP 5xx responses.
+ */
+export async function validateExternalContextAuthority(
+  validator: ContextActivationValidator,
+  organizationId: string,
+  repositoryKey: string,
+  mode: ExternalContextAuthorityMode,
+): Promise<ExternalContextAuthorityResult> {
+  const policy = AUTHORITY_POLICIES[mode];
+  let failure: ClassifiedAuthorityFailure | undefined;
+  for (let attempt = 0; attempt < policy.attempts; attempt++) {
+    try {
+      const response = await validator.validateMemberContextActivation(
+        organizationId,
+        {
+          schemaVersion: 1,
+          repositoryKey,
+        },
+        { retry: false, timeoutMs: policy.timeoutMs },
+      );
+      return {
+        outcome: "validated",
+        response,
+      };
+    } catch (error) {
+      failure = classifyAuthorityFailure(error);
+      if (!failure.retryable) break;
+    }
+  }
+  return (failure ?? classifyAuthorityFailure(undefined)).result;
+}
+
+type ClassifiedAuthorityFailure = {
+  result: ExternalContextAuthorityUnavailable;
+  retryable: boolean;
+};
+
+function classifyAuthorityFailure(error: unknown): ClassifiedAuthorityFailure {
+  const statusCode = errorNumberField(error, "statusCode");
+  const errorName = errorStringField(error, "name");
+  if (statusCode === 401 || errorName === "AuthRefreshFailedError") {
+    return terminalFailure(
+      "authority_authentication_required",
+      "First Tree Context authority requires a fresh First Tree login. No cached Team authority was used.",
+    );
+  }
+  if (statusCode === 403) {
+    return terminalFailure(
+      "authority_forbidden",
+      "First Tree Context authority was denied for the bound Team. No cached Team authority was used.",
+    );
+  }
+  if (statusCode !== undefined && statusCode >= 500) {
+    return transientFailure(
+      "authority_server_error",
+      "First Tree Context authority service returned a temporary server error. Normal coding can continue; no cached Team authority was used.",
+    );
+  }
+  if ((statusCode !== undefined && statusCode >= 400) || errorName === "AuthRefreshRateLimitedError") {
+    return terminalFailure(
+      "authority_request_rejected",
+      "First Tree Context authority request was rejected. No cached Team authority was used.",
+    );
+  }
+
+  const transportCategory = classifyCliTransportError(error);
+  if (transportCategory === "timeout") {
+    return transientFailure(
+      "authority_timeout",
+      "First Tree Context authority check timed out. Normal coding can continue; no cached Team authority was used.",
+    );
+  }
+  if (transportCategory === "connection") {
+    return transientFailure(
+      "authority_network_error",
+      "First Tree Context authority service could not be reached. Normal coding can continue; no cached Team authority was used.",
+    );
+  }
+  return terminalFailure(
+    "authority_unavailable",
+    "First Tree Context is temporarily unavailable. Normal coding can continue; no cached Team authority was used.",
+  );
+}
+
+function transientFailure(
+  reasonCode: ExternalContextAuthorityUnavailable["reasonCode"],
+  systemMessage: string,
+): ClassifiedAuthorityFailure {
+  return {
+    retryable: true,
+    result: {
+      outcome: "unavailable",
+      reasonCode,
+      systemMessage,
+    },
+  };
+}
+
+function terminalFailure(
+  reasonCode: ExternalContextAuthorityUnavailable["reasonCode"],
+  systemMessage: string,
+): ClassifiedAuthorityFailure {
+  return {
+    retryable: false,
+    result: {
+      outcome: "unavailable",
+      reasonCode,
+      systemMessage,
+    },
+  };
+}
+
+function errorNumberField(error: unknown, field: string): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const value = Reflect.get(error, field);
+  return typeof value === "number" ? value : undefined;
+}
+
+function errorStringField(error: unknown, field: string): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const value = Reflect.get(error, field);
+  return typeof value === "string" ? value : undefined;
+}

--- a/apps/cli/src/core/context-integration/status.ts
+++ b/apps/cli/src/core/context-integration/status.ts
@@ -6,6 +6,7 @@ import type {
 import semver from "semver";
 import { channelConfig } from "../channel.js";
 import type { ContextActivationValidator } from "./activation.js";
+import { validateExternalContextAuthority } from "./authority.js";
 import {
   ContextClientPreflightError,
   type ContextClientPreflightErrorCode,
@@ -70,6 +71,7 @@ type LiveActivationStatus =
     }
   | {
       state: "unavailable";
+      reasonCode: string;
       message: string;
       nextAction: string;
     }
@@ -233,39 +235,29 @@ export async function inspectContextIntegrationStatus(
     organizationId: binding.organizationId,
     repositoryKey: binding.repositoryKey,
   };
-  try {
-    const response = await validator.validateMemberContextActivation(
-      binding.organizationId,
-      {
-        schemaVersion: 1,
-        repositoryKey: binding.repositoryKey,
-      },
-      { retry: false, timeoutMs: 2_000 },
-    );
-    return {
-      provider: providerStatus,
-      plugin: pluginStatus,
-      hook,
-      runtime,
-      checkout,
-      binding: bindingStatus,
-      activation: activationStatus(response),
-    };
-  } catch (error) {
-    return {
-      provider: providerStatus,
-      plugin: pluginStatus,
-      hook,
-      runtime,
-      checkout,
-      binding: bindingStatus,
-      activation: {
-        state: "unavailable",
-        message: `First Tree live activation could not be checked: ${message(error)}`,
-        nextAction: `Check the First Tree connection and rerun \`${channelConfig.binName} context status --provider ${driver.provider}\`.`,
-      },
-    };
-  }
+  const authority = await validateExternalContextAuthority(
+    validator,
+    binding.organizationId,
+    binding.repositoryKey,
+    "explicit",
+  );
+  return {
+    provider: providerStatus,
+    plugin: pluginStatus,
+    hook,
+    runtime,
+    checkout,
+    binding: bindingStatus,
+    activation:
+      authority.outcome === "validated"
+        ? activationStatus(authority.response)
+        : {
+            state: "unavailable",
+            reasonCode: authority.reasonCode,
+            message: authority.systemMessage,
+            nextAction: `Check the First Tree connection and rerun \`${channelConfig.binName} context status --provider ${driver.provider}\`.`,
+          },
+  };
 }
 
 function inspectProviderHook(

--- a/apps/cli/src/core/context-tree-binding.ts
+++ b/apps/cli/src/core/context-tree-binding.ts
@@ -1,6 +1,7 @@
 import { createLogger, SdkError } from "@first-tree/client";
 import { contextTreeActiveBindingSchema, contextTreeInfoSchema } from "@first-tree/shared";
 import { AuthRefreshFailedError } from "./bootstrap.js";
+import { classifyCliTransportError } from "./transport-error.js";
 
 export type ContextTreeBindingResult =
   | { status: "bound"; repo: string; branch: string }
@@ -35,21 +36,6 @@ type ContextTreeUnreadableOptions = {
   exitCode: 1 | 3 | 6;
   httpStatus?: number;
 };
-
-const CONNECTION_ERROR_CODES = new Set([
-  "EAI_AGAIN",
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "EHOSTUNREACH",
-  "ENETDOWN",
-  "ENETUNREACH",
-  "ENOTFOUND",
-  "EPIPE",
-  "ETIMEDOUT",
-  "UND_ERR_CONNECT_TIMEOUT",
-  "UND_ERR_HEADERS_TIMEOUT",
-  "UND_ERR_SOCKET",
-]);
 
 export class ContextTreeUnreadableError extends Error {
   readonly code = "CONTEXT_TREE_UNREADABLE";
@@ -180,7 +166,7 @@ export function classifyContextTreeReadError(error: unknown): ContextTreeUnreada
     );
   }
 
-  const transportCategory = classifyTransportError(error);
+  const transportCategory = classifyCliTransportError(error);
   if (transportCategory === "timeout") {
     return new ContextTreeUnreadableError("Timed out while reading the Context Tree binding.", {
       category: "timeout",
@@ -205,48 +191,6 @@ function invalidResponseError(): ContextTreeUnreadableError {
     category: "invalid-response",
     exitCode: 1,
   });
-}
-
-function classifyTransportError(error: unknown): "connection" | "timeout" | null {
-  let current: unknown = error;
-  let sawConnectionError = false;
-
-  for (let depth = 0; depth < 6 && current !== undefined && current !== null; depth++) {
-    const name = readStringProperty(current, "name");
-    const code = readStringProperty(current, "code");
-    const message = readStringProperty(current, "message");
-
-    if (
-      name === "AbortError" ||
-      name === "TimeoutError" ||
-      code === "ERR_ABORTED" ||
-      code?.includes("TIMEOUT") ||
-      message?.toLowerCase().includes("timed out") ||
-      message?.toLowerCase().includes("timeout")
-    ) {
-      return "timeout";
-    }
-    if (code && CONNECTION_ERROR_CODES.has(code)) {
-      if (code === "ETIMEDOUT") return "timeout";
-      sawConnectionError = true;
-    }
-    if (message?.toLowerCase().includes("fetch failed")) {
-      sawConnectionError = true;
-    }
-    if (current instanceof TypeError && hasProperty(current, "cause")) {
-      sawConnectionError = true;
-    }
-
-    current = readProperty(current, "cause");
-  }
-
-  return sawConnectionError ? "connection" : null;
-}
-
-function hasProperty(value: unknown, property: string): boolean {
-  return (typeof value === "object" && value !== null) || typeof value === "function"
-    ? Reflect.has(value, property)
-    : false;
 }
 
 function readProperty(value: unknown, property: string): unknown {

--- a/apps/cli/src/core/transport-error.ts
+++ b/apps/cli/src/core/transport-error.ts
@@ -1,0 +1,78 @@
+const CONNECTION_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+export type CliTransportErrorCategory = "connection" | "timeout";
+
+/**
+ * Classify Node/undici transport failures without exposing their messages.
+ *
+ * Keep this as the CLI's single transport taxonomy for Context bootstrap and
+ * authority paths. The cause walk handles undici's `TypeError("fetch
+ * failed").cause` shape while the explicit code set also covers bare DNS/TCP
+ * errors that have no outer fetch message.
+ */
+export function classifyCliTransportError(error: unknown): CliTransportErrorCategory | null {
+  let current: unknown = error;
+  let sawConnectionError = false;
+
+  for (let depth = 0; depth < 6 && current !== undefined && current !== null; depth++) {
+    const name = readStringProperty(current, "name");
+    const code = readStringProperty(current, "code");
+    const message = readStringProperty(current, "message");
+    const normalizedMessage = message?.toLowerCase();
+
+    if (
+      name === "AbortError" ||
+      name === "TimeoutError" ||
+      code === "ERR_ABORTED" ||
+      code?.includes("TIMEOUT") ||
+      normalizedMessage?.includes("timed out") ||
+      normalizedMessage?.includes("timeout")
+    ) {
+      return "timeout";
+    }
+    if (code && CONNECTION_ERROR_CODES.has(code)) {
+      if (code === "ECONNABORTED" || code === "ETIMEDOUT") return "timeout";
+      sawConnectionError = true;
+    }
+    if (normalizedMessage?.includes("fetch failed")) {
+      sawConnectionError = true;
+    }
+    if (current instanceof TypeError && hasProperty(current, "cause")) {
+      sawConnectionError = true;
+    }
+
+    current = readProperty(current, "cause");
+  }
+
+  return sawConnectionError ? "connection" : null;
+}
+
+function hasProperty(value: unknown, property: string): boolean {
+  return (typeof value === "object" && value !== null) || typeof value === "function"
+    ? Reflect.has(value, property)
+    : false;
+}
+
+function readProperty(value: unknown, property: string): unknown {
+  if ((typeof value !== "object" || value === null) && typeof value !== "function") return undefined;
+  return Reflect.get(value, property);
+}
+
+function readStringProperty(value: unknown, property: string): string | undefined {
+  const result = readProperty(value, property);
+  return typeof result === "string" ? result : undefined;
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1092,14 +1092,23 @@ when nothing still uses it. Provider-native hook trust remains provider-owned.
 
 `context activate` is an internal SessionStart bridge and is intentionally
 hidden from help. It always allows the provider session to continue, even when
-First Tree is offline or activation fails.
+First Tree is offline or activation fails. Its single two-second authority
+attempt covers both access-token refresh and the validator request, and runs
+inside a five-second provider hook budget so First Tree can return a controlled
+unavailable result instead of being terminated by the provider.
 
 The external Plugin also uses hidden `context read` and `context write`
 bridges. They do not accept `--team`: each derives Team from the exact current
 provider + checkout binding, repeats live membership and selected-Team
 repository validation, and only then delegates to the ordinary `tree read` or
-`tree write` implementation. Managed and clean explicit-Team callers continue
-to use the public `tree` commands directly.
+`tree write` implementation. Status and these explicit routes use five-second
+authority attempts covering token refresh plus validation, and retry the same
+exact Team + repository once only after a timeout, network failure, or HTTP 5xx
+response. Authentication, authorization, binding, scope, and typed disabled
+results do not retry.
+Failures retain stable timeout, network, server, or rejection reason codes
+without using cached authority. Managed and clean explicit-Team callers
+continue to use the public `tree` commands directly.
 
 ---
 

--- a/docs/context-integration.md
+++ b/docs/context-integration.md
@@ -42,6 +42,16 @@ manifest also records both adapter digests and the canonical Policy digest.
   push, and PR/MR creation.
 - Activation failure never blocks ordinary provider work and never falls back
   to another Team or cached authority.
+- SessionStart uses one non-retrying two-second live-authority attempt covering
+  access-token refresh and the validator request inside a five-second provider
+  hook budget, so timeout or network failure can return a controlled
+  unavailable envelope instead of being killed by the provider. Explicit
+  status, Read, and Write activation use a five-second attempt covering the
+  same two stages and retry the same exact Team + repository once only for
+  timeout, network, or HTTP 5xx failures. Authentication, authorization,
+  binding, scope, and typed disabled results never retry. Failures expose
+  stable timeout, network, server, or rejection reason codes without returning
+  cached authority.
 - Read does not depend on Reviewer readiness. A new official Write fails before
   remote mutation when Automatic Review is absent, disabled, structurally
   incomplete, or offline.

--- a/packages/client/src/__tests__/sdk-context-activation.test.ts
+++ b/packages/client/src/__tests__/sdk-context-activation.test.ts
@@ -48,6 +48,48 @@ describe("SDK Context activation", () => {
     );
   });
 
+  it("uses one attempt signal for token acquisition and the activation request", async () => {
+    let tokenSignal: AbortSignal | undefined;
+    const getAccessToken = vi.fn((options?: { signal?: AbortSignal }) => {
+      tokenSignal = options?.signal;
+      return "member-token";
+    });
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      expect(init?.signal).toBe(tokenSignal);
+      return new Response(
+        JSON.stringify({
+          schemaVersion: 1,
+          outcome: "connected",
+          team: {
+            organizationId: "org_acme",
+            displayName: "Acme",
+            role: "member",
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const sdk = new FirstTreeHubSDK({
+      serverUrl: "https://first-tree.example",
+      getAccessToken,
+    });
+
+    await expect(
+      sdk.validateMemberContextActivation(
+        "org_acme",
+        {
+          schemaVersion: 1,
+          repositoryKey: "github.com/acme/payments",
+        },
+        { retry: false, timeoutMs: 5_000 },
+      ),
+    ).resolves.toMatchObject({ outcome: "connected" });
+    expect(tokenSignal).toBeInstanceOf(AbortSignal);
+    expect(getAccessToken).toHaveBeenCalledWith({ signal: tokenSignal });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("fails on an unknown Server outcome", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -79,7 +79,7 @@ import { createLogger } from "./observability/logger.js";
  * proactive-refresh path would reuse a cached token that is about to expire
  * and immediately get kicked off with `auth:expired`.
  */
-export type AccessTokenProvider = (opts?: { minValidityMs?: number }) => string | Promise<string>;
+export type AccessTokenProvider = (opts?: { minValidityMs?: number; signal?: AbortSignal }) => string | Promise<string>;
 export type RuntimeSessionTokenProvider = () => string | undefined;
 
 export type SdkConfig = {
@@ -1038,7 +1038,11 @@ export class FirstTreeHubSDK {
 
   private async doFetchOnce(path: string, init?: RequestInit, opts?: SdkCallOptions): Promise<Response> {
     const url = `${this._baseUrl}${path}`;
-    const token = await this.getAccessToken();
+    const timeout = AbortSignal.timeout(opts?.timeoutMs ?? FETCH_TIMEOUT_MS);
+    const signal = init?.signal ? AbortSignal.any([init.signal, timeout]) : timeout;
+    signal.throwIfAborted();
+    const token = await this.getAccessToken({ signal });
+    signal.throwIfAborted();
     const headers: Record<string, string> = {
       Authorization: `Bearer ${token}`,
     };
@@ -1063,8 +1067,6 @@ export class FirstTreeHubSDK {
     if (init?.headers) {
       Object.assign(headers, init.headers as Record<string, string>);
     }
-    const timeout = AbortSignal.timeout(opts?.timeoutMs ?? FETCH_TIMEOUT_MS);
-    const signal = init?.signal ? AbortSignal.any([init.signal, timeout]) : timeout;
     return fetch(url, { ...init, headers, signal });
   }
 

--- a/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
+++ b/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
@@ -1,0 +1,80 @@
+---
+id: runtime-external-byo-context-activation-resilience
+description: Validate fail-closed BYO Context activation across provider hooks and explicit CLI operations under transient authority failures.
+areas: [runtime]
+surfaces: [cli, client]
+---
+
+# External BYO Context Activation Resilience
+
+## Goal
+
+Confirm that a user-scoped Claude Code or Codex Context Plugin activates only for
+the exact enabled checkout, remains within the provider hook's execution budget,
+and gives explicit Context operations a bounded recovery path when live authority
+is temporarily slow or unavailable.
+
+Use this case for release qualification when SessionStart behavior, activation
+latency, or live authority resilience changes. Stable retry classification and
+timeout values belong in product tests; this case validates the real provider,
+installed Plugin, CLI artifact, network boundary, and user-visible behavior
+together.
+
+## Preconditions
+
+- Run the target release artifact in an isolated QA cell with a real supported
+  Claude Code or Codex provider bridge.
+- Install the Context Plugin through the real user-scope lifecycle and enable it
+  for one exact source checkout through a Team-scoped handoff.
+- Keep a second checkout of the same repository unbound as a negative control.
+- Use only throwaway Team/repository data and credentials. Do not reuse or mutate
+  an operator's Plugin installation, account state, or checkout binding.
+- Establish provider readiness with `runtime-provider-readiness` before treating
+  a hook transcript as product evidence.
+
+## Operate And Observe
+
+- Start, resume, clear, and compact a provider session in the bound checkout.
+  Observe the real SessionStart hook transcript and measure end-to-end hook time.
+- Repeat in the unbound checkout and confirm no Team Context is injected.
+- Exercise `context status`, guarded Read, and guarded Write preflight through the
+  shipped CLI artifact while the activation endpoint is healthy.
+- Repeat with an access token that requires refresh. Introduce slow refresh,
+  refresh-network, and refresh-5xx conditions and confirm they consume the same
+  per-attempt budget and retry policy as the validator request rather than
+  extending the operation behind the provider hook.
+- Introduce controlled transient authority conditions for timeout, network
+  failure, and server 5xx. Verify an explicit operation retries only the same
+  exact Team and repository, at most once, and reports a stable safe reason if it
+  still cannot activate.
+- Introduce authentication/authorization failure, a client 4xx, revoked
+  membership, and repository-scope removal. Verify these do not retry as
+  transient failures and do not fall back to another Team or cached authority.
+- Make live authority slower than the SessionStart internal budget. Confirm the
+  provider hook completes within its outer budget with a controlled unavailable
+  result, normal coding remains usable, and no Context is injected.
+
+Record provider version, Plugin release digest, bound checkout identity, exact
+Team identifier, hook transcript, operation output, endpoint fault used, attempt
+count, and latency. Redact credentials and private Context content.
+
+## Expected Result
+
+`PASS`: bound healthy sessions inject the exact Team Context; unbound sessions
+remain inactive; SessionStart always returns within the provider hook budget;
+explicit operations make only the allowed same-target transient retry; and every
+unresolved authority failure remains fail closed with a stable actionable
+classification.
+
+`FAIL`: a hook is killed by its outer timeout under a valid supported latency
+condition, an explicit operation exceeds its retry bound, a non-transient failure
+is retried, cached or alternate-Team authority is used, or unavailable authority
+still permits Read/Write.
+
+`BLOCKED`: the provider cannot be made one-turn-ready, the Plugin cannot be
+installed in the isolated environment, or controlled authority faults cannot be
+introduced without changing shared production state.
+
+`INCONCLUSIVE`: timing or retry evidence is incomplete, the failure cannot be
+attributed to the target release, or provider and authority failures overlap in a
+way that prevents classification.

--- a/scripts/build-context-integration-bundle.mjs
+++ b/scripts/build-context-integration-bundle.mjs
@@ -363,7 +363,7 @@ function writeSessionStartHook(pluginRoot, provider) {
                 provider === "codex"
                   ? `"\${PLUGIN_ROOT}/bin/context-session-start" --release-digest __RELEASE_DIGEST__`
                   : `"\${CLAUDE_PLUGIN_ROOT}/bin/context-session-start" --release-digest __RELEASE_DIGEST__`,
-              timeout: 3,
+              timeout: 5,
               statusMessage: "Connecting First Tree Context",
               additionalContextLimit: 2048,
             },


### PR DESCRIPTION
## Summary

- give Claude Code and Codex SessionStart hooks a 5-second outer budget while keeping live authority to one 2-second, non-retrying attempt
- give explicit Context status/read/write operations two 5-second attempts, retrying only timeout, network, and HTTP 5xx failures against the same exact Team and repository
- apply each attempt deadline across access-token refresh and activation validation, including cancellation-aware shared refresh handling
- centralize CLI transport classification, preserve stable fail-closed reason codes, and document the runtime contract
- add deterministic regression coverage and a reusable provider-backed QA case

## Safety boundaries

- no cached authority or alternate-Team fallback
- authentication, authorization, HTTP 4xx, binding/scope, and typed disabled outcomes do not retry
- ordinary provider coding continues when SessionStart authority is unavailable
- this PR does not change CLI channel-name selection or Codex hook-trust status UX

## Validation

- `pnpm --filter first-tree-dev exec vitest run src/__tests__/context-activation.test.ts src/__tests__/context-bundle-manifest.test.ts src/__tests__/ensure-fresh-access-token.test.ts src/__tests__/context-tree-binding-core.test.ts --maxWorkers=2` (69 passed)
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/sdk-context-activation.test.ts --maxWorkers=2` (4 passed)
- `pnpm --filter first-tree-dev typecheck`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter first-tree-dev build`
- `pnpm --filter @first-tree/client build`
- `pnpm check` (passes with existing warnings)
- `pnpm typecheck` (11/11 tasks)
- `git diff --check`

## QA

Formal provider-backed QA is warranted before release. The new `runtime-external-byo-context-activation-resilience` case covers real Claude Code/Codex SessionStart lifecycle events, stale-token refresh, transient authority fault injection, exact-checkout fail-closed behavior, and latency evidence.
