### PR TITLE
feat(resources): project complete Team Skill bundles at runtime

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,6 +41,7 @@
     "smol-toml": "^1.7.0",
     "ws": "^8.20.0",
     "yaml": "^2.8.3",
+    "yauzl": "^3.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
@@ -49,7 +50,9 @@
     "@types/node": "^22.16.0",
     "@types/semver": "^7.5.8",
     "@types/ws": "^8.18.1",
+    "@types/yauzl": "^3.4.0",
     "@vitest/coverage-v8": "3.2.4",
+    "fflate": "^0.8.2",
     "tsdown": "^0.21.4",
     "vitest": "^3.2.0"
   }

--- a/packages/client/src/__tests__/managed-skills.test.ts
+++ b/packages/client/src/__tests__/managed-skills.test.ts
@@ -12,14 +12,24 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { RuntimeProvider, RuntimeResourceSkill } from "@first-tree/shared";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type AgentRuntimeConfig,
+  type RuntimeProvider,
+  type RuntimeResourceSkill,
+  type RuntimeTeamSkillAttachmentEntry,
+  type RuntimeTeamSkillEntry,
+  TEAM_SKILL_BUNDLE_LIMITS,
+} from "@first-tree/shared";
+import { strToU8, zipSync } from "fflate";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CORE_SKILL_NAMES } from "../runtime/first-tree-skills/installer.js";
 import {
   authoritativeTeamSkillSnapshot,
+  type ManagedSkillAttachmentFetcher,
   type ManagedSkillsCheckpoint,
   providerSkillRoot,
   reconcileManagedSkills,
+  teamSkillSnapshotFromConfig,
 } from "../runtime/managed-skills.js";
 import {
   MANAGED_SKILLS_JOURNAL_REL,
@@ -28,6 +38,7 @@ import {
   readManagedState,
   readManagedStateResult,
 } from "../runtime/managed-state.js";
+import { extractTeamSkillBundle } from "../runtime/team-skill-bundle.js";
 
 const PROVIDERS: readonly RuntimeProvider[] = ["claude-code", "claude-code-tui", "codex", "cursor", "kimi-code"];
 
@@ -40,6 +51,133 @@ function teamSkill(overrides: Partial<RuntimeResourceSkill> = {}): RuntimeResour
     metadata: { owner: "platform" },
     ...overrides,
   };
+}
+
+function teamBundleZip(
+  name = "review",
+  body = "# Review\n\nUse the supporting files.",
+  wrapper = "",
+  supporting: Record<string, Uint8Array> = {
+    "scripts/run.sh": strToU8("#!/bin/sh\necho bundled\n"),
+    "references/policy.md": strToU8("bundled policy\n"),
+  },
+): Buffer {
+  const prefix = wrapper ? `${wrapper}/` : "";
+  const entries: Record<string, Uint8Array> = {
+    [`${prefix}SKILL.md`]: strToU8(
+      ["---", `name: ${name}`, "description: Review changes.", "---", "", body, ""].join("\n"),
+    ),
+  };
+  for (const [path, bytes] of Object.entries(supporting)) entries[`${prefix}${path}`] = bytes;
+  return Buffer.from(zipSync(entries));
+}
+
+function maximumAdmissibleTeamBundleZip(): Buffer {
+  const manifest = strToU8(
+    ["---", "name: review", "description: Review changes.", "---", "", "# Review", "", "At the limit.", ""].join("\n"),
+  );
+  const entries: Record<string, Uint8Array> = { "SKILL.md": manifest };
+  const tinyFiles = 251;
+  for (let index = 0; index < tinyFiles; index++) {
+    entries[`references/tiny-${index}.txt`] = Uint8Array.of(index % 256);
+  }
+  for (let index = 0; index < 3; index++) {
+    entries[`references/full-${index}.bin`] = new Uint8Array(TEAM_SKILL_BUNDLE_LIMITS.fileBytes);
+  }
+  const remaining =
+    TEAM_SKILL_BUNDLE_LIMITS.totalBytes - manifest.byteLength - tinyFiles - 3 * TEAM_SKILL_BUNDLE_LIMITS.fileBytes;
+  entries["references/remainder.bin"] = new Uint8Array(remaining);
+  return Buffer.from(zipSync(entries));
+}
+
+function attachmentEntry(
+  attachmentId: string,
+  bytes: Buffer,
+  overrides: Partial<RuntimeTeamSkillAttachmentEntry> = {},
+): RuntimeTeamSkillAttachmentEntry {
+  return {
+    kind: "attachment-bundle",
+    resourceId: "resource-review",
+    name: "review",
+    description: "Review changes.",
+    attachmentId,
+    sizeBytes: bytes.byteLength,
+    ...overrides,
+  };
+}
+
+function attachmentSnapshot(resourceConfigVersion: number, entries: readonly RuntimeTeamSkillEntry[]) {
+  return {
+    kind: "authoritative" as const,
+    resourceConfigVersion,
+    entries,
+  };
+}
+
+function runtimeConfig(
+  version: number,
+  resourceSkills: readonly RuntimeResourceSkill[],
+  teamSkillSnapshot?: unknown,
+): AgentRuntimeConfig {
+  return {
+    agentId: "agent-1",
+    version,
+    payload: {
+      kind: "codex",
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [...resourceSkills],
+      ...(teamSkillSnapshot === undefined ? {} : { teamSkillSnapshot }),
+      reasoningEffort: "high",
+      serviceTier: "default",
+    },
+    updatedAt: new Date(0).toISOString(),
+    updatedBy: "member-1",
+  };
+}
+
+function mutateFirstZipEntry(
+  source: Buffer,
+  mutateLocal: (bytes: Buffer, offset: number) => void,
+  mutateCentral: (bytes: Buffer, offset: number) => void,
+): Buffer {
+  const bytes = Buffer.from(source);
+  const local = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+  const central = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+  if (local < 0 || central < 0) throw new Error("fixture ZIP headers are missing");
+  mutateLocal(bytes, local);
+  mutateCentral(bytes, central);
+  return bytes;
+}
+
+function encryptedZip(source: Buffer): Buffer {
+  return mutateFirstZipEntry(
+    source,
+    (bytes, offset) => bytes.writeUInt16LE(bytes.readUInt16LE(offset + 6) | 0x1, offset + 6),
+    (bytes, offset) => bytes.writeUInt16LE(bytes.readUInt16LE(offset + 8) | 0x1, offset + 8),
+  );
+}
+
+function unixTypeZip(source: Buffer, mode: number): Buffer {
+  return mutateFirstZipEntry(
+    source,
+    () => {},
+    (bytes, offset) => {
+      bytes.writeUInt16LE((3 << 8) | 20, offset + 4);
+      bytes.writeUInt32LE((mode << 16) >>> 0, offset + 38);
+    },
+  );
+}
+
+function mismatchedSizeZip(source: Buffer): Buffer {
+  return mutateFirstZipEntry(
+    source,
+    (bytes, offset) => bytes.writeUInt32LE(bytes.readUInt32LE(offset + 22) + 1, offset + 22),
+    (bytes, offset) => bytes.writeUInt32LE(bytes.readUInt32LE(offset + 24) + 1, offset + 24),
+  );
 }
 
 function writeCoreBundle(parent: string, version = "1.0.0", label = version): string {
@@ -212,6 +350,558 @@ describe("managed Skill reconciler", () => {
     expect(revoked.removed).toContain("resource:resource-review@.agents/skills/review");
     expect(existsSync(target(workspace, "codex", "review"))).toBe(false);
     expect(readManagedState(workspace)?.resourceConfigVersion).toBe(12);
+  });
+
+  it("uses a recognized snapshot exclusively and preserves LKG for malformed or future snapshots", () => {
+    const legacy = teamSkill();
+    const absent = teamSkillSnapshotFromConfig(runtimeConfig(3, [legacy]));
+    expect(absent).toEqual(authoritativeTeamSkillSnapshot(3, [legacy]));
+
+    const recognized = teamSkillSnapshotFromConfig(
+      runtimeConfig(4, [legacy], { kind: "authoritative", schemaVersion: 1, entries: [] }),
+    );
+    expect(recognized).toEqual(attachmentSnapshot(4, []));
+
+    expect(
+      teamSkillSnapshotFromConfig(
+        runtimeConfig(5, [legacy], { kind: "authoritative", schemaVersion: 1, entries: "invalid" }),
+      ),
+    ).toEqual({ kind: "unavailable" });
+    expect(
+      teamSkillSnapshotFromConfig(runtimeConfig(6, [legacy], { kind: "authoritative", schemaVersion: 2, entries: [] })),
+    ).toEqual({ kind: "unavailable" });
+  });
+
+  it.each([
+    "",
+    "review-wrapper",
+  ])("installs a complete %s attachment bundle, skips unchanged downloads, and repairs supporting-file drift", async (wrapper) => {
+    const attachmentId = "11111111-1111-4111-8111-111111111111";
+    const bytes = teamBundleZip("review", undefined, wrapper);
+    const fetchAttachment = vi.fn<ManagedSkillAttachmentFetcher>(async () => ({
+      bytes,
+      size: bytes.byteLength,
+    }));
+    const snapshot = attachmentSnapshot(20, [attachmentEntry(attachmentId, bytes)]);
+
+    const installed = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: snapshot,
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(installed.ok, JSON.stringify(installed.failures)).toBe(true);
+    expect(readFileSync(join(target(workspace, "codex", "review"), "scripts", "run.sh"), "utf-8")).toContain("bundled");
+    expect(readFileSync(join(target(workspace, "codex", "review"), "references", "policy.md"), "utf-8")).toContain(
+      "bundled policy",
+    );
+    const marker = readFileSync(join(target(workspace, "codex", "review"), ".first-tree-managed.json"), "utf-8");
+    expect(marker).not.toContain(attachmentId);
+    expect(readFileSync(join(workspace, MANAGED_STATE_REL), "utf-8")).not.toContain(attachmentId);
+    expect(fetchAttachment).toHaveBeenCalledTimes(1);
+    expect(fetchAttachment).toHaveBeenCalledWith({
+      id: attachmentId,
+      maxBytes: 10 * 1024 * 1024,
+      timeoutMs: 15_000,
+    });
+
+    const unchanged = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: snapshot,
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(unchanged.skipped).toContain("resource:resource-review");
+    expect(fetchAttachment).toHaveBeenCalledTimes(1);
+
+    writeFileSync(join(target(workspace, "codex", "review"), "references", "policy.md"), "drift\n");
+    const repaired = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: snapshot,
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(repaired.installed).toContain("resource:resource-review");
+    expect(fetchAttachment).toHaveBeenCalledTimes(2);
+    expect(readFileSync(join(target(workspace, "codex", "review"), "references", "policy.md"), "utf-8")).toContain(
+      "bundled policy",
+    );
+  });
+
+  it("installs an archive at the exact file and byte limits plus generated managed metadata", async () => {
+    const attachmentId = "11111111-1111-4111-8111-111111111111";
+    const bytes = maximumAdmissibleTeamBundleZip();
+    const fetchAttachment = vi.fn<ManagedSkillAttachmentFetcher>(async () => ({
+      bytes,
+      size: bytes.byteLength,
+    }));
+
+    const installed = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(21, [attachmentEntry(attachmentId, bytes)]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+
+    expect(installed.ok, JSON.stringify(installed.failures)).toBe(true);
+    expect(existsSync(join(target(workspace, "codex", "review"), ".first-tree-managed.json"))).toBe(true);
+    expect(existsSync(join(target(workspace, "codex", "review"), "references", "remainder.bin"))).toBe(true);
+  });
+
+  it("preserves LKG on download failure and retries the same config version", async () => {
+    const oldId = "11111111-1111-4111-8111-111111111111";
+    const newId = "22222222-2222-4222-8222-222222222222";
+    const oldBytes = teamBundleZip("review", "# Review\n\nOld bundle.");
+    const newBytes = teamBundleZip("review", "# Review\n\nNew bundle.");
+    const responses = new Map<string, Buffer>([[oldId, oldBytes]]);
+    const fetchAttachment = vi.fn<ManagedSkillAttachmentFetcher>(async ({ id }) => {
+      const bytes = responses.get(id);
+      if (!bytes) throw new Error("missing fixture attachment");
+      return { bytes, size: bytes.byteLength };
+    });
+
+    await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(30, [attachmentEntry(oldId, oldBytes)]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    const failed = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(31, [attachmentEntry(newId, newBytes)]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(failed.ok).toBe(false);
+    expect(readFileSync(join(target(workspace, "codex", "review"), "SKILL.md"), "utf-8")).toContain("Old bundle.");
+    expect(readManagedState(workspace)?.resourceConfigVersion).toBe(31);
+    expect(existsSync(join(workspace, MANAGED_SKILLS_JOURNAL_REL))).toBe(false);
+
+    responses.set(newId, newBytes);
+    const retried = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(31, [attachmentEntry(newId, newBytes)]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(retried.installed).toContain("resource:resource-review");
+    expect(readFileSync(join(target(workspace, "codex", "review"), "SKILL.md"), "utf-8")).toContain("New bundle.");
+  });
+
+  it("leaves no target, staging directory, or journal after a first-install bundle failure", async () => {
+    const attachmentId = "11111111-1111-4111-8111-111111111111";
+    const valid = teamBundleZip();
+    const invalid = Buffer.alloc(valid.byteLength);
+    const fetchAttachment = vi.fn<ManagedSkillAttachmentFetcher>(async () => ({
+      bytes: invalid,
+      size: invalid.byteLength,
+    }));
+
+    const result = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(35, [attachmentEntry(attachmentId, valid)]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(existsSync(target(workspace, "codex", "review"))).toBe(false);
+    expect(existsSync(join(workspace, MANAGED_SKILLS_JOURNAL_REL))).toBe(false);
+    expect(
+      readdirSync(join(workspace, ".agents", "skills")).some(
+        (name) => name.startsWith(".review.ft-") && name.endsWith(".staging"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not replace a user target created while an attachment is downloading", async () => {
+    const attachmentId = "11111111-1111-4111-8111-111111111111";
+    const bytes = teamBundleZip();
+    const userTarget = target(workspace, "codex", "review");
+    const fetchAttachment = vi.fn<ManagedSkillAttachmentFetcher>(async () => {
+      mkdirSync(userTarget, { recursive: true });
+      writeFileSync(join(userTarget, "SKILL.md"), "user content created during download\n");
+      return { bytes, size: bytes.byteLength };
+    });
+
+    const result = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(36, [attachmentEntry(attachmentId, bytes)]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+
+    expect(result.failures).toContainEqual({
+      key: "resource:resource-review",
+      reason: expect.stringContaining("target created while staging"),
+    });
+    expect(readFileSync(join(userTarget, "SKILL.md"), "utf-8")).toBe("user content created during download\n");
+    expect(existsSync(join(userTarget, ".first-tree-managed.json"))).toBe(false);
+    expect(existsSync(join(workspace, MANAGED_SKILLS_JOURNAL_REL))).toBe(false);
+    expect(
+      readdirSync(join(workspace, ".agents", "skills")).some(
+        (name) => name.startsWith(".review.ft-") && name.endsWith(".staging"),
+      ),
+    ).toBe(false);
+  });
+
+  it("preserves user content that replaces a previously managed target on update and revoke", async () => {
+    const attachmentIdV1 = "11111111-1111-4111-8111-111111111111";
+    const attachmentIdV2 = "22222222-2222-4222-8222-222222222222";
+    const bytesV1 = teamBundleZip("review", "# Review\n\nManaged v1.");
+    const bytesV2 = teamBundleZip("review", "# Review\n\nManaged v2.");
+    const responses = new Map<string, Buffer>([
+      [attachmentIdV1, bytesV1],
+      [attachmentIdV2, bytesV2],
+    ]);
+    const fetchAttachment = vi.fn<ManagedSkillAttachmentFetcher>(async ({ id }) => {
+      const bytes = responses.get(id);
+      if (!bytes) throw new Error("missing fixture attachment");
+      return { bytes, size: bytes.byteLength };
+    });
+    const userTarget = target(workspace, "codex", "review");
+
+    const installed = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(37, [attachmentEntry(attachmentIdV1, bytesV1)]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(installed.ok, JSON.stringify(installed.failures)).toBe(true);
+
+    rmSync(userTarget, { recursive: true, force: true });
+    mkdirSync(userTarget, { recursive: true });
+    writeFileSync(join(userTarget, "SKILL.md"), "user replacement\n");
+
+    const update = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(38, [attachmentEntry(attachmentIdV2, bytesV2)]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(update.failures).toContainEqual({
+      key: "resource:resource-review",
+      reason: expect.stringContaining("refusing to mutate unowned managed Skill target"),
+    });
+    expect(readFileSync(join(userTarget, "SKILL.md"), "utf-8")).toBe("user replacement\n");
+
+    const revoke = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(39, []),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(revoke.failures).toContainEqual({
+      key: "resource:resource-review",
+      reason: expect.stringContaining("cleanup .agents/skills/review: refusing to mutate unowned managed Skill target"),
+    });
+    expect(readFileSync(join(userTarget, "SKILL.md"), "utf-8")).toBe("user replacement\n");
+    expect(existsSync(join(workspace, MANAGED_SKILLS_JOURNAL_REL))).toBe(false);
+  });
+
+  it("preserves unowned directories even when their names resemble internal staging paths", async () => {
+    const skillsRoot = join(workspace, ".agents", "skills");
+    const userDirectory = join(skillsRoot, ".review.ft-0123456789abcdef.staging");
+    mkdirSync(userDirectory, { recursive: true });
+    writeFileSync(join(userDirectory, "keep.txt"), "keep\n");
+
+    const result = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: authoritativeTeamSkillSnapshot(1, []),
+      bundledSkillsRoot,
+    });
+
+    expect(result.ok, JSON.stringify(result.failures)).toBe(true);
+    expect(readFileSync(join(userDirectory, "keep.txt"), "utf-8")).toBe("keep\n");
+  });
+
+  it("materializes explicit empty directories from root and wrapped bundles", async () => {
+    for (const wrapper of ["", "wrapped"]) {
+      const destination = join(workspace, `empty-directory-${wrapper || "root"}`);
+      mkdirSync(destination, { recursive: true });
+      const bytes = teamBundleZip("review", "# Review\n\nEmpty template.", wrapper, {
+        "templates/empty/": new Uint8Array(),
+      });
+
+      await extractTeamSkillBundle(bytes, destination);
+
+      expect(lstatSync(join(destination, "templates", "empty")).isDirectory()).toBe(true);
+      expect(readdirSync(join(destination, "templates", "empty"))).toEqual([]);
+    }
+  });
+
+  it("preserves an unavailable Skill while other entries update, then revokes only on omission", async () => {
+    const reviewV1 = teamBundleZip("review", "# Review\n\nReview v1.");
+    const deployV1 = teamBundleZip("deploy", "# Deploy\n\nDeploy v1.");
+    const deployV2 = teamBundleZip("deploy", "# Deploy\n\nDeploy v2.");
+    const ids = {
+      review: "11111111-1111-4111-8111-111111111111",
+      deployV1: "22222222-2222-4222-8222-222222222222",
+      deployV2: "33333333-3333-4333-8333-333333333333",
+    };
+    const responses = new Map<string, Buffer>([
+      [ids.review, reviewV1],
+      [ids.deployV1, deployV1],
+      [ids.deployV2, deployV2],
+    ]);
+    const fetchAttachment = vi.fn<ManagedSkillAttachmentFetcher>(async ({ id }) => {
+      const bytes = responses.get(id);
+      if (!bytes) throw new Error("missing fixture attachment");
+      return { bytes, size: bytes.byteLength };
+    });
+    const review = attachmentEntry(ids.review, reviewV1);
+    const deploy = attachmentEntry(ids.deployV1, deployV1, {
+      resourceId: "resource-deploy",
+      name: "deploy",
+    });
+
+    await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(40, [review, deploy]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    const partial = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(41, [
+        { kind: "unavailable", resourceId: "resource-review", reason: "skill_bundle_unavailable" },
+        attachmentEntry(ids.deployV2, deployV2, { resourceId: "resource-deploy", name: "deploy" }),
+      ]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(partial.failures).toContainEqual({
+      key: "resource:resource-review",
+      reason: "skill_bundle_unavailable",
+    });
+    expect(readFileSync(join(target(workspace, "codex", "review"), "SKILL.md"), "utf-8")).toContain("Review v1.");
+    expect(readFileSync(join(target(workspace, "codex", "deploy"), "SKILL.md"), "utf-8")).toContain("Deploy v2.");
+
+    const revoked = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(42, []),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    expect(revoked.removed).toEqual(
+      expect.arrayContaining([
+        "resource:resource-review@.agents/skills/review",
+        "resource:resource-deploy@.agents/skills/deploy",
+      ]),
+    );
+  });
+
+  it("rewrites a bundle manifest to a deterministic alternate name without changing supporting files", async () => {
+    const userTarget = target(workspace, "codex", "review");
+    mkdirSync(userTarget, { recursive: true });
+    writeFileSync(join(userTarget, "SKILL.md"), "user-owned review\n");
+    const attachmentId = "11111111-1111-4111-8111-111111111111";
+    const bytes = teamBundleZip("Review");
+    const fetchAttachment = vi.fn<ManagedSkillAttachmentFetcher>(async () => ({
+      bytes,
+      size: bytes.byteLength,
+    }));
+
+    const result = await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: attachmentSnapshot(50, [attachmentEntry(attachmentId, bytes, { name: "Review" })]),
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+
+    expect(result.teamSkills[0]?.name).toBe("review-first-tree");
+    expect(readFileSync(join(userTarget, "SKILL.md"), "utf-8")).toBe("user-owned review\n");
+    expect(readFileSync(join(target(workspace, "codex", "review-first-tree"), "SKILL.md"), "utf-8")).toContain(
+      "name: review-first-tree",
+    );
+    expect(
+      readFileSync(join(target(workspace, "codex", "review-first-tree"), "references", "policy.md"), "utf-8"),
+    ).toContain("bundled policy");
+  });
+
+  it("installs the new provider target before removing the old provider bundle target", async () => {
+    const attachmentId = "11111111-1111-4111-8111-111111111111";
+    const bytes = teamBundleZip();
+    const fetchAttachment = vi.fn<ManagedSkillAttachmentFetcher>(async () => ({
+      bytes,
+      size: bytes.byteLength,
+    }));
+    const snapshot = attachmentSnapshot(60, [attachmentEntry(attachmentId, bytes)]);
+
+    await reconcileManagedSkills({
+      workspace,
+      provider: "codex",
+      teamSnapshot: snapshot,
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+    const switched = await reconcileManagedSkills({
+      workspace,
+      provider: "claude-code",
+      teamSnapshot: snapshot,
+      bundledSkillsRoot,
+      fetchAttachment,
+    });
+
+    expect(switched.installed).toContain("resource:resource-review");
+    expect(existsSync(target(workspace, "claude-code", "review"))).toBe(true);
+    expect(existsSync(target(workspace, "codex", "review"))).toBe(false);
+  });
+
+  it.each([
+    [
+      "path traversal",
+      Buffer.from(
+        zipSync({
+          "../SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+        }),
+      ),
+    ],
+    [
+      "absolute path",
+      Buffer.from(
+        zipSync({
+          "/SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+        }),
+      ),
+    ],
+    [
+      "backslash path",
+      Buffer.from(
+        zipSync({
+          "wrapped\\SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+        }),
+      ),
+    ],
+    [
+      "wrong-case manifest",
+      Buffer.from(
+        zipSync({
+          "skill.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+        }),
+      ),
+    ],
+    [
+      "case-colliding files",
+      Buffer.from(
+        zipSync({
+          "SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+          "scripts/run.sh": strToU8("one"),
+          "scripts/RUN.sh": strToU8("two"),
+        }),
+      ),
+    ],
+    [
+      "wrapped-root extra content",
+      Buffer.from(
+        zipSync({
+          "wrapped/SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+          "outside.txt": strToU8("outside"),
+        }),
+      ),
+    ],
+    [
+      "Windows device name",
+      Buffer.from(
+        zipSync({
+          "SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+          "scripts/CON": strToU8("device"),
+        }),
+      ),
+    ],
+    [
+      "trailing-dot segment",
+      Buffer.from(
+        zipSync({
+          "SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+          "references./policy.md": strToU8("unsafe"),
+        }),
+      ),
+    ],
+    [
+      "reserved ownership marker",
+      Buffer.from(
+        zipSync({
+          "SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+          ".first-tree-managed.json": strToU8("{}"),
+        }),
+      ),
+    ],
+    [
+      "case-varied ownership marker",
+      Buffer.from(
+        zipSync({
+          "SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+          ".FIRST-TREE-MANAGED.JSON": strToU8("{}"),
+        }),
+      ),
+    ],
+    [
+      "ownership marker child",
+      Buffer.from(
+        zipSync({
+          "SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+          ".first-tree-managed.json/data": strToU8("unsafe"),
+        }),
+      ),
+    ],
+    [
+      "file parent",
+      Buffer.from(
+        zipSync({
+          "SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+          scripts: strToU8("file"),
+          "scripts/run.sh": strToU8("nested"),
+        }),
+      ),
+    ],
+    [
+      "wrapped-root outside empty directory",
+      Buffer.from(
+        zipSync({
+          "wrapped/SKILL.md": strToU8("---\nname: review\ndescription: Review changes.\n---\n"),
+          "outside/": new Uint8Array(),
+        }),
+      ),
+    ],
+    [
+      "overlong path segment",
+      teamBundleZip("review", "# Review\n\nUnsafe.", "", {
+        [`references/${"a".repeat(TEAM_SKILL_BUNDLE_LIMITS.segmentCodeUnits + 1)}.txt`]: strToU8("unsafe"),
+      }),
+    ],
+    [
+      "overlong extracted path",
+      teamBundleZip("review", "# Review\n\nUnsafe.", "", {
+        [`${Array.from({ length: 8 }, () => "a".repeat(100)).join("/")}/file.txt`]: strToU8("unsafe"),
+      }),
+    ],
+    ["encrypted entry", encryptedZip(teamBundleZip())],
+    ["symlink entry", unixTypeZip(teamBundleZip(), 0o120777)],
+    ["special entry", unixTypeZip(teamBundleZip(), 0o010644)],
+    ["declared size mismatch", mismatchedSizeZip(teamBundleZip())],
+  ])("rejects a Team Skill ZIP with %s", async (_label, bytes) => {
+    const destination = join(workspace, "zip-attack");
+    mkdirSync(destination, { recursive: true });
+    await expect(extractTeamSkillBundle(bytes, destination)).rejects.toThrow();
+    expect(existsSync(join(workspace, "SKILL.md"))).toBe(false);
   });
 
   it("serializes callers and prevents an older Team snapshot from rolling back a newer one", async () => {

--- a/packages/client/src/__tests__/sdk-comprehensive.test.ts
+++ b/packages/client/src/__tests__/sdk-comprehensive.test.ts
@@ -1,3 +1,4 @@
+import { Writable } from "node:stream";
 import {
   AGENT_RUNTIME_SESSION_HEADER,
   AGENT_SELECTOR_HEADER,
@@ -80,6 +81,19 @@ function requestInit(fetchMock: ReturnType<typeof vi.fn>, index: number): Reques
   const init = fetchMock.mock.calls[index]?.[1] as RequestInit | undefined;
   if (!init) throw new Error(`missing fetch init at call ${index}`);
   return init;
+}
+
+function collectLogs(): { destination: Writable; read: () => string } {
+  const chunks: string[] = [];
+  return {
+    destination: new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(chunk.toString());
+        callback();
+      },
+    }),
+    read: () => chunks.join(""),
+  };
 }
 
 async function flush<T>(promise: Promise<T>, maxFlushes = 50): Promise<T> {
@@ -480,12 +494,53 @@ describe("FirstTreeHubSDK comprehensive wrappers", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     vi.unstubAllGlobals();
-    fetchMock = mockFetch(jsonResponse({ error: "attachment missing" }, 404));
+    fetchMock = mockFetch(jsonResponse({ error: "Attachment not found" }, 404));
     await expect(makeSdk().fetchAttachment({ id: "att-missing" })).rejects.toMatchObject({
       statusCode: 404,
-      message: "attachment missing",
+      message: "Attachment not found",
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds attachment downloads by both declared and streamed bytes", async () => {
+    const fetchMock = mockFetch(
+      binaryResponse(new Uint8Array([1, 2, 3]), { "content-length": "3" }),
+      binaryResponse(new Uint8Array([1, 2, 3])),
+    );
+    const sdk = makeSdk();
+
+    await expect(sdk.fetchAttachment({ id: "declared-large", maxBytes: 2, timeoutMs: 1_000 })).rejects.toThrow(
+      "caller limit",
+    );
+    await expect(sdk.fetchAttachment({ id: "streamed-large", maxBytes: 2, timeoutMs: 1_000 })).rejects.toThrow(
+      "caller limit",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds attachment error bodies and omits capability ids from retry logs", async () => {
+    const oversizedError = new Uint8Array(64 * 1024 + 1);
+    let fetchMock = mockFetch(new Response(oversizedError, { status: 400 }));
+    await expect(makeSdk().fetchAttachment({ id: "sensitive-capability" })).rejects.toThrow(
+      "response body exceeded 65536 bytes",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.useFakeTimers();
+    vi.unstubAllGlobals();
+    const { destination, read } = collectLogs();
+    applyClientLoggerConfig({ level: "warn", format: "json", destination });
+    fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(textResponse("temporary", 503))
+      .mockResolvedValueOnce(binaryResponse(new Uint8Array([1])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(flush(makeSdk().fetchAttachment({ id: "sensitive-capability" }))).resolves.toMatchObject({
+      size: 1,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(read()).not.toContain("sensitive-capability");
   });
 
   it("parses SDK errors, Retry-After dates, invalid Retry-After values, and invalid success JSON", async () => {

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -680,6 +680,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
               runtimeProvider,
               agentConfigCache?.get(sessionCtx.agent.agentId),
               sessionCtx.log,
+              (options) => sessionCtx.sdk.fetchAttachment(options),
             )
           ).teamSkills;
           const providerEnv = buildEnv(sessionCtx, payload);
@@ -746,6 +747,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
               runtimeProvider,
               agentConfigCache?.get(sessionCtx.agent.agentId),
               sessionCtx.log,
+              (options) => sessionCtx.sdk.fetchAttachment(options),
             )
           ).teamSkills;
           const providerEnv = buildEnv(sessionCtx, payload);

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1575,7 +1575,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // at the old version until the next session restart.
     const providerEnv = buildEnv(sessionCtx);
     if (cwd) {
-      const reconcileResult = await reconcileManagedSkillsForConfig(cwd, runtimeProvider, cached, sessionCtx.log);
+      const reconcileResult = await reconcileManagedSkillsForConfig(
+        cwd,
+        runtimeProvider,
+        cached,
+        sessionCtx.log,
+        (options) => sessionCtx.sdk.fetchAttachment(options),
+      );
       reconciledTeamSkills = reconcileResult.teamSkills;
       const switchedBriefing = currentBriefing(sessionCtx, cwd, newPayload);
       writeAgentBriefing(cwd, switchedBriefing);
@@ -2173,7 +2179,9 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // source-repo list names the paths + upstreams the agent manages.
       declareSourceRepos(cwd, payload);
       reconciledTeamSkills = (
-        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+          sessionCtx.sdk.fetchAttachment(options),
+        )
       ).teamSkills;
 
       const providerEnv = buildEnv(sessionCtx);
@@ -2260,7 +2268,9 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         // `legacyCwd` here (set above), NOT the agent home, so provider-native
         // discovery and its managed transaction state are session-local.
         reconciledTeamSkills = (
-          await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+          await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+            sessionCtx.sdk.fetchAttachment(options),
+          )
         ).teamSkills;
         const providerEnv = buildEnv(sessionCtx);
         writeAgentBriefing(legacyCwd, currentBriefing(sessionCtx, legacyCwd, payload));
@@ -2295,7 +2305,9 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       chatContextForPrompt = chatContext;
       declareSourceRepos(cwd, payload);
       reconciledTeamSkills = (
-        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+          sessionCtx.sdk.fetchAttachment(options),
+        )
       ).teamSkills;
 
       const providerEnv = buildEnv(sessionCtx);

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -452,8 +452,11 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const chatContext = await fetchChatContextOrLog(sessionCtx);
     pendingChatContextPrompt = renderChatContextPrompt(chatContext);
     declareSourceRepos(payload, cwd);
-    reconciledTeamSkills = (await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log))
-      .teamSkills;
+    reconciledTeamSkills = (
+      await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+        sessionCtx.sdk.fetchAttachment(options),
+      )
+    ).teamSkills;
     let env = buildEnv(sessionCtx);
     if (workspaceOnly) {
       const { accessToken } = await sessionCtx.sdk.createAgentOutboxToken(sessionCtx.chatId);
@@ -1715,7 +1718,9 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       if (!runtimeConfig) return null;
       const payload = runtimeConfig.payload;
       reconciledTeamSkills = (
-        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+          sessionCtx.sdk.fetchAttachment(options),
+        )
       ).teamSkills;
       const briefing = buildBriefing(sessionCtx, payload, cwd);
       const fingerprint = computeBriefingFingerprint(briefing);

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -1444,7 +1444,9 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       if (!runtimeConfig) return null;
       const payload = runtimeConfig.payload;
       reconciledTeamSkills = (
-        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+          sessionCtx.sdk.fetchAttachment(options),
+        )
       ).teamSkills;
       const briefing = buildBriefing(sessionCtx, payload, cwd);
       const fingerprint = computeBriefingFingerprint(briefing);
@@ -1581,7 +1583,9 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       // source-repo paths the agent should know about.
       declareSourceRepos(payload, cwd);
       reconciledTeamSkills = (
-        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+          sessionCtx.sdk.fetchAttachment(options),
+        )
       ).teamSkills;
 
       const providerEnv = buildEnv(sessionCtx);
@@ -1663,7 +1667,9 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
 
       declareSourceRepos(payload, cwd);
       reconciledTeamSkills = (
-        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+          sessionCtx.sdk.fetchAttachment(options),
+        )
       ).teamSkills;
 
       const providerEnv = buildEnv(sessionCtx);

--- a/packages/client/src/handlers/cursor/index.ts
+++ b/packages/client/src/handlers/cursor/index.ts
@@ -1517,7 +1517,9 @@ export const createCursorHandler: HandlerFactory = (config) => {
       if (!runtimeConfig) return null;
       const payload = runtimeConfig.payload;
       reconciledTeamSkills = (
-        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+        await reconcileManagedSkillsForConfig(cwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+          sessionCtx.sdk.fetchAttachment(options),
+        )
       ).teamSkills;
       const briefing = buildBriefing(sessionCtx, payload, cwd);
       const fingerprint = computeBriefingFingerprint(briefing);
@@ -1623,7 +1625,9 @@ export const createCursorHandler: HandlerFactory = (config) => {
 
     declareSourceRepos(payload, workspaceCwd);
     reconciledTeamSkills = (
-      await reconcileManagedSkillsForConfig(workspaceCwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+      await reconcileManagedSkillsForConfig(workspaceCwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+        sessionCtx.sdk.fetchAttachment(options),
+      )
     ).teamSkills;
 
     const briefing = buildBriefing(sessionCtx, payload, workspaceCwd);

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -671,7 +671,9 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
 
     sourceReposForPrompt = declaredSourceRepos(workspaceCwd, payload);
     reconciledTeamSkills = (
-      await reconcileManagedSkillsForConfig(workspaceCwd, runtimeProvider, runtimeConfig, sessionCtx.log)
+      await reconcileManagedSkillsForConfig(workspaceCwd, runtimeProvider, runtimeConfig, sessionCtx.log, (options) =>
+        sessionCtx.sdk.fetchAttachment(options),
+      )
     ).teamSkills;
     const briefing = buildBriefing(sessionCtx, payload, workspaceCwd);
     ensureAgentBootstrap({

--- a/packages/client/src/runtime/managed-skills.ts
+++ b/packages/client/src/runtime/managed-skills.ts
@@ -14,8 +14,19 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
-import type { AgentRuntimeConfig, RuntimeProvider, RuntimeResourceSkill } from "@first-tree/shared";
-import { parse as parseYaml } from "yaml";
+import {
+  type AgentRuntimeConfig,
+  parseTeamSkillMarkdown,
+  type RuntimeProvider,
+  type RuntimeResourceSkill,
+  type RuntimeTeamSkillAttachmentEntry,
+  type RuntimeTeamSkillEntry,
+  runtimeTeamSkillSnapshotSchema,
+  TEAM_SKILL_BUNDLE_LIMITS,
+  TEAM_SKILL_OWNERSHIP_MARKER,
+  TEAM_SKILL_RUNTIME_NAME_MAX,
+} from "@first-tree/shared";
+import { stringify as stringifyYaml } from "yaml";
 import { CORE_SKILL_NAMES, resolveBundledSkillsRoot } from "./first-tree-skills/installer.js";
 import {
   clearManagedSkillsJournal,
@@ -31,16 +42,25 @@ import {
   writeManagedSkillsJournal,
   writeManagedState,
 } from "./managed-state.js";
+import { extractTeamSkillBundle } from "./team-skill-bundle.js";
 import { acquireWorkspaceFileLock, type WorkspaceFileLock } from "./workspace-file-lock.js";
 
-const OWNERSHIP_MARKER = ".first-tree-managed.json";
+const OWNERSHIP_MARKER = TEAM_SKILL_OWNERSHIP_MARKER;
 const LEGACY_RESOURCE_SKILLS_ROOT = ".first-tree/resources/skills";
-const MAX_SKILL_FILES = 512;
-const MAX_SKILL_TOTAL_BYTES = 16 * 1024 * 1024;
-const MAX_SKILL_FILE_BYTES = 4 * 1024 * 1024;
-const MAX_SKILL_DEPTH = 16;
-const MAX_SKILL_NAME_LENGTH = 63;
+const MAX_SKILL_FILES = TEAM_SKILL_BUNDLE_LIMITS.files;
+const MAX_SKILL_TOTAL_BYTES = TEAM_SKILL_BUNDLE_LIMITS.totalBytes;
+const MAX_SKILL_FILE_BYTES = TEAM_SKILL_BUNDLE_LIMITS.fileBytes;
+const MAX_SKILL_DEPTH = TEAM_SKILL_BUNDLE_LIMITS.depth;
+const MAX_OWNERSHIP_MARKER_BYTES = 4 * 1024;
+// Installed trees contain one Client-generated ownership marker and may
+// contain a canonicalized SKILL.md. Archive extraction remains bound by the
+// shared payload limits; these small, explicit allowances cover only managed
+// metadata and manifest rewriting during staging/digest validation.
+const MAX_INSTALLED_SKILL_FILES = MAX_SKILL_FILES + 1;
+const MAX_INSTALLED_SKILL_TOTAL_BYTES = MAX_SKILL_TOTAL_BYTES + MAX_SKILL_FILE_BYTES + MAX_OWNERSHIP_MARKER_BYTES;
+const MAX_SKILL_NAME_LENGTH = TEAM_SKILL_RUNTIME_NAME_MAX;
 const DEFAULT_LOCK_TIMEOUT_MS = 10_000;
+const TEAM_SKILL_DOWNLOAD_TIMEOUT_MS = 15_000;
 
 const PROVIDER_SKILL_ROOTS: Readonly<Record<RuntimeProvider, string>> = {
   "claude-code": ".claude/skills",
@@ -84,9 +104,15 @@ export type TeamSkillSnapshot =
   | Readonly<{
       kind: "authoritative";
       resourceConfigVersion: number;
-      skills: readonly RuntimeResourceSkill[];
+      entries: readonly RuntimeTeamSkillEntry[];
     }>
   | Readonly<{ kind: "unavailable" }>;
+
+export type ManagedSkillAttachmentFetcher = (options: {
+  id: string;
+  maxBytes: number;
+  timeoutMs: number;
+}) => Promise<{ bytes: Buffer; size: number }>;
 
 export type ReconciledTeamSkill = Readonly<{
   key: `resource:${string}`;
@@ -134,6 +160,7 @@ export type ReconcileManagedSkillsOptions = Readonly<{
   testFailureAt?: ManagedSkillsCheckpoint;
   /** Forces the rollback path to preserve its journal and abort reconciliation. */
   testRecoveryFailure?: boolean;
+  fetchAttachment?: ManagedSkillAttachmentFetcher;
 }>;
 
 type DesiredManagedSkill = Readonly<{
@@ -145,7 +172,9 @@ type DesiredManagedSkill = Readonly<{
   validationError: string | null;
   source:
     | Readonly<{ kind: "bundled-directory"; path: string }>
-    | Readonly<{ kind: "inline-skill"; skill: RuntimeResourceSkill }>;
+    | Readonly<{ kind: "inline-skill"; skill: RuntimeResourceSkill }>
+    | Readonly<{ kind: "attachment-bundle"; descriptor: RuntimeTeamSkillAttachmentEntry }>
+    | Readonly<{ kind: "unavailable" }>;
 }>;
 
 type AllocatedManagedSkill = Readonly<{
@@ -158,7 +187,26 @@ type StagedManagedSkill = Readonly<{
   allocated: AllocatedManagedSkill;
   staging: string;
   entry: ManagedSkillEntry;
+  targetPrecondition: Readonly<{ kind: "absent" }> | Readonly<{ kind: "present"; proof: ManagedTargetOwnershipProof }>;
 }>;
+
+type ManagedTargetOwnershipProof =
+  | Readonly<{
+      kind: "marker";
+      key: ManagedSkillEntry["key"];
+      revision: string;
+      digest: `sha256:${string}`;
+    }>
+  | Readonly<{
+      kind: "ledger-digest";
+      key: ManagedSkillEntry["key"];
+      digest: `sha256:${string}`;
+    }>
+  | Readonly<{
+      kind: "legacy-symlink";
+      key: ManagedSkillEntry["key"];
+      linkTarget: string;
+    }>;
 
 type MutableReconcileResult = {
   installed: string[];
@@ -187,13 +235,26 @@ export function authoritativeTeamSkillSnapshot(
   resourceConfigVersion: number,
   skills: readonly RuntimeResourceSkill[],
 ): TeamSkillSnapshot {
-  return { kind: "authoritative", resourceConfigVersion, skills };
+  return {
+    kind: "authoritative",
+    resourceConfigVersion,
+    entries: skills.map((skill) => ({ kind: "inline", ...skill })),
+  };
 }
 
 export function teamSkillSnapshotFromConfig(config: AgentRuntimeConfig | null | undefined): TeamSkillSnapshot {
-  return config
-    ? authoritativeTeamSkillSnapshot(config.version, config.payload.resourceSkills)
-    : { kind: "unavailable" };
+  if (!config) return { kind: "unavailable" };
+  const rawSnapshot = config.payload.teamSkillSnapshot;
+  if (rawSnapshot === undefined) {
+    return authoritativeTeamSkillSnapshot(config.version, config.payload.resourceSkills);
+  }
+  const parsed = runtimeTeamSkillSnapshotSchema.safeParse(rawSnapshot);
+  if (!parsed.success) return { kind: "unavailable" };
+  return {
+    kind: "authoritative",
+    resourceConfigVersion: config.version,
+    entries: parsed.data.entries,
+  };
 }
 
 export async function reconcileManagedSkillsForConfig(
@@ -201,12 +262,14 @@ export async function reconcileManagedSkillsForConfig(
   provider: RuntimeProvider,
   config: AgentRuntimeConfig | null | undefined,
   log?: (message: string) => void,
+  fetchAttachment?: ManagedSkillAttachmentFetcher,
 ): Promise<ReconcileManagedSkillsResult> {
   return reconcileManagedSkills({
     workspace,
     provider,
     teamSnapshot: teamSkillSnapshotFromConfig(config),
     log,
+    fetchAttachment,
   });
 }
 
@@ -252,7 +315,7 @@ export async function reconcileManagedSkills(
         });
       }
       if (authoritative && options.teamSnapshot.kind === "authoritative") {
-        state = await adoptLegacyResourceSkills(options.workspace, state, options.teamSnapshot.skills, options.log);
+        state = await adoptLegacyResourceSkills(options.workspace, state, options.teamSnapshot.entries, options.log);
       } else if (options.teamSnapshot.kind === "unavailable") {
         options.log?.(
           "Managed skills Team Resource snapshot unavailable; preserving last-known-good Team Skills until control-plane recovery",
@@ -297,7 +360,13 @@ export async function reconcileManagedSkills(
               continue;
             }
           }
-          const staged = await stageManagedSkill(options.workspace, allocated);
+          const targetPrecondition = await captureInstallTargetPrecondition(
+            options.workspace,
+            allocated.target,
+            state,
+            allocated.desired.key,
+          );
+          const staged = await stageManagedSkill(options, allocated, targetPrecondition);
           state = await installStagedSkill(options, state, staged);
           mutable.installed.push(staged.entry.key);
           successfulTargets.set(staged.entry.key, staged.entry.target);
@@ -521,11 +590,13 @@ async function digestLegacyTargetIfOwned(
 async function adoptLegacyResourceSkills(
   workspace: string,
   state: ManagedState,
-  skills: readonly RuntimeResourceSkill[],
+  entries: readonly RuntimeTeamSkillEntry[],
   log?: (message: string) => void,
 ): Promise<ManagedState> {
   const additions: ManagedSkillEntry[] = [];
-  for (const skill of skills) {
+  for (const entry of entries) {
+    if (entry.kind !== "inline") continue;
+    const skill: RuntimeResourceSkill = entry;
     if (!isSafeLegacyResourceId(skill.resourceId)) continue;
     const target = `${LEGACY_RESOURCE_SKILLS_ROOT}/${skill.resourceId}`;
     if (state.skills.some((entry) => entry.target === target)) continue;
@@ -598,45 +669,61 @@ async function buildDesiredSkills(
   }
   if (!authoritativeTeamSnapshot || options.teamSnapshot.kind !== "authoritative") return desired;
 
-  const sorted = [...options.teamSnapshot.skills].sort((left, right) =>
+  const sorted = [...options.teamSnapshot.entries].sort((left, right) =>
     left.resourceId.localeCompare(right.resourceId),
   );
   const resourceIdCounts = new Map<string, number>();
-  for (const skill of sorted) {
-    resourceIdCounts.set(skill.resourceId, (resourceIdCounts.get(skill.resourceId) ?? 0) + 1);
+  for (const entry of sorted) {
+    resourceIdCounts.set(entry.resourceId, (resourceIdCounts.get(entry.resourceId) ?? 0) + 1);
   }
   const emittedDuplicateIds = new Set<string>();
-  for (const skill of sorted) {
-    const key = `resource:${skill.resourceId}` as const;
-    if ((resourceIdCounts.get(skill.resourceId) ?? 0) > 1) {
-      if (!emittedDuplicateIds.has(skill.resourceId)) {
-        emittedDuplicateIds.add(skill.resourceId);
+  for (const entry of sorted) {
+    const key = `resource:${entry.resourceId}` as const;
+    const revision = teamSkillEntryRevision(entry);
+    const description = entry.kind === "unavailable" ? "Unavailable Team Skill" : entry.description || "No description";
+    const source = teamSkillEntrySource(entry);
+    if ((resourceIdCounts.get(entry.resourceId) ?? 0) > 1) {
+      if (!emittedDuplicateIds.has(entry.resourceId)) {
+        emittedDuplicateIds.add(entry.resourceId);
         options.log?.(`Managed Team Skill rejected (${key}): duplicate resourceId in authoritative snapshot`);
         desired.push({
           key,
           kind: "team",
           requestedSlug: "",
-          description: skill.description || "No description",
-          revision: inlineSkillRevision(skill),
+          description,
+          revision,
           validationError: "duplicate resourceId in authoritative snapshot",
-          source: { kind: "inline-skill", skill },
+          source,
         });
       }
       continue;
     }
+    if (entry.kind === "unavailable") {
+      options.log?.(`Managed Team Skill unavailable (${key}): ${entry.reason}`);
+      desired.push({
+        key,
+        kind: "team",
+        requestedSlug: "",
+        description,
+        revision,
+        validationError: entry.reason,
+        source,
+      });
+      continue;
+    }
     try {
-      const requestedSlug = normalizeRequestedSlug(skill.name);
+      const requestedSlug = normalizeRequestedSlug(entry.name);
       if (RESERVED_CORE_SLUGS.has(requestedSlug)) {
-        throw new Error(`Team Skill name "${skill.name}" is reserved by First Tree`);
+        throw new Error(`Team Skill name "${entry.name}" is reserved by First Tree`);
       }
       desired.push({
         key,
         kind: "team",
         requestedSlug,
-        description: skill.description || "No description",
-        revision: inlineSkillRevision(skill),
+        description,
+        revision,
         validationError: null,
-        source: { kind: "inline-skill", skill },
+        source,
       });
     } catch (error) {
       options.log?.(`Managed Team Skill rejected (${key}): ${error instanceof Error ? error.message : String(error)}`);
@@ -646,10 +733,10 @@ async function buildDesiredSkills(
         key,
         kind: "team",
         requestedSlug: "",
-        description: skill.description || "No description",
-        revision: inlineSkillRevision(skill),
+        description,
+        revision,
         validationError: error instanceof Error ? error.message : String(error),
-        source: { kind: "inline-skill", skill },
+        source,
       });
     }
   }
@@ -746,7 +833,14 @@ async function ensureTargetOwnership(
   state: ManagedState,
   allocated: AllocatedManagedSkill,
 ): Promise<ManagedState> {
-  if (state.skills.some((entry) => entry.key === allocated.desired.key && entry.target === allocated.target)) {
+  const stateEntry = state.skills.find(
+    (entry) => entry.key === allocated.desired.key && entry.target === allocated.target,
+  );
+  if (stateEntry) {
+    const targetPath = resolveWorkspacePath(workspace, allocated.target, "target");
+    if (await pathExists(targetPath)) {
+      await proveManagedTargetOwnership(workspace, stateEntry);
+    }
     return state;
   }
   const targetPath = resolveWorkspacePath(workspace, allocated.target, "target");
@@ -794,19 +888,41 @@ async function ensureTargetOwnership(
   });
 }
 
-async function stageManagedSkill(workspace: string, allocated: AllocatedManagedSkill): Promise<StagedManagedSkill> {
+async function stageManagedSkill(
+  options: ReconcileManagedSkillsOptions,
+  allocated: AllocatedManagedSkill,
+  targetPrecondition: StagedManagedSkill["targetPrecondition"],
+): Promise<StagedManagedSkill> {
+  const { workspace } = options;
   const targetPath = resolveWorkspacePath(workspace, allocated.target, "target");
   await mkdir(dirname(targetPath), { recursive: true });
   const stagingName = `.${basename(targetPath)}.ft-${randomBytes(8).toString("hex")}.staging`;
   const stagingPath = join(dirname(targetPath), stagingName);
   const staging = portableRelative(workspace, stagingPath);
   await rm(stagingPath, { recursive: true, force: true });
-  await mkdir(stagingPath, { recursive: false });
+  await mkdir(stagingPath, { recursive: false, mode: 0o700 });
   try {
     if (allocated.desired.source.kind === "bundled-directory") {
       await copySanitizedSkillTree(allocated.desired.source.path, stagingPath);
-    } else {
+    } else if (allocated.desired.source.kind === "inline-skill") {
       await writeInlineSkillTree(stagingPath, allocated);
+    } else if (allocated.desired.source.kind === "attachment-bundle") {
+      if (!options.fetchAttachment) throw new Error("Team Skill bundle download is unavailable");
+      const descriptor = allocated.desired.source.descriptor;
+      const downloaded = await options.fetchAttachment({
+        id: descriptor.attachmentId,
+        maxBytes: TEAM_SKILL_BUNDLE_LIMITS.compressedBytes,
+        timeoutMs: TEAM_SKILL_DOWNLOAD_TIMEOUT_MS,
+      });
+      if (downloaded.size !== descriptor.sizeBytes || downloaded.bytes.byteLength !== descriptor.sizeBytes) {
+        throw new Error(
+          `Team Skill bundle size mismatch: expected ${descriptor.sizeBytes}, received ${downloaded.bytes.byteLength}`,
+        );
+      }
+      await extractTeamSkillBundle(downloaded.bytes, stagingPath);
+      await rewriteAttachmentSkillManifest(stagingPath, descriptor, allocated.effectiveName);
+    } else {
+      throw new Error("unavailable Team Skill cannot be staged");
     }
     await writeOwnershipMarker(stagingPath, allocated.desired.key, allocated.desired.revision);
     const metadata = await validateSkillManifest(stagingPath, allocated.effectiveName);
@@ -819,6 +935,7 @@ async function stageManagedSkill(workspace: string, allocated: AllocatedManagedS
     return {
       allocated,
       staging,
+      targetPrecondition,
       entry: {
         key: allocated.desired.key,
         target: allocated.target,
@@ -834,6 +951,19 @@ async function stageManagedSkill(workspace: string, allocated: AllocatedManagedS
   }
 }
 
+async function captureInstallTargetPrecondition(
+  workspace: string,
+  target: string,
+  state: ManagedState,
+  key: ManagedSkillEntry["key"],
+): Promise<StagedManagedSkill["targetPrecondition"]> {
+  const targetPath = resolveWorkspacePath(workspace, target, "target");
+  if (!(await pathExists(targetPath))) return { kind: "absent" };
+  const entry = state.skills.find((candidate) => candidate.key === key && candidate.target === target);
+  if (!entry) throw new Error(`cannot prove managed target ownership before staging ${target}`);
+  return { kind: "present", proof: await proveManagedTargetOwnership(workspace, entry) };
+}
+
 async function installStagedSkill(
   options: ReconcileManagedSkillsOptions,
   beforeState: ManagedState,
@@ -845,6 +975,26 @@ async function installStagedSkill(
   const backupPath = join(dirname(targetPath), `.${basename(targetPath)}.ft-${randomBytes(8).toString("hex")}.backup`);
   const backup = portableRelative(options.workspace, backupPath);
   const targetExists = await pathExists(targetPath);
+  try {
+    if (staged.targetPrecondition.kind === "absent") {
+      if (targetExists) {
+        throw new Error(`refusing to replace target created while staging ${staged.entry.target}`);
+      }
+    } else {
+      if (!targetExists) {
+        throw new Error(`managed target disappeared while staging ${staged.entry.target}`);
+      }
+      await assertManagedRootMatchesProof(
+        resolveWorkspacePath(options.workspace, staged.entry.target, "target"),
+        options.workspace,
+        staged.targetPrecondition.proof,
+        `managed target changed while staging ${staged.entry.target}`,
+      );
+    }
+  } catch (error) {
+    await rm(stagingPath, { recursive: true, force: true });
+    throw error;
+  }
   let journal: ManagedSkillsJournal = {
     schemaVersion: 1,
     operationId: randomBytes(16).toString("hex"),
@@ -862,6 +1012,15 @@ async function installStagedSkill(
   try {
     if (targetExists) {
       await rename(targetPath, backupPath);
+      if (staged.targetPrecondition.kind !== "present") {
+        throw new Error(`managed target ownership proof is missing for ${staged.entry.target}`);
+      }
+      await assertManagedRootMatchesProof(
+        backupPath,
+        options.workspace,
+        staged.targetPrecondition.proof,
+        `managed target ownership changed before replacement ${staged.entry.target}`,
+      );
       journal = writeJournalPhase(options.workspace, journal, "target_backed_up");
       maybeFault(options, "target_backed_up");
     }
@@ -898,6 +1057,7 @@ async function removeManagedEntry(
   if (!(await pathExists(targetPath))) {
     return persistStateMonotonic(options.workspace, afterState);
   }
+  const ownershipProof = await proveManagedTargetOwnership(options.workspace, entry);
   const backupPath = join(dirname(targetPath), `.${basename(targetPath)}.ft-${randomBytes(8).toString("hex")}.backup`);
   const backup = portableRelative(options.workspace, backupPath);
   let journal: ManagedSkillsJournal = {
@@ -916,6 +1076,12 @@ async function removeManagedEntry(
   maybeFault(options, "prepared");
   try {
     await rename(targetPath, backupPath);
+    await assertManagedRootMatchesProof(
+      backupPath,
+      options.workspace,
+      ownershipProof,
+      `managed target ownership changed before removal ${entry.target}`,
+    );
     journal = writeJournalPhase(options.workspace, journal, "target_backed_up");
     maybeFault(options, "target_backed_up");
     const persisted = persistStateMonotonic(options.workspace, afterState);
@@ -1153,14 +1319,91 @@ function ownershipMarkerContent(key: ManagedSkillEntry["key"], revision: string)
   return `${JSON.stringify({ schemaVersion: 1, key, revision }, null, 2)}\n`;
 }
 
+async function proveManagedTargetOwnership(
+  workspace: string,
+  entry: ManagedSkillEntry,
+): Promise<ManagedTargetOwnershipProof> {
+  const targetPath = resolveWorkspacePath(workspace, entry.target, "target");
+  const targetStat = await lstat(targetPath);
+  if (targetStat.isSymbolicLink()) {
+    const linkTarget = toPortablePath(await readlink(targetPath));
+    if (
+      entry.revision === "legacy-v1" &&
+      entry.key.startsWith("core:") &&
+      entry.target === `.claude/skills/${entry.key.slice("core:".length)}` &&
+      linkTarget === `../../.agents/skills/${entry.key.slice("core:".length)}`
+    ) {
+      return { kind: "legacy-symlink", key: entry.key, linkTarget };
+    }
+    throw new Error(`refusing to mutate unowned managed Skill target ${entry.target}`);
+  }
+  if (!targetStat.isDirectory()) {
+    throw new Error(`refusing to mutate non-directory managed Skill target ${entry.target}`);
+  }
+
+  const digest = await digestDirectory(targetPath);
+  const marker = await readOwnershipMarkerAtRoot(targetPath);
+  if (marker?.key === entry.key && marker.revision === entry.revision) {
+    return {
+      kind: "marker",
+      key: entry.key,
+      revision: entry.revision,
+      digest,
+    };
+  }
+  if (digest === entry.installedDigest) {
+    return { kind: "ledger-digest", key: entry.key, digest };
+  }
+  throw new Error(`refusing to mutate unowned managed Skill target ${entry.target}`);
+}
+
+async function assertManagedRootMatchesProof(
+  rootPath: string,
+  workspace: string,
+  proof: ManagedTargetOwnershipProof,
+  errorMessage: string,
+): Promise<void> {
+  const workspaceRoot = realpathSync(resolve(workspace));
+  const absoluteRoot = resolve(rootPath);
+  if (absoluteRoot === workspaceRoot || !absoluteRoot.startsWith(`${workspaceRoot}${sep}`)) {
+    throw new ManagedSkillsFatalError("managed Skill ownership proof path escapes workspace");
+  }
+  const rootStat = await lstat(absoluteRoot);
+  if (proof.kind === "legacy-symlink") {
+    if (!rootStat.isSymbolicLink() || toPortablePath(await readlink(absoluteRoot)) !== proof.linkTarget) {
+      throw new Error(errorMessage);
+    }
+    return;
+  }
+  if (!rootStat.isDirectory()) throw new Error(errorMessage);
+  const digest = await digestDirectory(absoluteRoot);
+  if (digest !== proof.digest) throw new Error(errorMessage);
+  if (proof.kind === "marker") {
+    const marker = await readOwnershipMarkerAtRoot(absoluteRoot);
+    if (marker?.key !== proof.key || marker.revision !== proof.revision) {
+      throw new Error(errorMessage);
+    }
+  }
+}
+
 async function readOwnershipMarker(
   workspace: string,
   target: string,
 ): Promise<Readonly<{ key: ManagedSkillEntry["key"]; revision: string }> | null> {
+  const targetRoot = resolveWorkspacePath(workspace, target, "target");
   try {
-    const raw: unknown = JSON.parse(
-      await readFile(join(resolveWorkspacePath(workspace, target, "target"), OWNERSHIP_MARKER), "utf-8"),
-    );
+    if (!(await lstat(targetRoot)).isDirectory()) return null;
+    return readOwnershipMarkerAtRoot(targetRoot);
+  } catch {
+    return null;
+  }
+}
+
+async function readOwnershipMarkerAtRoot(
+  targetRoot: string,
+): Promise<Readonly<{ key: ManagedSkillEntry["key"]; revision: string }> | null> {
+  try {
+    const raw: unknown = JSON.parse(await readFile(join(targetRoot, OWNERSHIP_MARKER), "utf-8"));
     if (!isRecord(raw) || raw.schemaVersion !== 1 || typeof raw.key !== "string" || typeof raw.revision !== "string") {
       return null;
     }
@@ -1184,22 +1427,66 @@ async function validateSkillManifest(
   expectedName: string,
 ): Promise<Readonly<{ name: string; description: string }>> {
   const markdown = await readFile(join(stagingPath, "SKILL.md"), "utf-8");
-  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(markdown);
-  if (!match?.[1]) throw new Error("SKILL.md must contain YAML frontmatter");
-  let parsed: unknown;
+  let parsed: ReturnType<typeof parseTeamSkillMarkdown>;
   try {
-    parsed = parseYaml(match[1]);
+    parsed = parseTeamSkillMarkdown(markdown);
   } catch (error) {
     throw new Error(`SKILL.md frontmatter is invalid: ${error instanceof Error ? error.message : String(error)}`);
   }
-  if (!isRecord(parsed) || typeof parsed.name !== "string" || typeof parsed.description !== "string") {
+  if (
+    !isRecord(parsed.frontmatter) ||
+    typeof parsed.frontmatter.name !== "string" ||
+    typeof parsed.frontmatter.description !== "string"
+  ) {
     throw new Error("SKILL.md frontmatter requires string name and description");
   }
-  if (parsed.name !== expectedName) {
-    throw new Error(`SKILL.md name "${parsed.name}" does not match effective name "${expectedName}"`);
+  if (parsed.frontmatter.name !== expectedName) {
+    throw new Error(`SKILL.md name "${parsed.frontmatter.name}" does not match effective name "${expectedName}"`);
   }
-  if (parsed.description.trim().length === 0) throw new Error("SKILL.md description must not be empty");
-  return { name: parsed.name, description: parsed.description };
+  if (parsed.frontmatter.description.trim().length === 0) {
+    throw new Error("SKILL.md description must not be empty");
+  }
+  return { name: parsed.frontmatter.name, description: parsed.frontmatter.description };
+}
+
+async function rewriteAttachmentSkillManifest(
+  stagingPath: string,
+  descriptor: RuntimeTeamSkillAttachmentEntry,
+  effectiveName: string,
+): Promise<void> {
+  const path = join(stagingPath, "SKILL.md");
+  const bytes = await readFile(path);
+  let markdown: string;
+  try {
+    markdown = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error("SKILL.md must be valid UTF-8");
+  }
+  let parsed: ReturnType<typeof parseTeamSkillMarkdown>;
+  try {
+    parsed = parseTeamSkillMarkdown(markdown);
+  } catch (error) {
+    throw new Error(`SKILL.md frontmatter is invalid: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (
+    !isRecord(parsed.frontmatter) ||
+    typeof parsed.frontmatter.name !== "string" ||
+    typeof parsed.frontmatter.description !== "string"
+  ) {
+    throw new Error("SKILL.md frontmatter requires string name and description");
+  }
+  if (
+    parsed.frontmatter.name.trim() !== descriptor.name ||
+    parsed.frontmatter.description.trim() !== descriptor.description
+  ) {
+    throw new Error("Team Skill bundle manifest does not match its authoritative descriptor");
+  }
+  const frontmatter = stringifyYaml({ ...parsed.frontmatter, name: effectiveName }).trimEnd();
+  const rewritten = `---\n${frontmatter}\n---\n${parsed.body}`;
+  if (Buffer.byteLength(rewritten, "utf-8") > MAX_SKILL_FILE_BYTES) {
+    throw new Error(`rewritten SKILL.md exceeds max size ${MAX_SKILL_FILE_BYTES}`);
+  }
+  await writeFile(path, rewritten, { encoding: "utf-8", mode: 0o600 });
 }
 
 async function copySanitizedSkillTree(sourceRoot: string, destinationRoot: string): Promise<void> {
@@ -1368,11 +1655,14 @@ async function hashDirectoryRecursive(
     caseInsensitiveNames.add(folded);
     const relativePath = relativeDir ? `${relativeDir}/${name}` : name;
     if (!relativeDir && virtualRootFile?.name === name && !entryByName.has(name)) {
+      if (virtualRootFile.content.byteLength > MAX_OWNERSHIP_MARKER_BYTES) {
+        throw new Error(`Skill tree ownership marker exceeds max size ${MAX_OWNERSHIP_MARKER_BYTES}`);
+      }
       treeStats.files++;
       treeStats.bytes += virtualRootFile.content.byteLength;
       if (
-        treeStats.files > MAX_SKILL_FILES ||
-        treeStats.bytes > MAX_SKILL_TOTAL_BYTES ||
+        treeStats.files > MAX_INSTALLED_SKILL_FILES ||
+        treeStats.bytes > MAX_INSTALLED_SKILL_TOTAL_BYTES ||
         virtualRootFile.content.byteLength > MAX_SKILL_FILE_BYTES
       ) {
         throw new Error(`Skill tree exceeds configured bundle limits at ${relativePath}`);
@@ -1393,11 +1683,14 @@ async function hashDirectoryRecursive(
       continue;
     }
     if (!entryStat.isFile()) throw new Error(`Skill tree special files are not allowed: ${relativePath}`);
+    if (!relativeDir && name === OWNERSHIP_MARKER && entryStat.size > MAX_OWNERSHIP_MARKER_BYTES) {
+      throw new Error(`Skill tree ownership marker exceeds max size ${MAX_OWNERSHIP_MARKER_BYTES}`);
+    }
     treeStats.files++;
     treeStats.bytes += entryStat.size;
     if (
-      treeStats.files > MAX_SKILL_FILES ||
-      treeStats.bytes > MAX_SKILL_TOTAL_BYTES ||
+      treeStats.files > MAX_INSTALLED_SKILL_FILES ||
+      treeStats.bytes > MAX_INSTALLED_SKILL_TOTAL_BYTES ||
       entryStat.size > MAX_SKILL_FILE_BYTES
     ) {
       throw new Error(`Skill tree exceeds configured bundle limits at ${relativePath}`);
@@ -1446,6 +1739,37 @@ function suffixSkillName(base: string, suffix: string): string {
 
 function inlineSkillRevision(skill: RuntimeResourceSkill): string {
   return `sha256:${createHash("sha256").update(stableJson(skill)).digest("hex")}`;
+}
+
+function inlineEntrySkill(entry: Extract<RuntimeTeamSkillEntry, { kind: "inline" }>): RuntimeResourceSkill {
+  return {
+    resourceId: entry.resourceId,
+    name: entry.name,
+    description: entry.description,
+    body: entry.body,
+    metadata: entry.metadata,
+  };
+}
+
+function attachmentBundleRevision(entry: RuntimeTeamSkillAttachmentEntry): string {
+  return `sha256:${createHash("sha256")
+    .update("first-tree-attachment-bundle-v1\0")
+    .update(entry.attachmentId)
+    .update("\0")
+    .update(String(entry.sizeBytes))
+    .digest("hex")}`;
+}
+
+function teamSkillEntryRevision(entry: RuntimeTeamSkillEntry): string {
+  if (entry.kind === "inline") return inlineSkillRevision(inlineEntrySkill(entry));
+  if (entry.kind === "attachment-bundle") return attachmentBundleRevision(entry);
+  return `unavailable:${createHash("sha256").update(entry.reason).digest("hex")}`;
+}
+
+function teamSkillEntrySource(entry: RuntimeTeamSkillEntry): DesiredManagedSkill["source"] {
+  if (entry.kind === "inline") return { kind: "inline-skill", skill: inlineEntrySkill(entry) };
+  if (entry.kind === "attachment-bundle") return { kind: "attachment-bundle", descriptor: entry };
+  return { kind: "unavailable" };
 }
 
 function stableJson(value: unknown): string {
@@ -1566,7 +1890,7 @@ function resolveWorkspacePath(
   assertExistingPathChainIsDirectory(
     workspaceRoot,
     absolute,
-    kind === "root" || kind === "temporary",
+    kind === "root" || (kind === "temporary" && portablePath.endsWith(".staging")),
     kind,
     portablePath,
   );

--- a/packages/client/src/runtime/managed-state.ts
+++ b/packages/client/src/runtime/managed-state.ts
@@ -31,7 +31,7 @@ export type ManagedSkillEntry = Readonly<{
   target: string;
   requestedSlug: string;
   effectiveName: string;
-  /** Source identity: bundled VERSION, inline DTO digest, or attachment id. */
+  /** Source identity: bundled VERSION, inline DTO digest, or hashed attachment identity. */
   revision: string;
   /** Digest of the final installed bytes after all runtime transformations. */
   installedDigest: `sha256:${string}`;

--- a/packages/client/src/runtime/team-skill-bundle.ts
+++ b/packages/client/src/runtime/team-skill-bundle.ts
@@ -1,0 +1,252 @@
+import { createWriteStream } from "node:fs";
+import { chmod, mkdir } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+import type { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import {
+  isTeamSkillOwnershipMarkerPath,
+  parseTeamSkillBundleEntryPath,
+  TEAM_SKILL_BUNDLE_LIMITS,
+  TEAM_SKILL_OWNERSHIP_MARKER,
+  type TeamSkillBundleEntryPath,
+  teamSkillBundleCollisionKey,
+  teamSkillBundleTopologyConflict,
+} from "@first-tree/shared";
+import yauzl, { type Entry, type ZipFile } from "yauzl";
+
+type PlannedEntry = Readonly<{
+  rawPath: string;
+  parsedPath: TeamSkillBundleEntryPath;
+  relativePath: string;
+  directory: boolean;
+  uncompressedSize: number;
+  executableBits: number;
+}>;
+
+type InspectedEntry = Omit<PlannedEntry, "relativePath">;
+
+export async function extractTeamSkillBundle(bytes: Buffer, destinationRoot: string): Promise<void> {
+  if (bytes.byteLength > TEAM_SKILL_BUNDLE_LIMITS.compressedBytes) {
+    throw new Error(`Skill ZIP exceeds ${TEAM_SKILL_BUNDLE_LIMITS.compressedBytes} compressed bytes`);
+  }
+  const plan = await inspectBundle(bytes);
+  const planByRawPath = new Map(plan.map((entry) => [entry.rawPath, entry]));
+  const zipFile = await openZip(bytes);
+  let actualTotal = 0;
+  try {
+    await forEachEntry(zipFile, async (entry) => {
+      const planned = planByRawPath.get(entry.fileName);
+      if (!planned) throw new Error(`Skill ZIP entry changed during extraction: ${entry.fileName}`);
+      if (planned.relativePath.length === 0) return;
+      const destination = resolve(destinationRoot, ...planned.relativePath.split("/"));
+      const root = resolve(destinationRoot);
+      if (destination === root || !destination.startsWith(`${root}${sep}`)) {
+        throw new Error(`Skill ZIP entry escapes staging: ${planned.relativePath}`);
+      }
+      if (planned.directory) {
+        await mkdir(destination, { recursive: true, mode: 0o700 });
+        return;
+      }
+      await mkdir(dirname(destination), { recursive: true, mode: 0o700 });
+      const stream = await openEntryStream(zipFile, entry);
+      let measured = 0;
+      stream.on("data", (chunk: Buffer | Uint8Array) => {
+        measured += chunk.byteLength;
+        if (
+          measured > planned.uncompressedSize ||
+          measured > TEAM_SKILL_BUNDLE_LIMITS.fileBytes ||
+          actualTotal + measured > TEAM_SKILL_BUNDLE_LIMITS.totalBytes
+        ) {
+          stream.destroy(new Error(`Skill ZIP entry size is invalid: ${planned.relativePath}`));
+        }
+      });
+      await pipeline(
+        stream,
+        createWriteStream(destination, {
+          flags: "wx",
+          mode: 0o600 | planned.executableBits,
+        }),
+      );
+      if (measured !== planned.uncompressedSize) {
+        throw new Error(`Skill ZIP entry size is invalid: ${planned.relativePath}`);
+      }
+      actualTotal += measured;
+      await chmod(destination, 0o600 | planned.executableBits);
+    });
+  } finally {
+    zipFile.close();
+  }
+}
+
+async function inspectBundle(bytes: Buffer): Promise<readonly PlannedEntry[]> {
+  const zipFile = await openZip(bytes);
+  const entries: InspectedEntry[] = [];
+  const seenRawPaths = new Set<string>();
+  const skillMarkdownPaths: string[] = [];
+  let files = 0;
+  let declaredTotal = 0;
+  try {
+    await forEachEntry(zipFile, async (entry) => {
+      if (entries.length >= TEAM_SKILL_BUNDLE_LIMITS.entries) {
+        throw new Error(`Skill ZIP cannot contain more than ${TEAM_SKILL_BUNDLE_LIMITS.entries} entries`);
+      }
+      const parsedPath = parseTeamSkillBundleEntryPath(entry.fileName);
+      if (!parsedPath) throw new Error(`Skill ZIP contains an unsafe path: ${entry.fileName}`);
+      const collisionKey = teamSkillBundleCollisionKey(parsedPath.normalized);
+      if (seenRawPaths.has(collisionKey)) {
+        throw new Error(`Skill ZIP contains a duplicate or case-colliding path: ${parsedPath.normalized}`);
+      }
+      seenRawPaths.add(collisionKey);
+      if ((entry.generalPurposeBitFlag & 0x1) !== 0) {
+        throw new Error(`Skill ZIP contains an encrypted entry: ${parsedPath.normalized}`);
+      }
+      validateEntryType(entry, parsedPath.directory, parsedPath.normalized);
+      if (parsedPath.directory) {
+        if (entry.uncompressedSize !== 0) {
+          throw new Error(`Skill ZIP directory has non-zero content: ${parsedPath.normalized}`);
+        }
+      } else {
+        files++;
+        if (files > TEAM_SKILL_BUNDLE_LIMITS.files) {
+          throw new Error(`Skill ZIP cannot contain more than ${TEAM_SKILL_BUNDLE_LIMITS.files} files`);
+        }
+        if (entry.uncompressedSize > TEAM_SKILL_BUNDLE_LIMITS.fileBytes) {
+          throw new Error(
+            `Skill ZIP entry exceeds ${TEAM_SKILL_BUNDLE_LIMITS.fileBytes} bytes: ${parsedPath.normalized}`,
+          );
+        }
+        declaredTotal += entry.uncompressedSize;
+        if (declaredTotal > TEAM_SKILL_BUNDLE_LIMITS.totalBytes) {
+          throw new Error(`Skill ZIP exceeds ${TEAM_SKILL_BUNDLE_LIMITS.totalBytes} uncompressed bytes`);
+        }
+        if (parsedPath.segments.at(-1) === "SKILL.md") {
+          if (entry.uncompressedSize > TEAM_SKILL_BUNDLE_LIMITS.skillMarkdownBytes) {
+            throw new Error(`SKILL.md exceeds ${TEAM_SKILL_BUNDLE_LIMITS.skillMarkdownBytes} bytes`);
+          }
+          skillMarkdownPaths.push(parsedPath.normalized);
+        }
+      }
+      entries.push({
+        rawPath: entry.fileName,
+        parsedPath,
+        directory: parsedPath.directory,
+        uncompressedSize: entry.uncompressedSize,
+        executableBits: unixExecutableBits(entry),
+      });
+    });
+  } finally {
+    zipFile.close();
+  }
+
+  const topologyConflict = teamSkillBundleTopologyConflict(
+    entries.map((entry) => ({ path: entry.parsedPath.normalized, directory: entry.directory })),
+  );
+  if (topologyConflict) {
+    throw new Error(`Skill ZIP path ${topologyConflict.path} is nested below file ${topologyConflict.fileParent}`);
+  }
+  if (skillMarkdownPaths.length !== 1) throw new Error("Skill ZIP must contain exactly one exact-case SKILL.md");
+  const skillPath = skillMarkdownPaths[0];
+  if (!skillPath) throw new Error("Skill ZIP must contain SKILL.md");
+  const skillSegments = skillPath.split("/");
+  if (skillSegments.length > 2 || skillSegments.at(-1) !== "SKILL.md") {
+    throw new Error("SKILL.md must be at the ZIP root or inside one top-level directory");
+  }
+  const wrapper = skillSegments.length === 2 ? skillSegments[0] : null;
+  if (
+    wrapper &&
+    entries.some(
+      (entry) => entry.parsedPath.normalized !== wrapper && !entry.parsedPath.normalized.startsWith(`${wrapper}/`),
+    )
+  ) {
+    throw new Error("A wrapped Skill ZIP cannot contain entries outside its top-level directory");
+  }
+
+  const planned: PlannedEntry[] = [];
+  const seenRelativePaths = new Set<string>();
+  for (const entry of entries) {
+    const relativePath = wrapper
+      ? entry.parsedPath.normalized === wrapper
+        ? ""
+        : entry.parsedPath.normalized.slice(wrapper.length + 1)
+      : entry.parsedPath.normalized;
+    if (!relativePath) {
+      if (!entry.directory) throw new Error("Wrapped Skill root must be a directory");
+      planned.push({ ...entry, relativePath });
+      continue;
+    }
+    const collisionKey = teamSkillBundleCollisionKey(relativePath);
+    if (seenRelativePaths.has(collisionKey)) {
+      throw new Error(`Skill ZIP contains a case-colliding extracted path: ${relativePath}`);
+    }
+    seenRelativePaths.add(collisionKey);
+    if (isTeamSkillOwnershipMarkerPath(relativePath)) {
+      throw new Error(`Skill ZIP may not provide reserved file ${TEAM_SKILL_OWNERSHIP_MARKER}`);
+    }
+    planned.push({ ...entry, relativePath });
+  }
+  return planned;
+}
+
+function validateEntryType(entry: Entry, directory: boolean, path: string): void {
+  const madeByUnix = entry.versionMadeBy >>> 8 === 3;
+  if (!madeByUnix) return;
+  const type = (entry.externalFileAttributes >>> 16) & 0o170000;
+  if (type === 0) return;
+  if (type === 0o120000) throw new Error(`Skill ZIP cannot contain symlinks: ${path}`);
+  const expected = directory ? 0o040000 : 0o100000;
+  if (type !== expected) throw new Error(`Skill ZIP cannot contain special files: ${path}`);
+}
+
+function unixExecutableBits(entry: Entry): number {
+  if (entry.versionMadeBy >>> 8 !== 3) return 0;
+  return (entry.externalFileAttributes >>> 16) & 0o111;
+}
+
+function openZip(bytes: Buffer): Promise<ZipFile> {
+  return new Promise((resolvePromise, reject) => {
+    yauzl.fromBuffer(
+      bytes,
+      { lazyEntries: true, strictFileNames: true, validateEntrySizes: true },
+      (error, zipFile) => {
+        if (error || !zipFile) reject(error ?? new Error("Unable to open ZIP"));
+        else resolvePromise(zipFile);
+      },
+    );
+  });
+}
+
+function openEntryStream(zipFile: ZipFile, entry: Entry): Promise<Readable> {
+  return new Promise((resolvePromise, reject) => {
+    zipFile.openReadStream(entry, (error, stream) => {
+      if (error || !stream) reject(error ?? new Error(`Unable to read ${entry.fileName}`));
+      else resolvePromise(stream);
+    });
+  });
+}
+
+function forEachEntry(zipFile: ZipFile, visit: (entry: Entry) => Promise<void>): Promise<void> {
+  return new Promise((resolvePromise, reject) => {
+    let settled = false;
+    const fail = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+    zipFile.once("error", fail);
+    zipFile.once("end", () => {
+      if (settled) return;
+      settled = true;
+      resolvePromise();
+    });
+    zipFile.on("entry", (entry) => {
+      void visit(entry).then(
+        () => zipFile.readEntry(),
+        (error) => {
+          zipFile.close();
+          fail(error);
+        },
+      );
+    });
+    zipFile.readEntry();
+  });
+}

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -157,6 +157,7 @@ export type PaginatedResult<T> = {
 };
 
 const FETCH_TIMEOUT_MS = 15_000;
+const SDK_ERROR_BODY_MAX_BYTES = 64 * 1024;
 
 /**
  * Shorter per-call budget for startup-critical GETs (currently
@@ -861,13 +862,50 @@ export class FirstTreeHubSDK {
    */
   public async fetchAttachment(opts: {
     id: string;
+    /** Refuse a declared or streamed payload beyond this caller-owned bound. */
+    maxBytes?: number;
+    /** Per-attempt download timeout; defaults to the SDK-wide 15 second bound. */
+    timeoutMs?: number;
   }): Promise<{ bytes: Buffer; mimeType: string; filename: string; size: number }> {
-    const response = await this.doFetch(`/api/v1/attachments/${encodeURIComponent(opts.id)}`);
+    const response = await this.doFetch(`/api/v1/attachments/${encodeURIComponent(opts.id)}`, undefined, {
+      timeoutMs: opts.timeoutMs,
+      logRetries: false,
+    });
     if (!response.ok) {
-      throw await this.toSdkError(response);
+      throw await this.toSdkError(response, SDK_ERROR_BODY_MAX_BYTES);
     }
-    const arrayBuffer = await response.arrayBuffer();
-    const bytes = Buffer.from(arrayBuffer);
+    const contentLengthHeader = response.headers.get("content-length");
+    const contentLength = contentLengthHeader === null ? null : Number(contentLengthHeader);
+    if (
+      opts.maxBytes !== undefined &&
+      Number.isFinite(contentLength) &&
+      contentLength !== null &&
+      contentLength > opts.maxBytes
+    ) {
+      await response.body?.cancel();
+      throw new Error(`Attachment exceeds caller limit of ${opts.maxBytes} bytes`);
+    }
+    const chunks: Buffer[] = [];
+    let measured = 0;
+    if (response.body) {
+      const reader = response.body.getReader();
+      try {
+        while (true) {
+          const next = await reader.read();
+          if (next.done) break;
+          const chunk = Buffer.from(next.value);
+          measured += chunk.byteLength;
+          if (opts.maxBytes !== undefined && measured > opts.maxBytes) {
+            await reader.cancel();
+            throw new Error(`Attachment exceeds caller limit of ${opts.maxBytes} bytes`);
+          }
+          chunks.push(chunk);
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    }
+    const bytes = Buffer.concat(chunks, measured);
     return {
       bytes,
       mimeType: response.headers.get("content-type") ?? "application/octet-stream",
@@ -1017,6 +1055,7 @@ export class FirstTreeHubSDK {
         const response = await this.doFetchOnce(path, init, opts);
         const isLastAttempt = attempt === delays.length - 1;
         if (response.status >= 500 && !isLastAttempt) {
+          await response.body?.cancel();
           if (opts?.logRetries !== false) {
             this.logger.warn(`retry attempt=${attempt + 1} reason=http-${response.status} path=${path}`);
           }
@@ -1070,8 +1109,9 @@ export class FirstTreeHubSDK {
     return fetch(url, { ...init, headers, signal });
   }
 
-  private async toSdkError(response: Response): Promise<SdkError> {
-    const body = await response.text();
+  private async toSdkError(response: Response, maxBodyBytes?: number): Promise<SdkError> {
+    const body =
+      maxBodyBytes === undefined ? await response.text() : await readResponseTextBounded(response, maxBodyBytes);
     let message: string;
     let code: string | undefined;
     try {
@@ -1088,6 +1128,39 @@ export class FirstTreeHubSDK {
       retryAfterMs: parseRetryAfterMs(retryAfter),
     });
   }
+}
+
+async function readResponseTextBounded(response: Response, maxBytes: number): Promise<string> {
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    await response.body?.cancel();
+    return `HTTP ${response.status} response body exceeded ${maxBytes} bytes`;
+  }
+  if (!response.body) return "";
+  const chunks: Uint8Array[] = [];
+  let measured = 0;
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      measured += next.value.byteLength;
+      if (measured > maxBytes) {
+        await reader.cancel();
+        return `HTTP ${response.status} response body exceeded ${maxBytes} bytes`;
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(measured);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
 }
 
 export class SdkError extends Error {

--- a/packages/qa/cases/runtime/managed-skill-projection.md
+++ b/packages/qa/cases/runtime/managed-skill-projection.md
@@ -26,11 +26,18 @@ degradation.
   plan, never an operator workspace.
 - Make at least one selected provider `one-turn-ready`. Cross-provider claims
   require each named provider to be independently ready.
-- Use disposable Team Skills with non-sensitive bodies and a disposable
-  user-authored Skill conflict. Do not inspect provider credentials or include
-  private Skill content in evidence.
+- Upload disposable complete Team Skill ZIPs with non-sensitive `SKILL.md`,
+  `scripts/`, and `references/` content, plus a disposable user-authored Skill
+  conflict. The supporting script must produce a unique run-local token and
+  the reference must contain a different unique token. Do not inspect provider
+  credentials or include private Skill content in evidence.
 - Preserve the tested product checkout; all workspace and Cloud Resource
   changes must be run-local fixtures.
+- Roll out the snapshot-aware Client before enabling the new Server projection
+  and legacy bundle backfill. The compatible mixed-version window is new
+  Client + old Server, where the Client falls back to `resourceSkills`. Do not
+  enable new Server bundle snapshots while old Clients are still active:
+  bundle-backed rows intentionally have no derived inline fallback.
 
 ## Checklist
 
@@ -38,13 +45,17 @@ degradation.
   under the native root: Claude `.claude/skills`, Codex `.agents/skills`,
   Cursor `.cursor/skills`, or Kimi `.kimi-code/skills`. A real turn must be
   able to discover and invoke a Core Skill without a cross-provider symlink.
-- Bind a disposable Team Skill in Cloud, start or inject the next turn, and
-  confirm the provider discovers its normalized effective name. The generated
-  briefing should list the Team Skill description without exposing a
-  filesystem path.
-- Change the Team Skill body and confirm the next reconciled turn observes the
-  new content. Remove the binding and confirm a later authoritative reconcile
-  revokes it before the provider turn begins.
+- Bind the uploaded complete Team Skill in Cloud, start or inject the next
+  turn, and confirm the provider discovers its normalized effective name. In
+  one real provider turn, explicitly invoke the Skill and require it to execute
+  the bundled supporting script and use the bundled reference; the response
+  must contain both run-local tokens. A response derived only from
+  `SKILL.md` is insufficient. The generated briefing should list the Team
+  Skill description without exposing a filesystem path.
+- Replace the Team Skill with a new complete ZIP whose script/reference tokens
+  and `SKILL.md` body all change, then confirm the next reconciled turn observes
+  the new supporting files. Remove the binding and confirm a later
+  authoritative reconcile revokes it before the provider turn begins.
 - Plant a user-owned Skill at the requested Team name. The managed Team Skill
   must receive a deterministic First Tree suffix while the original directory
   remains byte-for-byte unchanged. Plant a conflicting Core name with
@@ -54,6 +65,11 @@ degradation.
   last-known-good Team directory must remain on disk, the Client must emit a
   bounded warning, and no empty fallback may revoke it. Once an authoritative
   newer snapshot returns, convergence resumes.
+- During the client-first rollout window, verify a new Client still installs a
+  legacy inline Team Skill from an old Server with no snapshot field. After
+  Server activation, verify a bundle-backed row is never dual-sent through
+  `resourceSkills`; an unsupported old Client must see the Skill as unavailable
+  rather than a prompt-only installation.
 - If the environment can move one disposable agent workspace between provider
   runtimes, confirm the new provider projection is usable before recorded old
   targets disappear. Claude TUI and Claude SDK should share the Claude root
@@ -65,9 +81,10 @@ degradation.
 ## Expected Result
 
 `PASS` requires real provider evidence that every selected runtime discovers
-the reconciled Skill in its native root, Cloud update and revoke behavior
-settles before the relevant turn, unavailable config preserves
-last-known-good content, and user-owned conflicts are not overwritten.
+the reconciled Skill in its native root and uses both a bundled script and
+reference, Cloud complete-bundle update and revoke behavior settles before the
+relevant turn, unavailable config preserves last-known-good content, and
+user-owned conflicts are not overwritten.
 
 `FAIL` includes a provider missing a settled Skill, a Team Skill appearing in
 the wrong provider root, a stale/empty fallback revoking live content, user
@@ -82,8 +99,10 @@ discovery from prompt-only behavior.
 ## Evidence
 
 Keep sanitized Cloud Resource version/readback, provider start/resume logs,
-workspace-relative directory listings, ownership-marker keys and revisions,
-briefing excerpts, effective Skill names, and a short real-turn transcript
-showing discovery. Record warnings and timing around configuration failure and
-recovery. Do not retain absolute home paths, Skill bodies beyond disposable
-fixtures, credentials, tokens, or private provider state.
+workspace-relative directory listings, sanitized supporting-file digests,
+ownership-marker keys and hashed revisions, briefing excerpts, effective Skill
+names, and a short real-turn transcript showing the disposable script and
+reference tokens. Record warnings and timing around configuration failure and
+recovery. Do not retain attachment capability ids, absolute home paths, Skill
+bodies beyond disposable fixtures, credentials, tokens, or private provider
+state.

--- a/packages/server/src/__tests__/attachments-route.test.ts
+++ b/packages/server/src/__tests__/attachments-route.test.ts
@@ -661,8 +661,10 @@ describe("attachments route — upload + capability download", () => {
   it("returns 404 for unknown attachment id", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `nf-${crypto.randomUUID().slice(0, 6)}` });
-    const reply = await getAttachment(app, admin, "00000000-0000-4000-8000-000000000000");
+    const capability = "00000000-0000-4000-8000-000000000000";
+    const reply = await getAttachment(app, admin, capability);
     expect(reply.statusCode).toBe(404);
+    expect(reply.body).not.toContain(capability);
   });
 
   it("rejects upload to an org the caller is not a member of (403)", async () => {

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
 import { agents } from "../db/schema/agents.js";
+import { attachments } from "../db/schema/attachments.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
@@ -22,6 +23,7 @@ import { createAttachment } from "../services/attachment.js";
 import { LANDING_CAMPAIGN_TRIAL_PROMPT } from "../services/landing-campaigns/trial-prompt.js";
 import { createOrganization } from "../services/organization.js";
 import { backfillResourcesPhase1 } from "../services/resources-migration.js";
+import { RuntimeConfigSnapshotChangedError } from "../services/runtime-config-snapshot.js";
 import { buildLegacySkillBundle } from "../services/skill-bundle.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -133,6 +135,31 @@ describe("Resources Phase 1", () => {
       .where(and(eq(agentResourceBindings.agentId, agent.uuid), eq(agentResourceBindings.type, "skill")));
     expect(bindings).toHaveLength(1);
     expect(bindings[0]?.resourceId).toBe(legacyResourceId);
+
+    const resolved = await app.resourcesService.resolveRuntimeConfig(await app.configService.get(agent.uuid));
+    expect(resolved.payload.resourceSkills).toEqual([
+      {
+        resourceId: legacyResourceId,
+        name: "production-scan",
+        description: "legacy",
+        body: "LEGACY BODY",
+        metadata: {},
+      },
+    ]);
+    expect(resolved.payload.teamSkillSnapshot).toEqual({
+      kind: "authoritative",
+      schemaVersion: 1,
+      entries: [
+        {
+          kind: "inline",
+          resourceId: legacyResourceId,
+          name: "production-scan",
+          description: "legacy",
+          body: "LEGACY BODY",
+          metadata: {},
+        },
+      ],
+    });
   });
 
   it("resolves inline prompt replace as resourceId=null plus replacesResourceId", async () => {
@@ -877,6 +904,21 @@ describe("Resources Phase 1", () => {
     expect(resolved.payload.prompt.append.length).toBeLessThanOrEqual(PROMPT_APPEND_MAX_LENGTH);
   });
 
+  it("refuses to label a Resource snapshot with a stale base config version", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const stale = await app.configService.get(agent.uuid);
+    await app.db
+      .update(agentConfigs)
+      .set({ version: stale.version + 1 })
+      .where(eq(agentConfigs.agentId, agent.uuid));
+
+    await expect(app.resourcesService.resolveRuntimeConfig(stale)).rejects.toBeInstanceOf(
+      RuntimeConfigSnapshotChangedError,
+    );
+  });
+
   it("preserves legacy stored MCP servers until Team MCP resources take over", async () => {
     const app = getApp();
     const owner = await createOrgUser(app, "admin");
@@ -1045,7 +1087,7 @@ describe("Resources Phase 1", () => {
     );
   });
 
-  it("projects team skill resources into runtime config skills", async () => {
+  it("projects bundle-backed Team Skills only through the authoritative attachment snapshot", async () => {
     const app = getApp();
     const owner = await createOrgUser(app, "admin");
     const agent = await createRuntimeAgent(app, owner);
@@ -1059,15 +1101,66 @@ describe("Resources Phase 1", () => {
     const baseConfig = await app.configService.get(agent.uuid);
     const resolved = await app.resourcesService.resolveRuntimeConfig(baseConfig);
 
-    expect(resolved.payload.resourceSkills).toEqual([
-      {
-        resourceId: skill.id,
-        name: "reviewer",
-        description: "Review changes.",
-        body: "# Reviewer\n\nCheck edge cases.",
-        metadata: { source: "team" },
-      },
-    ]);
+    expect(resolved.payload.resourceSkills).toEqual([]);
+    expect(resolved.payload.teamSkillSnapshot).toEqual({
+      kind: "authoritative",
+      schemaVersion: 1,
+      entries: [
+        {
+          kind: "attachment-bundle",
+          resourceId: skill.id,
+          name: "reviewer",
+          description: "Review changes.",
+          attachmentId: skill.bundleAttachmentId,
+          sizeBytes: expect.any(Number),
+        },
+      ],
+    });
+  });
+
+  it.each([
+    "missing",
+    "wrong-org",
+    "not-ready",
+  ] as const)("emits an unavailable sentinel instead of inline fallback for a %s authoritative bundle", async (failure) => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const skill = await createTeamSkill(app, owner, "recommended", {
+      name: `bundle-required-${failure}`,
+      description: "Needs supporting files.",
+      body: "Do not use this derived body alone.",
+      metadata: {},
+    });
+    if (!skill.bundleAttachmentId) throw new Error("fixture Skill bundle is missing");
+
+    if (failure === "missing") {
+      await app.db.delete(attachments).where(eq(attachments.id, skill.bundleAttachmentId));
+    } else if (failure === "wrong-org") {
+      await app.db
+        .update(attachments)
+        .set({ organizationId: uuidv7() })
+        .where(eq(attachments.id, skill.bundleAttachmentId));
+    } else if (failure === "not-ready") {
+      await app.db
+        .update(attachments)
+        .set({ lifecycleState: "deleting" })
+        .where(eq(attachments.id, skill.bundleAttachmentId));
+    }
+    const resolved = await app.resourcesService.resolveRuntimeConfig(await app.configService.get(agent.uuid));
+
+    expect(resolved.payload.resourceSkills).toEqual([]);
+    expect(resolved.payload.teamSkillSnapshot).toEqual({
+      kind: "authoritative",
+      schemaVersion: 1,
+      entries: [
+        {
+          kind: "unavailable",
+          resourceId: skill.id,
+          reason: "skill_bundle_unavailable",
+        },
+      ],
+    });
   });
 
   it("validates resource create/update edge paths and bumps recommended updates", async () => {

--- a/packages/server/src/__tests__/runtime-config-snapshot.test.ts
+++ b/packages/server/src/__tests__/runtime-config-snapshot.test.ts
@@ -1,0 +1,41 @@
+import { type AgentRuntimeConfig, DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import { ServiceUnavailableError } from "../errors.js";
+import { RuntimeConfigSnapshotChangedError, resolveCurrentRuntimeConfig } from "../services/runtime-config-snapshot.js";
+
+function config(version: number): AgentRuntimeConfig {
+  return {
+    agentId: "agent-1",
+    version,
+    payload: { ...DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD },
+    updatedAt: new Date(version).toISOString(),
+    updatedBy: "member-1",
+  };
+}
+
+describe("runtime config snapshot resolution", () => {
+  it("reloads the base config when the Resource projection crosses a version fence", async () => {
+    const loadConfig = vi.fn().mockResolvedValue(config(2));
+    const resolveConfig = vi
+      .fn()
+      .mockRejectedValueOnce(new RuntimeConfigSnapshotChangedError())
+      .mockResolvedValueOnce(config(2));
+
+    await expect(resolveCurrentRuntimeConfig(loadConfig, resolveConfig, config(1))).resolves.toMatchObject({
+      version: 2,
+    });
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(resolveConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails boundedly when config changes on every resolution attempt", async () => {
+    const loadConfig = vi.fn().mockResolvedValue(config(2));
+    const resolveConfig = vi.fn().mockRejectedValue(new RuntimeConfigSnapshotChangedError());
+
+    await expect(resolveCurrentRuntimeConfig(loadConfig, resolveConfig, config(1))).rejects.toBeInstanceOf(
+      ServiceUnavailableError,
+    );
+    expect(loadConfig).toHaveBeenCalledTimes(2);
+    expect(resolveConfig).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/server/src/__tests__/service-branch-defaults.test.ts
+++ b/packages/server/src/__tests__/service-branch-defaults.test.ts
@@ -779,12 +779,14 @@ describe("service branch defaults", () => {
           order: 1,
         }),
       ],
+      [validSkill, invalidSkill],
+      [{ version: 7 }],
     ]);
     const service = createResourcesService({ db: db as never, notifier });
 
     const config = await service.resolveRuntimeConfig({
       agentId: "agent_1",
-      version: 1,
+      version: 7,
       payload: {
         kind: "claude-code",
         prompt: { append: "base" },
@@ -799,6 +801,24 @@ describe("service branch defaults", () => {
     expect(config.payload.resourceSkills).toEqual([
       expect.objectContaining({ resourceId: "skill_valid", name: "skill", metadata: { source: "test" } }),
     ]);
+    expect(config.payload.teamSkillSnapshot).toEqual(
+      expect.objectContaining({
+        kind: "authoritative",
+        schemaVersion: 1,
+        entries: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "inline",
+            resourceId: "skill_valid",
+            name: "skill",
+            metadata: { source: "test" },
+          }),
+          expect.objectContaining({
+            kind: "unavailable",
+            resourceId: "skill_bad",
+          }),
+        ]),
+      }),
+    );
     expect(config.payload.mcpServers).toEqual([
       expect.objectContaining({ name: "mcp", transport: "http", url: "https://mcp.example.test/rpc" }),
     ]);
@@ -907,13 +927,14 @@ describe("service branch defaults", () => {
         [{ version: 3 }],
         [],
         [],
+        [{ version: 3 }],
       ]) as never,
       notifier,
     });
 
     const config = await service.resolveRuntimeConfig({
       agentId: "agent_1",
-      version: 1,
+      version: 3,
       payload: {
         kind: "claude-code",
         prompt: { append: "" },

--- a/packages/server/src/__tests__/skill-bundles.test.ts
+++ b/packages/server/src/__tests__/skill-bundles.test.ts
@@ -1,14 +1,15 @@
-import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER } from "@first-tree/shared";
+import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER, TEAM_SKILL_BUNDLE_LIMITS } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { strToU8, zipSync } from "fflate";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { attachments } from "../db/schema/attachments.js";
 import { organizations } from "../db/schema/organizations.js";
 import { resources } from "../db/schema/resources.js";
 import { sweepOrphanAttachments } from "../services/attachment.js";
 import { ensureMembership } from "../services/membership.js";
+import { backfillSkillResourceBundles } from "../services/skill-bundle.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, seedAgentFactory, useTestApp } from "./helpers.js";
 
@@ -22,6 +23,57 @@ function skillZip(name: string, entries: Record<string, Uint8Array> = {}, wrappe
       [`${prefix}SKILL.md`]: strToU8(markdown),
       ...entries,
     }),
+  );
+}
+
+function maximumAdmissibleSkillZip(): Buffer {
+  const manifest = strToU8(
+    ["---", "name: at-limit", "description: At the exact runtime limits.", "---", "", "# At limit", ""].join("\n"),
+  );
+  const entries: Record<string, Uint8Array> = { "SKILL.md": manifest };
+  const tinyFiles = 251;
+  for (let index = 0; index < tinyFiles; index++) {
+    entries[`references/tiny-${index}.txt`] = Uint8Array.of(index % 256);
+  }
+  for (let index = 0; index < 3; index++) {
+    entries[`references/full-${index}.bin`] = new Uint8Array(TEAM_SKILL_BUNDLE_LIMITS.fileBytes);
+  }
+  const remaining =
+    TEAM_SKILL_BUNDLE_LIMITS.totalBytes - manifest.byteLength - tinyFiles - 3 * TEAM_SKILL_BUNDLE_LIMITS.fileBytes;
+  entries["references/remainder.bin"] = new Uint8Array(remaining);
+  return Buffer.from(zipSync(entries));
+}
+
+function mutateFirstZipEntry(
+  source: Buffer,
+  mutateLocal: (bytes: Buffer, offset: number) => void,
+  mutateCentral: (bytes: Buffer, offset: number) => void,
+): Buffer {
+  const bytes = Buffer.from(source);
+  const local = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+  const central = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+  if (local < 0 || central < 0) throw new Error("fixture ZIP headers are missing");
+  mutateLocal(bytes, local);
+  mutateCentral(bytes, central);
+  return bytes;
+}
+
+function encryptedZip(source: Buffer): Buffer {
+  return mutateFirstZipEntry(
+    source,
+    (bytes, offset) => bytes.writeUInt16LE(bytes.readUInt16LE(offset + 6) | 0x1, offset + 6),
+    (bytes, offset) => bytes.writeUInt16LE(bytes.readUInt16LE(offset + 8) | 0x1, offset + 8),
+  );
+}
+
+function unixTypeZip(source: Buffer, mode: number): Buffer {
+  return mutateFirstZipEntry(
+    source,
+    () => {},
+    (bytes, offset) => {
+      bytes.writeUInt16LE((3 << 8) | 20, offset + 4);
+      bytes.writeUInt32LE((mode << 16) >>> 0, offset + 38);
+    },
   );
 }
 
@@ -68,7 +120,7 @@ describe("Team Skill bundles", () => {
     );
 
     const reply = await createSkill(app, admin, bundleId);
-    expect(reply.statusCode).toBe(201);
+    expect(reply.statusCode, reply.body).toBe(201);
     expect(reply.json()).toMatchObject({
       type: "skill",
       name: "release-notes",
@@ -80,6 +132,17 @@ describe("Team Skill bundles", () => {
         metadata: { owner: "platform" },
       },
     });
+  });
+
+  it("accepts a bundle at the exact shared file and uncompressed-byte limits", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const bundleId = await upload(app, admin, maximumAdmissibleSkillZip());
+
+    const reply = await createSkill(app, admin, bundleId);
+
+    expect(reply.statusCode, reply.body).toBe(201);
+    expect(reply.json()).toMatchObject({ name: "at-limit", bundleAttachmentId: bundleId });
   });
 
   it("atomically replaces a bundle, bumps impacted configs, and removes the old object", async () => {
@@ -147,6 +210,78 @@ describe("Team Skill bundles", () => {
     expect((await createSkill(app, admin, unsafe)).statusCode).toBe(400);
   });
 
+  it.each([
+    [
+      "wrong-case manifest",
+      Buffer.from(zipSync({ "skill.md": strToU8("---\nname: unsafe\ndescription: unsafe\n---\n") })),
+    ],
+    [
+      "backslash path",
+      Buffer.from(zipSync({ "wrapped\\SKILL.md": strToU8("---\nname: unsafe\ndescription: unsafe\n---\n") })),
+    ],
+    [
+      "case collision",
+      skillZip("case-collision", {
+        "scripts/run.sh": strToU8("one"),
+        "scripts/RUN.sh": strToU8("two"),
+      }),
+    ],
+    ["wrapped-root extra content", skillZip("wrapped-extra", { "outside.txt": strToU8("outside") }, "wrapped")],
+    ["Windows device name", skillZip("device-name", { "scripts/CON": strToU8("device") })],
+    ["trailing-dot path", skillZip("trailing-dot", { "references./policy.md": strToU8("unsafe") })],
+    ["reserved ownership marker", skillZip("managed-marker", { ".first-tree-managed.json": strToU8("{}") })],
+    [
+      "reserved ownership marker directory",
+      skillZip("managed-marker-directory", { ".first-tree-managed.json/": new Uint8Array() }),
+    ],
+    ["case-varied ownership marker", skillZip("managed-marker-case", { ".FIRST-TREE-MANAGED.JSON": strToU8("{}") })],
+    [
+      "ownership marker child",
+      skillZip("managed-marker-child", { ".first-tree-managed.json/data": strToU8("unsafe") }),
+    ],
+    [
+      "file parent",
+      skillZip("file-parent", {
+        scripts: strToU8("file"),
+        "scripts/run.sh": strToU8("nested"),
+      }),
+    ],
+    ["wrapped-root outside empty directory", skillZip("wrapped-empty", { "outside/": new Uint8Array() }, "wrapped")],
+    ["excessive depth", skillZip("deep-tree", { [`${"nested/".repeat(17)}file.txt`]: strToU8("deep") })],
+    [
+      "overlong path segment",
+      skillZip("long-segment", {
+        [`references/${"a".repeat(TEAM_SKILL_BUNDLE_LIMITS.segmentCodeUnits + 1)}.txt`]: strToU8("unsafe"),
+      }),
+    ],
+    [
+      "overlong extracted path",
+      skillZip("long-path", {
+        [`${Array.from({ length: 8 }, () => "a".repeat(100)).join("/")}/file.txt`]: strToU8("unsafe"),
+      }),
+    ],
+    ["oversized file", skillZip("large-file", { "references/large.bin": new Uint8Array(4 * 1024 * 1024 + 1) })],
+    ["runtime name longer than 63 characters", skillZip("a".repeat(64))],
+    [
+      "invalid YAML accepted differently by another parser",
+      Buffer.from(
+        zipSync({
+          "SKILL.md": strToU8(
+            "---\nname: invalid-yaml\ndescription: invalid YAML\nmetadata:\n  values: [a,,b]\n---\n\n# Invalid\n",
+          ),
+        }),
+      ),
+    ],
+    ["encrypted entry", encryptedZip(skillZip("encrypted"))],
+    ["symlink entry", unixTypeZip(skillZip("symlink"), 0o120777)],
+    ["special entry", unixTypeZip(skillZip("special"), 0o010644)],
+  ])("rejects a runtime-inadmissible bundle with %s", async (_label, bytes) => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const bundleId = await upload(app, admin, bytes);
+    expect((await createSkill(app, admin, bundleId)).statusCode).toBe(400);
+  });
+
   it("keeps an uploaded bundle orphaned on validation failure and sweeps it after 24 hours", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -199,5 +334,88 @@ describe("Team Skill bundles", () => {
 
     const [stored] = await app.db.select().from(resources).where(eq(resources.id, resourceId));
     expect(stored?.name).toBe("dedupe");
+  });
+
+  it("backfills a legacy bundle with an atomic config-version fence and runtime notification", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const createAgent = await seedAgentFactory(app);
+    const agent = await createAgent({ name: `legacy-bundle-${crypto.randomUUID().slice(0, 6)}` });
+    const resourceId = uuidv7();
+    await app.db.insert(resources).values({
+      id: resourceId,
+      organizationId: admin.organizationId,
+      type: "skill",
+      scope: "team",
+      ownerAgentId: null,
+      name: "legacy-backfill",
+      repoCanonicalKey: null,
+      bundleAttachmentId: null,
+      defaultEnabled: "recommended",
+      status: "active",
+      payload: {
+        name: "legacy-backfill",
+        description: "Legacy backfill.",
+        body: "# Legacy backfill",
+        metadata: {},
+      },
+      createdBy: admin.memberId,
+      updatedBy: admin.memberId,
+    });
+    const [before] = await app.db
+      .select({ version: agentConfigs.version })
+      .from(agentConfigs)
+      .where(eq(agentConfigs.agentId, agent.uuid));
+    const notifyAgent = vi.fn(async () => {});
+
+    const result = await backfillSkillResourceBundles(app.db, app.attachmentBlobStore, { notifyAgent });
+
+    const [stored] = await app.db
+      .select({ bundleAttachmentId: resources.bundleAttachmentId })
+      .from(resources)
+      .where(eq(resources.id, resourceId));
+    const [after] = await app.db
+      .select({ version: agentConfigs.version })
+      .from(agentConfigs)
+      .where(eq(agentConfigs.agentId, agent.uuid));
+    expect(result).toMatchObject({ migrated: 1, affectedAgentCount: expect.any(Number) });
+    expect(stored?.bundleAttachmentId).toBeTruthy();
+    expect(after?.version).toBe((before?.version ?? 0) + 1);
+    expect(notifyAgent).toHaveBeenCalledWith(agent.uuid);
+  });
+
+  it("keeps a legacy inline Skill when generated frontmatter would exceed runtime bundle limits", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const resourceId = uuidv7();
+    await app.db.insert(resources).values({
+      id: resourceId,
+      organizationId: admin.organizationId,
+      type: "skill",
+      scope: "team",
+      ownerAgentId: null,
+      name: "legacy-too-large",
+      repoCanonicalKey: null,
+      bundleAttachmentId: null,
+      defaultEnabled: "recommended",
+      status: "active",
+      payload: {
+        name: "legacy-too-large",
+        description: "Legacy Skill that must remain inline.",
+        body: "x".repeat(TEAM_SKILL_BUNDLE_LIMITS.skillMarkdownBytes),
+        metadata: {},
+      },
+      createdBy: admin.memberId,
+      updatedBy: admin.memberId,
+    });
+
+    const result = await backfillSkillResourceBundles(app.db, app.attachmentBlobStore);
+
+    const [stored] = await app.db
+      .select({ bundleAttachmentId: resources.bundleAttachmentId })
+      .from(resources)
+      .where(eq(resources.id, resourceId));
+    expect(result).toMatchObject({ migrated: 0, skipped: 1, affectedAgentCount: 0 });
+    expect(stored?.bundleAttachmentId).toBeNull();
   });
 });

--- a/packages/server/src/api/agent/config.ts
+++ b/packages/server/src/api/agent/config.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { requireAgent } from "../../middleware/require-identity.js";
+import { resolveCurrentRuntimeConfig } from "../../services/runtime-config-snapshot.js";
 
 /**
  * Agent-facing runtime config endpoint (Step 4).
@@ -12,7 +13,9 @@ import { requireAgent } from "../../middleware/require-identity.js";
 export async function agentConfigRoutes(app: FastifyInstance): Promise<void> {
   app.get("/config", async (request) => {
     const identity = requireAgent(request);
-    const cfg = await app.configService.getDecrypted(identity.uuid);
-    return app.resourcesService.resolveRuntimeConfig(cfg);
+    return resolveCurrentRuntimeConfig(
+      () => app.configService.getDecrypted(identity.uuid),
+      (config) => app.resourcesService.resolveRuntimeConfig(config),
+    );
   });
 }

--- a/packages/server/src/api/agents-config.ts
+++ b/packages/server/src/api/agents-config.ts
@@ -5,6 +5,7 @@ import { agentPresence } from "../db/schema/agent-presence.js";
 import { requireAgentAccess } from "../scope/require-resource.js";
 import { assertNoRuntimeSwitchInProgress } from "../services/agent-runtime-switch.js";
 import { assertMutableAgentIsNotLandingCampaignTrial } from "../services/landing-campaigns/guards.js";
+import { resolveCurrentRuntimeConfig } from "../services/runtime-config-snapshot.js";
 
 /**
  * Class C — `/api/v1/agents/:uuid/config`. Runtime config (system prompt,
@@ -13,8 +14,10 @@ import { assertMutableAgentIsNotLandingCampaignTrial } from "../services/landing
 export async function agentConfigRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { uuid: string } }>("/:uuid/config", async (request) => {
     await requireAgentAccess(request, app.db, "manage");
-    const cfg = await app.configService.get(request.params.uuid);
-    return app.resourcesService.resolveRuntimeConfig(cfg);
+    return resolveCurrentRuntimeConfig(
+      () => app.configService.get(request.params.uuid),
+      (config) => app.resourcesService.resolveRuntimeConfig(config),
+    );
   });
 
   app.patch<{ Params: { uuid: string } }>("/:uuid/config", { config: { otelRecordBody: true } }, async (request) => {
@@ -23,7 +26,11 @@ export async function agentConfigRoutes(app: FastifyInstance): Promise<void> {
     assertNoRuntimeSwitchInProgress(agent);
     const body = updateAgentRuntimeConfigSchema.parse(request.body);
     const cfg = await app.configService.update(request.params.uuid, body, scope.memberId);
-    return app.resourcesService.resolveRuntimeConfig(cfg);
+    return resolveCurrentRuntimeConfig(
+      () => app.configService.get(request.params.uuid),
+      (config) => app.resourcesService.resolveRuntimeConfig(config),
+      cfg,
+    );
   });
 
   app.post<{ Params: { uuid: string } }>(

--- a/packages/server/src/api/attachments.ts
+++ b/packages/server/src/api/attachments.ts
@@ -28,7 +28,7 @@ export async function attachmentRoutes(app: FastifyInstance): Promise<void> {
     // never drags the bytea payload out of PG.
     const meta = await loadAttachmentMeta(app.db, id);
     if (!meta) {
-      throw new NotFoundError(`Attachment "${id}" not found`);
+      throw new NotFoundError("Attachment not found");
     }
 
     // If-None-Match: cheap ETag check. id is content-stable (UUIDv4 + bytes
@@ -43,7 +43,7 @@ export async function attachmentRoutes(app: FastifyInstance): Promise<void> {
     if (!stream) {
       // Deleted between the metadata read and now — vanishingly rare, but
       // surface it honestly rather than streaming an empty body.
-      throw new NotFoundError(`Attachment "${id}" not found`);
+      throw new NotFoundError("Attachment not found");
     }
 
     reply

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -729,7 +729,9 @@ export async function buildApp(config: Config, options: BuildAppOptions = {}) {
     await backfillExternalAttachmentsToPostgres(db, attachmentBlobStore).catch((err) => {
       app.log.warn({ err }, "legacy S3 attachment reverse backfill failed");
     });
-    await backfillSkillResourceBundles(db, attachmentBlobStore).catch((err) => {
+    await backfillSkillResourceBundles(db, attachmentBlobStore, {
+      notifyAgent: (agentId) => notifier.notifyConfigChange(`agent:${agentId}`),
+    }).catch((err) => {
       app.log.warn({ err }, "legacy Skill bundle backfill failed");
     });
     const gitlabAttentionBackfill = await backfillGitlabAttentionPairs(db);

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -25,7 +25,9 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
 
   async function maintainAttachments(): Promise<void> {
     const legacyAttachments = await backfillExternalAttachmentsToPostgres(app.db, app.attachmentBlobStore);
-    const legacySkills = await backfillSkillResourceBundles(app.db, app.attachmentBlobStore);
+    const legacySkills = await backfillSkillResourceBundles(app.db, app.attachmentBlobStore, {
+      notifyAgent: (agentId) => app.notifier.notifyConfigChange(`agent:${agentId}`),
+    });
     const sweep = await sweepOrphanAttachments(app.db, app.attachmentBlobStore);
     if (legacyAttachments.migrated > 0 || legacySkills.migrated > 0 || sweep.deleted > 0) {
       log.info({ legacyAttachments, legacySkills, sweep }, "attachment maintenance completed");

--- a/packages/server/src/services/resources.ts
+++ b/packages/server/src/services/resources.ts
@@ -26,8 +26,11 @@ import {
   type ResourceType,
   type ResourceUsageOutput,
   type RuntimeResourceSkill,
+  type RuntimeTeamSkillEntry,
+  type RuntimeTeamSkillSnapshot,
   repoResourcePayloadSchema,
   skillResourcePayloadSchema,
+  TEAM_SKILL_BUNDLE_LIMITS,
   type UpdateAgentResources,
   type UpdateTeamResource,
 } from "@first-tree/shared";
@@ -49,6 +52,7 @@ import {
   LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_NAME,
 } from "./landing-campaigns/trial-prompt.js";
 import type { Notifier } from "./notifier.js";
+import { RuntimeConfigSnapshotChangedError } from "./runtime-config-snapshot.js";
 import { validateSkillBundle } from "./skill-bundle.js";
 
 type ResourceDbRow = typeof resources.$inferSelect;
@@ -823,19 +827,129 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
       });
   }
 
-  function runtimeSkills(rows: EffectiveResourceRow[]): RuntimeResourceSkill[] {
-    return rows
-      .filter((row) => row.mode === "enabled" && row.resourceId)
-      .map((row) => {
-        const payload = skillResourcePayloadSchema.parse(row.payload);
-        return {
-          resourceId: row.resourceId ?? "",
-          name: payload.name,
-          description: payload.description,
-          body: payload.body,
-          metadata: payload.metadata,
-        };
+  async function runtimeSkillProjection(
+    rows: EffectiveResourceRow[],
+  ): Promise<Readonly<{ legacySkills: RuntimeResourceSkill[]; snapshot: RuntimeTeamSkillSnapshot }>> {
+    const selectedRows = rows.filter((row) => (row.mode === "enabled" || row.mode === "unavailable") && row.resourceId);
+    const resourceIds = Array.from(new Set(selectedRows.flatMap((row) => (row.resourceId ? [row.resourceId] : []))));
+    const storedResources =
+      resourceIds.length === 0
+        ? []
+        : await db
+            .select({
+              id: resources.id,
+              organizationId: resources.organizationId,
+              bundleAttachmentId: resources.bundleAttachmentId,
+            })
+            .from(resources)
+            .where(inArray(resources.id, resourceIds));
+    const resourceById = new Map(storedResources.map((resource) => [resource.id, resource]));
+    const attachmentIds = Array.from(
+      new Set(
+        storedResources.flatMap((resource) => (resource.bundleAttachmentId ? [resource.bundleAttachmentId] : [])),
+      ),
+    );
+    const attachmentRows =
+      attachmentIds.length === 0
+        ? []
+        : await db
+            .select({
+              id: attachments.id,
+              organizationId: attachments.organizationId,
+              lifecycleState: attachments.lifecycleState,
+              sizeBytes: attachments.sizeBytes,
+              payloadReady: sql<boolean>`${attachments.data} is not null or ${attachments.objectKey} is not null`,
+            })
+            .from(attachments)
+            .where(inArray(attachments.id, attachmentIds));
+    const attachmentById = new Map(attachmentRows.map((attachment) => [attachment.id, attachment]));
+
+    const entries: RuntimeTeamSkillEntry[] = [];
+    const seen = new Set<string>();
+    const duplicateIds = new Set<string>();
+    for (const row of selectedRows) {
+      if (!row.resourceId) continue;
+      if (seen.has(row.resourceId)) duplicateIds.add(row.resourceId);
+      seen.add(row.resourceId);
+    }
+    const emitted = new Set<string>();
+    for (const row of selectedRows) {
+      const resourceId = row.resourceId;
+      if (!resourceId || emitted.has(resourceId)) continue;
+      emitted.add(resourceId);
+      if (duplicateIds.has(resourceId)) {
+        entries.push({ kind: "unavailable", resourceId, reason: "duplicate_skill_resource" });
+        continue;
+      }
+      if (row.mode === "unavailable") {
+        entries.push({
+          kind: "unavailable",
+          resourceId,
+          reason: row.unavailableReason ?? "skill_unavailable",
+        });
+        continue;
+      }
+      const resource = resourceById.get(resourceId);
+      const payload = skillResourcePayloadSchema.safeParse(row.payload);
+      if (!resource || !payload.success) {
+        entries.push({ kind: "unavailable", resourceId, reason: "invalid_skill_payload" });
+        continue;
+      }
+      const attachmentId = resource.bundleAttachmentId;
+      if (!attachmentId) {
+        entries.push({
+          kind: "inline",
+          resourceId,
+          name: payload.data.name,
+          description: payload.data.description,
+          body: payload.data.body,
+          metadata: payload.data.metadata,
+        });
+        continue;
+      }
+      const attachment = attachmentById.get(attachmentId);
+      if (
+        !attachment ||
+        attachment.organizationId !== resource.organizationId ||
+        attachment.lifecycleState !== "ready" ||
+        !attachment.payloadReady ||
+        attachment.sizeBytes <= 0 ||
+        attachment.sizeBytes > TEAM_SKILL_BUNDLE_LIMITS.compressedBytes
+      ) {
+        entries.push({ kind: "unavailable", resourceId, reason: "skill_bundle_unavailable" });
+        continue;
+      }
+      entries.push({
+        kind: "attachment-bundle",
+        resourceId,
+        name: payload.data.name,
+        description: payload.data.description,
+        attachmentId,
+        sizeBytes: attachment.sizeBytes,
       });
+    }
+
+    const legacySkills: RuntimeResourceSkill[] = entries.flatMap((entry) =>
+      entry.kind === "inline"
+        ? [
+            {
+              resourceId: entry.resourceId,
+              name: entry.name,
+              description: entry.description,
+              body: entry.body,
+              metadata: entry.metadata,
+            },
+          ]
+        : [],
+    );
+    return {
+      legacySkills,
+      snapshot: {
+        kind: "authoritative",
+        schemaVersion: 1,
+        entries,
+      },
+    };
   }
 
   function runtimeMcp(rows: EffectiveResourceRow[]): NoSecretMcpServer[] {
@@ -844,8 +958,15 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
 
   async function resolveRuntimeConfig(config: AgentRuntimeConfig): Promise<AgentRuntimeConfig> {
     const effective = await resolveEffectiveResources(config.agentId);
+    if (effective.version !== config.version) {
+      throw new RuntimeConfigSnapshotChangedError();
+    }
     const resolvedPrompt = runtimePromptAppend(effective.prompts);
     const resolvedMcp = runtimeMcp(effective.mcp);
+    const skillProjection = await runtimeSkillProjection(effective.skills);
+    if ((await getConfigVersion(config.agentId)) !== effective.version) {
+      throw new RuntimeConfigSnapshotChangedError();
+    }
     return {
       ...config,
       version: effective.version,
@@ -862,7 +983,14 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
         },
         mcpServers:
           effective.mcp.length === 0 && config.payload.mcpServers.length > 0 ? config.payload.mcpServers : resolvedMcp,
-        resourceSkills: runtimeSkills(effective.skills),
+        // Older Clients understand only inline Team Skills. Bundle-backed
+        // rows never dual-send a derived body because that would expose an
+        // incomplete, falsely-successful installation without support files.
+        // Release ordering is therefore Client-first: snapshot-aware Clients
+        // can consume an old Server's legacy field before this projection is
+        // activated for the fleet.
+        resourceSkills: skillProjection.legacySkills,
+        teamSkillSnapshot: skillProjection.snapshot,
       },
     };
   }

--- a/packages/server/src/services/runtime-config-snapshot.ts
+++ b/packages/server/src/services/runtime-config-snapshot.ts
@@ -1,0 +1,29 @@
+import type { AgentRuntimeConfig } from "@first-tree/shared";
+import { ServiceUnavailableError } from "../errors.js";
+
+const MAX_RUNTIME_CONFIG_RESOLUTION_ATTEMPTS = 3;
+
+export class RuntimeConfigSnapshotChangedError extends Error {
+  constructor() {
+    super("Agent runtime config changed while its Resource snapshot was being resolved");
+    this.name = "RuntimeConfigSnapshotChangedError";
+  }
+}
+
+export async function resolveCurrentRuntimeConfig(
+  loadConfig: () => Promise<AgentRuntimeConfig>,
+  resolveConfig: (config: AgentRuntimeConfig) => Promise<AgentRuntimeConfig>,
+  initialConfig?: AgentRuntimeConfig,
+): Promise<AgentRuntimeConfig> {
+  let config = initialConfig;
+  for (let attempt = 0; attempt < MAX_RUNTIME_CONFIG_RESOLUTION_ATTEMPTS; attempt++) {
+    config ??= await loadConfig();
+    try {
+      return await resolveConfig(config);
+    } catch (error) {
+      if (!(error instanceof RuntimeConfigSnapshotChangedError)) throw error;
+      config = undefined;
+    }
+  }
+  throw new ServiceUnavailableError("Agent runtime config changed repeatedly; retry the request");
+}

--- a/packages/server/src/services/skill-bundle.ts
+++ b/packages/server/src/services/skill-bundle.ts
@@ -1,14 +1,28 @@
 import { createWriteStream } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { join } from "node:path";
+import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { SKILL_NAME_REGEX, type SkillResourcePayload, skillResourcePayloadSchema } from "@first-tree/shared";
-import { and, eq, isNull } from "drizzle-orm";
+import {
+  isTeamSkillOwnershipMarkerPath,
+  parseTeamSkillBundleEntryPath,
+  parseTeamSkillMarkdown,
+  SKILL_NAME_REGEX,
+  type SkillResourcePayload,
+  skillResourcePayloadSchema,
+  TEAM_SKILL_BUNDLE_LIMITS,
+  TEAM_SKILL_OWNERSHIP_MARKER,
+  TEAM_SKILL_RUNTIME_NAME_MAX,
+  teamSkillBundleCollisionKey,
+  teamSkillBundleTopologyConflict,
+} from "@first-tree/shared";
+import { and, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 import { strToU8, zipSync } from "fflate";
-import matter from "gray-matter";
 import yauzl, { type Entry, type ZipFile } from "yauzl";
 import type { Database } from "../db/connection.js";
+import { agentConfigs } from "../db/schema/agent-configs.js";
+import { agents } from "../db/schema/agents.js";
 import { members } from "../db/schema/members.js";
 import { resources } from "../db/schema/resources.js";
 import { BadRequestError } from "../errors.js";
@@ -19,10 +33,6 @@ import {
   openAttachmentStream,
 } from "./attachment.js";
 import type { AttachmentBlobStore } from "./attachment-blob-store.js";
-
-const MAX_SKILL_FILES = 256;
-const MAX_SKILL_UNCOMPRESSED_BYTES = 25 * 1024 * 1024;
-const MAX_SKILL_MARKDOWN_BYTES = 256 * 1024;
 
 const RESERVED_SKILL_NAMES = new Set([
   "first-tree-welcome",
@@ -55,13 +65,32 @@ export async function validateSkillBundle(
   if (!meta || meta.organizationId !== organizationId) {
     throw new BadRequestError("Skill bundle attachment must be a ready attachment owned by this organization");
   }
+  if (meta.sizeBytes > TEAM_SKILL_BUNDLE_LIMITS.compressedBytes) {
+    throw new BadRequestError(`Skill ZIP exceeds ${TEAM_SKILL_BUNDLE_LIMITS.compressedBytes} compressed bytes`);
+  }
   const stream = await openAttachmentStream(db, blobStore, attachmentId);
   if (!stream) throw new BadRequestError("Skill bundle attachment bytes are unavailable");
 
   const tempDir = await mkdtemp(join(tmpdir(), "first-tree-skill-"));
   const zipPath = join(tempDir, "bundle.zip");
   try {
-    await pipeline(stream, createWriteStream(zipPath, { flags: "wx" }));
+    let measuredCompressedBytes = 0;
+    const limiter = new Transform({
+      transform(chunk: Buffer | Uint8Array, _encoding, callback) {
+        measuredCompressedBytes += chunk.byteLength;
+        if (measuredCompressedBytes > TEAM_SKILL_BUNDLE_LIMITS.compressedBytes) {
+          callback(
+            new BadRequestError(`Skill ZIP exceeds ${TEAM_SKILL_BUNDLE_LIMITS.compressedBytes} compressed bytes`),
+          );
+          return;
+        }
+        callback(null, chunk);
+      },
+    });
+    await pipeline(stream, limiter, createWriteStream(zipPath, { flags: "wx" }));
+    if (measuredCompressedBytes !== meta.sizeBytes) {
+      throw new BadRequestError("Skill ZIP stored size does not match its attachment metadata");
+    }
     return await inspectZip(zipPath);
   } catch (error) {
     if (error instanceof BadRequestError) throw error;
@@ -74,46 +103,67 @@ export async function validateSkillBundle(
 async function inspectZip(path: string): Promise<ValidatedSkillBundle> {
   const zipFile = await openZip(path);
   const seenPaths = new Set<string>();
+  const pathTypes: Array<{ path: string; directory: boolean }> = [];
   const files: string[] = [];
   const skillMarkdown = new Map<string, Buffer>();
   let totalUncompressed = 0;
+  let entryCount = 0;
 
   try {
     await forEachEntry(zipFile, async (entry) => {
-      const normalized = validateEntryPath(entry.fileName);
-      const collisionKey = normalized.toLocaleLowerCase("en-US");
+      entryCount++;
+      if (entryCount > TEAM_SKILL_BUNDLE_LIMITS.entries) {
+        throw new BadRequestError(`Skill ZIP cannot contain more than ${TEAM_SKILL_BUNDLE_LIMITS.entries} entries`);
+      }
+      const parsedPath = parseTeamSkillBundleEntryPath(entry.fileName);
+      if (!parsedPath) throw new BadRequestError(`Skill ZIP contains an unsafe path: ${entry.fileName}`);
+      const normalized = parsedPath.normalized;
+      const collisionKey = teamSkillBundleCollisionKey(normalized);
       if (seenPaths.has(collisionKey)) {
         throw new BadRequestError(`Skill ZIP contains a duplicate path: ${normalized}`);
       }
       seenPaths.add(collisionKey);
+      pathTypes.push({ path: normalized, directory: parsedPath.directory });
       if ((entry.generalPurposeBitFlag & 0x1) !== 0) {
         throw new BadRequestError(`Skill ZIP contains an encrypted entry: ${normalized}`);
       }
-      if (isSymlink(entry)) {
-        throw new BadRequestError(`Skill ZIP cannot contain symlinks: ${normalized}`);
+      validateEntryType(entry, parsedPath.directory, normalized);
+      if (parsedPath.directory) {
+        if (entry.uncompressedSize !== 0) {
+          throw new BadRequestError(`Skill ZIP directory has non-zero content: ${normalized}`);
+        }
+        return;
       }
-      if (entry.fileName.endsWith("/")) return;
 
       files.push(normalized);
-      if (files.length > MAX_SKILL_FILES) {
-        throw new BadRequestError(`Skill ZIP cannot contain more than ${MAX_SKILL_FILES} files`);
+      if (files.length > TEAM_SKILL_BUNDLE_LIMITS.files) {
+        throw new BadRequestError(`Skill ZIP cannot contain more than ${TEAM_SKILL_BUNDLE_LIMITS.files} files`);
+      }
+      if (entry.uncompressedSize > TEAM_SKILL_BUNDLE_LIMITS.fileBytes) {
+        throw new BadRequestError(`Skill ZIP entry exceeds ${TEAM_SKILL_BUNDLE_LIMITS.fileBytes} bytes: ${normalized}`);
       }
       totalUncompressed += entry.uncompressedSize;
-      if (totalUncompressed > MAX_SKILL_UNCOMPRESSED_BYTES) {
-        throw new BadRequestError(`Skill ZIP exceeds ${MAX_SKILL_UNCOMPRESSED_BYTES} uncompressed bytes`);
+      if (totalUncompressed > TEAM_SKILL_BUNDLE_LIMITS.totalBytes) {
+        throw new BadRequestError(`Skill ZIP exceeds ${TEAM_SKILL_BUNDLE_LIMITS.totalBytes} uncompressed bytes`);
       }
 
-      const isSkillMarkdown = basename(normalized).toLocaleLowerCase("en-US") === "skill.md";
-      if (isSkillMarkdown && entry.uncompressedSize > MAX_SKILL_MARKDOWN_BYTES) {
-        throw new BadRequestError(`SKILL.md exceeds ${MAX_SKILL_MARKDOWN_BYTES} bytes`);
+      const isSkillMarkdown = parsedPath.segments.at(-1) === "SKILL.md";
+      if (isSkillMarkdown && entry.uncompressedSize > TEAM_SKILL_BUNDLE_LIMITS.skillMarkdownBytes) {
+        throw new BadRequestError(`SKILL.md exceeds ${TEAM_SKILL_BUNDLE_LIMITS.skillMarkdownBytes} bytes`);
       }
-      const bytes = await readEntry(zipFile, entry, isSkillMarkdown ? MAX_SKILL_MARKDOWN_BYTES : 0);
+      const bytes = await readEntry(zipFile, entry, isSkillMarkdown ? TEAM_SKILL_BUNDLE_LIMITS.skillMarkdownBytes : 0);
       if (isSkillMarkdown) skillMarkdown.set(normalized, bytes);
     });
   } finally {
     zipFile.close();
   }
 
+  const topologyConflict = teamSkillBundleTopologyConflict(pathTypes);
+  if (topologyConflict) {
+    throw new BadRequestError(
+      `Skill ZIP path ${topologyConflict.path} is nested below file ${topologyConflict.fileParent}`,
+    );
+  }
   if (skillMarkdown.size !== 1) {
     throw new BadRequestError("Skill ZIP must contain exactly one SKILL.md");
   }
@@ -121,12 +171,23 @@ async function inspectZip(path: string): Promise<ValidatedSkillBundle> {
   if (!skillEntry) throw new BadRequestError("Skill ZIP must contain SKILL.md");
   const [skillPath, bytes] = skillEntry;
   const segments = skillPath.split("/");
-  if (segments.length > 2 || segments.at(-1)?.toLocaleLowerCase("en-US") !== "skill.md") {
+  if (segments.length > 2 || segments.at(-1) !== "SKILL.md") {
     throw new BadRequestError("SKILL.md must be at the ZIP root or inside one top-level directory");
   }
   const rootPrefix = segments.length === 2 ? `${segments[0]}/` : "";
-  if (rootPrefix && files.some((file) => !file.startsWith(rootPrefix))) {
-    throw new BadRequestError("A wrapped Skill ZIP cannot contain files outside its top-level directory");
+  const rootName = segments.length === 2 ? segments[0] : null;
+  if (
+    rootPrefix &&
+    pathTypes.some(({ path: entryPath }) => entryPath !== rootName && !entryPath.startsWith(rootPrefix))
+  ) {
+    throw new BadRequestError("A wrapped Skill ZIP cannot contain entries outside its top-level directory");
+  }
+  const strippedPaths = pathTypes.flatMap(({ path: entryPath }) => {
+    const stripped = rootPrefix ? (entryPath === rootName ? "" : entryPath.slice(rootPrefix.length)) : entryPath;
+    return stripped ? [stripped] : [];
+  });
+  if (strippedPaths.some(isTeamSkillOwnershipMarkerPath)) {
+    throw new BadRequestError(`Skill ZIP may not provide reserved file ${TEAM_SKILL_OWNERSHIP_MARKER}`);
   }
 
   let markdown: string;
@@ -135,16 +196,20 @@ async function inspectZip(path: string): Promise<ValidatedSkillBundle> {
   } catch {
     throw new BadRequestError("SKILL.md must be valid UTF-8");
   }
-  let parsed: matter.GrayMatterFile<string>;
+  let parsed: ReturnType<typeof parseTeamSkillMarkdown>;
   try {
-    parsed = matter(markdown);
+    parsed = parseTeamSkillMarkdown(markdown);
   } catch (error) {
     throw new BadRequestError(`SKILL.md frontmatter is invalid: ${error instanceof Error ? error.message : error}`);
   }
-  const name = typeof parsed.data.name === "string" ? parsed.data.name.trim() : "";
-  const description = typeof parsed.data.description === "string" ? parsed.data.description.trim() : "";
-  const namespace = typeof parsed.data.namespace === "string" ? parsed.data.namespace.trim() : undefined;
-  if (!name || name.length > 100 || !SKILL_NAME_REGEX.test(name)) {
+  const frontmatter =
+    parsed.frontmatter && typeof parsed.frontmatter === "object" && !Array.isArray(parsed.frontmatter)
+      ? (parsed.frontmatter as Record<string, unknown>)
+      : {};
+  const name = typeof frontmatter.name === "string" ? frontmatter.name.trim() : "";
+  const description = typeof frontmatter.description === "string" ? frontmatter.description.trim() : "";
+  const namespace = typeof frontmatter.namespace === "string" ? frontmatter.namespace.trim() : undefined;
+  if (!name || name.length > TEAM_SKILL_RUNTIME_NAME_MAX || !SKILL_NAME_REGEX.test(name)) {
     throw new BadRequestError("SKILL.md name must start with an alphanumeric and contain only letters, digits, _ or -");
   }
   if (RESERVED_SKILL_NAMES.has(name.toLocaleLowerCase("en-US"))) {
@@ -156,7 +221,7 @@ async function inspectZip(path: string): Promise<ValidatedSkillBundle> {
   if (namespace && (namespace.length > 100 || !SKILL_NAME_REGEX.test(namespace))) {
     throw new BadRequestError("SKILL.md namespace must contain only letters, digits, _ or -");
   }
-  const rawMetadata = parsed.data.metadata;
+  const rawMetadata = frontmatter.metadata;
   const metadata =
     rawMetadata && typeof rawMetadata === "object" && !Array.isArray(rawMetadata)
       ? (rawMetadata as Record<string, unknown>)
@@ -165,32 +230,21 @@ async function inspectZip(path: string): Promise<ValidatedSkillBundle> {
     name,
     ...(namespace ? { namespace } : {}),
     description,
-    body: parsed.content.trim(),
+    body: parsed.body.trim(),
     metadata,
   });
   return { name, payload };
 }
 
-function validateEntryPath(raw: string): string {
-  if (!raw || raw.includes("\0") || raw.includes("\\")) {
-    throw new BadRequestError("Skill ZIP contains an invalid path");
-  }
-  if (raw.startsWith("/") || /^[A-Za-z]:/.test(raw)) {
-    throw new BadRequestError(`Skill ZIP contains an absolute path: ${raw}`);
-  }
-  const withoutTrailingSlash = raw.endsWith("/") ? raw.slice(0, -1) : raw;
-  const segments = withoutTrailingSlash.split("/");
-  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
-    throw new BadRequestError(`Skill ZIP contains an unsafe path: ${raw}`);
-  }
-  return withoutTrailingSlash;
-}
-
-function isSymlink(entry: Entry): boolean {
+function validateEntryType(entry: Entry, directory: boolean, path: string): void {
   const madeByUnix = entry.versionMadeBy >>> 8 === 3;
-  if (!madeByUnix) return false;
+  if (!madeByUnix) return;
   const mode = entry.externalFileAttributes >>> 16;
-  return (mode & 0o170000) === 0o120000;
+  const type = mode & 0o170000;
+  if (type === 0) return;
+  if (type === 0o120000) throw new BadRequestError(`Skill ZIP cannot contain symlinks: ${path}`);
+  const expected = directory ? 0o040000 : 0o100000;
+  if (type !== expected) throw new BadRequestError(`Skill ZIP cannot contain special files: ${path}`);
 }
 
 function openZip(path: string): Promise<ZipFile> {
@@ -247,25 +301,44 @@ function readEntry(zipFile: ZipFile, entry: Entry, captureLimit: number): Promis
         }
       });
       stream.once("error", reject);
-      stream.once("end", () => resolve(captureLimit > 0 ? Buffer.concat(chunks) : Buffer.alloc(0)));
+      stream.once("end", () => {
+        if (measured !== entry.uncompressedSize) {
+          reject(new BadRequestError(`Skill ZIP entry size is invalid: ${entry.fileName}`));
+          return;
+        }
+        resolve(captureLimit > 0 ? Buffer.concat(chunks) : Buffer.alloc(0));
+      });
     });
   });
 }
 
 export function buildLegacySkillBundle(payload: SkillResourcePayload): Buffer {
   const metadata = JSON.stringify(payload.metadata) ?? "{}";
-  const markdown = [
-    "---",
-    `name: ${JSON.stringify(payload.name)}`,
-    ...(payload.namespace ? [`namespace: ${JSON.stringify(payload.namespace)}`] : []),
-    `description: ${JSON.stringify(payload.description)}`,
-    `metadata: ${metadata}`,
-    "---",
-    "",
-    payload.body,
-    "",
-  ].join("\n");
-  return Buffer.from(zipSync({ "SKILL.md": strToU8(markdown) }, { level: 6 }));
+  const markdown = strToU8(
+    [
+      "---",
+      `name: ${JSON.stringify(payload.name)}`,
+      ...(payload.namespace ? [`namespace: ${JSON.stringify(payload.namespace)}`] : []),
+      `description: ${JSON.stringify(payload.description)}`,
+      `metadata: ${metadata}`,
+      "---",
+      "",
+      payload.body,
+      "",
+    ].join("\n"),
+  );
+  if (markdown.byteLength > TEAM_SKILL_BUNDLE_LIMITS.skillMarkdownBytes) {
+    throw new BadRequestError(
+      `Legacy Skill cannot be bundled because SKILL.md exceeds ${TEAM_SKILL_BUNDLE_LIMITS.skillMarkdownBytes} bytes`,
+    );
+  }
+  const bundle = Buffer.from(zipSync({ "SKILL.md": markdown }, { level: 6 }));
+  if (bundle.byteLength > TEAM_SKILL_BUNDLE_LIMITS.compressedBytes) {
+    throw new BadRequestError(
+      `Legacy Skill cannot be bundled because its ZIP exceeds ${TEAM_SKILL_BUNDLE_LIMITS.compressedBytes} bytes`,
+    );
+  }
+  return bundle;
 }
 
 /**
@@ -275,8 +348,12 @@ export function buildLegacySkillBundle(payload: SkillResourcePayload): Buffer {
 export async function backfillSkillResourceBundles(
   db: Database,
   blobStore: AttachmentBlobStore,
-  batchSize = 50,
-): Promise<{ migrated: number; skipped: number }> {
+  options: Readonly<{
+    batchSize?: number;
+    notifyAgent?: (agentId: string) => Promise<void>;
+  }> = {},
+): Promise<{ migrated: number; skipped: number; affectedAgentCount: number }> {
+  const batchSize = options.batchSize ?? 50;
   const rows = await db
     .select({
       id: resources.id,
@@ -290,15 +367,16 @@ export async function backfillSkillResourceBundles(
     .limit(batchSize);
   let migrated = 0;
   let skipped = 0;
+  const affectedAgentIds = new Set<string>();
   for (const row of rows) {
     const parsed = skillResourcePayloadSchema.safeParse(row.payload);
     if (!parsed.success) {
       skipped++;
       continue;
     }
-    const body = buildLegacySkillBundle(parsed.data);
     let attachmentId: string | undefined;
     try {
+      const body = buildLegacySkillBundle(parsed.data);
       let uploaderId = row.ownerAgentId;
       if (!uploaderId) {
         const [creator] = await db
@@ -317,21 +395,47 @@ export async function backfillSkillResourceBundles(
         uploadedBy: uploaderId ?? "system:skill-resource-backfill",
       });
       attachmentId = attachment.id;
-      const updated = await db
-        .update(resources)
-        .set({ bundleAttachmentId: attachment.id, updatedAt: new Date() })
-        .where(and(eq(resources.id, row.id), isNull(resources.bundleAttachmentId)))
-        .returning({ id: resources.id });
-      if (updated.length === 0) {
+      const updated = await db.transaction(async (tx) => {
+        const claimed = await tx
+          .update(resources)
+          .set({ bundleAttachmentId: attachment.id, updatedAt: new Date() })
+          .where(and(eq(resources.id, row.id), isNull(resources.bundleAttachmentId)))
+          .returning({ id: resources.id });
+        if (claimed.length === 0) return { claimed: false as const, agentIds: [] };
+        const runtimeAgents = await tx
+          .select({ agentId: agents.uuid })
+          .from(agents)
+          .where(
+            and(eq(agents.organizationId, row.organizationId), ne(agents.status, "deleted"), ne(agents.type, "human")),
+          );
+        const agentIds = runtimeAgents.map(({ agentId }) => agentId);
+        if (agentIds.length > 0) {
+          await tx
+            .update(agentConfigs)
+            .set({
+              version: sql`${agentConfigs.version} + 1`,
+              updatedAt: new Date(),
+              updatedBy: row.createdBy,
+            })
+            .where(inArray(agentConfigs.agentId, agentIds));
+        }
+        return { claimed: true as const, agentIds };
+      });
+      if (!updated.claimed) {
         await deleteAttachmentIfUnreferenced(db, blobStore, attachment.id);
         skipped++;
       } else {
         migrated++;
+        for (const agentId of updated.agentIds) affectedAgentIds.add(agentId);
       }
     } catch {
       if (attachmentId) await deleteAttachmentIfUnreferenced(db, blobStore, attachmentId).catch(() => undefined);
       skipped++;
     }
   }
-  return { migrated, skipped };
+  const notifyAgent = options.notifyAgent;
+  if (notifyAgent) {
+    await Promise.allSettled(Array.from(affectedAgentIds, (agentId) => notifyAgent(agentId)));
+  }
+  return { migrated, skipped, affectedAgentCount: affectedAgentIds.size };
 }

--- a/packages/shared/src/__tests__/agent-runtime-config.test.ts
+++ b/packages/shared/src/__tests__/agent-runtime-config.test.ts
@@ -19,6 +19,7 @@ import {
   isRedactedEnvValue,
   isSafeRepoLocalPath,
   normalizeRepoLocalPath,
+  runtimeTeamSkillSnapshotSchema,
   updateAgentRuntimeConfigSchema,
 } from "../schemas/agent-runtime-config.js";
 
@@ -34,6 +35,46 @@ function effortOf(payload: AgentRuntimeConfigPayload): string | undefined {
 function serviceTierOf(payload: AgentRuntimeConfigPayload): string | undefined {
   return "serviceTier" in payload ? payload.serviceTier : undefined;
 }
+
+describe("Team Skill runtime snapshot", () => {
+  it("keeps the optional wire field opaque while validating the recognized v1 shape separately", () => {
+    const snapshot = {
+      kind: "authoritative",
+      schemaVersion: 1,
+      entries: [
+        {
+          kind: "attachment-bundle",
+          resourceId: "resource-review",
+          name: "review",
+          description: "Review changes.",
+          attachmentId: "11111111-1111-4111-8111-111111111111",
+          sizeBytes: 1024,
+        },
+        {
+          kind: "unavailable",
+          resourceId: "resource-missing",
+          reason: "skill_bundle_unavailable",
+        },
+      ],
+    };
+
+    const payload = agentRuntimeConfigPayloadSchema.parse({ teamSkillSnapshot: snapshot });
+    expect(payload.teamSkillSnapshot).toEqual(snapshot);
+    expect(runtimeTeamSkillSnapshotSchema.parse(payload.teamSkillSnapshot)).toEqual(snapshot);
+  });
+
+  it("preserves future and malformed snapshot values for Client last-known-good handling", () => {
+    const future = { kind: "authoritative", schemaVersion: 2, entries: [] };
+    const malformed = { kind: "authoritative", schemaVersion: 1, entries: "invalid" };
+
+    expect(agentRuntimeConfigPayloadSchema.parse({ teamSkillSnapshot: future }).teamSkillSnapshot).toEqual(future);
+    expect(agentRuntimeConfigPayloadSchema.parse({ teamSkillSnapshot: malformed }).teamSkillSnapshot).toEqual(
+      malformed,
+    );
+    expect(runtimeTeamSkillSnapshotSchema.safeParse(future).success).toBe(false);
+    expect(runtimeTeamSkillSnapshotSchema.safeParse(malformed).success).toBe(false);
+  });
+});
 
 /**
  * Lock the server-side default model. This default backs two separate paths:

--- a/packages/shared/src/__tests__/team-skill-bundle.test.ts
+++ b/packages/shared/src/__tests__/team-skill-bundle.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { parseTeamSkillBundleEntryPath, TEAM_SKILL_BUNDLE_LIMITS } from "../schemas/team-skill-bundle.js";
+
+describe("Team Skill bundle paths", () => {
+  it("accepts portable paths within the shared cross-platform bounds", () => {
+    expect(parseTeamSkillBundleEntryPath("references/policy.md")).toMatchObject({
+      normalized: "references/policy.md",
+      directory: false,
+    });
+    expect(parseTeamSkillBundleEntryPath(`${"a".repeat(TEAM_SKILL_BUNDLE_LIMITS.segmentCodeUnits)}/file.txt`)).not.toBe(
+      null,
+    );
+  });
+
+  it("rejects segments and extracted paths beyond the shared materialization bounds", () => {
+    expect(
+      parseTeamSkillBundleEntryPath(`${"a".repeat(TEAM_SKILL_BUNDLE_LIMITS.segmentCodeUnits + 1)}/file.txt`),
+    ).toBeNull();
+    expect(parseTeamSkillBundleEntryPath(`${"界".repeat(80)}.txt`)).toBeNull();
+
+    const overlongPath = `${Array.from({ length: 8 }, () => "a".repeat(100)).join("/")}/file.txt`;
+    expect(overlongPath.length).toBeGreaterThan(TEAM_SKILL_BUNDLE_LIMITS.pathCodeUnits);
+    expect(parseTeamSkillBundleEntryPath(overlongPath)).toBeNull();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -165,7 +165,17 @@ export {
   promptSectionSchema,
   promptSectionScopeSchema,
   type RuntimeResourceSkill,
+  type RuntimeTeamSkillAttachmentEntry,
+  type RuntimeTeamSkillEntry,
+  type RuntimeTeamSkillInlineEntry,
+  type RuntimeTeamSkillSnapshot,
+  type RuntimeTeamSkillUnavailableEntry,
   runtimeResourceSkillSchema,
+  runtimeTeamSkillAttachmentEntrySchema,
+  runtimeTeamSkillEntrySchema,
+  runtimeTeamSkillInlineEntrySchema,
+  runtimeTeamSkillSnapshotSchema,
+  runtimeTeamSkillUnavailableEntrySchema,
   type UpdateAgentRuntimeConfig,
   updateAgentRuntimeConfigSchema,
 } from "./schemas/agent-runtime-config.js";
@@ -1282,6 +1292,18 @@ export {
   type Stats,
   statsSchema,
 } from "./schemas/stats.js";
+export {
+  isTeamSkillOwnershipMarkerPath,
+  type ParsedTeamSkillMarkdown,
+  parseTeamSkillBundleEntryPath,
+  parseTeamSkillMarkdown,
+  TEAM_SKILL_BUNDLE_LIMITS,
+  TEAM_SKILL_OWNERSHIP_MARKER,
+  TEAM_SKILL_RUNTIME_NAME_MAX,
+  type TeamSkillBundleEntryPath,
+  teamSkillBundleCollisionKey,
+  teamSkillBundleTopologyConflict,
+} from "./schemas/team-skill-bundle.js";
 export {
   isGithubEventCardContent,
   isGithubSystemSenderMetadata,

--- a/packages/shared/src/observability/__tests__/redact-url.test.ts
+++ b/packages/shared/src/observability/__tests__/redact-url.test.ts
@@ -15,6 +15,13 @@ describe("redactUrl", () => {
     expect(redactUrl("/api/v1/webhooks/gitlab/secret-bearer/extra")).toBe("/api/v1/webhooks/gitlab/***/extra");
   });
 
+  it("redacts attachment capability path segments", () => {
+    expect(redactUrl("/api/v1/attachments/11111111-1111-4111-8111-111111111111")).toBe("/api/v1/attachments/***");
+    expect(redactUrl("https://first-tree.test/api/v1/attachments/private-capability?download=1")).toBe(
+      "https://first-tree.test/api/v1/attachments/***?download=1",
+    );
+  });
+
   it("returns the URL unchanged when the query string is empty", () => {
     // Path ends with `?` but no params — keep the trailing `?` to preserve
     // the original shape, since we only redact values, never structure.

--- a/packages/shared/src/observability/redact-url.ts
+++ b/packages/shared/src/observability/redact-url.ts
@@ -36,7 +36,9 @@ const REDACTED = "***";
  * value happens to look.
  */
 export function redactUrl(url: string): string {
-  const pathRedacted = url.replace(/(\/api\/v1\/webhooks\/gitlab\/)[^/?#]+/g, `$1${REDACTED}`);
+  const pathRedacted = url
+    .replace(/(\/api\/v1\/webhooks\/gitlab\/)[^/?#]+/g, `$1${REDACTED}`)
+    .replace(/(\/api\/v1\/attachments\/)[^/?#]+/g, `$1${REDACTED}`);
   const qIdx = pathRedacted.indexOf("?");
   if (qIdx === -1) return pathRedacted;
   const path = pathRedacted.slice(0, qIdx);

--- a/packages/shared/src/schemas/agent-runtime-config.ts
+++ b/packages/shared/src/schemas/agent-runtime-config.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { runtimeProviderSchema } from "./runtime-provider.js";
+import { TEAM_SKILL_BUNDLE_LIMITS } from "./team-skill-bundle.js";
 
 /**
  * Agent runtime configuration.
@@ -94,6 +95,50 @@ export const runtimeResourceSkillSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).default({}),
 });
 export type RuntimeResourceSkill = z.infer<typeof runtimeResourceSkillSchema>;
+
+export const runtimeTeamSkillInlineEntrySchema = runtimeResourceSkillSchema.extend({
+  kind: z.literal("inline"),
+});
+export type RuntimeTeamSkillInlineEntry = z.infer<typeof runtimeTeamSkillInlineEntrySchema>;
+
+export const runtimeTeamSkillAttachmentEntrySchema = z.object({
+  kind: z.literal("attachment-bundle"),
+  resourceId: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().default(""),
+  attachmentId: z.string().uuid(),
+  sizeBytes: z.number().int().positive().max(TEAM_SKILL_BUNDLE_LIMITS.compressedBytes),
+});
+export type RuntimeTeamSkillAttachmentEntry = z.infer<typeof runtimeTeamSkillAttachmentEntrySchema>;
+
+export const runtimeTeamSkillUnavailableEntrySchema = z.object({
+  kind: z.literal("unavailable"),
+  resourceId: z.string().min(1),
+  reason: z.string().min(1),
+});
+export type RuntimeTeamSkillUnavailableEntry = z.infer<typeof runtimeTeamSkillUnavailableEntrySchema>;
+
+export const runtimeTeamSkillEntrySchema = z.discriminatedUnion("kind", [
+  runtimeTeamSkillInlineEntrySchema,
+  runtimeTeamSkillAttachmentEntrySchema,
+  runtimeTeamSkillUnavailableEntrySchema,
+]);
+export type RuntimeTeamSkillEntry = z.infer<typeof runtimeTeamSkillEntrySchema>;
+
+/**
+ * Authoritative current Team Skill selection. The payload keeps this field as
+ * `unknown` below so future snapshot versions reach older Clients intact:
+ * recognized v1 snapshots win, while malformed/future snapshots can preserve
+ * last-known-good state instead of invalidating the whole runtime config.
+ */
+export const runtimeTeamSkillSnapshotSchema = z
+  .object({
+    kind: z.literal("authoritative"),
+    schemaVersion: z.literal(1),
+    entries: z.array(runtimeTeamSkillEntrySchema),
+  })
+  .strict();
+export type RuntimeTeamSkillSnapshot = z.infer<typeof runtimeTeamSkillSnapshotSchema>;
 
 export const envEntrySchema = z.object({
   key: z.string().regex(ENV_KEY_PATTERN, "Env key must match /^[A-Z][A-Z0-9_]*$/"),
@@ -232,6 +277,7 @@ export const agentRuntimeConfigPayloadShape = z.object({
   env: z.array(envEntrySchema).default([]),
   gitRepos: z.array(gitRepoSchema).default([]),
   resourceSkills: z.array(runtimeResourceSkillSchema).default([]),
+  teamSkillSnapshot: z.unknown().optional(),
 });
 
 /**

--- a/packages/shared/src/schemas/team-skill-bundle.ts
+++ b/packages/shared/src/schemas/team-skill-bundle.ts
@@ -1,0 +1,164 @@
+import { parse as parseYaml } from "yaml";
+import { MAX_ATTACHMENT_BYTES } from "./attachment.js";
+
+/**
+ * One compatible limit set for Server upload validation and Client runtime
+ * extraction. A bundle accepted by the Server must remain admissible when a
+ * Client installs it.
+ */
+export const TEAM_SKILL_BUNDLE_LIMITS = Object.freeze({
+  compressedBytes: MAX_ATTACHMENT_BYTES,
+  entries: 512,
+  files: 256,
+  totalBytes: 16 * 1024 * 1024,
+  fileBytes: 4 * 1024 * 1024,
+  skillMarkdownBytes: 256 * 1024,
+  depth: 16,
+  segmentBytes: 240,
+  segmentCodeUnits: 120,
+  pathBytes: 1024,
+  pathCodeUnits: 768,
+});
+
+export const TEAM_SKILL_OWNERSHIP_MARKER = ".first-tree-managed.json";
+export const TEAM_SKILL_RUNTIME_NAME_MAX = 63;
+
+const WINDOWS_RESERVED_NAMES = new Set<string>([
+  "con",
+  "prn",
+  "aux",
+  "nul",
+  "com1",
+  "com2",
+  "com3",
+  "com4",
+  "com5",
+  "com6",
+  "com7",
+  "com8",
+  "com9",
+  "lpt1",
+  "lpt2",
+  "lpt3",
+  "lpt4",
+  "lpt5",
+  "lpt6",
+  "lpt7",
+  "lpt8",
+  "lpt9",
+]);
+
+export type TeamSkillBundleEntryPath = Readonly<{
+  normalized: string;
+  segments: readonly string[];
+  directory: boolean;
+}>;
+
+export type ParsedTeamSkillMarkdown = Readonly<{
+  frontmatter: unknown;
+  body: string;
+}>;
+
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function isPortableSegment(segment: string): boolean {
+  if (
+    segment.length === 0 ||
+    segment.length > TEAM_SKILL_BUNDLE_LIMITS.segmentCodeUnits ||
+    new TextEncoder().encode(segment).byteLength > TEAM_SKILL_BUNDLE_LIMITS.segmentBytes ||
+    segment === "." ||
+    segment === ".." ||
+    segment.includes("\\") ||
+    containsControlCharacter(segment) ||
+    /[<>:"|?*]/u.test(segment) ||
+    segment.endsWith(".") ||
+    segment.endsWith(" ")
+  ) {
+    return false;
+  }
+  const windowsBase = segment.split(".", 1)[0]?.toLocaleLowerCase("en-US") ?? "";
+  return !WINDOWS_RESERVED_NAMES.has(windowsBase);
+}
+
+/**
+ * Validate one raw ZIP entry name without consulting the host filesystem.
+ * Forward slashes are the only separators so the same archive has the same
+ * meaning on Unix and Windows.
+ */
+export function parseTeamSkillBundleEntryPath(raw: string): TeamSkillBundleEntryPath | null {
+  if (
+    raw.length === 0 ||
+    raw.startsWith("/") ||
+    /^[A-Za-z]:/u.test(raw) ||
+    raw.includes("\\") ||
+    containsControlCharacter(raw)
+  ) {
+    return null;
+  }
+  const directory = raw.endsWith("/");
+  const normalized = directory ? raw.slice(0, -1) : raw;
+  if (normalized.length === 0) return null;
+  if (
+    normalized.length > TEAM_SKILL_BUNDLE_LIMITS.pathCodeUnits ||
+    new TextEncoder().encode(normalized).byteLength > TEAM_SKILL_BUNDLE_LIMITS.pathBytes
+  ) {
+    return null;
+  }
+  const segments = normalized.split("/");
+  if (segments.some((segment) => !isPortableSegment(segment))) return null;
+  if (segments.length - 1 > TEAM_SKILL_BUNDLE_LIMITS.depth) return null;
+  return { normalized, segments, directory };
+}
+
+export function teamSkillBundleCollisionKey(path: string): string {
+  return path.normalize("NFKC").toLocaleLowerCase("en-US");
+}
+
+export function isTeamSkillOwnershipMarkerPath(path: string): boolean {
+  const firstSegment = path.split("/", 1)[0] ?? "";
+  return teamSkillBundleCollisionKey(firstSegment) === teamSkillBundleCollisionKey(TEAM_SKILL_OWNERSHIP_MARKER);
+}
+
+/**
+ * Parse the exact frontmatter shape used by both Cloud acceptance and Client
+ * installation. Keeping the parser and delimiter handling here prevents a ZIP
+ * from being accepted by one side and rejected by the other.
+ */
+export function parseTeamSkillMarkdown(markdown: string): ParsedTeamSkillMarkdown {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(markdown);
+  if (!match) throw new Error("SKILL.md must contain YAML frontmatter");
+  return {
+    frontmatter: parseYaml(match[1] ?? ""),
+    body: markdown.slice(match[0].length),
+  };
+}
+
+/**
+ * Return the first path whose explicit parent is declared as a file.
+ *
+ * ZIPs do not require directory entries, so missing parents are valid. An
+ * explicit file parent is not: extraction would otherwise depend on entry
+ * order and fail only after upload validation had succeeded. Collision keys
+ * deliberately match the case-insensitive target-filesystem policy.
+ */
+export function teamSkillBundleTopologyConflict(
+  entries: readonly Readonly<{ path: string; directory: boolean }>[],
+): Readonly<{ path: string; fileParent: string }> | null {
+  const pathTypes = new Map(entries.map((entry) => [teamSkillBundleCollisionKey(entry.path), entry.directory]));
+  for (const entry of entries) {
+    const segments = entry.path.split("/");
+    for (let depth = 1; depth < segments.length; depth++) {
+      const parent = segments.slice(0, depth).join("/");
+      if (pathTypes.get(teamSkillBundleCollisionKey(parent)) === false) {
+        return { path: entry.path, fileParent: parent };
+      }
+    }
+  }
+  return null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
+      yauzl:
+        specifier: ^3.4.0
+        version: 3.4.0
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -160,9 +163,15 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      '@types/yauzl':
+        specifier: ^3.4.0
+        version: 3.4.0
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       tsdown:
         specifier: ^0.21.4
         version: 0.21.4(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- Project complete, admin-uploaded Team Skill ZIP bundles through a versioned authoritative runtime snapshot instead of reducing them to an inline `SKILL.md`.
- Resolve bundle-backed resources to authenticated attachment descriptors on the Server, and preserve per-Skill last-known-good state when a selected bundle is temporarily unavailable.
- Add an `attachment-bundle` Client source that downloads only when an install, update, or drift repair is required, then feeds the extracted directory through the existing provider-native managed-Skill transaction.
- Keep null-bundle legacy Team Skills compatible through the existing inline projection.
- Advance agent config versions when legacy bundle backfill changes the authoritative resource snapshot so a Client cannot reconcile mixed revisions.

This closes the final runtime gap after complete Team Skill bundle upload/storage landed: supporting scripts, references, and agents now reach the active provider's native Skill root.

## Runtime and failure semantics

- A recognized authoritative snapshot wins and is never merged with `resourceSkills`.
- A missing snapshot falls back to legacy `resourceSkills`, supporting a new Client with an old Server.
- A malformed or future snapshot preserves the whole Team Skill last-known-good projection.
- A per-resource unavailable sentinel keeps that Skill in `desiredKeys`, while other Skills can continue to reconcile.
- Omission from a valid authoritative snapshot is a revoke.
- Bundle-backed rows never dual-send a derived inline body, avoiding a false-success installation without supporting files.
- Runtime config resolution uses a version fence and bounded retry so resource selection and attachment descriptors come from one coherent snapshot.

## Security

- Uses authenticated `fetchAttachment`; attachment capability paths are redacted from logs and missing capabilities return a generic response.
- Streams downloads and ZIP entries with independent Client-side limits for compressed bytes, files, total bytes, per-file bytes, path depth, and portable path length.
- Rejects traversal, absolute/drive/backslash/control paths, empty/dot segments, Windows device names, trailing dot/space, duplicate or case-colliding paths, encryption, symlinks/special files, size mismatches, extra wrapper-root content, and archive-owned management metadata.
- Accepts exactly one exact-case `SKILL.md`, with either root files or one optional wrapper directory.
- Creates contained files with exclusive creation, preserves only executable bits, and completes all remote I/O before opening a managed-Skill journal.
- Reuses the existing lock, ownership proof, manifest/digest validation, journaled swap, crash recovery, monotonic fence, conflict handling, and provider-switch semantics.

## Rollout

Client-first rollout is a hard prerequisite:

1. Deploy snapshot-aware Clients first. They continue to consume an old Server's legacy `resourceSkills`.
2. Deploy the new Server only after those Clients are available.
3. Old Clients receiving a new Server configuration can use only null-bundle legacy inline Skills; bundle-backed Skills intentionally do not receive an incomplete inline fallback.

## Validation

- [x] `pnpm check` — passed; 16 existing warnings and 1 informational diagnostic, no errors.
- [x] `pnpm typecheck` — 11/11 tasks passed.
- [ ] `pnpm test` — executed twice. The controlled monorepo run exercised the full suite but did not finish green because of unrelated long scheduler stalls and two `packages/web` tests outside this diff. The timed-out CLI and Server files passed in isolation; the Web SSR timeout passed in isolation; one unchanged Web focus-retention test still reproduces in isolation. Package and focused evidence below is green.

Focused and package evidence:

- `pnpm --filter @first-tree/shared exec vitest run src/__tests__/team-skill-bundle.test.ts src/__tests__/agent-runtime-config.test.ts src/observability/__tests__/redact-url.test.ts` — 76/76 passed.
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/skill-bundles.test.ts src/__tests__/resources-phase1.test.ts src/__tests__/attachments-route.test.ts src/__tests__/runtime-config-snapshot.test.ts src/__tests__/service-branch-defaults.test.ts` — 109/109 passed.
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/managed-skills.test.ts src/__tests__/sdk-comprehensive.test.ts` — 81/81 passed.
- `pnpm --filter @first-tree/server test` — full Server package suite passed.
- The controlled monorepo run completed the full Client suite with 1,734 passed / 3 skipped and the full Shared suite with 729 passed.
- Isolated environmental failures: `client-service.test.ts` 15/15, `message-dispatcher.test.ts` 11/11, `context-policy-runtime-layout.test.ts` 5/5, and `page-ssr-smoke.test.tsx` 9/9 passed.
- The concrete `context-tree-value-audit-0.2.5.zip` acceptance bundle was accepted and extracted with its supporting files under the runtime limits.

Four independent Codex review passes covered correctness and security. Findings fixed before this commit included exact-limit metadata overhead, wrapped-root edge cases, config snapshot consistency, attachment capability redaction, target ownership races, unsafe staging cleanup, legacy backfill size bounds, portable path limits, and explicit empty-directory extraction.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [x] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- Package or install behavior changes: complete Team Skill bundles are installed into only the active provider-native Skill root.
- Docs or tests updated to match: `packages/qa/cases/runtime/managed-skill-projection.md` now requires a real provider turn to execute a bundled supporting script and consume a bundled reference.
- Follow-up work: formal provider-backed QA with `context-tree-value-audit-0.2.5.zip` remains warranted before production rollout.

## Context Tree

Implemented against `agent-team-foundation/first-tree-context@5099df1d035d48dd6062eb2e5a9735ba70e29c7d`:

- `system/cloud/agents/resources.md` — Runtime Projection Boundary
- `system/architecture.md` — Skill Payload Shape
- `system/context-management/workspace-layout.md` — File Layout
