### PR TITLE
Keep chat composer stable during open-request checks

### DIFF
--- a/packages/web/src/lib/__tests__/use-chat-draft-text.test.tsx
+++ b/packages/web/src/lib/__tests__/use-chat-draft-text.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
-import { act } from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, type Dispatch, type SetStateAction, useLayoutEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDomHarness, type DomHarness } from "../../test-utils/dom-harness.js";
 import { chatDraftScope, loadDraft, saveDraft } from "../draft-store.js";
 import { useChatDraftText } from "../use-chat-draft-text.js";
@@ -18,8 +18,24 @@ afterEach(() => h.cleanup());
  *  it with a changing `chatId` / `userId` (same element type at the root)
  *  reconciles in place — it does NOT remount — which is exactly how ChatView
  *  switches chats (and how a re-login swaps the user without a fresh mount). */
-function Probe({ userId = "user-1", chatId }: { userId?: string; chatId: string }) {
+function Probe({
+  userId = "user-1",
+  chatId,
+  onCommit,
+  onSetter,
+}: {
+  userId?: string;
+  chatId: string;
+  onCommit?: (value: { chatId: string; draft: string }) => void;
+  onSetter?: (value: { chatId: string; setDraft: Dispatch<SetStateAction<string>> }) => void;
+}) {
   const [draft, setDraft] = useChatDraftText(userId, chatId);
+  useLayoutEffect(() => {
+    onCommit?.({ chatId, draft });
+  }, [chatId, draft, onCommit]);
+  useLayoutEffect(() => {
+    onSetter?.({ chatId, setDraft });
+  }, [chatId, onSetter, setDraft]);
   return (
     <div>
       <span data-testid="draft">{draft}</span>
@@ -77,6 +93,64 @@ describe("useChatDraftText", () => {
     h.render(<Probe chatId="chat-a" />);
     await h.flush();
     expect(draftText()).toBe("body-chat-a");
+  });
+
+  it("never commits the previous scope while switching between distinct stored drafts", async () => {
+    const chatAScope = chatDraftScope("user-1", "chat-a");
+    const chatBScope = chatDraftScope("user-1", "chat-b");
+    saveDraft(chatAScope, { text: "draft-a" });
+    saveDraft(chatBScope, { text: "draft-b" });
+    const setItem = vi.spyOn(window.localStorage, "setItem");
+    const commits: Array<{ chatId: string; draft: string }> = [];
+    const recordCommit = (value: { chatId: string; draft: string }) => commits.push(value);
+
+    h.render(<Probe chatId="chat-a" onCommit={recordCommit} />);
+    await h.flush();
+    commits.length = 0;
+    setItem.mockClear();
+
+    // Layout effects observe every committed render before passive effects.
+    // The first chat-b commit must already be scoped to chat-b: chat-a's value
+    // may never reach the newly exposed composer, even transiently.
+    h.render(<Probe chatId="chat-b" onCommit={recordCommit} />);
+    await h.flush();
+    expect(commits).toEqual([{ chatId: "chat-b", draft: "draft-b" }]);
+    // Switching scopes is read-only: in particular, there can be no
+    // transient write of chat-a's value under chat-b before effects settle.
+    expect(setItem).not.toHaveBeenCalled();
+    expect(loadDraft(chatAScope)?.text).toBe("draft-a");
+    expect(loadDraft(chatBScope)?.text).toBe("draft-b");
+  });
+
+  it("routes a stale setter to its original scope after a chat switch", async () => {
+    const chatAScope = chatDraftScope("user-1", "chat-a");
+    const chatBScope = chatDraftScope("user-1", "chat-b");
+    saveDraft(chatAScope, { text: "draft-a" });
+    saveDraft(chatBScope, { text: "draft-b" });
+    const setters = new Map<string, Dispatch<SetStateAction<string>>>();
+    const recordSetter = ({ chatId, setDraft }: { chatId: string; setDraft: Dispatch<SetStateAction<string>> }) => {
+      setters.set(chatId, setDraft);
+    };
+
+    h.render(<Probe chatId="chat-a" onSetter={recordSetter} />);
+    await h.flush();
+    h.render(<Probe chatId="chat-b" onSetter={recordSetter} />);
+    await h.flush();
+
+    // A stale functional update reads chat-a's own stored value, never chat-b's
+    // live value, and remains invisible in the current composer.
+    act(() => setters.get("chat-a")?.((current) => `${current}-updated`));
+
+    expect(draftText()).toBe("draft-b");
+    expect(loadDraft(chatAScope)?.text).toBe("draft-a-updated");
+    expect(loadDraft(chatBScope)?.text).toBe("draft-b");
+
+    // Mirrors an async send from chat-a settling after chat-b has committed.
+    act(() => setters.get("chat-a")?.(""));
+
+    expect(draftText()).toBe("draft-b");
+    expect(loadDraft(chatAScope)).toBeNull();
+    expect(loadDraft(chatBScope)?.text).toBe("draft-b");
   });
 
   it("does not leak a draft across users on the same chat", async () => {

--- a/packages/web/src/lib/use-chat-draft-text.ts
+++ b/packages/web/src/lib/use-chat-draft-text.ts
@@ -1,5 +1,14 @@
-import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useLayoutEffect, useRef, useState } from "react";
 import { chatDraftScope, loadDraft, saveDraft } from "./draft-store.js";
+
+type ScopedDraft = {
+  scope: string;
+  text: string;
+};
+
+function loadScopedDraft(scope: string): ScopedDraft {
+  return { scope, text: loadDraft(scope)?.text ?? "" };
+}
 
 /**
  * In-chat composer draft text, persisted per user + chat in browser-local
@@ -19,21 +28,42 @@ import { chatDraftScope, loadDraft, saveDraft } from "./draft-store.js";
  */
 export function useChatDraftText(userId: string | null, chatId: string): [string, Dispatch<SetStateAction<string>>] {
   const scope = chatDraftScope(userId, chatId);
-  const [draft, setDraft] = useState<string>(() => loadDraft(scope)?.text ?? "");
-  // The scope the current `draft` value belongs to. Lets the persist effect
-  // write under the right scope and detect a switch (the scope changes a
-  // render before the state catches up).
-  const scopeRef = useRef(scope);
+  const [storedDraft, setStoredDraft] = useState<ScopedDraft>(() => loadScopedDraft(scope));
+  const draft = storedDraft.scope === scope ? storedDraft : loadScopedDraft(scope);
+  const committedDraftRef = useRef(draft);
 
-  useEffect(() => {
-    if (scopeRef.current === scope) return;
-    scopeRef.current = scope;
-    setDraft(loadDraft(scope)?.text ?? "");
-  }, [scope]);
+  // ChatView is reconciled in place when chatId changes. Adjust the tagged
+  // state during render so React restarts this component before committing its
+  // children; the previous chat's draft is never exposed under the new scope.
+  if (draft !== storedDraft) {
+    setStoredDraft(draft);
+  }
 
-  useEffect(() => {
-    saveDraft(scopeRef.current, { text: draft });
+  // A concurrent render may be abandoned. Only a committed render may change
+  // which scope a setter is allowed to expose in the live composer.
+  useLayoutEffect(() => {
+    committedDraftRef.current = draft;
   }, [draft]);
 
-  return [draft, setDraft];
+  const setDraft = useCallback<Dispatch<SetStateAction<string>>>(
+    (next) => {
+      const committedDraft = committedDraftRef.current;
+      const currentText = committedDraft.scope === scope ? committedDraft.text : (loadDraft(scope)?.text ?? "");
+      const nextText = typeof next === "function" ? next(currentText) : next;
+      if (nextText === currentText) return;
+
+      // A send started in one chat may settle after ChatView has switched to
+      // another. Persist through the setter's captured scope, then update live
+      // state only while that scope is still active.
+      saveDraft(scope, { text: nextText });
+      if (committedDraftRef.current.scope !== scope) return;
+
+      const nextDraft = { scope, text: nextText };
+      committedDraftRef.current = nextDraft;
+      setStoredDraft(nextDraft);
+    },
+    [scope],
+  );
+
+  return [draft.text, setDraft];
 }

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1196,12 +1196,13 @@ describe("page SSR smoke coverage", () => {
   it("renders ChatView alternate chrome, composer, and recovery states", async () => {
     const { ChatView } = await import("../workspace/center/chat-view.js");
 
-    // SSR/initial paint: no mount-scope open-request fetch has completed, so
-    // the composer fail-closes into the checking state until the client
-    // confirms the chat's open-request snapshot.
-    expect(renderWithClient(<ChatView agentId="agent-1" chatId="chat-1" />, createClient())).toContain(
-      "Checking for open questions…",
-    );
+    // SSR/initial paint: no mount-scope open-request fetch has completed.
+    // Keep the stable draft surface visible, while the send control remains
+    // fail-closed until the client confirms the chat's snapshot.
+    const pendingHtml = renderWithClient(<ChatView agentId="agent-1" chatId="chat-1" />, createClient());
+    expect(pendingHtml).toContain("<textarea");
+    expect(pendingHtml).toContain('aria-label="Checking for open questions"');
+    expect(pendingHtml).not.toContain("Checking for open questions…");
 
     const readOnlyClient = createClient();
     expect(

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -2572,14 +2572,21 @@ describe("ChatView", () => {
       "/?showAsk=false",
     );
 
-    // Pending: no ordinary composer, no reopen affordance — fail closed.
-    expect(container.querySelector("textarea")).toBeNull();
+    // Pending: the stable composer remains editable, but sending stays
+    // fail-closed until this viewing has a fresh open-request snapshot.
+    const pendingTextarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!pendingTextarea) throw new Error("Composer textarea missing");
     expect(container.querySelector("[data-inspect-ask-composer]")).toBeNull();
-    await waitForText(container, "Checking for open questions…");
+    await setValue(pendingTextarea, "Draft while questions load");
+    expect(pendingTextarea.value).toBe("Draft while questions load");
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Checking for open questions"]')?.disabled,
+    ).toBe(true);
+    expect(container.textContent).not.toContain("Checking for open questions");
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
     // The query confirms the still-open request: the reopen affordance
-    // replaces the pending panel; the ordinary composer stays hidden.
+    // takes over the stable composer.
     await act(async () => {
       resolveOpenRequests({ items: [buriedAsk] });
     });
@@ -2591,7 +2598,7 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
-  it("shows a retryable error instead of the ordinary composer when the open-requests source fails", async () => {
+  it("keeps the ordinary composer and shows a compact retry when the open-requests source fails", async () => {
     const { ChatView } = await import("../chat-view.js");
     chatMocks.listChatOpenRequests.mockRejectedValue(new Error("open requests unavailable"));
 
@@ -2601,19 +2608,27 @@ describe("ChatView", () => {
       "/?showAsk=false",
     );
 
-    // Failed: no ordinary composer either — an understandable recovery path.
+    // Failed: the draft surface stays stable, while the send gate and compact
+    // recovery row explain why this chat cannot send yet.
     await waitForText(container, "Couldn’t check for open questions.");
-    expect(container.querySelector("textarea")).toBeNull();
+    const failedTextarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!failedTextarea) throw new Error("Composer textarea missing");
+    await setValue(failedTextarea, "Keep this draft while retrying");
+    expect(container.querySelector("[data-open-requests-error]")).not.toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Send unavailable — couldn’t check for open questions"]',
+      )?.disabled,
+    ).toBe(true);
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
-    // Retry succeeds with a CONFIRMED zero: only now may the ordinary
-    // composer return.
+    // Retry succeeds with a CONFIRMED zero: the recovery row clears and the
+    // stable composer remains in place.
     chatMocks.listChatOpenRequests.mockResolvedValue({ items: [] });
     await click(buttonByText(container, "Retry"));
-    await waitForCondition(
-      () => container.querySelector("textarea") !== null,
-      "ordinary composer after confirmed zero",
-    );
+    await waitForCondition(() => container.querySelector("[data-open-requests-error]") === null, "retry row to clear");
+    expect(container.querySelector("textarea")).toBe(failedTextarea);
+    expect(failedTextarea.value).toBe("Keep this draft while retrying");
 
     await act(async () => root.unmount());
   });
@@ -2652,10 +2667,14 @@ describe("ChatView", () => {
       "/?showAsk=false",
     );
 
-    // Stale cached zero must NOT restore the ordinary composer.
-    expect(container.querySelector("textarea")).toBeNull();
+    // Stale cached zero may render the stable draft surface, but must NOT
+    // enable ordinary sending before this viewing confirms the snapshot.
+    expect(container.querySelector("textarea")).not.toBeNull();
     expect(container.querySelector("[data-inspect-ask-composer]")).toBeNull();
-    await waitForText(container, "Checking for open questions…");
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Checking for open questions"]')?.disabled,
+    ).toBe(true);
+    expect(container.textContent).not.toContain("Checking for open questions");
     expect(chatMocks.listChatOpenRequests).toHaveBeenCalled();
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
@@ -2687,18 +2706,17 @@ describe("ChatView", () => {
     );
 
     // The mount refetch fails while the stale cached zero keeps status
-    // "success": still no ordinary composer — a retryable error instead.
+    // "success": the draft surface stays mounted, with a retryable error.
     await waitForText(container, "Couldn’t check for open questions.");
-    expect(container.querySelector("textarea")).toBeNull();
+    expect(container.querySelector("textarea")).not.toBeNull();
+    expect(container.querySelector("[data-open-requests-error]")).not.toBeNull();
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
-    // Retry confirms a fresh zero in this mount: the composer may return.
+    // Retry confirms a fresh zero in this mount: the recovery row clears.
     chatMocks.listChatOpenRequests.mockResolvedValue({ items: [] });
     await click(buttonByText(container, "Retry"));
-    await waitForCondition(
-      () => container.querySelector("textarea") !== null,
-      "ordinary composer after mount-confirmed zero",
-    );
+    await waitForCondition(() => container.querySelector("[data-open-requests-error]") === null, "retry row to clear");
+    expect(container.querySelector("textarea")).not.toBeNull();
 
     await act(async () => root.unmount());
   });
@@ -2730,8 +2748,17 @@ describe("ChatView", () => {
       "/",
     );
 
-    expect(container.querySelector("textarea")).toBeNull();
-    await waitForText(container, "Checking for open questions…");
+    const pendingTextarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!pendingTextarea) throw new Error("Composer textarea missing");
+    await setValue(pendingTextarea, "Draft before the request arrives @nova");
+    expect(pendingTextarea.value).toBe("Draft before the request arrives @nova");
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Checking for open questions"]')?.disabled,
+    ).toBe(true);
+    expect(container.textContent).not.toContain("Checking for open questions");
+    await act(async () => {
+      pendingTextarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    });
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
     // The query lands with the still-open request: the blocking takeover
@@ -2759,16 +2786,16 @@ describe("ChatView", () => {
     );
 
     await waitForText(container, "Couldn’t check for open questions.");
-    expect(container.querySelector("textarea")).toBeNull();
+    expect(container.querySelector("textarea")).not.toBeNull();
+    expect(container.querySelector("[data-open-requests-error]")).not.toBeNull();
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
-    // Retry confirms a fresh zero in this mount: the composer may return.
+    // Retry confirms a fresh zero in this mount: the recovery row clears
+    // without swapping the composer.
     chatMocks.listChatOpenRequests.mockResolvedValue({ items: [] });
     await click(buttonByText(container, "Retry"));
-    await waitForCondition(
-      () => container.querySelector("textarea") !== null,
-      "ordinary composer after mount-confirmed zero on the normal route",
-    );
+    await waitForCondition(() => container.querySelector("[data-open-requests-error]") === null, "retry row to clear");
+    expect(container.querySelector("textarea")).not.toBeNull();
 
     await act(async () => root.unmount());
   });
@@ -2806,8 +2833,11 @@ describe("ChatView", () => {
       "/",
     );
 
-    expect(container.querySelector("textarea")).toBeNull();
-    await waitForText(container, "Checking for open questions…");
+    expect(container.querySelector("textarea")).not.toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Checking for open questions"]')?.disabled,
+    ).toBe(true);
+    expect(container.textContent).not.toContain("Checking for open questions");
     expect(chatMocks.listChatOpenRequests).toHaveBeenCalled();
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
@@ -2843,11 +2873,15 @@ describe("ChatView", () => {
       "/",
     );
 
-    // chat-1 confirms a zero: the composer appears.
+    // chat-1 confirms a zero: the stable composer stays in place and its send
+    // control leaves the verification state.
     await act(async () => {
       pendingResolvers.get("chat-1")?.({ items: [] });
     });
-    await waitForCondition(() => container.querySelector("textarea") !== null, "composer after chat-1 confirmed");
+    await waitForCondition(
+      () => container.querySelector('button[aria-label="Send"]') !== null,
+      "send control after chat-1 confirmed",
+    );
 
     // A transient poll failure AFTER the latch must not re-block the composer
     // or surface the retry panel — this viewing is already confirmed.
@@ -2860,7 +2894,7 @@ describe("ChatView", () => {
     expect(container.textContent).not.toContain("Couldn’t check for open questions.");
 
     // Switch to chat-2 WITHOUT remounting ChatView: the latch must reset, so
-    // the pending source is unverified again — no composer.
+    // the stable composer remains visible but sending is unverified again.
     deferAll();
     seedChat(queryClient, chatDetail({ id: "chat-2" }), messages([]));
     await act(async () => {
@@ -2875,15 +2909,22 @@ describe("ChatView", () => {
       );
     });
     await flush();
-    expect(container.querySelector("textarea")).toBeNull();
-    await waitForText(container, "Checking for open questions…");
+    expect(container.querySelector("textarea")).not.toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Checking for open questions"]')?.disabled,
+    ).toBe(true);
+    expect(container.textContent).not.toContain("Checking for open questions");
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
-    // chat-2 confirms: composer returns.
+    // chat-2 confirms: the stable composer stays put and the verification
+    // label lifts from the send control.
     await act(async () => {
       pendingResolvers.get("chat-2")?.({ items: [] });
     });
-    await waitForCondition(() => container.querySelector("textarea") !== null, "composer after chat-2 confirmed");
+    await waitForCondition(
+      () => container.querySelector('button[aria-label="Send"]') !== null,
+      "send control after chat-2 confirmed",
+    );
 
     // Back to chat-1 (still without remount): the earlier chat-1 latch was
     // cleared on switch, so this viewing re-verifies too.
@@ -2899,16 +2940,19 @@ describe("ChatView", () => {
       );
     });
     await flush();
-    expect(container.querySelector("textarea")).toBeNull();
+    expect(container.querySelector("textarea")).not.toBeNull();
     // chat-1's query still carries the blip's error status, so this viewing
-    // shows the retryable fail-closed error (not the neutral checking state);
+    // shows the compact retryable error while preserving the draft surface;
     // the in-flight mount refetch settles it.
     await waitForText(container, "Couldn’t check for open questions.");
 
     await act(async () => {
       pendingResolvers.get("chat-1")?.({ items: [] });
     });
-    await waitForCondition(() => container.querySelector("textarea") !== null, "composer after chat-1 re-confirmed");
+    await waitForCondition(
+      () => container.querySelector('button[aria-label="Send"]') !== null,
+      "send control after chat-1 re-confirmed",
+    );
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -7,7 +7,7 @@ import {
   encodeProviderRetryEventMessage,
 } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, type ReactElement } from "react";
+import { act, type ReactElement, useLayoutEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,6 +16,7 @@ import type { MessageWithDelivery, PaginatedMessages } from "../../../../api/cha
 import type { ChatSessionEventsResponse, SessionEventRow } from "../../../../api/sessions.js";
 import { agentSessionsQueryKey } from "../../../../api/sessions.js";
 import { ToastProvider } from "../../../../components/ui/toast.js";
+import { chatDraftScope, loadDraft, saveDraft } from "../../../../lib/draft-store.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -2866,9 +2867,21 @@ describe("ChatView", () => {
       );
     };
     deferAll();
+    saveDraft(chatDraftScope(null, "chat-1"), { text: "draft for chat one" });
+    saveDraft(chatDraftScope(null, "chat-2"), { text: "draft for chat two" });
+    const draftCommits: Array<{ chatId: string; draft: string | null }> = [];
+    function ObservedChat({ chatId }: { chatId: string }) {
+      useLayoutEffect(() => {
+        draftCommits.push({
+          chatId,
+          draft: document.querySelector<HTMLTextAreaElement>("textarea")?.value ?? null,
+        });
+      }, [chatId]);
+      return <ChatView agentId="agent-1" chatId={chatId} />;
+    }
 
     const { container, queryClient, root } = await renderDom(
-      <ChatView agentId="agent-1" chatId="chat-1" />,
+      <ObservedChat chatId="chat-1" />,
       (client) => seedChat(client, chatDetail(), messages([])),
       "/",
     );
@@ -2882,6 +2895,7 @@ describe("ChatView", () => {
       () => container.querySelector('button[aria-label="Send"]') !== null,
       "send control after chat-1 confirmed",
     );
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("draft for chat one");
 
     // A transient poll failure AFTER the latch must not re-block the composer
     // or surface the retry panel — this viewing is already confirmed.
@@ -2897,12 +2911,13 @@ describe("ChatView", () => {
     // the stable composer remains visible but sending is unverified again.
     deferAll();
     seedChat(queryClient, chatDetail({ id: "chat-2" }), messages([]));
+    draftCommits.length = 0;
     await act(async () => {
       root.render(
         <MemoryRouter initialEntries={["/"]}>
           <QueryClientProvider client={queryClient}>
             <ToastProvider>
-              <ChatView agentId="agent-1" chatId="chat-2" />
+              <ObservedChat chatId="chat-2" />
             </ToastProvider>
           </QueryClientProvider>
         </MemoryRouter>,
@@ -2914,6 +2929,10 @@ describe("ChatView", () => {
       container.querySelector<HTMLButtonElement>('button[aria-label="Checking for open questions"]')?.disabled,
     ).toBe(true);
     expect(container.textContent).not.toContain("Checking for open questions");
+    expect(draftCommits).toEqual([{ chatId: "chat-2", draft: "draft for chat two" }]);
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("draft for chat two");
+    expect(loadDraft(chatDraftScope(null, "chat-1"))?.text).toBe("draft for chat one");
+    expect(loadDraft(chatDraftScope(null, "chat-2"))?.text).toBe("draft for chat two");
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
     // chat-2 confirms: the stable composer stays put and the verification
@@ -2933,7 +2952,7 @@ describe("ChatView", () => {
         <MemoryRouter initialEntries={["/"]}>
           <QueryClientProvider client={queryClient}>
             <ToastProvider>
-              <ChatView agentId="agent-1" chatId="chat-1" />
+              <ObservedChat chatId="chat-1" />
             </ToastProvider>
           </QueryClientProvider>
         </MemoryRouter>,

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -30,7 +30,6 @@ import {
   Download,
   ExternalLink,
   Eye,
-  LoaderCircle,
   Menu,
   MessageSquare,
   PanelRight,
@@ -4283,7 +4282,7 @@ export function ChatView({
                       ? blockedComposerRef
                       : readOnly
                         ? readOnlyComposerRef
-                        : inspectAskMode || openRequestsUnverified
+                        : inspectAskMode && openRequestCount > 0
                           ? inspectComposerRef
                           : textareaRef
                   }
@@ -4386,59 +4385,6 @@ export function ChatView({
                       Open
                     </span>
                   </button>
-                ) : openRequestsUnverified ? (
-                  /* Fail-closed state, BOTH routes: the window-independent
-                     open-requests source has not confirmed this chat's state
-                     in this mount, so the ordinary composer must NOT render —
-                     a fast send would bypass a possibly still-open request.
-                     Shares the inspect composer's focus ref so
-                     ComposeStatusBar keeps a stable fallback target. */
-                  <div
-                    ref={(el) => {
-                      inspectComposerRef.current = el;
-                    }}
-                    tabIndex={-1}
-                    data-open-requests-unverified
-                    className="composer-card flex items-center"
-                    style={{
-                      gap: "var(--sp-3)",
-                      minHeight: composerMobile ? 52 : 46,
-                      padding: "var(--sp-2_5) var(--sp-3)",
-                      border: "var(--hairline) solid var(--border)",
-                      background: "var(--bg-raised)",
-                      color: "var(--fg-3)",
-                    }}
-                  >
-                    {openRequestsMountFailed ? (
-                      <>
-                        <span className="text-body flex-1" style={{ color: "var(--fg-2)" }}>
-                          Couldn’t check for open questions.
-                        </span>
-                        <button
-                          type="button"
-                          onClick={() => void openRequestsQuery.refetch()}
-                          className="text-label inline-flex shrink-0 items-center transition-colors hover:bg-[var(--bg-hover)]"
-                          style={{
-                            minHeight: 32,
-                            padding: "0 var(--sp-3)",
-                            border: "var(--hairline) solid var(--border)",
-                            borderRadius: "var(--radius-input)",
-                            background: "var(--bg-raised)",
-                            color: "var(--fg-2)",
-                          }}
-                        >
-                          Retry
-                        </button>
-                      </>
-                    ) : (
-                      <>
-                        <LoaderCircle aria-hidden className="h-4 w-4 shrink-0 animate-spin" />
-                        <span className="text-body" role="status">
-                          Checking for open questions…
-                        </span>
-                      </>
-                    )}
-                  </div>
                 ) : (
                   <>
                     {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload */}
@@ -4958,15 +4904,25 @@ export function ChatView({
                             disabled={sendDisabled}
                             aria-disabled={sendBlockedByMentionGate || undefined}
                             title={
-                              sendBlockedByMentionGate
-                                ? "@mention someone to send — a group message must address someone"
-                                : // On mobile Enter inserts a newline, so the button is
-                                  // the only way to send — don't advertise the Enter shortcut.
-                                  composerMobile
-                                  ? "Send"
-                                  : "Send (Enter)"
+                              openRequestsMountFailed
+                                ? "Couldn’t check for open questions"
+                                : openRequestsUnverified
+                                  ? "Checking for open questions"
+                                  : sendBlockedByMentionGate
+                                    ? "@mention someone to send — a group message must address someone"
+                                    : // On mobile Enter inserts a newline, so the button is
+                                      // the only way to send — don't advertise the Enter shortcut.
+                                      composerMobile
+                                      ? "Send"
+                                      : "Send (Enter)"
                             }
-                            aria-label="Send"
+                            aria-label={
+                              openRequestsMountFailed
+                                ? "Send unavailable — couldn’t check for open questions"
+                                : openRequestsUnverified
+                                  ? "Checking for open questions"
+                                  : "Send"
+                            }
                             className={cn(
                               "inline-flex items-center justify-center transition-opacity",
                               sendDimmed && "opacity-40",
@@ -4990,6 +4946,25 @@ export function ChatView({
                         </span>
                       </div>
                     </div>
+                    {openRequestsMountFailed && (
+                      <div
+                        data-open-requests-error
+                        className="flex items-center justify-between"
+                        style={{ padding: "var(--sp-1_5) var(--sp-0_5) 0" }}
+                      >
+                        <span className="mono text-label" role="status" style={{ color: "var(--fg-3)" }}>
+                          Couldn’t check for open questions.
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="xs"
+                          onClick={() => void openRequestsQuery.refetch()}
+                        >
+                          Retry
+                        </Button>
+                      </div>
+                    )}
                     {(sendMut.isError || uploadError) && (
                       <p
                         className="mono text-label"


### PR DESCRIPTION
## Summary

- keep the ordinary chat composer mounted while the open-request snapshot is loading or unavailable
- keep both the disabled send control and the mutation-boundary guard fail-closed until the snapshot is confirmed
- show a neutral inline retry row on verification failure, preserving the textarea node and draft
- retain the existing open-request takeover once a pending question is confirmed

## Testing

- `pnpm --filter @first-tree/web exec vitest run src/pages/workspace/center/__tests__/chat-view-dom.test.tsx src/pages/__tests__/page-ssr-smoke.test.tsx` (73 tests)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm check` (passes; 16 pre-existing warnings and 1 info)
- full Web suite: 218 files, 1,871 tests
- Playwright browser QA for pending, failed, and retry-success states

## Review

- independent logic review: approved after adding an Enter-key fail-closed regression
- independent UX/accessibility review: approved after aligning failure-state color and accessible naming with the design system
