### PR TITLE
test(web): make Ask Agent timeout fixture relative

### DIFF
--- a/packages/web/src/components/chat/__tests__/ask-agent-nav-lock.test.tsx
+++ b/packages/web/src/components/chat/__tests__/ask-agent-nav-lock.test.tsx
@@ -395,19 +395,20 @@ function AskAgentProbe() {
 
 describe("useAskAgent navigation lock publishing", () => {
   it("locks while a clarification awaits a reply and unlocks when the reply lands", async () => {
+    const startedAt = Date.now();
     const clarification = message({
       id: "clarification-1",
       senderId: "human-1",
       inReplyTo: "req-1",
       metadata: { askAgent: { requestId: "req-1", agentId: "agent-1" } },
-      createdAt: "2026-07-28T10:01:00.000Z",
+      createdAt: new Date(startedAt).toISOString(),
     });
     const reply = message({
       id: "reply-1",
       senderId: "agent-1",
       inReplyTo: clarification.id,
       content: "The migration keeps the old API compatible.",
-      createdAt: "2026-07-28T10:02:00.000Z",
+      createdAt: new Date(startedAt + 1_000).toISOString(),
     });
     chatMocks.listRequestThread.mockResolvedValue({ items: [clarification] });
     agentStatusMocks.fetchChatAgentStatuses.mockResolvedValue([]);


### PR DESCRIPTION
## Summary

- replace the Ask Agent navigation-lock test's fixed July 28 timestamps with timestamps relative to the test start
- keep the production 45-second reply timeout unchanged

## Why

The test fixture became older than the production timeout window on July 30. The hook therefore failed the pending attempt immediately, making the test deterministically fail both locally and in CI even though the navigation-lock behavior had not regressed.

## Validation

- `pnpm --filter @first-tree/web exec vitest run src/components/chat/__tests__/ask-agent-nav-lock.test.tsx` — 7/7 passed
- `pnpm --filter @first-tree/web typecheck` — passed
- design-token guardrails — passed

This is test-only and does not change runtime behavior.
