### PR TITLE
fix(context): keep Plugin integrity checks PATH-stable

### DIFF
--- a/apps/cli/src/__tests__/context-bundle-manifest.test.ts
+++ b/apps/cli/src/__tests__/context-bundle-manifest.test.ts
@@ -418,9 +418,13 @@ describe("context integration bundle", () => {
     };
 
     const plan = planContextIntegrationInstall(driver, { releaseRoot });
-    installContextIntegration(driver, plan);
+    const installed = installContextIntegration(driver, plan);
     const marketplaceSource = contextIntegrationMarketplaceSourcePath("codex");
     expect(existsSync(join(marketplaceSource, "plugins", "first-tree-context"))).toBe(true);
+    expect(installed.manifest.materializedInvocation).toBeTruthy();
+    expect(
+      readFileSync(join(marketplaceSource, "plugins", "first-tree-context", "bin", "context-session-start"), "utf8"),
+    ).toContain(installed.manifest.materializedInvocation);
 
     uninstallContextIntegration(driver);
     expect(existsSync(marketplaceSource)).toBe(false);

--- a/apps/cli/src/__tests__/context-runtime-health.test.ts
+++ b/apps/cli/src/__tests__/context-runtime-health.test.ts
@@ -20,10 +20,15 @@ import { providerPluginRoot, resolveContextIntegrationRelease } from "../core/co
 import { inspectContextIntegrationRuntime } from "../core/context-integration/runtime-health.js";
 
 const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
+const originalPath = process.env.PATH;
+const materializedProgram = "/opt/first-tree/bin/first-tree-dev";
+const materializedInvocation = `'${materializedProgram}'`;
 
 afterEach(() => {
   if (originalFirstTreeHome === undefined) delete process.env.FIRST_TREE_HOME;
   else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
 });
 
 function buildRelease(): string {
@@ -85,6 +90,7 @@ function writeMatchingInstall(releaseRoot: string): void {
     adapterDigest: release.manifest.providers.codex.adapterDigest,
     marketplaceName: "first-tree-dev",
     pluginName: "first-tree-context",
+    materializedInvocation,
     installedAt: "2026-07-28T00:00:00.000Z",
   });
 }
@@ -95,7 +101,10 @@ function prepareHealthyPayload(releaseRoot: string): string {
   const installedPlugin = join(process.env.FIRST_TREE_HOME ?? "", "provider-cache", "first-tree-context");
   mkdirSync(dirname(stablePlugin), { recursive: true });
   cpSync(providerPluginRoot(releaseRoot, "codex"), stablePlugin, { recursive: true });
-  materializeContextPluginPayload(stablePlugin, release.manifest.providers.codex.adapterDigest);
+  materializeContextPluginPayload(stablePlugin, release.manifest.providers.codex.adapterDigest, {
+    kind: "bin",
+    program: materializedProgram,
+  });
   cpSync(stablePlugin, installedPlugin, { recursive: true });
   return installedPlugin;
 }
@@ -137,6 +146,40 @@ describe("Context integration runtime health", () => {
     const health = inspectContextIntegrationRuntime(driver(providerProbe()), { releaseRoot });
     expect(health.healthy).toBe(false);
     expect(health.issues.join(" ")).toContain("Installed Context manifest is invalid");
+  });
+
+  it("keeps a healthy materialized Plugin valid when the Hook PATH differs from install time", () => {
+    process.env.FIRST_TREE_HOME = mkdtempSync(join(tmpdir(), "first-tree-context-health-home-"));
+    const releaseRoot = buildRelease();
+    writeMatchingInstall(releaseRoot);
+    const installedPath = prepareHealthyPayload(releaseRoot);
+    const restrictedPath = mkdtempSync(join(tmpdir(), "first-tree-context-hook-path-"));
+    process.env.PATH = restrictedPath;
+    const value = driver(providerProbe({ installedPath }));
+
+    const health = inspectContextIntegrationRuntime(value, { releaseRoot });
+    expect(health.healthy).toBe(true);
+    expect(health.issues).toEqual([]);
+    expect(planContextIntegrationInstall(value, { releaseRoot }).operation).toBe("unchanged");
+  });
+
+  it("requires one repair to record the materialized invocation for an older install manifest", () => {
+    process.env.FIRST_TREE_HOME = mkdtempSync(join(tmpdir(), "first-tree-context-health-home-"));
+    const releaseRoot = buildRelease();
+    writeMatchingInstall(releaseRoot);
+    const installPath = contextIntegrationInstallManifestPath("codex");
+    const previous = JSON.parse(readFileSync(installPath, "utf8"));
+    delete previous.materializedInvocation;
+    writeFileSync(installPath, `${JSON.stringify(previous)}\n`);
+    const installedPath = prepareHealthyPayload(releaseRoot);
+    const value = driver(providerProbe({ installedPath }));
+
+    const health = inspectContextIntegrationRuntime(value, { releaseRoot });
+    expect(health.healthy).toBe(false);
+    expect(health.issues).toContain(
+      "The Context Plugin install manifest does not record its materialized CLI invocation.",
+    );
+    expect(planContextIntegrationInstall(value, { releaseRoot }).operation).toBe("repair");
   });
 
   it.each([

--- a/apps/cli/src/core/context-integration/installer.ts
+++ b/apps/cli/src/core/context-integration/installer.ts
@@ -62,6 +62,7 @@ export function planContextIntegrationInstall(
     join(contextIntegrationMarketplaceSourcePath(driver.provider), "plugins", PLUGIN_NAME),
     release,
     driver.provider,
+    previous?.materializedInvocation,
   );
   const incomplete = readContextIntegrationInstallJournal();
   const operation =
@@ -134,7 +135,7 @@ function installContextIntegrationLocked(
     rollbackMarketplaceRoot =
       plan.previous && plan.probe.installed ? prepareRollbackMarketplace(stagingRoot, driver.provider, plan) : null;
     cpSync(providerReleaseRoot, stagedMarketplaceRoot, { recursive: true });
-    materializeContextPluginPayload(
+    const materializedInvocation = materializeContextPluginPayload(
       join(stagedMarketplaceRoot, "plugins", PLUGIN_NAME),
       plan.release.manifest.providers[driver.provider].adapterDigest,
     );
@@ -152,6 +153,7 @@ function installContextIntegrationLocked(
       join(stableMarketplaceRoot, "plugins", PLUGIN_NAME),
       plan.release,
       driver.provider,
+      materializedInvocation,
     );
     verifyProviderInstalledContextPlugin(probe, installedPayloadDigest);
     writeInstallJournal({ ...journal, phase: "provider_installed" });
@@ -166,6 +168,7 @@ function installContextIntegrationLocked(
       adapterDigest: plan.release.manifest.providers[driver.provider].adapterDigest,
       marketplaceName: plan.marketplaceName,
       pluginName: PLUGIN_NAME,
+      materializedInvocation,
       installedAt: new Date().toISOString(),
     };
     writeContextIntegrationInstallManifest(manifest);

--- a/apps/cli/src/core/context-integration/payload-integrity.ts
+++ b/apps/cli/src/core/context-integration/payload-integrity.ts
@@ -15,7 +15,7 @@ export function materializeContextPluginPayload(
   pluginRoot: string,
   adapterDigest: string,
   invocation: ResolvedBinary = resolveCliInvocation(),
-): void {
+): string {
   const renderedInvocation = renderCliInvocation(invocation);
   const launcherPath = join(pluginRoot, LAUNCHER_PATH);
   writeFileSync(
@@ -44,6 +44,7 @@ export function materializeContextPluginPayload(
       ),
     );
   }
+  return renderedInvocation;
 }
 
 /**
@@ -54,6 +55,7 @@ export function verifyMaterializedContextPlugin(
   pluginRoot: string,
   release: ContextIntegrationRelease,
   provider: ContextIntegrationProvider,
+  renderedInvocation: string,
 ): string {
   assertLauncherExecutable(pluginRoot);
   const releaseRoot = providerPluginRoot(release.root, provider);
@@ -66,7 +68,6 @@ export function verifyMaterializedContextPlugin(
   }
 
   const adapterDigest = release.manifest.providers[provider].adapterDigest;
-  const renderedInvocation = renderCliInvocation(resolveCliInvocation());
   for (let index = 0; index < releaseFiles.length; index += 1) {
     const name = releaseNames[index] ?? "";
     const expected = materializedFile(name, readFileSync(releaseFiles[index] ?? ""), adapterDigest, renderedInvocation);
@@ -98,10 +99,14 @@ export function inspectContextPluginPayload(
   stablePluginRoot: string,
   release: ContextIntegrationRelease,
   provider: ContextIntegrationProvider,
+  renderedInvocation: string | undefined,
 ): string[] {
   if (!probe.installed || !probe.enabled) return [];
+  if (!renderedInvocation) {
+    return ["The Context Plugin install manifest does not record its materialized CLI invocation."];
+  }
   try {
-    const expectedDigest = verifyMaterializedContextPlugin(stablePluginRoot, release, provider);
+    const expectedDigest = verifyMaterializedContextPlugin(stablePluginRoot, release, provider, renderedInvocation);
     verifyProviderInstalledContextPlugin(probe, expectedDigest);
     return [];
   } catch (error) {

--- a/apps/cli/src/core/context-integration/runtime-health.ts
+++ b/apps/cli/src/core/context-integration/runtime-health.ts
@@ -82,6 +82,7 @@ export function inspectContextIntegrationRuntime(
       ),
       release,
       driver.provider,
+      install?.materializedInvocation,
     )) {
       if (!issues.includes(issue)) issues.push(issue);
     }

--- a/packages/shared/src/__tests__/context-integration.test.ts
+++ b/packages/shared/src/__tests__/context-integration.test.ts
@@ -110,9 +110,27 @@ describe("context integration contracts", () => {
         adapterDigest: DIGEST,
         marketplaceName: "first-tree",
         pluginName: "first-tree-context",
+        materializedInvocation: "/opt/first-tree/bin/first-tree",
         installedAt: "2026-07-28T00:00:00.000Z",
       }).policyDigest,
     ).toBe(DIGEST);
+
+    expect(
+      contextIntegrationInstallManifestSchema.safeParse({
+        schemaVersion: 1,
+        channel: "prod",
+        provider: "codex",
+        firstTreeVersion: "1.0.0",
+        bundleVersion: "1.0.0",
+        bundleDigest: DIGEST,
+        policyDigest: DIGEST,
+        adapterDigest: DIGEST,
+        marketplaceName: "first-tree",
+        pluginName: "first-tree-context",
+        materializedInvocation: "",
+        installedAt: "2026-07-28T00:00:00.000Z",
+      }).success,
+    ).toBe(false);
 
     expect(
       contextIntegrationReleaseManifestSchema.parse({

--- a/packages/shared/src/schemas/context-integration.ts
+++ b/packages/shared/src/schemas/context-integration.ts
@@ -130,6 +130,7 @@ export const contextIntegrationInstallManifestSchema = z
     adapterDigest: sha256DigestSchema,
     marketplaceName: z.string().min(1),
     pluginName: z.string().min(1),
+    materializedInvocation: z.string().min(1).optional(),
     installedAt: z.string().datetime(),
   })
   .strict();


### PR DESCRIPTION
## Summary

- persist the exact CLI invocation used to materialize the Context Plugin
- verify the stable marketplace payload against that install-time invocation instead of re-resolving it from the Hook `PATH`
- require one repair for older manifests that do not yet record the invocation

## Why

Codex SessionStart runs with a more restricted `PATH` than an ordinary Agent shell. A freshly enabled Plugin could therefore be materialized with the globally installed First Tree entry point, then immediately be compared against the Node fallback entry point in the Hook. The two invocations execute the same CLI but differ byte-for-byte, producing a false stale-Plugin report at `bin/context-session-start`.

The install manifest now records the exact rendered invocation. Install-time verification, later SessionStart health checks, and repair planning all reuse that value, while the existing release and provider-cache digest checks continue to detect real payload drift.

## Verification

- `pnpm exec vitest run packages/shared/src/__tests__/context-integration.test.ts apps/cli/src/__tests__/context-runtime-health.test.ts apps/cli/src/__tests__/context-bundle-manifest.test.ts apps/cli/src/__tests__/context-operation.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/shared typecheck`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm exec biome check` on all changed files
- `git diff --check`

The full-repository `pnpm check` remains blocked by pre-existing warnings/errors outside this diff; all changed files pass Biome directly.
