### PR TITLE
fix(web): show display names for composer mentions

### DIFF
--- a/packages/web/src/components/__tests__/mention-composer-model.test.ts
+++ b/packages/web/src/components/__tests__/mention-composer-model.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "vitest";
+import type { MentionCandidate } from "../mention-autocomplete.js";
+import {
+  adjustTokensForEdit,
+  buildDisplayMentionInsert,
+  type ComposerMentionToken,
+  composerOverlaySegments,
+  diffTextEdit,
+  hydrateComposerDisplay,
+  mentionDisplayLiteral,
+  normalizeTokens,
+  removeDisplayRange,
+  serializeComposer,
+  toCanonicalOffset,
+  tokenAtCaret,
+  triggerOverlapsToken,
+} from "../mention-composer-model.js";
+
+/** Test helper — mirrors mention-autocomplete.test.ts's `cand`. */
+function cand(partial: Partial<MentionCandidate> & Pick<MentionCandidate, "agentId">): MentionCandidate {
+  return {
+    name: partial.agentId,
+    displayName: partial.agentId,
+    managedByMe: false,
+    ...partial,
+  };
+}
+
+const alice = cand({ agentId: "a1", name: "alice-w", displayName: "Alice Wang" });
+const bob = cand({ agentId: "a2", name: "bob", displayName: "Bob" });
+
+/** Token over `@Alice Wang` at offset 0 (label length 11). */
+const aliceToken: ComposerMentionToken = { agentId: "a1", name: "alice-w", start: 0, end: 11 };
+
+describe("mentionDisplayLiteral", () => {
+  it("prefers the display name", () => {
+    expect(mentionDisplayLiteral(alice)).toBe("@Alice Wang");
+  });
+
+  it("falls back to the slug when displayName is null or blank", () => {
+    expect(mentionDisplayLiteral(cand({ agentId: "a3", name: "carol", displayName: null }))).toBe("@carol");
+    expect(mentionDisplayLiteral(cand({ agentId: "a3", name: "carol", displayName: "  " }))).toBe("@carol");
+  });
+
+  it("returns null without a slug — a mention needs a routing target", () => {
+    expect(mentionDisplayLiteral(cand({ agentId: "a4", name: null, displayName: "Nameless" }))).toBeNull();
+  });
+});
+
+describe("buildDisplayMentionInsert", () => {
+  it("inserts the DISPLAY literal and records the canonical slug in the token", () => {
+    const source = "hi @al";
+    const result = buildDisplayMentionInsert(source, { triggerIndex: 3 }, source.length, alice);
+    expect(result).toEqual({
+      text: "hi @Alice Wang ",
+      cursor: "hi @Alice Wang ".length,
+      token: { agentId: "a1", name: "alice-w", start: 3, end: 3 + "@Alice Wang".length },
+    });
+  });
+
+  it("keeps existing trailing whitespace instead of doubling it", () => {
+    const source = "hi @al world";
+    const result = buildDisplayMentionInsert(source, { triggerIndex: 3 }, 6, bob);
+    expect(result?.text).toBe("hi @Bob world");
+    expect(result?.cursor).toBe("hi @Bob".length);
+  });
+
+  it("returns null when the candidate has no slug", () => {
+    const result = buildDisplayMentionInsert("@", { triggerIndex: 0 }, 1, cand({ agentId: "x", name: null }));
+    expect(result).toBeNull();
+  });
+});
+
+describe("serializeComposer", () => {
+  it("replaces token spans with canonical `@<name>`, leaving other text untouched", () => {
+    expect(serializeComposer("@Alice Wang please review", [aliceToken])).toBe("@alice-w please review");
+  });
+
+  it("serializes multiple tokens right-to-left so offsets stay valid", () => {
+    const text = "@Alice Wang and @Bob";
+    const tokens: ComposerMentionToken[] = [aliceToken, { agentId: "a2", name: "bob", start: 16, end: 20 }];
+    expect(serializeComposer(text, tokens)).toBe("@alice-w and @bob");
+  });
+
+  it("passes literally-typed `@<name>` through byte-for-byte (still routable)", () => {
+    expect(serializeComposer("ping @alice-w", [])).toBe("ping @alice-w");
+  });
+
+  it("guards the canonical boundary when text is typed flush against a token", () => {
+    // The user typed `x` immediately before/after the display label — the
+    // token survives (boundary edit), but naive serialization would emit
+    // `x@alice-w` / `@alice-wx`, which MENTION_REGEX rejects. The canonical
+    // form gains a separating space; the display text is untouched.
+    const text = "x@Alice Wangy";
+    const token: ComposerMentionToken = { agentId: "a1", name: "alice-w", start: 1, end: 12 };
+    expect(serializeComposer(text, [token])).toBe("x @alice-w y");
+  });
+});
+
+describe("hydrateComposerDisplay", () => {
+  it("renders resolved mentions as display literals with tokens", () => {
+    const { text, tokens } = hydrateComposerDisplay("hi @alice-w !", [alice]);
+    expect(text).toBe("hi @Alice Wang !");
+    expect(tokens).toEqual([{ agentId: "a1", name: "alice-w", start: 3, end: 14 }]);
+  });
+
+  it("round-trips: serialize(hydrate(canonical)) === canonical", () => {
+    const canonical = "hi @alice-w and @bob, look";
+    const hydrated = hydrateComposerDisplay(canonical, [alice, bob]);
+    expect(serializeComposer(hydrated.text, hydrated.tokens)).toBe(canonical);
+  });
+
+  it("keeps unresolved/ghost `@tokens` as plain text (safe degradation)", () => {
+    const { text, tokens } = hydrateComposerDisplay("hi @ghost", [alice]);
+    expect(text).toBe("hi @ghost");
+    expect(tokens).toEqual([]);
+  });
+
+  it("falls back to the slug label when the display name is empty", () => {
+    const { text, tokens } = hydrateComposerDisplay("@carol hi", [
+      cand({ agentId: "a3", name: "carol", displayName: null }),
+    ]);
+    expect(text).toBe("@carol hi");
+    expect(tokens).toEqual([{ agentId: "a3", name: "carol", start: 0, end: 6 }]);
+  });
+
+  it("keeps `@<name>` inside code fences as plain text (segmentMentions contract)", () => {
+    const { tokens } = hydrateComposerDisplay("use `@alice-w` literally", [alice]);
+    expect(tokens).toEqual([]);
+  });
+});
+
+describe("diffTextEdit", () => {
+  it("reports a pure insertion", () => {
+    expect(diffTextEdit("ac", "abc")).toEqual({ start: 1, removedEnd: 1, insertedLength: 1 });
+  });
+
+  it("reports a deletion", () => {
+    expect(diffTextEdit("abc", "ac")).toEqual({ start: 1, removedEnd: 2, insertedLength: 0 });
+  });
+
+  it("reports a replacement", () => {
+    expect(diffTextEdit("abc", "aXc")).toEqual({ start: 1, removedEnd: 2, insertedLength: 1 });
+  });
+});
+
+describe("adjustTokensForEdit", () => {
+  const text = "hi @Alice Wang !";
+
+  it("shifts tokens after an insertion before them", () => {
+    const token: ComposerMentionToken = { ...aliceToken, start: 3, end: 14 };
+    const next = adjustTokensForEdit([token], text, `hey, ${text}`);
+    expect(next).toEqual([{ ...token, start: 8, end: 19 }]);
+  });
+
+  it("keeps tokens before the edit untouched", () => {
+    const token: ComposerMentionToken = { ...aliceToken, start: 3, end: 14 };
+    expect(adjustTokensForEdit([token], text, `${text} more`)).toEqual([token]);
+  });
+
+  it("keeps the token on a pure insertion flush against either boundary", () => {
+    const token: ComposerMentionToken = { ...aliceToken, start: 3, end: 14 };
+    // Typing `x` immediately BEFORE the label…
+    expect(adjustTokensForEdit([token], text, "hi x@Alice Wang !")).toEqual([{ ...token, start: 4, end: 15 }]);
+    // …and immediately AFTER it.
+    expect(adjustTokensForEdit([token], text, "hi @Alice Wangx !")).toEqual([token]);
+  });
+
+  it("drops the token when the edit touches its interior", () => {
+    const token: ComposerMentionToken = { ...aliceToken, start: 3, end: 14 };
+    // Backspace inside the label: `@Alice Wan`
+    expect(adjustTokensForEdit([token], text, "hi @Alice Wan !")).toEqual([]);
+    // Typing inside the label.
+    expect(adjustTokensForEdit([token], text, "hi @Alicex Wang !")).toEqual([]);
+    // Selection delete across part of the label.
+    expect(adjustTokensForEdit([token], text, "hi @A !")).toEqual([]);
+  });
+
+  it("drops only the tokens an edit actually overlaps", () => {
+    const full = "@Alice Wang and @Bob ";
+    const tokens: ComposerMentionToken[] = [aliceToken, { agentId: "a2", name: "bob", start: 16, end: 20 }];
+    const next = adjustTokensForEdit(tokens, full, "@Alice Wang ");
+    expect(next).toEqual([aliceToken]);
+  });
+});
+
+describe("normalizeTokens", () => {
+  it("sorts by start and drops overlapping spans (first wins)", () => {
+    const a: ComposerMentionToken = { agentId: "a1", name: "a", start: 5, end: 9 };
+    const b: ComposerMentionToken = { agentId: "a2", name: "b", start: 0, end: 4 };
+    const overlap: ComposerMentionToken = { agentId: "a3", name: "c", start: 3, end: 6 };
+    expect(normalizeTokens([a, b, overlap])).toEqual([b, a]);
+  });
+});
+
+describe("triggerOverlapsToken", () => {
+  // "@Bob rest" with a committed token over `@Bob` (0..4).
+  const tokens: ComposerMentionToken[] = [{ agentId: "a2", name: "bob", start: 0, end: 4 }];
+
+  it("suppresses a trigger at the token end (pick that reused existing whitespace)", () => {
+    expect(triggerOverlapsToken({ triggerIndex: 0 }, 4, tokens)).toBe(true);
+  });
+
+  it("suppresses a trigger inside the token (user clicked into the label)", () => {
+    expect(triggerOverlapsToken({ triggerIndex: 0 }, 2, tokens)).toBe(true);
+  });
+
+  it("allows a trigger after the token", () => {
+    expect(triggerOverlapsToken({ triggerIndex: 5 }, 8, tokens)).toBe(false);
+  });
+
+  it("allows a trigger flush before the token", () => {
+    const later: ComposerMentionToken[] = [{ agentId: "a2", name: "bob", start: 3, end: 7 }];
+    expect(triggerOverlapsToken({ triggerIndex: 0 }, 3, later)).toBe(false);
+  });
+});
+
+describe("removeDisplayRange + tokenAtCaret", () => {
+  const text = "hi @Alice Wang !";
+  const token: ComposerMentionToken = { ...aliceToken, start: 3, end: 14 };
+
+  it("finds the token flush against a collapsed caret", () => {
+    expect(tokenAtCaret([token], 14, "back")).toEqual(token);
+    expect(tokenAtCaret([token], 3, "forward")).toEqual(token);
+    expect(tokenAtCaret([token], 13, "back")).toBeNull();
+    expect(tokenAtCaret([token], 4, "forward")).toBeNull();
+  });
+
+  it("removes a whole token atomically", () => {
+    const removed = removeDisplayRange(text, [token], 3, 14);
+    expect(removed).toEqual({ text: "hi  !", cursor: 3, tokens: [] });
+  });
+});
+
+describe("toCanonicalOffset", () => {
+  // display: "hi @Alice Wang !" (token 3..14) ↔ canonical: "hi @alice-w !" (token 3..11)
+  const text = "hi @Alice Wang !";
+  const token: ComposerMentionToken = { ...aliceToken, start: 3, end: 14 };
+
+  it("maps offsets before the token unchanged", () => {
+    expect(toCanonicalOffset(text, [token], 3)).toBe(3);
+  });
+
+  it("maps offsets after the token by the length delta", () => {
+    expect(toCanonicalOffset(text, [token], 16)).toBe(13);
+  });
+
+  it("clamps an offset inside the token to just past its canonical form", () => {
+    expect(toCanonicalOffset(text, [token], 8)).toBe(11);
+  });
+
+  it("stays consistent with serializeComposer's boundary padding", () => {
+    const padded = "x@Alice Wangy";
+    const t: ComposerMentionToken = { agentId: "a1", name: "alice-w", start: 1, end: 12 };
+    // canonical: "x @alice-w y" — the end of the display string maps to the
+    // end of the canonical string, pads included.
+    expect(toCanonicalOffset(padded, [t], padded.length)).toBe("x @alice-w y".length);
+  });
+});
+
+describe("composerOverlaySegments", () => {
+  const participants = [
+    { agentId: "a1", name: "alice-w" },
+    { agentId: "a2", name: "bob" },
+  ];
+
+  it("chips both committed tokens and literally-typed `@<name>`", () => {
+    const text = "@Alice Wang said hi @bob";
+    const segments = composerOverlaySegments(text, [aliceToken], participants);
+    expect(segments).toEqual([
+      { kind: "token", value: "@Alice Wang", name: "alice-w", agentId: "a1" },
+      { kind: "text", value: " said hi " },
+      { kind: "mention", value: "@bob", name: "bob", agentId: "a2" },
+    ]);
+  });
+
+  it("never double-chips `@word`-shaped text inside a display label", () => {
+    // displayName "@bob" would look like a typed mention to the segmenter.
+    const tricky = cand({ agentId: "a9", name: "tricky", displayName: "@bob fan" });
+    const { text, tokens } = hydrateComposerDisplay("@tricky hi", [tricky]);
+    expect(text).toBe("@@bob fan hi");
+    const segments = composerOverlaySegments(text, tokens, participants);
+    expect(segments.filter((s) => s.kind !== "text")).toEqual([
+      { kind: "token", value: "@@bob fan", name: "tricky", agentId: "a9" },
+    ]);
+  });
+
+  it("keeps typed `@<name>` inside code fences un-chipped", () => {
+    const segments = composerOverlaySegments("use `@bob`", [], participants);
+    expect(segments).toEqual([{ kind: "text", value: "use `@bob`" }]);
+  });
+
+  it("matches segmentMentions exactly when no tokens exist", () => {
+    const segments = composerOverlaySegments("hi @bob", [], participants);
+    expect(segments).toEqual([
+      { kind: "text", value: "hi " },
+      { kind: "mention", value: "@bob", name: "bob", agentId: "a2" },
+    ]);
+  });
+});

--- a/packages/web/src/components/__tests__/use-mention-composer-dom.test.tsx
+++ b/packages/web/src/components/__tests__/use-mention-composer-dom.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment happy-dom
+
+import { act, useRef, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type ActiveTrigger, type MentionCandidate, useMentionAutocomplete } from "../mention-autocomplete.js";
+import { useMentionComposer } from "../use-mention-composer.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * DOM-level contract for the display/canonical split every mention-capable
+ * composer runs on (chat composer, new-chat draft, ask answer):
+ *
+ *   1. picking a candidate shows `@<displayName>` in the textarea while the
+ *      host's canonical state receives `@<name>` + the original agentId;
+ *   2. edits around a committed mention keep its routing token — edits
+ *      THROUGH it degrade it to plain text; Backspace flush against it
+ *      deletes the whole token atomically and re-pins the DOM caret;
+ *   3. a committed token is never re-detected as an autocomplete trigger
+ *      (click inside the label, caret at its end after a whitespace-reusing
+ *      pick, repeated Enter/pick);
+ *   4. external canonical replacement (draft restore / send clear / failed
+ *      send rollback) and scope switches rehydrate the display side;
+ *   5. duplicate display names keep the picked agentId — identity lives in
+ *      the token, never in the label.
+ */
+
+const alice: MentionCandidate = { agentId: "a1", name: "alice-w", displayName: "Alice Wang", managedByMe: false };
+const bob: MentionCandidate = { agentId: "a2", name: "bob", displayName: "Bob", managedByMe: false };
+
+type Harness = {
+  /** Latest canonical text the host received. */
+  canonical: string;
+  pick: (candidate: MentionCandidate) => void;
+  composer: ReturnType<typeof useMentionComposer> | null;
+  mentionTrigger: ActiveTrigger | null;
+  setCanonical: (next: string) => void;
+  setCandidates: (next: MentionCandidate[]) => void;
+  setScope: (next: string) => void;
+};
+
+function Composer({ harness }: { harness: Harness }) {
+  const [canonical, setCanonical] = useState("");
+  const [candidates, setCandidates] = useState<MentionCandidate[]>([alice, bob]);
+  const [scope, setScope] = useState("scope-a");
+  const [cursor, setCursor] = useState(0);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  const composer = useMentionComposer({ canonical, onCanonicalChange: setCanonical, candidates, scope });
+  const mention = useMentionAutocomplete({
+    value: composer.displayText,
+    cursor,
+    candidates,
+    tokens: composer.tokens,
+    onSelect: (_update, candidate, trigger) => {
+      const applied = composer.applyPick(trigger, cursor, candidate);
+      if (applied) setCursor(applied.cursor);
+    },
+  });
+  harness.canonical = canonical;
+  harness.composer = composer;
+  harness.mentionTrigger = mention.trigger;
+  harness.pick = (candidate) => mention.pick(candidate);
+  harness.setCanonical = setCanonical;
+  harness.setCandidates = setCandidates;
+  harness.setScope = setScope;
+  return (
+    <textarea
+      data-ta
+      ref={taRef}
+      value={composer.displayText}
+      onChange={(e) => {
+        composer.handleInput(e.target.value);
+        setCursor(e.target.selectionStart ?? e.target.value.length);
+      }}
+      onSelect={(e) => setCursor(e.currentTarget.selectionStart ?? composer.displayText.length)}
+      onKeyDown={(e) => {
+        if (e.key === "Backspace" || e.key === "Delete") {
+          const el = taRef.current;
+          if (el && el.selectionStart === el.selectionEnd) {
+            const removed = composer.deleteTokenAtCaret(
+              el.selectionStart ?? cursor,
+              e.key === "Backspace" ? "back" : "forward",
+            );
+            if (removed) {
+              e.preventDefault();
+              setCursor(removed.cursor);
+              // Same re-pin the hosts apply: the native deletion that would
+              // have moved the DOM caret was preventDefaulted.
+              requestAnimationFrame(() => {
+                const ta = taRef.current;
+                if (!ta) return;
+                ta.setSelectionRange(removed.cursor, removed.cursor);
+              });
+              return;
+            }
+          }
+        }
+        mention.handleKey(e);
+      }}
+    />
+  );
+}
+
+let container: HTMLElement;
+let root: Root;
+let harness: Harness;
+let originalRaf: typeof globalThis.requestAnimationFrame;
+let rafQueue: FrameRequestCallback[];
+
+beforeEach(() => {
+  // Queue rAF callbacks so the caret re-pin runs AFTER React commits the
+  // new value — the real ordering the hosts rely on (an immediate stub
+  // would pin the selection before the value update and lose it).
+  originalRaf = globalThis.requestAnimationFrame;
+  rafQueue = [];
+  globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    rafQueue.push(callback);
+    return rafQueue.length;
+  };
+});
+
+function flushRaf() {
+  const queue = rafQueue.splice(0);
+  act(() => {
+    for (const cb of queue) cb(0);
+  });
+}
+
+function mount() {
+  harness = {
+    canonical: "",
+    pick: () => {},
+    composer: null,
+    mentionTrigger: null,
+    setCanonical: () => {},
+    setCandidates: () => {},
+    setScope: () => {},
+  };
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(<Composer harness={harness} />));
+}
+
+const ta = (): HTMLTextAreaElement => {
+  const el = container.querySelector<HTMLTextAreaElement>("[data-ta]");
+  if (!el) throw new Error("textarea not mounted");
+  return el;
+};
+
+/** Simulate a real textarea edit the way the browser reports it. */
+function type(text: string, caret?: number) {
+  const el = ta();
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+  setter?.call(el, text);
+  el.setSelectionRange(caret ?? text.length, caret ?? text.length);
+  act(() => {
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function key(k: string) {
+  const el = ta();
+  act(() => {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true }));
+  });
+}
+
+function selectCaret(at: number) {
+  const el = ta();
+  el.setSelectionRange(at, at);
+  act(() => {
+    el.dispatchEvent(new Event("select", { bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  globalThis.requestAnimationFrame = originalRaf;
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useMentionComposer", () => {
+  it("shows `@<displayName>` on pick while canonical state gets `@<name>` + agentId", () => {
+    mount();
+    type("@ali");
+    act(() => harness.pick(alice));
+    expect(ta().value).toBe("@Alice Wang ");
+    expect(harness.canonical).toBe("@alice-w ");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a1", name: "alice-w", start: 0, end: 11 }]);
+  });
+
+  it("keeps the route when typing around a committed mention", () => {
+    mount();
+    type("@ali");
+    act(() => harness.pick(alice));
+    type("@Alice Wang please review");
+    expect(harness.canonical).toBe("@alice-w please review");
+    // Typing BEFORE the token shifts it; canonical keeps one clean mention.
+    type("hey @Alice Wang please review");
+    expect(harness.canonical).toBe("hey @alice-w please review");
+  });
+
+  it("degrades a mention to plain text when the edit saws through its label", () => {
+    mount();
+    type("@ali");
+    act(() => harness.pick(alice));
+    // Backspace inside the label (native path — caret not flush at the end).
+    type("@Alice Wan");
+    expect(harness.canonical).toBe("@Alice Wan");
+    expect(harness.composer?.tokens).toEqual([]);
+  });
+
+  it("deletes a whole mention atomically on Backspace at its end and re-pins the DOM caret", () => {
+    mount();
+    type("@ali");
+    act(() => harness.pick(alice));
+    // Caret sits right after "@Alice Wang " — one position past the token
+    // end because of the trailing space, so move it flush first.
+    selectCaret("@Alice Wang".length);
+    key("Backspace");
+    // The whole token goes in one keystroke; the trailing separator space
+    // the insertion added stays behind as plain text.
+    expect(ta().value).toBe(" ");
+    expect(harness.canonical).toBe(" ");
+    flushRaf();
+    expect(ta().selectionStart).toBe(0);
+    expect(ta().selectionEnd).toBe(0);
+  });
+
+  it("closes the picker after a whitespace-reusing pick and never re-triggers on the token", () => {
+    mount();
+    // Type a query with an existing trailing space, caret inside the run.
+    type("@bo rest", 3);
+    expect(harness.mentionTrigger).toEqual({ triggerIndex: 0, query: "bo" });
+    act(() => harness.pick(bob));
+    // The pick reused the existing space: "@Bob rest", caret at token end.
+    expect(ta().value).toBe("@Bob rest");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a2", name: "bob", start: 0, end: 4 }]);
+    // The popover must stay closed — the committed token is not a query.
+    expect(harness.mentionTrigger).toBeNull();
+    // Repeated Enter / pick is a no-op and cannot stack overlapping tokens.
+    key("Enter");
+    act(() => harness.pick(bob));
+    expect(ta().value).toBe("@Bob rest");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a2", name: "bob", start: 0, end: 4 }]);
+    // Clicking INTO the display label doesn't reopen the picker either.
+    selectCaret(2);
+    expect(harness.mentionTrigger).toBeNull();
+    act(() => harness.pick(bob));
+    expect(ta().value).toBe("@Bob rest");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a2", name: "bob", start: 0, end: 4 }]);
+  });
+
+  it("rehydrates display state from an external canonical replace (draft restore)", () => {
+    mount();
+    act(() => harness.setCanonical("ping @alice-w now"));
+    expect(ta().value).toBe("ping @Alice Wang now");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a1", name: "alice-w", start: 5, end: 16 }]);
+  });
+
+  it("falls back to raw `@<name>` while candidates have not loaded", () => {
+    mount();
+    act(() => harness.setCandidates([]));
+    act(() => harness.setCanonical("hi @alice-w"));
+    expect(ta().value).toBe("hi @alice-w");
+    expect(harness.canonical).toBe("hi @alice-w");
+  });
+
+  it("resets the model on scope change even when the canonical text is identical", () => {
+    mount();
+    act(() => harness.setCanonical("@alice-w "));
+    expect(ta().value).toBe("@Alice Wang ");
+    expect(harness.composer?.tokens).toHaveLength(1);
+    // Switch to a scope whose roster cannot resolve the slug, with the SAME
+    // canonical draft text: the display model must rehydrate from scratch
+    // (here: safe `@<name>` fallback), not leak the previous scope's token.
+    act(() => {
+      harness.setCandidates([]);
+      harness.setScope("scope-b");
+    });
+    expect(ta().value).toBe("@alice-w ");
+    expect(harness.composer?.tokens).toEqual([]);
+    expect(harness.canonical).toBe("@alice-w ");
+  });
+
+  it("keeps the picked agentId when two agents share one displayName", () => {
+    mount();
+    const builder1: MentionCandidate = { agentId: "b1", name: "builder-1", displayName: "Builder", managedByMe: false };
+    const builder2: MentionCandidate = { agentId: "b2", name: "builder-2", displayName: "Builder", managedByMe: false };
+    act(() => harness.setCandidates([builder1, builder2]));
+    type("@bu");
+    act(() => harness.pick(builder2));
+    expect(ta().value).toBe("@Builder ");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "b2", name: "builder-2", start: 0, end: 8 }]);
+    expect(harness.canonical).toBe("@builder-2 ");
+  });
+});

--- a/packages/web/src/components/__tests__/use-mention-composer-dom.test.tsx
+++ b/packages/web/src/components/__tests__/use-mention-composer-dom.test.tsx
@@ -297,3 +297,38 @@ describe("useMentionComposer", () => {
     expect(harness.canonical).toBe("@builder-2 ");
   });
 });
+
+describe("useMentionComposer — candidate-arrival upgrade", () => {
+  it("upgrades an unedited restored draft when candidates arrive (canonical unchanged)", () => {
+    mount();
+    // Restored canonical draft, roster not yet loaded → raw `@<name>`.
+    act(() => harness.setCandidates([]));
+    act(() => harness.setCanonical("hi @alice-w"));
+    expect(ta().value).toBe("hi @alice-w");
+    expect(harness.composer?.tokens).toEqual([]);
+    // Roster arrives (canonical + scope untouched): the SAME draft
+    // re-resolves into the display label with the correct agentId.
+    act(() => harness.setCandidates([alice, bob]));
+    expect(ta().value).toBe("hi @Alice Wang");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a1", name: "alice-w", start: 3, end: 14 }]);
+    expect(harness.canonical).toBe("hi @alice-w");
+  });
+
+  it("never upgrades after a local edit — the user's text and tokens stand", () => {
+    mount();
+    act(() => harness.setCandidates([]));
+    act(() => harness.setCanonical("hi @alice-w"));
+    // Local edit before the roster arrives (typing + a real pick).
+    type("hi @alice-w!");
+    expect(harness.canonical).toBe("hi @alice-w!");
+    type("hi @alice-w! @bo");
+    act(() => harness.pick(bob));
+    expect(ta().value).toBe("hi @alice-w! @Bob ");
+    // The late roster must not rewrite the edited text or forge tokens
+    // for the raw `@alice-w` the user typed themselves.
+    act(() => harness.setCandidates([alice, bob]));
+    expect(ta().value).toBe("hi @alice-w! @Bob ");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a2", name: "bob", start: 13, end: 17 }]);
+    expect(harness.canonical).toBe("hi @alice-w! @bob ");
+  });
+});

--- a/packages/web/src/components/__tests__/use-mention-composer-dom.test.tsx
+++ b/packages/web/src/components/__tests__/use-mention-composer-dom.test.tsx
@@ -332,3 +332,47 @@ describe("useMentionComposer — candidate-arrival upgrade", () => {
     expect(harness.canonical).toBe("hi @alice-w! @bob ");
   });
 });
+
+describe("useMentionComposer — upgrade monotonicity", () => {
+  it("ignores roster removal, replacement, and displayName-only changes after an upgrade", () => {
+    mount();
+    act(() => harness.setCandidates([]));
+    act(() => harness.setCanonical("hi @alice-w"));
+    act(() => harness.setCandidates([alice, bob]));
+    expect(ta().value).toBe("hi @Alice Wang");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a1", name: "alice-w", start: 3, end: 14 }]);
+    // displayName change for a resolved agent → model untouched.
+    act(() => harness.setCandidates([{ ...alice, displayName: "Alice W." }, bob]));
+    expect(ta().value).toBe("hi @Alice Wang");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a1", name: "alice-w", start: 3, end: 14 }]);
+    // Roster removal → no degradation, model untouched.
+    act(() => harness.setCandidates([bob]));
+    expect(ta().value).toBe("hi @Alice Wang");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a1", name: "alice-w", start: 3, end: 14 }]);
+    // Replacement (alice out, a different agent with the same slug-shape in) → untouched.
+    act(() =>
+      harness.setCandidates([bob, { agentId: "a9", name: "alice-w", displayName: "Impostor", managedByMe: false }]),
+    );
+    expect(ta().value).toBe("hi @Alice Wang");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a1", name: "alice-w", start: 3, end: 14 }]);
+    expect(harness.canonical).toBe("hi @alice-w");
+  });
+
+  it("keeps filling in unresolved mentions as the roster arrives in batches", () => {
+    mount();
+    act(() => harness.setCandidates([]));
+    act(() => harness.setCanonical("@alice-w and @bob look"));
+    // First batch resolves Alice only.
+    act(() => harness.setCandidates([alice]));
+    expect(ta().value).toBe("@Alice Wang and @bob look");
+    expect(harness.composer?.tokens).toEqual([{ agentId: "a1", name: "alice-w", start: 0, end: 11 }]);
+    // Second batch adds Bob — Alice's identity is preserved in order.
+    act(() => harness.setCandidates([alice, bob]));
+    expect(ta().value).toBe("@Alice Wang and @Bob look");
+    expect(harness.composer?.tokens).toEqual([
+      { agentId: "a1", name: "alice-w", start: 0, end: 11 },
+      { agentId: "a2", name: "bob", start: 16, end: 20 },
+    ]);
+    expect(harness.canonical).toBe("@alice-w and @bob look");
+  });
+});

--- a/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
@@ -608,12 +608,13 @@ describe("AskTakeover", () => {
   it("commits a mention from the popover and through the explicit mention button", async () => {
     const restoreRaf = installImmediateAnimationFrame();
     try {
+      const onReply = vi.fn();
       const c = await renderDom(
         <AskTakeover
           body="# Who?"
           payload={{ multiSelect: false }}
           mentionCandidates={CANDIDATES}
-          onReply={() => {}}
+          onReply={onReply}
           onSkip={() => {}}
         />,
       );
@@ -624,14 +625,24 @@ describe("AskTakeover", () => {
       if (!alice) throw new Error("mention option missing");
       const picked = await mouseDown(alice);
       expect(picked.defaultPrevented).toBe(true);
-      expect(ta.value).toBe("@alice ");
+      // The composer shows the DISPLAY name; routing still serializes to the slug.
+      expect(ta.value).toBe("@Alice ");
 
       await act(async () => {
         ta.setSelectionRange(ta.value.length, ta.value.length);
         ta.dispatchEvent(new Event("select", { bubbles: true }));
       });
       await click(c.querySelector('[aria-label="Mention an agent"]'));
-      expect(ta.value).toBe("@alice @");
+      expect(ta.value).toBe("@Alice @");
+
+      // The resolving answer keeps the canonical `@<name>` literal on the
+      // wire plus the structured recipient id.
+      await click(btn(c, "Submit"));
+      expect(onReply).toHaveBeenCalledWith({
+        content: "@alice @",
+        mentions: ["agent-alice"],
+        images: [],
+      });
     } finally {
       restoreRaf();
     }

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -44,6 +44,7 @@ import {
 import { MentionHighlightOverlay } from "../mention-highlight-overlay.js";
 import { FileChip } from "../ui/file-chip.js";
 import { Markdown, type MarkdownProps } from "../ui/markdown.js";
+import { useMentionComposer } from "../use-mention-composer.js";
 import type { AskAgentExchange } from "./ask-agent-state.js";
 import { ImageRefGallery, type ReferencedImage } from "./image-ref-gallery.js";
 import { allRequiredAnswered, buildResolveAnswer } from "./request-state.js";
@@ -284,21 +285,39 @@ export function AskTakeover({
   const taRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Display-side composer model (see mention-composer-model.ts): the answer
+  // box shows `@<displayName>` for committed mentions while `freeText` stays
+  // the canonical `@<name>` text that `reply()` (buildResolveAnswer +
+  // extractMentions) and the request-scoped draft cache already consume.
+  const mentionComposer = useMentionComposer({
+    canonical: freeText,
+    onCanonicalChange: setFreeText,
+    candidates: mentionCandidates,
+    // The card is keyed by request id in chat, but Need You reuses one
+    // component across requests — reset the display model per request.
+    scope: requestId,
+  });
+
   const mention = useMentionAutocomplete({
-    value: freeText,
+    value: mentionComposer.displayText,
     cursor,
     candidates: mentionCandidates,
     disabled: interactionLocked,
-    onSelect: (update) => {
-      setFreeText(update.text);
-      setCursor(update.cursor);
+    tokens: mentionComposer.tokens,
+    onSelect: (_update, candidate, trigger) => {
+      // Token-model commit: the visible text gets `@<displayName>` while the
+      // canonical slug/agentId rides along as a token (the legacy `@<name>`
+      // insertion in `_update` is intentionally unused).
+      const applied = mentionComposer.applyPick(trigger, cursor, candidate);
+      if (!applied) return;
+      setCursor(applied.cursor);
       // Defer so React commits the new value before we move the selection —
       // otherwise the textarea snaps back to its old caret position.
       requestAnimationFrame(() => {
         const el = taRef.current;
         if (!el) return;
         el.focus();
-        el.setSelectionRange(update.cursor, update.cursor);
+        el.setSelectionRange(applied.cursor, applied.cursor);
       });
     },
   });
@@ -333,10 +352,11 @@ export function AskTakeover({
   const insertMentionTrigger = () => {
     if (interactionLocked) return;
     const el = taRef.current;
-    const start = el?.selectionStart ?? freeText.length;
+    const text = mentionComposer.displayText;
+    const start = el?.selectionStart ?? text.length;
     const end = el?.selectionEnd ?? start;
-    const next = `${freeText.slice(0, start)}@${freeText.slice(end)}`;
-    setFreeText(next);
+    const next = `${text.slice(0, start)}@${text.slice(end)}`;
+    mentionComposer.replaceDisplay(next);
     setCursor(start + 1);
     requestAnimationFrame(() => {
       el?.focus();
@@ -463,8 +483,9 @@ export function AskTakeover({
         />
       )}
       <MentionHighlightOverlay
-        value={freeText}
+        value={mentionComposer.displayText}
         participants={mentionParticipants}
+        tokens={mentionComposer.tokens}
         textareaRef={taRef}
         chipClassName="mention-text"
         mirrorStyle={mirrorStyle}
@@ -476,13 +497,15 @@ export function AskTakeover({
         // utility colors the placeholder — without these the transparent text
         // color cascades to the placeholder and it renders invisible.
         className="mention-composer-textarea placeholder:text-muted-foreground"
-        value={freeText}
+        value={mentionComposer.displayText}
         disabled={interactionLocked}
         onChange={(e) => {
-          setFreeText(e.target.value);
+          // Token-model edit: adjusts mention tokens through the diff and
+          // persists the canonical `@<name>` form into `freeText`.
+          mentionComposer.handleInput(e.target.value);
           setCursor(e.target.selectionStart ?? e.target.value.length);
         }}
-        onSelect={(e) => setCursor(e.currentTarget.selectionStart ?? freeText.length)}
+        onSelect={(e) => setCursor(e.currentTarget.selectionStart ?? mentionComposer.displayText.length)}
         onPaste={(e) => {
           // No attachments on the trial answer input — let text paste
           // fall through to the default handler.
@@ -496,6 +519,30 @@ export function AskTakeover({
         onKeyDown={(e) => {
           // Skip while an IME is composing so Enter confirms the candidate.
           if (e.nativeEvent.isComposing) return;
+          // Atomic mention deletion: a collapsed caret flush against a
+          // committed mention removes the whole token, not one character of
+          // its display label.
+          if (!isTrial && (e.key === "Backspace" || e.key === "Delete")) {
+            const el = taRef.current;
+            if (el && el.selectionStart === el.selectionEnd) {
+              const removed = mentionComposer.deleteTokenAtCaret(
+                el.selectionStart ?? cursor,
+                e.key === "Backspace" ? "back" : "forward",
+              );
+              if (removed) {
+                e.preventDefault();
+                setCursor(removed.cursor);
+                // Re-pin the DOM selection after commit — the native
+                // deletion that would have moved it was preventDefaulted.
+                requestAnimationFrame(() => {
+                  const ta = taRef.current;
+                  if (!ta) return;
+                  ta.setSelectionRange(removed.cursor, removed.cursor);
+                });
+                return;
+              }
+            }
+          }
           // Mention autocomplete gets first crack: when the caret is inside an
           // active `@trigger`, Enter/Tab/Arrows/Escape drive the popover (and
           // are preventDefaulted, so the window-level Enter→Reply / non-resolving

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -238,7 +238,7 @@ export function AgentToken({ candidate, onRemove }: { candidate: MentionCandidat
   );
 }
 
-type ActiveTrigger = {
+export type ActiveTrigger = {
   /** Text index of the leading `@` (the char at `triggerIndex` is `@`). */
   triggerIndex: number;
   /** The substring between `@` and the cursor, already lowercased. */
@@ -482,12 +482,24 @@ export function useMentionAutocomplete({
   candidates,
   onSelect,
   disabled,
+  tokens,
 }: {
   value: string;
   cursor: number;
   candidates: MentionCandidate[];
-  onSelect: (update: MentionInsert) => void;
+  /** Commit callback. `update` is the legacy canonical-text insertion
+   *  (`@<name>`); hosts on the token composer model ignore it and rebuild
+   *  the insertion from `candidate` + `trigger` so the composer can show
+   *  the display name while keeping the canonical slug for routing. */
+  onSelect: (update: MentionInsert, candidate: MentionCandidate, trigger: ActiveTrigger) => void;
   disabled?: boolean;
+  /** Committed mention tokens over `value` (composer token model). A
+   *  trigger intersecting a token span is suppressed: a committed mention
+   *  is not a query — clicking into a display label (or landing at its end
+   *  after a pick that reused existing whitespace) must not reopen the
+   *  picker, or a re-pick would rewrite part of the label and stack a
+   *  duplicate overlapping token. */
+  tokens?: ReadonlyArray<{ start: number; end: number }>;
 }): {
   trigger: ActiveTrigger | null;
   results: MentionCandidate[];
@@ -501,8 +513,12 @@ export function useMentionAutocomplete({
 
   const trigger = useMemo(() => {
     if (disabled) return null;
-    return detectMentionTrigger(value, cursor);
-  }, [value, cursor, disabled]);
+    const detected = detectMentionTrigger(value, cursor);
+    // A committed mention token is not a query: suppress triggers whose
+    // `@<query>` run intersects a token span (see the `tokens` option).
+    if (detected && tokens?.some((t) => detected.triggerIndex < t.end && cursor > t.start)) return null;
+    return detected;
+  }, [value, cursor, disabled, tokens]);
 
   const results = useMemo(() => (trigger ? rankCandidates(candidates, trigger.query) : []), [trigger, candidates]);
 
@@ -538,7 +554,7 @@ export function useMentionAutocomplete({
     if (!trigger) return;
     const insert = buildMentionInsert(value, trigger, cursor, candidate);
     if (!insert) return;
-    onSelect(insert);
+    onSelect(insert, candidate, trigger);
   }
 
   const handleKey: MentionKeyHandler = (e) => {

--- a/packages/web/src/components/mention-composer-model.ts
+++ b/packages/web/src/components/mention-composer-model.ts
@@ -1,0 +1,382 @@
+import { type MentionParticipant, segmentMentions } from "@first-tree/shared";
+import type { MentionCandidate } from "./mention-autocomplete.js";
+
+/**
+ * Composer mention token model — the display/canonical split behind every
+ * `@mention`-capable body input (chat composer, new-chat draft, ask answer).
+ *
+ * Product contract (first-tree-context agent-naming: `displayName` is the
+ * human-facing label, `name` is the immutable routing slug):
+ *
+ *   - The textarea holds DISPLAY text: a picked mention appears as
+ *     `@<displayName>` (falling back to `@<name>` when the display name is
+ *     blank). Because the textarea content IS what the user sees, the
+ *     caret, selection, IME composition, and the transparent-text mirror
+ *     overlay all stay glyph-aligned by construction — no overlay
+ *     re-typesetting that would push the caret off the visible glyphs.
+ *   - Tokens carry the routing identity (`agentId` + canonical `name`)
+ *     out-of-band as offset ranges over the display text. Serialization
+ *     back to the canonical wire/persistence form replaces each token span
+ *     with `@<name>` by OFFSET, never by parsing the mutable, possibly
+ *     duplicated, possibly space-containing display name.
+ *   - A `@<name>` typed (or pasted) literally without a picker commit stays
+ *     plain text; it still routes because canonical serialization leaves it
+ *     untouched and extractMentions resolves it — same as before this model
+ *     existed.
+ *
+ * Scope is deliberately minimal: picked mentions are atomic tokens, edits
+ * outside them rebase them, edits through them degrade them to plain text.
+ * No browser-history state machine, no roster live-revalidation, no
+ * code-range rewriting, no clipboard rewriting.
+ *
+ * Everything in this file is pure so the edit/adjust/serialize rules are
+ * unit-testable without a DOM. The React binding lives in
+ * `use-mention-composer.ts`.
+ */
+
+/** One committed mention: routing identity + its span in the DISPLAY text. */
+export type ComposerMentionToken = {
+  agentId: string;
+  /** Canonical immutable slug (no leading `@`). Routing truth. */
+  name: string;
+  /** `[start, end)` offsets in the display text, covering the full `@…` literal. */
+  start: number;
+  end: number;
+};
+
+/**
+ * The visible literal for a picked candidate: `@<displayName>`, falling back
+ * to `@<name>` when the display name is missing or blank (an empty display
+ * name must never render as a bare `@`).
+ */
+export function mentionDisplayLiteral(candidate: Pick<MentionCandidate, "name" | "displayName">): string | null {
+  if (!candidate.name) return null;
+  const label =
+    candidate.displayName && candidate.displayName.trim().length > 0 ? candidate.displayName : candidate.name;
+  return `@${label}`;
+}
+
+type ActiveTriggerLike = {
+  triggerIndex: number;
+};
+
+export type DisplayMentionInsert = {
+  /** New display text after inserting the mention. */
+  text: string;
+  /** Caret offset into the new display text (after the trailing space). */
+  cursor: number;
+  /** The committed token, spanning exactly the inserted `@…` literal. */
+  token: ComposerMentionToken;
+};
+
+/**
+ * Build the display-side insertion tuple for a picked candidate. Mirrors
+ * `buildMentionInsert`'s layout contract (replace the `@<query>` run under
+ * the caret, one trailing space unless whitespace already follows) but the
+ * inserted literal is the display name and the routing identity rides along
+ * as a token. Returns null when the candidate has no `name` — a mention
+ * requires a slug target.
+ */
+export function buildDisplayMentionInsert(
+  source: string,
+  trigger: ActiveTriggerLike,
+  cursor: number,
+  candidate: MentionCandidate,
+): DisplayMentionInsert | null {
+  if (!candidate.name) return null;
+  const literal = mentionDisplayLiteral(candidate);
+  if (!literal) return null;
+  const before = source.slice(0, trigger.triggerIndex);
+  const after = source.slice(cursor);
+  const needsSpace = after.length === 0 || !/\s/.test(after[0] ?? "");
+  const tail = needsSpace ? ` ${after}` : after;
+  const text = `${before}${literal}${tail}`;
+  const token: ComposerMentionToken = {
+    agentId: candidate.agentId,
+    name: candidate.name,
+    start: before.length,
+    end: before.length + literal.length,
+  };
+  return { text, cursor: token.end + (needsSpace ? 1 : 0), token };
+}
+
+type TextEdit = {
+  /** Start of the replaced range in the OLD text. */
+  start: number;
+  /** End (exclusive) of the replaced range in the OLD text. */
+  removedEnd: number;
+  /** Replacement length in the new text. */
+  insertedLength: number;
+};
+
+/**
+ * Minimal single-range diff between two textarea values (common prefix +
+ * common suffix). Textarea edits — typing, paste, cut, native undo, IME
+ * composition updates — are all single-range, so this shape covers every
+ * `onChange` the composer can receive. Ambiguous edits (e.g. inserting a
+ * repeated char at a repetition boundary) resolve to the leftmost
+ * interpretation, which is safe: worst case a token overlapping the
+ * ambiguity is dropped (mention degrades to plain text), never re-pointed
+ * at a different agent.
+ */
+export function diffTextEdit(prev: string, next: string): TextEdit {
+  let start = 0;
+  const maxStart = Math.min(prev.length, next.length);
+  while (start < maxStart && prev[start] === next[start]) start++;
+  let prevEnd = prev.length;
+  let nextEnd = next.length;
+  while (prevEnd > start && nextEnd > start && prev[prevEnd - 1] === next[nextEnd - 1]) {
+    prevEnd--;
+    nextEnd--;
+  }
+  return { start, removedEnd: prevEnd, insertedLength: nextEnd - start };
+}
+
+/**
+ * Re-base tokens through an edit. A token fully before the edit is
+ * unchanged; fully after shifts by the length delta; anything the edit
+ * touches (typing inside a display label, deleting across part of it,
+ * pasting over it) is DROPPED — the mention degrades to the plain text the
+ * user now sees, which is the only honest outcome once the visible literal
+ * no longer matches what the token claims. Pure insertions exactly at a
+ * token boundary keep the token (boundary edits don't alter the literal);
+ * canonical serialization guards the routing boundary that creates (see
+ * {@link serializeComposer}).
+ */
+export function adjustTokensForEdit(
+  tokens: ComposerMentionToken[],
+  prev: string,
+  next: string,
+): ComposerMentionToken[] {
+  if (tokens.length === 0 || prev === next) return tokens;
+  const edit = diffTextEdit(prev, next);
+  const delta = edit.insertedLength - (edit.removedEnd - edit.start);
+  const out: ComposerMentionToken[] = [];
+  for (const t of tokens) {
+    if (t.end <= edit.start) {
+      // Edit starts at/after the token end (including a pure insertion
+      // flush against it): the literal is untouched.
+      out.push(t);
+      continue;
+    }
+    if (t.start >= edit.removedEnd) {
+      // Edit ends at/before the token start (including a pure insertion
+      // flush against it): the token shifts right with the text after it.
+      out.push({ ...t, start: t.start + delta, end: t.end + delta });
+    }
+    // Overlapping edit: the visible literal changed, so the token's claim
+    // ("this span routes to agentId") is no longer true. Drop it.
+  }
+  return out;
+}
+
+/**
+ * Defensive invariant for the token array handed to the serializer /
+ * overlay / caret mapping: sorted by start, no overlapping spans (the
+ * first span wins).
+ */
+export function normalizeTokens(tokens: ComposerMentionToken[]): ComposerMentionToken[] {
+  const sorted = [...tokens].sort((a, b) => a.start - b.start || a.end - b.end);
+  const out: ComposerMentionToken[] = [];
+  for (const t of sorted) {
+    const last = out[out.length - 1];
+    if (last && t.start < last.end) continue;
+    out.push(t);
+  }
+  return out;
+}
+
+/** Chars that would break a canonical `@<name>` token's left boundary. */
+const CANONICAL_LEFT_BREAK = /[A-Za-z0-9_.@-]/;
+/** Chars that would break a canonical `@<name>` token's right boundary. */
+const CANONICAL_RIGHT_BREAK = /[A-Za-z0-9_/-]/;
+
+/**
+ * Serialize display text + tokens back to the canonical wire/persistence
+ * form: every token span becomes `@<name>`, everything else passes through
+ * byte-for-byte (so a literally-typed `@<name>` keeps routing exactly as
+ * before). Tokens are applied right-to-left so earlier offsets stay valid.
+ *
+ * Boundary guard: a token edited flush against identifier chars (the user
+ * typed `x` immediately before/after the display label — allowed, since
+ * boundary insertions keep the token) would serialize to `x@name` / `@namex`,
+ * which `MENTION_REGEX` deliberately rejects and the mention would silently
+ * stop routing. Emit a separating space in the CANONICAL form only; the
+ * display text is untouched. One harmless space on the wire beats a lost
+ * wake-up.
+ */
+export function serializeComposer(text: string, tokens: ComposerMentionToken[]): string {
+  if (tokens.length === 0) return text;
+  const sorted = [...tokens].sort((a, b) => b.start - a.start);
+  let out = text;
+  for (const t of sorted) {
+    const before = out.slice(0, t.start);
+    const after = out.slice(t.end);
+    const leftPad = before.length > 0 && CANONICAL_LEFT_BREAK.test(before[before.length - 1] ?? "") ? " " : "";
+    const rightPad = after.length > 0 && CANONICAL_RIGHT_BREAK.test(after[0] ?? "") ? " " : "";
+    out = `${before}${leftPad}@${t.name}${rightPad}${after}`;
+  }
+  return out;
+}
+
+export type HydratedComposer = {
+  /** Display text: resolved mentions rendered as `@<displayName>`. */
+  text: string;
+  tokens: ComposerMentionToken[];
+};
+
+/**
+ * Rehydrate display state from canonical text (draft restore, failed-send
+ * rollback, greeting prefill). Resolved `@<name>` mentions become display
+ * literals + tokens; unresolved/ghost tokens stay plain text (they keep
+ * routing through the canonical fallback path if they later resolve).
+ * Candidates that haven't loaded yet degrade safely to the `@<name>`
+ * literal — never dropped, never re-pointed.
+ */
+export function hydrateComposerDisplay(canonical: string, candidates: MentionCandidate[]): HydratedComposer {
+  if (canonical.length === 0) return { text: "", tokens: [] };
+  const participants: MentionParticipant[] = candidates.map((c) => ({ agentId: c.agentId, name: c.name }));
+  const byId = new Map(candidates.map((c) => [c.agentId, c] as const));
+  const segments = segmentMentions(canonical, participants);
+  let text = "";
+  const tokens: ComposerMentionToken[] = [];
+  for (const seg of segments) {
+    if (seg.kind !== "mention") {
+      text += seg.value;
+      continue;
+    }
+    const candidate = byId.get(seg.agentId);
+    const literal = candidate ? (mentionDisplayLiteral(candidate) ?? `@${seg.name}`) : `@${seg.name}`;
+    tokens.push({ agentId: seg.agentId, name: seg.name, start: text.length, end: text.length + literal.length });
+    text += literal;
+  }
+  return { text, tokens };
+}
+
+/**
+ * A `@<query>` autocomplete trigger is only honest when it sits OUTSIDE
+ * every committed token. `detectMentionTrigger` is purely lexical, so a
+ * display label without spaces (e.g. `@Bob`) would re-open the picker when
+ * the caret lands at/inside the token — clicking into a committed mention,
+ * or right after a pick that reused existing trailing whitespace. Re-picking
+ * from that state would rewrite part of the label and stack a duplicate
+ * overlapping token. Suppress any trigger whose `[triggerIndex, cursor)`
+ * range intersects a token span; the hosts feed this the model's tokens so
+ * the popover, keyboard hijack, and NewChatDraft's server-side search all
+ * agree a committed mention is not a query.
+ */
+export function triggerOverlapsToken(
+  trigger: ActiveTriggerLike,
+  cursor: number,
+  tokens: ReadonlyArray<Pick<ComposerMentionToken, "start" | "end">>,
+): boolean {
+  return tokens.some((t) => trigger.triggerIndex < t.end && cursor > t.start);
+}
+
+/**
+ * The token flush against a collapsed caret, for atomic deletion:
+ * `"back"` (Backspace) finds the token ENDING at the caret, `"forward"`
+ * (Delete) the token STARTING at it. Returns null when no token touches the
+ * caret, so the host falls through to native single-char deletion.
+ */
+export function tokenAtCaret(
+  tokens: ComposerMentionToken[],
+  caret: number,
+  dir: "back" | "forward",
+): ComposerMentionToken | null {
+  for (const t of tokens) {
+    if (dir === "back" && t.end === caret) return t;
+    if (dir === "forward" && t.start === caret) return t;
+  }
+  return null;
+}
+
+export type RemovedRange = {
+  text: string;
+  cursor: number;
+  tokens: ComposerMentionToken[];
+};
+
+/**
+ * Delete `[start, end)` from the display text and re-base tokens through
+ * the deletion (via the same adjust rules as a typed edit, so a partially
+ * covered token degrades to plain text).
+ */
+export function removeDisplayRange(
+  text: string,
+  tokens: ComposerMentionToken[],
+  start: number,
+  end: number,
+): RemovedRange {
+  const next = `${text.slice(0, start)}${text.slice(end)}`;
+  return { text: next, cursor: start, tokens: adjustTokensForEdit(tokens, text, next) };
+}
+
+/**
+ * Map a display-text caret offset to the equivalent offset in the canonical
+ * serialization — needed by consumers that reason about the canonical draft
+ * (e.g. slash-command mention context, which scans `@<name>` tokens before
+ * the caret). A caret inside a token maps to just past the token's
+ * canonical form: the mention reads as "before the caret", matching the
+ * visible reality that the user committed it.
+ */
+export function toCanonicalOffset(text: string, tokens: ComposerMentionToken[], displayOffset: number): number {
+  let offset = displayOffset;
+  const sorted = [...tokens].sort((a, b) => a.start - b.start);
+  for (const t of sorted) {
+    if (t.start >= displayOffset) break;
+    const displayLen = t.end - t.start;
+    let canonicalLen = 1 + t.name.length;
+    // Keep the mapping consistent with serializeComposer's boundary pads.
+    const prevChar = t.start > 0 ? text[t.start - 1] : undefined;
+    const nextChar = t.end < text.length ? text[t.end] : undefined;
+    if (prevChar && CANONICAL_LEFT_BREAK.test(prevChar)) canonicalLen += 1;
+    if (nextChar && CANONICAL_RIGHT_BREAK.test(nextChar)) canonicalLen += 1;
+    if (displayOffset >= t.end) {
+      offset += canonicalLen - displayLen;
+    } else {
+      // Inside the token: clamp to just past its canonical form.
+      offset += canonicalLen - (displayOffset - t.start);
+    }
+  }
+  return offset;
+}
+
+export type ComposerOverlaySegment =
+  | { kind: "text"; value: string }
+  | { kind: "mention"; value: string; name: string; agentId: string }
+  | { kind: "token"; value: string; name: string; agentId: string };
+
+/**
+ * Segments for the mirror overlay: committed tokens (from the model) plus
+ * literally-typed `@<name>` runs (resolved via `segmentMentions` so code
+ * fences / email addresses keep the existing no-chip contract). Token
+ * ranges win on overlap — a display label can itself contain `@word`-shaped
+ * text, which must not double-chip inside the token.
+ */
+export function composerOverlaySegments(
+  text: string,
+  tokens: ComposerMentionToken[],
+  participants: MentionParticipant[],
+): ComposerOverlaySegment[] {
+  if (tokens.length === 0) return segmentMentions(text, participants);
+  // Split the text around token spans and run the shared segmenter on each
+  // gap, so code-fence / email / boundary suppression keeps the exact
+  // segmentMentions semantics without us re-deriving offsets. A display
+  // label containing `@word`-shaped text can never double-chip, because the
+  // segmenter never sees the token span.
+  const sorted = [...tokens].sort((a, b) => a.start - b.start);
+  const out: ComposerOverlaySegment[] = [];
+  let cursor = 0;
+  for (const t of sorted) {
+    if (t.start > cursor) {
+      out.push(...segmentMentions(text.slice(cursor, t.start), participants));
+    }
+    out.push({ kind: "token", value: text.slice(t.start, t.end), name: t.name, agentId: t.agentId });
+    cursor = t.end;
+  }
+  if (cursor < text.length) {
+    out.push(...segmentMentions(text.slice(cursor), participants));
+  }
+  return out;
+}

--- a/packages/web/src/components/mention-highlight-overlay.tsx
+++ b/packages/web/src/components/mention-highlight-overlay.tsx
@@ -1,5 +1,6 @@
-import { type MentionParticipant, segmentMentions } from "@first-tree/shared";
+import type { MentionParticipant } from "@first-tree/shared";
 import { type CSSProperties, type RefObject, useEffect, useRef } from "react";
+import { type ComposerMentionToken, composerOverlaySegments } from "./mention-composer-model.js";
 
 /**
  * Renders a mirror layer that paints `@<participant>` chips behind a
@@ -8,6 +9,14 @@ import { type CSSProperties, type RefObject, useEffect, useRef } from "react";
  * the host sets `color: transparent; caret-color: var(--fg)` on the
  * textarea so the caret + selection stay visible while the text is
  * actually drawn by this overlay.
+ *
+ * Two chip sources, merged by {@link composerOverlaySegments}:
+ *   - `tokens` — committed picker mentions from the composer token model.
+ *     The textarea's display text already shows `@<displayName>` for these,
+ *     so the overlay only re-colors the span (identity lives in the token,
+ *     never re-parsed from the visible label).
+ *   - `participants` — literally-typed `@<name>` runs, resolved through the
+ *     shared segmenter (code fences / emails keep the no-chip contract).
  *
  * Layout contract — to keep the rendered glyphs character-for-character
  * aligned with the textarea, the overlay MUST inherit the textarea's
@@ -35,12 +44,17 @@ import { type CSSProperties, type RefObject, useEffect, useRef } from "react";
 export function MentionHighlightOverlay({
   value,
   participants,
+  tokens = [],
   textareaRef,
   mirrorStyle,
   chipClassName,
 }: {
   value: string;
   participants: MentionParticipant[];
+  /** Committed mention tokens over `value` (display text), painted as chips
+   *  without re-parsing. Omit for hosts without the token model — the
+   *  overlay then behaves exactly as before (typed `@<name>` only). */
+  tokens?: ComposerMentionToken[];
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   /** Style overrides that MUST match the textarea so glyph positions
    *  align (font, padding, line-height, white-space, box-sizing). */
@@ -50,7 +64,7 @@ export function MentionHighlightOverlay({
   chipClassName: string;
 }) {
   const innerRef = useRef<HTMLDivElement | null>(null);
-  const segments = segmentMentions(value, participants);
+  const segments = composerOverlaySegments(value, tokens, participants);
 
   // Mirror the textarea's scroll position into the inner mirror box.
   // Listen to `scroll` for manual scrolls, and re-sync after every render
@@ -106,7 +120,7 @@ export function MentionHighlightOverlay({
         }}
       >
         {segments.map((seg, i) =>
-          seg.kind === "mention" ? (
+          seg.kind === "mention" || seg.kind === "token" ? (
             // biome-ignore lint/suspicious/noArrayIndexKey: segments are recomputed every render; positional key is stable for THIS frame.
             <span key={`m-${i}`} className={chipClassName}>
               {seg.value}

--- a/packages/web/src/components/use-mention-composer.ts
+++ b/packages/web/src/components/use-mention-composer.ts
@@ -1,0 +1,177 @@
+import { useCallback, useRef, useState } from "react";
+import type { ActiveTrigger, MentionCandidate } from "./mention-autocomplete.js";
+import {
+  adjustTokensForEdit,
+  buildDisplayMentionInsert,
+  type ComposerMentionToken,
+  hydrateComposerDisplay,
+  normalizeTokens,
+  removeDisplayRange,
+  serializeComposer,
+  toCanonicalOffset,
+  tokenAtCaret,
+} from "./mention-composer-model.js";
+
+/**
+ * React binding for the composer mention token model (see
+ * `mention-composer-model.ts` for the display/canonical contract).
+ *
+ * The host keeps owning its CANONICAL draft state (`canonical` /
+ * `onCanonicalChange`) — every existing consumer of that state (send path,
+ * mention gating, draft persistence, failed-send rollback, slash-command
+ * context) keeps working on routable `@<name>` text, unchanged. This hook
+ * derives and owns the DISPLAY side: the textarea binds `displayText`, and
+ * every edit path funnels through one of the callbacks below so tokens stay
+ * consistent:
+ *
+ *   - `handleInput`     — textarea `onChange` (typing, paste, IME)
+ *   - `replaceDisplay`  — programmatic edits in display space (slash-command
+ *                         insert, the `@` toolbar button, focus priming)
+ *   - `applyPick`       — mention autocomplete commit
+ *   - `deleteTokenAtCaret` — atomic Backspace/Delete of a whole mention
+ *
+ * External canonical changes (chat switch, send clear, failed-send restore,
+ * greeting prefill) re-derive the display via rehydration; the
+ * `lastCanonical` ref distinguishes those from this hook's own commits.
+ * `scope` identifies the draft's owner (chat id, request id, compose
+ * context) and forces the same reset even when two drafts share the same
+ * canonical text (ChatView is NOT remounted on chat switch).
+ *
+ * Deliberately minimal: no browser undo/redo state machine (a native
+ * undo/redo that crosses a mention simply degrades it to plain text), no
+ * roster live-revalidation, no code-range rewriting, no caret remapping.
+ */
+export function useMentionComposer({
+  canonical,
+  onCanonicalChange,
+  candidates,
+  scope,
+}: {
+  /** Canonical draft text (`@<name>` literals) owned by the host. */
+  canonical: string;
+  /** Persist a new canonical draft (the host's existing setDraft). */
+  onCanonicalChange: (next: string) => void;
+  /** Mention roster used to resolve display labels on hydrate. */
+  candidates: MentionCandidate[];
+  /** Draft-owner identity (chat id / request id / compose scope). A change
+   *  resets the display model even when the canonical text is unchanged. */
+  scope?: string | number;
+}): {
+  /** What the textarea shows: display names, not slugs. */
+  displayText: string;
+  /** Committed mention tokens over `displayText` (offset-based identity). */
+  tokens: ComposerMentionToken[];
+  /** Textarea `onChange`: adjust tokens through the edit, persist canonical. */
+  handleInput: (nextDisplay: string) => void;
+  /** Programmatic whole-text edit in display space (tokens diff-adjusted). */
+  replaceDisplay: (nextDisplay: string) => void;
+  /** Autocomplete commit. Returns the new display text + caret, or null. */
+  applyPick: (
+    trigger: ActiveTrigger,
+    cursor: number,
+    candidate: MentionCandidate,
+  ) => { text: string; cursor: number } | null;
+  /**
+   * Atomic mention deletion: with a collapsed caret flush against a token,
+   * remove the whole mention instead of one character. Returns the new
+   * display text + caret when a token was consumed, else null (host falls
+   * through to native editing).
+   */
+  deleteTokenAtCaret: (caret: number, dir: "back" | "forward") => { text: string; cursor: number } | null;
+  /** Map a display caret to its canonical-text offset. */
+  toCanonicalCursor: (displayCursor: number) => number;
+} {
+  const candidatesRef = useRef(candidates);
+  candidatesRef.current = candidates;
+
+  const [model, setModel] = useState(() => hydrateComposerDisplay(canonical, candidates));
+  // Mirror of the committed model for event handlers (they may fire between
+  // a state update and the render that exposes it).
+  const modelRef = useRef(model);
+  modelRef.current = model;
+  /** Canonical text corresponding to `model` — distinguishes this hook's own
+   *  commits from external replacements (chat switch, restore, clear). */
+  const lastCanonicalRef = useRef(canonical);
+  const scopeRef = useRef(scope);
+
+  // Scope change (chat/request switch without remount), or external
+  // canonical change (not one of our commits): rehydrate the display.
+  // Adjusting state during render mirrors `useChatDraftText`'s scope-swap
+  // pattern so the textarea never shows one frame of the previous scope's
+  // text under the new one.
+  if (scope !== scopeRef.current || canonical !== lastCanonicalRef.current) {
+    scopeRef.current = scope;
+    lastCanonicalRef.current = canonical;
+    const hydrated = hydrateComposerDisplay(canonical, candidatesRef.current);
+    modelRef.current = hydrated;
+    setModel(hydrated);
+  }
+
+  const commit = useCallback(
+    (nextDisplay: string, nextTokens: ComposerMentionToken[]) => {
+      const tokens = normalizeTokens(nextTokens);
+      const nextCanonical = serializeComposer(nextDisplay, tokens);
+      lastCanonicalRef.current = nextCanonical;
+      const nextModel = { text: nextDisplay, tokens };
+      modelRef.current = nextModel;
+      setModel(nextModel);
+      onCanonicalChange(nextCanonical);
+    },
+    [onCanonicalChange],
+  );
+
+  const applyTextEdit = useCallback(
+    (nextDisplay: string) => {
+      const prev = modelRef.current;
+      commit(nextDisplay, adjustTokensForEdit(prev.tokens, prev.text, nextDisplay));
+    },
+    [commit],
+  );
+
+  const handleInput = useCallback((nextDisplay: string) => applyTextEdit(nextDisplay), [applyTextEdit]);
+
+  const replaceDisplay = useCallback((nextDisplay: string) => applyTextEdit(nextDisplay), [applyTextEdit]);
+
+  const applyPick = useCallback(
+    (trigger: ActiveTrigger, cursor: number, candidate: MentionCandidate) => {
+      const prev = modelRef.current;
+      const insert = buildDisplayMentionInsert(prev.text, trigger, cursor, candidate);
+      if (!insert) return null;
+      // Re-base existing tokens through the replacement (the `@<query>` run
+      // never overlaps a committed token — the hosts suppress triggers over
+      // tokens via `triggerOverlapsToken` — but a trigger typed flush
+      // BEFORE a token must still shift it).
+      const tokens = [...adjustTokensForEdit(prev.tokens, prev.text, insert.text), insert.token];
+      commit(insert.text, tokens);
+      return { text: insert.text, cursor: insert.cursor };
+    },
+    [commit],
+  );
+
+  const deleteTokenAtCaret = useCallback(
+    (caret: number, dir: "back" | "forward") => {
+      const prev = modelRef.current;
+      const token = tokenAtCaret(prev.tokens, caret, dir);
+      if (!token) return null;
+      const removed = removeDisplayRange(prev.text, prev.tokens, token.start, token.end);
+      commit(removed.text, removed.tokens);
+      return { text: removed.text, cursor: removed.cursor };
+    },
+    [commit],
+  );
+
+  const toCanonicalCursor = useCallback(
+    (displayCursor: number) => toCanonicalOffset(modelRef.current.text, modelRef.current.tokens, displayCursor),
+    [],
+  );
+
+  return {
+    displayText: model.text,
+    tokens: model.tokens,
+    handleInput,
+    replaceDisplay,
+    applyPick,
+    deleteTokenAtCaret,
+    toCanonicalCursor,
+  };
+}

--- a/packages/web/src/components/use-mention-composer.ts
+++ b/packages/web/src/components/use-mention-composer.ts
@@ -146,7 +146,7 @@ export function useMentionComposer({
     if (!upgradeEligibleRef.current) return;
     const hydrated = hydrateComposerDisplay(lastCanonicalRef.current, candidatesRef.current);
     setModel((prev) => {
-      const identity = (t: ComposerMentionToken): string => `${t.agentId}${t.name}`;
+      const identity = (t: ComposerMentionToken): string => JSON.stringify([t.agentId, t.name]);
       const prevIds = prev.tokens.map(identity);
       const nextIds = hydrated.tokens.map(identity);
       // prevIds must be an ordered subsequence of nextIds, and the token

--- a/packages/web/src/components/use-mention-composer.ts
+++ b/packages/web/src/components/use-mention-composer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ActiveTrigger, MentionCandidate } from "./mention-autocomplete.js";
 import {
   adjustTokensForEdit,
@@ -36,6 +36,13 @@ import {
  * `scope` identifies the draft's owner (chat id, request id, compose
  * context) and forces the same reset even when two drafts share the same
  * canonical text (ChatView is NOT remounted on chat switch).
+ *
+ * Restored/direct-loaded drafts can hydrate before the roster arrives
+ * (raw `@<name>` on screen). While the model is still purely a hydrate —
+ * no local commit since — a later candidate roster re-resolves the SAME
+ * canonical text into display labels + tokens (agentIds unchanged). The
+ * first local edit/pick/delete revokes that eligibility so a late roster
+ * never rewrites the user's text under them.
  *
  * Deliberately minimal: no browser undo/redo state machine (a native
  * undo/redo that crosses a mention simply degrades it to plain text), no
@@ -92,6 +99,13 @@ export function useMentionComposer({
   /** Canonical text corresponding to `model` — distinguishes this hook's own
    *  commits from external replacements (chat switch, restore, clear). */
   const lastCanonicalRef = useRef(canonical);
+  /** Eligibility for the candidate-arrival label upgrade: true only while
+   *  the model is purely a hydrate of the current canonical (initial mount,
+   *  external canonical replace, scope reset). Any local commit
+   *  (typing, pick, atomic delete, programmatic edit) revokes it, so a
+   *  late roster never rewrites text the user is editing or tokens they
+   *  already picked. */
+  const upgradeEligibleRef = useRef(true);
   const scopeRef = useRef(scope);
 
   // Scope change (chat/request switch without remount), or external
@@ -102,16 +116,52 @@ export function useMentionComposer({
   if (scope !== scopeRef.current || canonical !== lastCanonicalRef.current) {
     scopeRef.current = scope;
     lastCanonicalRef.current = canonical;
+    upgradeEligibleRef.current = true;
     const hydrated = hydrateComposerDisplay(canonical, candidatesRef.current);
     modelRef.current = hydrated;
     setModel(hydrated);
   }
+
+  // Candidate-arrival label upgrade: a restored/direct-loaded draft is
+  // hydrated with whatever roster is available (often empty on first
+  // paint), leaving raw `@<name>` literals on screen. While the model is
+  // still purely that hydrate (upgradeEligibleRef), a roster arriving —
+  // in one batch or several — re-resolves the SAME canonical text into
+  // display labels + tokens. Canonical content and agentIds never change
+  // (rehydrate is a pure projection; serialize round-trips). The stable
+  // signature dep avoids re-running on array-identity-only changes.
+  const candidatesSignature = useMemo(
+    () => candidates.map((c) => `${c.agentId}:${c.name ?? ""}:${c.displayName ?? ""}`).join("|"),
+    [candidates],
+  );
+  // biome-ignore lint/correctness/useExhaustiveDependencies: candidatesSignature IS the dep — its value controls when we re-resolve; the body reads the roster via candidatesRef.
+  useEffect(() => {
+    if (!upgradeEligibleRef.current) return;
+    const hydrated = hydrateComposerDisplay(lastCanonicalRef.current, candidatesRef.current);
+    setModel((prev) => {
+      if (
+        hydrated.text === prev.text &&
+        hydrated.tokens.length === prev.tokens.length &&
+        hydrated.tokens.every((t, i) => {
+          const p = prev.tokens[i];
+          return p && t.agentId === p.agentId && t.name === p.name && t.start === p.start && t.end === p.end;
+        })
+      ) {
+        return prev;
+      }
+      modelRef.current = hydrated;
+      return hydrated;
+    });
+  }, [candidatesSignature]);
 
   const commit = useCallback(
     (nextDisplay: string, nextTokens: ComposerMentionToken[]) => {
       const tokens = normalizeTokens(nextTokens);
       const nextCanonical = serializeComposer(nextDisplay, tokens);
       lastCanonicalRef.current = nextCanonical;
+      // Any local commit revokes the label-upgrade eligibility: from here
+      // on, the text belongs to the user's editing, not to a hydrate.
+      upgradeEligibleRef.current = false;
       const nextModel = { text: nextDisplay, tokens };
       modelRef.current = nextModel;
       setModel(nextModel);

--- a/packages/web/src/components/use-mention-composer.ts
+++ b/packages/web/src/components/use-mention-composer.ts
@@ -128,10 +128,17 @@ export function useMentionComposer({
   // still purely that hydrate (upgradeEligibleRef), a roster arriving —
   // in one batch or several — re-resolves the SAME canonical text into
   // display labels + tokens. Canonical content and agentIds never change
-  // (rehydrate is a pure projection; serialize round-trips). The stable
-  // signature dep avoids re-running on array-identity-only changes.
+  // (rehydrate is a pure projection; serialize round-trips). Acceptance
+  // is MONOTONE: a rehydrate is applied only when every previously
+  // resolved token's identity survives in order (new tokens may be
+  // inserted) AND at least one new token appears — candidate removals,
+  // replacements, and displayName-only changes leave the model untouched
+  // (eligibility stays open for a later genuinely-additive roster). This
+  // is deliberately NOT live-roster revalidation. The JSON signature dep
+  // is collision-free (displayName may contain any character) and avoids
+  // re-running on array-identity-only changes.
   const candidatesSignature = useMemo(
-    () => candidates.map((c) => `${c.agentId}:${c.name ?? ""}:${c.displayName ?? ""}`).join("|"),
+    () => JSON.stringify(candidates.map((c) => [c.agentId, c.name ?? null, c.displayName ?? null])),
     [candidates],
   );
   // biome-ignore lint/correctness/useExhaustiveDependencies: candidatesSignature IS the dep — its value controls when we re-resolve; the body reads the roster via candidatesRef.
@@ -139,16 +146,17 @@ export function useMentionComposer({
     if (!upgradeEligibleRef.current) return;
     const hydrated = hydrateComposerDisplay(lastCanonicalRef.current, candidatesRef.current);
     setModel((prev) => {
-      if (
-        hydrated.text === prev.text &&
-        hydrated.tokens.length === prev.tokens.length &&
-        hydrated.tokens.every((t, i) => {
-          const p = prev.tokens[i];
-          return p && t.agentId === p.agentId && t.name === p.name && t.start === p.start && t.end === p.end;
-        })
-      ) {
-        return prev;
+      const identity = (t: ComposerMentionToken): string => `${t.agentId}${t.name}`;
+      const prevIds = prev.tokens.map(identity);
+      const nextIds = hydrated.tokens.map(identity);
+      // prevIds must be an ordered subsequence of nextIds, and the token
+      // set must strictly grow.
+      let i = 0;
+      for (const id of nextIds) {
+        if (i < prevIds.length && id === prevIds[i]) i++;
       }
+      const preserved = i === prevIds.length;
+      if (!preserved || nextIds.length <= prevIds.length) return prev;
       modelRef.current = hydrated;
       return hydrated;
     });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -144,6 +144,7 @@ import { Markdown, type MarkdownProps } from "../../../components/ui/markdown.js
 import { StatusGlyph } from "../../../components/ui/status-glyph.js";
 import { useToast } from "../../../components/ui/toast.js";
 import { UnreadDivider } from "../../../components/unread-divider.js";
+import { useMentionComposer } from "../../../components/use-mention-composer.js";
 import { useChatScroll } from "../../../hooks/use-chat-scroll.js";
 import { useGitlabEntityPresentation } from "../../../hooks/use-gitlab-entity-presentation.js";
 import { useReadTracker } from "../../../hooks/use-read-tracker.js";
@@ -1867,8 +1868,9 @@ export function ChatView({
 
   // Auto-grow the composer up to the CSS `max-height` cap (10.5rem ≈ 8
   // visible lines). Same hook as the new-chat composer for a consistent
-  // typing experience across both entry points.
-  useAutoResizeTextarea(textareaRef, draft);
+  // typing experience across both entry points. NOTE: the call site lives
+  // further down, right after `mentionComposer` — the effect must be
+  // driven by the textarea's actual bound value (`displayText`).
   /** Once-per-chat guard for the focus auto-prime: after the user has
    * focused the input even once, we don't keep slapping `@` back into an
    * empty draft. Reset when switching chats. */
@@ -3562,6 +3564,22 @@ export function ChatView({
     () => mentionCandidates.map((c) => ({ agentId: c.agentId, name: c.name })),
     [mentionCandidates],
   );
+
+  // Display-side composer model (see mention-composer-model.ts): the
+  // textarea shows `@<displayName>` for committed mentions while `draft`
+  // stays the canonical `@<name>` text that send / gating / persistence /
+  // slash-context already consume. `cursor` (below) is display-space; the
+  // model maps it back to canonical where a consumer needs that.
+  const mentionComposer = useMentionComposer({
+    canonical: draft,
+    onCanonicalChange: setDraft,
+    candidates: mentionCandidates,
+    // ChatView is NOT remounted on chat switch — reset the display model on
+    // chatId change even when two chats' drafts coincide textually.
+    scope: chatId,
+  });
+  // Auto-grow is driven by the textarea's actual bound value.
+  useAutoResizeTextarea(textareaRef, mentionComposer.displayText);
   // Rendered-message projection: all chat speakers (including self) carry
   // `displayName` for the visible chip while the immutable `name` remains the
   // resolver key and copy target. Reading directly from chat detail preserves
@@ -3641,21 +3659,26 @@ export function ChatView({
   const sendDimmed = sendDisabled || sendBlockedByMentionGate;
 
   const mention = useMentionAutocomplete({
-    value: draft,
+    value: mentionComposer.displayText,
     cursor,
     candidates: mentionCandidates,
     disabled: landingCampaignChatLocked || sendMut.isPending || uploading,
-    onSelect: (update) => {
+    tokens: mentionComposer.tokens,
+    onSelect: (_update, candidate, trigger) => {
       autoPrimedDraftRef.current = false;
-      setDraft(update.text);
-      setCursor(update.cursor);
+      // Token-model commit: inserts `@<displayName>` into the visible text
+      // and records the canonical slug/agentId as a token (the legacy
+      // `@<name>` insertion in `_update` is intentionally unused).
+      const applied = mentionComposer.applyPick(trigger, cursor, candidate);
+      if (!applied) return;
+      setCursor(applied.cursor);
       // Defer so React has committed the new value before we move the
       // selection — otherwise the textarea snaps back to its old cursor.
       requestAnimationFrame(() => {
         const el = textareaRef.current;
         if (!el) return;
         el.focus();
-        el.setSelectionRange(update.cursor, update.cursor);
+        el.setSelectionRange(applied.cursor, applied.cursor);
       });
     },
   });
@@ -3669,7 +3692,9 @@ export function ChatView({
    *   - group chats with no resolved @ show only system commands
    */
   const slashMentionContext = useMemo<{ agentId: string; displayName: string } | null>(() => {
-    const explicit = resolveMentionContext(draft, cursor, mentionCandidates);
+    // `draft` is canonical text; map the display-space caret back so the
+    // `@<name>` scan sees the same position the user does.
+    const explicit = resolveMentionContext(draft, mentionComposer.toCanonicalCursor(cursor), mentionCandidates);
     if (explicit) return explicit;
     if (!requiresMention && mentionCandidates.length === 1) {
       const c = mentionCandidates[0];
@@ -3677,7 +3702,7 @@ export function ChatView({
       return { agentId: c.agentId, displayName: c.displayName ?? c.name ?? c.agentId };
     }
     return null;
-  }, [draft, cursor, mentionCandidates, requiresMention]);
+  }, [draft, cursor, mentionCandidates, requiresMention, mentionComposer.toCanonicalCursor]);
 
   // Phase 1C ships with a single in-product system command (`/clear`).
   // The four-command roadmap from the design doc (`/help`, `/me`,
@@ -3705,7 +3730,7 @@ export function ChatView({
   });
 
   const slash = useSlashCommand({
-    value: draft,
+    value: mentionComposer.displayText,
     cursor,
     systemCommands: slashSystemCommands,
     agentSkills: slashMentionContext
@@ -3719,7 +3744,9 @@ export function ChatView({
     disabled: sendMut.isPending || uploading,
     onSelect: (update, picked) => {
       autoPrimedDraftRef.current = false;
-      setDraft(update.text);
+      // Slash inserts plain text (`/<command> `) — a display-space edit the
+      // token model diff-adjusts existing mentions through.
+      mentionComposer.replaceDisplay(update.text);
       setCursor(update.cursor);
       requestAnimationFrame(() => {
         const el = textareaRef.current;
@@ -4572,8 +4599,9 @@ export function ChatView({
                           align character-for-character; padding / sizing
                           must match the textarea's inline style below. */}
                         <MentionHighlightOverlay
-                          value={draft}
+                          value={mentionComposer.displayText}
                           participants={mentionParticipants}
+                          tokens={mentionComposer.tokens}
                           textareaRef={textareaRef}
                           chipClassName="mention-text"
                           mirrorStyle={{
@@ -4600,10 +4628,13 @@ export function ChatView({
                         />
                         <textarea
                           ref={textareaRef}
-                          value={draft}
+                          value={mentionComposer.displayText}
                           onChange={(e) => {
                             autoPrimedDraftRef.current = false;
-                            setDraft(e.target.value);
+                            // Token-model edit: adjusts mention tokens through
+                            // the diff and persists the canonical `@<name>`
+                            // form into `draft` (see useMentionComposer).
+                            mentionComposer.handleInput(e.target.value);
                             setCursor(e.target.selectionStart ?? e.target.value.length);
                             // Dismiss a stale upload error (e.g. the "no @mention"
                             // hint) the moment the user starts fixing it. Mirrors
@@ -4616,7 +4647,7 @@ export function ChatView({
                             dismissMentionTip();
                           }}
                           onSelect={(e) => {
-                            setCursor(e.currentTarget.selectionStart ?? draft.length);
+                            setCursor(e.currentTarget.selectionStart ?? mentionComposer.displayText.length);
                           }}
                           onFocus={() => {
                             // Group / about-to-be-group chats: prime the input with `@`
@@ -4648,7 +4679,7 @@ export function ChatView({
                             }
                             focusPrimedRef.current = true;
                             autoPrimedDraftRef.current = true;
-                            setDraft("@");
+                            mentionComposer.replaceDisplay("@");
                             setCursor(1);
                             requestAnimationFrame(() => {
                               const el = textareaRef.current;
@@ -4700,6 +4731,34 @@ export function ChatView({
                             // Trial: no slash commands / mention autocomplete, so `/` and
                             // `@` type literally and Enter always sends.
                             if (!isTrial) {
+                              // Atomic mention deletion: a collapsed caret flush
+                              // against a committed mention removes the whole
+                              // token (Backspace at its end / Delete at its
+                              // start) instead of sawing one character off the
+                              // display label and silently breaking the route.
+                              if (e.key === "Backspace" || e.key === "Delete") {
+                                const el = textareaRef.current;
+                                if (el && el.selectionStart === el.selectionEnd) {
+                                  const removed = mentionComposer.deleteTokenAtCaret(
+                                    el.selectionStart ?? cursor,
+                                    e.key === "Backspace" ? "back" : "forward",
+                                  );
+                                  if (removed) {
+                                    e.preventDefault();
+                                    setCursor(removed.cursor);
+                                    // The native deletion was preventDefaulted,
+                                    // so the DOM selection still points at the
+                                    // pre-delete caret — re-pin it after React
+                                    // commits the shortened value.
+                                    requestAnimationFrame(() => {
+                                      const ta = textareaRef.current;
+                                      if (!ta) return;
+                                      ta.setSelectionRange(removed.cursor, removed.cursor);
+                                    });
+                                    return;
+                                  }
+                                }
+                              }
                               // Slash command popover handles navigation keys when active.
                               // Sits before mention so `/`-typed draft never falls through to
                               // mention-autocomplete (the trigger predicates are disjoint, but
@@ -4815,11 +4874,12 @@ export function ChatView({
                                 // keyboard trick.
                                 const el = textareaRef.current;
                                 if (!el) return;
-                                const start = el.selectionStart ?? draft.length;
+                                const text = mentionComposer.displayText;
+                                const start = el.selectionStart ?? text.length;
                                 const end = el.selectionEnd ?? start;
-                                const next = `${draft.slice(0, start)}@${draft.slice(end)}`;
+                                const next = `${text.slice(0, start)}@${text.slice(end)}`;
                                 autoPrimedDraftRef.current = false;
-                                setDraft(next);
+                                mentionComposer.replaceDisplay(next);
                                 setCursor(start + 1);
                                 requestAnimationFrame(() => {
                                   el.focus();

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -26,7 +26,9 @@ import {
   mentionOptionTitle,
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
+import { triggerOverlapsToken } from "../../../components/mention-composer-model.js";
 import { FileChip } from "../../../components/ui/file-chip.js";
+import { useMentionComposer } from "../../../components/use-mention-composer.js";
 import { clearDraft, type DraftSnapshot, loadDraft, newChatDraftScope, saveDraft } from "../../../lib/draft-store.js";
 import { useAgentIdentityMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
@@ -144,8 +146,9 @@ export function NewChatDraft({
 
   // Auto-grow the textarea up to the CSS `max-height` cap (10.5rem ≈ 8
   // visible lines). Re-measure on every keystroke so paste and delete
-  // both adjust instantly; past the cap content scrolls inside.
-  useAutoResizeTextarea(textareaRef, draft);
+  // both adjust instantly; past the cap content scrolls inside. NOTE:
+  // the call site lives below `mentionComposer` — the effect must be
+  // driven by the textarea's actual bound value (`displayText`).
 
   /** First-page baseline of org-wide addressable agents (humans + AI),
    *  backed by `GET /orgs/:orgId/agents` via `useOrgAgents`. Used to feed
@@ -239,6 +242,25 @@ export function NewChatDraft({
     mergeKnown([defaultCandidates.agent]);
   }, [defaultCandidates?.agent, mergeKnown]);
 
+  // Display-side composer model (see mention-composer-model.ts): the
+  // textarea shows `@<displayName>` for committed mentions while `draft`
+  // stays the canonical `@<name>` text that persistence, `extractMentions`
+  // (bodyMentions → chips), and the create-chat send all consume. Hydrate
+  // labels come from `knownAgents` — the session roster — so this hook can
+  // live above the trigger-search union (`candidates`) that itself depends
+  // on the display-side trigger detection below.
+  const hydrateCandidates = useMemo<MentionCandidate[]>(() => Array.from(knownAgents.values()), [knownAgents]);
+  const mentionComposer = useMentionComposer({
+    canonical: draft,
+    onCanonicalChange: setDraft,
+    candidates: hydrateCandidates,
+    // The compose context can change in place (different seed participants
+    // share this component) — reset the display model per draft scope.
+    scope: draftScope,
+  });
+  // Auto-grow is driven by the textarea's actual bound value.
+  useAutoResizeTextarea(textareaRef, mentionComposer.displayText);
+
   /** Active `@<query>` trigger derived from the textarea's text +
    *  cursor. Drives a server-side search so the autocomplete popover
    *  can show matches past the first-page cap. We compute it inline
@@ -253,7 +275,14 @@ export function NewChatDraft({
    *  three GETs (`b` / `bo` / `bob`), each a fresh React Query key with
    *  no dedup. `useOrgAgentsSearch`'s docstring puts debouncing on the
    *  caller; matches what the chip picker already does. */
-  const trigger = useMemo(() => detectMentionTrigger(draft, cursor), [draft, cursor]);
+  const trigger = useMemo(() => {
+    const detected = detectMentionTrigger(mentionComposer.displayText, cursor);
+    // A committed mention token is not a query — without this guard the
+    // server-side search would fire (and the popover would reopen) when the
+    // caret sits inside/at the end of a committed display label.
+    if (detected && triggerOverlapsToken(detected, cursor, mentionComposer.tokens)) return null;
+    return detected;
+  }, [mentionComposer.displayText, mentionComposer.tokens, cursor]);
   const triggerQuery = trigger?.query ?? "";
   const debouncedTriggerQuery = useDebouncedValue(triggerQuery, 100);
   const { data: triggerSearchPage } = useOrgAgentsSearch(debouncedTriggerQuery, { addressableOnly: true });
@@ -384,18 +413,23 @@ export function NewChatDraft({
   // inside the textarea would duplicate that signal — the chip row
   // visualisation is enough on this surface.
   const mention = useMentionAutocomplete({
-    value: draft,
+    value: mentionComposer.displayText,
     cursor,
     candidates,
     disabled: sending,
-    onSelect: (update) => {
-      setDraft(update.text);
-      setCursor(update.cursor);
+    tokens: mentionComposer.tokens,
+    onSelect: (_update, candidate, trigger) => {
+      // Token-model commit: the visible text gets `@<displayName>` while
+      // the canonical slug/agentId rides along as a token (the legacy
+      // `@<name>` insertion in `_update` is intentionally unused).
+      const applied = mentionComposer.applyPick(trigger, cursor, candidate);
+      if (!applied) return;
+      setCursor(applied.cursor);
       requestAnimationFrame(() => {
         const el = textareaRef.current;
         if (!el) return;
         el.focus();
-        el.setSelectionRange(update.cursor, update.cursor);
+        el.setSelectionRange(applied.cursor, applied.cursor);
       });
     },
   });
@@ -747,13 +781,15 @@ export function NewChatDraft({
               />
               <textarea
                 ref={textareaRef}
-                value={draft}
+                value={mentionComposer.displayText}
                 onChange={(e) => {
-                  setDraft(e.target.value);
+                  // Token-model edit: adjusts mention tokens through the diff
+                  // and persists the canonical `@<name>` form into `draft`.
+                  mentionComposer.handleInput(e.target.value);
                   setCursor(e.target.selectionStart ?? e.target.value.length);
                 }}
                 onSelect={(e) => {
-                  setCursor(e.currentTarget.selectionStart ?? draft.length);
+                  setCursor(e.currentTarget.selectionStart ?? mentionComposer.displayText.length);
                 }}
                 onPaste={(e) => {
                   const files = Array.from(e.clipboardData.files);
@@ -768,6 +804,30 @@ export function NewChatDraft({
                 rows={1}
                 onKeyDown={(e) => {
                   if (e.nativeEvent.isComposing) return;
+                  // Atomic mention deletion: a collapsed caret flush against a
+                  // committed mention removes the whole token, not one
+                  // character of its display label.
+                  if (e.key === "Backspace" || e.key === "Delete") {
+                    const el = textareaRef.current;
+                    if (el && el.selectionStart === el.selectionEnd) {
+                      const removed = mentionComposer.deleteTokenAtCaret(
+                        el.selectionStart ?? cursor,
+                        e.key === "Backspace" ? "back" : "forward",
+                      );
+                      if (removed) {
+                        e.preventDefault();
+                        setCursor(removed.cursor);
+                        // Re-pin the DOM selection after commit — the native
+                        // deletion that would have moved it was preventDefaulted.
+                        requestAnimationFrame(() => {
+                          const ta = textareaRef.current;
+                          if (!ta) return;
+                          ta.setSelectionRange(removed.cursor, removed.cursor);
+                        });
+                        return;
+                      }
+                    }
+                  }
                   if (mention.handleKey(e)) return;
                   // Mobile soft keyboards have no Shift+Enter, so Enter inserts a
                   // newline; sending is the button only. Desktop keeps Enter-to-send.
@@ -819,7 +879,7 @@ export function NewChatDraft({
                     overflow: "hidden",
                   }}
                 >
-                  {draft}
+                  {mentionComposer.displayText}
                   <span style={{ color: "var(--fg-4)" }}>{"  ← @ a group member to send"}</span>
                 </div>
               )}


### PR DESCRIPTION
## Summary

- show the selected agent's `displayName` in ChatView, NewChatDraft, and AskTakeover mention composers, with blank labels falling back to `name`
- keep canonical `@name` text and the selected agent ID for drafts, sends, failed-send restoration, request answers, and routing
- upgrade an untouched restored/direct-loaded canonical draft when its async mention roster arrives, without overwriting local edits or turning roster changes into live revalidation
- share one minimal display/canonical token model across the desktop and mobile composer surfaces without changing Server, Shared, Client, API, or wire schemas

## Scope

This intentionally stays within the product request. Candidate-arrival upgrades are accepted only while the model remains a pure canonical hydration, only when resolved tokens strictly increase, and only when all prior `(agentId, name)` identities remain in order.

It does not add custom undo/redo history, live-roster invalidation, stale-popover handling, code-range rewriting, generalized caret remapping, or clipboard rewriting.

## Validation

Final exact head: `8f891d62bb7c1abe7d2da567d58019e155f882fe`

- focused changed Web tests: 3 files / 84 tests passed
- full Web: 220 files / 1,932 tests passed
- full Shared: 66 files / 745 tests passed
- `pnpm check` passed
- full typecheck: 11/11 tasks passed
- independent Docker/browser QA PASS on the exact head:
  - real desktop and 390×844 NewChatDraft restored canonical text upgraded from `@name` to `@displayName` after the normal roster poll
  - pre-arrival local edits were preserved and batched candidate arrivals were monotone
  - HTTP 201, PostgreSQL readback, and runtime delivery remained canonical `@name` plus the original structured agent ID
- previous broad cross-surface QA covered existing chat, NewChatDraft, Need You, in-chat answer, and mobile Ask Sheet on the pre-follow-up baseline; the final delta is confined to the shared hook and its DOM tests
