### PR TITLE
Simplify sign-in method settings

### DIFF
--- a/packages/web/src/components/ui/__tests__/popover-behavior.test.tsx
+++ b/packages/web/src/components/ui/__tests__/popover-behavior.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { act } from "react";
+import { act, useEffect, useRef, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Popover } from "../popover.js";
@@ -128,5 +128,69 @@ describe("Popover", () => {
 
     expect(document.body.querySelector('[role="dialog"]')).toBeNull();
     expect(document.activeElement).toBe(trigger);
+  });
+
+  it("preserves focus when an action closes the popover and opens a modal", async () => {
+    function ModalHandoff(): React.JSX.Element {
+      const [modalOpen, setModalOpen] = useState(false);
+      const modalButtonRef = useRef<HTMLButtonElement>(null);
+
+      useEffect(() => {
+        if (modalOpen) modalButtonRef.current?.focus();
+      }, [modalOpen]);
+
+      return (
+        <>
+          <Popover
+            className="test-popover-trigger"
+            panelAriaLabel="Actions"
+            trigger={({ open, toggle }) => (
+              <button type="button" aria-expanded={open} onClick={toggle}>
+                Open actions
+              </button>
+            )}
+          >
+            {({ close }) => (
+              <button
+                type="button"
+                onClick={() => {
+                  setModalOpen(true);
+                  close();
+                }}
+              >
+                Open modal
+              </button>
+            )}
+          </Popover>
+          {modalOpen && (
+            <div role="dialog" aria-label="Repository settings">
+              <button ref={modalButtonRef} type="button">
+                Save
+              </button>
+            </div>
+          )}
+        </>
+      );
+    }
+
+    const container = document.getElementById("root");
+    if (!container) throw new Error("Missing test root");
+    root = createRoot(container);
+    await act(async () => root?.render(<ModalHandoff />));
+
+    const trigger = container.querySelector<HTMLButtonElement>("button");
+    if (!trigger) throw new Error("Missing trigger");
+    await act(async () => trigger.click());
+    const action = document.body.querySelector<HTMLButtonElement>('[role="dialog"][aria-label="Actions"] button');
+    if (!action) throw new Error("Missing popover action");
+    await act(async () => action.click());
+    await flush();
+
+    const modalButton = container.querySelector<HTMLButtonElement>(
+      '[role="dialog"][aria-label="Repository settings"] button',
+    );
+    expect(document.body.querySelector('[role="dialog"][aria-label="Actions"]')).toBeNull();
+    expect(document.activeElement).toBe(modalButton);
+    expect(document.activeElement).not.toBe(trigger);
   });
 });

--- a/packages/web/src/components/ui/__tests__/popover-behavior.test.tsx
+++ b/packages/web/src/components/ui/__tests__/popover-behavior.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Popover } from "../popover.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let triggerTop = 208;
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function numericStyle(value: string): number {
+  return Number.parseFloat(value);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>';
+  triggerTop = 208;
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 320 });
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: 240 });
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    callback(0);
+    return 1;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+    if (this.classList.contains("test-popover-trigger")) {
+      return {
+        x: 280,
+        y: triggerTop,
+        top: triggerTop,
+        left: 280,
+        right: 312,
+        bottom: triggerTop + 28,
+        width: 32,
+        height: 28,
+        toJSON: () => undefined,
+      } as DOMRect;
+    }
+    if (this.getAttribute("role") === "dialog") {
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 240,
+        bottom: 72,
+        width: 240,
+        height: 72,
+        toJSON: () => undefined,
+      } as DOMRect;
+    }
+    return {
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      toJSON: () => undefined,
+    } as DOMRect;
+  });
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("Popover", () => {
+  it("names and focuses the panel, restores focus on Escape, and reflows inside the viewport", async () => {
+    const container = document.getElementById("root");
+    if (!container) throw new Error("Missing test root");
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        <Popover
+          className="test-popover-trigger"
+          panelAriaLabel="Available sign-in methods"
+          focusOnOpen
+          panelStyle={{ width: 240 }}
+          trigger={({ open, toggle }) => (
+            <button type="button" aria-expanded={open} onClick={toggle}>
+              Add method
+            </button>
+          )}
+        >
+          {() => <button type="button">Google</button>}
+        </Popover>,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>("button");
+    if (!trigger) throw new Error("Missing trigger");
+    await act(async () => trigger.click());
+    await flush();
+
+    const panel = document.body.querySelector<HTMLElement>('[role="dialog"][aria-label="Available sign-in methods"]');
+    const option = panel?.querySelector<HTMLButtonElement>("button");
+    expect(panel).toBeTruthy();
+    expect(document.activeElement).toBe(option);
+    expect(numericStyle(panel?.style.left ?? "")).toBe(72);
+    expect(numericStyle(panel?.style.top ?? "")).toBe(132);
+    expect(numericStyle(panel?.style.maxHeight ?? "")).toBe(196);
+    expect(numericStyle(panel?.style.maxWidth ?? "")).toBe(304);
+
+    triggerTop = 40;
+    await act(async () => window.dispatchEvent(new Event("resize")));
+    await flush();
+    expect(numericStyle(panel?.style.top ?? "")).toBe(72);
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    await flush();
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/packages/web/src/components/ui/popover.tsx
+++ b/packages/web/src/components/ui/popover.tsx
@@ -1,8 +1,12 @@
-import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "../../lib/utils.js";
 
 type PopoverState = { open: boolean; toggle: () => void; close: () => void };
+
+const VIEWPORT_MARGIN = 8;
+const FOCUSABLE_SELECTOR =
+  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
 type PopoverProps = {
   trigger: (state: PopoverState) => ReactNode;
@@ -17,6 +21,10 @@ type PopoverProps = {
   panelStyle?: React.CSSProperties;
   /** Optional className applied to the trigger wrapper. */
   className?: string;
+  /** Accessible name announced for the dialog panel. */
+  panelAriaLabel?: string;
+  /** Move focus to the first interactive control when the panel opens. */
+  focusOnOpen?: boolean;
 };
 
 /**
@@ -38,6 +46,8 @@ export function Popover({
   panelClassName,
   panelStyle,
   className,
+  panelAriaLabel,
+  focusOnOpen = false,
 }: PopoverProps) {
   const triggerRef = useRef<HTMLSpanElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -45,47 +55,118 @@ export function Popover({
   // Position is recomputed every time the popover opens so a layout
   // shift (sidebar resize, keyboard appearing on mobile, etc) between
   // mounts doesn't anchor the next open onto stale coordinates.
-  const [position, setPosition] = useState<{ top: number; left: number | undefined; right: number | undefined }>({
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+    maxHeight: number | undefined;
+    maxWidth: number | undefined;
+  }>({
     top: 0,
-    left: undefined,
-    right: undefined,
+    left: 0,
+    maxHeight: undefined,
+    maxWidth: undefined,
   });
 
-  const close = (): void => setOpen(false);
+  const focusTrigger = useCallback((): void => {
+    triggerRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+  }, []);
+  const close = useCallback((): void => {
+    setOpen(false);
+    window.setTimeout(focusTrigger, 0);
+  }, [focusTrigger]);
   const toggle = (): void => setOpen((v) => !v);
 
-  // Outside click + Escape. Bound only while open so a closed popover
-  // doesn't pay the global listener cost.
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent): void => {
-      const t = e.target as Node;
-      if (triggerRef.current?.contains(t)) return;
-      if (panelRef.current?.contains(t)) return;
-      setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    window.addEventListener("mousedown", onDown);
-    window.addEventListener("keydown", onKey);
-    return () => {
-      window.removeEventListener("mousedown", onDown);
-      window.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
+  const computePosition = useCallback((): void => {
+    const trigger = triggerRef.current;
+    const panel = panelRef.current;
+    if (!trigger || !panel) return;
+
+    const rect = trigger.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
+    const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+    const viewportLeft = window.visualViewport?.offsetLeft ?? 0;
+    const viewportTop = window.visualViewport?.offsetTop ?? 0;
+    const panelWidth = panelRect.width || panel.offsetWidth;
+    const panelHeight = panelRect.height || panel.offsetHeight;
+    const below = viewportTop + viewportHeight - rect.bottom - offset - VIEWPORT_MARGIN;
+    const above = rect.top - viewportTop - offset - VIEWPORT_MARGIN;
+    const openUp = panelHeight > below && above > below;
+    const availableHeight = Math.max(0, openUp ? above : below);
+    const renderedHeight = Math.min(panelHeight, availableHeight);
+    const desiredLeft = align === "start" ? rect.left : rect.right - panelWidth;
+    const minLeft = viewportLeft + VIEWPORT_MARGIN;
+    const maxLeft = Math.max(minLeft, viewportLeft + viewportWidth - panelWidth - VIEWPORT_MARGIN);
+    const left = Math.max(minLeft, Math.min(desiredLeft, maxLeft));
+    const top = openUp
+      ? Math.max(viewportTop + VIEWPORT_MARGIN, rect.top - offset - renderedHeight)
+      : Math.min(rect.bottom + offset, viewportTop + viewportHeight - VIEWPORT_MARGIN - renderedHeight);
+
+    setPosition({
+      top,
+      left,
+      maxHeight: availableHeight,
+      maxWidth: Math.max(0, viewportWidth - VIEWPORT_MARGIN * 2),
+    });
+  }, [align, offset]);
 
   // Anchor the panel under the trigger. `useLayoutEffect` so the panel
   // never flashes at (0,0) before snapping into place on first paint.
   useLayoutEffect(() => {
-    if (!open || !triggerRef.current) return;
-    const rect = triggerRef.current.getBoundingClientRect();
-    setPosition({
-      top: rect.bottom + offset,
-      left: align === "start" ? rect.left : undefined,
-      right: align === "end" ? window.innerWidth - rect.right : undefined,
+    if (!open) return;
+    computePosition();
+  }, [open, computePosition]);
+
+  // Outside click + Escape + viewport reflow. Bound only while open so a
+  // closed popover doesn't pay the global listener cost.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent): void => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopPropagation();
+      close();
+    };
+    let frame = 0;
+    const onReflow = (): void => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        computePosition();
+      });
+    };
+    document.addEventListener("pointerdown", onDown);
+    document.addEventListener("keydown", onKey, true);
+    window.addEventListener("scroll", onReflow, true);
+    window.addEventListener("resize", onReflow);
+    window.visualViewport?.addEventListener("scroll", onReflow);
+    window.visualViewport?.addEventListener("resize", onReflow);
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      document.removeEventListener("pointerdown", onDown);
+      document.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("scroll", onReflow, true);
+      window.removeEventListener("resize", onReflow);
+      window.visualViewport?.removeEventListener("scroll", onReflow);
+      window.visualViewport?.removeEventListener("resize", onReflow);
+    };
+  }, [open, close, computePosition]);
+
+  useEffect(() => {
+    if (!open || !focusOnOpen) return;
+    const frame = window.requestAnimationFrame(() => {
+      const panel = panelRef.current;
+      if (!panel) return;
+      (panel.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ?? panel).focus();
     });
-  }, [open, align, offset]);
+    return () => window.cancelAnimationFrame(frame);
+  }, [open, focusOnOpen]);
 
   return (
     <>
@@ -97,12 +178,16 @@ export function Popover({
           <div
             ref={panelRef}
             role="dialog"
+            aria-label={panelAriaLabel}
+            tabIndex={focusOnOpen ? -1 : undefined}
             className={cn("z-50", panelClassName)}
             style={{
               position: "fixed",
               top: position.top,
               left: position.left,
-              right: position.right,
+              maxHeight: position.maxHeight,
+              maxWidth: position.maxWidth,
+              overflowY: "auto",
               background: "var(--bg-raised)",
               border: "var(--hairline) solid var(--border)",
               borderRadius: "var(--radius-panel)",

--- a/packages/web/src/components/ui/popover.tsx
+++ b/packages/web/src/components/ui/popover.tsx
@@ -35,8 +35,9 @@ type PopoverProps = {
  *
  * Trigger and content are render-props so callers can fully style the
  * trigger button (active state, count badges, focus rings) while still
- * sharing the open/close mechanics. Content receives `close` for any
- * "Done" / "Apply" buttons that should dismiss the popover.
+ * sharing the open/close mechanics. Content receives `close` for actions
+ * that dismiss the popover without taking focus away from their next target.
+ * Escape is the dismissal path that restores focus to the trigger.
  */
 export function Popover({
   trigger,
@@ -71,6 +72,9 @@ export function Popover({
     triggerRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
   }, []);
   const close = useCallback((): void => {
+    setOpen(false);
+  }, []);
+  const closeAndRestoreFocus = useCallback((): void => {
     setOpen(false);
     window.setTimeout(focusTrigger, 0);
   }, [focusTrigger]);
@@ -131,7 +135,7 @@ export function Popover({
       if (e.key !== "Escape") return;
       e.preventDefault();
       e.stopPropagation();
-      close();
+      closeAndRestoreFocus();
     };
     let frame = 0;
     const onReflow = (): void => {
@@ -156,7 +160,7 @@ export function Popover({
       window.visualViewport?.removeEventListener("scroll", onReflow);
       window.visualViewport?.removeEventListener("resize", onReflow);
     };
-  }, [open, close, computePosition]);
+  }, [open, closeAndRestoreFocus, computePosition]);
 
   useEffect(() => {
     if (!open || !focusOnOpen) return;

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -420,7 +420,7 @@ describe("settings panels", () => {
     await act(async () => desktop.root.unmount());
 
     const account = await renderDom(<SettingsLayout />, "/settings/account");
-    expect(account.container.textContent).toContain("Manage your profile and sign-in methods.");
+    expect(account.container.textContent).toContain("Manage your profile and ways to sign in.");
     expect(account.container.textContent).toContain("Account child");
     await act(async () => account.root.unmount());
 

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -40,7 +40,7 @@ type ItemGroup = {
 const ACCOUNT_ITEM: Item = {
   to: "/settings/account",
   label: "Account",
-  description: "Manage your profile and sign-in methods. These settings follow you across all your teams.",
+  description: "Manage your profile and ways to sign in. These settings follow you across all your teams.",
 };
 const SETUP_ITEM: Item = { to: "/settings/setup", label: "Setup" };
 const COMPUTERS_ITEM: Item = { to: "/settings/computers", label: "Computers" };

--- a/packages/web/src/pages/settings/__tests__/account-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/account-dom.test.tsx
@@ -144,7 +144,13 @@ describe("Settings account", () => {
     expect(container.textContent).toContain("@gandy2025");
     expect(container.textContent).toContain("Your avatar comes from the provider you signed up with.");
     expect(container.textContent).toContain("Profile");
-    expect(container.textContent).toContain("Sign-in methods");
+    expect(container.textContent).toContain("Ways to sign in");
+    expect(container.textContent).toContain("Use any available connected account to sign in to First Tree.");
+    expect(container.textContent).toContain("Add another sign-in method");
+    expect(container.textContent).toContain("Connected");
+    expect(container.textContent).not.toContain("Connected 7/15/2026");
+    expect(container.textContent).not.toContain("Connect another sign-in method before disconnecting.");
+    expect(container.textContent).not.toContain("Sign-in methods");
     expect(container.textContent).not.toContain("Authentication connections");
 
     const inputs = container.querySelectorAll<HTMLInputElement>("input");
@@ -157,11 +163,10 @@ describe("Settings account", () => {
     if (!saveButton) throw new Error("Expected save button");
     expect(saveButton.disabled).toBe(true);
 
-    const disconnect = [...container.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+    const disconnect = [...container.querySelectorAll<HTMLButtonElement>("button")].filter((button) =>
       button.textContent?.includes("Disconnect"),
     );
-    expect(disconnect?.disabled).toBe(true);
-    expect(container.textContent).toContain("Connect another sign-in method before disconnecting.");
+    expect(disconnect).toHaveLength(0);
 
     await setInputValue(displayNameInput, "  Gandy   New  ");
     expect(saveButton.disabled).toBe(false);
@@ -177,6 +182,151 @@ describe("Settings account", () => {
     expect(authMock.value.refreshMe).toHaveBeenCalled();
     expect(queryClient.getQueryState(["chat-detail", "chat-1"])?.isInvalidated).toBe(true);
     expect(container.textContent).toContain("Saved");
+  });
+
+  it("offers only unconnected available providers from the compact picker", async () => {
+    providerMocks.startProviderLink.mockReturnValue(new Promise<never>(() => undefined));
+    const { container } = await renderAccount();
+    await waitForText(container, "Add another sign-in method");
+
+    const addMethod = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent?.trim() === "Add another sign-in method",
+    );
+    if (!addMethod) throw new Error("Expected add sign-in method button");
+    expect(addMethod.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => addMethod.click());
+    await flush();
+
+    expect(addMethod.getAttribute("aria-expanded")).toBe("true");
+    const picker = document.body.querySelector<HTMLElement>('[role="dialog"][aria-label="Available sign-in methods"]');
+    const githubOption = [...document.body.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent?.trim() === "GitHub",
+    );
+    const googleOption = [...document.body.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent?.trim() === "Google",
+    );
+    expect(picker).toBeTruthy();
+    expect(githubOption).toBeTruthy();
+    expect(googleOption).toBeUndefined();
+    expect(document.activeElement).toBe(githubOption);
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    await flush();
+
+    expect(document.body.querySelector('[role="dialog"][aria-label="Available sign-in methods"]')).toBeNull();
+    expect(addMethod.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(addMethod);
+
+    await act(async () => addMethod.click());
+    await flush();
+    const reopenedGithubOption = [...document.body.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent?.trim() === "GitHub",
+    );
+
+    await act(async () => reopenedGithubOption?.click());
+    await flush();
+
+    expect(providerMocks.startProviderLink).toHaveBeenCalledWith("github");
+    expect(addMethod.getAttribute("aria-expanded")).toBe("false");
+    expect(addMethod.textContent).toContain("Starting…");
+  });
+
+  it("names and routes disconnect actions only when another usable credential remains", async () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    providerMocks.startProviderUnlink.mockReturnValue(new Promise<never>(() => undefined));
+    providerMocks.getAuthProviders.mockResolvedValue({
+      providers: [
+        {
+          provider: "google",
+          available: true,
+          connected: true,
+          accountName: "gandy@example.com",
+          email: "gandy@example.com",
+          avatarUrl: null,
+          connectedAt: "2026-07-15T12:00:00.000Z",
+          canUnlink: true,
+          unlinkBlockedReason: null,
+        },
+        {
+          provider: "github",
+          available: true,
+          connected: true,
+          accountName: "Gandy2025",
+          email: null,
+          avatarUrl: null,
+          connectedAt: "2026-07-16T12:00:00.000Z",
+          canUnlink: true,
+          unlinkBlockedReason: null,
+        },
+      ],
+    });
+
+    const { container } = await renderAccount();
+    await waitForText(container, "Gandy2025");
+
+    const disconnect = [...container.querySelectorAll<HTMLButtonElement>("button")].filter(
+      (button) => button.textContent?.trim() === "Disconnect",
+    );
+    expect(disconnect).toHaveLength(2);
+    expect(container.querySelector('button[aria-label="Disconnect Google"]')).toBeTruthy();
+    const disconnectGithub = container.querySelector<HTMLButtonElement>('button[aria-label="Disconnect GitHub"]');
+    expect(disconnectGithub).toBeTruthy();
+    expect(container.textContent).not.toContain("Add another sign-in method");
+
+    await act(async () => disconnectGithub?.click());
+    await flush();
+
+    expect(confirm).toHaveBeenCalledWith("Disconnect GitHub?");
+    expect(providerMocks.startProviderUnlink).toHaveBeenCalledWith("github");
+  });
+
+  it("does not promise that a connected but unavailable provider can sign in", async () => {
+    providerMocks.getAuthProviders.mockResolvedValue({
+      providers: [
+        {
+          provider: "google",
+          available: false,
+          connected: true,
+          accountName: "gandy@example.com",
+          email: "gandy@example.com",
+          avatarUrl: null,
+          connectedAt: "2026-07-15T12:00:00.000Z",
+          canUnlink: false,
+          unlinkBlockedReason: null,
+        },
+        {
+          provider: "github",
+          available: true,
+          connected: false,
+          accountName: null,
+          email: null,
+          avatarUrl: null,
+          connectedAt: null,
+          canUnlink: false,
+          unlinkBlockedReason: null,
+        },
+      ],
+    });
+
+    const { container } = await renderAccount();
+    await waitForText(container, "currently unavailable");
+
+    expect(container.textContent).toContain("Your connected sign-in methods are currently unavailable.");
+    expect(container.textContent).toContain("Unavailable");
+    expect(container.textContent).not.toContain("Use any available connected account");
+  });
+
+  it("keeps provider load failures distinct from an empty deployment", async () => {
+    providerMocks.getAuthProviders.mockRejectedValue(new Error("Could not reach account settings."));
+
+    const { container } = await renderAccount();
+    await waitForText(container, "Could not reach account settings.");
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("Could not reach account settings.");
+    expect(container.textContent).not.toContain("No additional sign-in methods are available.");
   });
 
   it("shows callback errors and removes the transient query from browser history", async () => {

--- a/packages/web/src/pages/settings/account.tsx
+++ b/packages/web/src/pages/settings/account.tsx
@@ -1,6 +1,6 @@
 import type { AuthProvider, AuthProviderConnection } from "@first-tree/shared";
 import { useQueryClient } from "@tanstack/react-query";
-import { Github, Link2, Unlink } from "lucide-react";
+import { Check, Github, Plus, Unlink } from "lucide-react";
 import type { FormEvent } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { useLocation } from "react-router";
@@ -9,6 +9,7 @@ import { getAuthProviders, startProviderLink, startProviderUnlink } from "../../
 import { useAuth } from "../../auth/auth-context.js";
 import { Avatar } from "../../components/avatar.js";
 import { Button } from "../../components/ui/button.js";
+import { Popover } from "../../components/ui/popover.js";
 import { Section } from "../../components/ui/section.js";
 import { SettingsField, SettingsSaveButton } from "../../components/ui/settings-field.js";
 import { invalidateDisplayNameQueries } from "../../lib/identity-cache.js";
@@ -33,20 +34,19 @@ export function SettingsAccountPage() {
   const [displayName, setDisplayName] = useState(user?.displayName ?? "");
   const [providers, setProviders] = useState<AuthProviderConnection[]>([]);
   const [loading, setLoading] = useState(true);
+  const [providerLoadError, setProviderLoadError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [profileSaved, setProfileSaved] = useState(false);
 
   const loadProviders = useCallback(async () => {
     setLoading(true);
+    setProviderLoadError(null);
     try {
       const result = await getAuthProviders();
       setProviders(result.providers);
     } catch (error) {
-      setFeedback({
-        kind: "error",
-        message: error instanceof Error ? error.message : "Could not load sign-in methods.",
-      });
+      setProviderLoadError(error instanceof Error ? error.message : "Could not load ways to sign in.");
     } finally {
       setLoading(false);
     }
@@ -122,6 +122,9 @@ export function SettingsAccountPage() {
   };
 
   const displayNameForIdentity = user?.displayName || user?.username || "User";
+  const connectedProviders = providers.filter((provider) => provider.connected);
+  const usableConnectedProviders = connectedProviders.filter((provider) => provider.available);
+  const availableProviders = providers.filter((provider) => provider.available && !provider.connected);
 
   return (
     <div
@@ -174,16 +177,55 @@ export function SettingsAccountPage() {
         </form>
       </Section>
 
-      <Section title="Sign-in methods">
+      <Section title="Ways to sign in">
         {loading ? (
           <p className="text-body m-0" role="status" style={{ color: "var(--fg-3)", padding: "var(--sp-4) 0" }}>
-            Loading sign-in methods…
+            Loading ways to sign in…
+          </p>
+        ) : providerLoadError ? (
+          <p className="text-body m-0" role="alert" style={{ color: "var(--color-error)", padding: "var(--sp-4) 0" }}>
+            {providerLoadError}
           </p>
         ) : (
-          <div className="flex flex-col" style={{ gap: "var(--sp-3)", padding: "var(--sp-3) 0 var(--sp-1)" }}>
-            {providers.map((provider) => (
-              <ProviderRow key={provider.provider} provider={provider} busy={busy} onAction={providerAction} />
-            ))}
+          <div style={{ padding: "var(--sp-3) 0 var(--sp-1)" }}>
+            <p className="text-body m-0" style={{ color: "var(--fg-3)" }}>
+              {connectedProviders.length > 0
+                ? usableConnectedProviders.length > 0
+                  ? "Use any available connected account to sign in to First Tree."
+                  : "Your connected sign-in methods are currently unavailable."
+                : availableProviders.length > 0
+                  ? "Connect an account to sign in with Google or GitHub."
+                  : "No additional sign-in methods are available."}
+            </p>
+            {connectedProviders.length > 0 ? (
+              <div
+                style={{
+                  marginTop: "var(--sp-3)",
+                  borderTop: "var(--hairline) solid var(--border)",
+                  borderBottom: "var(--hairline) solid var(--border)",
+                }}
+              >
+                {connectedProviders.map((provider, index) => (
+                  <ProviderRow
+                    key={provider.provider}
+                    provider={provider}
+                    busy={busy}
+                    onAction={providerAction}
+                    separated={index < connectedProviders.length - 1}
+                  />
+                ))}
+              </div>
+            ) : null}
+            {availableProviders.length > 0 ? (
+              <div style={{ marginTop: "var(--sp-3)" }}>
+                <ProviderPicker
+                  providers={availableProviders}
+                  hasConnectedProvider={connectedProviders.length > 0}
+                  busy={busy}
+                  onAction={providerAction}
+                />
+              </div>
+            ) : null}
           </div>
         )}
       </Section>
@@ -217,70 +259,127 @@ function ProviderRow({
   provider,
   busy,
   onAction,
+  separated,
 }: {
   provider: AuthProviderConnection;
   busy: string | null;
   onAction: (provider: AuthProvider, action: "link" | "unlink") => Promise<void>;
+  separated: boolean;
 }) {
   const label = provider.provider === "google" ? "Google" : "GitHub";
-  const action = provider.connected ? "unlink" : "link";
-  const disabled = !provider.available || (action === "unlink" && !provider.canUnlink) || busy !== null;
   return (
-    <fieldset
-      aria-label={`${label} sign-in method`}
+    <div
       className="flex items-center justify-between"
       style={{
         gap: "var(--sp-4)",
-        padding: "var(--sp-3) var(--sp-4)",
-        margin: 0,
+        padding: "var(--sp-3) var(--sp-2)",
         minWidth: 0,
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-panel)",
-        background: "var(--bg-raised)",
+        borderBottom: separated ? "var(--hairline) solid var(--border-faint)" : undefined,
       }}
     >
       <div className="flex min-w-0 items-center" style={{ gap: "var(--sp-3)" }}>
-        {provider.provider === "github" ? (
-          <Github className="h-5 w-5 shrink-0" aria-hidden />
-        ) : (
-          <span className="flex h-5 w-5 shrink-0 items-center justify-center font-semibold" aria-hidden>
-            G
-          </span>
-        )}
+        <ProviderIcon provider={provider.provider} />
         <div className="min-w-0">
           <p className="text-body font-medium m-0" style={{ color: "var(--fg)" }}>
             {label}
           </p>
           <p className="text-label m-0 truncate" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
-            {!provider.available
-              ? "Not configured"
-              : provider.connected
-                ? provider.accountName || provider.email || "Connected"
-                : "Not connected"}
+            {provider.accountName || provider.email || "Connected"}
           </p>
-          {provider.connectedAt ? (
-            <p className="text-caption m-0" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
-              Connected {new Date(provider.connectedAt).toLocaleDateString()}
-            </p>
-          ) : null}
-          {provider.unlinkBlockedReason === "last-provider" ? (
-            <p className="text-caption m-0" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-              Connect another sign-in method before disconnecting.
-            </p>
-          ) : null}
         </div>
       </div>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="shrink-0"
-        disabled={disabled}
-        onClick={() => void onAction(provider.provider, action)}
-      >
-        {action === "link" ? <Link2 className="h-4 w-4" aria-hidden /> : <Unlink className="h-4 w-4" aria-hidden />}
-        {busy === `${provider.provider}-${action}` ? "Starting…" : action === "link" ? "Connect" : "Disconnect"}
-      </Button>
-    </fieldset>
+      {provider.available && provider.canUnlink ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          aria-label={`Disconnect ${label}`}
+          disabled={busy !== null}
+          onClick={() => void onAction(provider.provider, "unlink")}
+        >
+          <Unlink className="h-4 w-4" aria-hidden />
+          {busy === `${provider.provider}-unlink` ? "Starting…" : "Disconnect"}
+        </Button>
+      ) : (
+        <span
+          className="text-label inline-flex shrink-0 items-center"
+          style={{ gap: "var(--sp-1)", color: "var(--fg-3)" }}
+        >
+          {provider.available ? <Check className="h-4 w-4" aria-hidden /> : null}
+          {provider.available ? "Connected" : "Unavailable"}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ProviderPicker({
+  providers,
+  hasConnectedProvider,
+  busy,
+  onAction,
+}: {
+  providers: AuthProviderConnection[];
+  hasConnectedProvider: boolean;
+  busy: string | null;
+  onAction: (provider: AuthProvider, action: "link" | "unlink") => Promise<void>;
+}) {
+  const triggerLabel = hasConnectedProvider ? "Add another sign-in method" : "Add a sign-in method";
+  return (
+    <Popover
+      align="start"
+      panelStyle={{ minWidth: "var(--sp-60)", padding: "var(--sp-1)" }}
+      panelAriaLabel="Available sign-in methods"
+      focusOnOpen
+      trigger={({ open, toggle }) => (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          disabled={busy !== null}
+          onClick={toggle}
+        >
+          <Plus className="h-4 w-4" aria-hidden />
+          {busy?.endsWith("-link") ? "Starting…" : triggerLabel}
+        </Button>
+      )}
+    >
+      {({ close }) => (
+        <div>
+          {providers.map((provider) => {
+            const label = provider.provider === "google" ? "Google" : "GitHub";
+            return (
+              <Button
+                key={provider.provider}
+                type="button"
+                variant="ghost"
+                disabled={busy !== null}
+                className="h-auto w-full justify-start px-2 py-1.5 font-normal"
+                onClick={() => {
+                  close();
+                  void onAction(provider.provider, "link");
+                }}
+              >
+                <ProviderIcon provider={provider.provider} />
+                {label}
+              </Button>
+            );
+          })}
+        </div>
+      )}
+    </Popover>
+  );
+}
+
+function ProviderIcon({ provider }: { provider: AuthProvider }) {
+  return provider === "github" ? (
+    <Github className="h-5 w-5 shrink-0" aria-hidden />
+  ) : (
+    <span className="flex h-5 w-5 shrink-0 items-center justify-center font-semibold" aria-hidden>
+      G
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

- replace the card-heavy sign-in method list with compact connected-provider rows
- move available providers into an anchored “Add another sign-in method” picker
- hide connection timestamps and permanent lockout guidance while preserving backend unlink safeguards
- align Account Settings copy and add coverage for picker and disconnect states

## Validation

- `pnpm exec vitest run src/pages/settings/__tests__/account-dom.test.tsx src/pages/__tests__/settings-panels-dom.test.tsx`
- full `@first-tree/web` test suite: 220 files / 1,888 tests passed
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check` on the four changed files
- real-browser QA: closed state, provider picker, Escape dismissal, and browser console

No backend or OAuth contract changes are included.
