### PR TITLE
feat: record Context Tree read checkout heads

### DIFF
--- a/packages/client/src/__tests__/context-tree-file-refs.test.ts
+++ b/packages/client/src/__tests__/context-tree-file-refs.test.ts
@@ -278,6 +278,7 @@ describe("resolveContextTreeRelativePath — tree PR worktree (repo identity)", 
   });
 
   it("emits shell read refs for tree files read inside the tree PR worktree", () => {
+    const repoHeadCommit = git(treeWorktree, "rev-parse", "HEAD");
     const refs = toolFileRefsFromShellCommand({
       command: `cat ${join(treeWorktree, "NODE.md")}`,
       cwd: root,
@@ -292,6 +293,7 @@ describe("resolveContextTreeRelativePath — tree PR worktree (repo identity)", 
         localPath: join(treeWorktree, "NODE.md"),
         repoUrl: "https://github.com/acme/first-tree-context.git",
         repoBranch: "main",
+        repoHeadCommit,
         repoRelativePath: "NODE.md",
         pathKind: "file",
       },

--- a/packages/client/src/__tests__/git-repo-identity.test.ts
+++ b/packages/client/src/__tests__/git-repo-identity.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   clearGitRepoIdentityCacheForTests,
   findGitRepoRoot,
+  gitHeadCommitForRepoPath,
   gitRemoteOriginUrl,
   gitRepoRootMatchingRemote,
 } from "../runtime/git-repo-identity.js";
@@ -63,6 +64,18 @@ describe("git-repo-identity", () => {
 
   it("matches a checkout whose ssh remote equals the https binding URL", () => {
     expect(gitRepoRootMatchingRemote(join(treeClone, "NODE.md"), TREE_URL_HTTPS)).toBe(treeClone);
+  });
+
+  it("returns the exact checkout HEAD only for the expected repository", () => {
+    const expectedHead = git(treeClone, "rev-parse", "HEAD");
+    expect(gitHeadCommitForRepoPath(join(treeClone, "NODE.md"), TREE_URL_HTTPS)).toBe(expectedHead);
+    expect(gitHeadCommitForRepoPath(join(treeClone, "NODE.md"), SOURCE_URL)).toBeNull();
+  });
+
+  it("keeps HEAD provenance honest when the working-tree file is dirty", () => {
+    const expectedHead = git(treeClone, "rev-parse", "HEAD");
+    writeFileSync(join(treeClone, "NODE.md"), "dirty local content");
+    expect(gitHeadCommitForRepoPath(join(treeClone, "NODE.md"), TREE_URL_HTTPS)).toBe(expectedHead);
   });
 
   it("matches a linked git worktree (.git file) of the tree repo", () => {

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -33,7 +33,11 @@ import { renderDocumentAttachmentsForLLM } from "../runtime/agent-io.js";
 import { type PredeclaredSourceRepo, writeAgentBriefing } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
 import { renderChatContextPrompt, renderRuntimeOutputContract } from "../runtime/chat-context-section.js";
-import { resolveContextTreeRelativePath, toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
+import {
+  resolveContextTreeRelativePath,
+  toolFileRefsFromShellCommand,
+  withContextTreeRepoHeadCommit,
+} from "../runtime/context-tree-file-refs.js";
 import {
   type ContextTreeGitWriteTracker,
   createContextTreeGitWriteTracker,
@@ -487,7 +491,7 @@ function toolFileRef(toolName: string, input: unknown, contextTree?: ContextTree
           contextTreeRepoUrl: contextTree.repoUrl,
         })
       : null;
-  return {
+  const ref: ToolFileRef = {
     origin: "tool_arg",
     localPath: filePath,
     pathKind: "file",
@@ -499,6 +503,9 @@ function toolFileRef(toolName: string, input: unknown, contextTree?: ContextTree
         }
       : {}),
   };
+  return TREE_READ_TOOL_NAMES.has(toolName) && isAbsolute(filePath)
+    ? withContextTreeRepoHeadCommit(ref, filePath)
+    : ref;
 }
 
 function statIsFile(absolutePath: string): boolean {
@@ -539,19 +546,22 @@ function searchToolFileRef(
         contextTreeRepoUrl: contextTree.repoUrl,
       })
     : null;
-  return {
-    origin: "tool_arg",
-    localPath: absolutePath,
-    // Grep accepts a file as its search root; everything else is a directory.
-    pathKind: repoRelativePath === "/" ? "repo" : statIsFile(absolutePath) ? "file" : "directory",
-    ...(contextTree?.repoUrl && repoRelativePath !== null
-      ? {
-          repoUrl: contextTree.repoUrl,
-          ...(contextTree.branch ? { repoBranch: contextTree.branch } : {}),
-          repoRelativePath,
-        }
-      : {}),
-  };
+  return withContextTreeRepoHeadCommit(
+    {
+      origin: "tool_arg",
+      localPath: absolutePath,
+      // Grep accepts a file as its search root; everything else is a directory.
+      pathKind: repoRelativePath === "/" ? "repo" : statIsFile(absolutePath) ? "file" : "directory",
+      ...(contextTree?.repoUrl && repoRelativePath !== null
+        ? {
+            repoUrl: contextTree.repoUrl,
+            ...(contextTree.branch ? { repoBranch: contextTree.branch } : {}),
+            repoRelativePath,
+          }
+        : {}),
+    },
+    absolutePath,
+  );
 }
 
 function readCommandArg(input: unknown): string | null {

--- a/packages/client/src/handlers/cursor/index.ts
+++ b/packages/client/src/handlers/cursor/index.ts
@@ -22,6 +22,7 @@ import {
   type ContextTreeAttribution,
   resolveContextTreeRelativePath,
   toolFileRefsFromShellCommand,
+  withContextTreeRepoHeadCommit,
 } from "../../runtime/context-tree-file-refs.js";
 import {
   type ContextTreeGitWriteTracker,
@@ -741,20 +742,19 @@ export const createCursorHandler: HandlerFactory = (config) => {
     const attribution: ContextTreeAttribution = { contextTreePath, contextTreeRepoUrl };
     const absolutePath = isAbsolute(filePath) ? resolve(filePath) : resolve(cwd, filePath);
     const repoRelativePath = resolveContextTreeRelativePath(absolutePath, attribution);
-    return [
-      {
-        origin,
-        localPath: filePath,
-        pathKind: "file",
-        ...(contextTreeRepoUrl && repoRelativePath && repoRelativePath !== "/"
-          ? {
-              repoUrl: contextTreeRepoUrl,
-              ...(contextTreeBranch ? { repoBranch: contextTreeBranch } : {}),
-              repoRelativePath,
-            }
-          : {}),
-      },
-    ];
+    const ref: ToolFileRef = {
+      origin,
+      localPath: filePath,
+      pathKind: "file",
+      ...(contextTreeRepoUrl && repoRelativePath && repoRelativePath !== "/"
+        ? {
+            repoUrl: contextTreeRepoUrl,
+            ...(contextTreeBranch ? { repoBranch: contextTreeBranch } : {}),
+            repoRelativePath,
+          }
+        : {}),
+    };
+    return [origin === "tool_arg" ? withContextTreeRepoHeadCommit(ref, absolutePath) : ref];
   }
 
   /** Terminal-tool ref assembly: provider-derived refs + git-status-delta refs. */

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -32,6 +32,7 @@ import {
   type ContextTreeAttribution,
   resolveContextTreeRelativePath,
   toolFileRefsFromShellCommand,
+  withContextTreeRepoHeadCommit,
 } from "../runtime/context-tree-file-refs.js";
 import {
   type ContextTreeGitWriteTracker,
@@ -286,20 +287,19 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     const attribution: ContextTreeAttribution = { contextTreePath, contextTreeRepoUrl };
     const repoRelativePath = resolveContextTreeRelativePath(absolutePath, attribution);
     const pathKind = name === "Grep" || name === "Glob" ? ("directory" as const) : ("file" as const);
-    return [
-      {
-        origin: "tool_arg",
-        localPath: absolutePath,
-        pathKind,
-        ...(contextTreeRepoUrl && repoRelativePath
-          ? {
-              repoUrl: contextTreeRepoUrl,
-              ...(contextTreeBranch ? { repoBranch: contextTreeBranch } : {}),
-              repoRelativePath,
-            }
-          : {}),
-      },
-    ];
+    const ref: ToolFileRef = {
+      origin: "tool_arg",
+      localPath: absolutePath,
+      pathKind,
+      ...(contextTreeRepoUrl && repoRelativePath
+        ? {
+            repoUrl: contextTreeRepoUrl,
+            ...(contextTreeBranch ? { repoBranch: contextTreeBranch } : {}),
+            repoRelativePath,
+          }
+        : {}),
+    };
+    return [kimiToolIsReadOnly(name, args) ? withContextTreeRepoHeadCommit(ref, absolutePath) : ref];
   }
 
   function emitToolCall(

--- a/packages/client/src/runtime/context-tree-file-refs.ts
+++ b/packages/client/src/runtime/context-tree-file-refs.ts
@@ -1,7 +1,7 @@
 import { realpathSync, statSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { classifyShellCommandIo, type ShellIoPathKindHint, type ToolFileRef } from "@first-tree/shared";
-import { gitRepoRootMatchingRemote } from "./git-repo-identity.js";
+import { gitHeadCommitForRepoPath, gitRepoRootMatchingRemote } from "./git-repo-identity.js";
 
 export type ShellCommandFileRefsInput = {
   command: string;
@@ -115,6 +115,19 @@ function pathKindOf(
   }
 }
 
+/**
+ * Add the checkout HEAD observed for a successful Context Tree read.
+ *
+ * The value is deliberately named `repoHeadCommit`: it does not assert that a
+ * dirty working-tree file matched HEAD. It gives later auditors an exact
+ * candidate snapshot to compare against without storing Tree content.
+ */
+export function withContextTreeRepoHeadCommit(ref: ToolFileRef, absolutePath: string): ToolFileRef {
+  if (!ref.repoUrl) return ref;
+  const repoHeadCommit = gitHeadCommitForRepoPath(canonicalizeFsPath(absolutePath), ref.repoUrl);
+  return repoHeadCommit ? { ...ref, repoHeadCommit } : ref;
+}
+
 export function toolFileRefsFromShellCommand(input: ShellCommandFileRefsInput): ToolFileRef[] {
   if (!input.contextTreePath || !input.contextTreeRepoUrl) return [];
 
@@ -134,14 +147,19 @@ export function toolFileRefsFromShellCommand(input: ShellCommandFileRefsInput): 
     });
     if (repoRelativePath === null) continue;
 
-    refs.push({
-      origin: "tool_arg",
-      localPath: absolutePath,
-      repoUrl: input.contextTreeRepoUrl,
-      ...(input.contextTreeBranch ? { repoBranch: input.contextTreeBranch } : {}),
-      repoRelativePath,
-      pathKind: pathKindOf(absolutePath, repoRelativePath, pathArg.pathKindHint),
-    });
+    refs.push(
+      withContextTreeRepoHeadCommit(
+        {
+          origin: "tool_arg",
+          localPath: absolutePath,
+          repoUrl: input.contextTreeRepoUrl,
+          ...(input.contextTreeBranch ? { repoBranch: input.contextTreeBranch } : {}),
+          repoRelativePath,
+          pathKind: pathKindOf(absolutePath, repoRelativePath, pathArg.pathKindHint),
+        },
+        absolutePath,
+      ),
+    );
   }
   return refs;
 }

--- a/packages/client/src/runtime/git-repo-identity.ts
+++ b/packages/client/src/runtime/git-repo-identity.ts
@@ -107,3 +107,27 @@ export function gitRepoRootMatchingRemote(canonicalPath: string, repoUrl: string
   if (!remote || canonicalGitRepoUrl(remote) !== expected) return null;
   return root;
 }
+
+/**
+ * Exact HEAD commit of the checkout enclosing `canonicalPath`, provided that
+ * checkout belongs to `repoUrl`. This intentionally does not inspect file
+ * cleanliness: the value identifies the checkout snapshot observed at read
+ * time, while downstream evidence may independently verify whether the read
+ * content matched that commit.
+ */
+export function gitHeadCommitForRepoPath(canonicalPath: string, repoUrl: string): string | null {
+  const root = gitRepoRootMatchingRemote(canonicalPath, repoUrl);
+  if (!root) return null;
+  try {
+    const commit = execFileSync("git", ["-C", root, "rev-parse", "--verify", "HEAD^{commit}"], {
+      timeout: 2000,
+      maxBuffer: 1024 * 1024,
+    })
+      .toString("utf8")
+      .trim()
+      .toLowerCase();
+    return /^[0-9a-f]{40}$/.test(commit) ? commit : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -114,9 +114,103 @@ describe("context-tree IO service", () => {
     expect(summary.recentEvents[0]).toMatchObject({
       action: "read",
       targetPath: "domains/runtime/NODE.md",
+      treeHeadCommit: null,
       chatId: seed.chatId,
       chatTitle: "io",
       viewerCanAccess: false,
+    });
+  });
+
+  it("persists and exposes the checkout HEAD observed for a successful read", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    const repoHeadCommit = "a".repeat(40);
+    const persisted = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-read-head",
+        name: "Read",
+        args: { file_path: "/tmp/context-tree/NODE.md" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoHeadCommit,
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+
+    await recordFromSessionEvent(app.db, {
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      chatId: seed.chatId,
+      runtimeProvider: "claude-code",
+      sessionEvent: persisted,
+    });
+
+    const rows = await app.db
+      .select()
+      .from(contextTreeIoEvents)
+      .where(eq(contextTreeIoEvents.sourceSessionEventId, persisted.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.metadata).toMatchObject({ origin: "tool_arg", repoHeadCommit });
+
+    const summary = await summarizeContextTreeIo(app.db, seed.organizationId, 7);
+    expect(summary.recentEvents[0]).toMatchObject({
+      action: "read",
+      targetPath: "NODE.md",
+      treeHeadCommit: repoHeadCommit,
+    });
+  });
+
+  it("ignores checkout provenance smuggled through generic read metadata", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    const persisted = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-read-nested-head",
+        name: "Read",
+        args: { file_path: "/tmp/context-tree/NODE.md" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+            metadata: { repoHeadCommit: "c".repeat(40) },
+          },
+        ],
+      },
+    });
+
+    await recordFromSessionEvent(app.db, {
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      chatId: seed.chatId,
+      runtimeProvider: "claude-code",
+      sessionEvent: persisted,
+    });
+
+    const rows = await app.db
+      .select()
+      .from(contextTreeIoEvents)
+      .where(eq(contextTreeIoEvents.sourceSessionEventId, persisted.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.metadata).not.toHaveProperty("repoHeadCommit");
+
+    const summary = await summarizeContextTreeIo(app.db, seed.organizationId, 7);
+    expect(summary.recentEvents[0]).toMatchObject({
+      action: "read",
+      targetPath: "NODE.md",
+      treeHeadCommit: null,
     });
   });
 
@@ -137,8 +231,10 @@ describe("context-tree IO service", () => {
             localPath: "/tmp/tree/members/alice/NODE.md",
             repoUrl: TREE_REPO,
             repoBranch: "main",
+            repoHeadCommit: "b".repeat(40),
             repoRelativePath: "members/alice/NODE.md",
             pathKind: "file",
+            metadata: { repoHeadCommit: "c".repeat(40) },
           },
           {
             origin: "file_change",
@@ -178,6 +274,7 @@ describe("context-tree IO service", () => {
       targetPath: "members/alice/NODE.md",
       runtimeProvider: "codex",
     });
+    expect(rows[0]?.metadata).not.toHaveProperty("repoHeadCommit");
 
     const summary = await summarizeContextTreeIo(app.db, seed.organizationId, 7);
     expect(summary.summary.write).toMatchObject({ agentCount: 1, eventCount: 1, targetCount: 1 });

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -315,6 +315,7 @@ function normalizeFileRef(
   ref: ToolFileRef,
   bindingRepo: string,
   bindingBranch: string,
+  includeRepoHeadCommit: boolean,
 ): { ok: true; normalized: NormalizedFileRef } | { ok: false; reason: ContextTreeIoSkipReason } {
   const parsed = toolFileRefSchema.safeParse(ref);
   if (!parsed.success) return { ok: false, reason: "ref_schema_invalid" };
@@ -329,6 +330,10 @@ function normalizeFileRef(
   if (!parsed.data.repoRelativePath) return { ok: false, reason: "ref_path_invalid" };
   const targetPath = normalizeTargetPath(parsed.data.repoRelativePath, targetKind);
   if (!targetPath) return { ok: false, reason: "ref_path_invalid" };
+  const refMetadata = { ...(parsed.data.metadata ?? {}) };
+  // Reserved provenance must come only from the validated top-level field.
+  // Never let caller-controlled generic metadata smuggle it onto writes.
+  delete refMetadata.repoHeadCommit;
 
   return {
     ok: true,
@@ -338,9 +343,12 @@ function normalizeFileRef(
       targetKind,
       targetPath,
       metadata: {
-        ...(parsed.data.metadata ?? {}),
+        ...refMetadata,
         origin: parsed.data.origin,
         ...(parsed.data.localPath ? { localPath: parsed.data.localPath } : {}),
+        ...(includeRepoHeadCommit && parsed.data.repoHeadCommit
+          ? { repoHeadCommit: parsed.data.repoHeadCommit.toLowerCase() }
+          : {}),
       },
     },
   };
@@ -370,7 +378,7 @@ function buildContextTreeIoDecision(input: {
   for (const { ref, sourceIndex } of refs) {
     const refDerivation = ref.origin === GIT_STATUS_DELTA_REF_ORIGIN ? GIT_STATUS_DELTA_DERIVATION : baseDerivation;
     if (!refDerivation) continue;
-    const normalized = normalizeFileRef(ref, input.bindingRepo, input.bindingBranch);
+    const normalized = normalizeFileRef(ref, input.bindingRepo, input.bindingBranch, refDerivation.action === "read");
     if (!normalized.ok) {
       firstRejectedReason ??= normalized.reason;
       continue;
@@ -773,6 +781,7 @@ function allEventsSql(organizationId: string, sinceIso: string) {
         e.source,
         e.target_kind,
         e.target_path,
+        e.metadata,
         e.chat_id,
         e.created_at
       FROM context_tree_io_events e
@@ -1085,6 +1094,7 @@ export async function summarizeContextTreeIo(
       source: string;
       target_kind: string;
       target_path: string;
+      tree_head_commit: string | null;
       raw_chat_id: string;
       joined_chat_id: string | null;
       chat_topic: string | null;
@@ -1101,6 +1111,7 @@ export async function summarizeContextTreeIo(
         all_events.source,
         all_events.target_kind,
         all_events.target_path,
+        all_events.metadata->>'repoHeadCommit' AS tree_head_commit,
         all_events.chat_id AS raw_chat_id,
         c.id AS joined_chat_id,
         c.topic AS chat_topic,
@@ -1134,6 +1145,7 @@ export async function summarizeContextTreeIo(
       source: contextTreeIoSourceSchema.parse(row.source),
       targetKind: row.target_kind === "directory" || row.target_kind === "repo" ? row.target_kind : "file",
       targetPath: row.target_path,
+      treeHeadCommit: row.tree_head_commit && /^[0-9a-f]{40}$/.test(row.tree_head_commit) ? row.tree_head_commit : null,
       chatId: sameOrgChat ? row.raw_chat_id : null,
       chatTitle: sameOrgChat ? row.chat_topic : null,
       viewerCanAccess: sameOrgChat && accessibleChatIds.has(row.raw_chat_id),

--- a/packages/shared/src/__tests__/session-event-schema.test.ts
+++ b/packages/shared/src/__tests__/session-event-schema.test.ts
@@ -31,6 +31,48 @@ describe("sessionEventSchema", () => {
       expect(r.success).toBe(true);
     });
 
+    it("accepts a file ref with an exact checkout HEAD commit", () => {
+      const r = sessionEventSchema.safeParse({
+        kind: "tool_call",
+        payload: {
+          toolUseId: "t1",
+          name: "Read",
+          args: { file_path: "/tree/NODE.md" },
+          status: "ok",
+          toolFileRefs: [
+            {
+              origin: "tool_arg",
+              repoUrl: "https://github.com/acme/tree",
+              repoRelativePath: "NODE.md",
+              repoHeadCommit: "a".repeat(40),
+            },
+          ],
+        },
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it("rejects a malformed checkout HEAD commit", () => {
+      const r = sessionEventSchema.safeParse({
+        kind: "tool_call",
+        payload: {
+          toolUseId: "t1",
+          name: "Read",
+          args: { file_path: "/tree/NODE.md" },
+          status: "ok",
+          toolFileRefs: [
+            {
+              origin: "tool_arg",
+              repoUrl: "https://github.com/acme/tree",
+              repoRelativePath: "NODE.md",
+              repoHeadCommit: "not-a-commit",
+            },
+          ],
+        },
+      });
+      expect(r.success).toBe(false);
+    });
+
     it("accepts each valid status", () => {
       for (const status of ["pending", "ok", "error"] as const) {
         const r = sessionEventSchema.safeParse({

--- a/packages/shared/src/schemas/context-tree.ts
+++ b/packages/shared/src/schemas/context-tree.ts
@@ -237,6 +237,14 @@ export const contextTreeIoEventSchema = z.object({
   source: contextTreeIoSourceSchema,
   targetKind: contextTreeIoTargetKindSchema,
   targetPath: z.string(),
+  // Optional for rolling Client/Server compatibility. This is the local
+  // checkout HEAD observed for the read, not a claim that dirty content
+  // matched the commit.
+  treeHeadCommit: z
+    .string()
+    .regex(/^[0-9a-f]{40}$/)
+    .nullable()
+    .optional(),
   chatId: z.string().nullable(),
   chatTitle: z.string().nullable(),
   viewerCanAccess: z.boolean(),

--- a/packages/shared/src/schemas/session-event.ts
+++ b/packages/shared/src/schemas/session-event.ts
@@ -21,6 +21,13 @@ export const toolFileRefSchema = z.object({
   localPath: z.string().min(1).optional(),
   repoUrl: z.string().min(1).optional(),
   repoBranch: z.string().min(1).optional(),
+  // The checkout HEAD observed for the successful read. This identifies the
+  // candidate Git snapshot without claiming that a dirty local file
+  // necessarily matched that commit.
+  repoHeadCommit: z
+    .string()
+    .regex(/^[0-9a-f]{40}$/i)
+    .optional(),
   repoRelativePath: z.string().min(1).optional(),
   pathKind: toolFileRefPathKindSchema.optional(),
   origin: toolFileRefOriginSchema,


### PR DESCRIPTION
## Summary

- annotate successful Context Tree reads with the origin-verified checkout `HEAD`
- persist the optional commit in the existing Context Tree I/O event metadata and expose it on recent read events
- cover Claude, Codex shell reads, Cursor, and Kimi without changing Task or Effect semantics

## Design boundaries

- The existing read path remains the receipt; this does not add a table, service, UI, content copy, or content hash.
- `repoHeadCommit` identifies the checkout snapshot observed at read time. It does not claim that dirty local content matched that commit, and it is not causal evidence.
- The server treats `repoHeadCommit` as a reserved key: generic metadata cannot inject it, and write events never persist it.
- The API field is optional/nullable for rolling Client/Server compatibility. No database migration is required.
- Search tools record only their explicit root or path, not every matched file.

## Validation

- `pnpm check` (passes; existing unrelated warnings only)
- `pnpm typecheck`
- `TURBO_CONCURRENCY=1 pnpm test`
- targeted Shared, Client, and Server tests (192/192 before review fix)
- final `context-tree-io` regression suite (34/34)
- `git diff --check`
- two independent code reviews; the one trust-boundary blocker was fixed and re-reviewed

## QA

Formal cross-provider runtime QA is warranted. The existing Cursor and Kimi Context Tree I/O cases can be reused to verify that successful reads expose the checkout commit while failed reads and writes do not.
