### PR TITLE
fix: derive the team slug server-side on self-service create

### DIFF
--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -526,7 +526,7 @@ describe("small API route handlers", () => {
     await meRoutes(created.app as never);
     const createReply = makeReply();
     await route(created.routes, "POST", "/me/organizations").handler(
-      { body: { name: "new-org", displayName: "New Org" }, user: { userId: "user_1" } },
+      { body: { displayName: "New Org" }, user: { userId: "user_1" } },
       createReply,
     );
     expect(createReply).toMatchObject({
@@ -542,7 +542,7 @@ describe("small API route handlers", () => {
     await meRoutes(missingUser.app as never);
     await expect(
       route(missingUser.routes, "POST", "/me/organizations").handler(
-        { body: { name: "new-org", displayName: "New Org" }, user: { userId: "user_missing" } },
+        { body: { displayName: "New Org" }, user: { userId: "user_missing" } },
         makeReply(),
       ),
     ).rejects.toThrow("User not found");

--- a/packages/server/src/__tests__/me-multi-org.test.ts
+++ b/packages/server/src/__tests__/me-multi-org.test.ts
@@ -96,21 +96,38 @@ describe("Multi-org self-service", () => {
     // Display names carrying no ASCII alphanumerics all sanitize to the same
     // base slug. The slug is globally unique, so while the client chose it the
     // first such team anywhere rejected every later one with a 409 quoting an
-    // identifier the user never typed. Renaming did not help either: renames
-    // only touch displayName.
+    // identifier the user never typed.
     const first = await create("电商平台");
-    const renamedThenReused = await create("电商平台-商城");
-    const duplicate = await create("电商平台");
-    expect([first.statusCode, renamedThenReused.statusCode, duplicate.statusCode]).toEqual([201, 201, 201]);
+    expect(first.statusCode).toBe(201);
+    const firstId = first.json<{ organization: { id: string } }>().organization.id;
+    const [beforeRename] = await app.db.select().from(organizations).where(eq(organizations.id, firstId));
 
-    const ids = [first, renamedThenReused, duplicate].map(
-      (res) => res.json<{ organization: { id: string } }>().organization.id,
-    );
-    const rows = await app.db.select().from(organizations).where(inArray(organizations.id, ids));
-    expect(rows.length).toBe(3);
-    expect(new Set(rows.map((row) => row.name)).size).toBe(3);
+    // Renaming does not release the slug — it moves only the display name.
+    const renamed = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/orgs/${firstId}`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { displayName: "电商平台-商城" },
+    });
+    expect(renamed.statusCode).toBe(200);
+    const [afterRename] = await app.db.select().from(organizations).where(eq(organizations.id, firstId));
+    expect(afterRename?.displayName).toBe("电商平台-商城");
+    expect(afterRename?.name).toBe(beforeRename?.name);
+
+    // Reusing the original display name still succeeds, on a fresh slug.
+    const reused = await create("电商平台");
+    expect(reused.statusCode).toBe(201);
+    const reusedId = reused.json<{ organization: { id: string } }>().organization.id;
+
+    const rows = await app.db
+      .select()
+      .from(organizations)
+      .where(inArray(organizations.id, [firstId, reusedId]));
+    expect(rows.length).toBe(2);
+    expect(new Set(rows.map((row) => row.name)).size).toBe(2);
     // Display names are deliberately not unique — two teams may share one.
-    expect(rows.filter((row) => row.displayName === "电商平台").length).toBe(2);
+    const alsoSameName = await create("电商平台-商城");
+    expect(alsoSameName.statusCode).toBe(201);
   });
 
   it("POST /me/memberships/:memberId/leave soft-deletes membership", async () => {

--- a/packages/server/src/__tests__/me-multi-org.test.ts
+++ b/packages/server/src/__tests__/me-multi-org.test.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { invitationRedemptions } from "../db/schema/invitations.js";
@@ -65,7 +65,7 @@ describe("Multi-org self-service", () => {
       method: "POST",
       url: "/api/v1/me/organizations",
       headers: { authorization: `Bearer ${admin.accessToken}` },
-      payload: { name: `t-${crypto.randomUUID().slice(0, 8)}`, displayName: "Side Project" },
+      payload: { displayName: "Side Project" },
     });
     expect(res.statusCode).toBe(201);
     const body = res.json<{ organization: { id: string; role: string } }>();
@@ -82,6 +82,37 @@ describe("Multi-org self-service", () => {
     expect(meBody.memberships.some((m) => m.organizationId === body.organization.id)).toBe(true);
   });
 
+  it("POST /me/organizations disambiguates display names that derive the same slug", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const create = (displayName: string) =>
+      app.inject({
+        method: "POST",
+        url: "/api/v1/me/organizations",
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        payload: { displayName },
+      });
+
+    // Display names carrying no ASCII alphanumerics all sanitize to the same
+    // base slug. The slug is globally unique, so while the client chose it the
+    // first such team anywhere rejected every later one with a 409 quoting an
+    // identifier the user never typed. Renaming did not help either: renames
+    // only touch displayName.
+    const first = await create("电商平台");
+    const renamedThenReused = await create("电商平台-商城");
+    const duplicate = await create("电商平台");
+    expect([first.statusCode, renamedThenReused.statusCode, duplicate.statusCode]).toEqual([201, 201, 201]);
+
+    const ids = [first, renamedThenReused, duplicate].map(
+      (res) => res.json<{ organization: { id: string } }>().organization.id,
+    );
+    const rows = await app.db.select().from(organizations).where(inArray(organizations.id, ids));
+    expect(rows.length).toBe(3);
+    expect(new Set(rows.map((row) => row.name)).size).toBe(3);
+    // Display names are deliberately not unique — two teams may share one.
+    expect(rows.filter((row) => row.displayName === "电商平台").length).toBe(2);
+  });
+
   it("POST /me/memberships/:memberId/leave soft-deletes membership", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -90,7 +121,7 @@ describe("Multi-org self-service", () => {
       method: "POST",
       url: "/api/v1/me/organizations",
       headers: { authorization: `Bearer ${admin.accessToken}` },
-      payload: { name: `t-${crypto.randomUUID().slice(0, 8)}`, displayName: "Second" },
+      payload: { displayName: "Second" },
     });
 
     const leaveRes = await app.inject({

--- a/packages/server/src/__tests__/members.test.ts
+++ b/packages/server/src/__tests__/members.test.ts
@@ -1184,29 +1184,32 @@ describe("Members API", () => {
       expect(mirror?.name).toContain(created.agentId.slice(0, 8));
     });
 
-    it("selfCreateOrganization rejects duplicate and reserved slugs", async () => {
+    it("selfCreateOrganization derives a free slug instead of failing on a taken one", async () => {
       const app = getApp();
+      const userId = `user-${randomUUID()}`;
+      const username = `self-org-admin-${randomUUID().slice(0, 8)}`;
+      await app.db
+        .insert(usersTable)
+        .values({ id: userId, username, passwordHash: "x", displayName: "Self Org Admin" });
 
-      await expect(
-        selfCreateOrganization(app.db, {
-          userId: `user-${randomUUID()}`,
-          userDisplayName: "Self Org Admin",
-          username: "self-org-admin",
-          name: "default",
-          displayName: "Default Again",
-        }),
-      ).rejects.toThrow(/already exists/i);
+      // "Default" sanitizes to the `default` slug, which always exists. A slug
+      // collision is the server's problem, not a user-visible failure: the
+      // retry helper moves to a suffixed slug and the caller still gets a team.
+      const created = await selfCreateOrganization(app.db, {
+        userId,
+        userDisplayName: "Self Org Admin",
+        username,
+        displayName: "Default",
+      });
+      expect(created.name).toMatch(/^default-.+/);
 
-      await app.db.delete(organizationsTable).where(eq(organizationsTable.name, "default"));
-      await expect(
-        selfCreateOrganization(app.db, {
-          userId: `user-${randomUUID()}`,
-          userDisplayName: "Self Org Admin",
-          username: "self-org-admin",
-          name: "default",
-          displayName: "Reserved Default",
-        }),
-      ).rejects.toThrow(/reserved organization name/i);
+      const [defaultOrg] = await app.db
+        .select({ id: organizationsTable.id })
+        .from(organizationsTable)
+        .where(eq(organizationsTable.name, "default"))
+        .limit(1);
+      expect(defaultOrg?.id).toBeDefined();
+      expect(defaultOrg?.id).not.toBe(created.organizationId);
     });
   });
 });

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -623,7 +623,6 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       userId,
       userDisplayName: u.displayName,
       username: u.username,
-      name: body.name,
       displayName: body.displayName,
     });
     // Token reuse: signing-then-returning would just produce the same

--- a/packages/server/src/services/membership.ts
+++ b/packages/server/src/services/membership.ts
@@ -7,7 +7,7 @@ import { agents } from "../db/schema/agents.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { users } from "../db/schema/users.js";
-import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
+import { ConflictError, NotFoundError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
 import { forceDisconnect } from "./connection-manager.js";
 import { suspendGitlabLinksForMembership } from "./gitlab-identities.js";
@@ -733,31 +733,26 @@ export async function leaveOrganization(db: Database, memberId: string) {
 
 /**
  * Self-service "create another team" (operator clicks "Create team" in the
- * org switcher). Caller is the new team's admin. Slug uniqueness is
- * enforced by the underlying organizations.name UNIQUE constraint.
+ * org switcher). Caller is the new team's admin.
+ *
+ * The user only ever names the team's `displayName`; the slug is derived
+ * server-side and disambiguated by `insertOrgWithSlugRetry`, exactly like the
+ * personal team minted at sign-in. That matters because the slug is globally
+ * unique and is not a per-tenant name: letting a client send it made every
+ * team whose display name carries no ASCII alphanumerics collapse onto the
+ * same `"team"` fallback slug, so the first such team anywhere blocked every
+ * later one with a 409 naming an identifier the user never typed. Display
+ * names are deliberately not unique — two teams may share one.
+ *
+ * `"default"` needs no special-casing: the default org always exists, so the
+ * retry helper sees the collision and moves to a suffixed slug.
  */
 export async function selfCreateOrganization(
   db: Database,
-  data: { userId: string; userDisplayName: string; username: string; name: string; displayName: string },
+  data: { userId: string; userDisplayName: string; username: string; displayName: string },
 ) {
-  // Cheap pre-check so the API returns 409 rather than letting the FK
-  // explode further down. Race window with concurrent creates is fine —
-  // the unique constraint is the authoritative gate.
-  const [collision] = await db
-    .select({ id: organizations.id })
-    .from(organizations)
-    .where(eq(organizations.name, data.name))
-    .limit(1);
-  if (collision) {
-    throw new ConflictError(`Organization "${data.name}" already exists`);
-  }
-
-  if (data.name === "default") {
-    throw new BadRequestError('"default" is a reserved organization name');
-  }
-
   const orgId = uuidv7();
-  await db.insert(organizations).values({ id: orgId, name: data.name, displayName: data.displayName });
+  const name = await insertOrgWithSlugRetry(db, orgId, sanitizeOrgSlug(data.displayName), data.displayName);
   const member = await ensureMembership(db, {
     userId: data.userId,
     organizationId: orgId,
@@ -765,5 +760,5 @@ export async function selfCreateOrganization(
     displayName: data.userDisplayName,
     username: data.username,
   });
-  return { organizationId: orgId, memberId: member.id, name: data.name, displayName: data.displayName };
+  return { organizationId: orgId, memberId: member.id, name, displayName: data.displayName };
 }

--- a/packages/shared/src/schemas/me-extras.ts
+++ b/packages/shared/src/schemas/me-extras.ts
@@ -20,13 +20,15 @@ export const orgBriefSchema = z.object({
 });
 export type OrgBrief = z.infer<typeof orgBriefSchema>;
 
-/** Body for `POST /me/organizations` — operator wants to create another team. */
+/**
+ * Body for `POST /me/organizations` — operator wants to create another team.
+ *
+ * Only the display name is a user input. The org slug (`organizations.name`)
+ * is a server-derived internal identifier, so the client must not supply it:
+ * a client-chosen slug turns the global slug UNIQUE constraint into a
+ * user-visible 409 on a field the user never typed.
+ */
 export const createOrgFromMeSchema = z.object({
-  name: z
-    .string()
-    .min(2)
-    .max(50)
-    .regex(/^[a-z0-9][a-z0-9-]*$/),
   displayName: z.string().min(1).max(200),
 });
 export type CreateOrgFromMe = z.infer<typeof createOrgFromMeSchema>;

--- a/packages/web/src/components/__tests__/team-setup-modal-dom.test.tsx
+++ b/packages/web/src/components/__tests__/team-setup-modal-dom.test.tsx
@@ -88,7 +88,7 @@ afterEach(() => {
 });
 
 describe("TeamSetupModal", () => {
-  it("creates a team with a slugified name, selects it, enters onboarding, and closes", async () => {
+  it("sends only the display name, selects the team, enters onboarding, and closes", async () => {
     const onClose = vi.fn();
     clientMocks.post.mockResolvedValue({
       organization: { id: "org-new", name: "acme-robotics", displayName: "ACME Robotics!!!", role: "admin" },
@@ -102,8 +102,9 @@ describe("TeamSetupModal", () => {
     await setInputValue(input, "  ACME Robotics!!!  ");
     await submit(document.body.querySelector("form"));
 
+    // The slug is server-derived; a client-chosen one would resurface the
+    // global slug UNIQUE constraint as a user-visible 409.
     expect(clientMocks.post).toHaveBeenCalledWith("/me/organizations", {
-      name: "acme-robotics",
       displayName: "ACME Robotics!!!",
     });
     expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-new");

--- a/packages/web/src/components/team-setup-modal.tsx
+++ b/packages/web/src/components/team-setup-modal.tsx
@@ -36,24 +36,6 @@ export function TeamSetupModal({ action, onClose }: { action: "create" | "join" 
   );
 }
 
-/**
- * Server-side slug rules (membership.ts:sanitizeOrgSlug): lowercase,
- * alphanumeric + hyphens, leading/trailing hyphens stripped, max 40 chars.
- * Mirror that here so we can derive a slug from the display name without
- * surfacing it to the user. Server has its own collision-disambiguation
- * (pickAvailableOrgSlug), so any reasonable slug is safe to send.
- */
-function slugify(input: string): string {
-  return (
-    input
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, 40) || "team"
-  );
-}
-
 function CreateForm({ onDone }: { onDone: () => void }) {
   const { selectOrganization } = useAuth();
   const navigate = useNavigate();
@@ -77,7 +59,7 @@ function CreateForm({ onDone }: { onDone: () => void }) {
     try {
       const res = await api.post<{
         organization: { id: string; name: string; displayName: string; role: string };
-      }>("/me/organizations", { name: slugify(trimmed), displayName: trimmed });
+      }>("/me/organizations", { displayName: trimmed });
       // The caller is already authenticated and the user JWT is org-agnostic,
       // so no token adoption is needed (the endpoint returns none). Select the
       // freshly created org so the user lands in it.


### PR DESCRIPTION
## Problem

A user created a team named `电商平台`, renamed it to `电商平台-商城`, then tried to create `电商平台` again and was told the team already existed.

`POST /me/organizations` let the client choose `organizations.name`, and the Web modal derived it from the display name by replacing every character outside `[a-z0-9-]`. Any display name without an ASCII alphanumeric — every all-CJK team name — collapsed onto the same `"team"` fallback slug:

```
"电商平台"      -> "team"
"电商平台-商城"  -> "team"
"设计团队"      -> "team"
```

That slug is globally unique, not per-tenant. So the first such team **anywhere in the deployment** claimed `team`, and from then on any account creating a team with an all-CJK name got `409 Organization "team" already exists` — an identifier the user never typed, on a form that only asks for a display name. Renaming could not release it either: both rename surfaces (`team-switcher.tsx`, onboarding `step-team.tsx`) only patch `displayName`, so the slug never moves after creation.

Signup was unaffected: `createPersonalTeam` already derives its slug server-side and disambiguates through `insertOrgWithSlugRetry`. Only the self-service "Create team" path was missing that, which is why this surfaces the moment a user wants a second team.

A secondary failure mode: names leaving a single ASCII alphanumeric (`"A团队"` -> `"a"`, `"团队1"` -> `"1"`) failed the request schema's `min(2)` and returned a raw Zod validation error.

## Change

Treat the slug as what it already is everywhere else — a server-derived internal identifier:

- `createOrgFromMeSchema` drops `name`; the request carries only `displayName`.
- `selfCreateOrganization` derives the slug from the display name and reuses `insertOrgWithSlugRetry`, so collisions are disambiguated silently instead of surfacing as a user-visible failure.
- The Web modal stops slugifying and sends only the display name. Its comment claiming the server had a `pickAvailableOrgSlug` collision-disambiguation helper went with it — no such helper existed, which is exactly why this path was unguarded.

`"default"` loses its special case: the default org always exists, so the retry helper already moves past that slug rather than needing a separate reserved-name branch.

Display names remain deliberately non-unique — two teams may share one, and there is now no user-visible naming conflict at all.

## Scope notes

- No migration. The existing row holding `team` stops blocking anyone once slugs are server-derived.
- `organization.ts`'s admin/webhook `createOrganization` is untouched; there the caller supplies `name` explicitly and a 409 is the correct semantic.
- `updateOrganizationSchema` still accepts `name`. No Web surface sends it, but an API caller can still rename a slug into a 409. Removing it is a separate, independently revertable change.
- `sanitizeOrgSlug` can still return a 1-character slug. It is not routed, not rendered, and uniqueness is handled by the retry, so this is left alone rather than given a new minimum-length rule.

## Tests

- `me-multi-org.test.ts`: three teams whose display names all derive the same base slug (including the reported rename-then-reuse sequence) each create successfully with distinct slugs, and two of them keep the same display name.
- `members.test.ts`: the old "rejects duplicate and reserved slugs" case is replaced by one asserting a display name deriving `default` gets a suffixed slug and leaves the default org intact.
- `team-setup-modal-dom.test.tsx`: asserts the request body carries only `displayName`.

`pnpm check`, `pnpm typecheck`, and the server (2855) / web (1940) / shared (777) suites pass. The one unrelated failure in the monorepo run is a 20s timeout in `skill-evals`' `first-tree-seed` real-source fixture case, which passed at 19.25s on the preceding run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
