### PR TITLE
fix(server): bound inbox ACK cost to the partition's non-acked rows

### DIFF
--- a/packages/server/src/__tests__/inbox-ack-prefix-scan.test.ts
+++ b/packages/server/src/__tests__/inbox-ack-prefix-scan.test.ts
@@ -1,0 +1,195 @@
+import { INBOX_ENTRY_STATUSES, inboxEntryStatusSchema } from "@first-tree/shared";
+import { and, eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import type { FastifyInstance } from "fastify";
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import type { Database } from "../db/connection.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import * as schema from "../db/schema/index.js";
+import { messages } from "../db/schema/messages.js";
+import * as inboxService from "../services/inbox.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Guards for the ACK-through prefix scan (PERF-008 / #1671).
+ *
+ * The scan used to read every notify=true row in the `(inbox_id, chat_id)`
+ * partition below the cursor, including rows acked long ago, making a single
+ * ACK cost O(chat history). These tests pin the two properties that keep it
+ * bounded, plus the `chat_id IS NULL` branch that the existing ACK coverage
+ * does not reach.
+ */
+describe("inbox ACK prefix scan", () => {
+  const getApp = useTestApp();
+
+  /** Create a chat between two agents and bulk-seed `history` acked rows for
+   *  the recipient, followed by `live` delivered rows it can still ACK. */
+  async function seedHistory(
+    app: FastifyInstance,
+    opts: { history: number; live: number; nullChat?: boolean },
+  ): Promise<{ inboxId: string; chatId: string; liveIds: number[] }> {
+    const uid = crypto.randomUUID().slice(0, 8);
+    const sender = await createTestAgent(app, { name: `ack-s-${uid}` });
+    const recipient = await createTestAgent(app, { name: `ack-r-${uid}` });
+    const chatRes = await sender.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [recipient.agent.uuid],
+    });
+    const chatId: string = chatRes.json().id;
+    const inboxId = recipient.agent.inboxId;
+    const total = opts.history + opts.live;
+
+    // Bulk-insert rather than sending `total` real messages: this exercises the
+    // ACK read path, and the fan-out path has its own coverage elsewhere.
+    const messageRows = Array.from({ length: total }, (_, i) => ({
+      id: `ack-msg-${uid}-${i}`,
+      chatId,
+      senderId: sender.agent.uuid,
+      format: "text",
+      content: `seed ${i}`,
+      source: "api" as const,
+    }));
+    await app.db.insert(messages).values(messageRows);
+    await app.db.insert(inboxEntries).values(
+      messageRows.map((m, i) => ({
+        inboxId,
+        messageId: m.id,
+        chatId: opts.nullChat ? null : chatId,
+        notify: true,
+        status: i < opts.history ? INBOX_ENTRY_STATUSES.ACKED : INBOX_ENTRY_STATUSES.DELIVERED,
+        deliveredAt: new Date(),
+        ackedAt: i < opts.history ? new Date() : null,
+      })),
+    );
+    await app.db.execute(sql`ANALYZE inbox_entries`);
+
+    const live = await app.db
+      .select({ id: inboxEntries.id })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, INBOX_ENTRY_STATUSES.DELIVERED)));
+    return { inboxId, chatId, liveIds: live.map((r) => r.id).sort((a, b) => a - b) };
+  }
+
+  describe("scanned status set", () => {
+    it("is derived from the status domain rather than hardcoded", () => {
+      // The direction of this assertion is the point. If a fourth status is
+      // added, it must land in the scanned set so an ACK can still reject it
+      // as a prefix gap. A hardcoded ["pending", "delivered"] would silently
+      // skip it and let the commit through.
+      expect([...inboxService.ACK_PREFIX_SCAN_STATUSES].sort()).toEqual(
+        inboxEntryStatusSchema.options.filter((s) => s !== INBOX_ENTRY_STATUSES.ACKED).sort(),
+      );
+      expect(inboxService.ACK_PREFIX_SCAN_STATUSES).not.toContain(INBOX_ENTRY_STATUSES.ACKED);
+    });
+
+    it("covers every status the database itself allows", async () => {
+      // Cross-check against the live CHECK constraint: it was added NOT VALID
+      // and the domain has changed once before (a legacy `failed` value). If
+      // the database domain and the shared enum ever diverge, the derived set
+      // stops being equivalent to "everything except acked" and this fails.
+      const [row] = await getApp().db.execute<{ def: string }>(sql`
+        SELECT pg_get_constraintdef(oid) AS def
+          FROM pg_constraint WHERE conname = 'ck_inbox_entries_status'`);
+      const dbDomain = [...String(row?.def ?? "").matchAll(/'([a-z_]+)'/g)].map((m) => m[1]).sort();
+      expect(dbDomain).toEqual([...inboxEntryStatusSchema.options].sort());
+    });
+  });
+
+  it("keeps ACK cost independent of chat history", async () => {
+    const app = getApp();
+
+    /** Run one real ACK, capturing every statement the service emits, then
+     *  replay each against EXPLAIN ANALYZE and report the widest scan.
+     *
+     *  Capturing the service's own SQL — rather than a copy of the query
+     *  written into this test — is what makes the guard survive refactors:
+     *  inlining the query back into the service, or dropping the status
+     *  restriction, both show up here. */
+    async function widestScan(cursor: number, inboxId: string): Promise<number> {
+      const captured: Array<{ query: string; params: unknown[] }> = [];
+      const client = postgres(process.env.DATABASE_URL ?? "", { max: 1 });
+      const instrumented = Object.assign(
+        drizzle(client, {
+          schema,
+          logger: { logQuery: (query, params) => captured.push({ query, params }) },
+        }),
+        { end: () => client.end() },
+      ) as unknown as Database;
+
+      try {
+        await inboxService.ackThroughEntryIdForBoundAgents(instrumented, cursor, [inboxId]);
+        const reads = captured.filter((c) => /^\s*select/i.test(c.query) && c.query.includes("inbox_entries"));
+        expect(reads.length).toBeGreaterThan(0);
+
+        let widest = 0;
+        for (const c of reads) {
+          const plan = await client.unsafe(`EXPLAIN (ANALYZE, FORMAT JSON) ${c.query}`, c.params as never[]);
+          widest = Math.max(widest, deepestActualRows(plan[0]?.["QUERY PLAN"]?.[0]?.Plan));
+        }
+        return widest;
+      } finally {
+        await client.end();
+      }
+    }
+
+    const small = await seedHistory(app, { history: 300, live: 4 });
+    const smallScan = await widestScan(small.liveIds[0] ?? 0, small.inboxId);
+
+    const large = await seedHistory(app, { history: 1500, live: 4 });
+    const largeScan = await widestScan(large.liveIds[0] ?? 0, large.inboxId);
+
+    // Five times the history must not cost more rows read. A few rows of slack
+    // absorbs the live window; it is nowhere near the 1200-row difference a
+    // history-proportional scan would produce.
+    expect(largeScan).toBeLessThanOrEqual(smallScan + 8);
+    expect(largeScan).toBeLessThan(100);
+  });
+
+  it("commits through a long acked history in the chat_id IS NULL partition", async () => {
+    const app = getApp();
+    const { inboxId, liveIds } = await seedHistory(app, { history: 400, live: 3, nullChat: true });
+    const target = liveIds[liveIds.length - 1];
+    expect(target).toBeDefined();
+
+    const result = await inboxService.ackThroughEntryIdForBoundAgents(app.db, target ?? 0, [inboxId]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.disposition).toBe("acked");
+    expect(result.ackedCount).toBe(3);
+
+    const remaining = await app.db
+      .select({ id: inboxEntries.id })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, INBOX_ENTRY_STATUSES.DELIVERED)));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("still rejects a gap that sits behind a long acked history", async () => {
+    const app = getApp();
+    const { inboxId, liveIds } = await seedHistory(app, { history: 400, live: 3 });
+    const [first, , third] = liveIds;
+    expect(first).toBeDefined();
+
+    // Turn the first live row into a never-delivered pending row: it is now a
+    // genuine prefix gap sitting far above the acked history.
+    await app.db
+      .update(inboxEntries)
+      .set({ status: INBOX_ENTRY_STATUSES.PENDING, deliveredAt: null })
+      .where(eq(inboxEntries.id, first ?? 0));
+
+    const rejected = await inboxService.ackThroughEntryIdForBoundAgents(app.db, third ?? 0, [inboxId]);
+    expect(rejected).toEqual({ ok: false, reason: "prefix_gap" });
+  });
+});
+
+type PlanNode = { "Actual Rows"?: number; Plans?: PlanNode[] };
+
+/** Rows touched by the deepest scan node — what "how much did this read" means
+ *  once the planner has layered sorts and lock nodes on top. */
+function deepestActualRows(node: PlanNode | undefined): number {
+  if (!node) return 0;
+  const children = node.Plans ?? [];
+  if (children.length === 0) return node["Actual Rows"] ?? 0;
+  return Math.max(...children.map(deepestActualRows));
+}

--- a/packages/server/src/__tests__/inbox-ack-prefix-scan.test.ts
+++ b/packages/server/src/__tests__/inbox-ack-prefix-scan.test.ts
@@ -105,7 +105,13 @@ describe("inbox ACK prefix scan", () => {
      *  Capturing the service's own SQL — rather than a copy of the query
      *  written into this test — is what makes the guard survive refactors:
      *  inlining the query back into the service, or dropping the status
-     *  restriction, both show up here. */
+     *  restriction, both show up here.
+     *
+     *  The replay runs after the ACK has committed, so a correct
+     *  implementation matches close to zero rows rather than the handful it
+     *  saw live. What is being asserted is the presence of the restriction,
+     *  not the live row count: a query missing it still reads the whole
+     *  partition on replay, which is what makes the two cases separable. */
     async function widestScan(cursor: number, inboxId: string): Promise<number> {
       const captured: Array<{ query: string; params: unknown[] }> = [];
       const client = postgres(process.env.DATABASE_URL ?? "", { max: 1 });

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -642,6 +642,14 @@ export async function ackThroughEntryIdForBoundAgents(
       // for a duplicate ACK that commits nothing. It has to be a positive IN:
       // `status <> 'acked'` is not sargable, stays a filter, and saves only
       // the row locks.
+      //
+      // Operational caveat: on PostgreSQL 16 the index condition is only
+      // reached under a custom plan. Measured stable under the default
+      // `plan_cache_mode = auto` on 16.14 and 17.10 — the generic estimate is
+      // far more expensive, so the planner keeps rejecting it — but a
+      // deployment that forces `force_generic_plan` globally would silently
+      // return this scan to O(history) on 16. PostgreSQL 17 uses the bound
+      // parameters as an index condition either way.
       const prefixRows = await tx
         .select()
         .from(inboxEntries)

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -1,4 +1,5 @@
 import {
+  INBOX_ENTRY_STATUSES,
   type InboxEntryWithMessage,
   inboxEntryStatusSchema,
   messageSourceSchema,
@@ -17,6 +18,23 @@ import { buildClientMessagePayloadsForInbox } from "./message-dispatcher.js";
 /** Claimed `inbox_entries` row, typed via Drizzle `$inferSelect` so column-mode
  *  conversions (bigserial → number, timestamp → Date) flow through. */
 type ClaimedEntry = typeof inboxEntries.$inferSelect;
+
+/**
+ * The statuses whose rows can still change an ACK-through decision.
+ *
+ * Derived from the shared status domain minus the terminal one rather than
+ * written out as a literal pair. The direction matters: if a fourth status is
+ * ever added, a derived set keeps scanning it — so an unknown status can still
+ * reject the commit as a prefix gap, exactly as the original status-agnostic
+ * query did. A hand-written `["pending", "delivered"]` would instead start
+ * skipping those rows and let the ACK through, turning a safe rejection into
+ * silent data loss. The table's status domain has changed once already (a
+ * legacy `failed` value, normalised by migration 0066), and its CHECK
+ * constraint was added `NOT VALID`, so this is not a hypothetical.
+ */
+export const ACK_PREFIX_SCAN_STATUSES = inboxEntryStatusSchema.options.filter(
+  (status) => status !== INBOX_ENTRY_STATUSES.ACKED,
+);
 
 export type AckEntryResult =
   | {
@@ -606,6 +624,24 @@ export async function ackThroughEntryIdForBoundAgents(
       if (!entry.notify) return { ok: false, reason: "non_notify" };
 
       const chatPredicate = entry.chatId === null ? isNull(inboxEntries.chatId) : eq(inboxEntries.chatId, entry.chatId);
+      // Scan only the rows that can still change the outcome. Already-acked
+      // rows flip none of the three decisions made below: they never form a
+      // prefix gap, are never committable, and are never reset-from-pending.
+      // Excluding them is therefore an exact equivalence rather than an
+      // approximation, and it holds because `acked` is terminal for status
+      // transitions — every UPDATE against this table is guarded on 'pending'
+      // or 'delivered', and the single statement that touches acked rows at
+      // all is the GC DELETE in `pruneStaleSilentEntries`, restricted to
+      // notify=false.
+      //
+      // This clause is also what bounds the scan. `idx_inbox_chat_silent` is
+      // (inbox_id, chat_id, notify, status); leaving `status` unconstrained
+      // used only three of its four equality columns, so the planner had to
+      // walk every row of the partition and re-check `id <= cursor` as a
+      // filter — O(chat history) per ACK and O(N^2) over a chat's life, even
+      // for a duplicate ACK that commits nothing. It has to be a positive IN:
+      // `status <> 'acked'` is not sargable, stays a filter, and saves only
+      // the row locks.
       const prefixRows = await tx
         .select()
         .from(inboxEntries)
@@ -614,6 +650,7 @@ export async function ackThroughEntryIdForBoundAgents(
             eq(inboxEntries.inboxId, entry.inboxId),
             chatPredicate,
             eq(inboxEntries.notify, true),
+            inArray(inboxEntries.status, ACK_PREFIX_SCAN_STATUSES),
             sql`${inboxEntries.id} <= ${entryId}`,
           ),
         )


### PR DESCRIPTION
Fixes the quadratic ACK cost described in #1671 (PERF-008).

## The problem

`ackThroughEntryIdForBoundAgents` selected — and, under `FOR UPDATE`, locked — **every**
`notify=true` row in the `(inbox_id, chat_id)` partition below the ACK cursor, including rows
acked long ago. Those rows were then materialised as JS objects. Cost per ACK was O(chat
history) and O(N²) over a chat's lifetime, and a duplicate ACK that commits nothing paid the
full price.

Measured end-to-end through the real service call (not just the SQL), on a migrated database
with the production index set:

| chat history | one duplicate ACK (commits nothing) |
| --- | --- |
| 50,000 | 119.6 ms |
| 150,000 | 341.4 ms |
| 300,000 | **545.0 ms** |

Roughly 2 µs per row of history, strictly linear.

## Root cause

Not a missing index. **`idx_inbox_chat_silent (inbox_id, chat_id, notify, status)` already
exists and the planner was already using it** — the query just never constrained `status`, so a
four-column index was used as a three-column one. Every row of the partition came back and
`id <= cursor` was re-checked as a heap filter:

```
Sort (actual rows=168001)  Sort Method: quicksort  Memory: 21895kB
  -> Index Scan using idx_inbox_chat_silent on inbox_entries (actual rows=168001)
       Index Cond: ((inbox_id = $1) AND (chat_id = $2) AND (notify = $3))
       Filter: (id <= $4)
```

The locking cost was larger than the scan: with `FOR UPDATE`, that same statement touched
338,980 buffers and dirtied 2,800 pages, purely to take row locks on rows that were already in
their terminal state.

## The change

One clause on the prefix scan, restricting it to the statuses an ACK decision can still be
changed by. **No schema change, no new index, no migration.**

### Why it is an exact equivalence

The prefix rows feed exactly three decisions, and an acked row contributes to none of them:

| decision | predicate | acked row |
| --- | --- | --- |
| prefix gap | `status !== 'acked' && status !== 'delivered' && !isResetDelivered` | always false |
| committable delivered | `status === 'delivered'` | always false |
| committable reset-from-pending | `status === 'pending' && deliveredAt !== null` | always false |

This holds because `acked` is terminal for status transitions. Every `UPDATE` against
`inbox_entries` is guarded on `'pending'` or `'delivered'`; the only statement that touches
acked rows at all is the GC `DELETE` in `pruneStaleSilentEntries`, which is restricted to
`notify=false` and therefore disjoint from this `notify=true` scan.

The ACK expansion set is unchanged — same inbox, same chat, same cursor. The scan simply stops
reading members of it that cannot affect the outcome.

### Why a positive `IN` rather than `<> 'acked'`

`<>` is not sargable. Measured on the same dataset, `status <> $4` stays a filter and removes
168,000 rows after reading them — it saves the row locks and nothing else:

| spelling | rows scanned | buffers | time |
| --- | --- | --- | --- |
| `status <> $4` | 168,020 | 2,851 | 9.6 ms |
| `status IN ($4, $5)` | 20 | 4 | 0.03 ms |

### Why the status set is derived rather than written out

`ACK_PREFIX_SCAN_STATUSES` is computed from the shared status domain minus the terminal value.
The failure direction is what matters. If a fourth status is ever added, a derived set keeps
scanning it, so an unknown status still rejects the commit as a prefix gap — the same
fail-closed behaviour the original status-agnostic query had. A hardcoded
`["pending", "delivered"]` would instead skip those rows and let the ACK through, turning a
safe rejection into silent data loss. This is not hypothetical: the column's domain has changed
once already (a legacy `failed` value, normalised by migration `0066`), and
`ck_inbox_entries_status` was added `NOT VALID`.

## Results

End-to-end service call, median of 40 samples after warm-up, on **both** PostgreSQL major
versions this repo runs (`docker-compose.yml` uses `postgres:16-alpine`, CI uses `postgres:17`):

| chat history | before | after (PG 17.10) | after (PG 16.14) |
| --- | --- | --- | --- |
| 50,000 | 119.6 ms | 1.46 ms | 2.53 ms |
| 150,000 | 341.4 ms | 2.25 ms | 2.77 ms |
| 300,000 | **545.0 ms** | **2.66 ms** | **2.61 ms** |

Flat instead of linear. The residual ~2.5 ms is the transaction's fixed cost — an ACK against a
chat with *no* history measures 3.0–3.2 ms — so history no longer contributes at all.

Query level, same dataset, verified on 16.14 and 17.10 through the real driver (postgres-js
named prepared statements, repeated executions, default `plan_cache_mode`):

| scenario | before | after |
| --- | --- | --- |
| incremental ACK | 168,001 rows / 2,940 buffers | 1 row / 4 buffers |
| duplicate ACK | 168,000 rows / 2,937 buffers | 0 rows / 4 buffers |
| with `FOR UPDATE` | 338,980 buffers / 2,800 dirtied | 44 buffers / 0 dirtied |
| `chat_id IS NULL` partition | 120,015 rows / 1,582 buffers | 15 rows / 4 buffers |

`LockRows` still sits above the `Sort`, so rows are still locked in ascending id order and the
lock ordering between concurrent ACKs on one partition is unchanged. The rows that stop being
locked are exactly the acked ones, which no production statement mutates.

### Operational caveat

On PostgreSQL 16 the status restriction only reaches the index condition under a **custom**
plan. That is what the default `plan_cache_mode = auto` produces here, stably: the generic
estimate is hundreds of times more expensive, so the planner keeps rejecting it — verified over
repeated executions and across a plan-pollution sequence (same prepared statement serving a
small partition first, then the large one). But a deployment that sets
`plan_cache_mode = force_generic_plan` globally would silently return this scan to O(history) on
16. PostgreSQL 17 uses the bound parameters as an index condition either way. Noted in the code
next to the clause.

### Scope of the win, stated precisely

Cost now tracks **the number of non-acked rows in the partition**, not the cursor position and
not the history. `id <= cursor` is still a filter, so a partition holding a large `pending`
backlog (an agent offline for a long time — `delivered` is capped per chat, `pending` is not)
still costs proportionally to that backlog. Draining such a backlog one ACK at a time remains
O(N²) in the backlog size. That is one to two orders of magnitude better than the previous
behaviour and removes the history dependence #1671 is about, but it is not O(1).

## Alternatives considered and rejected

**A per-`(inbox, chat)` high-water cursor** (the issue's first suggestion) is not merely
heavier — it is incorrect here. `inbox_entries.id` comes from a sequence allocated at INSERT
time, while the fan-out INSERT in `services/message.ts` happens *before* the only serialisation
point in that transaction (`UPDATE chats SET updated_at`). Commit order therefore does not
follow id order. Reproduced with two sessions: A allocates id 1 and holds its transaction open,
B allocates id 2 and commits; an observer at that instant sees only id 2. A watermark advanced
to 2 would leave id 1 permanently below it once A commits — the client's ACK for row 1 would
hit the "already acked" short circuit, the row would stay `delivered` forever, bind-time
recovery would reset it to `pending`, redeliver, and short-circuit again. An unbounded
redelivery loop. Today's code self-heals in that scenario. Closing the hole would require the
delivery path to walk the watermark backwards — a new invariant spanning delivery, ACK and
recovery, plus a table and a migration.

**Extending `idx_inbox_chat_silent` with a trailing `id`** would make `id <= cursor` an index
condition. Measured: the planner keeps choosing the existing four-column index even when the
five-column one is available, and that index costs 147 MB against 19 MB on a table that sits on
the message fan-out write path. Not worth it.

**Rewriting the three decisions as pure SQL** to remove the JS materialisation: once the scan
is bounded to the non-acked window, materialising it is negligible. A larger diff for no
measurable gain.

## Not adding a migration is a feature here

`inbox_entries` already carries five indexes plus a unique constraint on the fan-out write path.
Beyond that, CI pins `packages/server/drizzle/LATEST` to the latest journal tag specifically so
racing PRs conflict — #2108 landed while this was in progress and took slot `0091`. A migration
in this PR would have needed rebasing; there is nothing here to rebase. Drizzle migrations also
run inside a transaction, so `CREATE INDEX CONCURRENTLY` is unavailable and any new index would
hold a lock on a large table for the duration.

## Tests

`packages/server/src/__tests__/inbox-ack-prefix-scan.test.ts`:

- **Cost guard.** Runs a real ACK through a logger-instrumented database, captures the SQL the
  service actually emits, and replays each read against `EXPLAIN (ANALYZE)`. Asserts the widest
  scan does not grow when the history grows 5×. It asserts on the service's own statements
  rather than a copy of the query, so inlining the query back into the service or dropping the
  predicate both surface. **Fault-injected:** removing the status clause turns it red
  (`expected 1501 to be less than or equal to 309`). The replay happens after the ACK has
  committed, so a correct implementation matches close to zero rows rather than the handful it
  saw live — what is asserted is the presence of the restriction, not the live row count.
- **Derived-set guard.** Pins that the scanned set is the status domain minus the terminal
  value, and cross-checks the shared enum against the live `CHECK` constraint so a database-side
  domain change cannot drift away unnoticed.
- **Behaviour.** ACK-through across a long acked history in the `chat_id IS NULL` partition (the
  `isNull` branch of `chatPredicate`, previously uncovered), and a prefix gap sitting above a
  long acked history still rejected.

Equivalence was additionally checked exhaustively in SQL before implementation: every
(partition × cursor) combination over an adversarial dataset — acked rows interleaved before,
between and after every interesting row, the NULL-chat partition, recovery-reset rows,
cross-inbox interference, gaps on either side of the cursor — derived all three decisions both
ways and diffed them. 60 cases, 0 disagreements; a deliberately broken variant produced 29,
confirming the check has detection power.

`pnpm check`, `pnpm typecheck` and the `packages/server` suite pass.
