### PR TITLE
fix(web): align TeamSwitcher current-team rows on the shared menu grid

### DIFF
--- a/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
+++ b/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
@@ -266,6 +266,40 @@ describe("TeamSwitcher", () => {
     await act(async () => root.unmount());
   });
 
+  it("aligns every menu action row and eyebrow on one shared grid across groups", async () => {
+    const { container, root } = await renderHarness(vi.fn(async () => {}));
+
+    await click(anchorOf(container));
+
+    const rows = [
+      buttonByText(container, "Invite teammates"),
+      buttonByText(container, "Leave team"),
+      buttonByText(container, "Globex"),
+      buttonByText(container, "Create team"),
+      buttonByText(container, "Join with invite link"),
+    ];
+    if (rows.some((row) => !row)) throw new Error("menu action rows missing");
+
+    // One shared row grid across Current team / Switch team / Add or join:
+    // same gutter, icon column, and full-bleed hover hit area — no
+    // Current-team-only inset, rounding, or extra row spacing.
+    const rowClasses = new Set(rows.flatMap((row) => (row ? [row.className] : [])));
+    expect(rowClasses.size).toBe(1);
+    const [rowClass] = rowClasses;
+    expect(rowClass).toContain("px-3.5");
+    expect(rowClass).toContain("py-1.5");
+    expect(rowClass).not.toContain("mt-2");
+    expect(rowClass).not.toContain("px-2");
+    expect(rowClass).not.toContain("rounded");
+
+    // All three section eyebrows share the same section padding.
+    const eyebrows = [...container.querySelectorAll<HTMLElement>(".text-eyebrow")];
+    expect(eyebrows.map((eyebrow) => eyebrow.textContent)).toEqual(["Current team", "Switch team", "Add or join"]);
+    expect(new Set(eyebrows.map((eyebrow) => eyebrow.style.padding)).size).toBe(1);
+
+    await act(async () => root.unmount());
+  });
+
   it("lets admins rename the current team in a dialog and refreshes auth state", async () => {
     const refreshMe = vi.fn(async () => {});
     const { container, root } = await renderHarness(

--- a/packages/web/src/components/team-switcher.tsx
+++ b/packages/web/src/components/team-switcher.tsx
@@ -21,6 +21,13 @@ import { Input } from "./ui/input.js";
 // frame. Tunable by feel during QA.
 const MIN_SHOW_MS = 300;
 
+// One row grid for every menu action (Invite / Leave / Switch / Create /
+// Join): same gutter, same icon column, same full-bleed hover hit area,
+// so the groups can't drift apart again. Per-row color and disabled opacity
+// stay on the row's own `style`.
+const MENU_ROW_CLASS =
+  "flex w-full items-center gap-2 px-3.5 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]";
+
 /**
  * Header-left team anchor: the always-present "which team am I in" marker and
  * the entry point for switching teams + team management. Consolidates the
@@ -367,15 +374,17 @@ export function TeamSwitcher({
             style={{ width: "var(--sp-70)", borderColor: "var(--border)" }}
           >
             {/* ① Current team identity and membership actions — always shown. */}
-            <div role="presentation" className="border-b px-3.5 py-2.5" style={{ borderColor: "var(--border)" }}>
+            <div role="presentation" className="border-b pb-1" style={{ borderColor: "var(--border)" }}>
               <div
                 aria-hidden="true"
                 className="text-eyebrow"
-                style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1_5)" }}
+                style={{ color: "var(--fg-3)", padding: "var(--sp-1_25) var(--sp-3_5) var(--sp-0_75)" }}
               >
                 Current team
               </div>
-              <div role="presentation" className="flex items-start gap-2.5">
+              {/* Identity row: taller than an action row (avatar + two text
+                  lines), but on the same gutter as every other row. */}
+              <div role="presentation" className="flex items-start gap-2.5 px-3.5 py-1.5">
                 <Avatar seed={currentOrg.id} name={currentOrg.displayName} size={26} />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-subtitle" title={currentOrg.displayName} style={{ color: "var(--fg)" }}>
@@ -416,7 +425,7 @@ export function TeamSwitcher({
                   setOpen(false);
                   setInviteOpen(true);
                 }}
-                className="mt-2 flex w-full items-center gap-2 rounded-[var(--radius-input)] px-2 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+                className={MENU_ROW_CLASS}
                 style={{ color: "var(--fg)", opacity: askAgentNavLocked ? 0.5 : undefined }}
               >
                 <UserPlus className="h-3.5 w-3.5" />
@@ -428,7 +437,7 @@ export function TeamSwitcher({
                 tabIndex={-1}
                 onClick={openLeaveConfirm}
                 disabled={askAgentNavLocked}
-                className="mt-2 flex w-full items-center gap-2 rounded-[var(--radius-input)] px-2 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+                className={MENU_ROW_CLASS}
                 style={{ color: "var(--state-error)", opacity: askAgentNavLocked ? 0.5 : undefined }}
               >
                 <LogOut className="h-3.5 w-3.5" />
@@ -464,7 +473,7 @@ export function TeamSwitcher({
                         disabled={!!switchingOrg || askAgentNavLocked}
                         aria-busy={isBusy}
                         onClick={() => void handleSwitch(o)}
-                        className="flex w-full items-center gap-2 px-3.5 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+                        className={MENU_ROW_CLASS}
                         style={{
                           color: "var(--fg)",
                           opacity: (switchingOrg || askAgentNavLocked) && !isBusy ? 0.45 : undefined,
@@ -520,7 +529,7 @@ export function TeamSwitcher({
                   setOpen(false);
                   setSetupAction("create");
                 }}
-                className="flex w-full items-center gap-2 px-3.5 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+                className={MENU_ROW_CLASS}
                 style={{ color: "var(--fg)", opacity: askAgentNavLocked ? 0.5 : undefined }}
               >
                 <Plus className="h-3.5 w-3.5" />
@@ -536,7 +545,7 @@ export function TeamSwitcher({
                   setOpen(false);
                   setSetupAction("join");
                 }}
-                className="flex w-full items-center gap-2 px-3.5 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+                className={MENU_ROW_CLASS}
                 style={{ color: "var(--fg)", opacity: askAgentNavLocked ? 0.5 : undefined }}
               >
                 <Link2 className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Problem

Follow-up to #2091 (merged). In the reorganized TeamSwitcher menu, the **Current team** action rows (`Invite teammates`, `Leave team`) carried a second inset and `mt-2`, so their icon baseline, hover width, and vertical rhythm did not align with **Switch team** and **Add or join**.

This PR supersedes #2102 with the exact same source tree. The earlier PR's sole commit used an agent-local author identity that the CLA bot could not map to a GitHub account; this replacement preserves the reviewed code byte-for-byte under the signed `yuezengwu` identity without rewriting or force-pushing the published branch.

## Approach

Presentation-only alignment, with no behavior changes:

- Extract one shared `MENU_ROW_CLASS` used by Invite / Leave / Switch / Create / Join.
- Give every action row the same 14px gutter, icon column, vertical padding, and full-width hover hit area.
- Give the Current team eyebrow the same section padding as the other two groups.
- Keep the taller identity row on the same gutter while preserving its avatar, name, role, and rename action.
- Remove only the Current-actions-specific `mt-2`, secondary `px-2`, and rounded hover treatment.

Leave remains destructive red. Disabled states, rename, Ask-agent navigation locks, switch/create/join/leave/invite behavior, and Context Tree setup routing are unchanged.

## Verification

- The replacement commit tree exactly matches #2102 head `4ef758ca6` (`c80a0a67f1d66781b5a6475414e761c43b0e46c1`).
- Added a deterministic DOM regression that requires all action rows to share one grid and all section eyebrows to share one padding contract.
- Kiven-FTE reported 217 Web test files / 1882 cases passing, plus Web typecheck, design-token guard, and Biome.
- Real `/preview/team-switcher` Chromium light/dark checks show aligned rows and full-width hover treatment.
- Independent formal QA is being run against this exact replacement head.
