### PR TITLE
Fix Need you handling for inactive chats and agents

### DIFF
--- a/packages/server/src/__tests__/chat-engagement.test.ts
+++ b/packages/server/src/__tests__/chat-engagement.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { sql } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createMeChat } from "../services/me-chat.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
@@ -33,6 +33,7 @@ describe("POST /chats/:chatId/engagement", () => {
     const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
       participantIds: [peer.agent.uuid],
     });
+    const notifySpy = vi.spyOn(app.notifier, "notifyMeChatsChanged");
 
     for (const status of ["archived", "active", "deleted", "active"] as const) {
       const res = await app.inject({
@@ -51,6 +52,9 @@ describe("POST /chats/:chatId/engagement", () => {
       );
       expect(row?.engagement_status).toBe(status);
     }
+    expect(notifySpy).toHaveBeenCalledTimes(4);
+    expect(notifySpy).toHaveBeenLastCalledWith(admin.humanAgentUuid, admin.organizationId);
+    notifySpy.mockRestore();
   });
 
   it("GET /chats/:chatId returns caller engagement (defaults to 'active' before any write)", async () => {

--- a/packages/server/src/__tests__/message-edge-coverage.test.ts
+++ b/packages/server/src/__tests__/message-edge-coverage.test.ts
@@ -64,6 +64,51 @@ describe("message service edge coverage", () => {
     ).toThrow(/Deleted agents cannot receive new messages/);
   });
 
+  it("allows only a human closed resolution to degrade after its declared target is missing", () => {
+    const human = {
+      agentId: "human-1",
+      name: "human",
+      displayName: "Human",
+      status: "active",
+      type: "human",
+    } satisfies SendIntentParticipant;
+    const closed = preflightMessageSendIntent({
+      chatId: "chat-1",
+      senderId: human.agentId,
+      senderType: "human",
+      data: {
+        source: "web",
+        format: "text",
+        content: "(Skipped — no answer provided.)",
+        metadata: {
+          mentions: ["missing-asker"],
+          resolves: { request: "request-1", kind: "closed" },
+        },
+      },
+      participants: [human],
+    });
+    expect(closed.mentionedAgentIds).toEqual([]);
+    expect(closed.metadata.mentions).toEqual([]);
+
+    expect(() =>
+      preflightMessageSendIntent({
+        chatId: "chat-1",
+        senderId: human.agentId,
+        senderType: "human",
+        data: {
+          source: "web",
+          format: "text",
+          content: "Answer",
+          metadata: {
+            mentions: ["missing-asker"],
+            resolves: { request: "request-1", kind: "answered" },
+          },
+        },
+        participants: [human],
+      }),
+    ).toThrow(/requires an explicit recipient/i);
+  });
+
   it("returns null when a double-encoded string candidate is not valid JSON", () => {
     expect(maybeUnwrapDoubleEncoded('"bad\\n\\x"')).toBeNull();
   });

--- a/packages/server/src/__tests__/need-you.test.ts
+++ b/packages/server/src/__tests__/need-you.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { chats } from "../db/schema/chats.js";
 import { organizations } from "../db/schema/organizations.js";
 import { createAgent } from "../services/agent.js";
-import { createMeChat } from "../services/me-chat.js";
+import { createMeChat, setChatEngagement } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
 import { listNeedYouRequests, listRequestThread } from "../services/need-you.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -81,6 +81,32 @@ describe("Need you request queue and Ask agent protocol", () => {
     });
     expect(next.total).toBe(2);
     expect(next.items.map((item) => item.request.id)).toEqual([secondRequest.id]);
+  });
+
+  it("projects only the viewer's active chats into both queue rows and exact total", async () => {
+    const input = await setup("engagement-filter");
+    const request = await ask(input, "Which active rollout?");
+
+    const queue = async () =>
+      listNeedYouRequests(input.app.db, input.owner.humanAgentUuid, input.owner.organizationId, { limit: 50 });
+
+    // A missing user-state row has the lazy default `active`.
+    await expect(queue()).resolves.toMatchObject({
+      total: 1,
+      items: [{ request: { id: request.id } }],
+    });
+
+    await setChatEngagement(input.app.db, input.chatId, input.owner.humanAgentUuid, "archived");
+    await expect(queue()).resolves.toMatchObject({ total: 0, items: [] });
+
+    await setChatEngagement(input.app.db, input.chatId, input.owner.humanAgentUuid, "deleted");
+    await expect(queue()).resolves.toMatchObject({ total: 0, items: [] });
+
+    await setChatEngagement(input.app.db, input.chatId, input.owner.humanAgentUuid, "active");
+    await expect(queue()).resolves.toMatchObject({
+      total: 1,
+      items: [{ request: { id: request.id } }],
+    });
   });
 
   it("keeps Ask agent clarification and reply in a durable thread without resolving the request", async () => {

--- a/packages/server/src/__tests__/need-you.test.ts
+++ b/packages/server/src/__tests__/need-you.test.ts
@@ -1,5 +1,7 @@
 import { ASK_AGENT_METADATA_KEY, readAskAgentMessageMetadata } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
 import { organizations } from "../db/schema/organizations.js";
 import { createAgent } from "../services/agent.js";
@@ -107,6 +109,107 @@ describe("Need you request queue and Ask agent protocol", () => {
       total: 1,
       items: [{ request: { id: request.id } }],
     });
+  });
+
+  it("closes a skipped request and notifies an active asker", async () => {
+    const input = await setup("skip-active");
+    const request = await ask(input, "Which rollout?");
+
+    const result = await sendMessage(input.app.db, input.chatId, input.owner.humanAgentUuid, {
+      source: "web",
+      format: "text",
+      content: "(Skipped — no answer provided.)",
+      metadata: {
+        mentions: [input.asker.uuid],
+        resolves: { request: request.id, kind: "closed" },
+      },
+      inReplyTo: request.id,
+    });
+
+    expect(result.message.metadata).toMatchObject({
+      mentions: [input.asker.uuid],
+      resolves: { request: request.id, kind: "closed" },
+    });
+    expect(result.recipients).toContain(input.asker.inboxId);
+    await expect(
+      listNeedYouRequests(input.app.db, input.owner.humanAgentUuid, input.owner.organizationId, { limit: 50 }),
+    ).resolves.toMatchObject({ total: 0, items: [] });
+  });
+
+  it.each([
+    "suspended",
+    "deleted",
+  ] as const)("lets the target human close a request after the asker becomes %s without weakening other sends", async (status) => {
+    const input = await setup(`skip-${status}`);
+    const request = await ask(input, "Which rollout?");
+    await input.app.db
+      .update(agents)
+      .set({ status, ...(status === "deleted" ? { name: null } : {}) })
+      .where(eq(agents.uuid, input.asker.uuid));
+
+    const expectInactiveRouteFailure = async (send: () => ReturnType<typeof sendMessage>): Promise<void> => {
+      await expect(send()).rejects.toThrow(/Cannot route .* because the agent is (suspended|deleted)/);
+    };
+
+    await expectInactiveRouteFailure(() =>
+      sendMessage(input.app.db, input.chatId, input.owner.humanAgentUuid, {
+        source: "web",
+        format: "text",
+        content: "Ordinary message",
+        metadata: { mentions: [input.asker.uuid] },
+      }),
+    );
+    await expectInactiveRouteFailure(() =>
+      sendMessage(input.app.db, input.chatId, input.owner.humanAgentUuid, {
+        source: "web",
+        format: "text",
+        content: "Ordinary answer",
+        metadata: {
+          mentions: [input.asker.uuid],
+          resolves: { request: request.id, kind: "answered" },
+        },
+        inReplyTo: request.id,
+      }),
+    );
+    await expectInactiveRouteFailure(() =>
+      sendMessage(
+        input.app.db,
+        input.chatId,
+        input.owner.humanAgentUuid,
+        {
+          source: "web",
+          format: "text",
+          content: "Can you clarify?",
+          metadata: { mentions: [input.asker.uuid] },
+          inReplyTo: request.id,
+        },
+        { askAgentRequestId: request.id },
+      ),
+    );
+
+    await expect(
+      listNeedYouRequests(input.app.db, input.owner.humanAgentUuid, input.owner.organizationId, { limit: 50 }),
+    ).resolves.toMatchObject({ total: 1, items: [{ request: { id: request.id } }] });
+
+    const result = await sendMessage(input.app.db, input.chatId, input.owner.humanAgentUuid, {
+      source: "web",
+      format: "text",
+      content: "(Skipped — no answer provided.)",
+      metadata: {
+        mentions: [input.asker.uuid],
+        resolves: { request: request.id, kind: "closed" },
+      },
+      inReplyTo: request.id,
+    });
+
+    expect(result.message.metadata).toMatchObject({
+      mentions: [],
+      resolves: { request: request.id, kind: "closed" },
+    });
+    expect(result.recipients).toEqual([]);
+    await expect(
+      listNeedYouRequests(input.app.db, input.owner.humanAgentUuid, input.owner.organizationId, { limit: 50 }),
+    ).resolves.toMatchObject({ total: 0, items: [] });
   });
 
   it("keeps Ask agent clarification and reply in a durable thread without resolving the request", async () => {

--- a/packages/server/src/__tests__/open-question.test.ts
+++ b/packages/server/src/__tests__/open-question.test.ts
@@ -1,5 +1,6 @@
 import { and, eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
 import { chatUserState } from "../db/schema/chat-user-state.js";
 import { messages } from "../db/schema/messages.js";
 import { BadRequestError } from "../errors.js";
@@ -432,6 +433,42 @@ describe("open-question (format=request) + open_request_count", () => {
       .from(messages)
       .where(and(eq(messages.chatId, chat.id), eq(messages.senderId, other.uuid)));
     expect(stray).toHaveLength(0);
+  });
+
+  it("still enforces target-human authorization after a stale asker route is dropped", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const asker = await createTestAgent(app, { name: `oq-stale-asker-${uid}` });
+    const { agent: target } = await createTestAgent(app, { name: `oq-stale-target-${uid}`, type: "human" });
+    const { agent: otherHuman } = await createTestAgent(app, {
+      name: `oq-stale-other-${uid}`,
+      type: "human",
+    });
+    const chat = await createChat(app.db, asker.agent.uuid, {
+      type: "group",
+      participantIds: [target.uuid, otherHuman.uuid],
+    });
+    const { message: question } = await sendMessage(app.db, chat.id, asker.agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "Ship now?",
+      metadata: { mentions: [target.uuid] },
+    });
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, asker.agent.uuid));
+
+    await expect(
+      sendMessage(app.db, chat.id, otherHuman.uuid, {
+        source: "web",
+        format: "text",
+        content: "(Skipped — no answer provided.)",
+        metadata: {
+          mentions: [asker.agent.uuid],
+          resolves: { request: question.id, kind: "closed" },
+        },
+        inReplyTo: question.id,
+      }),
+    ).rejects.toThrow(/Only the question's target may resolve/i);
+    expect(await openReqCount(app, chat.id, target.uuid)).toBe(1);
   });
 
   it("a resolves pointed at a nonexistent message id is REJECTED and writes nothing", async () => {

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -429,6 +429,10 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
       const { scope } = await requireChatAccess(request, app.db);
       const body = patchChatEngagementSchema.parse(request.body);
       await setChatEngagement(app.db, request.params.chatId, scope.humanAgentId, body.status);
+      // Engagement is private per user, so notify only this viewer's sockets.
+      // Other tabs/devices use the frame to refresh both their conversation
+      // projection and the Active-scoped Need you queue.
+      void app.notifier.notifyMeChatsChanged(scope.humanAgentId, scope.organizationId);
       return reply.status(200).send({ chatId: request.params.chatId, engagementStatus: body.status });
     },
   );

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -492,22 +492,40 @@ export function preflightMessageSendIntent(input: {
 
   const incomingMeta = stripUntrustedMetadataKeys(rawIncomingMeta, options);
   validateDocumentContext(incomingMeta);
-  if (incomingMeta.resolves !== undefined && !requestResolutionSchema.safeParse(incomingMeta.resolves).success) {
+  const parsedResolution = requestResolutionSchema.safeParse(incomingMeta.resolves);
+  if (incomingMeta.resolves !== undefined && !parsedResolution.success) {
     throw new BadRequestError(
       'Malformed "metadata.resolves": expected {request: <messageId>, kind: "answered"|"closed", reason?}.',
     );
   }
+  // Skip is a lifecycle close, not an ordinary message. The web still declares
+  // the original asker so an active agent is notified and can continue. If that
+  // asker is no longer a live participant, preflight may drop only that stale
+  // route and let the durable close reach the transaction-level request/chat/
+  // target-human authorization below. Answers and every other send keep the
+  // normal fail-closed recipient contract.
+  const isHumanClosedResolution =
+    senderType === "human" && parsedResolution.success && parsedResolution.data.kind === "closed";
 
   const explicitMentionsRaw = incomingMeta.mentions;
   const explicitMentionsRawList = Array.isArray(explicitMentionsRaw)
     ? explicitMentionsRaw.filter((m): m is string => typeof m === "string")
     : [];
   const participantsById = new Map(participants.map((p) => [p.agentId, p]));
+  let droppedClosedResolutionMention = false;
+  const dropInactiveMentionTargets = options.dropInactiveMentionTargets || isHumanClosedResolution;
   const explicitMentions = explicitMentionsRawList.filter((id) => {
     if (id === senderId) return true;
     const participant = participantsById.get(id);
-    if (!participant) return false;
-    return !options.dropInactiveMentionTargets || participant.status === "active";
+    if (!participant) {
+      if (isHumanClosedResolution) droppedClosedResolutionMention = true;
+      return false;
+    }
+    if (dropInactiveMentionTargets && participant.status !== "active") {
+      if (isHumanClosedResolution) droppedClosedResolutionMention = true;
+      return false;
+    }
+    return true;
   });
 
   const receiverNames = data.receiverNames ?? [];
@@ -588,7 +606,7 @@ export function preflightMessageSendIntent(input: {
     : [];
   const metadataToStore: Record<string, unknown> = {
     ...incomingMeta,
-    ...(options.dropInactiveMentionTargets
+    ...(dropInactiveMentionTargets
       ? { mentions: mergedMentions }
       : mergedMentions.length > 0
         ? { mentions: mergedMentions }
@@ -617,7 +635,10 @@ export function preflightMessageSendIntent(input: {
   // (Resolution stays human-only — enforced by the resolution authorization
   // below, independent of who may send.)
 
-  const skipRecipientEnforcement = purposeProfile.skipMentionEnforcement || options.allowRecipientlessSend === true;
+  const skipRecipientEnforcement =
+    purposeProfile.skipMentionEnforcement ||
+    options.allowRecipientlessSend === true ||
+    (isHumanClosedResolution && droppedClosedResolutionMention);
   if (!skipRecipientEnforcement) {
     const hasActiveAddressed = (options.addressedToAgentIds ?? []).some(
       (id) => id !== senderId && participantsById.get(id)?.status === "active",
@@ -715,6 +736,9 @@ export async function sendMessage(
  * shapes:
  *   - `data.purpose === "agent-final-text"` — silent history-only write
  *   - `options.allowRecipientlessSend === true` — trusted system opt-out
+ *   - a target human's `kind="closed"` request resolution after preflight
+ *     drops its declared asker because that agent is inactive or missing;
+ *     transaction-level request/chat/target authorization still applies
  *
  * The server never parses `@<name>` tokens out of content. Clients that
  * surface IM-style `@-mention` UX (web composer, future mobile) must
@@ -1030,6 +1054,25 @@ async function sendMessageInner(
       // authoritative gate for the resolution itself.
       if (senderId !== target) {
         throw new ForbiddenError("Only the question's target may resolve it — the human answers in the web UI.");
+      }
+      // A Skip still routes to and wakes a live asker. Recipientless close is
+      // only the degraded lifecycle path for an asker that preflight found
+      // suspended, deleted, or missing. This check prevents a caller from
+      // smuggling an unrelated stale mention through preflight to suppress
+      // routing to an otherwise-active asker.
+      const activeAsker = participants.find(
+        (participant) => participant.agentId === parent.senderId && participant.status === "active",
+      );
+      if (resolution.data.kind === "closed") {
+        const declaredMentions = Array.isArray(data.metadata?.mentions)
+          ? data.metadata.mentions.filter((mention): mention is string => typeof mention === "string")
+          : [];
+        if (activeAsker && !mergedMentions.includes(activeAsker.agentId)) {
+          throw new BadRequestError("Closing a request from an active asker must route the resolution to that asker.");
+        }
+        if (!activeAsker && !declaredMentions.includes(parent.senderId)) {
+          throw new BadRequestError("Closing a request must declare the original asker before routing can degrade.");
+        }
       }
       // Idempotency: only the FIRST resolution decrements (exclude the row we
       // just inserted). A prior resolution is any other message in this chat

--- a/packages/server/src/services/need-you.ts
+++ b/packages/server/src/services/need-you.ts
@@ -1,5 +1,6 @@
 import {
   ASK_AGENT_METADATA_KEY,
+  CHAT_ENGAGEMENT_STATUSES,
   type ListNeedYouRequestsQuery,
   type ListNeedYouRequestsResponse,
   MESSAGE_FORMATS,
@@ -68,7 +69,8 @@ export async function listNeedYouRequests(
     eq(chats.organizationId, organizationId),
     sql`${chats.parentChatId} IS NULL`,
     eq(chatMembership.agentId, viewerAgentId),
-    sql`COALESCE(${chatUserState.engagementStatus}, 'active') <> 'deleted'`,
+    sql`COALESCE(${chatUserState.engagementStatus}, ${CHAT_ENGAGEMENT_STATUSES.ACTIVE})
+        = ${CHAT_ENGAGEMENT_STATUSES.ACTIVE}`,
     openRequestPredicate(viewerAgentId),
   );
   const cursorPredicate = cursor

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -97,9 +97,9 @@ export const MESSAGE_FORMATS = {
    * Lifecycle is driven by an EXPLICIT resolution signal: a question is
    * answered/closed only by a later message carrying `metadata.resolves` (see
    * `requestResolutionSchema`), which drives `chat_user_state.open_request_count`
-   * down. The target's answer ALWAYS resolves it — picking an option OR typing
-   * free text both write `resolves` (kind="answered"). NEW resolutions are
-   * human-only — the server accepts a `resolves` write only from the target. An
+   * down. The target's Submit resolves it with `kind="answered"`; Skip resolves
+   * it with `kind="closed"`. NEW resolutions are human-only — the server accepts
+   * a `resolves` write only from the target. An
    * agent CAN post a plain `chat send <human>` follow-up (an informational free
    * reply; it carries no `resolves`, raises no red dot, and never resolves the
    * question), but it cannot answer/close the question itself. Lifecycle readers
@@ -164,9 +164,10 @@ export type AskRequest = z.infer<typeof askRequestSchema>;
  * `format="request"` message. This is the ONLY thing that answers or closes
  * an open question — `inReplyTo` no longer does (it is pure threading now).
  *
- * Written ONLY by the target human's web answer — picking an option OR typing
- * free text both attach `resolves` (kind="answered"); the blocking answer
- * surface has no "reply without resolving" path, so every human answer resolves.
+ * Written ONLY by the target human's web answer surface — picking an option OR
+ * typing free text attaches `resolves` (kind="answered"), while Skip attaches
+ * `resolves` (kind="closed"). The surface has no "reply without resolving"
+ * path, so every action completes the request lifecycle.
  * An agent (including the asker) **cannot** write a resolution: the server
  * authorizes a NEW resolution only from the question's target, so an agent
  * answers nothing and closes nothing. (Pre-refinement history may still hold
@@ -177,10 +178,9 @@ export type AskRequest = z.infer<typeof askRequestSchema>;
  *
  *   - kind="answered" — the question is answered. The readable answer stays in
  *     the message `content`.
- *   - kind="closed"   — the question is withdrawn. Retained as a server-honored
- *     resolution kind for compatibility; no current surface produces it (the
- *     human web answer only ever writes "answered"). `reason` optionally explains
- *     why.
+ *   - kind="closed"   — the target human skipped the question without providing
+ *     an answer. The readable Skip note stays in `content`; `reason` optionally
+ *     explains why.
  *
  * Server-opaque except for the `open_request_count` counter, whose −1 keys
  * off `resolves.request`. The web parses it with `safeParse`.

--- a/packages/web/src/components/chat/__tests__/ask-answer-transport.test.ts
+++ b/packages/web/src/components/chat/__tests__/ask-answer-transport.test.ts
@@ -64,6 +64,24 @@ describe("sendAskAnswer", () => {
     expect(chatMocks.sendFileMessageBatch).not.toHaveBeenCalled();
   });
 
+  it("routes an explicit Skip close to the asker without inferring lifecycle from its body", async () => {
+    await sendAskAnswer({
+      chatId: "chat-1",
+      request,
+      answer: {
+        content: "(Skipped — no answer provided.)",
+        mentions: [],
+        images: [],
+      },
+      resolutionKind: "closed",
+    });
+
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "(Skipped — no answer provided.)", ["asker-1"], {
+      inReplyTo: "request-1",
+      resolves: { request: "request-1", kind: "closed" },
+    });
+  });
+
   it("uses file transport for image answers and keeps cache warming best-effort", async () => {
     const image = new File(["image"], "proof.png", { type: "image/png" });
     imageStoreMocks.putImage.mockRejectedValueOnce(new Error("IndexedDB unavailable"));

--- a/packages/web/src/components/chat/ask-answer-transport.ts
+++ b/packages/web/src/components/chat/ask-answer-transport.ts
@@ -15,19 +15,24 @@ export type AskAnswerRequestRef = {
  * Surface components own pending/error state and their post-send effects. This
  * unit owns the invariants that unblock the requester: route to the asker plus
  * explicit mentions, upload staged files, choose text vs image-batch transport,
- * and attach the same in-reply-to + resolving metadata in either path.
+ * and attach the same in-reply-to + resolving metadata in either path. Submit
+ * defaults to `answered`; Skip explicitly selects `closed`. Both still declare
+ * the asker so an active agent is notified, while the server may drop that one
+ * route for a closed resolution when the asker is inactive or missing.
  */
 export async function sendAskAnswer({
   chatId,
   request,
   answer,
+  resolutionKind = "answered",
 }: {
   chatId: string;
   request: AskAnswerRequestRef;
   answer: AskAnswer;
+  resolutionKind?: RequestResolution["kind"];
 }): Promise<void> {
   const routedMentions = [...new Set([request.senderId, ...answer.mentions])];
-  const resolves: RequestResolution = { request: request.id, kind: "answered" };
+  const resolves: RequestResolution = { request: request.id, kind: resolutionKind };
   const documentRefs: AttachmentRef[] = [];
 
   for (const attachment of answer.attachments ?? []) {

--- a/packages/web/src/components/chat/request-state.ts
+++ b/packages/web/src/components/chat/request-state.ts
@@ -11,8 +11,7 @@ import { askRequestSchema, MENTION_REGEX, requestResolutionSchema } from "@first
  *   - `resolved`   — a `metadata.resolves` with `kind="answered"` from the
  *                    target human (the web answer) — or a legacy asker-authored
  *                    row (compat; see below).
- *   - `closed`     — same, `kind="closed"` (legacy/server-only; no surface
- *                    produces it now).
+ *   - `closed`     — same, `kind="closed"` from the target human's Skip action.
  * NEW resolutions are human-only: the server accepts a `resolves` write only
  * from the target, and an agent (including the asker) cannot answer or close a
  * question. The reader additionally honors a resolution authored by the asker

--- a/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
@@ -198,6 +198,21 @@ describe("useAdminWs", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["chat-right-sidebar", "cron-jobs"] });
   });
 
+  it("refreshes both private chat projections when me-chats changes on another client", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    await renderHook();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+    invalidateSpy.mockClear();
+
+    await act(async () => {
+      socket.emit({ type: "me-chats:changed" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["me", "chats"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["need-you"] });
+  });
+
   it("refreshes access tokens on auth close and reconnects immediately", async () => {
     const onMessage = await renderHook();
     const first = FakeWebSocket.instances[0];

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -293,11 +293,13 @@ function broadcast(msg: WsMessage) {
       }
     } else if (msg.type === "me-chats:changed") {
       // The viewer's OWN private me-chats projection changed on another device
-      // (a pin / unpin). The server sends this frame only to this user's own
-      // sockets (never broadcast — pin state is private), so a bare list
-      // invalidation regroups the rail across their devices in realtime. No
-      // chatId; nothing chat-specific to touch.
+      // (pin or engagement). The server sends this frame only to this user's own
+      // sockets, so refresh both private projections across their devices.
+      // Engagement controls whether a chat belongs to the Active-scoped Need
+      // you queue. Pin reuses the same bare event; its extra queue refetch is
+      // intentionally harmless.
       meChatsInvalidator.invalidate(latestQc);
+      needYouInvalidator.invalidate(latestQc);
     } else if (msg.type === "pulse:tick") {
       // Per-org runtime-state aggregate (pulse-aggregator broadcasts every 5s).
       // The composite `offline` (client_id → null) and runtime-`error` → failed

--- a/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
@@ -241,7 +241,8 @@ describe("mobile Chat card behavior", () => {
   it("opens Chat actions from the keyboard and archives only a settled chat with Undo", async () => {
     const settled = { ...row, openRequestCount: 0 };
     listResponse = { rows: [settled], priorityRows: { pinned: [] }, nextCursor: null };
-    renderPage(harness);
+    const queryClient = renderPage(harness);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
     await harness.waitFor(() => expect(harness.container.textContent).toContain(row.title));
     const card = harness.container.querySelector('[data-mobile-card="work"]');
 
@@ -253,9 +254,11 @@ describe("mobile Chat card behavior", () => {
     expect(buttonWithText("Archive")?.disabled).toBe(false);
     await click(buttonWithText("Archive"));
     await harness.waitFor(() => expect(chatMocks.patchChatEngagement).toHaveBeenCalledWith(row.chatId, "archived"));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["need-you"] });
     await harness.waitFor(() => expect(buttonWithText("Undo")).not.toBeNull());
     await click(buttonWithText("Undo"));
     await harness.waitFor(() => expect(chatMocks.patchChatEngagement).toHaveBeenCalledWith(row.chatId, "active"));
+    expect(invalidateSpy.mock.calls.filter(([options]) => options?.queryKey?.[0] === "need-you")).toHaveLength(2);
   });
 
   it("offers the inverse read action through the context-menu path", async () => {

--- a/packages/web/src/pages/mobile/ask-sheet.tsx
+++ b/packages/web/src/pages/mobile/ask-sheet.tsx
@@ -1,4 +1,4 @@
-import { imageAttachmentRefsFromMetadata } from "@first-tree/shared";
+import { imageAttachmentRefsFromMetadata, type RequestResolution } from "@first-tree/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -59,12 +59,12 @@ export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: (
     [agentId, detailQuery.data?.participants],
   );
 
-  const submit = async (answer: AskAnswer): Promise<void> => {
+  const submit = async (answer: AskAnswer, resolutionKind: RequestResolution["kind"] = "answered"): Promise<void> => {
     if (!request || sending) return;
     setError(null);
     setSending(true);
     try {
-      await sendAskAnswer({ chatId, request, answer });
+      await sendAskAnswer({ chatId, request, answer, resolutionKind });
       await commitMobileAskResolution(queryClient, chatId, request.id);
       addToast({ title: "Answer sent" });
       onClose();
@@ -96,7 +96,7 @@ export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: (
             void submit(answer);
           }}
           onSkip={() => {
-            void submit({ content: "(Skipped — no answer provided.)", mentions: [], images: [] });
+            void submit({ content: "(Skipped — no answer provided.)", mentions: [], images: [] }, "closed");
           }}
         />
       </div>

--- a/packages/web/src/pages/mobile/chat-actions-sheet.tsx
+++ b/packages/web/src/pages/mobile/chat-actions-sheet.tsx
@@ -24,20 +24,27 @@ export function MobileChatActionsSheet({ row, onClose }: { row: MeChatRow; onClo
     return () => previousFocus?.focus();
   }, []);
 
-  const invalidate = async (): Promise<void> => {
-    await Promise.all([
+  const invalidate = async (includeNeedYou = false): Promise<void> => {
+    const invalidations = [
       queryClient.invalidateQueries({ queryKey: ["me", "chats"] }),
       queryClient.invalidateQueries({ queryKey: ["chat-detail", row.chatId] }),
-    ]);
+    ];
+    if (includeNeedYou) invalidations.push(queryClient.invalidateQueries({ queryKey: ["need-you"] }));
+    await Promise.all(invalidations);
   };
 
-  const run = async (key: string, operation: () => Promise<unknown>, successTitle: string | null): Promise<boolean> => {
+  const run = async (
+    key: string,
+    operation: () => Promise<unknown>,
+    successTitle: string | null,
+    invalidateNeedYou = false,
+  ): Promise<boolean> => {
     if (pending) return false;
     setPending(key);
     setError(null);
     try {
       await operation();
-      void invalidate();
+      void invalidate(invalidateNeedYou);
       if (successTitle) addToast({ title: successTitle });
       onClose();
       return true;
@@ -50,7 +57,7 @@ export function MobileChatActionsSheet({ row, onClose }: { row: MeChatRow; onClo
 
   const archive = async (): Promise<void> => {
     if (archiveBlocker) return;
-    const succeeded = await run("archive", () => patchChatEngagement(row.chatId, "archived"), null);
+    const succeeded = await run("archive", () => patchChatEngagement(row.chatId, "archived"), null, true);
     if (!succeeded) return;
     addToast({
       title: "Chat moved to Archived",
@@ -58,7 +65,7 @@ export function MobileChatActionsSheet({ row, onClose }: { row: MeChatRow; onClo
         label: "Undo",
         onClick: () => {
           void patchChatEngagement(row.chatId, "active")
-            .then(invalidate)
+            .then(() => invalidate(true))
             .then(() => addToast({ title: "Archive undone" }))
             .catch(() =>
               addToast({ title: "Couldn't undo archive", description: "Open Archived to restore the chat." }),
@@ -158,7 +165,7 @@ export function MobileChatActionsSheet({ row, onClose }: { row: MeChatRow; onClo
               pending={pending === "unarchive"}
               disabled={pending !== null}
               onClick={() =>
-                void run("unarchive", () => patchChatEngagement(row.chatId, "active"), "Moved back to Chats")
+                void run("unarchive", () => patchChatEngagement(row.chatId, "active"), "Moved back to Chats", true)
               }
             />
           ) : (

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1130,13 +1130,18 @@ describe("ChatView", () => {
     const { ChatView } = await import("../chat-view.js");
     const deleted = chatDetail({ engagementStatus: "deleted", title: "Deleted launch" });
     chatMocks.getChat.mockResolvedValue(deleted);
+    let deletedQueryClient: QueryClient | null = null;
     const deletedView = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, (queryClient) => {
+      deletedQueryClient = queryClient;
       seedChat(queryClient, deleted);
     });
+    if (!deletedQueryClient) throw new Error("Missing deleted chat query client");
+    const invalidateSpy = vi.spyOn(deletedQueryClient, "invalidateQueries");
     await waitForText(deletedView.container, "Restore");
     await click(buttonByText(deletedView.container, "Restore"));
     await waitForCondition(() => chatMocks.patchChatEngagement.mock.calls.length > 0, "Expected restore");
     expect(chatMocks.patchChatEngagement).toHaveBeenCalledWith("chat-1", "active");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["need-you"] });
     await act(async () => deletedView.root.unmount());
 
     const onJoin = vi.fn();

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -2955,7 +2955,7 @@ describe("ChatView", () => {
     );
     expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "(Skipped — no answer provided.)", ["agent-1"], {
       inReplyTo: "req-skip",
-      resolves: { request: "req-skip", kind: "answered" },
+      resolves: { request: "req-skip", kind: "closed" },
     });
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -2482,12 +2482,16 @@ export function ChatView({
   // the card nor drops the typed answer / staged images — the user just sees
   // the error and retries. On success `askBusy` stays true so the card is inert
   // during the refetch window (no double-submit) and clears when it unmounts.
-  const submitAskAnswer = async (request: { id: string; senderId: string }, answer: AskAnswer) => {
+  const submitAskAnswer = async (
+    request: { id: string; senderId: string },
+    answer: AskAnswer,
+    resolutionKind: RequestResolution["kind"] = "answered",
+  ) => {
     if (askBusy) return;
     setAskError(null);
     setAskBusy(true);
     try {
-      await sendAskAnswer({ chatId, request, answer });
+      await sendAskAnswer({ chatId, request, answer, resolutionKind });
       clearAskTakeoverDraft(request.id);
       queryClient.invalidateQueries({ queryKey: messagesQueryKey });
       queryClient.invalidateQueries({ queryKey: ["chat-open-requests", chatId] });
@@ -2588,9 +2592,9 @@ export function ChatView({
   // `answerSelections` (kept here as state, NEVER written into the composer, so
   // a click only highlights the option and leaves typed text untouched), and
   // the composer holds free text only. Sending merges both into one canonical
-  // reply that ALWAYS carries `metadata.resolves` (kind="answered") — clicking
-  // an option or typing free text both resolve the question; there is no
-  // separate "leave it open for the asker to judge" path on this surface.
+  // reply that ALWAYS carries `metadata.resolves`: Submit uses `kind="answered"`
+  // and Skip uses `kind="closed"`. There is no separate "leave it open for the
+  // asker to judge" path on this surface.
   // Watchers never block — the read-only branch renders no composer.
   // `readRequestPayload` always yields an answer affordance (a well-formed
   // payload, or a free-text fallback for an absent / legacy / malformed one), so
@@ -3797,15 +3801,17 @@ export function ChatView({
                   void submitAskAnswer(dockRequest, answer);
                 }}
                 onSkip={() => {
-                  // Skip is an answer, not a dismiss: send a resolving reply
-                  // (kind="answered") carrying a "skipped" body so the open
-                  // request resolves, the red dot clears, and the asking agent
-                  // unblocks and proceeds with its own judgment.
-                  void submitAskAnswer(dockRequest, {
-                    content: "(Skipped — no answer provided.)",
-                    mentions: [],
-                    images: [],
-                  });
+                  // Skip is an explicit lifecycle close, not a dismiss or an
+                  // answer inferred from display copy.
+                  void submitAskAnswer(
+                    dockRequest,
+                    {
+                      content: "(Skipped — no answer provided.)",
+                      mentions: [],
+                      images: [],
+                    },
+                    "closed",
+                  );
                 }}
               />
             </div>

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -2540,6 +2540,7 @@ export function ChatView({
   const restoreMut = useMutation({
     mutationFn: () => patchChatEngagement(chatId, CHAT_ENGAGEMENT_STATUSES.ACTIVE),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["need-you"] });
       queryClient.invalidateQueries({ queryKey: ["me", "chats"] });
       queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] });
     },

--- a/packages/web/src/pages/workspace/conversations/__tests__/row-engagement-menu-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/row-engagement-menu-dom.test.tsx
@@ -135,11 +135,13 @@ afterEach(async () => {
 
 describe("RowEngagementMenu schedule warnings", () => {
   it("archives immediately when the chat has no schedules (pre-change behavior)", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
     await renderMenu("active");
     await selectMenuItem("Archive");
 
     expect(cronApiMocks.listChatCronJobs).toHaveBeenCalledWith("chat-1");
     expect(chatApiMocks.patchChatEngagement).toHaveBeenCalledWith("chat-1", "archived");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["need-you"] });
     expect(document.body.textContent).not.toContain("Archive this chat?");
   });
 

--- a/packages/web/src/pages/workspace/conversations/row-engagement-menu.tsx
+++ b/packages/web/src/pages/workspace/conversations/row-engagement-menu.tsx
@@ -110,6 +110,7 @@ export function RowEngagementMenu({
     onSuccess: (_data, next) => {
       setScheduleWarning(null);
       setLookupError(null);
+      queryClient.invalidateQueries({ queryKey: ["need-you"] });
       // The Server's owner-scoped pause on chat delete does NOT emit
       // `chat:updated`, and the action guard just populated fresh Active
       // rows — without this nudge the sidebar would show the pre-delete

--- a/packages/web/src/pages/workspace/need-you/__tests__/need-you-page-dom.test.tsx
+++ b/packages/web/src/pages/workspace/need-you/__tests__/need-you-page-dom.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const answerMocks = vi.hoisted(() => ({
+  sendAskAnswer: vi.fn(),
+}));
+const chatMocks = vi.hoisted(() => ({
+  getChat: vi.fn(),
+  listChatMessages: vi.fn(),
+}));
+const meChatMocks = vi.hoisted(() => ({
+  listNeedYouRequests: vi.fn(),
+}));
+
+vi.mock("../../../../api/chats.js", () => chatMocks);
+vi.mock("../../../../api/me-chats.js", () => meChatMocks);
+vi.mock("../../../../auth/auth-context.js", () => ({
+  useAuth: () => ({ organizationId: "org-1", agentId: "human-1" }),
+}));
+vi.mock("../../../../components/chat/ask-answer-transport.js", () => answerMocks);
+vi.mock("../../../../components/chat/use-ask-agent.js", () => ({
+  useAskAgent: () => ({
+    exchanges: [],
+    waiting: false,
+    sending: false,
+    error: null,
+    ask: vi.fn(),
+  }),
+}));
+vi.mock("../../../../hooks/use-gitlab-entity-presentation.js", () => ({
+  useGitlabEntityPresentation: () => ({ markdownComponents: undefined }),
+}));
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("NeedYouPage request resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    answerMocks.sendAskAnswer.mockResolvedValue(undefined);
+    meChatMocks.listNeedYouRequests.mockResolvedValue({ items: [], total: 0, nextCursor: null });
+  });
+
+  it("uses an explicit closed resolution when Skip is selected", async () => {
+    const { NeedYouPage } = await import("../need-you-page.js");
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+    });
+    queryClient.setQueryData(["need-you", "org-1"], {
+      items: [
+        {
+          request: {
+            id: "request-1",
+            chatId: "chat-1",
+            senderId: "asker-1",
+            format: "request",
+            content: "Choose the rollout.",
+            metadata: { mentions: ["human-1"], request: { multiSelect: false } },
+            inReplyTo: null,
+            source: "api",
+            createdAt: "2026-07-30T00:00:00.000Z",
+          },
+          chat: {
+            id: "chat-1",
+            title: "Rollout",
+            topic: "Rollout",
+            description: null,
+          },
+          asker: {
+            agentId: "asker-1",
+            name: "asker",
+            displayName: "Asker",
+            avatarColorToken: null,
+            avatarImageUrl: null,
+          },
+        },
+      ],
+      total: 1,
+      nextCursor: null,
+    });
+    queryClient.setQueryData(["chat-detail", "chat-1"], {
+      id: "chat-1",
+      type: "group",
+      organizationId: "org-1",
+      participants: [],
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <NeedYouPage onClose={vi.fn()} onOpenFullChat={vi.fn()} />
+        </QueryClientProvider>,
+      );
+    });
+    await flush();
+
+    const skip = [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === "Skip");
+    if (!skip) throw new Error("Missing Skip button");
+    await act(async () => {
+      skip.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+
+    expect(answerMocks.sendAskAnswer).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      request: expect.objectContaining({ id: "request-1", senderId: "asker-1" }),
+      answer: {
+        content: "(Skipped — no answer provided.)",
+        mentions: [],
+        images: [],
+      },
+      resolutionKind: "closed",
+    });
+
+    await act(async () => root.unmount());
+    queryClient.clear();
+    container.remove();
+  });
+});

--- a/packages/web/src/pages/workspace/need-you/need-you-page.tsx
+++ b/packages/web/src/pages/workspace/need-you/need-you-page.tsx
@@ -1,4 +1,9 @@
-import { imageAttachmentRefsFromMetadata, type Message, type NeedYouRequestItem } from "@first-tree/shared";
+import {
+  imageAttachmentRefsFromMetadata,
+  type Message,
+  type NeedYouRequestItem,
+  type RequestResolution,
+} from "@first-tree/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, CheckCircle2, ExternalLink, History, LoaderCircle } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
@@ -105,7 +110,10 @@ export function NeedYouPage({
   }, [onClose, reviewLocked]);
   const { markdownComponents } = useGitlabEntityPresentation(organizationId);
 
-  const resolveRequest = async (answer: AskAnswer): Promise<void> => {
+  const resolveRequest = async (
+    answer: AskAnswer,
+    resolutionKind: RequestResolution["kind"] = "answered",
+  ): Promise<void> => {
     if (!item || sendingRequestId === item.request.id) return;
     const resolvingId = item.request.id;
     setSendError(null);
@@ -115,6 +123,7 @@ export function NeedYouPage({
         chatId: item.chat.id,
         request: item.request,
         answer,
+        resolutionKind,
       });
       clearAskTakeoverDraft(resolvingId);
       removeResolvedNeedYouRequest(queryClient, organizationId, resolvingId);
@@ -262,11 +271,14 @@ export function NeedYouPage({
               void resolveRequest(answer);
             }}
             onSkip={() => {
-              void resolveRequest({
-                content: "(Skipped — no answer provided.)",
-                mentions: [],
-                images: [],
-              });
+              void resolveRequest(
+                {
+                  content: "(Skipped — no answer provided.)",
+                  mentions: [],
+                  images: [],
+                },
+                "closed",
+              );
             }}
           />
         )}


### PR DESCRIPTION
## Summary

- scope Need you rows and the exact total to the current human's `active` chats, excluding both archived and deleted conversations while allowing restored chats to reappear
- refresh the Need you query after every Web engagement mutation and after the viewer-private `me-chats:changed` event, so other tabs and devices converge immediately
- make Skip an explicit `closed` request resolution: active askers are still notified and woken, while suspended, deleted, or missing askers degrade to an authorized recipientless close

## Why

This is a follow-up to #2042. The request queue previously filtered out only deleted engagement, so archived conversations could still occupy the global Need you count and review surface. Local query caches could also retain a stale count after an engagement change.

Skip also reused ordinary answer routing. When the original asker was no longer active, recipient preflight rejected the send before the target human could close the request.

## Safety boundaries

- only the request's target human can resolve it
- an active asker must remain on the Skip route and receives the normal notification
- recipientless fallback is limited to a human-authored `closed` resolution whose declared original asker is inactive or missing
- ordinary messages, Submit (`answered`), and Ask agent continue to reject inactive recipients
- page rows and the exact count share one engagement predicate

## Validation

- focused Server Need you / resolution / recipient tests: 39/39 passed
- focused Web Skip host and transport tests: 68/68 passed
- focused engagement notification tests: Server 5/5 and Web 7/7 passed
- `pnpm check` passed (repository-existing warnings only)
- `pnpm typecheck` passed (11/11 tasks)
- full `pnpm test` passed (12/12 tasks)
- `git diff --check` passed

## QA

Independent exact-SHA QA: **PASS** at `f7431a3fda96888d6bea5a819024ea34ffd5cbe6`.

- exercised real desktop and mobile Web, authenticated REST, the private admin WebSocket, PostgreSQL state, inbox/session state, the packed CLI, and a foreground daemon/provider
- verified archived/deleted chats leave Need you and restored chats reappear; observed cross-device convergence after archive in 151 ms on desktop and 180 ms on mobile
- verified active-asker Skip keeps normal notification and wake-up routing
- verified suspended, deleted, and missing-participant askers permit only the target human's recipientless `closed` Skip; ordinary messages, `answered` resolution, and Ask agent remain fail closed
- verified a second human cannot close the request (HTTP 403)
- independent focused regressions passed: Server 44/44, Web 97/97, `pnpm check`, and monorepo typecheck 11/11

No reproducible candidate defect remained. QA classified the reusable journey update as `candidate-case-update`.

## Context Tree

Companion Context Tree draft: https://github.com/agent-team-foundation/first-tree-context/pull/857

The source PR should merge first. The Context Tree PR remains draft until it can be reconciled against merged source truth.
