### PR TITLE
Rename and relocate GitHub Task Agent settings

### DIFF
--- a/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
+++ b/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
@@ -21,10 +21,11 @@ together without a GitHub-specific post-delivery branch.
   requests read/write permissions. Use a disposable repository and test identities; do not point a production App at
   the run cell.
 - Create a chat with an eligible human/delegate pair and follow one disposable issue or pull request in that chat.
-- Select different active, organization-visible managed Agents for Context Reviewer and Team Agent. Confirm Setup rejects
-  either assignment when it would reuse the other role's Agent. Leave Automatic Review off for the first non-Context
+- Select different active, organization-visible managed Agents for Context Reviewer and GitHub Task Agent. Use Settings
+  → Setup for Context Reviewer and Settings → Integrations → GitHub → Task routing for GitHub Task Agent; confirm each
+  surface rejects an assignment that would reuse the other role's Agent. Leave Automatic Review off for the first non-Context
   repository observations so ordinary delegation is proven independently from Context Review.
-- Bind the Team's Context Tree to one GitHub repository. Use a second disposable GitHub repository for Team Agent
+- Bind the Team's Context Tree to one GitHub repository. Use a second disposable GitHub repository for GitHub Task Agent
   observations. A GitLab Context Tree binding can be used as an additional negative control.
 - Keep a matching client runtime connected if the plan includes observing the agent wake. A missing provider credential
   may block the later model turn, but it must not prevent card and inbox evidence.
@@ -45,24 +46,25 @@ together without a GitHub-specific post-delivery branch.
   `COLLABORATOR` Issue or PR author/commenter. Do not require GitHub's native mention picker: an ordinary GitHub App bot is
   not currently selectable there. Cover the structured App-assignee contract only with a correctly signed synthetic
   webhook payload or programmable provider mock; do not list assigning the ordinary App bot in the GitHub UI as a live
-  PASS prerequisite. Confirm each supported request creates or reuses one entity chat for the selected Team Agent, wakes
+  PASS prerequisite. Confirm each supported request creates or reuses one entity chat for the selected GitHub Task Agent, wakes
   that exact Agent, and persists
   `teamAgentTask: { agentUuid: "<selected UUID>", runId: "<server run>" }` on both the card and message metadata.
   Repeat a text mention from an untrusted public contributor and confirm no App-directed
   attention line, task marker, or Agent wake is created; normal followed-chat delivery must remain intact. Treat the
   structured assignee event as trusted independently of textual `author_association`.
 - Repeat the non-Context request where the GitHub actor already maps the entity to a different delegate. Confirm the
-  selected Team Agent is added as a chat participant and is woken, while the existing delegate remains unwoken and does
+  selected GitHub Task Agent is added as a chat participant and is woken, while the existing delegate remains unwoken and does
   not receive an executable task marker. Repeat with unrelated attention lines in the same chat and confirm task
   identity remains recipient-scoped.
 - In the bound GitHub Context Tree repository, make the same authorized App request and confirm only the Context Reviewer
   is targeted. Confirm repository matching tolerates canonical URL spelling, case, and `.git` differences. Verify the
-  second GitHub repository still targets Team Agent, and that a GitLab Context Tree binding does not classify any GitHub
+  second GitHub repository still targets GitHub Task Agent, and that a GitLab Context Tree binding does not classify any GitHub
   repository as the Context repository.
 - Remove or invalidate each role selection in turn and confirm only its App-directed attention line is skipped; existing
-  human targets and subscriptions still receive ordinary cards. Remove the verified App slug/login and confirm Setup
-  exposes a readiness blocker and assignment fails closed instead of silently degrading.
-- Let the Team Agent finish one App-targeted task. Confirm it inspects and acts through the normal host GitHub identity,
+  human targets and subscriptions still receive ordinary cards. Remove the verified App slug/login and confirm Settings
+  → Integrations → GitHub → Task routing exposes a GitHub Task Agent readiness blocker and assignment fails closed instead
+  of silently degrading.
+- Let the GitHub Task Agent finish one App-targeted task. Confirm it inspects and acts through the normal host GitHub identity,
   then uses `first-tree github reply --run <runId> --body-file <path>` for the terminal outcome. Observe an App-authored
   comment on the fixed originating Issue or PR; its hidden run marker is present, the visible body does not mention the
   App, and no delegated loop occurs. A First Tree chat-only result or a terminal host-identity comment is incomplete.
@@ -78,7 +80,7 @@ together without a GitHub-specific post-delivery branch.
   Discussion and commit events return `GITHUB_TASK_REPLY_ENTITY_UNSUPPORTED`, while a missing accepted write grant returns
   `GITHUB_TASK_REPLY_APP_PERMISSION_REQUIRED`. Both omit the task run and GitHub mutation while independent followed lines
   remain delivered.
-- Redeliver an App mention with a fresh delivery id on the same entity. Confirm the existing Team Agent chat/attention
+- Redeliver an App mention with a fresh delivery id on the same entity. Confirm the existing GitHub Task Agent chat/attention
   line is reused rather than creating another chat.
 - Enable Context Reviewer and include one supported Context Tree PR trigger. Confirm it reuses its dedicated reviewer
   chat and retains trusted review publication authority only for that path. The ordinary App-target card must not gain

--- a/packages/server/src/__tests__/context-reviewer-settings.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-settings.test.ts
@@ -955,13 +955,13 @@ describe("Context Reviewer assignment/readiness contract", () => {
   });
 });
 
-describe("Team Agent assignment contract", () => {
+describe("GitHub Task Agent assignment contract", () => {
   const getApp = useTestApp();
 
   it("is configurable without a Context Tree and requires a verified App login", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
-    const teamAgent = await createReviewer(app, admin, { displayName: "Team Agent" });
+    const teamAgent = await createReviewer(app, admin, { displayName: "GitHub Task Agent" });
 
     await expect(
       listTeamAgentCandidates(app.db, {
@@ -971,7 +971,7 @@ describe("Team Agent assignment contract", () => {
         staleSeconds: 60,
       }),
     ).resolves.toMatchObject({
-      items: [expect.objectContaining({ uuid: teamAgent.uuid, displayName: "Team Agent" })],
+      items: [expect.objectContaining({ uuid: teamAgent.uuid, displayName: "GitHub Task Agent" })],
       blockers: [],
     });
     await expect(
@@ -1048,10 +1048,10 @@ describe("Team Agent assignment contract", () => {
     });
   });
 
-  it("blocks Team Agent configuration when the connected App cannot publish both Issue and PR comments", async () => {
+  it("blocks GitHub Task Agent configuration when the connected App cannot publish both Issue and PR comments", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
-    const teamAgent = await createReviewer(app, admin, { displayName: "Team Agent" });
+    const teamAgent = await createReviewer(app, admin, { displayName: "GitHub Task Agent" });
     await upsertInstallationFromMetadata(app.db, {
       installation: {
         id: Number(`8${Math.floor(Math.random() * 1_000_000)}`),
@@ -1093,10 +1093,10 @@ describe("Team Agent assignment contract", () => {
     });
   });
 
-  it("exposes dedicated Team Agent endpoints to Team admins", async () => {
+  it("exposes dedicated GitHub Task Agent endpoints to Team admins", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
-    const teamAgent = await createReviewer(app, admin, { displayName: "Team Agent" });
+    const teamAgent = await createReviewer(app, admin, { displayName: "GitHub Task Agent" });
     const baseUrl = `/api/v1/orgs/${admin.organizationId}/team-agent`;
 
     const candidates = await app.inject({

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -1730,7 +1730,7 @@ describe("POST /webhooks/github-app", () => {
       expectedReason: "assigned",
       expectedLogin: "test-app-slug[bot]",
     },
-  ])("delegates an App $label to the selected Team Agent and wakes it", async (scenario) => {
+  ])("delegates an App $label to the selected GitHub Task Agent and wakes it", async (scenario) => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = scenario.action === "opened" ? 100032 : 100033;
@@ -1741,7 +1741,7 @@ describe("POST /webhooks/github-app", () => {
       .from(agents)
       .where(eq(agents.uuid, admin.humanAgentUuid))
       .limit(1);
-    if (!managerHuman?.name) throw new Error("Team Agent manager human is missing a GitHub-compatible name");
+    if (!managerHuman?.name) throw new Error("GitHub Task Agent manager human is missing a GitHub-compatible name");
 
     const payload = {
       action: scenario.action,
@@ -2081,7 +2081,7 @@ describe("POST /webhooks/github-app", () => {
     expect(reviewerNotification?.notify).toBe(true);
   });
 
-  it("reuses an existing human mapping, adds the Team Agent, and preserves the surviving followed wake", async () => {
+  it("reuses an existing human mapping, adds the GitHub Task Agent, and preserves the surviving followed wake", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = 100034;
@@ -2169,7 +2169,7 @@ describe("POST /webhooks/github-app", () => {
       .from(agents)
       .where(eq(agents.uuid, admin.humanAgentUuid))
       .limit(1);
-    if (!managerHuman?.name) throw new Error("Team Agent manager human is missing a GitHub-compatible name");
+    if (!managerHuman?.name) throw new Error("GitHub Task Agent manager human is missing a GitHub-compatible name");
 
     const historicalDelegate = await seedAgent(app, {
       orgId: admin.organizationId,

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -253,7 +253,7 @@ describe("resolveAudience", () => {
   it.each([
     ["mentioned", "test-app-slug"],
     ["assigned", "test-app-slug[bot]"],
-  ] as const)("routes an App %s target to the selected Team Agent while Automatic Review is off", async (reason, externalUsername) => {
+  ] as const)("routes an App %s target to the selected GitHub Task Agent while Automatic Review is off", async (reason, externalUsername) => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const teamAgentUuid = await configureTeamAgent(app, admin);
@@ -284,7 +284,7 @@ describe("resolveAudience", () => {
     ]);
   });
 
-  it("does not treat the App login as a human target when no Team Agent is selected", async () => {
+  it("does not treat the App login as a human target when no GitHub Task Agent is selected", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
 
@@ -352,7 +352,7 @@ describe("resolveAudience", () => {
     expect(resolution.appTaskBlocker).toBe(blocker);
   });
 
-  it("routes the bound GitHub Context Tree repo to the Context Reviewer and other repos to the Team Agent", async () => {
+  it("routes the bound GitHub Context Tree repo to the Context Reviewer and other repos to the GitHub Task Agent", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const teamAgentUuid = await configureTeamAgent(app, admin);

--- a/packages/server/src/__tests__/github-task-reply-publisher.test.ts
+++ b/packages/server/src/__tests__/github-task-reply-publisher.test.ts
@@ -334,7 +334,7 @@ describe("GitHub App task reply publisher", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
-  it("revokes publication when the selected Team Agent or installation permission changes", async () => {
+  it("revokes publication when the selected GitHub Task Agent or installation permission changes", async () => {
     const fixture = await createRunFixture(getApp());
     const replacement = await createAgent(fixture.app.db, {
       name: `replacement-${randomUUID().slice(0, 8)}`,
@@ -560,7 +560,7 @@ async function createRunFixture(
   const agent = await createAgent(app.db, {
     name: `team-agent-${randomUUID().slice(0, 8)}`,
     type: "agent",
-    displayName: "Team Agent",
+    displayName: "GitHub Task Agent",
     managerId: admin.memberId,
     clientId: admin.clientId,
   });

--- a/packages/server/src/services/context-reviewer-settings.ts
+++ b/packages/server/src/services/context-reviewer-settings.ts
@@ -284,7 +284,7 @@ export async function putContextReviewerAssignment(
     if (teamAgent.teamAgent.agentUuid === agent.uuid) {
       fail(
         blocker("team_agent_conflicts_context_reviewer", "select_team_agent"),
-        "Context Reviewer and Team Agent must be different Agents",
+        "Context Reviewer and GitHub Task Agent must be different Agents",
       );
     }
     const sameAgent = current.contextReviewer.agentUuid === agent.uuid;

--- a/packages/server/src/services/team-agent-settings.ts
+++ b/packages/server/src/services/team-agent-settings.ts
@@ -18,7 +18,7 @@ import { getOrgSetting } from "./org-settings.js";
 export class TeamAgentSettingsError extends ConflictError {
   constructor(
     readonly blocker: SetupBlocker,
-    message = "Team Agent is not ready",
+    message = "GitHub Task Agent is not ready",
   ) {
     super(message, { code: blocker.code });
     this.name = "TeamAgentSettingsError";
@@ -151,7 +151,7 @@ export async function putTeamAgentAssignment(
   if (agentUuid !== null && !options.appSlug?.trim()) {
     throw new TeamAgentSettingsError(
       blocker("github_app_slug_missing", null, "operator"),
-      "GitHub App login is required before selecting a Team Agent",
+      "GitHub App login is required before selecting a GitHub Task Agent",
     );
   }
 
@@ -172,7 +172,7 @@ export async function putTeamAgentAssignment(
       if (reviewerAgentUuid === agentUuid) {
         throw new TeamAgentSettingsError(
           blocker("team_agent_conflicts_context_reviewer", "select_team_agent"),
-          "Context Reviewer and Team Agent must be different Agents",
+          "Context Reviewer and GitHub Task Agent must be different Agents",
         );
       }
       const agent = await loadValidContextReviewerAgent(tx, {
@@ -182,7 +182,7 @@ export async function putTeamAgentAssignment(
       if (!agent) {
         throw new TeamAgentSettingsError(
           blocker("context_review_agent_missing", "select_team_agent"),
-          "Team Agent must be an active organization-visible non-human Agent with a managed runtime",
+          "GitHub Task Agent must be an active organization-visible non-human Agent with a managed runtime",
         );
       }
     }

--- a/packages/shared/src/schemas/normalized-event.ts
+++ b/packages/shared/src/schemas/normalized-event.ts
@@ -174,7 +174,7 @@ export const githubEventCardSchema = z.object({
   /**
    * Server-authored signal that this directed card exists because the
    * configured GitHub App itself was mentioned or assigned. The selected
-   * Team Agent treats it as work to complete and answer on GitHub.
+   * GitHub Task Agent treats it as work to complete and answer on GitHub.
    */
   teamAgentTask: githubAgentTaskSchema.optional(),
 });

--- a/packages/web/src/api/__tests__/team-agent-settings.test.ts
+++ b/packages/web/src/api/__tests__/team-agent-settings.test.ts
@@ -15,7 +15,7 @@ const candidates = teamAgentCandidatesOutputSchema.parse({
     {
       uuid: "agent-1",
       name: "team-agent",
-      displayName: "Team Agent",
+      displayName: "GitHub Task Agent",
       visibility: "organization",
       runtime: { health: "ready", blockers: [] },
     },
@@ -29,7 +29,7 @@ const features = orgGithubFeaturesOutputSchema.parse({
     agent: {
       uuid: "agent-1",
       name: "team-agent",
-      displayName: "Team Agent",
+      displayName: "GitHub Task Agent",
     },
   },
 });
@@ -40,8 +40,8 @@ beforeEach(() => {
   vi.mocked(api.put).mockResolvedValue(features);
 });
 
-describe("Team Agent owner API", () => {
-  it("uses the independent GitHub Team Agent namespace", async () => {
+describe("GitHub Task Agent owner API", () => {
+  it("uses the stable team-agent namespace", async () => {
     await expect(getTeamAgentCandidates("org/one")).resolves.toEqual(candidates);
     await expect(putTeamAgentAssignment("org/one", "agent-1")).resolves.toEqual(features);
 

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -407,7 +407,7 @@ describe("settings panels", () => {
     const desktopLinks = [...desktop.container.querySelectorAll<HTMLAnchorElement>("aside a")].map(
       (link) => link.textContent,
     );
-    expect(desktopLinks).toEqual(["Account", "Setup", "Computers", "Repositories", "Resources", "Integrations"]);
+    expect(desktopLinks).toEqual(["Account", "Setup", "Computers", "Repositories", "Resources", "GitHub & GitLab"]);
     expect(desktop.container.textContent).toContain("Integrations child");
     await act(async () => desktop.root.unmount());
 
@@ -424,7 +424,7 @@ describe("settings panels", () => {
     expect(narrow.container.textContent).toContain("Computers");
     expect(narrow.container.textContent).toContain("Repositories");
     expect(narrow.container.textContent).toContain("TEAM");
-    expect(narrow.container.textContent).toContain("Integrations");
+    expect(narrow.container.textContent).toContain("GitHub & GitLab");
     expect(narrow.container.textContent).not.toContain("Setup");
     expect(narrow.container.querySelector('a[href="/settings/setup"]')).toBeNull();
     await act(async () => narrow.root.unmount());

--- a/packages/web/src/pages/settings-github-preview.tsx
+++ b/packages/web/src/pages/settings-github-preview.tsx
@@ -1,6 +1,8 @@
 import { Building2, ChevronRight, ExternalLink, PauseCircle, User } from "lucide-react";
 import { useState } from "react";
 import { PageHeader } from "../components/ui/page-header.js";
+import { Section } from "../components/ui/section.js";
+import { Select } from "../components/ui/select.js";
 
 /**
  * DEV-only visual review for Settings → GitHub (the connected GitHub App
@@ -18,9 +20,9 @@ import { PageHeader } from "../components/ui/page-header.js";
  *   - **Not installed**         — the "Install on GitHub" CTA.
  *   - **Loading**               — the initial fetch state.
  *
- * Only the bound card draws a top hairline; the not-installed / loading states
- * sit flush under the page header (matching the real panel). The markup here
- * is a faithful copy of the real panel's; keep them in sync.
+ * Connection and task routing are separate provider-owned sections. The
+ * markup here mirrors the real page closely enough to review their hierarchy
+ * without a live GitHub installation.
  */
 
 const MOCK = {
@@ -142,12 +144,60 @@ function ConnectionDetails({ defaultOpen = false }: { defaultOpen?: boolean }) {
   );
 }
 
-/** PageHeader + content padding — the shell every state renders inside. */
+function TaskRoutingPreview() {
+  const [agentUuid, setAgentUuid] = useState("dev-agent");
+  const agentName = agentUuid === "release-agent" ? "Release Agent" : "Dev Assistant";
+
+  return (
+    <div
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-3)",
+        padding: "var(--sp-4)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        background: "var(--bg-sunken)",
+      }}
+    >
+      <div>
+        <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          GitHub Task Agent
+        </span>
+        <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
+          {agentName} handles GitHub App mentions and assignments outside the Context Tree repository.
+        </div>
+      </div>
+      <Select
+        aria-label="GitHub Task Agent"
+        value={agentUuid}
+        onChange={setAgentUuid}
+        options={[
+          { value: "dev-agent", label: "Dev Assistant", hint: "Runtime ready" },
+          { value: "release-agent", label: "Release Agent", hint: "Runtime ready" },
+        ]}
+      />
+      <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+        The GitHub Task Agent and Context Reviewer must be different Agents. Automatic Review does not control this
+        delegation.
+      </div>
+    </div>
+  );
+}
+
+/** PageHeader + provider-owned sections — the shell every state renders inside. */
 function PageShell({ children }: { children: React.ReactNode }) {
   return (
     <div>
       <PageHeader title="GitHub" subtitle="Connected GitHub App" />
-      <div style={{ padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>{children}</div>
+      <div className="flex flex-col" style={{ gap: "var(--sp-5)", padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
+        <Section title="Connection">{children}</Section>
+        <Section
+          title="Task routing"
+          description="Choose who handles requests sent directly to the First Tree GitHub App."
+        >
+          <TaskRoutingPreview />
+        </Section>
+      </div>
     </div>
   );
 }
@@ -157,8 +207,6 @@ function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?:
     <PageShell>
       <div
         style={{
-          borderTop: "var(--hairline) solid var(--border)",
-          paddingTop: "var(--sp-4)",
           display: "flex",
           flexDirection: "column",
           gap: "var(--sp-4)",
@@ -213,8 +261,7 @@ function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?:
 }
 
 /**
- * Not-installed CTA — flush under the header, no hairline (matches the real
- * panel). `waiting` mirrors the post-click state: the install opened in a new
+ * Not-installed CTA. `waiting` mirrors the post-click state: the install opened in a new
  * tab, the CTA is locked (a second mint would clobber the in-flight nonce
  * cookie), and this tab shows the "waiting + start over" affordance while it
  * polls for the install to land.
@@ -273,7 +320,7 @@ function NotInstalledCard({ waiting = false }: { waiting?: boolean }) {
   );
 }
 
-/** Loading — flush under the header, no hairline. */
+/** Loading connection state. */
 function LoadingCard() {
   return (
     <PageShell>
@@ -329,8 +376,8 @@ export function SettingsGithubPreviewPage() {
         </h1>
         <p className="text-body" style={{ color: "var(--fg-3)" }}>
           Lean default: who's connected + Manage on GitHub. Permissions, subscribed events, and the installation id sit
-          behind a collapsed "Connection details" disclosure (click to toggle). Only the bound card carries a top
-          hairline; not-installed and loading sit flush under the header.
+          behind a collapsed "Connection details" disclosure (click to toggle). GitHub Task Agent lives in the adjacent
+          Task routing section instead of appearing as a standalone Setup capability.
         </p>
       </div>
 
@@ -346,7 +393,7 @@ export function SettingsGithubPreviewPage() {
         <InstalledCard suspended />
       </Frame>
 
-      <Frame label="Not installed" note="the Install on GitHub CTA — flush under the header, no orphaned rule">
+      <Frame label="Not installed" note="the Install on GitHub CTA alongside provider-owned task routing">
         <NotInstalledCard />
       </Frame>
 
@@ -357,7 +404,7 @@ export function SettingsGithubPreviewPage() {
         <NotInstalledCard waiting />
       </Frame>
 
-      <Frame label="Loading" note="initial fetch — flush under the header">
+      <Frame label="Loading" note="initial connection fetch with task routing retained below">
         <LoadingCard />
       </Frame>
     </div>

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -56,8 +56,8 @@ const RESOURCES_ITEM: Item = {
 };
 const INTEGRATIONS_ITEM: Item = {
   to: "/settings/integrations",
-  label: "Integrations",
-  description: "Connect providers for webhooks, identity, and event routing.",
+  label: "GitHub & GitLab",
+  description: "Connect GitHub and GitLab for repository events, identity, and task routing.",
 };
 const ITEMS: Item[] = [ACCOUNT_ITEM, SETUP_ITEM, COMPUTERS_ITEM, REPOSITORIES_ITEM, RESOURCES_ITEM, INTEGRATIONS_ITEM];
 

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -57,7 +57,7 @@ const RESOURCES_ITEM: Item = {
 const INTEGRATIONS_ITEM: Item = {
   to: "/settings/integrations",
   label: "GitHub & GitLab",
-  description: "Connect GitHub and GitLab for repository events, identity, and task routing.",
+  description: "Connect GitHub and GitLab for repository events and identity. GitHub also supports task routing.",
 };
 const ITEMS: Item[] = [ACCOUNT_ITEM, SETUP_ITEM, COMPUTERS_ITEM, REPOSITORIES_ITEM, RESOURCES_ITEM, INTEGRATIONS_ITEM];
 

--- a/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
@@ -6,15 +6,29 @@ import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 // The GitHub round-trip return is the only logic under test here; stub the
 // installation panel so the test stays focused on the `?from=context` return
 // affordance. Team code access now belongs to the parent Integrations layout.
 const githubAppMocks = vi.hoisted(() => ({ getGithubAppInstallation: vi.fn() }));
+const orgSettingsMocks = vi.hoisted(() => ({ getGithubFeaturesSetting: vi.fn() }));
+const teamAgentMocks = vi.hoisted(() => ({
+  getTeamAgentCandidates: vi.fn(),
+  putTeamAgentAssignment: vi.fn(),
+}));
 const authMock = vi.hoisted(() => ({
   value: { role: "admin" as string | null, organizationId: "org-1" as string | null },
 }));
+let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+let scrollIntoView: ReturnType<typeof vi.fn>;
 
 vi.mock("../../../api/github-app.js", () => githubAppMocks);
+vi.mock("../../../api/org-settings.js", () => orgSettingsMocks);
+vi.mock("../../../api/team-agent-settings.js", () => teamAgentMocks);
+vi.mock("../../../api/setup-capabilities.js", () => ({
+  setupCapabilitiesQueryKey: (organizationId: string | null) => ["setup-capabilities", organizationId],
+}));
 vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
 vi.mock("../../github-app-installation-panel.js", () => ({
   GithubAppInstallationPanel: () => <div data-testid="panel-stub">panel</div>,
@@ -58,14 +72,53 @@ async function waitForText(container: ParentNode, text: string, timeoutMs = 3000
   throw new Error(`Expected text "${text}"\n${container.textContent ?? ""}`);
 }
 
+async function waitForSelector<T extends Element>(
+  container: ParentNode,
+  selector: string,
+  timeoutMs = 3000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const element = container.querySelector<T>(selector);
+    if (element) return element;
+    await flush();
+  }
+  throw new Error(`Expected selector "${selector}"`);
+}
+
 beforeEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
   authMock.value = { role: "admin", organizationId: "org-1" };
+  originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+  scrollIntoView = vi.fn();
+  HTMLElement.prototype.scrollIntoView = scrollIntoView;
   githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
+  orgSettingsMocks.getGithubFeaturesSetting.mockResolvedValue({
+    teamAgent: { agentUuid: null, agent: null },
+  });
+  teamAgentMocks.getTeamAgentCandidates.mockResolvedValue({
+    items: [
+      {
+        uuid: "dev-agent-1",
+        name: "dev-agent",
+        displayName: "Dev Agent One",
+        visibility: "organization",
+        runtime: { health: "ready", blockers: [] },
+      },
+    ],
+    blockers: [],
+  });
+  teamAgentMocks.putTeamAgentAssignment.mockResolvedValue({
+    teamAgent: {
+      agentUuid: "dev-agent-1",
+      agent: { uuid: "dev-agent-1", name: "dev-agent", displayName: "Dev Agent One" },
+    },
+  });
 });
 
 afterEach(() => {
+  HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
   document.body.innerHTML = "";
   vi.restoreAllMocks();
 });
@@ -107,6 +160,105 @@ describe("SettingsGithubPage — Context round-trip return", () => {
     // probe when not arriving from Context. (The real panel keeps its own query.)
     expect(githubAppMocks.getGithubAppInstallation).not.toHaveBeenCalled();
 
+    await act(async () => root.unmount());
+  });
+});
+
+describe("SettingsGithubPage — task routing", () => {
+  it.each([
+    ["#connection", "#connection", "GitHub connection"],
+    ["#task-routing", "#task-routing", "GitHub task routing"],
+  ])("positions and focuses the %s section", async (hash, selector, label) => {
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt(`/settings/integrations/github${hash}`, <SettingsGithubPage />);
+    const target = await waitForSelector<HTMLElement>(container, selector);
+
+    expect(target.getAttribute("aria-label")).toBe(label);
+    expect(target.tabIndex).toBe(-1);
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(document.activeElement).toBe(target);
+    await act(async () => root.unmount());
+  });
+
+  it("places GitHub Task Agent directly below the GitHub connection and updates its assignment", async () => {
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/integrations/github", <SettingsGithubPage />);
+    await waitForText(container, "Task routing");
+
+    const connection = await waitForSelector<HTMLElement>(container, "#connection");
+    const taskRouting = await waitForSelector<HTMLElement>(container, "#task-routing");
+    expect(connection.compareDocumentPosition(taskRouting) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(taskRouting.textContent).toContain("GitHub Task Agent");
+
+    const select = await waitForSelector<HTMLButtonElement>(taskRouting, '[aria-label="GitHub Task Agent"]');
+    await act(async () => select.click());
+    const option = [...document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')].find((candidate) =>
+      candidate.textContent?.includes("Dev Agent One"),
+    );
+    await act(async () => option?.click());
+    await flush();
+
+    expect(teamAgentMocks.putTeamAgentAssignment).toHaveBeenCalledWith("org-1", "dev-agent-1");
+    await act(async () => root.unmount());
+  });
+
+  it("shows members the configured Agent without exposing assignment controls", async () => {
+    authMock.value = { role: "member", organizationId: "org-1" };
+    orgSettingsMocks.getGithubFeaturesSetting.mockResolvedValue({
+      teamAgent: {
+        agentUuid: "dev-agent-1",
+        agent: { uuid: "dev-agent-1", name: "dev-agent", displayName: "Dev Agent One" },
+      },
+    });
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/integrations/github", <SettingsGithubPage />);
+    await waitForText(container, "Dev Agent One handles GitHub App mentions");
+
+    expect(container.querySelector('[aria-label="GitHub Task Agent"]')).toBeNull();
+    expect(teamAgentMocks.getTeamAgentCandidates).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it("shows a deployment-operator blocker without a misleading recovery link", async () => {
+    teamAgentMocks.getTeamAgentCandidates.mockResolvedValue({
+      items: [],
+      blockers: [{ code: "github_app_slug_missing", resolutionOwner: "operator", actionKind: null }],
+    });
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/integrations/github", <SettingsGithubPage />);
+    await waitForText(
+      container,
+      "A deployment operator must configure the GitHub App login before App-target delegation can run.",
+    );
+
+    const taskRouting = await waitForSelector<HTMLElement>(container, "#task-routing");
+    expect(taskRouting.textContent).not.toContain("Review connection");
+    expect(taskRouting.textContent).not.toContain("Manage Team Agents");
+    await act(async () => root.unmount());
+  });
+
+  it("links an App permission blocker back to the connection section", async () => {
+    teamAgentMocks.getTeamAgentCandidates.mockResolvedValue({
+      items: [],
+      blockers: [
+        {
+          code: "github_app_task_reply_permission_required",
+          resolutionOwner: "admin",
+          actionKind: "manage_github_installation",
+        },
+      ],
+    });
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/integrations/github", <SettingsGithubPage />);
+    await waitForText(
+      container,
+      "The GitHub App installation must grant Issues and Pull requests write access for App-authored task replies.",
+    );
+
+    expect(container.querySelector('a[href="/settings/integrations/github#connection"]')?.textContent).toBe(
+      "Review connection",
+    );
     await act(async () => root.unmount());
   });
 });

--- a/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
@@ -38,15 +38,17 @@ afterEach(() => {
 });
 
 describe("SettingsIntegrationsLayout", () => {
-  it("keeps Integrations focused on provider connections", async () => {
+  it("uses direct provider tabs without repeating generic integration copy", async () => {
     const { container, root } = await renderLayout();
 
-    expect(container.querySelector("h2")?.textContent).toBe("Connections");
-    expect(container.textContent).toContain("Connect providers for webhooks, identity, and event routing.");
+    expect(container.querySelector("h2")).toBeNull();
+    expect(container.textContent).not.toContain("Connections");
+    expect(container.textContent).not.toContain("Connect providers");
+    expect(container.querySelector('nav[aria-label="Git provider"]')).not.toBeNull();
     expect(container.textContent).toContain("GitHub connection content");
     expect(container.textContent).not.toContain("Code repositories");
 
-    const nav = container.querySelector('nav[aria-label="Connection provider"]');
+    const nav = container.querySelector('nav[aria-label="Git provider"]');
     expect(nav).not.toBeNull();
     expect(nav?.querySelector('a[href="/settings/integrations/github"]')?.getAttribute("aria-current")).toBe("page");
     expect(nav?.querySelector('a[href="/settings/integrations/gitlab"]')).not.toBeNull();
@@ -60,7 +62,7 @@ describe("SettingsIntegrationsLayout", () => {
     expect(container.textContent).not.toContain("Code repositories");
     expect(
       container
-        .querySelector('nav[aria-label="Connection provider"] a[href="/settings/integrations/gitlab"]')
+        .querySelector('nav[aria-label="Git provider"] a[href="/settings/integrations/gitlab"]')
         ?.getAttribute("aria-current"),
     ).toBe("page");
     await act(async () => root.unmount());

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -329,9 +329,12 @@ describe("Settings Setup overview", () => {
       "Your computer",
       "Your agent",
       "Code repositories",
-      "Repository automation",
+      "GitHub & GitLab",
       "Context Tree",
     ]);
+    expect(view.host.querySelector('[data-setup-row="repository-automation"]')?.textContent).toContain(
+      "Repository events, identity, and GitHub task routing.",
+    );
     expect(view.host.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
     expect(view.host.querySelector('[data-setup-row="work-access"] .lucide-message-circle')).not.toBeNull();
     const readyMarks = view.host.querySelectorAll("[data-setup-status-kind='ready'] .lucide-circle-check");

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -16,7 +16,6 @@ const contextTreeMocks = vi.hoisted(() => ({ getContextTreeSnapshot: vi.fn() }))
 const contextEnablementMocks = vi.hoisted(() => ({ getContextEnablementHandoff: vi.fn() }));
 const onboardingEventMocks = vi.hoisted(() => ({ reportOnboardingEvent: vi.fn() }));
 const orgSettingsMocks = vi.hoisted(() => ({
-  getGithubFeaturesSetting: vi.fn(),
   getRawContextTreeSetting: vi.fn(),
   putContextTreeSetting: vi.fn(),
 }));
@@ -25,10 +24,6 @@ const reviewerMocks = vi.hoisted(() => ({
   getContextReviewerCandidates: vi.fn(),
   putContextReviewerAssignment: vi.fn(),
   putContextReviewerEnablement: vi.fn(),
-}));
-const teamAgentMocks = vi.hoisted(() => ({
-  getTeamAgentCandidates: vi.fn(),
-  putTeamAgentAssignment: vi.fn(),
 }));
 const setupCapabilityMocks = vi.hoisted(() => ({ getTeamSetupCapabilitiesAt: vi.fn() }));
 const authMock = vi.hoisted(() => ({
@@ -53,7 +48,6 @@ vi.mock("../../../api/context-reviewer-settings.js", () => reviewerMocks);
 vi.mock("../../../api/onboarding-events.js", () => onboardingEventMocks);
 vi.mock("../../../api/org-settings.js", () => orgSettingsMocks);
 vi.mock("../../../api/resources.js", () => resourceMocks);
-vi.mock("../../../api/team-agent-settings.js", () => teamAgentMocks);
 vi.mock("../../../api/setup-capabilities.js", () => ({
   ...setupCapabilityMocks,
   setupCapabilitiesQueryKey: (organizationId: string | null) => ["setup-capabilities", organizationId],
@@ -192,7 +186,7 @@ async function renderSettingsSetupPage(initialEntry = "/") {
 
 function LocationProbe() {
   const location = useLocation();
-  return <output data-location>{location.pathname}</output>;
+  return <output data-location>{`${location.pathname}${location.hash}`}</output>;
 }
 
 async function waitForRowText(
@@ -243,16 +237,6 @@ async function openContextTreeControls(view: Awaited<ReturnType<typeof renderSet
   return { tree, manage, controls, reviewerControls };
 }
 
-async function openTeamAgentControls(view: Awaited<ReturnType<typeof renderSettingsSetupPage>>) {
-  const row = await waitForRowText(view.host, "team-agent", "Optional");
-  const manage = [...row.querySelectorAll<HTMLButtonElement>("button")].find(
-    (button) => button.textContent === "Manage",
-  );
-  await act(async () => manage?.click());
-  const controls = await waitForSelector<HTMLElement>(row, '[data-setup-owner-controls="team-agent"]');
-  return { row, manage, controls };
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
   activityMocks.listClients.mockResolvedValue([]);
@@ -275,12 +259,6 @@ beforeEach(() => {
     repo: "https://github.com/acme/context-tree.git",
     branch: "release",
     provider: "github",
-  });
-  orgSettingsMocks.getGithubFeaturesSetting.mockResolvedValue({
-    teamAgent: {
-      agentUuid: "team-agent-1",
-      agent: { uuid: "team-agent-1", name: "team-agent", displayName: "Team Agent One" },
-    },
   });
   reviewerMocks.getContextReviewerCandidates.mockResolvedValue({
     items: [
@@ -306,24 +284,6 @@ beforeEach(() => {
       enabled: true,
       agentUuid: "reviewer-1",
       reviewerAgent: { uuid: "reviewer-1", name: "context-reviewer", displayName: "Context Reviewer" },
-    },
-  });
-  teamAgentMocks.getTeamAgentCandidates.mockResolvedValue({
-    items: [
-      {
-        uuid: "team-agent-1",
-        name: "team-agent",
-        displayName: "Team Agent One",
-        visibility: "organization",
-        runtime: { health: "ready", blockers: [] },
-      },
-    ],
-    blockers: [],
-  });
-  teamAgentMocks.putTeamAgentAssignment.mockResolvedValue({
-    teamAgent: {
-      agentUuid: "team-agent-1",
-      agent: { uuid: "team-agent-1", name: "team-agent", displayName: "Team Agent One" },
     },
   });
   setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(capabilityFixture());
@@ -370,7 +330,6 @@ describe("Settings Setup overview", () => {
       "Your agent",
       "Code repositories",
       "Repository automation",
-      "Team Agent",
       "Context Tree",
     ]);
     expect(view.host.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
@@ -1249,6 +1208,14 @@ describe("Settings Setup overview", () => {
     await act(async () => view.root.unmount());
   });
 
+  it("redirects the retired Team Agent hash to GitHub task routing", async () => {
+    const view = await renderSettingsSetupPage("/settings/setup#team-agent");
+    await waitForText(view.host, "/settings/integrations/github#task-routing");
+
+    expect(view.host.querySelector("[data-location]")?.textContent).toBe("/settings/integrations/github#task-routing");
+    await act(async () => view.root.unmount());
+  });
+
   it("keeps Member Setup read-only without loading owner-only settings", async () => {
     authMock.value = { ...authMock.value, role: "member" };
     const view = await renderSettingsSetupPage("/settings/setup#automatic-review");
@@ -1474,89 +1441,6 @@ describe("Settings Setup overview", () => {
 
     expect(reviewerMocks.putContextReviewerAssignment).toHaveBeenCalledWith("org-1", null);
     expect(reviewerControls.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("false");
-    await act(async () => view.root.unmount());
-  });
-
-  it("keeps Team Agent configuration available without a bound Context Tree", async () => {
-    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(
-      capabilityFixture({
-        binding: { state: "unbound" },
-        review: { adoption: "unavailable", health: "not_observed", reviewerAgent: null },
-      }),
-    );
-    orgSettingsMocks.getGithubFeaturesSetting.mockResolvedValue({
-      teamAgent: { agentUuid: null, agent: null },
-    });
-
-    const view = await renderSettingsSetupPage();
-    await waitForRowText(view.host, "context-tree", "Not set up");
-    const { controls } = await openTeamAgentControls(view);
-    const agentSelect = await waitForSelector<HTMLButtonElement>(controls, '[aria-label="Team Agent"]');
-    await act(async () => agentSelect.click());
-    const option = [...document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')].find((candidate) =>
-      candidate.textContent?.includes("Team Agent One"),
-    );
-    await act(async () => option?.click());
-    await flush();
-
-    expect(contextTreeMocks.getContextTreeSnapshot).not.toHaveBeenCalled();
-    expect(reviewerMocks.getContextReviewerCandidates).not.toHaveBeenCalled();
-    expect(teamAgentMocks.getTeamAgentCandidates).toHaveBeenCalledWith("org-1");
-    expect(teamAgentMocks.putTeamAgentAssignment).toHaveBeenCalledWith("org-1", "team-agent-1");
-    expect(controls.textContent).toContain("Automatic Review does not control this delegation.");
-    await act(async () => view.root.unmount());
-  });
-
-  it("shows a deployment-operator blocker without an admin GitHub recovery link when the App slug is missing", async () => {
-    orgSettingsMocks.getGithubFeaturesSetting.mockResolvedValue({
-      teamAgent: { agentUuid: null, agent: null },
-    });
-    teamAgentMocks.getTeamAgentCandidates.mockResolvedValue({
-      items: [],
-      blockers: [
-        {
-          code: "github_app_slug_missing",
-          resolutionOwner: "operator",
-          actionKind: null,
-        },
-      ],
-    });
-
-    const view = await renderSettingsSetupPage();
-    const { controls } = await openTeamAgentControls(view);
-
-    await waitForText(
-      controls,
-      "A deployment operator must configure the GitHub App login before App-target delegation can run.",
-    );
-    expect(controls.querySelector('a[href="/settings/integrations/github"]')).toBeNull();
-    expect(controls.textContent).not.toContain("Manage GitHub");
-    expect(controls.textContent).not.toContain("Manage Team Agents");
-    await act(async () => view.root.unmount());
-  });
-
-  it("shows the App comment permission upgrade on the independent Team Agent control", async () => {
-    orgSettingsMocks.getGithubFeaturesSetting.mockResolvedValue({
-      teamAgent: { agentUuid: null, agent: null },
-    });
-    teamAgentMocks.getTeamAgentCandidates.mockResolvedValue({
-      items: [],
-      blockers: [
-        {
-          code: "github_app_task_reply_permission_required",
-          resolutionOwner: "admin",
-          actionKind: "manage_github_installation",
-        },
-      ],
-    });
-
-    const view = await renderSettingsSetupPage();
-    const { controls } = await openTeamAgentControls(view);
-    await waitForText(
-      controls,
-      "The GitHub App installation must grant Issues and Pull requests write access for App-authored task replies.",
-    );
-    expect(controls.querySelector('a[href="/settings/integrations/github"]')).not.toBeNull();
     await act(async () => view.root.unmount());
   });
 

--- a/packages/web/src/pages/settings/github-task-agent-controls.tsx
+++ b/packages/web/src/pages/settings/github-task-agent-controls.tsx
@@ -11,7 +11,7 @@ import { useAuth } from "../../auth/auth-context.js";
 import { Select } from "../../components/ui/select.js";
 import { setupBlockerCopy } from "./setup-blocker-copy.js";
 
-export function SetupTeamAgentControls({
+export function GithubTaskAgentControls({
   loadSetting = getGithubFeaturesSetting,
   loadCandidates = getTeamAgentCandidates,
   assignTeamAgent = putTeamAgentAssignment,
@@ -29,7 +29,7 @@ export function SetupTeamAgentControls({
     queryKey: ["team-agent", "setting", organizationId],
     queryFn: () =>
       organizationId ? loadSetting(organizationId) : Promise.reject(new Error("organization not loaded")),
-    enabled: isAdmin && !!organizationId,
+    enabled: (role === "admin" || role === "member") && !!organizationId,
   });
   const candidatesQuery = useQuery({
     queryKey: ["team-agent", "candidates", organizationId],
@@ -59,7 +59,29 @@ export function SetupTeamAgentControls({
     },
   });
 
-  if (!isAdmin) return null;
+  if (!isAdmin) {
+    const projectedAgent = settingQuery.data?.teamAgent.agent ?? null;
+    return (
+      <div
+        data-github-task-agent-controls="read-only"
+        className="flex flex-col"
+        style={{ gap: "var(--sp-1)", paddingTop: "var(--sp-3)" }}
+      >
+        <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          GitHub Task Agent
+        </span>
+        <span className="text-label" style={{ color: "var(--fg-3)" }}>
+          {settingQuery.isLoading
+            ? "Loading configured Agent…"
+            : settingQuery.error
+              ? "First Tree could not load the configured Agent."
+              : projectedAgent
+                ? `${projectedAgent.displayName} handles GitHub App mentions and assignments outside the Context Tree repository.`
+                : "Not configured. An admin can choose the Agent that handles GitHub App mentions and assignments outside the Context Tree repository."}
+        </span>
+      </div>
+    );
+  }
 
   const candidates = candidatesQuery.data?.items ?? [];
   const selectedCandidate = candidates.find((candidate) => candidate.uuid === selectedAgentUuid) ?? null;
@@ -70,7 +92,7 @@ export function SetupTeamAgentControls({
   const options = [
     {
       value: "",
-      label: selectedAgentUuid ? "No Team Agent selected" : "Select an eligible Team Agent",
+      label: selectedAgentUuid ? "No GitHub Task Agent selected" : "Select an eligible Agent",
       disabled: !selectedAgentUuid,
     },
     ...candidates.map((candidate) => ({
@@ -91,7 +113,7 @@ export function SetupTeamAgentControls({
 
   return (
     <div
-      data-setup-owner-controls="team-agent"
+      data-github-task-agent-controls="admin"
       className="flex flex-col"
       style={{
         gap: "var(--sp-3)",
@@ -103,7 +125,7 @@ export function SetupTeamAgentControls({
     >
       <div>
         <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
-          Team Agent
+          GitHub Task Agent
         </span>
         <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
           {selectedLabel
@@ -122,8 +144,12 @@ export function SetupTeamAgentControls({
           {manageGithubInstallation ? (
             <>
               {" "}
-              <Link to="/settings/integrations/github" className="font-medium" style={{ color: "var(--fg-2)" }}>
-                Manage GitHub
+              <Link
+                to="/settings/integrations/github#connection"
+                className="font-medium"
+                style={{ color: "var(--fg-2)" }}
+              >
+                Review connection
               </Link>
             </>
           ) : !appSlugMissing ? (
@@ -138,7 +164,7 @@ export function SetupTeamAgentControls({
       ) : (
         <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
           <Select
-            aria-label="Team Agent"
+            aria-label="GitHub Task Agent"
             value={selectedAgentUuid ?? ""}
             onChange={(agentUuid) => {
               const next = agentUuid || null;
@@ -147,11 +173,11 @@ export function SetupTeamAgentControls({
             }}
             disabled={assignmentMutation.isPending}
             options={options}
-            placeholder="Select an eligible Team Agent"
+            placeholder="Select an eligible Agent"
             searchable={candidates.length > 6}
           />
           <div className="text-caption" style={{ color: "var(--fg-4)" }}>
-            The Team Agent and Context Reviewer must be different Agents. Automatic Review does not control this
+            The GitHub Task Agent and Context Reviewer must be different Agents. Automatic Review does not control this
             delegation.
           </div>
         </div>
@@ -176,7 +202,7 @@ function teamAgentMutationError(error: unknown): string {
     const code = setupBlockerCodeSchema.safeParse(error.code);
     if (code.success) return setupBlockerCopy(code.data);
   }
-  return error instanceof Error ? error.message : "Failed to update Team Agent";
+  return error instanceof Error ? error.message : "Failed to update GitHub Task Agent";
 }
 
 function runtimeLabel(health: "not_observed" | "pending_verification" | "ready" | "degraded" | "unavailable"): string {

--- a/packages/web/src/pages/settings/github.tsx
+++ b/packages/web/src/pages/settings/github.tsx
@@ -1,11 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, Check } from "lucide-react";
-import { Link, useSearchParams } from "react-router";
+import { useEffect, useRef } from "react";
+import { Link, useLocation, useSearchParams } from "react-router";
 import { getGithubAppInstallation } from "../../api/github-app.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
 import { GithubAppInstallationPanel } from "../github-app-installation-panel.js";
+import { GithubTaskAgentControls } from "./github-task-agent-controls.js";
+
+const CONNECTION_HASH = "#connection";
+const TASK_ROUTING_HASH = "#task-routing";
 
 /**
  * Settings → Integrations → GitHub. Members can read the team's GitHub
@@ -22,8 +27,26 @@ import { GithubAppInstallationPanel } from "../github-app-installation-panel.js"
  */
 export function SettingsGithubPage() {
   const { role, organizationId } = useAuth();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
   const fromContext = searchParams.get("from") === "context";
+  const connectionRef = useRef<HTMLElement>(null);
+  const taskRoutingRef = useRef<HTMLElement>(null);
+
+  // React Router updates the fragment but not the app shell's persistent
+  // overflow container. Position and focus the requested GitHub section.
+  useEffect(() => {
+    if (role === null) return;
+    const target =
+      location.hash === CONNECTION_HASH
+        ? connectionRef.current
+        : location.hash === TASK_ROUTING_HASH
+          ? taskRoutingRef.current
+          : null;
+    if (!target) return;
+    target.scrollIntoView({ block: "start" });
+    target.focus({ preventScroll: true });
+  }, [location.hash, role]);
 
   // Only needed to drive the "back to building" return for the Context round
   // trip. Shares the query key the connection panel invalidates on connect, so
@@ -48,9 +71,31 @@ export function SettingsGithubPage() {
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-5)", padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
       {fromContext ? <ContextReturn connected={connected} /> : null}
-      <Section title="Connection">
-        <GithubAppInstallationPanel readOnly={!isAdmin} />
-      </Section>
+      <section
+        ref={connectionRef}
+        id={CONNECTION_HASH.slice(1)}
+        tabIndex={-1}
+        aria-label="GitHub connection"
+        style={{ scrollMarginTop: "var(--sp-4)" }}
+      >
+        <Section title="Connection">
+          <GithubAppInstallationPanel readOnly={!isAdmin} />
+        </Section>
+      </section>
+      <section
+        ref={taskRoutingRef}
+        id={TASK_ROUTING_HASH.slice(1)}
+        tabIndex={-1}
+        aria-label="GitHub task routing"
+        style={{ scrollMarginTop: "var(--sp-4)" }}
+      >
+        <Section
+          title="Task routing"
+          description="Choose who handles requests sent directly to the First Tree GitHub App."
+        >
+          <GithubTaskAgentControls />
+        </Section>
+      </section>
     </div>
   );
 }

--- a/packages/web/src/pages/settings/integrations.tsx
+++ b/packages/web/src/pages/settings/integrations.tsx
@@ -22,18 +22,10 @@ export function SettingsIntegrationsLayout() {
 
   return (
     <div>
-      <div style={{ padding: "var(--sp-2) var(--sp-5) 0" }}>
-        <h2 className="text-title font-semibold m-0" style={{ color: "var(--fg)" }}>
-          Connections
-        </h2>
-        <p className="text-label m-0" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
-          Connect providers for webhooks, identity, and event routing.
-        </p>
-      </div>
       <nav
-        aria-label="Connection provider"
+        aria-label="Git provider"
         className="flex"
-        style={{ gap: "var(--sp-1)", padding: "var(--sp-3) var(--sp-5) 0", overflowX: "auto" }}
+        style={{ gap: "var(--sp-1)", padding: "var(--sp-2) var(--sp-5) 0", overflowX: "auto" }}
       >
         {PROVIDERS.map((provider) => (
           <NavLink

--- a/packages/web/src/pages/settings/setup-blocker-copy.ts
+++ b/packages/web/src/pages/settings/setup-blocker-copy.ts
@@ -30,7 +30,7 @@ const SETUP_BLOCKER_COPY = {
     "The configured reviewer needs a supported runtime on a usable Computer owned by its manager.",
   context_review_agent_runtime_unavailable: "The configured reviewer's runtime is currently unavailable.",
   context_review_state_changed: "Reviewer settings changed while this request was in progress.",
-  team_agent_conflicts_context_reviewer: "The Team Agent and Context Reviewer must be different Agents.",
+  team_agent_conflicts_context_reviewer: "The GitHub Task Agent and Context Reviewer must be different Agents.",
 } satisfies Record<SetupBlockerCode, string>;
 
 export function setupBlockerCopy(code: SetupBlockerCode): string {

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -42,7 +42,6 @@ import { ContextPersonalAccess } from "./context-enablement.js";
 import { setupBlockerCopy } from "./setup-blocker-copy.js";
 import { SetupContextTreeControls } from "./setup-context-tree-controls.js";
 import { SetupReviewerControls } from "./setup-reviewer-controls.js";
-import { SetupTeamAgentControls } from "./setup-team-agent-controls.js";
 
 type Fact<T> =
   | { state: "loading" }
@@ -85,7 +84,7 @@ export type SetupFacts = {
 };
 
 export type SetupRowModel = {
-  key: "work-access" | "computer" | "agent" | "repositories" | "repository-automation" | "team-agent" | "context-tree";
+  key: "work-access" | "computer" | "agent" | "repositories" | "repository-automation" | "context-tree";
   title: string;
   description: string;
   icon: LucideIcon;
@@ -97,7 +96,7 @@ export type SetupRowModel = {
   action?: {
     label: string;
     to: string;
-    intent?: "resume-onboarding" | "open-context-tree-controls" | "open-team-agent-controls";
+    intent?: "resume-onboarding" | "open-context-tree-controls";
   };
 };
 
@@ -183,7 +182,7 @@ const ACTION_DESTINATIONS = {
   open_agent_owner_flow: "/team",
   manage_review_agent: "/settings/setup#context-tree",
   configure_github_app: "/settings/integrations/github",
-  select_team_agent: "/settings/setup#team-agent",
+  select_team_agent: "/settings/integrations/github#task-routing",
 } satisfies Record<SetupActionKind, string>;
 
 const ACTION_LABELS = {
@@ -198,7 +197,7 @@ const ACTION_LABELS = {
   open_agent_owner_flow: "Manage agents",
   manage_review_agent: "Manage reviewer",
   configure_github_app: "Configure GitHub App",
-  select_team_agent: "Choose Team Agent",
+  select_team_agent: "Choose GitHub Task Agent",
 } satisfies Record<SetupActionKind, string>;
 
 function blockerDetail(blockers: SetupBlocker[], isAdmin: boolean): string | undefined {
@@ -650,20 +649,6 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
       action: capabilities ? providerAction(capabilities.repositoryAutomation.providers, isAdmin) : undefined,
     },
     {
-      key: "team-agent",
-      title: "Team Agent",
-      description: "Handles GitHub App requests outside the Context Tree repository.",
-      icon: Bot,
-      status: {
-        label: "Optional",
-        detail: "Configured independently from Context Review",
-        kind: "optional",
-      },
-      action: isAdmin
-        ? { label: "Manage", to: "/settings/setup#team-agent", intent: "open-team-agent-controls" }
-        : undefined,
-    },
-    {
       key: "context-tree",
       title: "Context Tree",
       description: "Shared decisions and constraints available to agents.",
@@ -796,6 +781,12 @@ export function SettingsSetupPage() {
     expandedOwnerControl?.organizationId === organizationId ? expandedOwnerControl.key : null;
 
   useEffect(() => {
+    if (location.hash === "#team-agent") {
+      navigate("/settings/integrations/github#task-routing", { replace: true });
+    }
+  }, [location.hash, navigate]);
+
+  useEffect(() => {
     if (previousOrganizationId.current !== null && previousOrganizationId.current !== organizationId) {
       setExpandedOwnerControl(null);
       handledOwnerHash.current = null;
@@ -804,12 +795,7 @@ export function SettingsSetupPage() {
   }, [organizationId]);
 
   useEffect(() => {
-    const key =
-      location.hash === "#context-tree" || location.hash === "#automatic-review"
-        ? "context-tree"
-        : location.hash === "#team-agent"
-          ? "team-agent"
-          : null;
+    const key = location.hash === "#context-tree" || location.hash === "#automatic-review" ? "context-tree" : null;
     if (!key || !organizationId || facts.capabilities.state !== "ready") return;
 
     const hashKey = `${organizationId}:${location.hash}`;
@@ -821,12 +807,7 @@ export function SettingsSetupPage() {
   }, [facts.capabilities.state, location.hash, organizationId, personalContextAccessReady, role]);
 
   useEffect(() => {
-    const key =
-      location.hash === "#context-tree" || location.hash === "#automatic-review"
-        ? "context-tree"
-        : location.hash === "#team-agent"
-          ? "team-agent"
-          : null;
+    const key = location.hash === "#context-tree" || location.hash === "#automatic-review" ? "context-tree" : null;
     if (!key || facts.capabilities.state !== "ready") return;
     const canOpenForHash = role === "admin" || (location.hash === "#context-tree" && personalContextAccessReady);
     if (canOpenForHash && expandedOwnerControlKey !== key) return;
@@ -840,11 +821,6 @@ export function SettingsSetupPage() {
     facts.capabilities.state !== "ready"
       ? {}
       : {
-          ...(expandedOwnerControlKey === "team-agent"
-            ? {
-                "team-agent": <SetupTeamAgentControls key={`team-agent-${organizationId}`} />,
-              }
-            : {}),
           ...(expandedOwnerControlKey === "context-tree" && contextTree.state === "ready"
             ? {
                 "context-tree":
@@ -1067,8 +1043,7 @@ function SetupRow({
         className={cn("flex", !narrow && "justify-end")}
         style={narrow ? { paddingLeft: "var(--sp-11)" } : undefined}
       >
-        {(row.action?.intent === "open-context-tree-controls" || row.action?.intent === "open-team-agent-controls") &&
-        onToggleOwnerControl ? (
+        {row.action?.intent === "open-context-tree-controls" && onToggleOwnerControl ? (
           <button
             type="button"
             aria-expanded={Boolean(ownerControl)}

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -642,8 +642,8 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
     },
     {
       key: "repository-automation",
-      title: "Repository automation",
-      description: "GitHub or GitLab connections for events, identity, and webhooks.",
+      title: "GitHub & GitLab",
+      description: "Repository events, identity, and GitHub task routing.",
       icon: Webhook,
       status: repositoryAutomationStatus,
       action: capabilities ? providerAction(capabilities.repositoryAutomation.providers, isAdmin) : undefined,


### PR DESCRIPTION
## Summary

- rename the GitHub App request-routing role from **Team Agent** to **GitHub Task Agent** in product-facing copy
- move its assignment control out of the standalone Settings → Setup capability list and into Settings → GitHub & GitLab → GitHub → Task routing, immediately after Connection
- rename the persistent Settings navigation entry from **Integrations** to **GitHub & GitLab**, while retaining separate GitHub and GitLab provider tabs
- replace generic provider copy on that page with a direct GitHub/GitLab lead, explicitly scope task routing to GitHub, and remove the redundant **Connections** heading/description above the provider tabs
- rename the remaining Setup provider summary from **Repository automation** to **GitHub & GitLab**, with copy that explicitly limits task routing to GitHub
- preserve member read-only visibility, admin-only assignment, the independent Context Reviewer constraint, and all existing internal API/storage/event identifiers
- redirect the retired `/settings/setup#team-agent` entry and explicitly scroll/focus both GitHub section anchors in the persistent Settings shell
- update deterministic tests and the cross-surface GitHub routing QA case for the new name and location

## Compatibility

The stable implementation contracts remain unchanged, including `/team-agent`, `teamAgent`, `teamAgentTask`, and generic team-visible agent terminology. The technical `/settings/integrations/*` route also remains stable. This is a product-language and information-architecture change, not a storage or API migration.

## Validation

- `pnpm check` — passed (repository-existing warnings only)
- `pnpm typecheck` — 11/11 tasks passed
- focused Web Settings tests — 69/69 passed
- focused Web preview/API tests — 14/14 passed
- focused Server routing/settings tests — 143/143 passed
- latest Settings navigation/provider focused tests — 34/34 passed
- latest Web typecheck and design-token guardrails — passed
- browser QA at `/preview/settings-github` — verified Connection → Task routing hierarchy and Agent selection state
- browser QA at `/preview/setup` — verified the GitHub & GitLab summary, GitHub-specific task-routing copy, status, and destination
- two independent code reviews completed; findings were repaired and re-reviewed

The latest full Web test attempt passed 217 files and 1,874 tests; one unrelated existing navigation-lock test failed its waiting-state timeout and reproduced when run alone:

- `src/components/chat/__tests__/ask-agent-nav-lock.test.tsx`

That failure was a date-sensitive test fixture rather than a runtime regression: its fixed July 28 message timestamp aged past the production 45-second timeout. The isolated test-only fix is in https://github.com/agent-team-foundation/first-tree/pull/2092.

An earlier full `pnpm test` run also encountered two unrelated timing/focus flakes outside this change and stopped through Turbo:

- `chat-components-extra.test.tsx` focus preservation
- `context-policy-runtime-layout.test.ts` build hook timeout

Both earlier affected files passed when rerun independently (26/26 and 5/5 respectively).

## Context Tree

- paired draft: https://github.com/agent-team-foundation/first-tree-context/pull/858
- the Tree PR records both the persistent **GitHub & GitLab** navigation label and the GitHub-only Task Agent boundary
- the Tree PR remains draft until this source PR lands
