### PR TITLE
release: bump apps/cli to v0.5.18

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [

--- a/apps/cli/src/__tests__/context-bundle-manifest.test.ts
+++ b/apps/cli/src/__tests__/context-bundle-manifest.test.ts
@@ -20,6 +20,7 @@ import type {
   ContextIntegrationProviderDriver,
   ProviderPluginProbe,
 } from "../core/context-integration/provider-driver.js";
+import { COMMAND_VERSION } from "../core/version.js";
 
 const roots: string[] = [];
 const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
@@ -277,7 +278,7 @@ describe("context integration bundle", () => {
         "--out-dir",
         releaseRoot,
         "--version",
-        "0.5.17",
+        COMMAND_VERSION,
         "--channel",
         "dev",
       ],
@@ -384,7 +385,7 @@ describe("context integration bundle", () => {
         "--out-dir",
         releaseRoot,
         "--version",
-        "0.5.17",
+        COMMAND_VERSION,
         "--channel",
         "dev",
       ],
@@ -444,7 +445,7 @@ describe("context integration bundle", () => {
         "--out-dir",
         releaseRoot,
         "--version",
-        "0.5.17",
+        COMMAND_VERSION,
         "--channel",
         "dev",
       ],
@@ -496,7 +497,7 @@ describe("context integration bundle", () => {
         "--out-dir",
         releaseRoot,
         "--version",
-        "0.5.17",
+        COMMAND_VERSION,
         "--channel",
         "dev",
       ],
@@ -545,7 +546,7 @@ describe("context integration bundle", () => {
         "--out-dir",
         releaseRoot,
         "--version",
-        "0.5.17",
+        COMMAND_VERSION,
         "--channel",
         "dev",
       ],
@@ -589,7 +590,7 @@ describe("context integration bundle", () => {
         "--out-dir",
         releaseRoot,
         "--version",
-        "0.5.17",
+        COMMAND_VERSION,
         "--channel",
         "dev",
       ],

--- a/apps/cli/src/__tests__/context-runtime-health.test.ts
+++ b/apps/cli/src/__tests__/context-runtime-health.test.ts
@@ -18,6 +18,7 @@ import type {
 } from "../core/context-integration/provider-driver.js";
 import { providerPluginRoot, resolveContextIntegrationRelease } from "../core/context-integration/release.js";
 import { inspectContextIntegrationRuntime } from "../core/context-integration/runtime-health.js";
+import { COMMAND_VERSION } from "../core/version.js";
 
 const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
 const originalPath = process.env.PATH;
@@ -41,7 +42,7 @@ function buildRelease(): string {
       "--out-dir",
       root,
       "--version",
-      "0.5.17",
+      COMMAND_VERSION,
       "--channel",
       "dev",
     ],
@@ -83,7 +84,7 @@ function writeMatchingInstall(releaseRoot: string): void {
     schemaVersion: 1,
     channel: "dev",
     provider: "codex",
-    firstTreeVersion: "0.5.17",
+    firstTreeVersion: COMMAND_VERSION,
     bundleVersion: release.manifest.version,
     bundleDigest: release.manifest.bundleDigest,
     policyDigest: release.manifest.policyDigest,


### PR DESCRIPTION
## Summary

- bump `apps/cli/package.json` from `0.5.17` to `0.5.18`
- keep the source package identity as `first-tree-dev`
- make Context integration tests derive current-version fixtures from `COMMAND_VERSION` so release bumps remain self-consistent
- prepare the stable `v0.5.18` tag and trusted-publishing release

## Draft GitHub Release

**Title:** `v0.5.18 — BYO Context, GitHub task agents, complete Team Skills`

## Highlights

- Bring Team Context into Claude Code and Codex with provider-project and pathless activation, self-verifying setup, immediate in-session adoption, and a dedicated Context Tree settings page.
- Delegate GitHub Issue and pull-request tasks to a repository-scoped Team Agent, with terminal replies published by the First Tree GitHub App.
- Distribute complete Team Skill bundles—including nested references, scripts, and binary assets—across supported agent runtimes.
- Review open agent questions through the desktop and mobile **Need you** queue, ask for clarification without resolving the request, and process requests sequentially.
- Select Codex Fast mode and inject First Tree-managed MCP servers into Cursor and Kimi Code.
- Give invited members a progressive, personal-agent-first onboarding path and make the mobile PWA easier to install from desktop or phone.

## Notable fixes

- Improved GitLab project-hook routing and clarified Context Reviewer and private-project setup states.
- Kept chat navigation, the composer, pinned selection, and Mobile Work responsive under background activity.
- Strengthened daemon ownership, runtime token recovery, resumed-message custody, tracked-request images, and attachment persistence.
- Run the production container as a non-root user.

## Upgrade note

Existing First Tree GitHub App installations must re-approve the upgraded **Issues: write** permission before App-authored terminal replies can be published. Other GitHub automation continues to work while this permission is pending.

## Validation

- `npx --yes pnpm@10.12.1 install --frozen-lockfile`
- `npx --yes pnpm@10.12.1 check` (passed; 16 existing warnings and 1 existing info)
- `npx --yes pnpm@10.12.1 typecheck` (passed; 11/11 tasks)
- focused Context integration release tests (24/24 passed)
- `git diff --check`
- the first PR CI run exposed six current-version fixtures hardcoded to `0.5.17`; those fixtures now derive from `COMMAND_VERSION`, and the replacement CI run must pass before merge
- `npx --yes pnpm@10.12.1 test` could not complete locally because no container runtime was available for the Server PostgreSQL global setup; PR CI with its PostgreSQL service is required to pass before merge

## Post-merge

1. Wait for `main` CI, `npm Publish`, and Docker runs on the release merge commit.
2. Confirm the final version, tag, target commit, release title, and release body.
3. Create GitHub Release `v0.5.18` at the exact merge commit.
4. Verify the tag-triggered trusted npm publish, portable release, Docker image, and public npm coordinates.
