### PR TITLE
refactor: drop the org slug update path

### DIFF
--- a/packages/server/src/__tests__/me-multi-org.test.ts
+++ b/packages/server/src/__tests__/me-multi-org.test.ts
@@ -103,11 +103,13 @@ describe("Multi-org self-service", () => {
     const [beforeRename] = await app.db.select().from(organizations).where(eq(organizations.id, firstId));
 
     // Renaming does not release the slug — it moves only the display name.
+    // A `name` in the body is not an escape hatch either: the slug has no
+    // update path, so it is stripped rather than applied.
     const renamed = await app.inject({
       method: "PATCH",
       url: `/api/v1/orgs/${firstId}`,
       headers: { authorization: `Bearer ${admin.accessToken}` },
-      payload: { displayName: "电商平台-商城" },
+      payload: { displayName: "电商平台-商城", name: "squatted-slug" },
     });
     expect(renamed.statusCode).toBe(200);
     const [afterRename] = await app.db.select().from(organizations).where(eq(organizations.id, firstId));

--- a/packages/server/src/__tests__/organization-extra.test.ts
+++ b/packages/server/src/__tests__/organization-extra.test.ts
@@ -77,7 +77,7 @@ describe("organization service edge cases", () => {
     ).rejects.toThrow("Unexpected: INSERT RETURNING produced no row");
   });
 
-  it("reads and updates organizations with not-found and conflict handling", async () => {
+  it("reads and updates organizations with not-found handling", async () => {
     await expect(getOrganization(makeSelectDb([{ id: "org_1" }]) as never, "org_1")).resolves.toEqual({ id: "org_1" });
     await expect(getOrganization(makeSelectDb([]) as never, "missing")).rejects.toThrow(
       'Organization "missing" not found',
@@ -90,7 +90,6 @@ describe("organization service edge cases", () => {
         features: { beta: true },
         maxAgents: 10,
         maxMessagesPerMinute: 20,
-        name: "acme-inc",
       }),
     ).resolves.toMatchObject({ displayName: "Acme Inc" });
     expect(updates[0]).toMatchObject({
@@ -98,16 +97,14 @@ describe("organization service edge cases", () => {
       features: { beta: true },
       maxAgents: 10,
       maxMessagesPerMinute: 20,
-      name: "acme-inc",
     });
     expect((updates[0] as { updatedAt?: unknown }).updatedAt).toBeInstanceOf(Date);
+    // The slug has no update path, so an update can never touch it.
+    expect(updates[0]).not.toHaveProperty("name");
 
     await expect(updateOrganization(makeUpdateDb([]).db as never, "missing", {})).rejects.toThrow(
       'Organization "missing" not found',
     );
-    await expect(
-      updateOrganization(makeUpdateDb([], { cause: { code: "23505" } }).db as never, "org_1", { name: "taken" }),
-    ).rejects.toThrow('Organization name "taken" is already taken');
   });
 
   it("ensures the default organization idempotently", async () => {

--- a/packages/server/src/services/organization.ts
+++ b/packages/server/src/services/organization.ts
@@ -61,28 +61,25 @@ export async function getOrganization(db: Database, id: string) {
   return org;
 }
 
+/**
+ * Update the mutable fields of an organization row. The slug is not among
+ * them, so nothing here can violate a unique constraint and no conflict
+ * handling is needed — see `updateOrganizationSchema` for why the slug has no
+ * update path.
+ */
 export async function updateOrganization(db: Database, id: string, data: UpdateOrganization) {
   const updates: Partial<typeof organizations.$inferInsert> = { updatedAt: new Date() };
-  if (data.name !== undefined) updates.name = data.name;
   if (data.displayName !== undefined) updates.displayName = data.displayName;
   if (data.maxAgents !== undefined) updates.maxAgents = data.maxAgents;
   if (data.maxMessagesPerMinute !== undefined) updates.maxMessagesPerMinute = data.maxMessagesPerMinute;
   if (data.features !== undefined) updates.features = data.features;
 
-  try {
-    const [org] = await db.update(organizations).set(updates).where(eq(organizations.id, id)).returning();
+  const [org] = await db.update(organizations).set(updates).where(eq(organizations.id, id)).returning();
 
-    if (!org) {
-      throw new NotFoundError(`Organization "${id}" not found`);
-    }
-    return org;
-  } catch (err) {
-    const pgCode = (err as { code?: string })?.code ?? (err as { cause?: { code?: string } })?.cause?.code ?? "";
-    if (pgCode === "23505") {
-      throw new ConflictError(`Organization name "${data.name}" is already taken`);
-    }
-    throw err;
+  if (!org) {
+    throw new NotFoundError(`Organization "${id}" not found`);
   }
+  return org;
 }
 
 /**

--- a/packages/shared/src/schemas/organization.ts
+++ b/packages/shared/src/schemas/organization.ts
@@ -24,17 +24,14 @@ export type CreateOrganization = z.infer<typeof createOrganizationSchema>;
 /** Input type (before Zod defaults are applied) — use in service function signatures. */
 export type CreateOrganizationInput = z.input<typeof createOrganizationSchema>;
 
+/**
+ * `name` is intentionally absent. The slug is a server-derived internal
+ * identifier that is unique across the whole deployment, so an update path for
+ * it would let one tenant claim or probe another tenant's slug and would put a
+ * conflict back in front of a user who never chose the value. Provisioning
+ * callers still set it explicitly at creation.
+ */
 export const updateOrganizationSchema = z.object({
-  name: z
-    .string()
-    .min(2)
-    .max(50)
-    .regex(
-      /^[a-z0-9][a-z0-9-]*$/,
-      "Must start with a letter or digit and contain only lowercase alphanumeric and hyphens",
-    )
-    .refine((v) => !UUID_PATTERN.test(v), "Name must not be a UUID format")
-    .optional(),
   displayName: z.string().min(1).max(200).optional(),
   maxAgents: z.number().int().min(0).optional(),
   maxMessagesPerMinute: z.number().int().min(0).optional(),


### PR DESCRIPTION
Follow-up to #2115, which left this open deliberately.

## Problem

`updateOrganizationSchema` still accepted `name`, so `PATCH /orgs/:orgId` could rewrite an organization's slug. No Web surface sends it — both rename affordances patch only `displayName` — but the route is reachable by any Team admin, and Team admin is a product role every member who owns a Team holds, not an operator privilege. Every user is admin of the team auto-created at sign-in.

The slug namespace is global to the deployment, so that update path carried the same cross-tenant shape #2115 just removed from create: an admin could claim a slug another tenant might want, or enumerate which slugs exist by reading 409 against 200.

## Change

- `updateOrganizationSchema` drops `name`. The slug is fixed once the row exists.
- `updateOrganization` drops the corresponding assignment. With no unique column left in the update set, nothing there can raise 23505, so the conflict handler is unreachable and goes with it.
- Provisioning callers are unaffected: `createOrganization` still takes an explicit `name` and still reports a conflict, which is correct for a caller that chose an exact slug.

Requests that still send `name` are not rejected — the Zod object strips the unknown field, so stale clients keep working and simply no longer move the slug.

## Scope notes

`maxAgents`, `maxMessagesPerMinute`, and `features` remain settable through this same admin route. That is a separate and larger question than the slug — `maxAgents` is enforced in `services/agent.ts`, so a Team admin can currently raise their own agent limit — and it is deliberately left alone here rather than folded into a slug change. Flagged for a decision rather than fixed in passing.

## Tests

- `organization-extra.test.ts`: the update case no longer passes `name` and now asserts the built update set never carries one; the unreachable conflict assertion is dropped.
- `me-multi-org.test.ts`: the existing rename step now also sends `name: "squatted-slug"` and asserts the slug is unchanged, so the stripping behaviour is covered end to end through the route.

`pnpm check`, `pnpm typecheck`, server (2858) and shared (779) suites pass.

## Context Tree

Paired tree change: agent-team-foundation/first-tree-context#868 (draft until this merges). #866 recorded the administrative exception as covering both create and update; this narrows it to creation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
