### PR TITLE
feat(web): add optional BYO setup prompt preview

### DIFF
--- a/packages/web/src/components/byo-setup-prompt-actions.tsx
+++ b/packages/web/src/components/byo-setup-prompt-actions.tsx
@@ -1,0 +1,202 @@
+import { Check, Clipboard, Eye, LockKeyhole } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useCopyFeedback } from "../lib/use-copy-feedback.js";
+import { Button } from "./ui/button.js";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog.js";
+import { Textarea } from "./ui/textarea.js";
+
+type ByoSetupPromptActionsProps = {
+  align?: "start" | "end";
+  preparePrompt: () => Promise<string>;
+  resetKey: string;
+};
+
+type PendingAction = "copy" | "preview" | null;
+
+export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey }: ByoSetupPromptActionsProps) {
+  const copyFeedback = useCopyFeedback();
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [prepareFailed, setPrepareFailed] = useState(false);
+  const [prompt, setPrompt] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [copyingPreview, setCopyingPreview] = useState(false);
+  const prepareAttempt = useRef(0);
+  const copyAttempt = useRef(0);
+  const activeResetKey = useRef(resetKey);
+  const preparePromptRef = useRef(preparePrompt);
+  activeResetKey.current = resetKey;
+  preparePromptRef.current = preparePrompt;
+
+  useEffect(() => {
+    const renderedResetKey = resetKey;
+    prepareAttempt.current += 1;
+    copyAttempt.current += 1;
+    setPendingAction(null);
+    setPrepareFailed(false);
+    setPrompt(null);
+    setOpen(false);
+    setCopied(false);
+    setCopyingPreview(false);
+    copyFeedback.reset();
+    return () => {
+      if (activeResetKey.current === renderedResetKey) {
+        prepareAttempt.current += 1;
+        copyAttempt.current += 1;
+      }
+    };
+  }, [copyFeedback.reset, resetKey]);
+
+  const closePrompt = (): void => {
+    copyAttempt.current += 1;
+    setOpen(false);
+    setPrompt(null);
+    setCopyingPreview(false);
+    copyFeedback.reset();
+  };
+
+  const prepare = (action: Exclude<PendingAction, null>): void => {
+    const attempt = ++prepareAttempt.current;
+    const renderedResetKey = resetKey;
+    setPendingAction(action);
+    setPrepareFailed(false);
+    setCopied(false);
+    copyFeedback.reset();
+    void (async () => {
+      try {
+        const nextPrompt = await preparePromptRef.current();
+        if (prepareAttempt.current !== attempt || activeResetKey.current !== renderedResetKey) return;
+        if (action === "preview") {
+          setPendingAction(null);
+          setPrompt(nextPrompt);
+          setOpen(true);
+          return;
+        }
+
+        const copy = ++copyAttempt.current;
+        const result = await copyFeedback.copy(nextPrompt);
+        if (
+          prepareAttempt.current !== attempt ||
+          copyAttempt.current !== copy ||
+          activeResetKey.current !== renderedResetKey
+        ) {
+          return;
+        }
+        setPendingAction(null);
+        if (result === "copied") setCopied(true);
+      } catch {
+        if (prepareAttempt.current !== attempt || activeResetKey.current !== renderedResetKey) return;
+        setPendingAction(null);
+        setPrepareFailed(true);
+      }
+    })();
+  };
+
+  const copyPrompt = (): void => {
+    if (!prompt) return;
+    const copy = ++copyAttempt.current;
+    const renderedPrompt = prompt;
+    const renderedResetKey = resetKey;
+    setCopyingPreview(true);
+    void (async () => {
+      const result = await copyFeedback.copy(renderedPrompt);
+      if (copyAttempt.current !== copy || activeResetKey.current !== renderedResetKey) return;
+      setCopyingPreview(false);
+      if (result === "copied") {
+        setCopied(true);
+        setOpen(false);
+        setPrompt(null);
+      }
+    })();
+  };
+
+  return (
+    <div
+      data-byo-prompt-actions
+      className={`flex flex-col ${align === "end" ? "items-end" : "items-start"}`}
+      style={{ gap: "var(--sp-2)" }}
+    >
+      <div
+        className={`flex flex-wrap items-center ${align === "end" ? "justify-end" : "justify-start"}`}
+        style={{ gap: "var(--sp-1)" }}
+      >
+        <Button type="button" size="sm" disabled={pendingAction !== null} onClick={() => prepare("copy")}>
+          {copied ? <Check className="h-3.5 w-3.5" aria-hidden /> : <Clipboard className="h-3.5 w-3.5" aria-hidden />}
+          {pendingAction === "copy" ? "Preparing…" : "Copy setup prompt"}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={pendingAction !== null}
+          onClick={() => prepare("preview")}
+        >
+          <Eye className="h-3.5 w-3.5" aria-hidden />
+          {pendingAction === "preview" ? "Preparing…" : "Preview prompt"}
+        </Button>
+      </div>
+
+      {prepareFailed ? (
+        <p role="alert" className="text-label" style={{ margin: 0, color: "var(--state-error)" }}>
+          Could not prepare the setup prompt.
+        </p>
+      ) : copyFeedback.status === "failed" ? (
+        <p role="alert" className="text-label" style={{ margin: 0, color: "var(--state-error)" }}>
+          Could not copy the setup prompt.
+        </p>
+      ) : copied ? (
+        <p aria-live="polite" className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
+          Copied — paste it into the Claude Code or Codex chat you just opened.
+        </p>
+      ) : null}
+
+      <Dialog
+        open={open}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) closePrompt();
+        }}
+      >
+        <DialogContent className="max-h-[calc(100vh-var(--sp-8))] max-w-3xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Review setup prompt</DialogTitle>
+            <DialogDescription style={{ color: "var(--fg-2)" }}>
+              Check the exact instructions before copying. Nothing runs until you paste them into Claude Code or Codex.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Textarea
+            data-byo-setup-prompt-preview
+            aria-label="Setup prompt"
+            readOnly
+            spellCheck={false}
+            value={prompt ?? ""}
+            className="h-80 min-h-24 w-full max-h-[40vh] resize-none rounded-[var(--radius-panel)] border border-border bg-bg-sunken p-4 font-mono text-label text-foreground"
+          />
+
+          {copyFeedback.status === "failed" ? (
+            <p role="alert" className="text-label" style={{ margin: 0, color: "var(--state-error)" }}>
+              Could not copy the setup prompt.
+            </p>
+          ) : null}
+
+          <div className="flex items-center" style={{ gap: "var(--sp-2)", color: "var(--fg-3)" }}>
+            <LockKeyhole className="h-4 w-4 shrink-0" aria-hidden />
+            <p className="text-label" style={{ margin: 0 }}>
+              Contains a temporary sign-in code. Don&apos;t share it.
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={closePrompt}>
+              Cancel
+            </Button>
+            <Button type="button" disabled={copyingPreview} onClick={copyPrompt}>
+              <Clipboard className="h-4 w-4" aria-hidden />
+              {copyingPreview ? "Copying…" : "Copy prompt"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/packages/web/src/components/byo-setup-prompt-actions.tsx
+++ b/packages/web/src/components/byo-setup-prompt-actions.tsx
@@ -156,7 +156,10 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
           if (!nextOpen) closePrompt();
         }}
       >
-        <DialogContent className="max-h-[calc(100vh-var(--sp-8))] max-w-3xl overflow-y-auto">
+        <DialogContent
+          data-clarity-mask="true"
+          className="max-h-[calc(100vh-var(--sp-8))] max-w-3xl overflow-y-auto"
+        >
           <DialogHeader>
             <DialogTitle>Review setup prompt</DialogTitle>
             <DialogDescription style={{ color: "var(--fg-2)" }}>

--- a/packages/web/src/components/byo-setup-prompt-actions.tsx
+++ b/packages/web/src/components/byo-setup-prompt-actions.tsx
@@ -156,10 +156,7 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
           if (!nextOpen) closePrompt();
         }}
       >
-        <DialogContent
-          data-clarity-mask="true"
-          className="max-h-[calc(100vh-var(--sp-8))] max-w-3xl overflow-y-auto"
-        >
+        <DialogContent data-clarity-mask="true" className="max-h-[calc(100vh-var(--sp-8))] max-w-3xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Review setup prompt</DialogTitle>
             <DialogDescription style={{ color: "var(--fg-2)" }}>

--- a/packages/web/src/lib/__tests__/use-copy-feedback.test.tsx
+++ b/packages/web/src/lib/__tests__/use-copy-feedback.test.tsx
@@ -10,11 +10,16 @@ const writeText = vi.fn<(text: string) => Promise<void>>();
 
 /** Tiny probe component: exposes the hook's status as text + a copy button. */
 function Probe({ text }: { text: string }) {
-  const { status, copy } = useCopyFeedback();
+  const { status, copy, reset } = useCopyFeedback();
   return (
-    <button type="button" data-status={status satisfies CopyFeedbackStatus} onClick={() => void copy(text)}>
-      {status}
-    </button>
+    <>
+      <button type="button" data-status={status satisfies CopyFeedbackStatus} onClick={() => void copy(text)}>
+        {status}
+      </button>
+      <button type="button" onClick={reset}>
+        reset
+      </button>
+    </>
   );
 }
 
@@ -88,6 +93,52 @@ describe("useCopyFeedback", () => {
         vi.advanceTimersByTime(1_300);
       });
       expect(probeButton().textContent).toBe("idle");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores a deferred clipboard result after reset", async () => {
+    let rejectCopy: ((reason?: unknown) => void) | undefined;
+    writeText.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectCopy = reject;
+        }),
+    );
+    h.render(<Probe text="stale" />);
+
+    await clickCopy();
+    await act(async () => h.container.querySelector<HTMLButtonElement>("button:last-of-type")?.click());
+    await act(async () => {
+      rejectCopy?.(new Error("late denial"));
+      await Promise.resolve();
+    });
+
+    expect(probeButton().textContent).toBe("idle");
+  });
+
+  it("does not schedule feedback after a deferred clipboard result resolves post-unmount", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveCopy: (() => void) | undefined;
+      writeText.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCopy = resolve;
+          }),
+      );
+      h.render(<Probe text="unmounted" />);
+      await clickCopy();
+
+      h.cleanup();
+      await act(async () => {
+        resolveCopy?.();
+        await Promise.resolve();
+      });
+
+      expect(vi.getTimerCount()).toBe(0);
+      h = createDomHarness();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/web/src/lib/use-copy-feedback.ts
+++ b/packages/web/src/lib/use-copy-feedback.ts
@@ -15,10 +15,11 @@ export type CopyFeedbackStatus = "idle" | "copied" | "failed";
  * call site (issue 999).
  *
  * Contract (modeled on the most robust of the previous copies):
- *  - `copy(text)` writes to the clipboard and flips `status` to `"copied"`,
- *    or to `"failed"` when `navigator.clipboard.writeText` rejects (non-secure
- *    context, or the user denied the clipboard permission) — callers decide
- *    whether to surface the failed state or treat it as idle.
+ *  - `copy(text)` writes to the clipboard, returns the resulting status, and
+ *    flips `status` to `"copied"`, or to `"failed"` when
+ *    `navigator.clipboard.writeText` rejects (non-secure context, or the user
+ *    denied the clipboard permission) — callers decide whether to surface the
+ *    failed state or treat it as idle.
  *  - One reset timer, clear-before-set: a rapid second copy restarts the full
  *    feedback window instead of being cut short by the first timer.
  *  - The timer is cleared on unmount, so no state update fires after the
@@ -26,23 +27,28 @@ export type CopyFeedbackStatus = "idle" | "copied" | "failed";
  */
 export function useCopyFeedback(options?: { feedbackMs?: number }): {
   status: CopyFeedbackStatus;
-  copy: (text: string) => Promise<void>;
+  copy: (text: string) => Promise<CopyFeedbackStatus>;
   /** Snap back to idle immediately (e.g. when a host dialog reopens). */
   reset: () => void;
 } {
   const feedbackMs = options?.feedbackMs ?? COPY_FEEDBACK_MS;
   const [status, setStatus] = useState<CopyFeedbackStatus>("idle");
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const operation = useRef(0);
+  const mounted = useRef(false);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      operation.current += 1;
       if (resetTimer.current) clearTimeout(resetTimer.current);
-    },
-    [],
-  );
+    };
+  }, []);
 
   const copy = useCallback(
-    async (text: string): Promise<void> => {
+    async (text: string): Promise<CopyFeedbackStatus> => {
+      const currentOperation = ++operation.current;
       let next: CopyFeedbackStatus;
       try {
         await navigator.clipboard.writeText(text);
@@ -50,17 +56,20 @@ export function useCopyFeedback(options?: { feedbackMs?: number }): {
       } catch {
         next = "failed";
       }
+      if (!mounted.current || operation.current !== currentOperation) return "idle";
       setStatus(next);
       if (resetTimer.current) clearTimeout(resetTimer.current);
       resetTimer.current = setTimeout(() => setStatus("idle"), feedbackMs);
+      return next;
     },
     [feedbackMs],
   );
 
   const reset = useCallback((): void => {
+    operation.current += 1;
     if (resetTimer.current) clearTimeout(resetTimer.current);
     resetTimer.current = null;
-    setStatus("idle");
+    if (mounted.current) setStatus("idle");
   }, []);
 
   return { status, copy, reset };

--- a/packages/web/src/pages/__tests__/context-enablement.test.tsx
+++ b/packages/web/src/pages/__tests__/context-enablement.test.tsx
@@ -62,28 +62,48 @@ describe("personal Context access", () => {
     });
   }
 
-  it("copies one onboarding prompt without exposing raw commands or gating on this browser's Computer", async () => {
+  function buttonByText(root: ParentNode, text: string): HTMLButtonElement | undefined {
+    return [...root.querySelectorAll<HTMLButtonElement>("button")].find((button) => button.textContent === text);
+  }
+
+  function promptPreview(): HTMLTextAreaElement | null {
+    return document.body.querySelector<HTMLTextAreaElement>("[data-byo-setup-prompt-preview]");
+  }
+
+  async function clickAndFlush(button: HTMLButtonElement | undefined): Promise<void> {
+    await act(async () => {
+      button?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  it("offers an optional onboarding preview without gating on this browser's Computer", async () => {
     await render(true);
     expect(host.textContent).toContain("Use Team Context in your coding agent");
     expect(host.textContent).toContain("Copy setup prompt");
+    expect(host.textContent).toContain("Preview prompt");
     expect(host.textContent).not.toContain("context enable --provider");
     expect(apiMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
 
-    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
-    );
-    await act(async () => {
-      copy?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await clickAndFlush(buttonByText(host, "Preview prompt"));
 
     expect(activityMocks.generateConnectToken).toHaveBeenCalledTimes(1);
     expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "claude-code");
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    const preview = promptPreview();
+    expect(preview?.value).toContain("'first-tree-staging' login 'short-lived-code'");
+    expect(preview?.value).toContain("context enable --provider 'claude-code' --team 'org-1'");
+    expect(document.body.textContent).toContain("Nothing runs until you paste them into Claude Code or Codex.");
+    expect(document.body.textContent).toContain("Contains a temporary sign-in code. Don't share it.");
+
+    await clickAndFlush(buttonByText(document.body, "Copy prompt"));
     const copiedPrompt = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0];
     expect(copiedPrompt).toContain("'first-tree-staging' login 'short-lived-code'");
     expect(copiedPrompt).toContain("context enable --provider 'claude-code' --team 'org-1'");
     expect(copiedPrompt).toContain("First Tree Web owns onboarding completion separately.");
     expect(copiedPrompt).not.toContain("onboarding completion has been recorded");
+    expect(promptPreview()).toBeNull();
+    expect(host.textContent).toContain("Copied — paste it into the Claude Code or Codex chat you just opened.");
   });
 
   it("stays absent until Team Context prerequisites are ready", async () => {
@@ -109,13 +129,7 @@ describe("personal Context access", () => {
       (button) => button.textContent === "Codex",
     );
     await act(async () => codex?.click());
-    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
-    );
-    await act(async () => {
-      copy?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
 
     expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledTimes(1);
     expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "codex");
@@ -137,9 +151,7 @@ describe("personal Context access", () => {
     );
     await render(true);
 
-    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
-    );
+    const copy = buttonByText(host, "Copy setup prompt");
     await act(async () => copy?.click());
     await render(false);
     await act(async () => {
@@ -162,16 +174,23 @@ describe("personal Context access", () => {
     vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error("clipboard denied"));
     await render(true);
 
-    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
-    );
-    await act(async () => {
-      copy?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
 
-    expect(host.textContent).toContain("Could not copy the setup prompt.");
-    expect(host.textContent).toContain("Copy failed");
+    expect(document.body.textContent).toContain("Could not copy the setup prompt.");
+    expect(promptPreview()).toBeNull();
+  });
+
+  it("lets the member cancel without copying or retaining the temporary prompt", async () => {
+    await render(true);
+
+    await clickAndFlush(buttonByText(host, "Preview prompt"));
+    expect(promptPreview()).not.toBeNull();
+
+    await clickAndFlush(buttonByText(document.body, "Cancel"));
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(promptPreview()).toBeNull();
+    expect(host.textContent).not.toContain("Copied —");
   });
 
   it("rejects a server handoff for a different provider", async () => {
@@ -185,13 +204,7 @@ describe("personal Context access", () => {
     });
     await render(true);
 
-    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
-    );
-    await act(async () => {
-      copy?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
     for (let attempt = 0; attempt < 5 && !host.textContent?.includes("Could not prepare"); attempt += 1) {
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
@@ -227,15 +240,15 @@ describe("personal Context access", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(host.textContent).toContain("Use in your coding agent");
+    expect(host.textContent).toContain("Use Team Context in Claude Code or Codex");
+    expect(host.textContent).toContain("Open the project you want to use with Team Context");
     expect(host.textContent).not.toContain("context enable --provider");
-    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
-    );
-    await act(async () => {
-      copy?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await clickAndFlush(buttonByText(host, "Preview prompt"));
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(promptPreview()?.value).toContain("If you are Claude Code:");
+    expect(promptPreview()?.value).toContain("If you are Codex:");
+
+    await clickAndFlush(buttonByText(document.body, "Copy prompt"));
 
     const copiedPrompt = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0];
     expect(copiedPrompt).toContain("'first-tree-staging' login 'short-lived-code'");
@@ -245,7 +258,7 @@ describe("personal Context access", () => {
     expect(copiedPrompt).toContain("--provider 'codex' --team 'org-1'");
     expect(copiedPrompt).toContain("Do not run both and do not add, remove, or change command flags.");
     expect(copiedPrompt).toContain("Do not mark onboarding complete.");
-    expect(host.textContent).toContain("Copied");
+    expect(host.textContent).toContain("Copied — paste it into the Claude Code or Codex chat you just opened.");
     expect(activityMocks.generateConnectToken).toHaveBeenCalledTimes(1);
     expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledTimes(2);
   });
@@ -315,26 +328,49 @@ describe("personal Context access", () => {
       );
       await Promise.resolve();
     });
-    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
-    );
-    await act(async () => {
-      copy?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
 
-    const retry = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Retry",
-    );
-    expect(retry).toBeTruthy();
-    await act(async () => {
-      retry?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    expect(host.textContent).toContain("Could not prepare the setup prompt.");
+    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
 
-    expect(host.textContent).toContain("Copied");
+    expect(promptPreview()).toBeNull();
+    expect(host.textContent).toContain("Copied — paste it into the Claude Code or Codex chat you just opened.");
     expect(preparePrompt).toHaveBeenCalledTimes(2);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ready-prompt");
+  });
+
+  it("keeps a reopened prompt intact when an earlier clipboard write resolves late", async () => {
+    let resolveCopy: (() => void) | undefined;
+    vi.mocked(navigator.clipboard.writeText).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCopy = resolve;
+        }),
+    );
+    const preparePrompt = vi.fn().mockResolvedValueOnce("first-prompt").mockResolvedValueOnce("second-prompt");
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ContextPersonalAccess organizationId="org-1" preparePrompt={preparePrompt} />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+    });
+    await clickAndFlush(buttonByText(host, "Preview prompt"));
+    await clickAndFlush(buttonByText(document.body, "Copy prompt"));
+    await clickAndFlush(buttonByText(document.body, "Cancel"));
+    await clickAndFlush(buttonByText(host, "Preview prompt"));
+
+    expect(promptPreview()?.value).toBe("second-prompt");
+    await act(async () => {
+      resolveCopy?.();
+      await Promise.resolve();
+    });
+
+    expect(promptPreview()?.value).toBe("second-prompt");
+    expect(host.textContent).not.toContain("Copied —");
   });
 
   it("does not copy a stale Team prompt after the Settings consumer switches Team", async () => {
@@ -354,10 +390,7 @@ describe("personal Context access", () => {
         </QueryClientProvider>,
       );
     });
-    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
-    );
-    await act(async () => copy?.click());
+    await act(async () => buttonByText(host, "Copy setup prompt")?.click());
 
     await act(async () => {
       root.render(
@@ -373,6 +406,7 @@ describe("personal Context access", () => {
 
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
     expect(host.textContent).toContain("Copy setup prompt");
+    expect(promptPreview()).toBeNull();
   });
 
   it("does not copy a prompt after the Settings consumer unmounts", async () => {
@@ -392,10 +426,7 @@ describe("personal Context access", () => {
         </QueryClientProvider>,
       );
     });
-    const copy = [...host.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
-    );
-    await act(async () => copy?.click());
+    await act(async () => buttonByText(host, "Copy setup prompt")?.click());
     await act(async () => root.render(null));
     await act(async () => {
       resolvePrompt?.("unmounted-prompt");

--- a/packages/web/src/pages/__tests__/context-enablement.test.tsx
+++ b/packages/web/src/pages/__tests__/context-enablement.test.tsx
@@ -93,6 +93,7 @@ describe("personal Context access", () => {
     const preview = promptPreview();
     expect(preview?.value).toContain("'first-tree-staging' login 'short-lived-code'");
     expect(preview?.value).toContain("context enable --provider 'claude-code' --team 'org-1'");
+    expect(preview?.closest('[data-clarity-mask="true"]')).not.toBeNull();
     expect(document.body.textContent).toContain("Nothing runs until you paste them into Claude Code or Codex.");
     expect(document.body.textContent).toContain("Contains a temporary sign-in code. Don't share it.");
 

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -244,8 +244,9 @@ describe("extra preview pages", () => {
     expect(reviewerControls).not.toBeNull();
     expect(rendered.container.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
     expect(text(reviewerControls ?? treeRow)).toContain("Context Reviewer");
-    expect(text(treeControls ?? treeRow)).toContain("Use in your coding agent");
+    expect(text(treeControls ?? treeRow)).toContain("Use Team Context in Claude Code or Codex");
     expect(text(treeControls ?? treeRow)).toContain("Copy setup prompt");
+    expect(text(treeControls ?? treeRow)).toContain("Preview prompt");
     expect(text(treeControls ?? treeRow)).not.toContain("context enable --provider");
     const enablement = reviewerControls?.querySelector<HTMLButtonElement>('[role="switch"]');
     expect(enablement?.getAttribute("aria-checked")).toBe("true");
@@ -268,8 +269,9 @@ describe("extra preview pages", () => {
     const controls = treeRow.querySelector<HTMLElement>('[data-setup-owner-controls="context-tree"]');
     expect(controls).not.toBeNull();
     expect(controls?.querySelector<HTMLAnchorElement>('a[href="/context"]')?.textContent).toBe("Open Context →");
-    expect(text(controls ?? treeRow)).toContain("Personal access");
+    expect(text(controls ?? treeRow)).toContain("Use Team Context in Claude Code or Codex");
     expect(text(controls ?? treeRow)).toContain("Copy setup prompt");
+    expect(text(controls ?? treeRow)).toContain("Preview prompt");
     expect(controls?.querySelector('[data-setup-owner-controls="automatic-review"]')).toBeNull();
     expect(controls?.querySelector('[role="switch"]')).toBeNull();
 

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -984,21 +984,32 @@ describe("Settings Setup overview", () => {
     const { controls } = await openContextTreeControls(view);
     const personalAccess = await waitForSelector<HTMLElement>(controls, "[data-setup-personal-access]");
 
-    expect(personalAccess.textContent).toContain("Use in your coding agent");
-    expect(personalAccess.textContent).toContain("Personal access");
+    expect(personalAccess.textContent).toContain("Use Team Context in Claude Code or Codex");
+    expect(personalAccess.textContent).toContain("Open the project you want to use with Team Context");
     expect(personalAccess.textContent).toContain("Copy setup prompt");
+    expect(personalAccess.textContent).toContain("Preview prompt");
     expect(personalAccess.textContent).not.toContain("context enable --provider");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
 
-    const copy = [...personalAccess.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
+    const preview = [...personalAccess.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Preview prompt",
     );
-    await act(async () => copy?.click());
+    await act(async () => preview?.click());
     await flush();
 
     expect(activityMocks.generateConnectToken).toHaveBeenCalledTimes(1);
     expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "claude-code");
     expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "codex");
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(document.body.querySelector<HTMLTextAreaElement>("[data-byo-setup-prompt-preview]")?.value).toContain(
+      "first-tree-dev login short-lived-code",
+    );
+
+    const copy = [...document.body.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy prompt",
+    );
+    await act(async () => copy?.click());
+    await flush();
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining("first-tree-dev login short-lived-code"),
     );
@@ -1038,8 +1049,9 @@ describe("Settings Setup overview", () => {
     const openContext = [...controls.querySelectorAll<HTMLAnchorElement>("a")].find(
       (link) => link.textContent === "Open Context →",
     );
-    expect(personalAccess.textContent).toContain("Personal access");
+    expect(personalAccess.textContent).toContain("Use Team Context in Claude Code or Codex");
     expect(personalAccess.textContent).toContain("Copy setup prompt");
+    expect(personalAccess.textContent).toContain("Preview prompt");
     expect(openContext?.getAttribute("href")).toBe("/context");
     expect(controls.querySelector('[data-setup-owner-controls="automatic-review"]')).toBeNull();
     expect(controls.querySelector('[role="switch"]')).toBeNull();
@@ -1053,6 +1065,9 @@ describe("Settings Setup overview", () => {
     await flush();
     expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "claude-code");
     expect(contextEnablementMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "codex");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("first-tree-dev login short-lived-code"),
+    );
 
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/settings/context-enablement.tsx
+++ b/packages/web/src/pages/settings/context-enablement.tsx
@@ -1,11 +1,11 @@
 import type { ContextIntegrationProvider } from "@first-tree/shared";
-import { Check, Clipboard, RefreshCw, Terminal } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Terminal } from "lucide-react";
+import { useState } from "react";
 import { generateConnectToken } from "../../api/activity.js";
 import { getContextEnablementHandoff } from "../../api/context-enablement.js";
+import { ByoSetupPromptActions } from "../../components/byo-setup-prompt-actions.js";
 import { Button } from "../../components/ui/button.js";
 import { buildByoSetupPrompt } from "../../lib/byo-setup-prompt.js";
-import { useCopyFeedback } from "../../lib/use-copy-feedback.js";
 
 const PROVIDERS: Array<{ id: ContextIntegrationProvider; label: string }> = [
   { id: "claude-code", label: "Claude Code" },
@@ -14,28 +14,6 @@ const PROVIDERS: Array<{ id: ContextIntegrationProvider; label: string }> = [
 
 export function OnboardingContextPersonalAccess({ organizationId, ready }: { organizationId: string; ready: boolean }) {
   const [provider, setProvider] = useState<ContextIntegrationProvider>("claude-code");
-  const copyFeedback = useCopyFeedback();
-  const [prepareState, setPrepareState] = useState<"idle" | "loading" | "failed">("idle");
-  const prepareAttempt = useRef(0);
-  const activeSelection = useRef({ organizationId, provider, ready });
-  activeSelection.current = { organizationId, provider, ready };
-
-  useEffect(() => {
-    const renderedSelection = { organizationId, provider, ready };
-    prepareAttempt.current += 1;
-    setPrepareState("idle");
-    copyFeedback.reset();
-    return () => {
-      const current = activeSelection.current;
-      if (
-        current.organizationId === renderedSelection.organizationId &&
-        current.provider === renderedSelection.provider &&
-        current.ready === renderedSelection.ready
-      ) {
-        prepareAttempt.current += 1;
-      }
-    };
-  }, [copyFeedback.reset, organizationId, provider, ready]);
 
   if (!ready) return null;
 
@@ -77,74 +55,11 @@ export function OnboardingContextPersonalAccess({ organizationId, ready }: { org
         ))}
       </div>
 
-      {prepareState === "failed" ? (
-        <p role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
-          Could not prepare the setup prompt.
-        </p>
-      ) : null}
-      {copyFeedback.status === "failed" ? (
-        <p role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
-          Could not copy the setup prompt.
-        </p>
-      ) : null}
-
       <div style={{ marginTop: "var(--sp-3)" }}>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={prepareState === "loading"}
-          onClick={() => {
-            const attempt = ++prepareAttempt.current;
-            const selectedProvider = provider;
-            void (async () => {
-              setPrepareState("loading");
-              copyFeedback.reset();
-              try {
-                const prompt = await prepareOnboardingByoSetupPrompt(organizationId, selectedProvider);
-                const current = activeSelection.current;
-                if (
-                  prepareAttempt.current !== attempt ||
-                  current.organizationId !== organizationId ||
-                  current.provider !== selectedProvider ||
-                  !current.ready
-                ) {
-                  return;
-                }
-                setPrepareState("idle");
-                await copyFeedback.copy(prompt);
-              } catch {
-                const current = activeSelection.current;
-                if (
-                  prepareAttempt.current !== attempt ||
-                  current.organizationId !== organizationId ||
-                  current.provider !== selectedProvider ||
-                  !current.ready
-                ) {
-                  return;
-                }
-                setPrepareState("failed");
-              }
-            })();
-          }}
-        >
-          {prepareState === "failed" ? (
-            <RefreshCw className="h-3.5 w-3.5" aria-hidden />
-          ) : copyFeedback.status === "copied" ? (
-            <Check className="h-3.5 w-3.5" aria-hidden />
-          ) : (
-            <Clipboard className="h-3.5 w-3.5" aria-hidden />
-          )}
-          {prepareState === "loading"
-            ? "Preparing…"
-            : prepareState === "failed"
-              ? "Retry"
-              : copyFeedback.status === "copied"
-                ? "Copied"
-                : copyFeedback.status === "failed"
-                  ? "Copy failed"
-                  : "Copy setup prompt"}
-        </Button>
+        <ByoSetupPromptActions
+          preparePrompt={() => prepareOnboardingByoSetupPrompt(organizationId, provider)}
+          resetKey={`${organizationId}:${provider}:${ready}`}
+        />
       </div>
     </section>
   );
@@ -190,30 +105,6 @@ export function ContextPersonalAccess({
   organizationId: string;
   preparePrompt?: (organizationId: string) => Promise<string>;
 }) {
-  const copyFeedback = useCopyFeedback();
-  const [prepareState, setPrepareState] = useState<"idle" | "loading" | "failed">("idle");
-  const prepareAttempt = useRef(0);
-  const activeOrganizationId = useRef(organizationId);
-  activeOrganizationId.current = organizationId;
-  const copyLabel =
-    copyFeedback.status === "copied"
-      ? "Copied"
-      : copyFeedback.status === "failed"
-        ? "Copy failed"
-        : "Copy setup prompt";
-
-  useEffect(() => {
-    const renderedOrganizationId = organizationId;
-    prepareAttempt.current += 1;
-    setPrepareState("idle");
-    copyFeedback.reset();
-    return () => {
-      if (activeOrganizationId.current === renderedOrganizationId) {
-        prepareAttempt.current += 1;
-      }
-    };
-  }, [copyFeedback.reset, organizationId]);
-
   return (
     <div
       data-setup-personal-access
@@ -222,60 +113,18 @@ export function ContextPersonalAccess({
     >
       <div className="min-w-0" style={{ flex: "1 1 28rem" }}>
         <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
-          Use in your coding agent
+          Use Team Context in Claude Code or Codex
         </div>
         <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
-          Personal access · Work with this Team Context from Claude Code or Codex, outside First Tree Chat.
+          Open the project you want to use with Team Context in Claude Code or Codex, then copy and paste the setup
+          prompt. Your coding agent handles the setup.
         </div>
-        {prepareState === "failed" ? (
-          <div role="alert" className="text-label" style={{ marginTop: "var(--sp-2)", color: "var(--state-error)" }}>
-            Could not prepare the setup prompt.
-          </div>
-        ) : null}
       </div>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        disabled={prepareState === "loading"}
-        onClick={() => {
-          const attempt = ++prepareAttempt.current;
-          void (async () => {
-            setPrepareState("loading");
-            copyFeedback.reset();
-            try {
-              const prompt = await preparePrompt(organizationId);
-              if (prepareAttempt.current !== attempt || activeOrganizationId.current !== organizationId) return;
-              setPrepareState("idle");
-              await copyFeedback.copy(prompt);
-              if (prepareAttempt.current !== attempt || activeOrganizationId.current !== organizationId) return;
-            } catch {
-              if (prepareAttempt.current !== attempt || activeOrganizationId.current !== organizationId) return;
-              setPrepareState("failed");
-            }
-          })();
-        }}
-      >
-        {prepareState === "failed" ? (
-          <RefreshCw className="h-3.5 w-3.5" aria-hidden />
-        ) : copyFeedback.status === "copied" ? (
-          <Check className="h-3.5 w-3.5" aria-hidden />
-        ) : (
-          <Clipboard className="h-3.5 w-3.5" aria-hidden />
-        )}
-        {prepareState === "loading" ? "Preparing…" : prepareState === "failed" ? "Retry" : copyLabel}
-      </Button>
-      <span className="sr-only" aria-live="polite">
-        {prepareState === "loading"
-          ? "Preparing the setup prompt."
-          : prepareState === "failed"
-            ? "Setup prompt preparation failed."
-            : copyFeedback.status === "copied"
-              ? "Setup prompt copied."
-              : copyFeedback.status === "failed"
-                ? "Setup prompt copy failed."
-                : ""}
-      </span>
+      <ByoSetupPromptActions
+        align="end"
+        preparePrompt={() => preparePrompt(organizationId)}
+        resetKey={organizationId}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

The personal Context handoff copied a generated setup prompt without giving users an optional way to inspect it. Requiring a review step would make the primary flow feel heavier than the setup actually is.

## Solution

- Keep `Copy setup prompt` as the one-click primary action.
- Add a quiet `Preview prompt` action that opens the exact server-authored prompt in a read-only dialog.
- Explain that nothing runs before the prompt is pasted and that it contains a temporary sign-in code.
- Reuse the same action component in Settings and Member onboarding.
- Ignore stale prompt and clipboard completions after Team/provider changes, dialog close, or unmount.

No provider commands are exposed in the default UI, and the preview does not introduce Web-owned readiness or completion state.

## Validation

- Focused Web tests: 136/136 passed
- Full Web test suite: passed
- Root `pnpm check`: passed
- Root `pnpm typecheck`: passed
- Focused client tests rerun after root-suite load timeouts: 79/79 passed
- Preview QA: admin and member flows, direct copy, optional preview, desktop, and 844×390 landscape
- Two independent code/UX reviews: no blockers
