### PR TITLE
feat: self-verifying BYO Team Context setup with in-session activation

### DIFF
--- a/apps/cli/src/__tests__/context-status.test.ts
+++ b/apps/cli/src/__tests__/context-status.test.ts
@@ -1,6 +1,11 @@
 import type { ContextActivationResponse } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
-import { buildContextEnableNextActions, collectMissingSetupLayers } from "../commands/context/enable.js";
+import {
+  buildContextEnableNextActions,
+  collectMissingSetupLayers,
+  collectSetupRecoveryActions,
+  renderSetupVerdictLine,
+} from "../commands/context/enable.js";
 import { renderHookEnabled, renderHookTrust } from "../commands/context/status.js";
 import type { ContextActivationValidator } from "../core/context-integration/activation.js";
 import {
@@ -280,7 +285,7 @@ describe("Context enable Hook guidance", () => {
       "Run `/hooks`.",
       "Find First Tree Context → SessionStart, enable its checkbox, and choose Trust.",
       "Exit and start a new Codex session in this checkout.",
-      "Run `first-tree-staging context status --provider codex`; confirm Hook trusted/enabled are Yes and Live activation is Connected.",
+      "Re-run the same `first-tree-staging context enable` command; setup is complete only when it reports Setup: Complete.",
     ]);
   });
 
@@ -316,8 +321,10 @@ describe("Context enable Hook guidance", () => {
 
 describe("Context enable setup verdict", () => {
   const greenVerification = {
+    provider: { name: "codex" as const, available: true, version: "1.0.0", minimumVersion: "0.5.0", compatible: true },
     plugin: { installed: true, enabled: true, installedPath: "/tmp/plugin" },
     hook: { trust: "trusted" as const, enabled: true, source: "provider_api" as const, issues: [] },
+    runtime: { healthy: true, issues: [] },
     binding: { state: "exact" as const, organizationId: "org-1", repositoryKey: "github.com/acme/repo" },
     activation: {
       state: "connected" as const,
@@ -348,6 +355,91 @@ describe("Context enable setup verdict", () => {
         activation: { state: "not_checked", reason: "binding missing" },
       }),
     ).toEqual(["Exact binding: missing", "Live activation: not_checked"]);
+  });
+
+  it("renders the literal verdict anchor the setup prompt requires", () => {
+    expect(renderSetupVerdictLine({ complete: true, missingLayers: [] })).toBe(
+      "Setup: Complete — every layer verified",
+    );
+    expect(renderSetupVerdictLine({ complete: false, missingLayers: ["Hook trusted: No", "Hook enabled: No"] })).toBe(
+      "Setup: Incomplete — Hook trusted: No; Hook enabled: No",
+    );
+  });
+
+  it("stays Incomplete when the installed payload is unhealthy despite green plugin flags", () => {
+    expect(
+      collectMissingSetupLayers("claude-code", {
+        ...greenVerification,
+        runtime: { healthy: false, issues: ["The installed Plugin payload does not match the current release."] },
+      }),
+    ).toEqual(["Plugin payload healthy: No"]);
+    expect(
+      collectMissingSetupLayers("codex", {
+        ...greenVerification,
+        provider: { ...greenVerification.provider, compatible: false },
+      }),
+    ).toEqual(["Provider compatible: No"]);
+  });
+});
+
+describe("Context enable recovery actions", () => {
+  const greenVerification = {
+    provider: { name: "codex" as const, available: true, version: "1.0.0", minimumVersion: "0.5.0", compatible: true },
+    runtime: { healthy: true, issues: [] },
+    binding: { state: "exact" as const, organizationId: "org-1", repositoryKey: "github.com/acme/repo" },
+    activation: {
+      state: "connected" as const,
+      team: { organizationId: "org-1", displayName: "Acme", role: "member" as const },
+    },
+  };
+
+  it("returns nothing when every layer is green", () => {
+    expect(collectSetupRecoveryActions("claude-code", greenVerification, "first-tree-staging")).toEqual([]);
+  });
+
+  it("surfaces a repair step for an unhealthy payload", () => {
+    const actions = collectSetupRecoveryActions(
+      "claude-code",
+      {
+        ...greenVerification,
+        runtime: { healthy: false, issues: ["The installed Plugin payload does not match the current release."] },
+      },
+      "first-tree-staging",
+    );
+    expect(actions).toEqual([
+      "The installed Plugin payload does not match the current release. Run `first-tree-staging context repair --provider claude-code`.",
+    ]);
+  });
+
+  it("keeps a transient activation failure actionable", () => {
+    const actions = collectSetupRecoveryActions(
+      "claude-code",
+      {
+        ...greenVerification,
+        activation: {
+          state: "unavailable",
+          reasonCode: "validation_unavailable",
+          message: "First Tree could not validate Team Context.",
+          nextAction: "Check connectivity and re-run this command.",
+        },
+      },
+      "first-tree-staging",
+    );
+    expect(actions).toEqual([
+      "First Tree could not validate Team Context. Check connectivity and re-run this command.",
+    ]);
+  });
+
+  it("passes through the binding repair instruction", () => {
+    const actions = collectSetupRecoveryActions(
+      "codex",
+      {
+        ...greenVerification,
+        binding: { state: "missing", nextAction: "Run context enable from the target checkout." },
+      },
+      "first-tree-staging",
+    );
+    expect(actions).toEqual(["Run context enable from the target checkout."]);
   });
 });
 

--- a/apps/cli/src/__tests__/context-status.test.ts
+++ b/apps/cli/src/__tests__/context-status.test.ts
@@ -483,21 +483,53 @@ describe("Context enable recovery actions", () => {
     ]);
   });
 
-  it("never leaves an Incomplete verdict without a next step", () => {
+  it("surfaces the unreadable-binding diagnostic for Claude Code", () => {
+    const reason =
+      "The exact checkout binding could not be read: Invalid First Tree Context binding config at /home/u/.first-tree/config/context.yaml.";
     const verification = {
       ...greenVerification,
       hook: { trust: "provider_managed" as const, enabled: false, source: "provider_managed" as const, issues: [] },
-      binding: { state: "not_checked" as const, reason: "binding config unreadable" },
-      activation: { state: "not_checked" as const, reason: "binding not readable" },
+      binding: { state: "not_checked" as const, reason },
+      activation: { state: "not_checked" as const, reason },
     };
-    const missingLayers = collectMissingSetupLayers("claude-code", {
-      ...verification,
-      plugin: { installed: true, enabled: true, installedPath: "/tmp/plugin" },
-    });
     const actions = buildSetupNextActions(
       "claude-code",
       verification,
-      { complete: false, missingLayers },
+      { complete: false, missingLayers: ["Exact binding: not_checked", "Live activation: not_checked"] },
+      "first-tree-staging",
+    );
+    expect(actions).toEqual([
+      `${reason} Repair or remove that binding config, then re-run this \`first-tree-staging context enable\` command.`,
+    ]);
+  });
+
+  it("keeps the binding diagnostic ahead of the trusted-Hook Codex status reminder", () => {
+    const reason = "The exact checkout binding could not be read: EACCES: permission denied.";
+    const verification = {
+      ...greenVerification,
+      binding: { state: "not_checked" as const, reason },
+      activation: { state: "not_checked" as const, reason },
+    };
+    const actions = buildSetupNextActions(
+      "codex",
+      verification,
+      { complete: false, missingLayers: ["Exact binding: not_checked", "Live activation: not_checked"] },
+      "first-tree-staging",
+    );
+    expect(actions).toEqual([
+      `${reason} Repair or remove that binding config, then re-run this \`first-tree-staging context enable\` command.`,
+      "Run `first-tree-staging context status --provider codex` to verify every layer remains connected.",
+    ]);
+  });
+
+  it("never leaves an Incomplete verdict without a next step", () => {
+    const actions = buildSetupNextActions(
+      "claude-code",
+      {
+        ...greenVerification,
+        hook: { trust: "provider_managed" as const, enabled: false, source: "provider_managed" as const, issues: [] },
+      },
+      { complete: false, missingLayers: ["Plugin enabled: No"] },
       "first-tree-staging",
     );
     expect(actions).toEqual([

--- a/apps/cli/src/__tests__/context-status.test.ts
+++ b/apps/cli/src/__tests__/context-status.test.ts
@@ -2,6 +2,7 @@ import type { ContextActivationResponse } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildContextEnableNextActions,
+  buildSetupNextActions,
   collectMissingSetupLayers,
   collectSetupRecoveryActions,
   renderSetupVerdictLine,
@@ -325,6 +326,7 @@ describe("Context enable setup verdict", () => {
     plugin: { installed: true, enabled: true, installedPath: "/tmp/plugin" },
     hook: { trust: "trusted" as const, enabled: true, source: "provider_api" as const, issues: [] },
     runtime: { healthy: true, issues: [] },
+    checkout: { state: "ready" as const, root: "/work/repo", repositoryKey: "github.com/acme/repo" },
     binding: { state: "exact" as const, organizationId: "org-1", repositoryKey: "github.com/acme/repo" },
     activation: {
       state: "connected" as const,
@@ -380,12 +382,30 @@ describe("Context enable setup verdict", () => {
       }),
     ).toEqual(["Provider compatible: No"]);
   });
+
+  it("flags an unavailable checkout as its own layer", () => {
+    expect(
+      collectMissingSetupLayers("claude-code", {
+        ...greenVerification,
+        checkout: {
+          state: "unavailable",
+          reason: "not_signed_in",
+          message: "First Tree is not signed in.",
+          nextAction: "Run `first-tree-staging login <code>`, then rerun this command.",
+        },
+        binding: { state: "not_checked", reason: "checkout unavailable" },
+        activation: { state: "not_checked", reason: "checkout unavailable" },
+      }),
+    ).toEqual(["Checkout: unavailable", "Exact binding: not_checked", "Live activation: not_checked"]);
+  });
 });
 
 describe("Context enable recovery actions", () => {
   const greenVerification = {
     provider: { name: "codex" as const, available: true, version: "1.0.0", minimumVersion: "0.5.0", compatible: true },
     runtime: { healthy: true, issues: [] },
+    hook: { trust: "trusted" as const, enabled: true, source: "provider_api" as const, issues: [] },
+    checkout: { state: "ready" as const, root: "/work/repo", repositoryKey: "github.com/acme/repo" },
     binding: { state: "exact" as const, organizationId: "org-1", repositoryKey: "github.com/acme/repo" },
     activation: {
       state: "connected" as const,
@@ -440,6 +460,49 @@ describe("Context enable recovery actions", () => {
       "first-tree-staging",
     );
     expect(actions).toEqual(["Run context enable from the target checkout."]);
+  });
+
+  it("surfaces the checkout repair when the second preflight fails", () => {
+    const actions = collectSetupRecoveryActions(
+      "claude-code",
+      {
+        ...greenVerification,
+        checkout: {
+          state: "unavailable",
+          reason: "not_signed_in",
+          message: "First Tree is not signed in.",
+          nextAction: "Run `first-tree-staging login <code>`, then rerun this command.",
+        },
+        binding: { state: "not_checked", reason: "checkout unavailable" },
+        activation: { state: "not_checked", reason: "checkout unavailable" },
+      },
+      "first-tree-staging",
+    );
+    expect(actions).toEqual([
+      "First Tree is not signed in. Run `first-tree-staging login <code>`, then rerun this command.",
+    ]);
+  });
+
+  it("never leaves an Incomplete verdict without a next step", () => {
+    const verification = {
+      ...greenVerification,
+      hook: { trust: "provider_managed" as const, enabled: false, source: "provider_managed" as const, issues: [] },
+      binding: { state: "not_checked" as const, reason: "binding config unreadable" },
+      activation: { state: "not_checked" as const, reason: "binding not readable" },
+    };
+    const missingLayers = collectMissingSetupLayers("claude-code", {
+      ...verification,
+      plugin: { installed: true, enabled: true, installedPath: "/tmp/plugin" },
+    });
+    const actions = buildSetupNextActions(
+      "claude-code",
+      verification,
+      { complete: false, missingLayers },
+      "first-tree-staging",
+    );
+    expect(actions).toEqual([
+      "Fix the layers listed in the Setup line, then re-run this `first-tree-staging context enable` command.",
+    ]);
   });
 });
 

--- a/apps/cli/src/__tests__/context-status.test.ts
+++ b/apps/cli/src/__tests__/context-status.test.ts
@@ -499,8 +499,9 @@ describe("Context enable recovery actions", () => {
       "first-tree-staging",
     );
     expect(actions).toEqual([
-      `${reason} Repair or remove that binding config, then re-run this \`first-tree-staging context enable\` command.`,
+      `${reason} Re-run this \`first-tree-staging context enable\` command; if the failure persists, do not delete the binding config — it also holds bindings for other providers and checkouts. Back it up, then repair its file permissions or YAML together with the member before retrying.`,
     ]);
+    expect(actions[0]).not.toMatch(/remove/i);
   });
 
   it("keeps the binding diagnostic ahead of the trusted-Hook Codex status reminder", () => {
@@ -517,9 +518,10 @@ describe("Context enable recovery actions", () => {
       "first-tree-staging",
     );
     expect(actions).toEqual([
-      `${reason} Repair or remove that binding config, then re-run this \`first-tree-staging context enable\` command.`,
+      `${reason} Re-run this \`first-tree-staging context enable\` command; if the failure persists, do not delete the binding config — it also holds bindings for other providers and checkouts. Back it up, then repair its file permissions or YAML together with the member before retrying.`,
       "Run `first-tree-staging context status --provider codex` to verify every layer remains connected.",
     ]);
+    expect(actions[0]).not.toMatch(/remove/i);
   });
 
   it("never leaves an Incomplete verdict without a next step", () => {

--- a/apps/cli/src/__tests__/context-status.test.ts
+++ b/apps/cli/src/__tests__/context-status.test.ts
@@ -1,6 +1,6 @@
 import type { ContextActivationResponse } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
-import { buildContextEnableNextActions } from "../commands/context/enable.js";
+import { buildContextEnableNextActions, collectMissingSetupLayers } from "../commands/context/enable.js";
 import { renderHookEnabled, renderHookTrust } from "../commands/context/status.js";
 import type { ContextActivationValidator } from "../core/context-integration/activation.js";
 import {
@@ -311,6 +311,43 @@ describe("Context enable Hook guidance", () => {
 
     expect(actions.join(" ")).toContain("enable its checkbox");
     expect(actions.join(" ")).not.toContain("choose Trust");
+  });
+});
+
+describe("Context enable setup verdict", () => {
+  const greenVerification = {
+    plugin: { installed: true, enabled: true, installedPath: "/tmp/plugin" },
+    hook: { trust: "trusted" as const, enabled: true, source: "provider_api" as const, issues: [] },
+    binding: { state: "exact" as const, organizationId: "org-1", repositoryKey: "github.com/acme/repo" },
+    activation: {
+      state: "connected" as const,
+      team: { organizationId: "org-1", displayName: "Acme", role: "member" as const },
+    },
+  };
+
+  it("reports complete only when every layer is green", () => {
+    expect(collectMissingSetupLayers("codex", greenVerification)).toEqual([]);
+    expect(collectMissingSetupLayers("claude-code", greenVerification)).toEqual([]);
+  });
+
+  it("lists the missing Codex hook layers", () => {
+    expect(
+      collectMissingSetupLayers("codex", {
+        ...greenVerification,
+        hook: { trust: "review_required", enabled: false, source: "provider_api", issues: [] },
+      }),
+    ).toEqual(["Hook trusted: No", "Hook enabled: No"]);
+  });
+
+  it("ignores hook layers for Claude Code and flags binding and activation drift", () => {
+    expect(
+      collectMissingSetupLayers("claude-code", {
+        ...greenVerification,
+        hook: { trust: "provider_managed", enabled: false, source: "provider_managed", issues: [] },
+        binding: { state: "missing", nextAction: "Run context enable from the target checkout." },
+        activation: { state: "not_checked", reason: "binding missing" },
+      }),
+    ).toEqual(["Exact binding: missing", "Live activation: not_checked"]);
   });
 });
 

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -63,8 +63,21 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
 
   const driver = createContextIntegrationDriver(provider);
   const installPlan = planContextIntegrationInstall(driver);
-  const expectedConfig = readContextIntegrationConfig();
-  const previousBinding = findContextBinding(provider, preflight.checkoutRoot);
+  let expectedConfig: ReturnType<typeof readContextIntegrationConfig>;
+  let previousBinding: ReturnType<typeof findContextBinding>;
+  try {
+    expectedConfig = readContextIntegrationConfig();
+    previousBinding = findContextBinding(provider, preflight.checkoutRoot);
+  } catch (error) {
+    // Fail closed before displaying a plan built on unknown previous
+    // bindings; the shared config must never be deleted to recover.
+    print.fail(
+      "CONTEXT_BINDING_CONFIG_UNREADABLE",
+      `${error instanceof Error ? error.message : String(error)} Do not delete the binding config — it also holds bindings for other providers and checkouts. Back it up, then repair its file permissions or YAML together with the member before re-running this command.`,
+      1,
+    );
+    throw error;
+  }
   print.status("Provider", provider);
   print.status("Plugin", installPlan.operation);
   print.status("Repository", preflight.repositoryKey);
@@ -214,9 +227,11 @@ export function collectSetupRecoveryActions(
   } else if (verification.binding.state === "not_checked" && verification.checkout.state === "ready") {
     // A binding-read failure carries its diagnostic (including the config
     // path) only in `reason`; activation `not_checked` is the dependent layer
-    // and needs no separate action.
+    // and needs no separate action. The config is one account-scoped store
+    // for every provider and checkout, so recovery must stay
+    // preservation-safe and never suggest deleting the file.
     actions.push(
-      `${verification.binding.reason} Repair or remove that binding config, then re-run this \`${binName} context enable\` command.`,
+      `${verification.binding.reason} Re-run this \`${binName} context enable\` command; if the failure persists, do not delete the binding config — it also holds bindings for other providers and checkouts. Back it up, then repair its file permissions or YAML together with the member before retrying.`,
     );
   }
   if (verification.activation.state === "disabled" || verification.activation.state === "needs_admin") {

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -2,6 +2,7 @@ import { confirm } from "@inquirer/prompts";
 import type { Command } from "commander";
 import { channelConfig } from "../../core/channel.js";
 import { readActiveContextAccountClientId } from "../../core/context-integration/account-state-guard.js";
+import { buildConnectedContextAdditionalContext } from "../../core/context-integration/activation.js";
 import { inspectContextClientPreflight } from "../../core/context-integration/client-preflight.js";
 import {
   findContextBinding,
@@ -10,7 +11,10 @@ import {
 import { planContextIntegrationInstall } from "../../core/context-integration/installer.js";
 import { enableContextIntegrationOperation } from "../../core/context-integration/operation.js";
 import type { ProviderHookProbe } from "../../core/context-integration/provider-driver.js";
-import { inspectContextIntegrationStatus } from "../../core/context-integration/status.js";
+import {
+  type ContextIntegrationStatus,
+  inspectContextIntegrationStatus,
+} from "../../core/context-integration/status.js";
 import { print } from "../../core/output.js";
 import { createMemberSdk } from "../_shared/member.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
@@ -89,6 +93,12 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
   );
 
   const verification = await inspectContextIntegrationStatus(driver, sdk, preflight.checkoutRoot);
+  const activationContext =
+    verification.activation.state === "connected"
+      ? buildConnectedContextAdditionalContext(verification.activation.team)
+      : null;
+  const missingLayers = collectMissingSetupLayers(provider, verification);
+  const setup = { complete: missingLayers.length === 0, missingLayers };
   const nextActions = buildContextEnableNextActions(provider, verification.hook);
   const result = {
     provider,
@@ -97,6 +107,8 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
     repositoryKey: preflight.repositoryKey,
     plugin: installPlan.operation,
     verification,
+    setup,
+    activationContext,
     nextActions,
   };
   if (context.options.json) print.result(result);
@@ -118,10 +130,41 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
         ? `Connected — ${verification.activation.team.displayName}`
         : verification.activation.state,
     );
+    print.status(
+      "Setup",
+      setup.complete ? "Complete — every layer verified" : `Incomplete — ${setup.missingLayers.join("; ")}`,
+    );
+    if (activationContext) {
+      print.line(
+        setup.complete
+          ? "\nAdopt this Team Context in your current coding-agent session and follow it from now on; future sessions in this repository activate automatically:\n\n"
+          : "\nAdopt this Team Context in your current coding-agent session; finish the Next steps below so future sessions activate automatically:\n\n",
+      );
+      print.line(`${activationContext}\n`);
+    }
     nextActions.forEach((action, index) => {
       print.status(`Next ${index + 1}`, action);
     });
   }
+}
+
+/**
+ * Layered setup verdict: every layer the BYO setup prompt tells the agent to
+ * trust must be green before the command reports `Setup: Complete`. The hook
+ * layers apply only to Codex; Claude Code hooks are provider-managed.
+ */
+export function collectMissingSetupLayers(
+  provider: "claude-code" | "codex",
+  verification: Pick<ContextIntegrationStatus, "plugin" | "hook" | "binding" | "activation">,
+): string[] {
+  return [
+    ...(verification.plugin.installed ? [] : ["Plugin installed: No"]),
+    ...(verification.plugin.enabled ? [] : ["Plugin enabled: No"]),
+    ...(provider === "codex" && verification.hook.trust !== "trusted" ? ["Hook trusted: No"] : []),
+    ...(provider === "codex" && verification.hook.enabled !== true ? ["Hook enabled: No"] : []),
+    ...(verification.binding.state === "exact" ? [] : [`Exact binding: ${verification.binding.state}`]),
+    ...(verification.activation.state === "connected" ? [] : [`Live activation: ${verification.activation.state}`]),
+  ];
 }
 
 export function buildContextEnableNextActions(
@@ -130,13 +173,10 @@ export function buildContextEnableNextActions(
   binName = channelConfig.binName,
 ): string[] {
   if (provider === "claude-code") {
-    return ["Start a new Claude Code local session in this repository."];
+    return [];
   }
   if (hook.trust === "trusted" && hook.enabled === true) {
-    return [
-      "Start a new Codex session in this checkout so SessionStart can connect Context.",
-      `Run \`${binName} context status --provider codex\` to verify every layer remains connected.`,
-    ];
+    return [`Run \`${binName} context status --provider codex\` to verify every layer remains connected.`];
   }
   if (hook.trust === "trusted" && hook.enabled === false) {
     return [

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -99,7 +99,10 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
       : null;
   const missingLayers = collectMissingSetupLayers(provider, verification);
   const setup = { complete: missingLayers.length === 0, missingLayers };
-  const nextActions = buildContextEnableNextActions(provider, verification.hook);
+  const nextActions = [
+    ...collectSetupRecoveryActions(provider, verification),
+    ...buildContextEnableNextActions(provider, verification.hook),
+  ];
   const result = {
     provider,
     team: activation.team,
@@ -130,10 +133,7 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
         ? `Connected — ${verification.activation.team.displayName}`
         : verification.activation.state,
     );
-    print.status(
-      "Setup",
-      setup.complete ? "Complete — every layer verified" : `Incomplete — ${setup.missingLayers.join("; ")}`,
-    );
+    print.line(`\n${renderSetupVerdictLine(setup)}\n`);
     if (activationContext) {
       print.line(
         setup.complete
@@ -150,21 +150,73 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
 
 /**
  * Layered setup verdict: every layer the BYO setup prompt tells the agent to
- * trust must be green before the command reports `Setup: Complete`. The hook
- * layers apply only to Codex; Claude Code hooks are provider-managed.
+ * trust must be green before the command reports `Setup: Complete`, including
+ * provider compatibility and the installed payload's runtime health — a
+ * damaged or mismatched payload must not verify. The hook layers apply only
+ * to Codex; Claude Code hooks are provider-managed.
  */
 export function collectMissingSetupLayers(
   provider: "claude-code" | "codex",
-  verification: Pick<ContextIntegrationStatus, "plugin" | "hook" | "binding" | "activation">,
+  verification: Pick<ContextIntegrationStatus, "provider" | "plugin" | "hook" | "runtime" | "binding" | "activation">,
 ): string[] {
   return [
+    ...(verification.provider.available ? [] : ["Provider available: No"]),
+    ...(verification.provider.compatible ? [] : ["Provider compatible: No"]),
     ...(verification.plugin.installed ? [] : ["Plugin installed: No"]),
     ...(verification.plugin.enabled ? [] : ["Plugin enabled: No"]),
+    ...(verification.runtime.healthy ? [] : ["Plugin payload healthy: No"]),
     ...(provider === "codex" && verification.hook.trust !== "trusted" ? ["Hook trusted: No"] : []),
     ...(provider === "codex" && verification.hook.enabled !== true ? ["Hook enabled: No"] : []),
     ...(verification.binding.state === "exact" ? [] : [`Exact binding: ${verification.binding.state}`]),
     ...(verification.activation.state === "connected" ? [] : [`Live activation: ${verification.activation.state}`]),
   ];
+}
+
+/**
+ * The literal verdict line the BYO setup prompt anchors on: agents accept
+ * setup only when the rendered output contains exactly `Setup: Complete`.
+ */
+export function renderSetupVerdictLine(setup: { complete: boolean; missingLayers: string[] }): string {
+  return setup.complete
+    ? "Setup: Complete — every layer verified"
+    : `Setup: Incomplete — ${setup.missingLayers.join("; ")}`;
+}
+
+/**
+ * Every red layer must surface an actionable recovery step; the BYO setup
+ * prompt delegates all recovery to this command's output, so an Incomplete
+ * verdict with no next step is a dead end.
+ */
+export function collectSetupRecoveryActions(
+  provider: "claude-code" | "codex",
+  verification: Pick<ContextIntegrationStatus, "provider" | "runtime" | "binding" | "activation">,
+  binName = channelConfig.binName,
+): string[] {
+  const actions: string[] = [];
+  if (!verification.provider.available) {
+    actions.push(
+      `Install the ${provider} CLI (minimum ${verification.provider.minimumVersion}), then re-run this command.`,
+    );
+  } else if (!verification.provider.compatible) {
+    actions.push(`Upgrade ${provider} to at least ${verification.provider.minimumVersion}, then re-run this command.`);
+  }
+  if (!verification.runtime.healthy) {
+    actions.push(
+      `${verification.runtime.issues.join(" ")} Run \`${binName} context repair --provider ${provider}\`.`.trimStart(),
+    );
+  }
+  if (verification.binding.state === "missing" || verification.binding.state === "repository_mismatch") {
+    actions.push(verification.binding.nextAction);
+  }
+  if (verification.activation.state === "disabled" || verification.activation.state === "needs_admin") {
+    actions.push(
+      verification.activation.message +
+        (verification.activation.settingsUrl ? ` (${verification.activation.settingsUrl})` : ""),
+    );
+  } else if (verification.activation.state === "unavailable") {
+    actions.push(`${verification.activation.message} ${verification.activation.nextAction}`);
+  }
+  return actions;
 }
 
 export function buildContextEnableNextActions(
@@ -184,7 +236,7 @@ export function buildContextEnableNextActions(
       "Run `/hooks`.",
       "Find First Tree Context → SessionStart and enable its checkbox.",
       "Exit and start a new Codex session in this checkout.",
-      `Run \`${binName} context status --provider codex\`; confirm Hook trusted/enabled are Yes and Live activation is Connected.`,
+      `Re-run the same \`${binName} context enable\` command; setup is complete only when it reports Setup: Complete.`,
     ];
   }
   return [
@@ -192,7 +244,7 @@ export function buildContextEnableNextActions(
     "Run `/hooks`.",
     "Find First Tree Context → SessionStart, enable its checkbox, and choose Trust.",
     "Exit and start a new Codex session in this checkout.",
-    `Run \`${binName} context status --provider codex\`; confirm Hook trusted/enabled are Yes and Live activation is Connected.`,
+    `Re-run the same \`${binName} context enable\` command; setup is complete only when it reports Setup: Complete.`,
   ];
 }
 

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -211,6 +211,13 @@ export function collectSetupRecoveryActions(
   }
   if (verification.binding.state === "missing" || verification.binding.state === "repository_mismatch") {
     actions.push(verification.binding.nextAction);
+  } else if (verification.binding.state === "not_checked" && verification.checkout.state === "ready") {
+    // A binding-read failure carries its diagnostic (including the config
+    // path) only in `reason`; activation `not_checked` is the dependent layer
+    // and needs no separate action.
+    actions.push(
+      `${verification.binding.reason} Repair or remove that binding config, then re-run this \`${binName} context enable\` command.`,
+    );
   }
   if (verification.activation.state === "disabled" || verification.activation.state === "needs_admin") {
     actions.push(

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -99,10 +99,7 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
       : null;
   const missingLayers = collectMissingSetupLayers(provider, verification);
   const setup = { complete: missingLayers.length === 0, missingLayers };
-  const nextActions = [
-    ...collectSetupRecoveryActions(provider, verification),
-    ...buildContextEnableNextActions(provider, verification.hook),
-  ];
+  const nextActions = buildSetupNextActions(provider, verification, setup);
   const result = {
     provider,
     team: activation.team,
@@ -157,7 +154,10 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
  */
 export function collectMissingSetupLayers(
   provider: "claude-code" | "codex",
-  verification: Pick<ContextIntegrationStatus, "provider" | "plugin" | "hook" | "runtime" | "binding" | "activation">,
+  verification: Pick<
+    ContextIntegrationStatus,
+    "provider" | "plugin" | "hook" | "runtime" | "checkout" | "binding" | "activation"
+  >,
 ): string[] {
   return [
     ...(verification.provider.available ? [] : ["Provider available: No"]),
@@ -167,6 +167,7 @@ export function collectMissingSetupLayers(
     ...(verification.runtime.healthy ? [] : ["Plugin payload healthy: No"]),
     ...(provider === "codex" && verification.hook.trust !== "trusted" ? ["Hook trusted: No"] : []),
     ...(provider === "codex" && verification.hook.enabled !== true ? ["Hook enabled: No"] : []),
+    ...(verification.checkout.state === "ready" ? [] : ["Checkout: unavailable"]),
     ...(verification.binding.state === "exact" ? [] : [`Exact binding: ${verification.binding.state}`]),
     ...(verification.activation.state === "connected" ? [] : [`Live activation: ${verification.activation.state}`]),
   ];
@@ -189,7 +190,7 @@ export function renderSetupVerdictLine(setup: { complete: boolean; missingLayers
  */
 export function collectSetupRecoveryActions(
   provider: "claude-code" | "codex",
-  verification: Pick<ContextIntegrationStatus, "provider" | "runtime" | "binding" | "activation">,
+  verification: Pick<ContextIntegrationStatus, "provider" | "runtime" | "checkout" | "binding" | "activation">,
   binName = channelConfig.binName,
 ): string[] {
   const actions: string[] = [];
@@ -205,6 +206,9 @@ export function collectSetupRecoveryActions(
       `${verification.runtime.issues.join(" ")} Run \`${binName} context repair --provider ${provider}\`.`.trimStart(),
     );
   }
+  if (verification.checkout.state === "unavailable") {
+    actions.push(`${verification.checkout.message} ${verification.checkout.nextAction}`);
+  }
   if (verification.binding.state === "missing" || verification.binding.state === "repository_mismatch") {
     actions.push(verification.binding.nextAction);
   }
@@ -215,6 +219,28 @@ export function collectSetupRecoveryActions(
     );
   } else if (verification.activation.state === "unavailable") {
     actions.push(`${verification.activation.message} ${verification.activation.nextAction}`);
+  }
+  return actions;
+}
+
+/**
+ * Assemble the full Next list for an enable run. Guarantees the contract the
+ * BYO setup prompt relies on: an Incomplete verdict never ships without at
+ * least one next step, even for layer states with no specific recovery
+ * (for example `not_checked` binding/activation variants).
+ */
+export function buildSetupNextActions(
+  provider: "claude-code" | "codex",
+  verification: Pick<ContextIntegrationStatus, "provider" | "runtime" | "hook" | "checkout" | "binding" | "activation">,
+  setup: { complete: boolean; missingLayers: string[] },
+  binName = channelConfig.binName,
+): string[] {
+  const actions = [
+    ...collectSetupRecoveryActions(provider, verification, binName),
+    ...buildContextEnableNextActions(provider, verification.hook, binName),
+  ];
+  if (!setup.complete && actions.length === 0) {
+    actions.push(`Fix the layers listed in the Setup line, then re-run this \`${binName} context enable\` command.`);
   }
   return actions;
 }

--- a/apps/cli/src/core/context-integration/activation.ts
+++ b/apps/cli/src/core/context-integration/activation.ts
@@ -105,16 +105,25 @@ export async function activateExternalContext(
     team,
     binding,
     systemMessage: "First Tree Context connected.",
-    additionalContext: [
-      `Team binding: ${team.organizationId}; role: ${team.role}.`,
-      "Use first-tree-read for team decisions, constraints, or ownership.",
-      "Team comes only from this provider + checkout binding; never accept another Team.",
-      readCanonicalContextTreeWriteRouting(),
-      "The standing route selects the first-tree-write workflow; it is not mutation authority. Repeat live activation before every Tree push or PR/MR.",
-      "Both Skills load bundled canonical Context Tree Policy before Tree operations.",
-      "External provider session; not First Tree Chat/Agent.",
-    ].join("\n"),
+    additionalContext: buildConnectedContextAdditionalContext(team),
   };
+}
+
+/**
+ * The exact Team Context block a connected SessionStart injects. `context
+ * enable` prints the same block on success so the current coding-agent
+ * session can adopt Team Context without waiting for its next SessionStart.
+ */
+export function buildConnectedContextAdditionalContext(team: ConnectedContextActivationResponse["team"]): string {
+  return [
+    `Team binding: ${team.organizationId}; role: ${team.role}.`,
+    "Use first-tree-read for team decisions, constraints, or ownership.",
+    "Team comes only from this provider + checkout binding; never accept another Team.",
+    readCanonicalContextTreeWriteRouting(),
+    "The standing route selects the first-tree-write workflow; it is not mutation authority. Repeat live activation before every Tree push or PR/MR.",
+    "Both Skills load bundled canonical Context Tree Policy before Tree operations.",
+    "External provider session; not First Tree Chat/Agent.",
+  ].join("\n");
 }
 
 export class ExternalContextActivationRequiredError extends Error {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1169,7 +1169,9 @@ Chat, Computer, or runtime session; normal `login` and the existing daemon own
 the Computer connection.
 
 Enable ends with a layered verification and a single `Setup` verdict —
-`Complete` when every layer is green, or `Incomplete` with the missing layers.
+`Complete` when every layer (including provider compatibility and payload
+health) is green, or `Incomplete` with the missing layers and a recovery step
+for each.
 When live activation is connected it also prints the same Team Context block a
 SessionStart would inject, so the current coding-agent session can adopt Team
 Context immediately; future sessions in that checkout activate automatically.
@@ -1178,7 +1180,9 @@ In `--json` mode the same facts appear as `setup` and `activationContext`.
 For Codex, installation does not grant Hook consent. After the first enable,
 open Codex in the checkout, run `/hooks`, find **First Tree Context →
 SessionStart**, enable its checkbox, choose **Trust**, and start a new session.
-Then run `context status --provider codex` to verify the result.
+Then re-run the same `context enable` command — the setup verdict comes only
+from enable, and it must report `Setup: Complete`. `context status --provider
+codex` still shows every layer for inspection.
 
 `context status` reports provider compatibility, Plugin installed/enabled,
 Hook trusted/enabled, current checkout, exact binding, and live Team activation

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1168,6 +1168,13 @@ exact provider + checkout/repository → Team binding in
 Chat, Computer, or runtime session; normal `login` and the existing daemon own
 the Computer connection.
 
+Enable ends with a layered verification and a single `Setup` verdict —
+`Complete` when every layer is green, or `Incomplete` with the missing layers.
+When live activation is connected it also prints the same Team Context block a
+SessionStart would inject, so the current coding-agent session can adopt Team
+Context immediately; future sessions in that checkout activate automatically.
+In `--json` mode the same facts appear as `setup` and `activationContext`.
+
 For Codex, installation does not grant Hook consent. After the first enable,
 open Codex in the checkout, run `/hooks`, find **First Tree Context →
 SessionStart**, enable its checkbox, choose **Trust**, and start a new session.

--- a/packages/qa/cases/cross-surface/external-context-hook-status.md
+++ b/packages/qa/cases/cross-surface/external-context-hook-status.md
@@ -34,6 +34,9 @@ repository/Team activation.
   disposable checkout.
 - Follow only the displayed consent steps: open Codex, run `/hooks`, find First
   Tree Context → SessionStart, enable it, trust it, and start a new session.
+- Re-run the same Team-authored enable command after consent, in human and JSON
+  modes; capture its `Setup:` verdict line, next actions, and Team Context
+  block.
 - Run `context status --provider codex` in human and JSON modes before consent,
   after enabling without trust, after trust, and after starting the new
   session.
@@ -47,6 +50,16 @@ repository/Team activation.
 
 - Enable never passes a trust-bypass flag or writes trusted Hook state. Its
   output gives the `/hooks` path as ordered, verifiable steps.
+- Enable ends with one literal verdict line: `Setup: Complete` only when every
+  layer including provider compatibility and payload health is green, otherwise
+  `Setup: Incomplete — <missing layers>` with an actionable recovery step for
+  every red layer (never an empty next-step list). Before Hook consent the
+  verdict is `Incomplete`; after consent, re-running enable is what produces
+  `Setup: Complete`.
+- On connected live activation, enable prints the same Team Context block a
+  SessionStart injects (JSON `activationContext`), headed by the instruction to
+  adopt it in the current session; the `setup` object in JSON mirrors the
+  verdict.
 - Provider compatibility, Plugin installed, Plugin enabled, Hook trusted, Hook
   enabled, checkout, exact binding, and live activation are separate fields in
   human and JSON output.

--- a/packages/server/src/__tests__/context-enablement-handoff.test.ts
+++ b/packages/server/src/__tests__/context-enablement-handoff.test.ts
@@ -21,7 +21,7 @@ describe("Context enablement handoff", () => {
       role: "admin",
     });
     expect(response.json().command).toBe(
-      `'first-tree-staging' context enable --provider 'codex' --team '${admin.organizationId}'`,
+      `'first-tree-staging' context enable --provider 'codex' --team '${admin.organizationId}' --yes`,
     );
     expect(response.body).not.toContain("--no-start");
   });

--- a/packages/server/src/api/orgs/context-enablement.ts
+++ b/packages/server/src/api/orgs/context-enablement.ts
@@ -24,10 +24,13 @@ export async function orgContextEnablementRoutes(app: FastifyInstance): Promise<
         `${executable} context enable`,
         `--provider ${shellQuote(query.provider)}`,
         `--team ${shellQuote(scope.organizationId)}`,
-        ...(query.intent === "onboarding" ? ["--yes"] : []),
+        // Both intents run inside a non-TTY coding-agent session, where an
+        // interactive plan confirmation would stall; pasting the prompt is the
+        // member's acceptance of the displayed plan.
+        "--yes",
       ].join(" "),
       workingDirectoryInstruction:
-        "Run this once from the root of the code repository where this Team's Context should be enabled.",
+        "Run this once from inside the code repository where this Team's Context should be enabled; any subdirectory works.",
     });
   });
 }

--- a/packages/web/src/lib/byo-setup-prompt.ts
+++ b/packages/web/src/lib/byo-setup-prompt.ts
@@ -59,7 +59,7 @@ export function buildByoSetupPrompt({
   const commandInstructions =
     handoffs.length === 1
       ? [
-          `Then enable Team Context for this exact repository checkout with the server-provided ${providerNames[0]} command:`,
+          `Then enable Team Context for this repository with the server-provided ${providerNames[0]} command:`,
           "",
           handoffs[0]?.command ?? "",
         ]
@@ -74,23 +74,25 @@ export function buildByoSetupPrompt({
         ];
   const completion =
     intent === "onboarding"
-      ? "Only tell me setup is ready after First Tree verifies the provider integration, the exact-checkout Team binding, and live Team Context activation. First Tree Web owns onboarding completion separately."
-      : "After First Tree verifies the provider integration, the exact-checkout Team binding, and live Team Context activation, tell me the exact next step for starting a fresh coding-agent session. Do not mark onboarding complete.";
+      ? "Only tell me setup is ready after that. First Tree Web owns onboarding completion separately."
+      : "Do not mark onboarding complete. First Tree verifies completion separately.";
 
   return [
     `Set up First Tree Team Context for this repository in ${target}.`,
     "",
-    "Complete the whole setup inside this coding-agent session. Do not ask me to open Terminal.",
+    "Complete the whole setup inside this coding-agent session. Do not ask me to open Terminal. Setup is user-scoped: do not modify repository files — Team Context does not live in the repository.",
     "",
-    "First inspect this machine locally. If First Tree is missing or this computer is not signed in to my First Tree account, use this server-provided bootstrap:",
+    "First run this server-provided bootstrap. It installs or updates First Tree and signs this computer in, and every step is safe to re-run:",
     "",
     bootstrapCommand,
+    "",
+    "If the login step fails because its code is expired or already used, stop and ask me for a fresh setup prompt from First Tree Settings — never reuse an old code. If login reports this computer is signed in as a different First Tree user, stop and ask me before any switch.",
     "",
     ...commandInstructions,
     "",
     `Target Team ID: ${organizationId}`,
     "",
-    "Run the enable command from this repository's root. If this session is not at the repository root, stop and tell me where to reopen it. If First Tree detects a different local account, ask me before switching. Do not create a First Tree agent or open First Tree Chat, and do not modify repository files.",
+    "Run the enable command from inside this repository; any subdirectory works. If this session is not inside the target repository, stop and tell me where to reopen it.",
     ...(providers.has("codex")
       ? [
           "",
@@ -98,6 +100,6 @@ export function buildByoSetupPrompt({
         ]
       : []),
     "",
-    completion,
+    `The enable command verifies the whole setup and its output tells you what to do — follow it exactly. Setup is successful only when it reports "Setup: Complete". ${completion}`,
   ].join("\n");
 }

--- a/packages/web/src/lib/byo-setup-prompt.ts
+++ b/packages/web/src/lib/byo-setup-prompt.ts
@@ -86,7 +86,7 @@ export function buildByoSetupPrompt({
     "",
     bootstrapCommand,
     "",
-    "If the login step fails because its code is expired or already used, stop and ask me for a fresh setup prompt from First Tree Settings — never reuse an old code. If login reports this computer is signed in as a different First Tree user, stop and ask me before any switch.",
+    "If the login step fails because its code is expired or already used, stop and ask me for a fresh setup prompt from First Tree Settings — never reuse an old code. If login reports this computer is signed in as a different First Tree user, stop and ask me before any switch; that check consumes the code, so if I approve the switch, ask me for a fresh setup prompt and run its login line with `--force-switch` appended.",
     "",
     ...commandInstructions,
     "",
@@ -100,6 +100,6 @@ export function buildByoSetupPrompt({
         ]
       : []),
     "",
-    `The enable command verifies the whole setup and its output tells you what to do — follow it exactly. Setup is successful only when it reports "Setup: Complete". ${completion}`,
+    `The enable command verifies the whole setup and its output tells you what to do — follow it exactly. Setup is successful only when the enable command reports "Setup: Complete"; if it reports Incomplete, finish its Next steps and re-run the same enable command until it does. ${completion}`,
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

Makes the BYO Team Context setup self-verifying: the setup prompt stops teaching detection heuristics, and `context enable`'s own output becomes the single source of truth for "did setup succeed and what do I do next" — including immediate Team Context adoption in the current coding-agent session.

- **`context enable` (CLI)** now ends with a single layered `Setup` verdict — `Complete — every layer verified`, or `Incomplete — <missing layers>` (plugin installed/enabled, Codex hook trusted/enabled, exact binding, live activation). When live activation is connected it prints the exact Team Context block a SessionStart would inject, headed by an instruction to adopt it in the current session, so members no longer have to start a fresh session to get Team Context. `--json` adds `setup` and `activationContext`. Next-action guidance drops the now-obsolete "start a new session" steps (Codex `/hooks` consent steps are unchanged — provider-owned trust still requires them).
- **BYO setup prompt (Web template)** rewritten per the join-prompt improvement discussion (2026-07-30): always run the server bootstrap (installer + `login`; both safe to re-run), with two explicit stops — expired/consumed code → ask for a fresh prompt from Settings; account switch reported by `login` → stop and ask. Local-state detection heuristics are gone; the enable command may run from any subdirectory of the target repository; success is defined purely as the command reporting `Setup: Complete`.
- **Settings-intent handoff (Server)** now includes `--yes` like onboarding. Without it, the enable command stalls on an interactive plan confirmation inside non-TTY coding-agent sessions — the settings-generated prompt could never complete as written.
- `workingDirectoryInstruction` relaxed to "from inside the code repository; any subdirectory works" (matches the CLI, which resolves the checkout root via `git rev-parse --show-toplevel`).
- `docs/cli-reference.md` documents the new verdict/context output.

Related issues from the same discussion: #2088 (installer early-exit, required for the "always run install.sh" flow to be fast), #2090 (provider auto-detection / more BYO agent types), #2089 (reshape enable into a team-join command).

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — full web (218 files), server (252 files), and CLI suites green locally

## Change Surface

- [x] `apps/cli` public CLI or help output
- [x] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [x] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- Cross-surface provider/auth path touched: existing QA case `packages/qa/cases/cross-surface/external-context-hook-status.md` covers the Codex enable/consent/status flow; formal QA may be warranted before release.
- A colleague's in-flight multi-repo selection work will touch the same template; whichever lands second rebases (this PR keeps the single-repository shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
