### PR TITLE
Add dedicated Context Tree settings page

### DIFF
--- a/packages/server/src/__tests__/org-context-activation.test.ts
+++ b/packages/server/src/__tests__/org-context-activation.test.ts
@@ -48,6 +48,7 @@ describe("org-scoped member Context activation", () => {
       outcome: "needs_admin",
       reasonCode: "context_tree_unbound",
       team: { organizationId: admin.organizationId, role: "admin" },
+      nextAction: { settingsUrl: "/settings/context#binding" },
     });
 
     await putOrgSetting(

--- a/packages/server/src/services/context-activation.ts
+++ b/packages/server/src/services/context-activation.ts
@@ -13,7 +13,7 @@ import { getOrgContextTreeSettingState } from "./org-settings.js";
 import { getOrganization } from "./organization.js";
 
 const REPOSITORIES_SETTINGS_URL = "/settings/repositories#code-repositories";
-const SETUP_SETTINGS_URL = "/settings/setup#context-tree";
+const CONTEXT_TREE_SETTINGS_URL = "/settings/context#binding";
 
 export async function validateExternalContextActivation(
   db: Database,
@@ -114,7 +114,7 @@ function needsAdmin(
     reasonCode,
     nextAction: {
       message,
-      settingsUrl: SETUP_SETTINGS_URL,
+      settingsUrl: CONTEXT_TREE_SETTINGS_URL,
     },
   };
 }

--- a/packages/server/src/services/context-tree-write-preflight.ts
+++ b/packages/server/src/services/context-tree-write-preflight.ts
@@ -192,7 +192,7 @@ export async function preflightContextTreeWriteAuthority(
       "Automatic Review is not configured for the selected Team.",
       {
         message: "Ask a Team Admin to assign and enable a Context Reviewer.",
-        settingsUrl: "/settings/setup#automatic-review",
+        settingsUrl: "/settings/context#automatic-review",
       },
     );
   }
@@ -203,7 +203,7 @@ export async function preflightContextTreeWriteAuthority(
       "Automatic Review is disabled for the selected Team.",
       {
         message: "Ask a Team Admin to enable Automatic Review.",
-        settingsUrl: "/settings/setup#automatic-review",
+        settingsUrl: "/settings/context#automatic-review",
       },
     );
   }
@@ -222,7 +222,7 @@ export async function preflightContextTreeWriteAuthority(
       "Automatic Review prerequisites are incomplete for the selected Team.",
       {
         message: "Ask a Team Admin to repair the assigned Reviewer Agent, Computer, or provider.",
-        settingsUrl: "/settings/setup#automatic-review",
+        settingsUrl: "/settings/context#automatic-review",
       },
     );
   }
@@ -233,7 +233,7 @@ export async function preflightContextTreeWriteAuthority(
       "The selected Team's Reviewer is configured but currently offline or degraded.",
       {
         message: "Restore the Reviewer Computer and Agent, then retry this Write preflight.",
-        settingsUrl: "/settings/setup#automatic-review",
+        settingsUrl: "/settings/context#automatic-review",
       },
     );
   }

--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -130,10 +130,9 @@ vi.mock("../pages/settings.js", async () => {
 });
 vi.mock("../pages/settings/computers.js", () => ({ SettingsComputersPage: () => <div>settings computers</div> }));
 vi.mock("../pages/settings/account.js", () => ({ SettingsAccountPage: () => <div>settings account</div> }));
-vi.mock("../pages/settings/context-tree.js", async () => {
-  const { Navigate } = await import("react-router");
-  return { SettingsContextTreePage: () => <Navigate to="/settings/setup" replace /> };
-});
+vi.mock("../pages/settings/context-tree.js", () => ({
+  SettingsContextTreePage: () => <div>settings context tree</div>,
+}));
 vi.mock("../pages/settings/github.js", () => ({ SettingsGithubPage: () => <div>settings github</div> }));
 vi.mock("../pages/settings/gitlab.js", () => ({ SettingsGitlabPage: () => <div>settings gitlab</div> }));
 vi.mock("../pages/settings/integrations.js", async () => {
@@ -334,8 +333,8 @@ describe("App routes", () => {
     expect(await renderAppAt("/settings/repositories")).toContain("settings repositories");
     await resetRenderedApp();
 
-    expect(await renderAppAt("/settings/context")).toContain("settings setup");
-    expect(window.location.pathname).toBe("/settings/setup");
+    expect(await renderAppAt("/settings/context")).toContain("settings context tree");
+    expect(window.location.pathname).toBe("/settings/context");
     await resetRenderedApp();
 
     expect(await renderAppAt("/settings/resources")).toContain("settings resources");

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -160,6 +160,14 @@ const SetupPreviewPage = import.meta.env.DEV
   ? lazy(() => import("./pages/setup-preview.js").then((module) => ({ default: module.SetupPreviewPage })))
   : null;
 
+const SettingsContextTreePreviewPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("./pages/settings-context-tree-preview.js").then((module) => ({
+        default: module.SettingsContextTreePreviewPage,
+      })),
+    )
+  : null;
+
 // Public fixture preview for the BYO Context Tree handoff. It is compiled into
 // hosted builds so staging can expose it, but the route gate below fails closed
 // on production and unknown channels. It has no auth or backend mutations.
@@ -354,6 +362,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <SetupPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {SettingsContextTreePreviewPage ? (
+                <Route
+                  path="/preview/settings-context-tree"
+                  element={
+                    <Suspense fallback={null}>
+                      <SettingsContextTreePreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -68,7 +68,7 @@ vi.mock("../../auth/auth-context.js", () => ({
 
 function LocationProbe() {
   const location = useLocation();
-  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+  return <div data-testid="location">{`${location.pathname}${location.search}${location.hash}`}</div>;
 }
 
 async function flush(): Promise<void> {
@@ -100,6 +100,7 @@ async function renderDom(
           <LocationProbe />
           <Routes>
             <Route path="/" element={element} />
+            <Route path="/settings/context" element={<div>Context Tree settings route</div>} />
             <Route path="/settings/resources" element={<div>Resources route</div>} />
             <Route path="/onboarding" element={<div>Onboarding route</div>} />
           </Routes>
@@ -119,6 +120,7 @@ async function rerender(root: Root, queryClient: QueryClient, element: ReactElem
           <LocationProbe />
           <Routes>
             <Route path="/" element={element} />
+            <Route path="/settings/context" element={<div>Context Tree settings route</div>} />
             <Route path="/settings/resources" element={<div>Resources route</div>} />
             <Route path="/onboarding" element={<div>Onboarding route</div>} />
           </Routes>
@@ -144,15 +146,6 @@ async function waitForText(container: ParentNode, text: string, timeoutMs = 3000
     await flush();
   }
   throw new Error(`Missing text: ${text}\n${container.textContent ?? ""}`);
-}
-
-async function waitForCondition(check: () => boolean, message: string, timeoutMs = 3000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (check()) return;
-    await flush();
-  }
-  throw new Error(message);
 }
 
 function snapshot(overrides: Partial<ContextTreeSnapshot> = {}): ContextTreeSnapshot {
@@ -530,9 +523,8 @@ describe("ContextPage DOM behavior", () => {
     await act(async () => root.unmount());
   });
 
-  it("keeps recoverable GitLab unavailable states chat-first for admins", async () => {
+  it("routes recoverable GitLab unavailable states to Context Tree settings", async () => {
     authMock.value = { organizationId: "org-1", role: "admin" };
-    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
     contextApiMocks.getContextTreeSnapshot.mockResolvedValue(
       snapshot({
         provider: "gitlab",
@@ -555,10 +547,12 @@ describe("ContextPage DOM behavior", () => {
     const { ContextPage } = await import("../context.js");
     const { container, root } = await renderDom(<ContextPage />);
 
-    await waitForText(container, "Work on this in chat");
+    await waitForText(container, "Manage Context Tree");
     expect(container.textContent).toContain("GitLab repository or branch is unavailable");
     expect(container.textContent).toContain("Provider-specific diagnostic");
-    expect(agentApiMocks.listManagedAgents).toHaveBeenCalled();
+    expect(agentApiMocks.listManagedAgents).not.toHaveBeenCalled();
+    await click(container.querySelector('a[href="/settings/context#binding"]'));
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/settings/context#binding");
     await act(async () => root.unmount());
   });
 
@@ -575,14 +569,6 @@ describe("ContextPage DOM behavior", () => {
     status: "active",
     avatarImageUrl: null,
   };
-  const secondTreeAgent = {
-    ...treeAgent,
-    uuid: "agent-2",
-    name: "backup-agent",
-    displayName: "",
-    inboxId: "inbox-agent-2",
-    clientId: "client-agent-2",
-  };
   const unavailableSnapshot = () =>
     snapshot({
       repo: null,
@@ -591,10 +577,8 @@ describe("ContextPage DOM behavior", () => {
       contextStatus: { label: "Not configured", detail: null, severity: "warning" },
     });
 
-  it("routes a bound-tree sync failure to the setup chat without an App-install gate", async () => {
+  it("routes a bound-tree sync failure to settings without an App-install gate", async () => {
     authMock.value = { organizationId: "org-1", role: "admin" };
-    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
-    onboardingEventMocks.postTreeSetupStartChat.mockResolvedValue({ chatId: "chat-tree-recovery" });
     const { ContextPage } = await import("../context.js");
     contextApiMocks.getContextTreeSnapshot.mockResolvedValue(
       snapshot({
@@ -607,56 +591,32 @@ describe("ContextPage DOM behavior", () => {
     );
 
     const { container, root } = await renderDom(<ContextPage />);
-    await waitForText(container, "Work on this in chat");
-    expect(container.textContent).toContain("Open a chat with your agent to inspect the tree and this sync issue.");
+    await waitForText(container, "Manage Context Tree");
+    expect(container.textContent).toContain("Review the binding and recovery options in Settings.");
     expect(container.textContent).not.toContain("GitHub App");
     expect(githubAppMocks.getGithubAppInstallation).not.toHaveBeenCalled();
-
-    await click(buttonByText(container, "Work on this in chat"));
-    await waitForCondition(
-      () => onboardingEventMocks.postTreeSetupStartChat.mock.calls.length === 1,
-      "Expected the recovery setup chat to open",
-    );
-    expect(onboardingEventMocks.postTreeSetupStartChat).toHaveBeenCalledWith({
-      organizationId: "org-1",
-      agentUuid: "agent-1",
-    });
-    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/?c=chat-tree-recovery");
+    expect(onboardingEventMocks.postTreeSetupStartChat).not.toHaveBeenCalled();
+    await click(container.querySelector('a[href="/settings/context#binding"]'));
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/settings/context#binding");
 
     await act(async () => root.unmount());
   });
 
-  it("opens tree setup directly for a no-tree admin and lets them choose the agent", async () => {
+  it("routes a no-tree admin to the dedicated settings page", async () => {
     authMock.value = { organizationId: "org-1", role: "admin" };
-    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent, secondTreeAgent]);
-    onboardingEventMocks.postTreeSetupStartChat.mockResolvedValue({ chatId: "chat-tree-success" });
     const { ContextPage } = await import("../context.js");
     contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
 
     const { container, root } = await renderDom(<ContextPage />);
-    await waitForText(container, "Build your Context Tree");
-    expect(container.textContent).toContain("Share a local project folder or GitHub repository URL there.");
-    expect(container.textContent).toContain("backup-agent");
+    await waitForText(container, "Set up Context Tree");
+    expect(container.textContent).toContain("Set it up in Settings when your team is ready.");
+    expect(agentApiMocks.listManagedAgents).not.toHaveBeenCalled();
     expect(resourceApiMocks.listTeamResourcesForOrg).not.toHaveBeenCalled();
     expect(githubAppMocks.getGithubAppInstallation).not.toHaveBeenCalled();
     expect(githubMocks.listOrgGithubRepos).not.toHaveBeenCalled();
-
-    await click(container.querySelector('button[aria-label="Agent for the Context Tree chat"]'));
-    await click(
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Tree Agent") ?? null,
-    );
-    await click(buttonByText(container, "Build your Context Tree"));
-
-    await waitForCondition(
-      () => onboardingEventMocks.postTreeSetupStartChat.mock.calls.length === 1,
-      "Expected tree setup chat kickoff",
-    );
-    expect(onboardingEventMocks.postTreeSetupStartChat).toHaveBeenCalledWith({
-      organizationId: "org-1",
-      agentUuid: "agent-1",
-    });
+    await click(container.querySelector('a[href="/settings/context#binding"]'));
     expect(resourceApiMocks.createTeamResourceForOrg).not.toHaveBeenCalled();
-    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/?c=chat-tree-success");
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/settings/context#binding");
 
     await act(async () => root.unmount());
   });
@@ -698,16 +658,17 @@ describe("ContextPage DOM behavior", () => {
     await act(async () => root.unmount());
   });
 
-  it("routes a no-tree admin without an active agent into onboarding", async () => {
+  it("does not require an active agent before opening Context Tree settings", async () => {
     authMock.value = { organizationId: "org-1", role: "admin" };
     agentApiMocks.listManagedAgents.mockResolvedValue([]);
     const { ContextPage } = await import("../context.js");
     contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
 
     const { container, root } = await renderDom(<ContextPage />);
-    await waitForText(container, "Create an agent for your team first");
-    await click(buttonByText(container, "Create an agent"));
-    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/onboarding");
+    await waitForText(container, "Set up Context Tree");
+    expect(agentApiMocks.listManagedAgents).not.toHaveBeenCalled();
+    await click(container.querySelector('a[href="/settings/context#binding"]'));
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/settings/context#binding");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -17,6 +17,7 @@ import { MobilePreviewPage } from "../mobile-preview.js";
 import { MockTeamStepsA, MockTeamStepsB, MockWelcomeCeremonial } from "../onboarding-team-steps-mocks.js";
 import { RequestDockPreviewPage } from "../request-dock-preview.js";
 import { ResourcesPreviewPage } from "../resources-preview.js";
+import { SettingsContextTreePreviewPage } from "../settings-context-tree-preview.js";
 import { SettingsGithubPreviewPage } from "../settings-github-preview.js";
 import { SetupPreviewPage } from "../setup-preview.js";
 import { SupportMenuPreviewPage } from "../support-menu-preview.js";
@@ -238,45 +239,50 @@ describe("extra preview pages", () => {
     expect(text(rendered.container)).toContain("Context Tree");
     const treeRow = rendered.container.querySelector<HTMLElement>('[data-setup-row="context-tree"]');
     if (!treeRow) throw new Error("Missing Context Tree row");
-    await click(buttonByText(treeRow, "Manage"));
-    const treeControls = treeRow.querySelector<HTMLElement>('[data-setup-owner-controls="context-tree"]');
-    expect(treeControls).not.toBeNull();
-    const reviewerControls = treeControls?.querySelector<HTMLElement>('[data-setup-owner-controls="automatic-review"]');
-    expect(reviewerControls).not.toBeNull();
-    expect(rendered.container.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
-    expect(text(reviewerControls ?? treeRow)).toContain("Context Reviewer");
-    expect(text(treeControls ?? treeRow)).toContain("Use with Claude Code or Codex");
-    expect(text(treeControls ?? treeRow)).toContain("Copy setup prompt");
-    expect(text(treeControls ?? treeRow)).toContain("Preview prompt");
-    expect(text(treeControls ?? treeRow)).not.toContain("context enable --provider");
-    const enablement = reviewerControls?.querySelector<HTMLButtonElement>('[role="switch"]');
-    expect(enablement?.getAttribute("aria-checked")).toBe("true");
-    if (!enablement) throw new Error("Missing preview Reviewer enablement switch");
-    await click(enablement);
-    expect(enablement.getAttribute("aria-checked")).toBe("false");
-    await click(buttonByText(treeRow, "Manage"));
+    const manage = treeRow.querySelector<HTMLAnchorElement>('a[href="/settings/context"]');
+    expect(manage?.textContent).toBe("Manage");
     expect(treeRow.querySelector('[data-setup-owner-controls="context-tree"]')).toBeNull();
+    expect(rendered.container.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
     expect(globalThis.fetch).not.toHaveBeenCalled();
 
     await cleanupRendered(rendered);
   });
 
-  it("renders Member personal Context access without Admin controls", async () => {
+  it("keeps Member Setup as a read-only Context summary", async () => {
     const rendered = await renderPreview(<SetupPreviewPage />, "/preview/setup?role=member&state=ready");
     const treeRow = rendered.container.querySelector<HTMLElement>('[data-setup-row="context-tree"]');
     if (!treeRow) throw new Error("Missing Context Tree row");
 
-    await click(buttonByText(treeRow, "Access"));
-    const controls = treeRow.querySelector<HTMLElement>('[data-setup-owner-controls="context-tree"]');
-    expect(controls).not.toBeNull();
-    expect(controls?.querySelector<HTMLAnchorElement>('a[href="/context"]')?.textContent).toBe("Open Context →");
-    expect(text(controls ?? treeRow)).toContain("Use with Claude Code or Codex");
-    expect(text(controls ?? treeRow)).toContain("Copy setup prompt");
-    expect(text(controls ?? treeRow)).toContain("Preview prompt");
-    expect(controls?.querySelector('[data-setup-owner-controls="automatic-review"]')).toBeNull();
-    expect(controls?.querySelector('[role="switch"]')).toBeNull();
+    expect(treeRow.querySelector<HTMLAnchorElement>('a[href="/context"]')?.textContent).toBe("View");
+    expect(treeRow.querySelector('[data-setup-owner-controls="context-tree"]')).toBeNull();
+    expect(treeRow.querySelector('[role="switch"]')).toBeNull();
 
     await cleanupRendered(rendered);
+  });
+
+  it("renders the seeded Context Tree settings preview for Admins and Members without real APIs", async () => {
+    const admin = await renderPreview(<SettingsContextTreePreviewPage />, "/preview/settings-context-tree?role=admin");
+
+    expect(admin.container.querySelector('[data-settings-context-tree-preview="admin"]')).not.toBeNull();
+    expect(text(admin.container)).toContain("Binding");
+    expect(text(admin.container)).toContain("Automatic review");
+    expect(text(admin.container)).toContain("Coding-agent access");
+    expect(admin.container.querySelector('[data-setup-owner-controls="context-tree"]')).not.toBeNull();
+    expect(admin.container.querySelector('[role="switch"]')).not.toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await cleanupRendered(admin);
+
+    const member = await renderPreview(
+      <SettingsContextTreePreviewPage />,
+      "/preview/settings-context-tree?role=member",
+    );
+    expect(member.container.querySelector('[data-settings-context-tree-preview="member"]')).not.toBeNull();
+    expect(text(member.container)).toContain("Connected");
+    expect(text(member.container)).toContain("Reviewer · Context Reviewer");
+    expect(member.container.querySelector("[data-setup-owner-controls]")).toBeNull();
+    expect(member.container.querySelector('[role="switch"]')).toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await cleanupRendered(member);
   });
 
   it("renders the seeded agent-detail preview sections", async () => {

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -407,7 +407,15 @@ describe("settings panels", () => {
     const desktopLinks = [...desktop.container.querySelectorAll<HTMLAnchorElement>("aside a")].map(
       (link) => link.textContent,
     );
-    expect(desktopLinks).toEqual(["Account", "Setup", "Computers", "Repositories", "Resources", "GitHub & GitLab"]);
+    expect(desktopLinks).toEqual([
+      "Account",
+      "Setup",
+      "Computers",
+      "Repositories",
+      "Context Tree",
+      "Resources",
+      "GitHub & GitLab",
+    ]);
     expect(desktop.container.textContent).toContain("Integrations child");
     await act(async () => desktop.root.unmount());
 
@@ -423,6 +431,7 @@ describe("settings panels", () => {
     expect(narrow.container.textContent).toContain("PERSONAL");
     expect(narrow.container.textContent).toContain("Computers");
     expect(narrow.container.textContent).toContain("Repositories");
+    expect(narrow.container.textContent).toContain("Context Tree");
     expect(narrow.container.textContent).toContain("TEAM");
     expect(narrow.container.textContent).toContain("GitHub & GitLab");
     expect(narrow.container.textContent).not.toContain("Setup");

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -9,11 +9,12 @@ import { useQuery } from "@tanstack/react-query";
 import { stratify, tree } from "d3-hierarchy";
 import { AlertTriangle, Info, Network, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { getContextTreeSnapshot } from "../api/context-tree.js";
 import { useAuth } from "../auth/auth-context.js";
 import { resolveAvatarHue } from "../components/chat/chat-row-avatar.js";
 import { Identicon } from "../components/identicon.js";
+import { Button } from "../components/ui/button.js";
 import { PageHeader } from "../components/ui/page-header.js";
 import { Panel, PanelBody } from "../components/ui/panel.js";
 import {
@@ -21,7 +22,6 @@ import {
   GITLAB_WEB_CONTEXT_UNAVAILABLE_TITLE,
   isTeamNonActionableGitlabWebContext,
 } from "./context-tree-availability.js";
-import { ContextTreeBuildEntry } from "./context-tree-build-entry.js";
 import { ContextSectionTabs } from "./docs/context-section-tabs.js";
 
 const CONTEXT_WINDOW = "7d";
@@ -78,7 +78,7 @@ export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTree
         ) : null}
         {snapshot && (preview || !query.isLoading) ? (
           snapshot.snapshotStatus === "unavailable" ? (
-            <UnavailableState snapshot={snapshot} isAdmin={isAdmin} canOpenChat={!preview && isAdmin} />
+            <UnavailableState snapshot={snapshot} isAdmin={isAdmin} canManageSettings={!preview && isAdmin} />
           ) : (
             <>
               <ContextStatusNote snapshot={snapshot} />
@@ -639,11 +639,11 @@ function ErrorState({ message }: { message: string }) {
 function UnavailableState({
   snapshot,
   isAdmin,
-  canOpenChat,
+  canManageSettings,
 }: {
   snapshot: ContextTreeSnapshot;
   isAdmin: boolean;
-  canOpenChat: boolean;
+  canManageSettings: boolean;
 }) {
   const gitlabContentAvailability =
     snapshot.provider === "gitlab" && snapshot.contentAvailability?.status === "unavailable"
@@ -672,10 +672,10 @@ function UnavailableState({
       ? (gitlabCopy?.detail ??
         "The anonymous GitLab repository refresh failed. Use an Agent with local git/glab access to inspect it; inbound Webhook automation is independent.")
       : isAdmin
-        ? "Open a chat with your agent to inspect the tree and this sync issue."
+        ? "Review the binding and recovery options in Settings."
         : "Ask an admin to inspect this Context Tree sync issue."
     : isAdmin
-      ? "Your agent can build it with you in a chat. Share a local project folder or GitHub repository URL there."
+      ? "Set it up in Settings when your team is ready."
       : "Ask an admin to set up your team's Context Tree.";
   const syncDetail = teamNonActionableGitlabWebContext ? null : snapshot.contextStatus.detail;
   const repoLabel = snapshot.repo ? redactRepoForDisplay(snapshot.repo) : null;
@@ -703,12 +703,16 @@ function UnavailableState({
                 {syncDetail}
               </div>
             ) : null}
-            {/* Recoverable admin-facing unavailable states continue in the
-                chat-first setup flow. GitLab auth and operator-owned egress
-                failures are not Team setup debt. */}
-            {canOpenChat && !teamNonActionableGitlabWebContext ? (
+            {/* Context is permanently read-only. Team-actionable binding and
+                recovery work belongs to Settings; GitLab auth and
+                operator-owned egress failures are not Team setup debt. */}
+            {canManageSettings && !teamNonActionableGitlabWebContext ? (
               <div style={{ marginTop: "var(--sp-3)" }}>
-                <ContextTreeBuildEntry intent={snapshot.repo ? "recover" : "build"} />
+                <Button asChild type="button" variant="outline" size="sm">
+                  <Link to="/settings/context#binding">
+                    {snapshot.repo ? "Manage Context Tree" : "Set up Context Tree"}
+                  </Link>
+                </Button>
               </div>
             ) : null}
             {snapshot.repo || snapshot.branch ? (

--- a/packages/web/src/pages/settings-context-tree-preview.tsx
+++ b/packages/web/src/pages/settings-context-tree-preview.tsx
@@ -1,0 +1,116 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { Link, useSearchParams } from "react-router";
+import { setupCapabilitiesQueryKey } from "../api/setup-capabilities.js";
+import { AuthContext } from "../auth/auth-context.js";
+import { cn } from "../lib/utils.js";
+import { SettingsContextTreePage } from "./settings/context-tree.js";
+import { SettingsLayout } from "./settings.js";
+import { PREVIEW_CAPABILITIES } from "./setup-preview.js";
+
+type PreviewRole = "admin" | "member";
+
+const ORGANIZATION_ID = "org-preview";
+
+export function SettingsContextTreePreviewPage() {
+  const [searchParams] = useSearchParams();
+  const role: PreviewRole = searchParams.get("role") === "member" ? "member" : "admin";
+  const queryClient = useMemo(() => createPreviewQueryClient(), []);
+  const auth = {
+    isAuthenticated: true,
+    meLoaded: true,
+    role,
+    organizationId: ORGANIZATION_ID,
+    teamDisplayName: "Gandy's team",
+    currentOrgHasUsableAgent: true,
+    currentOrgHasPersonalAgent: true,
+    onboardingDismissedAt: null,
+    onboardingCompletedAt: "2026-07-23T00:00:00.000Z",
+  } as unknown as Parameters<typeof AuthContext.Provider>[0]["value"];
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider value={auth}>
+        <div data-settings-context-tree-preview={role} style={{ minHeight: "100vh", background: "var(--bg)" }}>
+          <SettingsLayout activePathname="/settings/context">
+            <SettingsContextTreePage />
+          </SettingsLayout>
+          <nav
+            aria-label="Context Tree settings preview controls"
+            className="fixed flex"
+            style={{
+              right: "var(--sp-4)",
+              bottom: "var(--sp-4)",
+              gap: "var(--sp-1)",
+              padding: "var(--sp-1)",
+              border: "var(--hairline) solid var(--border)",
+              borderRadius: "var(--radius-input)",
+              background: "var(--bg-raised)",
+              boxShadow: "var(--shadow-md)",
+            }}
+          >
+            {(["admin", "member"] as const).map((candidate) => (
+              <Link
+                key={candidate}
+                to={`/preview/settings-context-tree?role=${candidate}`}
+                aria-current={role === candidate ? "page" : undefined}
+                className={cn(
+                  "text-label font-medium",
+                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                )}
+                style={{
+                  padding: "var(--sp-1_5) var(--sp-3)",
+                  borderRadius: "var(--radius-input)",
+                  color: role === candidate ? "var(--fg)" : "var(--fg-3)",
+                  background: role === candidate ? "var(--bg-hover)" : "transparent",
+                  textDecoration: "none",
+                  textTransform: "capitalize",
+                }}
+              >
+                {candidate}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </AuthContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+function createPreviewQueryClient(): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Number.POSITIVE_INFINITY,
+      },
+    },
+  });
+  client.setQueryData(setupCapabilitiesQueryKey(ORGANIZATION_ID), PREVIEW_CAPABILITIES);
+  client.setQueryData(["context-tree-snapshot", ORGANIZATION_ID, "7d", false], {
+    snapshotStatus: "active",
+    contextStatus: { severity: "ok", label: "Available", detail: null },
+  });
+  client.setQueryData(
+    ["settings", "context-tree", "team-resources", ORGANIZATION_ID],
+    [{ type: "repo", status: "active" }],
+  );
+  client.setQueryData(["org-setting", ORGANIZATION_ID, "context_tree", "raw"], {
+    repo: "https://github.com/agent-team-foundation/first-tree-context",
+    branch: "main",
+    provider: "github",
+  });
+  client.setQueryData(["context-reviewer", "candidates", ORGANIZATION_ID], {
+    items: [
+      {
+        uuid: "agent-reviewer",
+        name: "context-reviewer",
+        displayName: "Context Reviewer",
+        visibility: "organization",
+        runtime: { health: "ready", blockers: [] },
+      },
+    ],
+    blockers: [],
+  });
+  return client;
+}

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -49,6 +49,11 @@ const REPOSITORIES_ITEM: Item = {
   label: "Repositories",
   description: "Manage the Team code repositories available to agents.",
 };
+const CONTEXT_TREE_ITEM: Item = {
+  to: "/settings/context",
+  label: "Context Tree",
+  description: "Manage shared context, automatic review, and coding-agent access for this Team.",
+};
 const RESOURCES_ITEM: Item = {
   to: "/settings/resources",
   label: "Resources",
@@ -59,10 +64,19 @@ const INTEGRATIONS_ITEM: Item = {
   label: "GitHub & GitLab",
   description: "Connect GitHub and GitLab for repository events and identity. GitHub also supports task routing.",
 };
-const ITEMS: Item[] = [ACCOUNT_ITEM, SETUP_ITEM, COMPUTERS_ITEM, REPOSITORIES_ITEM, RESOURCES_ITEM, INTEGRATIONS_ITEM];
+const ITEMS: Item[] = [
+  ACCOUNT_ITEM,
+  SETUP_ITEM,
+  COMPUTERS_ITEM,
+  REPOSITORIES_ITEM,
+  CONTEXT_TREE_ITEM,
+  RESOURCES_ITEM,
+  INTEGRATIONS_ITEM,
+];
 
-// Preserve the existing narrow Settings IA; only desktop removes visible
-// scope groups. Every link still uses the canonical Setup route.
+// Preserve the existing narrow Settings scope groups while placing Context
+// Tree with the other Team-owned settings. Each item keeps the same canonical
+// route as the desktop sidebar.
 const NARROW_GROUPS: ItemGroup[] = [
   {
     label: "Personal",
@@ -70,7 +84,7 @@ const NARROW_GROUPS: ItemGroup[] = [
   },
   {
     label: "Team",
-    items: [REPOSITORIES_ITEM, RESOURCES_ITEM, INTEGRATIONS_ITEM, SETUP_ITEM],
+    items: [REPOSITORIES_ITEM, CONTEXT_TREE_ITEM, RESOURCES_ITEM, INTEGRATIONS_ITEM, SETUP_ITEM],
   },
 ];
 

--- a/packages/web/src/pages/settings/__tests__/repositories-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/repositories-page-dom.test.tsx
@@ -48,7 +48,7 @@ async function renderPage(path = "/settings/repositories"): Promise<{ container:
       <MemoryRouter initialEntries={[path]}>
         <Routes>
           <Route path="/settings/repositories" element={<SettingsRepositoriesPage />} />
-          <Route path="/settings/setup" element={<LocationProbe />} />
+          <Route path="/settings/context" element={<LocationProbe />} />
         </Routes>
       </MemoryRouter>,
     );
@@ -109,12 +109,10 @@ describe("SettingsRepositoriesPage", () => {
     await act(async () => root.unmount());
   });
 
-  it("redirects the retired Context Tree anchor to canonical Setup controls", async () => {
+  it("redirects the retired Context Tree anchor to the dedicated settings page", async () => {
     const { container, root } = await renderPage("/settings/repositories#context-tree");
 
-    expect(container.querySelector("[data-location]")?.getAttribute("data-location")).toBe(
-      "/settings/setup#context-tree",
-    );
+    expect(container.querySelector("[data-location]")?.getAttribute("data-location")).toBe("/settings/context#binding");
     expect(container.querySelector('[data-testid="resource-sections"]')).toBeNull();
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import type { TeamSetupCapabilities } from "@first-tree/shared";
+import type { OrgContextTreeFeaturesOutput, OrgContextTreeOutput, TeamSetupCapabilities } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
@@ -171,23 +171,34 @@ async function renderSettingsSetupPage(initialEntry = "/") {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
   });
+  const page = () => (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <QueryClientProvider client={queryClient}>
+        <LocationProbe />
+        <Routes>
+          <Route path="/" element={<SettingsSetupPage />} />
+          <Route path="/settings/setup" element={<SettingsSetupPage />} />
+          <Route path="/settings/context" element={<SettingsContextTreePage />} />
+          <Route path="/settings/integrations/github" element={<div>GitHub settings</div>} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
   await act(async () => {
-    root.render(
-      <MemoryRouter initialEntries={[initialEntry]}>
-        <QueryClientProvider client={queryClient}>
-          <LocationProbe />
-          <Routes>
-            <Route path="/" element={<SettingsSetupPage />} />
-            <Route path="/settings/setup" element={<SettingsSetupPage />} />
-            <Route path="/settings/context" element={<SettingsContextTreePage />} />
-            <Route path="/settings/integrations/github" element={<div>GitHub settings</div>} />
-          </Routes>
-        </QueryClientProvider>
-      </MemoryRouter>,
-    );
+    root.render(page());
   });
   await flush();
-  return { host, root };
+  return {
+    host,
+    root,
+    queryClient,
+    rerender: async () => {
+      await act(async () => {
+        root.render(page());
+      });
+      await flush();
+    },
+  };
 }
 
 function LocationProbe() {
@@ -1099,6 +1110,175 @@ describe("Settings Setup overview", () => {
     expect(controls.textContent).toContain("release branch");
     expect(controls.textContent).toContain("Saved");
     expect(controls.querySelector('button[aria-label="Save"]')).not.toBeNull();
+    await act(async () => view.root.unmount());
+  });
+
+  it("drops binding editor state and a late save response when switching to a cached Team", async () => {
+    const teamACapabilities = capabilityFixture();
+    const teamBCapabilities: TeamSetupCapabilities = {
+      ...capabilityFixture({
+        binding: {
+          state: "bound",
+          provider: "gitlab",
+          repo: "https://gitlab.com/beta/context-tree.git",
+          branch: "stable",
+        },
+        review: {
+          reviewerAgent: { uuid: "reviewer-2", displayName: "Beta Reviewer" },
+        },
+      }),
+      organizationId: "org-2",
+    };
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockImplementation(async (organizationId: string) =>
+      organizationId === "org-2" ? teamBCapabilities : teamACapabilities,
+    );
+    orgSettingsMocks.getRawContextTreeSetting.mockImplementation(async (organizationId: string) =>
+      organizationId === "org-2"
+        ? {
+            repo: "https://gitlab.com/beta/context-tree.git",
+            branch: "stable",
+            provider: "gitlab",
+          }
+        : {
+            repo: "https://github.com/acme/context-tree.git",
+            branch: "main",
+            provider: "github",
+          },
+    );
+    let resolveTeamASave!: (value: OrgContextTreeOutput) => void;
+    orgSettingsMocks.putContextTreeSetting.mockImplementationOnce(
+      () =>
+        new Promise<OrgContextTreeOutput>((resolve) => {
+          resolveTeamASave = resolve;
+        }),
+    );
+
+    const view = await renderSettingsSetupPage("/settings/context");
+    const teamAControls = await waitForSelector<HTMLElement>(
+      view.host,
+      '[data-context-tree-settings="admin"] [data-setup-owner-controls="context-tree"]',
+    );
+    const edit = [...teamAControls.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Change repository or branch",
+    );
+    await act(async () => edit?.click());
+    const save = await waitForSelector<HTMLButtonElement>(teamAControls, 'button[aria-label="Save"]');
+    await act(async () => save.click());
+    await flush();
+    expect(orgSettingsMocks.putContextTreeSetting).toHaveBeenCalledWith("org-1", {
+      provider: null,
+      repo: "https://github.com/acme/context-tree.git",
+      branch: "main",
+    });
+
+    view.queryClient.setQueryData(["setup-capabilities", "org-2"], teamBCapabilities);
+    authMock.value = {
+      ...authMock.value,
+      organizationId: "org-2",
+      teamDisplayName: "Beta",
+    };
+    await view.rerender();
+
+    const teamBControls = await waitForSelector<HTMLElement>(
+      view.host,
+      '[data-context-tree-settings="admin"] [data-setup-owner-controls="context-tree"]',
+    );
+    expect(teamBControls.textContent).toContain("beta/context-tree · stable branch · GitLab");
+    expect(teamBControls.textContent).not.toContain("acme/context-tree");
+    expect(teamBControls.querySelector('input[placeholder*="github.com"]')).toBeNull();
+
+    await act(async () => {
+      resolveTeamASave({
+        repo: "https://github.com/acme/context-tree.git",
+        branch: "release",
+        provider: "github",
+      });
+    });
+    await flush();
+
+    expect(teamBControls.textContent).toContain("beta/context-tree · stable branch · GitLab");
+    expect(teamBControls.textContent).not.toContain("release branch");
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps a cached Team's Reviewer projection when the previous Team mutation settles late", async () => {
+    const teamACapabilities = capabilityFixture();
+    const teamBCapabilities: TeamSetupCapabilities = {
+      ...capabilityFixture({
+        review: {
+          adoption: "enabled",
+          health: "ready",
+          reviewerAgent: { uuid: "reviewer-2", displayName: "Beta Reviewer" },
+        },
+      }),
+      organizationId: "org-2",
+    };
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockImplementation(async (organizationId: string) =>
+      organizationId === "org-2" ? teamBCapabilities : teamACapabilities,
+    );
+    reviewerMocks.getContextReviewerCandidates.mockImplementation(async (organizationId: string) => ({
+      items: [
+        {
+          uuid: organizationId === "org-2" ? "reviewer-2" : "reviewer-1",
+          name: organizationId === "org-2" ? "beta-reviewer" : "context-reviewer",
+          displayName: organizationId === "org-2" ? "Beta Reviewer" : "Context Reviewer",
+          visibility: "organization",
+          runtime: { health: "ready", blockers: [] },
+        },
+      ],
+      blockers: [],
+    }));
+    let resolveTeamAEnablement!: (value: OrgContextTreeFeaturesOutput) => void;
+    reviewerMocks.putContextReviewerEnablement.mockImplementationOnce(
+      () =>
+        new Promise<OrgContextTreeFeaturesOutput>((resolve) => {
+          resolveTeamAEnablement = resolve;
+        }),
+    );
+
+    const view = await renderSettingsSetupPage("/settings/context");
+    const teamAReviewer = await waitForSelector<HTMLElement>(
+      view.host,
+      '[data-context-tree-settings="admin"] [data-setup-owner-controls="automatic-review"]',
+    );
+    const teamASwitch = teamAReviewer.querySelector<HTMLButtonElement>('[role="switch"]');
+    await act(async () => teamASwitch?.click());
+    await flush();
+    expect(reviewerMocks.putContextReviewerEnablement).toHaveBeenCalledWith("org-1", false);
+
+    view.queryClient.setQueryData(["setup-capabilities", "org-2"], teamBCapabilities);
+    authMock.value = {
+      ...authMock.value,
+      organizationId: "org-2",
+      teamDisplayName: "Beta",
+    };
+    await view.rerender();
+
+    const teamBReviewer = await waitForSelector<HTMLElement>(
+      view.host,
+      '[data-context-tree-settings="admin"] [data-setup-owner-controls="automatic-review"]',
+    );
+    await waitForText(teamBReviewer, "Beta Reviewer");
+    expect(teamBReviewer.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("true");
+
+    await act(async () => {
+      resolveTeamAEnablement({
+        contextReviewer: {
+          enabled: false,
+          agentUuid: "reviewer-1",
+          reviewerAgent: {
+            uuid: "reviewer-1",
+            name: "context-reviewer",
+            displayName: "Context Reviewer",
+          },
+        },
+      });
+    });
+    await flush();
+
+    expect(teamBReviewer.textContent).toContain("Beta Reviewer");
+    expect(teamBReviewer.textContent).not.toContain("Context Reviewer");
+    expect(teamBReviewer.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("true");
     await act(async () => view.root.unmount());
   });
 

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -4,9 +4,10 @@ import type { TeamSetupCapabilities } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { MemoryRouter, useLocation } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "../../../api/client.js";
+import { SettingsContextTreePage } from "../context-tree.js";
 import { buildSetupRows, SettingsSetupPage, type SetupFacts, SetupOverview } from "../setup.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -174,8 +175,13 @@ async function renderSettingsSetupPage(initialEntry = "/") {
     root.render(
       <MemoryRouter initialEntries={[initialEntry]}>
         <QueryClientProvider client={queryClient}>
-          <SettingsSetupPage />
           <LocationProbe />
+          <Routes>
+            <Route path="/" element={<SettingsSetupPage />} />
+            <Route path="/settings/setup" element={<SettingsSetupPage />} />
+            <Route path="/settings/context" element={<SettingsContextTreePage />} />
+            <Route path="/settings/integrations/github" element={<div>GitHub settings</div>} />
+          </Routes>
         </QueryClientProvider>
       </MemoryRouter>,
     );
@@ -225,16 +231,12 @@ async function waitForText(host: ParentNode, expected: string, timeoutMs = 3000)
 
 async function openContextTreeControls(view: Awaited<ReturnType<typeof renderSettingsSetupPage>>) {
   const tree = await waitForRowText(view.host, "context-tree", "Available");
-  const manage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
-    (button) => button.textContent === "Manage",
-  );
+  const manage = tree.querySelector<HTMLAnchorElement>('a[href="/settings/context"]');
   await act(async () => manage?.click());
-  const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
-  const reviewerControls = await waitForSelector<HTMLElement>(
-    controls,
-    '[data-setup-owner-controls="automatic-review"]',
-  );
-  return { tree, manage, controls, reviewerControls };
+  const page = await waitForSelector<HTMLElement>(view.host, '[data-context-tree-settings="admin"]');
+  const controls = await waitForSelector<HTMLElement>(page, '[data-setup-owner-controls="context-tree"]');
+  const reviewerControls = await waitForSelector<HTMLElement>(page, '[data-setup-owner-controls="automatic-review"]');
+  return { tree, manage, page, controls, reviewerControls };
 }
 
 beforeEach(() => {
@@ -439,7 +441,7 @@ describe("Settings Setup overview", () => {
     expect(rowFor("agent", input).status.detail).toBe("Optional while a team agent is available");
     expect(view.host.textContent).not.toContain("Action required");
     expect(view.host.textContent).not.toContain("Manage");
-    expect(rowFor("context-tree", input).action).toBeUndefined();
+    expect(rowFor("context-tree", input).action).toEqual({ label: "View", to: "/settings/context" });
     expect(view.host.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
 
     await act(async () => view.root.unmount());
@@ -620,9 +622,8 @@ describe("Settings Setup overview", () => {
     });
     expect(rowFor("repository-automation", memberFacts).action).toBeUndefined();
     expect(rowFor("context-tree", memberFacts).action).toEqual({
-      label: "Access",
-      to: "/settings/setup#context-tree",
-      intent: "open-context-tree-controls",
+      label: "View",
+      to: "/context",
     });
   });
 
@@ -735,9 +736,8 @@ describe("Settings Setup overview", () => {
     }
     expect(admin.action?.label).toBe("Manage");
     expect(member.action).toEqual({
-      label: "Access",
-      to: "/settings/setup#context-tree",
-      intent: "open-context-tree-controls",
+      label: "View",
+      to: "/context",
     });
   });
 
@@ -791,21 +791,19 @@ describe("Settings Setup overview", () => {
     expect(unbound.status).toEqual({ label: "Not set up", detail: "Optional", kind: "optional" });
     expect(unbound.action).toEqual({
       label: "Set up",
-      to: "/settings/setup#context-tree",
-      intent: "open-context-tree-controls",
+      to: "/settings/context#binding",
     });
     expect(unboundMember.status).toMatchObject({ label: "Not set up", kind: "optional" });
     expect(unboundMember.status.detail).toContain("Ask an admin");
-    expect(unboundMember.action).toBeUndefined();
+    expect(unboundMember.action).toEqual({ label: "View", to: "/settings/context" });
     expect(invalidAdmin.status).toMatchObject({ label: "Needs repair", kind: "attention" });
     expect(invalidAdmin.action).toEqual({
       label: "Repair",
-      to: "/settings/setup#context-tree",
-      intent: "open-context-tree-controls",
+      to: "/settings/context#binding",
     });
     expect(invalidMember.status).toMatchObject({ label: "Unavailable", kind: "blocked" });
     expect(invalidMember.status.detail).toContain("Ask an admin");
-    expect(invalidMember.action).toEqual({ label: "View", to: "/context" });
+    expect(invalidMember.action).toEqual({ label: "View", to: "/settings/context" });
   });
 
   it("keeps Team recovery read-only while preserving Member personal Context access", () => {
@@ -820,9 +818,8 @@ describe("Settings Setup overview", () => {
     expect(row.status).toMatchObject({ label: "Unavailable", kind: "blocked" });
     expect(row.status.detail).toContain("Ask an admin to recover");
     expect(row.action).toEqual({
-      label: "Access",
-      to: "/settings/setup#context-tree",
-      intent: "open-context-tree-controls",
+      label: "View",
+      to: "/context",
     });
   });
 
@@ -832,8 +829,7 @@ describe("Settings Setup overview", () => {
     expect(row.status).toMatchObject({ label: "Status unknown", kind: "unknown" });
     expect(row.action).toEqual({
       label: "Manage",
-      to: "/settings/setup#context-tree",
-      intent: "open-context-tree-controls",
+      to: "/settings/context",
     });
   });
 
@@ -933,9 +929,8 @@ describe("Settings Setup overview", () => {
     expect(member.status.detail).toContain("Ask an admin to resolve this: The configured reviewer is missing.");
     expect(member.status.detail).toContain("Context Tree available");
     expect(member.action).toEqual({
-      label: "Access",
-      to: "/settings/setup#context-tree",
-      intent: "open-context-tree-controls",
+      label: "View",
+      to: "/context",
     });
   });
 
@@ -951,26 +946,22 @@ describe("Settings Setup overview", () => {
     await act(async () => view.root.unmount());
   });
 
-  it("opens Context Tree and Reviewer owner controls only for an Admin", async () => {
+  it("routes an Admin from the Setup summary to Context Tree owner controls", async () => {
     const view = await renderSettingsSetupPage();
     const tree = await waitForRowText(view.host, "context-tree", "Available");
-    const manage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Manage",
-    );
+    const manage = tree.querySelector<HTMLAnchorElement>('a[href="/settings/context"]');
 
-    expect(manage?.getAttribute("aria-expanded")).toBe("false");
+    expect(tree.querySelector("[data-setup-owner-controls]")).toBeNull();
     const { controls, reviewerControls } = await openContextTreeControls(view);
-    expect(manage?.getAttribute("aria-expanded")).toBe("true");
-    expect(controls.textContent).toContain("acme/context-tree · main branch · github");
+    expect(view.host.querySelector("[data-location]")?.textContent).toBe("/settings/context");
+    expect(controls.textContent).toContain("acme/context-tree · main branch · GitHub");
     expect(orgSettingsMocks.getRawContextTreeSetting).toHaveBeenCalledWith("org-1");
     await waitForSelector(reviewerControls, '[aria-label="Automatic review Agent"]');
     expect(reviewerControls.textContent).toContain("Context Reviewer");
     expect(reviewerControls.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("true");
     expect(reviewerMocks.getContextReviewerCandidates).toHaveBeenCalledWith("org-1");
 
-    await act(async () => manage?.click());
-    expect(manage?.getAttribute("aria-expanded")).toBe("false");
-    expect(view.host.querySelector('[data-setup-owner-controls="context-tree"]')).toBeNull();
+    expect(manage?.textContent).toBe("Manage");
 
     await act(async () => view.root.unmount());
   });
@@ -995,8 +986,8 @@ describe("Settings Setup overview", () => {
 
     const view = await renderSettingsSetupPage();
     expect(view.host.querySelector("#context-access")).toBeNull();
-    const { controls } = await openContextTreeControls(view);
-    const personalAccess = await waitForSelector<HTMLElement>(controls, "[data-setup-personal-access]");
+    const { page } = await openContextTreeControls(view);
+    const personalAccess = await waitForSelector<HTMLElement>(page, "[data-setup-personal-access]");
 
     expect(personalAccess.textContent).toContain("Use with Claude Code or Codex");
     expect(personalAccess.textContent).toContain(
@@ -1033,7 +1024,7 @@ describe("Settings Setup overview", () => {
     await act(async () => view.root.unmount());
   });
 
-  it("lets a Member expand personal Context access without loading Admin Tree or Reviewer controls", async () => {
+  it("lets a Member use personal Context access without loading Admin Tree or Reviewer controls", async () => {
     authMock.value = { ...authMock.value, role: "member" };
     resourceMocks.listTeamResourcesForOrg.mockResolvedValue([
       {
@@ -1052,25 +1043,15 @@ describe("Settings Setup overview", () => {
       }),
     );
 
-    const view = await renderSettingsSetupPage();
-    const tree = await waitForRowText(view.host, "context-tree", "Available");
-    const access = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Access",
-    );
-    expect(access?.getAttribute("aria-expanded")).toBe("false");
-
-    await act(async () => access?.click());
-    const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
-    const personalAccess = await waitForSelector<HTMLElement>(controls, "[data-setup-personal-access]");
-    const openContext = [...controls.querySelectorAll<HTMLAnchorElement>("a")].find(
-      (link) => link.textContent === "Open Context →",
-    );
+    const view = await renderSettingsSetupPage("/settings/context");
+    const page = await waitForSelector<HTMLElement>(view.host, '[data-context-tree-settings="member"]');
+    const personalAccess = await waitForSelector<HTMLElement>(page, "[data-setup-personal-access]");
     expect(personalAccess.textContent).toContain("Use with Claude Code or Codex");
     expect(personalAccess.textContent).toContain("Copy setup prompt");
     expect(personalAccess.textContent).toContain("Preview prompt");
-    expect(openContext?.getAttribute("href")).toBe("/context");
-    expect(controls.querySelector('[data-setup-owner-controls="automatic-review"]')).toBeNull();
-    expect(controls.querySelector('[role="switch"]')).toBeNull();
+    expect(page.querySelector<HTMLAnchorElement>('a[href="/context"]')?.textContent).toContain("Open Context");
+    expect(page.querySelector("[data-setup-owner-controls]")).toBeNull();
+    expect(page.querySelector('[role="switch"]')).toBeNull();
     expect(reviewerMocks.getContextReviewerCandidates).not.toHaveBeenCalled();
     expect(orgSettingsMocks.getRawContextTreeSetting).not.toHaveBeenCalled();
 
@@ -1101,13 +1082,7 @@ describe("Settings Setup overview", () => {
 
   it("keeps the binding editor open and reflects the saved Server response immediately", async () => {
     const view = await renderSettingsSetupPage();
-    const tree = await waitForRowText(view.host, "context-tree", "Available");
-    const manage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Manage",
-    );
-
-    await act(async () => manage?.click());
-    const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
+    const { controls } = await openContextTreeControls(view);
     const edit = [...controls.querySelectorAll<HTMLButtonElement>("button")].find(
       (button) => button.textContent === "Change repository or branch",
     );
@@ -1165,12 +1140,7 @@ describe("Settings Setup overview", () => {
     );
 
     const view = await renderSettingsSetupPage();
-    const tree = await waitForRowText(view.host, "context-tree", "Available");
-    const manage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Manage",
-    );
-    await act(async () => manage?.click());
-    const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
+    const { controls } = await openContextTreeControls(view);
     const edit = [...controls.querySelectorAll<HTMLButtonElement>("button")].find(
       (button) => button.textContent === "Change repository or branch",
     );
@@ -1192,22 +1162,22 @@ describe("Settings Setup overview", () => {
       repo: nextRepo,
       branch: "main",
     });
-    expect(controls.textContent).toContain(`main branch · ${nextProvider}`);
+    expect(controls.textContent).toContain(`main branch · ${nextProvider === "github" ? "GitHub" : "GitLab"}`);
     expect(controls.textContent).toContain("Saved");
     await act(async () => view.root.unmount());
   });
 
   it.each([
-    ["#context-tree", "context-tree"],
-    ["#automatic-review", "context-tree"],
-  ] as const)("opens and focuses the canonical owner control for legacy hash %s", async (hash, key) => {
+    ["#context-tree", "/settings/context#binding", "binding"],
+    ["#automatic-review", "/settings/context#automatic-review", "automatic-review"],
+  ] as const)("redirects legacy hash %s to and focuses %s", async (hash, destination, targetId) => {
     const view = await renderSettingsSetupPage(`/settings/setup${hash}`);
-    const row = await waitForSelector<HTMLElement>(view.host, `[data-setup-row="${key}"]`);
-    await waitForSelector(row, `[data-setup-owner-controls="${key}"]`);
-    await waitForSelector(row, '[data-setup-owner-controls="automatic-review"]');
+    await waitForText(view.host, destination);
+    const target = await waitForSelector<HTMLElement>(view.host, `#${targetId}`);
+    await waitForSelector(view.host, '[data-context-tree-settings="admin"]');
 
-    expect(row.id).toBe(key);
-    expect(document.activeElement).toBe(row);
+    expect(view.host.querySelector("[data-location]")?.textContent).toBe(destination);
+    expect(document.activeElement).toBe(target);
     await act(async () => view.root.unmount());
   });
 
@@ -1222,12 +1192,13 @@ describe("Settings Setup overview", () => {
   it("keeps Member Setup read-only without loading owner-only settings", async () => {
     authMock.value = { ...authMock.value, role: "member" };
     const view = await renderSettingsSetupPage("/settings/setup#automatic-review");
-    await waitForRowText(view.host, "context-tree", "Review on");
+    await waitForText(view.host, "/settings/context#automatic-review");
+    const page = await waitForSelector<HTMLElement>(view.host, '[data-context-tree-settings="member"]');
 
-    expect(view.host.getAttribute("data-setup-overview")).toBeNull();
-    expect(view.host.querySelector('[data-setup-overview="member"]')).not.toBeNull();
-    expect(view.host.querySelector("[data-setup-owner-controls]")).toBeNull();
-    expect(view.host.querySelector('[role="switch"]')).toBeNull();
+    expect(view.host.querySelector("[data-location]")?.textContent).toBe("/settings/context#automatic-review");
+    expect(page.textContent).toContain("Context Reviewer");
+    expect(page.querySelector("[data-setup-owner-controls]")).toBeNull();
+    expect(page.querySelector('[role="switch"]')).toBeNull();
     expect(reviewerMocks.getContextReviewerCandidates).not.toHaveBeenCalled();
     expect(orgSettingsMocks.getRawContextTreeSetting).not.toHaveBeenCalled();
     await act(async () => view.root.unmount());
@@ -1326,15 +1297,18 @@ describe("Settings Setup overview", () => {
   });
 
   it("changes assignment through its split endpoint and keeps an offline candidate selectable", async () => {
-    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValueOnce(capabilityFixture()).mockResolvedValue(
-      capabilityFixture({
-        review: {
-          adoption: "disabled",
-          health: "degraded",
-          reviewerAgent: { uuid: "reviewer-2", displayName: "Offline Reviewer" },
-        },
-      }),
-    );
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt
+      .mockResolvedValueOnce(capabilityFixture())
+      .mockResolvedValueOnce(capabilityFixture())
+      .mockResolvedValue(
+        capabilityFixture({
+          review: {
+            adoption: "disabled",
+            health: "degraded",
+            reviewerAgent: { uuid: "reviewer-2", displayName: "Offline Reviewer" },
+          },
+        }),
+      );
     reviewerMocks.getContextReviewerCandidates.mockResolvedValue({
       items: [
         {
@@ -1463,12 +1437,13 @@ describe("Settings Setup overview", () => {
     );
     const view = await renderSettingsSetupPage();
     const tree = await waitForRowText(view.host, "context-tree", "Needs repair");
-    const repair = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Repair",
-    );
+    const repair = tree.querySelector<HTMLAnchorElement>('a[href="/settings/context#binding"]');
 
     await act(async () => repair?.click());
-    const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
+    const controls = await waitForSelector<HTMLElement>(
+      view.host,
+      '[data-context-tree-settings="admin"] [data-setup-owner-controls="context-tree"]',
+    );
     expect(controls.textContent).toContain("Bind it manually");
     expect(controls.textContent).not.toContain("Build your Context Tree");
     await act(async () => view.root.unmount());
@@ -1522,17 +1497,17 @@ describe("Settings Setup overview", () => {
 
     const view = await renderSettingsSetupPage();
     const row = await waitForRowText(view.host, "context-tree", "Connected");
-    const manage = [...row.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Manage",
-    );
 
     expect(row.textContent).not.toContain("Needs recovery");
     expect(row.textContent).not.toContain("Web Context unavailable");
     expect(row.textContent).not.toContain("GitLab deployment allowlist diagnostic");
+    const manage = row.querySelector<HTMLAnchorElement>('a[href="/settings/context"]');
     await act(async () => manage?.click());
-    const controls = await waitForSelector<HTMLElement>(row, '[data-setup-owner-controls="context-tree"]');
+    const page = await waitForSelector<HTMLElement>(view.host, '[data-context-tree-settings="admin"]');
+    const controls = await waitForSelector<HTMLElement>(page, '[data-setup-owner-controls="context-tree"]');
+    const reviewerControls = await waitForSelector<HTMLElement>(page, '[data-setup-owner-controls="automatic-review"]');
     expect(controls.textContent).not.toContain("Open Context");
-    expect(controls.textContent).toContain("Automatic review");
+    expect(reviewerControls.textContent).toContain("Enable automatic review");
     expect(controls.textContent).not.toContain("Work on this in chat");
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/settings/context-tree.tsx
+++ b/packages/web/src/pages/settings/context-tree.tsx
@@ -121,6 +121,7 @@ export function SettingsContextTreePage() {
           <div style={{ padding: "var(--sp-3) 0" }}>
             {isAdmin ? (
               <SetupContextTreeControls
+                key={`context-tree-${organizationId}`}
                 binding={binding}
                 availability={availability}
                 teamNonActionableGitlabWebContext={teamNonActionableGitlabWebContext}
@@ -150,7 +151,12 @@ export function SettingsContextTreePage() {
                 Available once this Team has a valid Context Tree binding.
               </p>
             ) : isAdmin ? (
-              <SetupReviewerControls review={review} embedded label="Enable automatic review" />
+              <SetupReviewerControls
+                key={`automatic-review-${organizationId}`}
+                review={review}
+                embedded
+                label="Enable automatic review"
+              />
             ) : (
               <ReadOnlyReview review={review} />
             )}

--- a/packages/web/src/pages/settings/context-tree.tsx
+++ b/packages/web/src/pages/settings/context-tree.tsx
@@ -1,9 +1,287 @@
-import { Navigate } from "react-router";
+import type { SetupAutomaticReview, SetupContextTreeBinding } from "@first-tree/shared";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { Link, useLocation } from "react-router";
+import { getContextTreeSnapshot } from "../../api/context-tree.js";
+import { listTeamResourcesForOrg } from "../../api/resources.js";
+import { getTeamSetupCapabilitiesAt, setupCapabilitiesQueryKey } from "../../api/setup-capabilities.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { Button } from "../../components/ui/button.js";
+import { Section } from "../../components/ui/section.js";
+import { isTeamNonActionableGitlabWebContext } from "../context-tree-availability.js";
+import { ContextPersonalAccess } from "./context-enablement.js";
+import { SetupContextTreeControls } from "./setup-context-tree-controls.js";
+import { SetupReviewerControls } from "./setup-reviewer-controls.js";
+
+const BINDING_HASH = "#binding";
+const AUTOMATIC_REVIEW_HASH = "#automatic-review";
+const CODING_AGENT_ACCESS_HASH = "#coding-agent-access";
+
+type ContextTreeAvailability = "active" | "stale" | "unavailable" | "checking" | "unknown" | null;
 
 /**
- * Compatibility entry for the former Settings → Context tree page. Permanent
- * Team capability setup and recovery now live in Settings → Setup.
+ * Canonical Context Tree configuration surface.
+ *
+ * The top-level `/context` page stays read-only and explains freshness and
+ * usage. This page owns the selected Team's binding, automatic-review
+ * assignment, and personal coding-agent handoff. Members see the same Team
+ * facts without receiving admin mutation controls.
  */
 export function SettingsContextTreePage() {
-  return <Navigate to="/settings/setup" replace />;
+  const { organizationId, role } = useAuth();
+  const location = useLocation();
+  const bindingRef = useRef<HTMLElement>(null);
+  const automaticReviewRef = useRef<HTMLElement>(null);
+  const codingAgentAccessRef = useRef<HTMLElement>(null);
+  const isAdmin = role === "admin";
+
+  const capabilitiesQuery = useQuery({
+    queryKey: setupCapabilitiesQueryKey(organizationId),
+    queryFn: () =>
+      organizationId ? getTeamSetupCapabilitiesAt(organizationId) : Promise.reject(new Error("no organization")),
+    enabled: !!organizationId,
+  });
+  const binding = capabilitiesQuery.data?.contextTree.binding;
+  const contextBound = binding?.state === "bound";
+  const snapshotQuery = useQuery({
+    queryKey: ["context-tree-snapshot", organizationId, "7d", false],
+    queryFn: () =>
+      organizationId ? getContextTreeSnapshot(organizationId, "7d") : Promise.reject(new Error("no organization")),
+    enabled: !!organizationId && contextBound,
+  });
+  const repositoriesQuery = useQuery({
+    queryKey: ["settings", "context-tree", "team-resources", organizationId],
+    queryFn: () =>
+      organizationId ? listTeamResourcesForOrg(organizationId) : Promise.reject(new Error("no organization")),
+    enabled: !!organizationId && contextBound,
+  });
+
+  const availability: ContextTreeAvailability = !contextBound
+    ? null
+    : snapshotQuery.isPending
+      ? "checking"
+      : snapshotQuery.isError || !snapshotQuery.data
+        ? "unknown"
+        : snapshotQuery.data.snapshotStatus;
+  const teamNonActionableGitlabWebContext = isTeamNonActionableGitlabWebContext(snapshotQuery.data);
+  const hasCodeRepository =
+    repositoriesQuery.data?.some((resource) => resource.type === "repo" && resource.status === "active") ?? false;
+  const personalAccessReady = contextBound && hasCodeRepository;
+
+  useEffect(() => {
+    if (role === null || !capabilitiesQuery.isSuccess) return;
+    const target =
+      location.hash === BINDING_HASH || location.hash === "#context-tree"
+        ? bindingRef.current
+        : location.hash === AUTOMATIC_REVIEW_HASH
+          ? automaticReviewRef.current
+          : location.hash === CODING_AGENT_ACCESS_HASH
+            ? codingAgentAccessRef.current
+            : null;
+    if (!target) return;
+    target.scrollIntoView({ block: "start" });
+    target.focus({ preventScroll: true });
+  }, [capabilitiesQuery.isSuccess, location.hash, role]);
+
+  if (role === null || !organizationId) {
+    return <PageState>Loading…</PageState>;
+  }
+
+  if (capabilitiesQuery.isPending) {
+    return <PageState>Loading Context Tree settings…</PageState>;
+  }
+
+  if (capabilitiesQuery.isError || !binding) {
+    return (
+      <PageState error>
+        {capabilitiesQuery.error instanceof Error
+          ? capabilitiesQuery.error.message
+          : "Failed to load Context Tree settings"}
+      </PageState>
+    );
+  }
+
+  const review = capabilitiesQuery.data.contextTree.automaticReview;
+
+  return (
+    <div
+      data-context-tree-settings={isAdmin ? "admin" : "member"}
+      className="flex flex-col"
+      style={{ gap: "var(--sp-5)", padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}
+    >
+      <section
+        ref={bindingRef}
+        id={BINDING_HASH.slice(1)}
+        tabIndex={-1}
+        aria-label="Context Tree binding"
+        style={{ scrollMarginTop: "var(--sp-4)" }}
+      >
+        <Section title="Binding" description="The repository and branch that store this Team's shared context.">
+          <div style={{ padding: "var(--sp-3) 0" }}>
+            {isAdmin ? (
+              <SetupContextTreeControls
+                binding={binding}
+                availability={availability}
+                teamNonActionableGitlabWebContext={teamNonActionableGitlabWebContext}
+                embedded
+              />
+            ) : (
+              <ReadOnlyBinding binding={binding} />
+            )}
+          </div>
+        </Section>
+      </section>
+
+      <section
+        ref={automaticReviewRef}
+        id={AUTOMATIC_REVIEW_HASH.slice(1)}
+        tabIndex={-1}
+        aria-label="Automatic Context Tree review"
+        style={{ scrollMarginTop: "var(--sp-4)" }}
+      >
+        <Section
+          title="Automatic review"
+          description="Choose the Agent that reviews eligible Context Tree pull requests and merge requests."
+        >
+          <div style={{ padding: "var(--sp-3) 0" }}>
+            {review.adoption === "unavailable" ? (
+              <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
+                Available once this Team has a valid Context Tree binding.
+              </p>
+            ) : isAdmin ? (
+              <SetupReviewerControls review={review} embedded label="Enable automatic review" />
+            ) : (
+              <ReadOnlyReview review={review} />
+            )}
+          </div>
+        </Section>
+      </section>
+
+      <section
+        ref={codingAgentAccessRef}
+        id={CODING_AGENT_ACCESS_HASH.slice(1)}
+        tabIndex={-1}
+        aria-label="Coding-agent access"
+        style={{ scrollMarginTop: "var(--sp-4)" }}
+      >
+        <Section title="Coding-agent access" description="Use this Team's Context Tree from Claude Code or Codex.">
+          <div style={{ padding: "var(--sp-3) 0" }}>
+            {repositoriesQuery.isPending && contextBound ? (
+              <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
+                Checking repository access…
+              </p>
+            ) : repositoriesQuery.isError && contextBound ? (
+              <p className="text-body" role="alert" style={{ margin: 0, color: "var(--state-error)" }}>
+                Failed to check coding-agent access.
+              </p>
+            ) : personalAccessReady ? (
+              <ContextPersonalAccess organizationId={organizationId} />
+            ) : (
+              <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
+                {contextBound
+                  ? "Add an active code repository before generating the coding-agent setup prompt."
+                  : "Available once this Team has a valid Context Tree binding."}
+              </p>
+            )}
+          </div>
+        </Section>
+      </section>
+    </div>
+  );
+}
+
+function PageState({ children, error = false }: { children: string; error?: boolean }) {
+  return (
+    <div
+      className="text-body"
+      role={error ? "alert" : undefined}
+      style={{ padding: "var(--sp-5)", color: error ? "var(--state-error)" : "var(--fg-3)" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ReadOnlyBinding({ binding }: { binding: SetupContextTreeBinding }) {
+  if (binding.state === "unbound") {
+    return (
+      <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
+        This Team does not have a Context Tree yet. Ask an admin to set one up.
+      </p>
+    );
+  }
+  if (binding.state === "invalid") {
+    return (
+      <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
+        The Context Tree binding needs repair. Ask an admin to update it.
+      </p>
+    );
+  }
+  return (
+    <div className="flex min-w-0 flex-wrap items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+      <div className="min-w-0">
+        <div className="text-body font-medium" style={{ color: "var(--success)" }}>
+          Connected
+        </div>
+        <div
+          className="text-label"
+          style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)", overflowWrap: "anywhere" }}
+        >
+          {repositoryLabel(binding.repo)} · {binding.branch} branch · {providerLabel(binding.provider)}
+        </div>
+      </div>
+      <Button asChild type="button" variant="outline" size="sm">
+        <Link to="/context">
+          <span>Open Context</span>
+          <ArrowRight className="h-4 w-4" aria-hidden />
+        </Link>
+      </Button>
+    </div>
+  );
+}
+
+function ReadOnlyReview({ review }: { review: SetupAutomaticReview }) {
+  const enabled = review.adoption === "enabled";
+  const status =
+    review.adoption === "disabled"
+      ? "Off"
+      : review.health === "ready"
+        ? "On"
+        : review.health === "pending_verification"
+          ? "Verification pending"
+          : review.health === "degraded"
+            ? "Degraded"
+            : "Unavailable";
+  const detail = review.reviewerAgent
+    ? `Reviewer · ${review.reviewerAgent.displayName}`
+    : enabled
+      ? "No reviewer is currently visible."
+      : "Optional";
+  return (
+    <div>
+      <div
+        className="text-body font-medium"
+        style={{ color: enabled && review.health === "ready" ? "var(--success)" : "var(--fg-2)" }}
+      >
+        {status}
+      </div>
+      <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
+        {detail}
+      </div>
+    </div>
+  );
+}
+
+function repositoryLabel(repo: string): string {
+  try {
+    const url = new URL(repo);
+    return url.pathname.replace(/^\/|\.git$/g, "") || url.hostname;
+  } catch {
+    return repo.replace(/^git@[^:]+:/, "").replace(/\.git$/, "");
+  }
+}
+
+function providerLabel(provider: "github" | "gitlab"): string {
+  return provider === "github" ? "GitHub" : "GitLab";
 }

--- a/packages/web/src/pages/settings/repositories.tsx
+++ b/packages/web/src/pages/settings/repositories.tsx
@@ -8,8 +8,8 @@ const CONTEXT_TREE_HASH = "#context-tree";
 
 /**
  * Settings → Repositories is the provider-neutral catalog of code available to
- * agents. Context Tree binding and Automatic Review owner controls live in the
- * canonical Settings → Setup surface.
+ * agents. Context Tree binding and Automatic Review live in the dedicated
+ * Settings → Context Tree surface.
  */
 export function SettingsRepositoriesPage() {
   const { role } = useAuth();
@@ -27,7 +27,7 @@ export function SettingsRepositoriesPage() {
   }, [location.hash, role]);
 
   if (location.hash === CONTEXT_TREE_HASH) {
-    return <Navigate to="/settings/setup#context-tree" replace />;
+    return <Navigate to="/settings/context#binding" replace />;
   }
 
   if (role === null) {

--- a/packages/web/src/pages/settings/setup-context-tree-controls.tsx
+++ b/packages/web/src/pages/settings/setup-context-tree-controls.tsx
@@ -20,6 +20,7 @@ export function SetupContextTreeControls({
   saveSetting = putContextTreeSetting,
   refreshFacts,
   children,
+  embedded = false,
 }: {
   binding: SetupContextTreeBinding;
   availability: ContextTreeAvailability;
@@ -28,6 +29,7 @@ export function SetupContextTreeControls({
   saveSetting?: (organizationId: string, input: OrgContextTreeInput) => Promise<OrgContextTreeOutput>;
   refreshFacts?: (organizationId: string) => Promise<void>;
   children?: ReactNode;
+  embedded?: boolean;
 }) {
   const { organizationId, role } = useAuth();
   const isAdmin = role === "admin";
@@ -91,11 +93,11 @@ export function SetupContextTreeControls({
     binding.state === "unbound" ||
     (hasBoundTree && availability === "unavailable" && !teamNonActionableGitlabWebContext);
   const bindingSummary = savedBinding?.repo
-    ? `${repositoryLabel(savedBinding.repo)} · ${savedBinding.branch ?? "main"} branch · ${
-        savedBinding.provider ?? "provider pending"
-      }`
+    ? `${repositoryLabel(savedBinding.repo)} · ${savedBinding.branch ?? "main"} branch · ${providerLabel(
+        savedBinding.provider,
+      )}`
     : binding.state === "bound"
-      ? `${repositoryLabel(binding.repo)} · ${binding.branch} branch · ${binding.provider}`
+      ? `${repositoryLabel(binding.repo)} · ${binding.branch} branch · ${providerLabel(binding.provider)}`
       : null;
 
   const handleSubmit = (event: FormEvent) => {
@@ -107,13 +109,17 @@ export function SetupContextTreeControls({
     <div
       data-setup-owner-controls="context-tree"
       className="flex flex-col"
-      style={{
-        gap: "var(--sp-3)",
-        padding: "var(--sp-4)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-panel)",
-        background: "var(--bg-sunken)",
-      }}
+      style={
+        embedded
+          ? { gap: "var(--sp-3)" }
+          : {
+              gap: "var(--sp-3)",
+              padding: "var(--sp-4)",
+              border: "var(--hairline) solid var(--border)",
+              borderRadius: "var(--radius-panel)",
+              background: "var(--bg-sunken)",
+            }
+      }
     >
       {bindingSummary ? (
         <div className="flex min-w-0 flex-wrap items-center justify-between" style={{ gap: "var(--sp-3)" }}>
@@ -206,4 +212,10 @@ function repositoryLabel(repo: string): string {
   } catch {
     return repo.replace(/^git@[^:]+:/, "").replace(/\.git$/, "");
   }
+}
+
+function providerLabel(provider: "github" | "gitlab" | null | undefined): string {
+  if (provider === "github") return "GitHub";
+  if (provider === "gitlab") return "GitLab";
+  return "provider pending";
 }

--- a/packages/web/src/pages/settings/setup-reviewer-controls.tsx
+++ b/packages/web/src/pages/settings/setup-reviewer-controls.tsx
@@ -27,6 +27,7 @@ export function SetupReviewerControls({
   assignReviewer = putContextReviewerAssignment,
   setReviewerEnabled = putContextReviewerEnablement,
   refreshFacts,
+  label = "Automatic review",
 }: {
   review: SetupAutomaticReview;
   embedded?: boolean;
@@ -34,6 +35,7 @@ export function SetupReviewerControls({
   assignReviewer?: (organizationId: string, agentUuid: string | null) => Promise<OrgContextTreeFeaturesOutput>;
   setReviewerEnabled?: (organizationId: string, enabled: boolean) => Promise<OrgContextTreeFeaturesOutput>;
   refreshFacts?: (organizationId: string) => Promise<void>;
+  label?: string;
 }) {
   const { organizationId, role } = useAuth();
   const queryClient = useQueryClient();
@@ -132,7 +134,7 @@ export function SetupReviewerControls({
       <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
         <div className="min-w-0">
           <span id={switchLabelId} className="text-body font-medium" style={{ color: "var(--fg)" }}>
-            Automatic review
+            {label}
           </span>
           <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
             {selectedLabel && !selectedCandidate
@@ -141,7 +143,7 @@ export function SetupReviewerControls({
                 ? enabled
                   ? "Reviews eligible Context Tree pull requests and merge requests as webhook events arrive."
                   : "Reviewer selection retained while Automatic review is off."
-                : "Choose an existing eligible Team Agent. Setup never creates one."}
+                : "Choose an existing eligible Team Agent."}
           </div>
         </div>
         <Switch
@@ -189,7 +191,7 @@ export function SetupReviewerControls({
             searchable={candidates.length > 6}
           />
           <div className="text-caption" style={{ color: "var(--fg-4)" }}>
-            Changing the assignment turns Automatic Review off. Re-enable it separately after confirming the selected
+            Changing the assignment turns automatic review off. Re-enable it separately after confirming the selected
             Agent.
           </div>
         </div>

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -11,8 +11,6 @@ import type {
 import { useQuery } from "@tanstack/react-query";
 import {
   Bot,
-  ChevronDown,
-  ChevronUp,
   CircleAlert,
   CircleCheck,
   CircleHelp,
@@ -26,7 +24,7 @@ import {
   MessageCircle,
   Webhook,
 } from "lucide-react";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 import { listClients } from "../../api/activity.js";
 import { getContextTreeSnapshot } from "../../api/context-tree.js";
@@ -38,10 +36,7 @@ import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { cn } from "../../lib/utils.js";
 import { isTeamNonActionableGitlabWebContext } from "../context-tree-availability.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
-import { ContextPersonalAccess } from "./context-enablement.js";
 import { setupBlockerCopy } from "./setup-blocker-copy.js";
-import { SetupContextTreeControls } from "./setup-context-tree-controls.js";
-import { SetupReviewerControls } from "./setup-reviewer-controls.js";
 
 type Fact<T> =
   | { state: "loading" }
@@ -96,7 +91,7 @@ export type SetupRowModel = {
   action?: {
     label: string;
     to: string;
-    intent?: "resume-onboarding" | "open-context-tree-controls";
+    intent?: "resume-onboarding";
   };
 };
 
@@ -175,12 +170,12 @@ const ACTION_DESTINATIONS = {
   manage_github_installation: "/settings/integrations/github",
   connect_gitlab: "/settings/integrations/gitlab",
   configure_gitlab_webhook: "/settings/integrations/gitlab",
-  repair_tree_binding: "/settings/setup#context-tree",
-  open_tree_setup_chat: "/context",
-  select_review_agent: "/settings/setup#context-tree",
-  replace_review_agent: "/settings/setup#context-tree",
+  repair_tree_binding: "/settings/context#binding",
+  open_tree_setup_chat: "/settings/context#binding",
+  select_review_agent: "/settings/context#automatic-review",
+  replace_review_agent: "/settings/context#automatic-review",
   open_agent_owner_flow: "/team",
-  manage_review_agent: "/settings/setup#context-tree",
+  manage_review_agent: "/settings/context#automatic-review",
   configure_github_app: "/settings/integrations/github",
   select_team_agent: "/settings/integrations/github#task-routing",
 } satisfies Record<SetupActionKind, string>;
@@ -379,39 +374,22 @@ function contextTreeStatus(
   return { label: "Status unknown", detail, kind: "unknown" };
 }
 
-function contextTreeAction(
-  contextTree: Fact<ContextTreeFact>,
-  isAdmin: boolean,
-  personalContextAccessReady: boolean,
-): SetupRowModel["action"] | undefined {
+function contextTreeAction(contextTree: Fact<ContextTreeFact>, isAdmin: boolean): SetupRowModel["action"] | undefined {
   if (contextTree.state !== "ready") return undefined;
   const { binding, availability, teamNonActionableGitlabWebContext } = contextTree.value;
   if (binding.state === "unbound") {
-    return isAdmin
-      ? { label: "Set up", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
-      : undefined;
+    return isAdmin ? { label: "Set up", to: "/settings/context#binding" } : { label: "View", to: "/settings/context" };
   }
   if (binding.state === "invalid") {
-    return isAdmin
-      ? { label: "Repair", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
-      : { label: "View", to: "/context" };
-  }
-  if (!isAdmin && personalContextAccessReady) {
-    return { label: "Access", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" };
+    return isAdmin ? { label: "Repair", to: "/settings/context#binding" } : { label: "View", to: "/settings/context" };
   }
   if (teamNonActionableGitlabWebContext) {
-    return isAdmin
-      ? { label: "Manage", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
-      : { label: "View", to: "/context" };
+    return isAdmin ? { label: "Manage", to: "/settings/context" } : { label: "View", to: "/context" };
   }
   if (availability === "unavailable") {
-    return isAdmin
-      ? { label: "Recover", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
-      : { label: "View", to: "/context" };
+    return isAdmin ? { label: "Recover", to: "/settings/context#binding" } : { label: "View", to: "/context" };
   }
-  return isAdmin
-    ? { label: "Manage", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
-    : { label: "View", to: "/context" };
+  return isAdmin ? { label: "Manage", to: "/settings/context" } : { label: "View", to: "/context" };
 }
 
 function reviewDiagnosticDetail(review: SetupAutomaticReview, isAdmin: boolean): string | undefined {
@@ -554,12 +532,6 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
 
   const capabilities = facts.capabilities.state === "ready" ? facts.capabilities.value : null;
   const contextTree = contextTreeFact(facts.capabilities, facts.contextTreeSnapshot);
-  const personalContextAccessReady =
-    (facts.role === "admin" || facts.role === "member") &&
-    facts.repositories.state === "ready" &&
-    facts.repositories.value > 0 &&
-    contextTree.state === "ready" &&
-    contextTree.value.binding.state === "bound";
   const repositoryAutomationStatus =
     facts.capabilities.state === "loading"
       ? loadingStatus()
@@ -658,7 +630,7 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
         automaticReviewStatus,
         capabilities ? reviewDiagnosticDetail(capabilities.contextTree.automaticReview, isAdmin) : undefined,
       ),
-      action: contextTreeAction(contextTree, isAdmin, personalContextAccessReady),
+      action: contextTreeAction(contextTree, isAdmin),
     },
   ];
 }
@@ -666,12 +638,6 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
 export function SettingsSetupPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const [expandedOwnerControl, setExpandedOwnerControl] = useState<{
-    organizationId: string | null;
-    key: SetupRowModel["key"];
-  } | null>(null);
-  const previousOrganizationId = useRef<string | null>(null);
-  const handledOwnerHash = useRef<string | null>(null);
   const {
     role,
     organizationId,
@@ -770,148 +736,30 @@ export function SettingsSetupPage() {
     navigate("/onboarding");
   };
 
-  const contextTree = contextTreeFact(capabilities, contextTreeSnapshot);
-  const personalContextAccessReady =
-    (role === "admin" || role === "member") &&
-    facts.repositories.state === "ready" &&
-    facts.repositories.value > 0 &&
-    contextTree.state === "ready" &&
-    contextTree.value.binding.state === "bound";
-  const expandedOwnerControlKey =
-    expandedOwnerControl?.organizationId === organizationId ? expandedOwnerControl.key : null;
-
   useEffect(() => {
     if (location.hash === "#team-agent") {
       navigate("/settings/integrations/github#task-routing", { replace: true });
+      return;
+    }
+    if (location.hash === "#context-tree") {
+      navigate("/settings/context#binding", { replace: true });
+      return;
+    }
+    if (location.hash === "#automatic-review") {
+      navigate("/settings/context#automatic-review", { replace: true });
     }
   }, [location.hash, navigate]);
 
-  useEffect(() => {
-    if (previousOrganizationId.current !== null && previousOrganizationId.current !== organizationId) {
-      setExpandedOwnerControl(null);
-      handledOwnerHash.current = null;
-    }
-    previousOrganizationId.current = organizationId;
-  }, [organizationId]);
-
-  useEffect(() => {
-    const key = location.hash === "#context-tree" || location.hash === "#automatic-review" ? "context-tree" : null;
-    if (!key || !organizationId || facts.capabilities.state !== "ready") return;
-
-    const hashKey = `${organizationId}:${location.hash}`;
-    if (handledOwnerHash.current === hashKey) return;
-    const canOpenForHash = role === "admin" || (location.hash === "#context-tree" && personalContextAccessReady);
-    if (!canOpenForHash) return;
-    handledOwnerHash.current = hashKey;
-    setExpandedOwnerControl({ organizationId, key });
-  }, [facts.capabilities.state, location.hash, organizationId, personalContextAccessReady, role]);
-
-  useEffect(() => {
-    const key = location.hash === "#context-tree" || location.hash === "#automatic-review" ? "context-tree" : null;
-    if (!key || facts.capabilities.state !== "ready") return;
-    const canOpenForHash = role === "admin" || (location.hash === "#context-tree" && personalContextAccessReady);
-    if (canOpenForHash && expandedOwnerControlKey !== key) return;
-
-    const row = document.getElementById(key);
-    row?.scrollIntoView?.({ block: "start" });
-    row?.focus();
-  }, [expandedOwnerControlKey, facts.capabilities.state, location.hash, personalContextAccessReady, role]);
-
-  const ownerControls: Partial<Record<SetupRowModel["key"], ReactNode>> =
-    facts.capabilities.state !== "ready"
-      ? {}
-      : {
-          ...(expandedOwnerControlKey === "context-tree" && contextTree.state === "ready"
-            ? {
-                "context-tree":
-                  role === "admin" ? (
-                    <SetupContextTreeControls
-                      key={`context-tree-${organizationId}`}
-                      binding={contextTree.value.binding}
-                      availability={contextTree.value.availability}
-                      teamNonActionableGitlabWebContext={contextTree.value.teamNonActionableGitlabWebContext}
-                    >
-                      {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ||
-                      personalContextAccessReady ? (
-                        <div className="flex flex-col">
-                          {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ? (
-                            <SetupReviewerControls
-                              key={`automatic-review-${organizationId}`}
-                              review={facts.capabilities.value.contextTree.automaticReview}
-                              embedded
-                            />
-                          ) : null}
-                          {personalContextAccessReady && organizationId ? (
-                            <div
-                              style={{
-                                marginTop:
-                                  facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
-                                    ? "var(--sp-4)"
-                                    : undefined,
-                                paddingTop:
-                                  facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
-                                    ? "var(--sp-4)"
-                                    : undefined,
-                                borderTop:
-                                  facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable"
-                                    ? "var(--hairline) solid var(--border-faint)"
-                                    : undefined,
-                              }}
-                            >
-                              <ContextPersonalAccess organizationId={organizationId} />
-                            </div>
-                          ) : null}
-                        </div>
-                      ) : null}
-                    </SetupContextTreeControls>
-                  ) : role === "member" && personalContextAccessReady && organizationId ? (
-                    <div
-                      data-setup-owner-controls="context-tree"
-                      style={{
-                        padding: "var(--sp-4)",
-                        border: "var(--hairline) solid var(--border)",
-                        borderRadius: "var(--radius-panel)",
-                        background: "var(--bg-sunken)",
-                      }}
-                    >
-                      <div className="flex justify-end" style={{ marginBottom: "var(--sp-3)" }}>
-                        <Link className="text-label font-medium text-primary hover:underline" to="/context">
-                          Open Context →
-                        </Link>
-                      </div>
-                      <ContextPersonalAccess organizationId={organizationId} />
-                    </div>
-                  ) : null,
-              }
-            : {}),
-        };
-
-  return (
-    <SetupOverview
-      facts={facts}
-      rows={buildSetupRows(facts)}
-      ownerControls={ownerControls}
-      onToggleOwnerControl={(key) => {
-        setExpandedOwnerControl((current) =>
-          current?.organizationId === organizationId && current.key === key ? null : { organizationId, key },
-        );
-      }}
-      onResumeOnboarding={resumeOnboarding}
-    />
-  );
+  return <SetupOverview facts={facts} rows={buildSetupRows(facts)} onResumeOnboarding={resumeOnboarding} />;
 }
 
 export function SetupOverview({
   facts,
   rows,
-  ownerControls = {},
-  onToggleOwnerControl,
   onResumeOnboarding,
 }: {
   facts: Pick<SetupFacts, "role" | "teamName">;
   rows: SetupRowModel[];
-  ownerControls?: Partial<Record<SetupRowModel["key"], ReactNode>>;
-  onToggleOwnerControl?: (key: SetupRowModel["key"]) => void;
   onResumeOnboarding?: () => Promise<void>;
 }) {
   const viewport = useWorkspaceViewport();
@@ -931,14 +779,7 @@ export function SetupOverview({
 
       <div style={{ borderTop: "var(--hairline) solid var(--border)" }}>
         {rows.map((row) => (
-          <SetupRow
-            key={row.key}
-            row={row}
-            narrow={narrow}
-            ownerControl={ownerControls[row.key]}
-            onToggleOwnerControl={onToggleOwnerControl}
-            onResumeOnboarding={onResumeOnboarding}
-          />
+          <SetupRow key={row.key} row={row} narrow={narrow} onResumeOnboarding={onResumeOnboarding} />
         ))}
       </div>
     </div>
@@ -971,14 +812,10 @@ function SetupStatusMark({ kind }: { kind: SetupStatusKind }) {
 function SetupRow({
   row,
   narrow,
-  ownerControl,
-  onToggleOwnerControl,
   onResumeOnboarding,
 }: {
   row: SetupRowModel;
   narrow: boolean;
-  ownerControl?: ReactNode;
-  onToggleOwnerControl?: (key: SetupRowModel["key"]) => void;
   onResumeOnboarding?: () => Promise<void>;
 }) {
   const Icon = row.icon;
@@ -1043,27 +880,7 @@ function SetupRow({
         className={cn("flex", !narrow && "justify-end")}
         style={narrow ? { paddingLeft: "var(--sp-11)" } : undefined}
       >
-        {row.action?.intent === "open-context-tree-controls" && onToggleOwnerControl ? (
-          <button
-            type="button"
-            aria-expanded={Boolean(ownerControl)}
-            aria-controls={`setup-${row.key}-owner-controls`}
-            onClick={() => onToggleOwnerControl(row.key)}
-            className={cn(
-              "text-label inline-flex items-center font-medium text-fg-2 transition-colors",
-              "rounded-[var(--radius-input)] hover:bg-bg-hover hover:text-foreground",
-              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
-            )}
-            style={{ minHeight: "var(--sp-8)", gap: "var(--sp-1)", padding: "0 var(--sp-2)" }}
-          >
-            {row.action.label}
-            {ownerControl ? (
-              <ChevronUp className="h-4 w-4" aria-hidden />
-            ) : (
-              <ChevronDown className="h-4 w-4" aria-hidden />
-            )}
-          </button>
-        ) : row.action ? (
+        {row.action ? (
           <Link
             to={row.action.to}
             onClick={
@@ -1089,17 +906,6 @@ function SetupRow({
           </Link>
         ) : null}
       </div>
-      {ownerControl ? (
-        <div
-          id={`setup-${row.key}-owner-controls`}
-          style={{
-            gridColumn: "1 / -1",
-            paddingLeft: narrow ? "var(--sp-4)" : "var(--sp-11)",
-          }}
-        >
-          {ownerControl}
-        </div>
-      ) : null}
     </section>
   );
 }

--- a/packages/web/src/pages/setup-preview.tsx
+++ b/packages/web/src/pages/setup-preview.tsx
@@ -1,27 +1,17 @@
-import type {
-  ContextReviewerCandidatesOutput,
-  OrgContextTreeFeaturesOutput,
-  OrgContextTreeInput,
-  OrgContextTreeOutput,
-  TeamSetupCapabilities,
-} from "@first-tree/shared";
+import type { TeamSetupCapabilities } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Link, useSearchParams } from "react-router";
 import { setupCapabilitiesQueryKey } from "../api/setup-capabilities.js";
 import { AuthContext } from "../auth/auth-context.js";
-import { buildByoSetupPrompt } from "../lib/byo-setup-prompt.js";
 import { cn } from "../lib/utils.js";
-import { ContextPersonalAccess } from "./settings/context-enablement.js";
 import { buildSetupRows, type SetupFacts, SetupOverview } from "./settings/setup.js";
-import { SetupContextTreeControls } from "./settings/setup-context-tree-controls.js";
-import { SetupReviewerControls } from "./settings/setup-reviewer-controls.js";
 import { SettingsLayout } from "./settings.js";
 
 type PreviewRole = "admin" | "member";
 type PreviewState = "ready" | "mixed";
 
-const PREVIEW_CAPABILITIES: TeamSetupCapabilities = {
+export const PREVIEW_CAPABILITIES: TeamSetupCapabilities = {
   organizationId: "org-preview",
   repositoryAutomation: {
     providers: [
@@ -98,115 +88,6 @@ const MIXED_CAPABILITIES: TeamSetupCapabilities = {
   },
 };
 
-const PREVIEW_REVIEWER_CANDIDATES: ContextReviewerCandidatesOutput = {
-  items: [
-    {
-      uuid: "agent-reviewer",
-      name: "context-reviewer",
-      displayName: "Context Reviewer",
-      visibility: "organization",
-      runtime: { health: "ready", blockers: [] },
-    },
-    {
-      uuid: "agent-offline-reviewer",
-      name: "offline-reviewer",
-      displayName: "Offline Reviewer",
-      visibility: "organization",
-      runtime: {
-        health: "degraded",
-        blockers: [
-          {
-            code: "context_review_agent_inactive",
-            resolutionOwner: "operator",
-            actionKind: null,
-          },
-        ],
-      },
-    },
-  ],
-  blockers: [],
-};
-
-async function previewLoadTreeSetting(): Promise<OrgContextTreeOutput> {
-  return {
-    provider: "github",
-    repo: "https://github.com/agent-team-foundation/first-tree-context",
-    branch: "main",
-  };
-}
-
-async function previewSaveTreeSetting(
-  _organizationId: string,
-  input: OrgContextTreeInput,
-): Promise<OrgContextTreeOutput> {
-  return {
-    provider: "github",
-    repo: input.repo ?? undefined,
-    branch: input.branch ?? undefined,
-  };
-}
-
-async function previewAssignReviewer(
-  _organizationId: string,
-  agentUuid: string | null,
-): Promise<OrgContextTreeFeaturesOutput> {
-  const candidate = PREVIEW_REVIEWER_CANDIDATES.items.find((item) => item.uuid === agentUuid);
-  return {
-    contextReviewer: {
-      enabled: false,
-      agentUuid,
-      reviewerAgent: candidate
-        ? { uuid: candidate.uuid, name: candidate.name, displayName: candidate.displayName }
-        : null,
-    },
-  };
-}
-
-async function previewSetReviewerEnabled(
-  _organizationId: string,
-  enabled: boolean,
-): Promise<OrgContextTreeFeaturesOutput> {
-  return {
-    contextReviewer: {
-      enabled,
-      agentUuid: "agent-reviewer",
-      reviewerAgent: { uuid: "agent-reviewer", name: "context-reviewer", displayName: "Context Reviewer" },
-    },
-  };
-}
-
-async function previewRefresh(): Promise<void> {}
-
-async function previewPersonalAccessPrompt(): Promise<string> {
-  return buildByoSetupPrompt({
-    organizationId: "org-preview",
-    bootstrapCommand: "'first-tree-staging' login 'preview-code'",
-    handoffs: [
-      {
-        protocolVersion: 1,
-        organizationId: "org-preview",
-        teamDisplayName: "Gandy's team",
-        role: "admin",
-        provider: "claude-code",
-        intent: "settings",
-        command: "'first-tree-staging' context enable --provider 'claude-code' --team 'org-preview'",
-        workingDirectoryInstruction: "Run this once from the repository root.",
-      },
-      {
-        protocolVersion: 1,
-        organizationId: "org-preview",
-        teamDisplayName: "Gandy's team",
-        role: "admin",
-        provider: "codex",
-        intent: "settings",
-        command: "'first-tree-staging' context enable --provider 'codex' --team 'org-preview'",
-        workingDirectoryInstruction: "Run this once from the repository root.",
-      },
-    ],
-    intent: "settings",
-  });
-}
-
 function previewFacts(role: PreviewRole, state: PreviewState): SetupFacts {
   if (state === "mixed") {
     return {
@@ -247,9 +128,6 @@ function previewFacts(role: PreviewRole, state: PreviewState): SetupFacts {
 
 export function SetupPreviewPage() {
   const [searchParams] = useSearchParams();
-  const [expandedOwnerControl, setExpandedOwnerControl] = useState<
-    ReturnType<typeof buildSetupRows>[number]["key"] | null
-  >(null);
   const role: PreviewRole = searchParams.get("role") === "member" ? "member" : "admin";
   const state: PreviewState = searchParams.get("state") === "mixed" ? "mixed" : "ready";
   const facts = previewFacts(role, state);
@@ -263,12 +141,6 @@ export function SetupPreviewPage() {
     client.setQueryData(["context-tree-snapshot", "org-preview", "7d", false], {
       snapshotStatus,
     });
-    client.setQueryData(["org-setting", "org-preview", "context_tree", "raw"], {
-      provider: "github",
-      repo: "https://github.com/agent-team-foundation/first-tree-context",
-      branch: "main",
-    });
-    client.setQueryData(["context-reviewer", "candidates", "org-preview"], PREVIEW_REVIEWER_CANDIDATES);
     return client;
   }, [capabilities, snapshotStatus]);
   const auth = {
@@ -283,74 +155,12 @@ export function SetupPreviewPage() {
     onboardingCompletedAt: facts.onboardingCompletedAt,
   } as unknown as Parameters<typeof AuthContext.Provider>[0]["value"];
 
-  const ownerControls =
-    expandedOwnerControl !== "context-tree"
-      ? {}
-      : {
-          "context-tree":
-            role === "admin" ? (
-              <SetupContextTreeControls
-                binding={capabilities.contextTree.binding}
-                availability={snapshotStatus}
-                loadSetting={previewLoadTreeSetting}
-                saveSetting={previewSaveTreeSetting}
-                refreshFacts={previewRefresh}
-              >
-                <div className="flex flex-col">
-                  {capabilities.contextTree.automaticReview.adoption !== "unavailable" ? (
-                    <SetupReviewerControls
-                      review={capabilities.contextTree.automaticReview}
-                      embedded
-                      loadCandidates={async () => PREVIEW_REVIEWER_CANDIDATES}
-                      assignReviewer={previewAssignReviewer}
-                      setReviewerEnabled={previewSetReviewerEnabled}
-                      refreshFacts={previewRefresh}
-                    />
-                  ) : null}
-                  {state === "ready" ? (
-                    <div
-                      style={{
-                        marginTop: "var(--sp-4)",
-                        paddingTop: "var(--sp-4)",
-                        borderTop: "var(--hairline) solid var(--border-faint)",
-                      }}
-                    >
-                      <ContextPersonalAccess organizationId="org-preview" preparePrompt={previewPersonalAccessPrompt} />
-                    </div>
-                  ) : null}
-                </div>
-              </SetupContextTreeControls>
-            ) : state === "ready" ? (
-              <div
-                data-setup-owner-controls="context-tree"
-                style={{
-                  padding: "var(--sp-4)",
-                  border: "var(--hairline) solid var(--border)",
-                  borderRadius: "var(--radius-panel)",
-                  background: "var(--bg-sunken)",
-                }}
-              >
-                <div className="flex justify-end" style={{ marginBottom: "var(--sp-3)" }}>
-                  <Link className="text-label font-medium text-primary hover:underline" to="/context">
-                    Open Context →
-                  </Link>
-                </div>
-                <ContextPersonalAccess organizationId="org-preview" preparePrompt={previewPersonalAccessPrompt} />
-              </div>
-            ) : null,
-        };
-
   return (
     <QueryClientProvider client={queryClient}>
       <AuthContext.Provider value={auth}>
         <div style={{ minHeight: "100vh", background: "var(--bg)" }} data-setup-preview={`${role}-${state}`}>
           <SettingsLayout activePathname="/settings/setup">
-            <SetupOverview
-              facts={facts}
-              rows={buildSetupRows(facts)}
-              ownerControls={ownerControls}
-              onToggleOwnerControl={(key) => setExpandedOwnerControl((current) => (current === key ? null : key))}
-            />
+            <SetupOverview facts={facts} rows={buildSetupRows(facts)} />
           </SettingsLayout>
           <nav
             aria-label="Setup preview controls"


### PR DESCRIPTION
## Summary

- add a dedicated **Settings → Context Tree** destination between Repositories and Resources
- make that page the canonical home for binding, Automatic review, and coding-agent access
- keep **Settings → Setup** as a summary-only readiness overview with links into the dedicated page
- keep `/context` read-only and route actionable binding/recovery states to Settings
- preserve legacy Setup and Repositories hashes with redirects to the new canonical sections
- update Server-provided recovery links so external Context activation and Tree Write preflight point to the new page

## UX and access boundaries

- desktop and narrow Settings navigation use the existing flat, text-only navigation patterns
- Admins retain binding and Reviewer assignment controls
- Members see the same Team facts without mutation controls and retain personal Claude Code/Codex access
- stateful binding and Reviewer controls remount at the selected-Team boundary
- provider-owned GitLab Web Context failures remain neutral and do not become Team setup debt
- `/settings/context`, `/context`, and Setup now have distinct configuration, consumption, and overview responsibilities

## Validation

- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm check` (clean for changed files; existing repository warnings remain)
- focused Web regression: 131/131
- Context Tree Settings suite: 60/60
- reviewer follow-up suite: 71/71, including cached Team switching and late mutation responses
- Server Context activation suite: 3/3
- full Web suite: 1,875/1,876 in the final concurrent run; the sole unrelated focus-retention test passed when rerun in isolation and had passed in the preceding full run
- real-browser QA on the seeded preview:
  - desktop Admin layout
  - 720 × 900 narrow layout
  - Member read-only layout
  - binding editor expansion
  - no browser console errors

## Context Tree

- Paired draft: [first-tree-context#859](https://github.com/agent-team-foundation/first-tree-context/pull/859)
- Tree base: `e36f5c04b6a4af6f7a803c5303559b94877baf39`

The paired draft records the durable page-ownership, permission, recovery, and redirect boundaries and will remain draft until this source PR lands.
