### PR TITLE
fix(web): render Skill upload pickers with app-owned English copy

### DIFF
--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -592,6 +592,14 @@ describe("resource editors", () => {
     expect(document.body.textContent).toContain("No file selected");
     expect(document.body.textContent).not.toContain("未选择任何文件");
 
+    // The hidden input's accessible value is gone with it, so the trigger must
+    // be tied to the status text (aria-describedby) and that text must be a
+    // live status that announces the selection after the dialog closes.
+    const status = document.getElementById("skill-file-status");
+    expect(status?.getAttribute("role")).toBe("status");
+    expect(status?.textContent?.trim()).toBe("No file selected");
+    expect(choose?.getAttribute("aria-describedby")).toBe("skill-file-status");
+
     // The button opens the hidden input's picker.
     const clickSpy = vi.spyOn(HTMLInputElement.prototype, "click").mockImplementation(() => {});
     await click(choose);
@@ -607,6 +615,8 @@ describe("resource editors", () => {
     await flush();
     expect(document.body.textContent).toContain("SKILL.md");
     expect(document.body.textContent).not.toContain("No file selected");
+    // The live status itself carries the selection (not just visible text).
+    expect(document.getElementById("skill-file-status")?.textContent?.trim()).toBe("SKILL.md");
     await pressEscape();
     await act(async () => root.unmount());
   });
@@ -627,6 +637,17 @@ describe("resource editors", () => {
     expect(choose?.type).toBe("button");
     expect(document.body.textContent).toContain("No folder selected");
 
+    const folderStatus = document.getElementById("skill-folder-status");
+    expect(folderStatus?.getAttribute("role")).toBe("status");
+    expect(folderStatus?.textContent?.trim()).toBe("No folder selected");
+    expect(choose?.getAttribute("aria-describedby")).toBe("skill-folder-status");
+
+    // The button opens the hidden input's picker (same contract as file mode).
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, "click").mockImplementation(() => {});
+    await click(choose);
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+
     await act(async () => {
       Object.defineProperty(folderInput, "files", {
         value: [new File(["a"], "SKILL.md"), new File(["b"], "helper.sh")],
@@ -637,6 +658,7 @@ describe("resource editors", () => {
     await flush();
     expect(document.body.textContent).toContain("2 files selected");
     expect(document.body.textContent).not.toContain("No folder selected");
+    expect(document.getElementById("skill-folder-status")?.textContent?.trim()).toBe("2 files selected");
     await pressEscape();
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -572,4 +572,72 @@ describe("resource editors", () => {
     await pressEscape();
     await act(async () => root.unmount());
   });
+
+  it("renders app-owned English copy for the Skill file picker, not the locale-dependent native input", async () => {
+    const { root } = await render();
+    await click(byAria("Add Skill"));
+    await selectOption("skill-input-mode", "Upload ZIP or SKILL.md");
+
+    // The native input stays mounted (it owns accept + the change event) but is
+    // hidden; its browser-localized button text must never be what the user sees.
+    const fileInput = input("skill-file");
+    expect(fileInput.type).toBe("file");
+    expect(fileInput.className).toContain("hidden");
+    expect(fileInput.getAttribute("accept")).toBe(".zip,.md,application/zip,text/markdown,text/plain");
+
+    // App-owned English trigger + empty state, not type=submit.
+    const choose = byText("Choose file");
+    expect(choose).toBeTruthy();
+    expect(choose?.type).toBe("button");
+    expect(document.body.textContent).toContain("No file selected");
+    expect(document.body.textContent).not.toContain("未选择任何文件");
+
+    // The button opens the hidden input's picker.
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, "click").mockImplementation(() => {});
+    await click(choose);
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+
+    // After a selection, the chosen file name is rendered by the app.
+    const file = new File(["---\nname: rel\n---"], "SKILL.md", { type: "text/markdown" });
+    await act(async () => {
+      Object.defineProperty(fileInput, "files", { value: [file], configurable: true });
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await flush();
+    expect(document.body.textContent).toContain("SKILL.md");
+    expect(document.body.textContent).not.toContain("No file selected");
+    await pressEscape();
+    await act(async () => root.unmount());
+  });
+
+  it("renders app-owned English copy for the Skill folder picker and reports the selection count", async () => {
+    const { root } = await render();
+    await click(byAria("Add Skill"));
+    await selectOption("skill-input-mode", "Choose Skill folder");
+
+    const folderInput = input("skill-folder");
+    expect(folderInput.type).toBe("file");
+    expect(folderInput.className).toContain("hidden");
+    expect(folderInput.multiple).toBe(true);
+    expect(folderInput.getAttribute("webkitdirectory")).not.toBeNull();
+
+    const choose = byText("Choose folder");
+    expect(choose).toBeTruthy();
+    expect(choose?.type).toBe("button");
+    expect(document.body.textContent).toContain("No folder selected");
+
+    await act(async () => {
+      Object.defineProperty(folderInput, "files", {
+        value: [new File(["a"], "SKILL.md"), new File(["b"], "helper.sh")],
+        configurable: true,
+      });
+      folderInput.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await flush();
+    expect(document.body.textContent).toContain("2 files selected");
+    expect(document.body.textContent).not.toContain("No folder selected");
+    await pressEscape();
+    await act(async () => root.unmount());
+  });
 });

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -646,6 +646,13 @@ function SkillEditor({ state, save, onClose }: EditorProps) {
   const [folderFiles, setFolderFiles] = useState<File[]>([]);
   const [preparing, setPreparing] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
+  // The native file inputs stay mounted (they own accept/multiple/webkitdirectory
+  // and the change events) but are hidden: browsers render their button and
+  // empty-state label ("选择文件 / 未选择任何文件") in the OS locale, which leaks
+  // non-English copy into the English product. App-owned Button + status text
+  // trigger and describe them instead, so the copy is always English.
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const folderInputRef = useRef<HTMLInputElement | null>(null);
 
   const prepareBundle = async (): Promise<PreparedSkillBundle> => {
     if (inputMode === "paste") {
@@ -731,27 +738,44 @@ function SkillEditor({ state, save, onClose }: EditorProps) {
                   </FieldShell>
                 ) : inputMode === "file" ? (
                   <FieldShell id="skill-file" label="ZIP or SKILL.md">
+                    <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+                      <Button type="button" variant="outline" size="sm" onClick={() => fileInputRef.current?.click()}>
+                        Choose file
+                      </Button>
+                      <p className="text-label" style={{ color: "var(--fg-3)", margin: 0 }}>
+                        {selectedFile ? selectedFile.name : "No file selected"}
+                      </p>
+                    </div>
                     <Input
                       id="skill-file"
                       type="file"
                       accept=".zip,.md,application/zip,text/markdown,text/plain"
+                      className="hidden"
+                      ref={fileInputRef}
                       onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
                     />
                   </FieldShell>
                 ) : (
                   <FieldShell id="skill-folder" label="Skill folder">
+                    <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+                      <Button type="button" variant="outline" size="sm" onClick={() => folderInputRef.current?.click()}>
+                        Choose folder
+                      </Button>
+                      <p className="text-label" style={{ color: "var(--fg-3)", margin: 0 }}>
+                        {folderFiles.length > 0 ? `${folderFiles.length} files selected` : "No folder selected"}
+                      </p>
+                    </div>
                     <Input
                       id="skill-folder"
                       type="file"
                       multiple
-                      ref={(node) => node?.setAttribute("webkitdirectory", "")}
+                      className="hidden"
+                      ref={(node) => {
+                        folderInputRef.current = node;
+                        node?.setAttribute("webkitdirectory", "");
+                      }}
                       onChange={(event) => setFolderFiles(Array.from(event.target.files ?? []))}
                     />
-                    {folderFiles.length > 0 ? (
-                      <p className="text-label" style={{ color: "var(--fg-3)", margin: 0 }}>
-                        {folderFiles.length} files selected
-                      </p>
-                    ) : null}
                   </FieldShell>
                 )}
               </>

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -739,10 +739,24 @@ function SkillEditor({ state, save, onClose }: EditorProps) {
                 ) : inputMode === "file" ? (
                   <FieldShell id="skill-file" label="ZIP or SKILL.md">
                     <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
-                      <Button type="button" variant="outline" size="sm" onClick={() => fileInputRef.current?.click()}>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        aria-describedby="skill-file-status"
+                        onClick={() => fileInputRef.current?.click()}
+                      >
                         Choose file
                       </Button>
-                      <p className="text-label" style={{ color: "var(--fg-3)", margin: 0 }}>
+                      {/* role="status" (polite live region, atomic) announces the
+                          selection change that the hidden input can no longer
+                          convey; aria-describedby ties it to the trigger. */}
+                      <p
+                        id="skill-file-status"
+                        role="status"
+                        className="text-label"
+                        style={{ color: "var(--fg-3)", margin: 0 }}
+                      >
                         {selectedFile ? selectedFile.name : "No file selected"}
                       </p>
                     </div>
@@ -758,10 +772,21 @@ function SkillEditor({ state, save, onClose }: EditorProps) {
                 ) : (
                   <FieldShell id="skill-folder" label="Skill folder">
                     <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
-                      <Button type="button" variant="outline" size="sm" onClick={() => folderInputRef.current?.click()}>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        aria-describedby="skill-folder-status"
+                        onClick={() => folderInputRef.current?.click()}
+                      >
                         Choose folder
                       </Button>
-                      <p className="text-label" style={{ color: "var(--fg-3)", margin: 0 }}>
+                      <p
+                        id="skill-folder-status"
+                        role="status"
+                        className="text-label"
+                        style={{ color: "var(--fg-3)", margin: 0 }}
+                      >
                         {folderFiles.length > 0 ? `${folderFiles.length} files selected` : "No folder selected"}
                       </p>
                     </div>


### PR DESCRIPTION
## Problem

In Settings → Resources, the Skill editor's **Upload ZIP or SKILL.md** and **Choose Skill folder** modes rendered the raw `input[type=file]`. Browsers draw that control's button and empty-state label in the OS locale (e.g. "选择文件 / 未选择任何文件"), so Chinese copy leaked into the English product UI.

## Change

`packages/web/src/pages/settings/resource-editors.tsx` (SkillEditor only):

- Keep both native file inputs mounted but hidden (`className="hidden"`), preserving `accept` / `multiple` / `webkitdirectory` and the existing change handlers.
- Add app-owned triggers via the existing `Button` (`type="button"`, `variant="outline"`): **Choose file** / **Choose folder**.
- Render selection state explicitly in English instead of relying on the browser: file mode shows the chosen file name with a "No file selected" empty state; folder mode shows "N files selected" with a "No folder selected" empty state.

Scope is limited to these two pickers — paste mode, bundle preparation, and all other upload entries are untouched.

## Tests

`packages/web/src/pages/__tests__/resource-editors-dom.test.tsx` gains two regression tests covering both modes:

- the native input stays mounted but hidden (attributes preserved), and the app-owned English trigger/empty-state copy is what renders;
- the trigger button is `type="button"` and clicks through to the hidden input;
- after a change event, the chosen file name / file count is displayed.

## Verification

- `pnpm --filter @first-tree/web exec vitest run src/pages/__tests__/resource-editors-dom.test.tsx` — 17/17 pass
- Full web suite (`pnpm --filter @first-tree/web test`) — 217 files / 1868 tests pass
- `pnpm check` — pass (pre-existing warnings only)
- `pnpm typecheck` — pass
