### PR TITLE
feat(web): add personal Context access under tree setup

### DIFF
--- a/packages/web/src/lib/byo-setup-prompt.ts
+++ b/packages/web/src/lib/byo-setup-prompt.ts
@@ -1,0 +1,103 @@
+import type { ContextEnablementHandoff, ContextIntegrationProvider } from "@first-tree/shared";
+
+export type ByoSetupPromptIntent = "onboarding" | "settings";
+
+type ByoSetupPromptBase = {
+  organizationId: string;
+  bootstrapCommand: string;
+};
+
+export type BuildByoSetupPromptOptions =
+  | (ByoSetupPromptBase & {
+      intent: "onboarding";
+      handoffs: readonly [ContextEnablementHandoff];
+    })
+  | (ByoSetupPromptBase & {
+      intent: "settings";
+      handoffs: readonly [ContextEnablementHandoff, ContextEnablementHandoff];
+    });
+
+const PROVIDER_LABELS: Record<ContextIntegrationProvider, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+};
+
+/**
+ * Builds the single self-contained artifact shared by Member onboarding and
+ * Settings. The Server remains authoritative for both the short-lived machine
+ * bootstrap and each exact-Team provider command; this renderer adds no flags
+ * and never asks the user to assemble the steps themselves.
+ */
+export function buildByoSetupPrompt({
+  organizationId,
+  bootstrapCommand,
+  handoffs,
+  intent,
+}: BuildByoSetupPromptOptions): string {
+  if (!bootstrapCommand.trim()) {
+    throw new Error("BYO setup requires a server-authored bootstrap command");
+  }
+  const providers = new Set<ContextIntegrationProvider>();
+  for (const handoff of handoffs) {
+    if (handoff.organizationId !== organizationId || !handoff.command.trim()) {
+      throw new Error("BYO setup handoffs must describe the expected Team and provider");
+    }
+    if (providers.has(handoff.provider)) {
+      throw new Error("BYO setup cannot contain duplicate provider handoffs");
+    }
+    providers.add(handoff.provider);
+  }
+  if (intent === "settings" && (!providers.has("claude-code") || !providers.has("codex"))) {
+    throw new Error("Settings BYO setup requires one handoff for each supported provider");
+  }
+
+  const providerNames = handoffs.map((handoff) => PROVIDER_LABELS[handoff.provider]);
+  const target =
+    providerNames.length === 1
+      ? providerNames[0]
+      : `${providerNames.slice(0, -1).join(", ")} or ${providerNames.at(-1)}`;
+  const commandInstructions =
+    handoffs.length === 1
+      ? [
+          `Then enable Team Context for this exact repository checkout with the server-provided ${providerNames[0]} command:`,
+          "",
+          handoffs[0]?.command ?? "",
+        ]
+      : [
+          "Then use exactly one of these server-provided commands, matching the coding agent you are currently running in. Do not run both and do not add, remove, or change command flags.",
+          "",
+          ...handoffs.flatMap((handoff, index) => [
+            `If you are ${PROVIDER_LABELS[handoff.provider]}:`,
+            handoff.command,
+            ...(index === handoffs.length - 1 ? [] : [""]),
+          ]),
+        ];
+  const completion =
+    intent === "onboarding"
+      ? "Only tell me setup is ready after First Tree verifies the provider integration, the exact-checkout Team binding, live Team Context activation, and that onboarding completion has been recorded."
+      : "After First Tree verifies the provider integration, the exact-checkout Team binding, and live Team Context activation, tell me the exact next step for starting a fresh coding-agent session. Do not mark onboarding complete.";
+
+  return [
+    `Set up First Tree Team Context for this repository in ${target}.`,
+    "",
+    "Complete the whole setup inside this coding-agent session. Do not ask me to open Terminal.",
+    "",
+    "First inspect this machine locally. If First Tree is missing or this computer is not signed in to my First Tree account, use this server-provided bootstrap:",
+    "",
+    bootstrapCommand,
+    "",
+    ...commandInstructions,
+    "",
+    `Target Team ID: ${organizationId}`,
+    "",
+    "Run the enable command from this repository's root. If this session is not at the repository root, stop and tell me where to reopen it. If First Tree detects a different local account, ask me before switching. Do not create a First Tree agent or open First Tree Chat, and do not modify repository files.",
+    ...(providers.has("codex")
+      ? [
+          "",
+          "If Codex requires First Tree hook approval, guide me through /hooks in Codex and then continue verification. Do not report success before the hook is trusted.",
+        ]
+      : []),
+    "",
+    completion,
+  ].join("\n");
+}

--- a/packages/web/src/lib/byo-setup-prompt.ts
+++ b/packages/web/src/lib/byo-setup-prompt.ts
@@ -74,7 +74,7 @@ export function buildByoSetupPrompt({
         ];
   const completion =
     intent === "onboarding"
-      ? "Only tell me setup is ready after First Tree verifies the provider integration, the exact-checkout Team binding, live Team Context activation, and that onboarding completion has been recorded."
+      ? "Only tell me setup is ready after First Tree verifies the provider integration, the exact-checkout Team binding, and live Team Context activation. First Tree Web owns onboarding completion separately."
       : "After First Tree verifies the provider integration, the exact-checkout Team binding, and live Team Context activation, tell me the exact next step for starting a fresh coding-agent session. Do not mark onboarding complete.";
 
   return [

--- a/packages/web/src/pages/__tests__/context-enablement.test.tsx
+++ b/packages/web/src/pages/__tests__/context-enablement.test.tsx
@@ -5,7 +5,7 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildByoSetupPrompt } from "../../lib/byo-setup-prompt.js";
-import { ContextEnablement, ContextPersonalAccess } from "../settings/context-enablement.js";
+import { ContextPersonalAccess, OnboardingContextPersonalAccess } from "../settings/context-enablement.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -14,7 +14,7 @@ const apiMocks = vi.hoisted(() => ({ getContextEnablementHandoff: vi.fn() }));
 vi.mock("../../api/activity.js", () => activityMocks);
 vi.mock("../../api/context-enablement.js", () => apiMocks);
 
-describe("ContextEnablement", () => {
+describe("personal Context access", () => {
   let host: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
@@ -47,12 +47,12 @@ describe("ContextEnablement", () => {
     vi.clearAllMocks();
   });
 
-  async function render(props: { teamRole: string; ready: boolean; computerConnected: boolean }) {
+  async function render(ready: boolean) {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     await act(async () => {
       root.render(
         <QueryClientProvider client={queryClient}>
-          <ContextEnablement organizationId="org-1" {...props} />
+          <OnboardingContextPersonalAccess organizationId="org-1" ready={ready} />
         </QueryClientProvider>,
       );
       await Promise.resolve();
@@ -62,17 +62,144 @@ describe("ContextEnablement", () => {
     });
   }
 
-  it("renders the server-authored exact Team handoff for a connected computer", async () => {
-    await render({ teamRole: "member", ready: true, computerConnected: true });
-    expect(host.textContent).toContain("Run this once from the repository root.");
-    expect(host.textContent).toContain("context enable --provider 'claude-code' --team 'org-1'");
+  it("copies one onboarding prompt without exposing raw commands or gating on this browser's Computer", async () => {
+    await render(true);
+    expect(host.textContent).toContain("Use Team Context in your coding agent");
+    expect(host.textContent).toContain("Copy setup prompt");
+    expect(host.textContent).not.toContain("context enable --provider");
+    expect(apiMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
+
+    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => {
+      copy?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(activityMocks.generateConnectToken).toHaveBeenCalledTimes(1);
     expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "claude-code");
+    const copiedPrompt = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0];
+    expect(copiedPrompt).toContain("'first-tree-staging' login 'short-lived-code'");
+    expect(copiedPrompt).toContain("context enable --provider 'claude-code' --team 'org-1'");
+    expect(copiedPrompt).toContain("First Tree Web owns onboarding completion separately.");
+    expect(copiedPrompt).not.toContain("onboarding completion has been recorded");
   });
 
-  it("shows Needs Admin to a member without querying a handoff", async () => {
-    await render({ teamRole: "member", ready: false, computerConnected: true });
-    expect(host.textContent).toContain("Needs Admin");
+  it("stays absent until Team Context prerequisites are ready", async () => {
+    await render(false);
+    expect(host.textContent).toBe("");
     expect(apiMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
+  });
+
+  it("copies only the selected provider handoff", async () => {
+    apiMocks.getContextEnablementHandoff.mockImplementation(
+      async (_organizationId: string, provider: "claude-code" | "codex") => ({
+        organizationId: "org-1",
+        teamDisplayName: "Acme",
+        role: "member",
+        provider,
+        command: `'first-tree-staging' context enable --provider '${provider}' --team 'org-1'`,
+        workingDirectoryInstruction: "Run this once from the repository root.",
+      }),
+    );
+    await render(true);
+
+    const codex = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Codex",
+    );
+    await act(async () => codex?.click());
+    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => {
+      copy?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "codex");
+    const copiedPrompt = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0];
+    expect(copiedPrompt).toContain("--provider 'codex'");
+    expect(copiedPrompt).not.toContain("--provider 'claude-code'");
+    expect(copiedPrompt).toContain("/hooks");
+  });
+
+  it("does not copy an onboarding prompt after its readiness is revoked", async () => {
+    let resolveHandoff:
+      | ((handoff: Awaited<ReturnType<typeof apiMocks.getContextEnablementHandoff>>) => void)
+      | undefined;
+    apiMocks.getContextEnablementHandoff.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveHandoff = resolve;
+        }),
+    );
+    await render(true);
+
+    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => copy?.click());
+    await render(false);
+    await act(async () => {
+      resolveHandoff?.({
+        organizationId: "org-1",
+        teamDisplayName: "Acme",
+        role: "member",
+        provider: "claude-code",
+        command: "'first-tree-staging' context enable --provider 'claude-code' --team 'org-1'",
+        workingDirectoryInstruction: "Run this once from the repository root.",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(host.textContent).toBe("");
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an onboarding clipboard failure", async () => {
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error("clipboard denied"));
+    await render(true);
+
+    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => {
+      copy?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(host.textContent).toContain("Could not copy the setup prompt.");
+    expect(host.textContent).toContain("Copy failed");
+  });
+
+  it("rejects a server handoff for a different provider", async () => {
+    apiMocks.getContextEnablementHandoff.mockResolvedValueOnce({
+      organizationId: "org-1",
+      teamDisplayName: "Acme",
+      role: "member",
+      provider: "codex",
+      command: "'first-tree-staging' context enable --provider 'codex' --team 'org-1'",
+      workingDirectoryInstruction: "Run this once from the repository root.",
+    });
+    await render(true);
+
+    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => {
+      copy?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    for (let attempt = 0; attempt < 5 && !host.textContent?.includes("Could not prepare"); attempt += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    expect(host.textContent).toContain("Could not prepare the setup prompt.");
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
   });
 
   it("copies one provider-neutral prompt containing both exact server-authored commands", async () => {
@@ -171,7 +298,8 @@ describe("ContextEnablement", () => {
     expect(prompt).toContain("bootstrap-command");
     expect(prompt).toContain("claude-command");
     expect(prompt).not.toContain("Codex");
-    expect(prompt).toContain("onboarding completion has been recorded");
+    expect(prompt).toContain("First Tree Web owns onboarding completion separately.");
+    expect(prompt).not.toContain("onboarding completion has been recorded");
     expect(prompt).not.toContain("Do not mark onboarding complete.");
   });
 

--- a/packages/web/src/pages/__tests__/context-enablement.test.tsx
+++ b/packages/web/src/pages/__tests__/context-enablement.test.tsx
@@ -4,11 +4,14 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ContextEnablement } from "../settings/context-enablement.js";
+import { buildByoSetupPrompt } from "../../lib/byo-setup-prompt.js";
+import { ContextEnablement, ContextPersonalAccess } from "../settings/context-enablement.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+const activityMocks = vi.hoisted(() => ({ generateConnectToken: vi.fn() }));
 const apiMocks = vi.hoisted(() => ({ getContextEnablementHandoff: vi.fn() }));
+vi.mock("../../api/activity.js", () => activityMocks);
 vi.mock("../../api/context-enablement.js", () => apiMocks);
 
 describe("ContextEnablement", () => {
@@ -19,6 +22,15 @@ describe("ContextEnablement", () => {
     host = document.createElement("div");
     document.body.append(host);
     root = createRoot(host);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn(async () => undefined) },
+    });
+    activityMocks.generateConnectToken.mockResolvedValue({
+      bootstrapCommand: "'first-tree-staging' login 'short-lived-code'",
+      installerUrl: "https://example.com/install.sh",
+      binName: "first-tree-staging",
+    });
     apiMocks.getContextEnablementHandoff.mockResolvedValue({
       organizationId: "org-1",
       teamDisplayName: "Acme",
@@ -61,5 +73,207 @@ describe("ContextEnablement", () => {
     await render({ teamRole: "member", ready: false, computerConnected: true });
     expect(host.textContent).toContain("Needs Admin");
     expect(apiMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
+  });
+
+  it("copies one provider-neutral prompt containing both exact server-authored commands", async () => {
+    apiMocks.getContextEnablementHandoff.mockImplementation(
+      async (_organizationId: string, provider: "claude-code" | "codex") => ({
+        organizationId: "org-1",
+        teamDisplayName: "Acme",
+        role: "admin",
+        provider,
+        command: `'first-tree-staging' context enable --provider '${provider}' --team 'org-1'`,
+        workingDirectoryInstruction: "Run this once from the repository root.",
+      }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ContextPersonalAccess organizationId="org-1" />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(host.textContent).toContain("Use in your coding agent");
+    expect(host.textContent).not.toContain("context enable --provider");
+    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => {
+      copy?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const copiedPrompt = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0];
+    expect(copiedPrompt).toContain("'first-tree-staging' login 'short-lived-code'");
+    expect(copiedPrompt).toContain("If you are Claude Code:");
+    expect(copiedPrompt).toContain("--provider 'claude-code' --team 'org-1'");
+    expect(copiedPrompt).toContain("If you are Codex:");
+    expect(copiedPrompt).toContain("--provider 'codex' --team 'org-1'");
+    expect(copiedPrompt).toContain("Do not run both and do not add, remove, or change command flags.");
+    expect(copiedPrompt).toContain("Do not mark onboarding complete.");
+    expect(host.textContent).toContain("Copied");
+    expect(activityMocks.generateConnectToken).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects mismatched Team handoffs instead of copying an ambiguous prompt", () => {
+    expect(() =>
+      buildByoSetupPrompt({
+        organizationId: "org-1",
+        bootstrapCommand: "bootstrap-command",
+        handoffs: [
+          {
+            organizationId: "org-1",
+            teamDisplayName: "Acme",
+            role: "admin",
+            provider: "claude-code",
+            command: "claude-command",
+            workingDirectoryInstruction: "Run from the repository root.",
+          },
+          {
+            organizationId: "org-2",
+            teamDisplayName: "Other",
+            role: "admin",
+            provider: "codex",
+            command: "codex-command",
+            workingDirectoryInstruction: "Run from the repository root.",
+          },
+        ],
+        intent: "settings",
+      }),
+    ).toThrow("expected Team");
+  });
+
+  it("builds a one-provider onboarding artifact without exposing the other provider", () => {
+    const prompt = buildByoSetupPrompt({
+      organizationId: "org-1",
+      bootstrapCommand: "bootstrap-command",
+      handoffs: [
+        {
+          organizationId: "org-1",
+          teamDisplayName: "Acme",
+          role: "member",
+          provider: "claude-code",
+          command: "claude-command",
+          workingDirectoryInstruction: "Run from the repository root.",
+        },
+      ],
+      intent: "onboarding",
+    });
+
+    expect(prompt).toContain("bootstrap-command");
+    expect(prompt).toContain("claude-command");
+    expect(prompt).not.toContain("Codex");
+    expect(prompt).toContain("onboarding completion has been recorded");
+    expect(prompt).not.toContain("Do not mark onboarding complete.");
+  });
+
+  it("lets the Admin retry prompt preparation after an API failure", async () => {
+    const preparePrompt = vi.fn().mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce("ready-prompt");
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ContextPersonalAccess organizationId="org-1" preparePrompt={preparePrompt} />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+    });
+    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => {
+      copy?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const retry = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Retry",
+    );
+    expect(retry).toBeTruthy();
+    await act(async () => {
+      retry?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(host.textContent).toContain("Copied");
+    expect(preparePrompt).toHaveBeenCalledTimes(2);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ready-prompt");
+  });
+
+  it("does not copy a stale Team prompt after the Settings consumer switches Team", async () => {
+    let resolveTeamA: ((prompt: string) => void) | undefined;
+    const preparePrompt = vi.fn(
+      (organizationId: string) =>
+        new Promise<string>((resolve) => {
+          if (organizationId === "org-a") resolveTeamA = resolve;
+        }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ContextPersonalAccess organizationId="org-a" preparePrompt={preparePrompt} />
+        </QueryClientProvider>,
+      );
+    });
+    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => copy?.click());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ContextPersonalAccess organizationId="org-b" preparePrompt={preparePrompt} />
+        </QueryClientProvider>,
+      );
+    });
+    await act(async () => {
+      resolveTeamA?.("stale-org-a-prompt");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(host.textContent).toContain("Copy setup prompt");
+  });
+
+  it("does not copy a prompt after the Settings consumer unmounts", async () => {
+    let resolvePrompt: ((prompt: string) => void) | undefined;
+    const preparePrompt = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ContextPersonalAccess organizationId="org-a" preparePrompt={preparePrompt} />
+        </QueryClientProvider>,
+      );
+    });
+    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => copy?.click());
+    await act(async () => root.render(null));
+    await act(async () => {
+      resolvePrompt?.("unmounted-prompt");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
@@ -64,6 +64,10 @@ beforeEach(() => {
   window.history.replaceState(null, "", "/preview/onboarding");
   localStorage.clear();
   sessionStorage.clear();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn(async () => undefined) },
+  });
 });
 
 afterEach(() => {
@@ -158,6 +162,30 @@ describe("onboarding preview review surface", () => {
         (scenario) => scenario.view === "experiments",
       ),
     ).toBe(true);
+  });
+
+  it("renders and copies the production personal Context handoff in the ready invitee preview", async () => {
+    authMock.memberships = [{}];
+    window.history.replaceState(null, "", "/preview/onboarding?role=invitee&view=flow&scenario=inv-ko-ready");
+
+    const { OnboardingPreviewPage } = await import("../onboarding-preview.js");
+    const { container, root } = await renderDom(
+      <MemoryRouter>
+        <OnboardingPreviewPage />
+      </MemoryRouter>,
+    );
+
+    await waitForText(container, "Use Team Context in your coding agent");
+    expect(container.textContent).not.toContain("context enable --provider");
+    await clickByText(container, "Copy setup prompt");
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("'first-tree' context enable --provider 'claude-code' --team 'org-acme'"),
+    );
+    const copiedPrompt = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0];
+    expect(copiedPrompt).not.toContain("--provider 'codex'");
+
+    await act(async () => root.unmount());
   });
 
   it("keeps GitHub preview states visually distinct", async () => {

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -244,6 +244,9 @@ describe("extra preview pages", () => {
     expect(reviewerControls).not.toBeNull();
     expect(rendered.container.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
     expect(text(reviewerControls ?? treeRow)).toContain("Context Reviewer");
+    expect(text(treeControls ?? treeRow)).toContain("Use in your coding agent");
+    expect(text(treeControls ?? treeRow)).toContain("Copy setup prompt");
+    expect(text(treeControls ?? treeRow)).not.toContain("context enable --provider");
     const enablement = reviewerControls?.querySelector<HTMLButtonElement>('[role="switch"]');
     expect(enablement?.getAttribute("aria-checked")).toBe("true");
     if (!enablement) throw new Error("Missing preview Reviewer enablement switch");

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -259,6 +259,23 @@ describe("extra preview pages", () => {
     await cleanupRendered(rendered);
   });
 
+  it("renders Member personal Context access without Admin controls", async () => {
+    const rendered = await renderPreview(<SetupPreviewPage />, "/preview/setup?role=member&state=ready");
+    const treeRow = rendered.container.querySelector<HTMLElement>('[data-setup-row="context-tree"]');
+    if (!treeRow) throw new Error("Missing Context Tree row");
+
+    await click(buttonByText(treeRow, "Access"));
+    const controls = treeRow.querySelector<HTMLElement>('[data-setup-owner-controls="context-tree"]');
+    expect(controls).not.toBeNull();
+    expect(controls?.querySelector<HTMLAnchorElement>('a[href="/context"]')?.textContent).toBe("Open Context →");
+    expect(text(controls ?? treeRow)).toContain("Personal access");
+    expect(text(controls ?? treeRow)).toContain("Copy setup prompt");
+    expect(controls?.querySelector('[data-setup-owner-controls="automatic-review"]')).toBeNull();
+    expect(controls?.querySelector('[role="switch"]')).toBeNull();
+
+    await cleanupRendered(rendered);
+  });
+
   it("renders the seeded agent-detail preview sections", async () => {
     const rendered = await renderPreview(<AgentDetailPreviewPage />);
 

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -2237,10 +2237,7 @@ describe("web DOM interaction coverage", () => {
     orgSettingsMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: "", branch: null });
     const inviteeNoTree = await renderOnboardingDom(<StepStartChat />, { path: "invitee", activeStep: "start-chat" });
     await waitForText("Start working with your agent", inviteeNoTree.container);
-    await waitForText(
-      "Needs Admin: ask a Team Admin to finish repository and Context Tree setup.",
-      inviteeNoTree.container,
-    );
+    expect(inviteeNoTree.container.textContent).not.toContain("Use Team Context in your coding agent");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     await click(findButton(inviteeNoTree.container, "Start chat"));
     await waitForText("Starting your agent", inviteeNoTree.container);
@@ -2261,10 +2258,8 @@ describe("web DOM interaction coverage", () => {
       path: "invitee",
       activeStep: "start-chat",
     });
-    await waitForText(
-      "Needs Admin: ask a Team Admin to finish repository and Context Tree setup.",
-      inviteeNoRepo.container,
-    );
+    await waitForText("Start working with your agent", inviteeNoRepo.container);
+    expect(inviteeNoRepo.container.textContent).not.toContain("Use Team Context in your coding agent");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     await unmountRoot(inviteeNoRepo.root);
 
@@ -2284,8 +2279,13 @@ describe("web DOM interaction coverage", () => {
     });
     await waitForText("Start working with your agent", inviteeNoInstall.container);
     await waitForText("Use Team Context in your coding agent", inviteeNoInstall.container);
-    await waitForText("--team 'org-1'", inviteeNoInstall.container);
+    expect(inviteeNoInstall.container.textContent).not.toContain("--team 'org-1'");
+    expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
+    await click(findButton(inviteeNoInstall.container, "Copy setup prompt"));
     expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "claude-code");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("context enable --provider 'claude-code' --team 'org-1'"),
+    );
     expect(findButton(inviteeNoInstall.container, "Start working with your agent")).toBeNull();
     await click(findButton(inviteeNoInstall.container, "Start chat"));
     expect(inviteeNoInstall.flow.completeAndEnterChat).toHaveBeenCalled();
@@ -2309,8 +2309,11 @@ describe("web DOM interaction coverage", () => {
     const inviteeReady = await renderOnboardingDom(<StepStartChat />, { path: "invitee", activeStep: "start-chat" });
     await waitForText("Start working with your agent", inviteeReady.container);
     await waitForText("Use Team Context in your coding agent", inviteeReady.container);
-    expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "claude-code");
-    await waitForText("--team 'org-1'", inviteeReady.container);
+    expect(inviteeReady.container.textContent).not.toContain("--team 'org-1'");
+    const callsBeforeCopy = contextEnablementMocks.getContextEnablementHandoff.mock.calls.length;
+    await click(findButton(inviteeReady.container, "Copy setup prompt"));
+    expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledTimes(callsBeforeCopy + 1);
+    expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenLastCalledWith("org-1", "claude-code");
     await click(findButton(inviteeReady.container, "Start chat"));
     // Ready invitee also lands in a value-first work chat, not the tree setup
     // chat. The inherited team tree is context for orientation.

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -286,6 +286,10 @@ type NetProfile = {
   orgAgents?: "pending" | "error" | Array<{ uuid: string; name: string; displayName: string; managerId: string }>;
   /** GET /orgs/:id/members — owner names for the picker's "Run by X" tag. */
   orgMembers?: boolean;
+  /** Member-readable Team resources used to establish personal Context readiness. */
+  activeTeamRepo?: boolean;
+  /** Fresh login bootstrap and exact-Team provider handoff used by the copy action. */
+  personalContextHandoff?: boolean;
 };
 
 // The active scenario's net profile, read by the shim. Set during render of the
@@ -312,9 +316,18 @@ function handleNet(rawUrl: string): Promise<Response> | Response | null {
   const idx = rawUrl.indexOf("/api/v1");
   if (idx < 0) return null;
   const p = rawUrl.slice(idx + "/api/v1".length).split("?")[0];
+  const provider = new URL(rawUrl, window.location.origin).searchParams.get("provider");
 
   if (p === "/me/organizations") {
     return jsonResponse([{ id: ORG_ID, name: "acme", displayName: TEAM_NAME, role: "admin" }]);
+  }
+  if (p === "/bootstrap/config") {
+    return jsonResponse({
+      channel: "prod",
+      connectBootstrapCommandTemplate: null,
+      growthLandingPagesEnabled: false,
+      authProviders: { google: true, github: true },
+    });
   }
   // Get-started fork picker: roster + owner names. Matched for ANY org id
   // because these requests carry the app-level selected org, not the fixture
@@ -378,6 +391,44 @@ function handleNet(rawUrl: string): Promise<Response> | Response | null {
   if (p === `/orgs/${ORG_ID}/settings/context_tree`) {
     if (activeNet.contextTree === "pending") return new Promise<Response>(() => {});
     return jsonResponse({ repo: activeNet.contextTree ?? null });
+  }
+  if (activeNet.activeTeamRepo && p === `/orgs/${ORG_ID}/resources`) {
+    return jsonResponse([
+      {
+        id: "resource-web",
+        organizationId: ORG_ID,
+        type: "repo",
+        scope: "team",
+        ownerAgentId: null,
+        name: "acme/web",
+        repoCanonicalKey: "github.com/acme/web",
+        defaultEnabled: "recommended",
+        status: "active",
+        payload: { url: REPO_WEB },
+        createdBy: "member-preview",
+        updatedBy: "member-preview",
+        createdAt: NOW_ISO,
+        updatedAt: NOW_ISO,
+      },
+    ]);
+  }
+  if (activeNet.personalContextHandoff && p === "/me/connect-tokens") {
+    return jsonResponse({
+      bootstrapCommand: SAMPLE_CLI,
+      installerUrl: "https://download.first-tree.ai/releases/prod/install.sh",
+      binName: "first-tree",
+    });
+  }
+  if (activeNet.personalContextHandoff && p === `/orgs/${ORG_ID}/context-enablement/handoff`) {
+    const selectedProvider = provider === "codex" ? "codex" : "claude-code";
+    return jsonResponse({
+      organizationId: ORG_ID,
+      teamDisplayName: TEAM_NAME,
+      role: "member",
+      provider: selectedProvider,
+      command: `'first-tree' context enable --provider '${selectedProvider}' --team '${ORG_ID}'`,
+      workingDirectoryInstruction: "Run this once from the repository root.",
+    });
   }
   // Managed agents used by start-chat and setup preview branches.
   if (p === "/me/managed-agents") {
@@ -897,7 +948,15 @@ export const ONBOARDING_PREVIEW_SCENARIOS: Scenario[] = [
     group: "Invitee flow",
     role: "invitee",
     view: "flow",
-    wizard: { step: "start-chat", net: { contextTree: TREE_URL, installExists: true } },
+    wizard: {
+      step: "start-chat",
+      net: {
+        contextTree: TREE_URL,
+        installExists: true,
+        activeTeamRepo: true,
+        personalContextHandoff: true,
+      },
+    },
   },
   {
     id: "inv-ko-starting",

--- a/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
@@ -11,7 +11,7 @@ import { CommunityChannels } from "../../../components/community-channels.js";
 import { Button } from "../../../components/ui/button.js";
 import { readCampaignActionHandoffFlag, writeCampaignActionHandoffFlag } from "../../../utils/onboarding-flags.js";
 import { getCampaign } from "../../quickstart/campaigns.js";
-import { ContextEnablement } from "../../settings/context-enablement.js";
+import { OnboardingContextPersonalAccess } from "../../settings/context-enablement.js";
 import {
   buildCampaignActionBootstrap,
   buildInviteeReadyBootstrap,
@@ -293,7 +293,7 @@ function AdminStartChat() {
 // ── Invitee ─────────────────────────────────────────────────────────────
 
 function InviteeStartChat() {
-  const { organizationId, computer } = useOnboardingFlow();
+  const { organizationId } = useOnboardingFlow();
   // BYO Context readiness and managed first-chat readiness are deliberately
   // separate. External Read needs only a bound Context Tree plus an active
   // Team code-repository resource; the legacy managed first chat may still
@@ -350,7 +350,7 @@ function InviteeStartChat() {
   // Read failure → not-ready; the query keeps polling so a transient blip
   // resolves on its own.
   if (teamQuery.isError || !teamQuery.data) {
-    return <InviteeNotReady contextReady={false} computerConnected={computer.connectedClient !== null} />;
+    return <InviteeNotReady contextReady={false} />;
   }
 
   const { treeUrl, hasInstallation, installationKnown, hasCodeRepository } = teamQuery.data;
@@ -363,9 +363,9 @@ function InviteeStartChat() {
   // polling, so it advances to ready on its own once install is confirmed.
   const installed = installationKnown && hasInstallation;
   return resolveInviteeStartChatState({ treeUrl, hasInstallation: installed }) === "ready" && hasCodeRepository ? (
-    <InviteeReady computerConnected={computer.connectedClient !== null} />
+    <InviteeReady />
   ) : (
-    <InviteeNotReady contextReady={contextReady} computerConnected={computer.connectedClient !== null} />
+    <InviteeNotReady contextReady={contextReady} />
   );
 }
 
@@ -377,7 +377,7 @@ function InviteeStartChat() {
  * (they're enabled for every org agent). This mirrors the admin finale as a
  * pure launch into a real chat. An invitee never mutates team config.
  */
-function InviteeReady({ computerConnected }: { computerConnected: boolean }) {
+function InviteeReady() {
   const { organizationId, completeAndEnterChat, reportStepFailure } = useOnboardingFlow();
   const [phase, setPhase] = useState<"idle" | "starting">("idle");
   const [error, setError] = useState<string | null>(null);
@@ -421,14 +421,7 @@ function InviteeReady({ computerConnected }: { computerConnected: boolean }) {
             {error}
           </FlowHint>
         )}
-        {organizationId && (
-          <ContextEnablement
-            organizationId={organizationId}
-            teamRole="member"
-            ready
-            computerConnected={computerConnected}
-          />
-        )}
+        {organizationId && <OnboardingContextPersonalAccess organizationId={organizationId} ready />}
         <div className="flex">
           <Button type="button" variant="cta" onClick={() => void handleStart()}>
             <span>{COPY.startChat.startWorking}</span>
@@ -451,7 +444,7 @@ function InviteeReady({ computerConnected }: { computerConnected: boolean }) {
  * `completeAndEnterChat` — not `finishLater` — means the button lands the user
  * in a real chat WITH the agent, instead of dropping them into an empty workspace.
  */
-function InviteeNotReady({ contextReady, computerConnected }: { contextReady: boolean; computerConnected: boolean }) {
+function InviteeNotReady({ contextReady }: { contextReady: boolean }) {
   const { organizationId, completeAndEnterChat, reportStepFailure } = useOnboardingFlow();
   const [phase, setPhase] = useState<"idle" | "starting">("idle");
   const [error, setError] = useState<string | null>(null);
@@ -492,14 +485,7 @@ function InviteeNotReady({ contextReady, computerConnected }: { contextReady: bo
             {error}
           </FlowHint>
         )}
-        {organizationId && (
-          <ContextEnablement
-            organizationId={organizationId}
-            teamRole="member"
-            ready={contextReady}
-            computerConnected={computerConnected}
-          />
-        )}
+        {organizationId && <OnboardingContextPersonalAccess organizationId={organizationId} ready={contextReady} />}
         {/* The primary action is not an escape hatch: the common not-ready case
             (admin finished without a tree) never resolves, so the real path
             forward is to start now. If the team does finish, the page still

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -11,7 +11,7 @@ import { buildSetupRows, SettingsSetupPage, type SetupFacts, SetupOverview } fro
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-const activityMocks = vi.hoisted(() => ({ listClients: vi.fn() }));
+const activityMocks = vi.hoisted(() => ({ generateConnectToken: vi.fn(), listClients: vi.fn() }));
 const contextTreeMocks = vi.hoisted(() => ({ getContextTreeSnapshot: vi.fn() }));
 const contextEnablementMocks = vi.hoisted(() => ({ getContextEnablementHandoff: vi.fn() }));
 const onboardingEventMocks = vi.hoisted(() => ({ reportOnboardingEvent: vi.fn() }));
@@ -231,6 +231,15 @@ async function openContextTreeControls(view: Awaited<ReturnType<typeof renderSet
 beforeEach(() => {
   vi.clearAllMocks();
   activityMocks.listClients.mockResolvedValue([]);
+  activityMocks.generateConnectToken.mockResolvedValue({
+    bootstrapCommand: "first-tree-dev login short-lived-code",
+    installerUrl: null,
+    binName: "first-tree-dev",
+  });
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn(async () => undefined) },
+  });
   resourceMocks.listTeamResourcesForOrg.mockResolvedValue([]);
   orgSettingsMocks.getRawContextTreeSetting.mockResolvedValue({
     repo: "https://github.com/acme/context-tree.git",
@@ -932,6 +941,62 @@ describe("Settings Setup overview", () => {
     await act(async () => manage?.click());
     expect(manage?.getAttribute("aria-expanded")).toBe("false");
     expect(view.host.querySelector('[data-setup-owner-controls="context-tree"]')).toBeNull();
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("nests optional personal coding-agent access under a bound Context Tree without assuming this browser's Computer", async () => {
+    resourceMocks.listTeamResourcesForOrg.mockResolvedValue([
+      {
+        type: "repo",
+        status: "active",
+      },
+    ]);
+    contextEnablementMocks.getContextEnablementHandoff.mockImplementation(
+      async (_organizationId: string, provider: "claude-code" | "codex") => ({
+        organizationId: "org-1",
+        teamDisplayName: "Acme",
+        role: "admin",
+        provider,
+        command: `first-tree-dev context enable --provider ${provider} --team org-1`,
+        workingDirectoryInstruction: "Run this from the target repository.",
+      }),
+    );
+
+    const view = await renderSettingsSetupPage();
+    expect(view.host.querySelector("#context-access")).toBeNull();
+    const { controls } = await openContextTreeControls(view);
+    const personalAccess = await waitForSelector<HTMLElement>(controls, "[data-setup-personal-access]");
+
+    expect(personalAccess.textContent).toContain("Use in your coding agent");
+    expect(personalAccess.textContent).toContain("Personal access");
+    expect(personalAccess.textContent).toContain("Copy setup prompt");
+    expect(personalAccess.textContent).not.toContain("context enable --provider");
+    expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
+
+    const copy = [...personalAccess.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => copy?.click());
+    await flush();
+
+    expect(activityMocks.generateConnectToken).toHaveBeenCalledTimes(1);
+    expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "claude-code");
+    expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "codex");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("first-tree-dev login short-lived-code"),
+    );
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("does not render a Personal access blocker when its prerequisites are incomplete", async () => {
+    const view = await renderSettingsSetupPage();
+    const { controls } = await openContextTreeControls(view);
+
+    expect(controls.querySelector("[data-setup-personal-access]")).toBeNull();
+    expect(controls.textContent).not.toContain("Personal access");
+    expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
 
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -605,7 +605,11 @@ describe("Settings Setup overview", () => {
       kind: "attention",
     });
     expect(rowFor("repository-automation", memberFacts).action).toBeUndefined();
-    expect(rowFor("context-tree", memberFacts).action).toEqual({ label: "View", to: "/context" });
+    expect(rowFor("context-tree", memberFacts).action).toEqual({
+      label: "Access",
+      to: "/settings/setup#context-tree",
+      intent: "open-context-tree-controls",
+    });
   });
 
   it("turns the same Team blocker into admin attention and member read-only explanation", () => {
@@ -716,7 +720,11 @@ describe("Settings Setup overview", () => {
       });
     }
     expect(admin.action?.label).toBe("Manage");
-    expect(member.action).toEqual({ label: "View", to: "/context" });
+    expect(member.action).toEqual({
+      label: "Access",
+      to: "/settings/setup#context-tree",
+      intent: "open-context-tree-controls",
+    });
   });
 
   it("keeps unbound optional and invalid role-aware", () => {
@@ -786,7 +794,7 @@ describe("Settings Setup overview", () => {
     expect(invalidMember.action).toEqual({ label: "View", to: "/context" });
   });
 
-  it("keeps bound Context Tree recovery read-only and explicit for a member", () => {
+  it("keeps Team recovery read-only while preserving Member personal Context access", () => {
     const row = rowFor(
       "context-tree",
       facts({
@@ -797,7 +805,11 @@ describe("Settings Setup overview", () => {
 
     expect(row.status).toMatchObject({ label: "Unavailable", kind: "blocked" });
     expect(row.status.detail).toContain("Ask an admin to recover");
-    expect(row.action).toEqual({ label: "View", to: "/context" });
+    expect(row.action).toEqual({
+      label: "Access",
+      to: "/settings/setup#context-tree",
+      intent: "open-context-tree-controls",
+    });
   });
 
   it("keeps snapshot lookup failure unknown rather than claiming recovery is needed", () => {
@@ -906,7 +918,11 @@ describe("Settings Setup overview", () => {
     expect(member.status).toMatchObject({ label: "Review service unavailable", kind: "blocked" });
     expect(member.status.detail).toContain("Ask an admin to resolve this: The configured reviewer is missing.");
     expect(member.status.detail).toContain("Context Tree available");
-    expect(member.action).toEqual({ label: "View", to: "/context" });
+    expect(member.action).toEqual({
+      label: "Access",
+      to: "/settings/setup#context-tree",
+      intent: "open-context-tree-controls",
+    });
   });
 
   it("uses the Team projection and only asks the snapshot owner endpoint for a bound tree", async () => {
@@ -986,6 +1002,57 @@ describe("Settings Setup overview", () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining("first-tree-dev login short-lived-code"),
     );
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("lets a Member expand personal Context access without loading Admin Tree or Reviewer controls", async () => {
+    authMock.value = { ...authMock.value, role: "member" };
+    resourceMocks.listTeamResourcesForOrg.mockResolvedValue([
+      {
+        type: "repo",
+        status: "active",
+      },
+    ]);
+    contextEnablementMocks.getContextEnablementHandoff.mockImplementation(
+      async (_organizationId: string, provider: "claude-code" | "codex") => ({
+        organizationId: "org-1",
+        teamDisplayName: "Acme",
+        role: "member",
+        provider,
+        command: `first-tree-dev context enable --provider ${provider} --team org-1`,
+        workingDirectoryInstruction: "Run this from the target repository.",
+      }),
+    );
+
+    const view = await renderSettingsSetupPage();
+    const tree = await waitForRowText(view.host, "context-tree", "Available");
+    const access = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Access",
+    );
+    expect(access?.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => access?.click());
+    const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
+    const personalAccess = await waitForSelector<HTMLElement>(controls, "[data-setup-personal-access]");
+    const openContext = [...controls.querySelectorAll<HTMLAnchorElement>("a")].find(
+      (link) => link.textContent === "Open Context →",
+    );
+    expect(personalAccess.textContent).toContain("Personal access");
+    expect(personalAccess.textContent).toContain("Copy setup prompt");
+    expect(openContext?.getAttribute("href")).toBe("/context");
+    expect(controls.querySelector('[data-setup-owner-controls="automatic-review"]')).toBeNull();
+    expect(controls.querySelector('[role="switch"]')).toBeNull();
+    expect(reviewerMocks.getContextReviewerCandidates).not.toHaveBeenCalled();
+    expect(orgSettingsMocks.getRawContextTreeSetting).not.toHaveBeenCalled();
+
+    const copy = [...personalAccess.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy setup prompt",
+    );
+    await act(async () => copy?.click());
+    await flush();
+    expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "claude-code");
+    expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "codex");
 
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/settings/context-enablement.tsx
+++ b/packages/web/src/pages/settings/context-enablement.tsx
@@ -1,5 +1,4 @@
 import type { ContextIntegrationProvider } from "@first-tree/shared";
-import { useQuery } from "@tanstack/react-query";
 import { Check, Clipboard, RefreshCw, Terminal } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { generateConnectToken } from "../../api/activity.js";
@@ -13,24 +12,32 @@ const PROVIDERS: Array<{ id: ContextIntegrationProvider; label: string }> = [
   { id: "codex", label: "Codex" },
 ];
 
-export function ContextEnablement({
-  organizationId,
-  teamRole,
-  ready,
-  computerConnected,
-}: {
-  organizationId: string;
-  teamRole: string | null;
-  ready: boolean;
-  computerConnected: boolean;
-}) {
+export function OnboardingContextPersonalAccess({ organizationId, ready }: { organizationId: string; ready: boolean }) {
   const [provider, setProvider] = useState<ContextIntegrationProvider>("claude-code");
-  const [copied, setCopied] = useState(false);
-  const handoff = useQuery({
-    queryKey: ["context-enablement-handoff", organizationId, provider],
-    queryFn: () => getContextEnablementHandoff(organizationId, provider),
-    enabled: ready && computerConnected,
-  });
+  const copyFeedback = useCopyFeedback();
+  const [prepareState, setPrepareState] = useState<"idle" | "loading" | "failed">("idle");
+  const prepareAttempt = useRef(0);
+  const activeSelection = useRef({ organizationId, provider, ready });
+  activeSelection.current = { organizationId, provider, ready };
+
+  useEffect(() => {
+    const renderedSelection = { organizationId, provider, ready };
+    prepareAttempt.current += 1;
+    setPrepareState("idle");
+    copyFeedback.reset();
+    return () => {
+      const current = activeSelection.current;
+      if (
+        current.organizationId === renderedSelection.organizationId &&
+        current.provider === renderedSelection.provider &&
+        current.ready === renderedSelection.ready
+      ) {
+        prepareAttempt.current += 1;
+      }
+    };
+  }, [copyFeedback.reset, organizationId, provider, ready]);
+
+  if (!ready) return null;
 
   return (
     <section
@@ -50,83 +57,116 @@ export function ContextEnablement({
             Use Team Context in your coding agent
           </h2>
           <p className="text-caption" style={{ margin: "var(--sp-1) 0 0", color: "var(--fg-3)" }}>
-            Enable First Tree once for each provider and code checkout. This does not connect the provider conversation
-            to First Tree Chat.
+            Optional · Copy one setup prompt into Claude Code or Codex. That conversation stays outside First Tree Chat.
           </p>
         </div>
       </div>
 
-      {!ready ? (
-        <p className="text-label" style={{ margin: "var(--sp-4) 0 0", color: "var(--state-needs-you)" }}>
-          {teamRole === "admin"
-            ? "Finish the Team's repository and Context Tree setup before enabling this checkout."
-            : "Needs Admin: ask a Team Admin to finish repository and Context Tree setup."}
+      <div className="flex flex-wrap" style={{ gap: "var(--sp-2)", marginTop: "var(--sp-4)" }}>
+        {PROVIDERS.map((item) => (
+          <Button
+            key={item.id}
+            type="button"
+            variant={provider === item.id ? "default" : "outline"}
+            size="sm"
+            aria-pressed={provider === item.id}
+            onClick={() => setProvider(item.id)}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </div>
+
+      {prepareState === "failed" ? (
+        <p role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
+          Could not prepare the setup prompt.
         </p>
-      ) : !computerConnected ? (
-        <p className="text-label" style={{ margin: "var(--sp-4) 0 0", color: "var(--state-needs-you)" }}>
-          Connect this computer to First Tree first. The normal login starts and maintains the Client daemon.
+      ) : null}
+      {copyFeedback.status === "failed" ? (
+        <p role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
+          Could not copy the setup prompt.
         </p>
-      ) : (
-        <>
-          <div className="flex flex-wrap" style={{ gap: "var(--sp-2)", marginTop: "var(--sp-4)" }}>
-            {PROVIDERS.map((item) => (
-              <Button
-                key={item.id}
-                type="button"
-                variant={provider === item.id ? "default" : "outline"}
-                size="sm"
-                onClick={() => {
-                  setProvider(item.id);
-                  setCopied(false);
-                }}
-              >
-                {item.label}
-              </Button>
-            ))}
-          </div>
-          {handoff.isError ? (
-            <p role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
-              Could not create the Team handoff. Try again.
-            </p>
-          ) : handoff.data ? (
-            <div style={{ marginTop: "var(--sp-3)" }}>
-              <p className="text-caption" style={{ color: "var(--fg-3)" }}>
-                {handoff.data.workingDirectoryInstruction}
-              </p>
-              <div
-                className="flex items-center"
-                style={{
-                  gap: "var(--sp-2)",
-                  padding: "var(--sp-3)",
-                  background: "var(--bg-sunken)",
-                  borderRadius: "var(--radius-input)",
-                }}
-              >
-                <code className="text-label min-w-0 flex-1 overflow-x-auto">{handoff.data.command}</code>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  aria-label="Copy enable command"
-                  onClick={async () => {
-                    await navigator.clipboard.writeText(handoff.data.command);
-                    setCopied(true);
-                  }}
-                >
-                  {copied ? <Check className="h-3.5 w-3.5" /> : <Clipboard className="h-3.5 w-3.5" />}
-                  {copied ? "Copied" : "Copy"}
-                </Button>
-              </div>
-            </div>
+      ) : null}
+
+      <div style={{ marginTop: "var(--sp-3)" }}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={prepareState === "loading"}
+          onClick={() => {
+            const attempt = ++prepareAttempt.current;
+            const selectedProvider = provider;
+            void (async () => {
+              setPrepareState("loading");
+              copyFeedback.reset();
+              try {
+                const prompt = await prepareOnboardingByoSetupPrompt(organizationId, selectedProvider);
+                const current = activeSelection.current;
+                if (
+                  prepareAttempt.current !== attempt ||
+                  current.organizationId !== organizationId ||
+                  current.provider !== selectedProvider ||
+                  !current.ready
+                ) {
+                  return;
+                }
+                setPrepareState("idle");
+                await copyFeedback.copy(prompt);
+              } catch {
+                const current = activeSelection.current;
+                if (
+                  prepareAttempt.current !== attempt ||
+                  current.organizationId !== organizationId ||
+                  current.provider !== selectedProvider ||
+                  !current.ready
+                ) {
+                  return;
+                }
+                setPrepareState("failed");
+              }
+            })();
+          }}
+        >
+          {prepareState === "failed" ? (
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+          ) : copyFeedback.status === "copied" ? (
+            <Check className="h-3.5 w-3.5" aria-hidden />
           ) : (
-            <p className="text-label" style={{ marginTop: "var(--sp-3)", color: "var(--fg-3)" }}>
-              Preparing the Team handoff…
-            </p>
+            <Clipboard className="h-3.5 w-3.5" aria-hidden />
           )}
-        </>
-      )}
+          {prepareState === "loading"
+            ? "Preparing…"
+            : prepareState === "failed"
+              ? "Retry"
+              : copyFeedback.status === "copied"
+                ? "Copied"
+                : copyFeedback.status === "failed"
+                  ? "Copy failed"
+                  : "Copy setup prompt"}
+        </Button>
+      </div>
     </section>
   );
+}
+
+export async function prepareOnboardingByoSetupPrompt(
+  organizationId: string,
+  provider: ContextIntegrationProvider,
+): Promise<string> {
+  const [bootstrap, handoff] = await Promise.all([
+    generateConnectToken(),
+    getContextEnablementHandoff(organizationId, provider),
+  ]);
+  if (handoff.provider !== provider) {
+    throw new Error("BYO setup handoff does not match the selected provider");
+  }
+  return buildByoSetupPrompt({
+    organizationId,
+    bootstrapCommand: bootstrap.bootstrapCommand,
+    handoffs: [handoff],
+    intent: "onboarding",
+  });
 }
 
 export async function prepareSettingsByoSetupPrompt(organizationId: string): Promise<string> {

--- a/packages/web/src/pages/settings/context-enablement.tsx
+++ b/packages/web/src/pages/settings/context-enablement.tsx
@@ -1,9 +1,12 @@
 import type { ContextIntegrationProvider } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { Check, Clipboard, Terminal } from "lucide-react";
-import { useState } from "react";
+import { Check, Clipboard, RefreshCw, Terminal } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { generateConnectToken } from "../../api/activity.js";
 import { getContextEnablementHandoff } from "../../api/context-enablement.js";
 import { Button } from "../../components/ui/button.js";
+import { buildByoSetupPrompt } from "../../lib/byo-setup-prompt.js";
+import { useCopyFeedback } from "../../lib/use-copy-feedback.js";
 
 const PROVIDERS: Array<{ id: ContextIntegrationProvider; label: string }> = [
   { id: "claude-code", label: "Claude Code" },
@@ -123,5 +126,116 @@ export function ContextEnablement({
         </>
       )}
     </section>
+  );
+}
+
+export async function prepareSettingsByoSetupPrompt(organizationId: string): Promise<string> {
+  const [bootstrap, claudeHandoff, codexHandoff] = await Promise.all([
+    generateConnectToken(),
+    getContextEnablementHandoff(organizationId, "claude-code"),
+    getContextEnablementHandoff(organizationId, "codex"),
+  ]);
+  return buildByoSetupPrompt({
+    organizationId,
+    bootstrapCommand: bootstrap.bootstrapCommand,
+    handoffs: [claudeHandoff, codexHandoff],
+    intent: "settings",
+  });
+}
+
+export function ContextPersonalAccess({
+  organizationId,
+  preparePrompt = prepareSettingsByoSetupPrompt,
+}: {
+  organizationId: string;
+  preparePrompt?: (organizationId: string) => Promise<string>;
+}) {
+  const copyFeedback = useCopyFeedback();
+  const [prepareState, setPrepareState] = useState<"idle" | "loading" | "failed">("idle");
+  const prepareAttempt = useRef(0);
+  const activeOrganizationId = useRef(organizationId);
+  activeOrganizationId.current = organizationId;
+  const copyLabel =
+    copyFeedback.status === "copied"
+      ? "Copied"
+      : copyFeedback.status === "failed"
+        ? "Copy failed"
+        : "Copy setup prompt";
+
+  useEffect(() => {
+    const renderedOrganizationId = organizationId;
+    prepareAttempt.current += 1;
+    setPrepareState("idle");
+    copyFeedback.reset();
+    return () => {
+      if (activeOrganizationId.current === renderedOrganizationId) {
+        prepareAttempt.current += 1;
+      }
+    };
+  }, [copyFeedback.reset, organizationId]);
+
+  return (
+    <div
+      data-setup-personal-access
+      className="flex flex-wrap items-center justify-between"
+      style={{ gap: "var(--sp-3)" }}
+    >
+      <div className="min-w-0" style={{ flex: "1 1 28rem" }}>
+        <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          Use in your coding agent
+        </div>
+        <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
+          Personal access · Work with this Team Context from Claude Code or Codex, outside First Tree Chat.
+        </div>
+        {prepareState === "failed" ? (
+          <div role="alert" className="text-label" style={{ marginTop: "var(--sp-2)", color: "var(--state-error)" }}>
+            Could not prepare the setup prompt.
+          </div>
+        ) : null}
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={prepareState === "loading"}
+        onClick={() => {
+          const attempt = ++prepareAttempt.current;
+          void (async () => {
+            setPrepareState("loading");
+            copyFeedback.reset();
+            try {
+              const prompt = await preparePrompt(organizationId);
+              if (prepareAttempt.current !== attempt || activeOrganizationId.current !== organizationId) return;
+              setPrepareState("idle");
+              await copyFeedback.copy(prompt);
+              if (prepareAttempt.current !== attempt || activeOrganizationId.current !== organizationId) return;
+            } catch {
+              if (prepareAttempt.current !== attempt || activeOrganizationId.current !== organizationId) return;
+              setPrepareState("failed");
+            }
+          })();
+        }}
+      >
+        {prepareState === "failed" ? (
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+        ) : copyFeedback.status === "copied" ? (
+          <Check className="h-3.5 w-3.5" aria-hidden />
+        ) : (
+          <Clipboard className="h-3.5 w-3.5" aria-hidden />
+        )}
+        {prepareState === "loading" ? "Preparing…" : prepareState === "failed" ? "Retry" : copyLabel}
+      </Button>
+      <span className="sr-only" aria-live="polite">
+        {prepareState === "loading"
+          ? "Preparing the setup prompt."
+          : prepareState === "failed"
+            ? "Setup prompt preparation failed."
+            : copyFeedback.status === "copied"
+              ? "Setup prompt copied."
+              : copyFeedback.status === "failed"
+                ? "Setup prompt copy failed."
+                : ""}
+      </span>
+    </div>
   );
 }

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -375,7 +375,11 @@ function contextTreeStatus(
   return { label: "Status unknown", detail, kind: "unknown" };
 }
 
-function contextTreeAction(contextTree: Fact<ContextTreeFact>, isAdmin: boolean): SetupRowModel["action"] | undefined {
+function contextTreeAction(
+  contextTree: Fact<ContextTreeFact>,
+  isAdmin: boolean,
+  personalContextAccessReady: boolean,
+): SetupRowModel["action"] | undefined {
   if (contextTree.state !== "ready") return undefined;
   const { binding, availability, teamNonActionableGitlabWebContext } = contextTree.value;
   if (binding.state === "unbound") {
@@ -387,6 +391,9 @@ function contextTreeAction(contextTree: Fact<ContextTreeFact>, isAdmin: boolean)
     return isAdmin
       ? { label: "Repair", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
       : { label: "View", to: "/context" };
+  }
+  if (!isAdmin && personalContextAccessReady) {
+    return { label: "Access", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" };
   }
   if (teamNonActionableGitlabWebContext) {
     return isAdmin
@@ -543,6 +550,12 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
 
   const capabilities = facts.capabilities.state === "ready" ? facts.capabilities.value : null;
   const contextTree = contextTreeFact(facts.capabilities, facts.contextTreeSnapshot);
+  const personalContextAccessReady =
+    (facts.role === "admin" || facts.role === "member") &&
+    facts.repositories.state === "ready" &&
+    facts.repositories.value > 0 &&
+    contextTree.state === "ready" &&
+    contextTree.value.binding.state === "bound";
   const repositoryAutomationStatus =
     facts.capabilities.state === "loading"
       ? loadingStatus()
@@ -641,7 +654,7 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
         automaticReviewStatus,
         capabilities ? reviewDiagnosticDetail(capabilities.contextTree.automaticReview, isAdmin) : undefined,
       ),
-      action: contextTreeAction(contextTree, isAdmin),
+      action: contextTreeAction(contextTree, isAdmin, personalContextAccessReady),
     },
   ];
 }
@@ -755,6 +768,7 @@ export function SettingsSetupPage() {
 
   const contextTree = contextTreeFact(capabilities, contextTreeSnapshot);
   const personalContextAccessReady =
+    (role === "admin" || role === "member") &&
     facts.repositories.state === "ready" &&
     facts.repositories.value > 0 &&
     contextTree.state === "ready" &&
@@ -776,67 +790,88 @@ export function SettingsSetupPage() {
 
     const hashKey = `${organizationId}:${location.hash}`;
     if (handledOwnerHash.current === hashKey) return;
+    const canOpenForHash = role === "admin" || (location.hash === "#context-tree" && personalContextAccessReady);
+    if (!canOpenForHash) return;
     handledOwnerHash.current = hashKey;
-    if (role === "admin") setExpandedOwnerControl({ organizationId, key });
-  }, [facts.capabilities.state, location.hash, organizationId, role]);
+    setExpandedOwnerControl({ organizationId, key });
+  }, [facts.capabilities.state, location.hash, organizationId, personalContextAccessReady, role]);
 
   useEffect(() => {
     const key = location.hash === "#context-tree" || location.hash === "#automatic-review" ? "context-tree" : null;
     if (!key || facts.capabilities.state !== "ready") return;
-    if (role === "admin" && expandedOwnerControlKey !== key) return;
+    const canOpenForHash = role === "admin" || (location.hash === "#context-tree" && personalContextAccessReady);
+    if (canOpenForHash && expandedOwnerControlKey !== key) return;
 
     const row = document.getElementById(key);
     row?.scrollIntoView?.({ block: "start" });
     row?.focus();
-  }, [expandedOwnerControlKey, facts.capabilities.state, location.hash, role]);
+  }, [expandedOwnerControlKey, facts.capabilities.state, location.hash, personalContextAccessReady, role]);
 
   const ownerControls: Partial<Record<SetupRowModel["key"], ReactNode>> =
-    role !== "admin" || facts.capabilities.state !== "ready"
+    facts.capabilities.state !== "ready"
       ? {}
       : {
           ...(expandedOwnerControlKey === "context-tree" && contextTree.state === "ready"
             ? {
-                "context-tree": (
-                  <SetupContextTreeControls
-                    key={`context-tree-${organizationId}`}
-                    binding={contextTree.value.binding}
-                    availability={contextTree.value.availability}
-                    teamNonActionableGitlabWebContext={contextTree.value.teamNonActionableGitlabWebContext}
-                  >
-                    {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ||
-                    personalContextAccessReady ? (
-                      <div className="flex flex-col">
-                        {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ? (
-                          <SetupReviewerControls
-                            key={`automatic-review-${organizationId}`}
-                            review={facts.capabilities.value.contextTree.automaticReview}
-                            embedded
-                          />
-                        ) : null}
-                        {personalContextAccessReady && organizationId ? (
-                          <div
-                            style={{
-                              marginTop:
-                                facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
-                                  ? "var(--sp-4)"
-                                  : undefined,
-                              paddingTop:
-                                facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
-                                  ? "var(--sp-4)"
-                                  : undefined,
-                              borderTop:
-                                facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
-                                  ? "var(--hairline) solid var(--border-faint)"
-                                  : undefined,
-                            }}
-                          >
-                            <ContextPersonalAccess organizationId={organizationId} />
-                          </div>
-                        ) : null}
+                "context-tree":
+                  role === "admin" ? (
+                    <SetupContextTreeControls
+                      key={`context-tree-${organizationId}`}
+                      binding={contextTree.value.binding}
+                      availability={contextTree.value.availability}
+                      teamNonActionableGitlabWebContext={contextTree.value.teamNonActionableGitlabWebContext}
+                    >
+                      {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ||
+                      personalContextAccessReady ? (
+                        <div className="flex flex-col">
+                          {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ? (
+                            <SetupReviewerControls
+                              key={`automatic-review-${organizationId}`}
+                              review={facts.capabilities.value.contextTree.automaticReview}
+                              embedded
+                            />
+                          ) : null}
+                          {personalContextAccessReady && organizationId ? (
+                            <div
+                              style={{
+                                marginTop:
+                                  facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
+                                    ? "var(--sp-4)"
+                                    : undefined,
+                                paddingTop:
+                                  facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
+                                    ? "var(--sp-4)"
+                                    : undefined,
+                                borderTop:
+                                  facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
+                                    ? "var(--hairline) solid var(--border-faint)"
+                                    : undefined,
+                              }}
+                            >
+                              <ContextPersonalAccess organizationId={organizationId} />
+                            </div>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </SetupContextTreeControls>
+                  ) : role === "member" && personalContextAccessReady && organizationId ? (
+                    <div
+                      data-setup-owner-controls="context-tree"
+                      style={{
+                        padding: "var(--sp-4)",
+                        border: "var(--hairline) solid var(--border)",
+                        borderRadius: "var(--radius-panel)",
+                        background: "var(--bg-sunken)",
+                      }}
+                    >
+                      <div className="flex justify-end" style={{ marginBottom: "var(--sp-3)" }}>
+                        <Link className="text-label font-medium text-primary hover:underline" to="/context">
+                          Open Context →
+                        </Link>
                       </div>
-                    ) : null}
-                  </SetupContextTreeControls>
-                ),
+                      <ContextPersonalAccess organizationId={organizationId} />
+                    </div>
+                  ) : null,
               }
             : {}),
         };

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -38,7 +38,7 @@ import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { cn } from "../../lib/utils.js";
 import { isTeamNonActionableGitlabWebContext } from "../context-tree-availability.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
-import { ContextEnablement } from "./context-enablement.js";
+import { ContextPersonalAccess } from "./context-enablement.js";
 import { setupBlockerCopy } from "./setup-blocker-copy.js";
 import { SetupContextTreeControls } from "./setup-context-tree-controls.js";
 import { SetupReviewerControls } from "./setup-reviewer-controls.js";
@@ -754,6 +754,11 @@ export function SettingsSetupPage() {
   };
 
   const contextTree = contextTreeFact(capabilities, contextTreeSnapshot);
+  const personalContextAccessReady =
+    facts.repositories.state === "ready" &&
+    facts.repositories.value > 0 &&
+    contextTree.state === "ready" &&
+    contextTree.value.binding.state === "bound";
   const expandedOwnerControlKey =
     expandedOwnerControl?.organizationId === organizationId ? expandedOwnerControl.key : null;
 
@@ -798,12 +803,37 @@ export function SettingsSetupPage() {
                     availability={contextTree.value.availability}
                     teamNonActionableGitlabWebContext={contextTree.value.teamNonActionableGitlabWebContext}
                   >
-                    {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ? (
-                      <SetupReviewerControls
-                        key={`automatic-review-${organizationId}`}
-                        review={facts.capabilities.value.contextTree.automaticReview}
-                        embedded
-                      />
+                    {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ||
+                    personalContextAccessReady ? (
+                      <div className="flex flex-col">
+                        {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ? (
+                          <SetupReviewerControls
+                            key={`automatic-review-${organizationId}`}
+                            review={facts.capabilities.value.contextTree.automaticReview}
+                            embedded
+                          />
+                        ) : null}
+                        {personalContextAccessReady && organizationId ? (
+                          <div
+                            style={{
+                              marginTop:
+                                facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
+                                  ? "var(--sp-4)"
+                                  : undefined,
+                              paddingTop:
+                                facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
+                                  ? "var(--sp-4)"
+                                  : undefined,
+                              borderTop:
+                                facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
+                                  ? "var(--hairline) solid var(--border-faint)"
+                                  : undefined,
+                            }}
+                          >
+                            <ContextPersonalAccess organizationId={organizationId} />
+                          </div>
+                        ) : null}
+                      </div>
                     ) : null}
                   </SetupContextTreeControls>
                 ),
@@ -812,32 +842,17 @@ export function SettingsSetupPage() {
         };
 
   return (
-    <>
-      <SetupOverview
-        facts={facts}
-        rows={buildSetupRows(facts)}
-        ownerControls={ownerControls}
-        onToggleOwnerControl={(key) => {
-          setExpandedOwnerControl((current) =>
-            current?.organizationId === organizationId && current.key === key ? null : { organizationId, key },
-          );
-        }}
-        onResumeOnboarding={resumeOnboarding}
-      />
-      {organizationId ? (
-        <ContextEnablement
-          organizationId={organizationId}
-          teamRole={role}
-          ready={
-            facts.repositories.state === "ready" &&
-            facts.repositories.value > 0 &&
-            contextTree.state === "ready" &&
-            contextTree.value.binding.state === "bound"
-          }
-          computerConnected={facts.computers.state === "ready" && facts.computers.value.connected > 0}
-        />
-      ) : null}
-    </>
+    <SetupOverview
+      facts={facts}
+      rows={buildSetupRows(facts)}
+      ownerControls={ownerControls}
+      onToggleOwnerControl={(key) => {
+        setExpandedOwnerControl((current) =>
+          current?.organizationId === organizationId && current.key === key ? null : { organizationId, key },
+        );
+      }}
+      onResumeOnboarding={resumeOnboarding}
+    />
   );
 }
 

--- a/packages/web/src/pages/setup-preview.tsx
+++ b/packages/web/src/pages/setup-preview.tsx
@@ -279,49 +279,60 @@ export function SetupPreviewPage() {
     onboardingCompletedAt: facts.onboardingCompletedAt,
   } as unknown as Parameters<typeof AuthContext.Provider>[0]["value"];
   const ownerControls =
-    role !== "admin"
+    expandedOwnerControl !== "context-tree"
       ? {}
       : {
-          ...(expandedOwnerControl === "context-tree"
-            ? {
-                "context-tree": (
-                  <SetupContextTreeControls
-                    binding={capabilities.contextTree.binding}
-                    availability={snapshotStatus}
-                    loadSetting={previewLoadTreeSetting}
-                    saveSetting={previewSaveTreeSetting}
-                    refreshFacts={previewRefresh}
-                  >
-                    <div className="flex flex-col">
-                      {capabilities.contextTree.automaticReview.adoption !== "unavailable" ? (
-                        <SetupReviewerControls
-                          review={capabilities.contextTree.automaticReview}
-                          embedded
-                          loadCandidates={async () => PREVIEW_REVIEWER_CANDIDATES}
-                          assignReviewer={previewAssignReviewer}
-                          setReviewerEnabled={previewSetReviewerEnabled}
-                          refreshFacts={previewRefresh}
-                        />
-                      ) : null}
-                      {state === "ready" ? (
-                        <div
-                          style={{
-                            marginTop: "var(--sp-4)",
-                            paddingTop: "var(--sp-4)",
-                            borderTop: "var(--hairline) solid var(--border-faint)",
-                          }}
-                        >
-                          <ContextPersonalAccess
-                            organizationId="org-preview"
-                            preparePrompt={previewPersonalAccessPrompt}
-                          />
-                        </div>
-                      ) : null}
+          "context-tree":
+            role === "admin" ? (
+              <SetupContextTreeControls
+                binding={capabilities.contextTree.binding}
+                availability={snapshotStatus}
+                loadSetting={previewLoadTreeSetting}
+                saveSetting={previewSaveTreeSetting}
+                refreshFacts={previewRefresh}
+              >
+                <div className="flex flex-col">
+                  {capabilities.contextTree.automaticReview.adoption !== "unavailable" ? (
+                    <SetupReviewerControls
+                      review={capabilities.contextTree.automaticReview}
+                      embedded
+                      loadCandidates={async () => PREVIEW_REVIEWER_CANDIDATES}
+                      assignReviewer={previewAssignReviewer}
+                      setReviewerEnabled={previewSetReviewerEnabled}
+                      refreshFacts={previewRefresh}
+                    />
+                  ) : null}
+                  {state === "ready" ? (
+                    <div
+                      style={{
+                        marginTop: "var(--sp-4)",
+                        paddingTop: "var(--sp-4)",
+                        borderTop: "var(--hairline) solid var(--border-faint)",
+                      }}
+                    >
+                      <ContextPersonalAccess organizationId="org-preview" preparePrompt={previewPersonalAccessPrompt} />
                     </div>
-                  </SetupContextTreeControls>
-                ),
-              }
-            : {}),
+                  ) : null}
+                </div>
+              </SetupContextTreeControls>
+            ) : state === "ready" ? (
+              <div
+                data-setup-owner-controls="context-tree"
+                style={{
+                  padding: "var(--sp-4)",
+                  border: "var(--hairline) solid var(--border)",
+                  borderRadius: "var(--radius-panel)",
+                  background: "var(--bg-sunken)",
+                }}
+              >
+                <div className="flex justify-end" style={{ marginBottom: "var(--sp-3)" }}>
+                  <Link className="text-label font-medium text-primary hover:underline" to="/context">
+                    Open Context →
+                  </Link>
+                </div>
+                <ContextPersonalAccess organizationId="org-preview" preparePrompt={previewPersonalAccessPrompt} />
+              </div>
+            ) : null,
         };
 
   return (
@@ -333,11 +344,7 @@ export function SetupPreviewPage() {
               facts={facts}
               rows={buildSetupRows(facts)}
               ownerControls={ownerControls}
-              onToggleOwnerControl={
-                role === "admin"
-                  ? (key) => setExpandedOwnerControl((current) => (current === key ? null : key))
-                  : undefined
-              }
+              onToggleOwnerControl={(key) => setExpandedOwnerControl((current) => (current === key ? null : key))}
             />
           </SettingsLayout>
           <nav

--- a/packages/web/src/pages/setup-preview.tsx
+++ b/packages/web/src/pages/setup-preview.tsx
@@ -10,7 +10,9 @@ import { useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { setupCapabilitiesQueryKey } from "../api/setup-capabilities.js";
 import { AuthContext } from "../auth/auth-context.js";
+import { buildByoSetupPrompt } from "../lib/byo-setup-prompt.js";
 import { cn } from "../lib/utils.js";
+import { ContextPersonalAccess } from "./settings/context-enablement.js";
 import { buildSetupRows, type SetupFacts, SetupOverview } from "./settings/setup.js";
 import { SetupContextTreeControls } from "./settings/setup-context-tree-controls.js";
 import { SetupReviewerControls } from "./settings/setup-reviewer-controls.js";
@@ -175,6 +177,32 @@ async function previewSetReviewerEnabled(
 
 async function previewRefresh(): Promise<void> {}
 
+async function previewPersonalAccessPrompt(): Promise<string> {
+  return buildByoSetupPrompt({
+    organizationId: "org-preview",
+    bootstrapCommand: "'first-tree-staging' login 'preview-code'",
+    handoffs: [
+      {
+        organizationId: "org-preview",
+        teamDisplayName: "Gandy's team",
+        role: "admin",
+        provider: "claude-code",
+        command: "'first-tree-staging' context enable --provider 'claude-code' --team 'org-preview'",
+        workingDirectoryInstruction: "Run this once from the repository root.",
+      },
+      {
+        organizationId: "org-preview",
+        teamDisplayName: "Gandy's team",
+        role: "admin",
+        provider: "codex",
+        command: "'first-tree-staging' context enable --provider 'codex' --team 'org-preview'",
+        workingDirectoryInstruction: "Run this once from the repository root.",
+      },
+    ],
+    intent: "settings",
+  });
+}
+
 function previewFacts(role: PreviewRole, state: PreviewState): SetupFacts {
   if (state === "mixed") {
     return {
@@ -264,16 +292,32 @@ export function SetupPreviewPage() {
                     saveSetting={previewSaveTreeSetting}
                     refreshFacts={previewRefresh}
                   >
-                    {capabilities.contextTree.automaticReview.adoption !== "unavailable" ? (
-                      <SetupReviewerControls
-                        review={capabilities.contextTree.automaticReview}
-                        embedded
-                        loadCandidates={async () => PREVIEW_REVIEWER_CANDIDATES}
-                        assignReviewer={previewAssignReviewer}
-                        setReviewerEnabled={previewSetReviewerEnabled}
-                        refreshFacts={previewRefresh}
-                      />
-                    ) : null}
+                    <div className="flex flex-col">
+                      {capabilities.contextTree.automaticReview.adoption !== "unavailable" ? (
+                        <SetupReviewerControls
+                          review={capabilities.contextTree.automaticReview}
+                          embedded
+                          loadCandidates={async () => PREVIEW_REVIEWER_CANDIDATES}
+                          assignReviewer={previewAssignReviewer}
+                          setReviewerEnabled={previewSetReviewerEnabled}
+                          refreshFacts={previewRefresh}
+                        />
+                      ) : null}
+                      {state === "ready" ? (
+                        <div
+                          style={{
+                            marginTop: "var(--sp-4)",
+                            paddingTop: "var(--sp-4)",
+                            borderTop: "var(--hairline) solid var(--border-faint)",
+                          }}
+                        >
+                          <ContextPersonalAccess
+                            organizationId="org-preview"
+                            preparePrompt={previewPersonalAccessPrompt}
+                          />
+                        </div>
+                      ) : null}
+                    </div>
                   </SetupContextTreeControls>
                 ),
               }


### PR DESCRIPTION
## Summary

- nest optional personal coding-agent access under `Settings → Setup → Context Tree`
- expose the same personal access to Admins and Members while keeping Team binding and Reviewer mutations Admin-only
- preserve the Member's read-only `Open Context` path alongside the optional external coding-agent handoff
- use one shared BYO setup prompt builder in production Member onboarding and Settings
- combine a fresh server-authored login bootstrap with exact-Team provider handoffs in one copyable artifact
- keep onboarding one-provider and Settings provider-neutral without adding a BYO completion state
- invalidate stale copy attempts across Team, provider, readiness, and unmount changes

## Product boundaries

- personal BYO remains optional and does not gate onboarding, Tree setup, Review, or First Tree Chat
- no raw command display, separate BYO wizard, provider status, connected-Computer inference, or new Server API
- the external coding-agent session verifies provider activation; First Tree Web owns onboarding completion separately
- Member onboarding and Settings remain separate consumers with one shared prompt contract

## Validation

- `pnpm --dir packages/web test` — 208 files, 1,788 tests
- focused personal-access/onboarding/setup preview suite — 95 tests
- two final independent review passes — no blockers
- `pnpm --dir packages/web run typecheck`
- design-token guardrails
- `pnpm check` — no errors; only pre-existing unrelated warnings
- `git diff --check`
- real-browser desktop and narrow-viewport Settings verification
