### PR TITLE
fix(web): keep BYO copy feedback layout stable

### DIFF
--- a/packages/web/src/components/byo-setup-prompt-actions.tsx
+++ b/packages/web/src/components/byo-setup-prompt-actions.tsx
@@ -19,7 +19,6 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
   const [prepareFailed, setPrepareFailed] = useState(false);
   const [prompt, setPrompt] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
   const [copyingPreview, setCopyingPreview] = useState(false);
   const prepareAttempt = useRef(0);
   const copyAttempt = useRef(0);
@@ -36,7 +35,6 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
     setPrepareFailed(false);
     setPrompt(null);
     setOpen(false);
-    setCopied(false);
     setCopyingPreview(false);
     copyFeedback.reset();
     return () => {
@@ -60,7 +58,6 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
     const renderedResetKey = resetKey;
     setPendingAction(action);
     setPrepareFailed(false);
-    setCopied(false);
     copyFeedback.reset();
     void (async () => {
       try {
@@ -74,7 +71,7 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
         }
 
         const copy = ++copyAttempt.current;
-        const result = await copyFeedback.copy(nextPrompt);
+        await copyFeedback.copy(nextPrompt);
         if (
           prepareAttempt.current !== attempt ||
           copyAttempt.current !== copy ||
@@ -83,7 +80,6 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
           return;
         }
         setPendingAction(null);
-        if (result === "copied") setCopied(true);
       } catch {
         if (prepareAttempt.current !== attempt || activeResetKey.current !== renderedResetKey) return;
         setPendingAction(null);
@@ -103,7 +99,6 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
       if (copyAttempt.current !== copy || activeResetKey.current !== renderedResetKey) return;
       setCopyingPreview(false);
       if (result === "copied") {
-        setCopied(true);
         setOpen(false);
         setPrompt(null);
       }
@@ -121,7 +116,11 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
         style={{ gap: "var(--sp-1)" }}
       >
         <Button type="button" size="sm" disabled={pendingAction !== null} onClick={() => prepare("copy")}>
-          {copied ? <Check className="h-3.5 w-3.5" aria-hidden /> : <Clipboard className="h-3.5 w-3.5" aria-hidden />}
+          {copyFeedback.status === "copied" ? (
+            <Check className="h-3.5 w-3.5" aria-hidden />
+          ) : (
+            <Clipboard className="h-3.5 w-3.5" aria-hidden />
+          )}
           {pendingAction === "copy" ? "Preparing…" : "Copy setup prompt"}
         </Button>
         <Button
@@ -134,6 +133,9 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
           <Eye className="h-3.5 w-3.5" aria-hidden />
           {pendingAction === "preview" ? "Preparing…" : "Preview prompt"}
         </Button>
+        <span aria-live="polite" className="sr-only">
+          {copyFeedback.status === "copied" ? "Setup prompt copied." : ""}
+        </span>
       </div>
 
       {prepareFailed ? (
@@ -143,10 +145,6 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
       ) : copyFeedback.status === "failed" ? (
         <p role="alert" className="text-label" style={{ margin: 0, color: "var(--state-error)" }}>
           Could not copy the setup prompt.
-        </p>
-      ) : copied ? (
-        <p aria-live="polite" className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
-          Copied — paste it into the Claude Code or Codex chat you just opened.
         </p>
       ) : null}
 

--- a/packages/web/src/pages/__tests__/context-enablement.test.tsx
+++ b/packages/web/src/pages/__tests__/context-enablement.test.tsx
@@ -5,6 +5,7 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildByoSetupPrompt } from "../../lib/byo-setup-prompt.js";
+import { COPY_FEEDBACK_MS } from "../../lib/use-copy-feedback.js";
 import { ContextPersonalAccess, OnboardingContextPersonalAccess } from "../settings/context-enablement.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -106,7 +107,8 @@ describe("personal Context access", () => {
     expect(copiedPrompt).toContain("First Tree Web owns onboarding completion separately.");
     expect(copiedPrompt).not.toContain("onboarding completion has been recorded");
     expect(promptPreview()).toBeNull();
-    expect(host.textContent).toContain("Copied — paste it into the Claude Code or Codex chat you just opened.");
+    expect(host.textContent).toContain("Setup prompt copied.");
+    expect(host.textContent).not.toContain("Copied — paste it into");
   });
 
   it("stays absent until Team Context prerequisites are ready", async () => {
@@ -243,8 +245,10 @@ describe("personal Context access", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(host.textContent).toContain("Use Team Context in Claude Code or Codex");
-    expect(host.textContent).toContain("Open the project you want to use with Team Context");
+    expect(host.textContent).toContain("Use with Claude Code or Codex");
+    expect(host.textContent).toContain(
+      "Open your project in Claude Code or Codex, then copy and paste the setup prompt.",
+    );
     expect(host.textContent).not.toContain("context enable --provider");
     await clickAndFlush(buttonByText(host, "Preview prompt"));
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
@@ -261,7 +265,8 @@ describe("personal Context access", () => {
     expect(copiedPrompt).toContain("--provider 'codex' --team 'org-1'");
     expect(copiedPrompt).toContain("Do not run both and do not add, remove, or change command flags.");
     expect(copiedPrompt).toContain("Do not mark onboarding complete.");
-    expect(host.textContent).toContain("Copied — paste it into the Claude Code or Codex chat you just opened.");
+    expect(host.textContent).toContain("Setup prompt copied.");
+    expect(host.textContent).not.toContain("Copied — paste it into");
     expect(activityMocks.generateConnectToken).toHaveBeenCalledTimes(1);
     expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledTimes(2);
   });
@@ -343,9 +348,52 @@ describe("personal Context access", () => {
     await clickAndFlush(buttonByText(host, "Copy setup prompt"));
 
     expect(promptPreview()).toBeNull();
-    expect(host.textContent).toContain("Copied — paste it into the Claude Code or Codex chat you just opened.");
+    expect(host.textContent).toContain("Setup prompt copied.");
+    expect(host.textContent).not.toContain("Copied — paste it into");
     expect(preparePrompt).toHaveBeenCalledTimes(2);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ready-prompt");
+  });
+
+  it("keeps successful copy feedback transient without adding a visible helper row", async () => {
+    vi.useFakeTimers();
+    try {
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const preparePrompt = vi.fn().mockResolvedValue("ready-prompt");
+
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <ContextPersonalAccess organizationId="org-1" preparePrompt={preparePrompt} />
+          </QueryClientProvider>,
+        );
+        await Promise.resolve();
+      });
+
+      const actions = host.querySelector<HTMLElement>("[data-byo-prompt-actions]");
+      const actionChildCount = actions?.childElementCount;
+      await act(async () => {
+        buttonByText(host, "Copy setup prompt")?.click();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(host.querySelector("svg.lucide-check")).not.toBeNull();
+      expect(host.textContent).toContain("Setup prompt copied.");
+      expect(actions?.childElementCount).toBe(actionChildCount);
+      expect(actions?.querySelector('span.sr-only[aria-live="polite"]')?.textContent).toBe("Setup prompt copied.");
+      expect(actions?.querySelector('p[aria-live="polite"]')).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(COPY_FEEDBACK_MS);
+      });
+
+      expect(host.querySelector("svg.lucide-check")).toBeNull();
+      expect(host.querySelector("svg.lucide-clipboard")).not.toBeNull();
+      expect(host.textContent).not.toContain("Setup prompt copied.");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps a reopened prompt intact when an earlier clipboard write resolves late", async () => {

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -245,7 +245,7 @@ describe("extra preview pages", () => {
     expect(reviewerControls).not.toBeNull();
     expect(rendered.container.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
     expect(text(reviewerControls ?? treeRow)).toContain("Context Reviewer");
-    expect(text(treeControls ?? treeRow)).toContain("Use Team Context in Claude Code or Codex");
+    expect(text(treeControls ?? treeRow)).toContain("Use with Claude Code or Codex");
     expect(text(treeControls ?? treeRow)).toContain("Copy setup prompt");
     expect(text(treeControls ?? treeRow)).toContain("Preview prompt");
     expect(text(treeControls ?? treeRow)).not.toContain("context enable --provider");
@@ -270,7 +270,7 @@ describe("extra preview pages", () => {
     const controls = treeRow.querySelector<HTMLElement>('[data-setup-owner-controls="context-tree"]');
     expect(controls).not.toBeNull();
     expect(controls?.querySelector<HTMLAnchorElement>('a[href="/context"]')?.textContent).toBe("Open Context →");
-    expect(text(controls ?? treeRow)).toContain("Use Team Context in Claude Code or Codex");
+    expect(text(controls ?? treeRow)).toContain("Use with Claude Code or Codex");
     expect(text(controls ?? treeRow)).toContain("Copy setup prompt");
     expect(text(controls ?? treeRow)).toContain("Preview prompt");
     expect(controls?.querySelector('[data-setup-owner-controls="automatic-review"]')).toBeNull();

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -2240,7 +2240,7 @@ describe("web DOM interaction coverage", () => {
     orgSettingsMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: "", branch: null });
     const inviteeNoTree = await renderOnboardingDom(<StepStartChat />, { path: "invitee", activeStep: "start-chat" });
     await waitForText("Start your first Agent Chat", inviteeNoTree.container);
-    expect(inviteeNoTree.container.textContent).not.toContain("Use Team Context in Claude Code or Codex");
+    expect(inviteeNoTree.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(inviteeNoTree.container.textContent).not.toContain("Needs Admin");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     await click(findButton(inviteeNoTree.container, "Start chat"));
@@ -2263,7 +2263,7 @@ describe("web DOM interaction coverage", () => {
       activeStep: "start-chat",
     });
     await waitForText("Start your first Agent Chat", inviteeNoRepo.container);
-    expect(inviteeNoRepo.container.textContent).not.toContain("Use Team Context in Claude Code or Codex");
+    expect(inviteeNoRepo.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(inviteeNoRepo.container.textContent).not.toContain("Needs Admin");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     await unmountRoot(inviteeNoRepo.root);
@@ -2283,7 +2283,7 @@ describe("web DOM interaction coverage", () => {
       activeStep: "start-chat",
     });
     await waitForText("Start your first Agent Chat", inviteeNoInstall.container);
-    expect(inviteeNoInstall.container.textContent).not.toContain("Use Team Context in Claude Code or Codex");
+    expect(inviteeNoInstall.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     expect(findButton(inviteeNoInstall.container, "Start your first Agent Chat")).toBeNull();
     await click(findButton(inviteeNoInstall.container, "Start chat"));
@@ -2301,7 +2301,7 @@ describe("web DOM interaction coverage", () => {
       activeStep: "start-chat",
     });
     await waitForText("Start your first Agent Chat", inviteeProbeFail.container);
-    expect(inviteeProbeFail.container.textContent).not.toContain("Use Team Context in Claude Code or Codex");
+    expect(inviteeProbeFail.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     expect(findButton(inviteeProbeFail.container, "Start your first Agent Chat")).toBeNull();
     await unmountRoot(inviteeProbeFail.root);
@@ -2311,7 +2311,7 @@ describe("web DOM interaction coverage", () => {
     contextEnablementMocks.getContextEnablementHandoff.mockClear();
     const inviteeReady = await renderOnboardingDom(<StepStartChat />, { path: "invitee", activeStep: "start-chat" });
     await waitForText("Start your first Agent Chat", inviteeReady.container);
-    expect(inviteeReady.container.textContent).not.toContain("Use Team Context in Claude Code or Codex");
+    expect(inviteeReady.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     await click(findButton(inviteeReady.container, "Start chat"));
     // Ready invitee also lands in a value-first work chat, not the tree setup

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -1036,8 +1036,10 @@ describe("Settings Setup overview", () => {
     const { controls } = await openContextTreeControls(view);
     const personalAccess = await waitForSelector<HTMLElement>(controls, "[data-setup-personal-access]");
 
-    expect(personalAccess.textContent).toContain("Use Team Context in Claude Code or Codex");
-    expect(personalAccess.textContent).toContain("Open the project you want to use with Team Context");
+    expect(personalAccess.textContent).toContain("Use with Claude Code or Codex");
+    expect(personalAccess.textContent).toContain(
+      "Open your project in Claude Code or Codex, then copy and paste the setup prompt.",
+    );
     expect(personalAccess.textContent).toContain("Copy setup prompt");
     expect(personalAccess.textContent).toContain("Preview prompt");
     expect(personalAccess.textContent).not.toContain("context enable --provider");
@@ -1101,7 +1103,7 @@ describe("Settings Setup overview", () => {
     const openContext = [...controls.querySelectorAll<HTMLAnchorElement>("a")].find(
       (link) => link.textContent === "Open Context →",
     );
-    expect(personalAccess.textContent).toContain("Use Team Context in Claude Code or Codex");
+    expect(personalAccess.textContent).toContain("Use with Claude Code or Codex");
     expect(personalAccess.textContent).toContain("Copy setup prompt");
     expect(personalAccess.textContent).toContain("Preview prompt");
     expect(openContext?.getAttribute("href")).toBe("/context");

--- a/packages/web/src/pages/settings/context-enablement.tsx
+++ b/packages/web/src/pages/settings/context-enablement.tsx
@@ -113,11 +113,10 @@ export function ContextPersonalAccess({
     >
       <div className="min-w-0" style={{ flex: "1 1 28rem" }}>
         <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
-          Use Team Context in Claude Code or Codex
+          Use with Claude Code or Codex
         </div>
         <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
-          Open the project you want to use with Team Context in Claude Code or Codex, then copy and paste the setup
-          prompt. Your coding agent handles the setup.
+          Open your project in Claude Code or Codex, then copy and paste the setup prompt.
         </div>
       </div>
       <ByoSetupPromptActions


### PR DESCRIPTION
## Summary

- rename the Settings personal Context access heading to “Use with Claude Code or Codex”
- simplify the supporting copy to one direct instruction
- keep successful copy feedback inside the button for 1.5 seconds instead of adding a persistent helper row
- preserve an `sr-only` live-region announcement without changing layout

## Verification

- `pnpm --filter @first-tree/web exec vitest run src/pages/__tests__/context-enablement.test.tsx src/pages/__tests__/preview-pages-extra.test.tsx src/pages/settings/__tests__/setup-dom.test.tsx src/pages/__tests__/web-dom-interactions.test.tsx` — 123 passed
- `pnpm --filter @first-tree/web test` — 217 files, 1866 tests passed
- `pnpm --filter @first-tree/web typecheck`
- `pnpm check && pnpm typecheck`
- Biome check on all changed files
- Playwright QA on `/preview/setup?role=admin&state=ready`
  - desktop personal-access height: `38.296875` before and after copy
  - 844×390 personal-access height: `82.296875` before and after copy
  - successful copy shows only the transient check icon and hidden live-region status

## Review

- independent async/state review: no blockers
- independent UX/accessibility/design-system review: no blockers
