### PR TITLE
feat(cli): add agent-scoped Context Tree IO feed

### DIFF
--- a/apps/cli/src/__tests__/command-registration-smoke.test.ts
+++ b/apps/cli/src/__tests__/command-registration-smoke.test.ts
@@ -127,9 +127,12 @@ describe("CLI command registration", () => {
     // `verify` survived the 2026-06 cleanup, `tree` is the narrow hierarchy
     // browser added back for agents and scripted consumers, and `init` was
     // reintroduced in 2026-07 as the agent/local-`gh` tree-repo creation path;
-    // `review` is the narrow App-backed verdict publisher.
+    // `review` is the narrow App-backed verdict publisher, and `io` is the
+    // agent-scoped durable Context Tree read/write feed a value audit reads
+    // instead of mining local runtime transcripts.
     expect(tree.commands.map((entry) => entry.name()).sort()).toEqual([
       "init",
+      "io",
       "read",
       "review",
       "seed",

--- a/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
+++ b/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
@@ -574,6 +574,7 @@ describe("tree verify strict content policy", () => {
       "verify",
       "tree",
       "read",
+      "io",
       "write",
       "review",
       "seed",

--- a/apps/cli/src/commands/tree/index.ts
+++ b/apps/cli/src/commands/tree/index.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { registerSubcommands } from "../groups.js";
 import type { CommandModule } from "../types.js";
 import { initCommand } from "./init.js";
+import { treeIoCommand } from "./io.js";
 import { treeReadCommand } from "./read.js";
 import { treeReviewCommand } from "./review.js";
 import { treeSeedCommand } from "./seed.js";
@@ -57,6 +58,7 @@ export const treeCommand: CommandModule = {
       verifyCommand,
       treeTreeCommand,
       treeReadCommand,
+      treeIoCommand,
       treeWriteCommand,
       treeReviewCommand,
       treeSeedCommand,

--- a/apps/cli/src/commands/tree/io.ts
+++ b/apps/cli/src/commands/tree/io.ts
@@ -1,10 +1,11 @@
 import { agentContextTreeIoQuerySchema } from "@first-tree/shared";
 import type { Command } from "commander";
 import { isJsonMode, print } from "../../core/output.js";
-import { createMemberSdk } from "../_shared/member.js";
+import { createSdk, handleSdkError } from "../_shared/local-agent.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
 
 type TreeIoOptions = {
+  agent?: string;
   chat?: string;
   action?: string;
   since?: string;
@@ -19,6 +20,7 @@ const MAX_ALL_PAGES = 50;
 
 function configureTreeIoCommand(command: Command): void {
   command
+    .option("--agent <name>", "local agent whose IO feed to read (defaults to FIRST_TREE_AGENT_ID)")
     .option("--chat <chat-id>", "restrict to one Chat")
     .option("--action <action>", "restrict to `read` or `write`")
     .option("--since <rfc3339>", "only events at or after this timestamp")
@@ -43,22 +45,28 @@ export async function runTreeIoCommand(context: CommandContext): Promise<void> {
     throw new Error(`Invalid option: ${issue ? `${issue.path.join(".")} ${issue.message}` : "bad request"}`);
   }
 
-  const sdk = createMemberSdk();
+  // The feed is a Class D route: it needs `X-Agent-Id` plus this agent's
+  // runtime-session proof, which only the agent-scoped SDK attaches.
+  const sdk = createSdk(options.agent);
   const items: unknown[] = [];
   let cursor = parsed.data.cursor;
   let pages = 0;
   let truncated = false;
 
-  do {
-    const page = await sdk.listAgentContextTreeIo({ ...parsed.data, ...(cursor ? { cursor } : {}) });
-    items.push(...page.items);
-    cursor = page.nextCursor ?? undefined;
-    pages += 1;
-    if (options.all && cursor && pages >= MAX_ALL_PAGES) {
-      truncated = true;
-      break;
-    }
-  } while (options.all && cursor);
+  try {
+    do {
+      const page = await sdk.listAgentContextTreeIo({ ...parsed.data, ...(cursor ? { cursor } : {}) });
+      items.push(...page.items);
+      cursor = page.nextCursor ?? undefined;
+      pages += 1;
+      if (options.all && cursor && pages >= MAX_ALL_PAGES) {
+        truncated = true;
+        break;
+      }
+    } while (options.all && cursor);
+  } catch (error) {
+    handleSdkError(error);
+  }
 
   if (context.options.json || isJsonMode()) {
     print.result({

--- a/apps/cli/src/commands/tree/io.ts
+++ b/apps/cli/src/commands/tree/io.ts
@@ -1,0 +1,98 @@
+import { agentContextTreeIoQuerySchema } from "@first-tree/shared";
+import type { Command } from "commander";
+import { isJsonMode, print } from "../../core/output.js";
+import { createMemberSdk } from "../_shared/member.js";
+import type { CommandContext, SubcommandModule } from "../types.js";
+
+type TreeIoOptions = {
+  chat?: string;
+  action?: string;
+  since?: string;
+  until?: string;
+  limit?: string;
+  cursor?: string;
+  all?: boolean;
+};
+
+/** Hard stop on `--all` so one command can never walk an unbounded feed. */
+const MAX_ALL_PAGES = 50;
+
+function configureTreeIoCommand(command: Command): void {
+  command
+    .option("--chat <chat-id>", "restrict to one Chat")
+    .option("--action <action>", "restrict to `read` or `write`")
+    .option("--since <rfc3339>", "only events at or after this timestamp")
+    .option("--until <rfc3339>", "only events at or before this timestamp")
+    .option("--limit <n>", "page size (1-200, default 50)")
+    .option("--cursor <cursor>", "continue from a previous page")
+    .option("--all", "follow pagination and emit every page (bounded)");
+}
+
+export async function runTreeIoCommand(context: CommandContext): Promise<void> {
+  const options = context.command.opts<TreeIoOptions>();
+  const parsed = agentContextTreeIoQuerySchema.safeParse({
+    ...(options.chat ? { chatId: options.chat } : {}),
+    ...(options.action ? { action: options.action } : {}),
+    ...(options.since ? { since: options.since } : {}),
+    ...(options.until ? { until: options.until } : {}),
+    ...(options.limit ? { limit: options.limit } : {}),
+    ...(options.cursor ? { cursor: options.cursor } : {}),
+  });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new Error(`Invalid option: ${issue ? `${issue.path.join(".")} ${issue.message}` : "bad request"}`);
+  }
+
+  const sdk = createMemberSdk();
+  const items: unknown[] = [];
+  let cursor = parsed.data.cursor;
+  let pages = 0;
+  let truncated = false;
+
+  do {
+    const page = await sdk.listAgentContextTreeIo({ ...parsed.data, ...(cursor ? { cursor } : {}) });
+    items.push(...page.items);
+    cursor = page.nextCursor ?? undefined;
+    pages += 1;
+    if (options.all && cursor && pages >= MAX_ALL_PAGES) {
+      truncated = true;
+      break;
+    }
+  } while (options.all && cursor);
+
+  if (context.options.json || isJsonMode()) {
+    print.result({
+      items,
+      nextCursor: cursor ?? null,
+      ...(truncated ? { truncated: true } : {}),
+    });
+    return;
+  }
+
+  if (items.length === 0) {
+    print.line("No Context Tree IO events for this agent in the requested range.");
+    return;
+  }
+  for (const item of items as Array<{
+    createdAt: string;
+    action: string;
+    targetKind: string;
+    targetPath: string;
+    source: string;
+  }>) {
+    print.line(
+      `${item.createdAt}  ${item.action.padEnd(5)}  ${item.targetKind.padEnd(9)}  ${item.targetPath}  (${item.source})`,
+    );
+  }
+  if (cursor) print.line(`\nMore results — continue with --cursor ${cursor}`);
+  if (truncated) print.line(`Stopped after ${MAX_ALL_PAGES} pages; rerun with --cursor to continue.`);
+}
+
+export const treeIoCommand: SubcommandModule = {
+  name: "io",
+  alias: "",
+  summary: "",
+  description: "List this agent's own Context Tree read/write events.",
+  configure: configureTreeIoCommand,
+  action: runTreeIoCommand,
+};

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1249,8 +1249,8 @@ continue to use the public `tree` commands directly.
 
 Context Tree task-read activation, source-backed write and Seed preflight,
 GitHub App-backed review publication, provider-aware creation/adoption,
-structural validation, and hierarchy browsing. The `tree` namespace carries `read`, `write`, `review`, `seed`,
-`verify`, `tree`, and `init`; the rest (`migrate` / `upgrade` / `status` /
+structural validation, hierarchy browsing, and durable IO readback. The `tree` namespace carries `read`, `write`, `review`, `seed`,
+`verify`, `tree`, `init`, and `io`; the rest (`migrate` / `upgrade` / `status` /
 `codeowners` / `claude-hook` / `inject` / `automation` / `skill` groups) was
 retired in the 2026-06 cleanup because the cloud now owns workspace + tree
 provisioning and the client runtime inlines its own skill payload install.
@@ -1269,7 +1269,10 @@ first-tree tree
 │        [--confirm-source URL] \
 │        [--expected-source-key KEY]          # preflight and optional Admin-confirmed source batch
 ├── verify [--tree-path PATH]                # validate a Context Tree repo
-└── tree [path] [-L depth] [-P pattern]      # browse Context Tree nodes as a hierarchy
+├── tree [path] [-L depth] [-P pattern]      # browse Context Tree nodes as a hierarchy
+└── io [--chat ID] [--action read|write] \
+│      [--since TS] [--until TS] \
+│      [--limit N] [--cursor C] [--all]    # this agent's own Context Tree read/write events
 ```
 
 `first-tree tree read` is the BYO Working Agent activation boundary for one
@@ -1735,6 +1738,33 @@ structured nodes with `kind`, `name`, `relativePath`, `depth`, `metadata`,
 `description`, and `owners`. Human tree text and branch warnings are not
 written to stderr in JSON mode, so stdout stays reserved for machine-readable
 JSON.
+
+`first-tree tree io` lists the **calling agent's own** durable Context Tree
+read/write events. It is the supported way to recover which tree nodes an agent
+actually opened, instead of mining local runtime transcripts. The underlying
+`context_tree_io_events` rows are recorded at tool-execution time across every
+runtime and deliberately outlive session timeline rows, which are dropped when a
+session is terminated or its agent switches runtime.
+
+This command speaks on the runtime agent's behalf: it resolves the local agent
+(`--agent <name>`, otherwise `FIRST_TREE_AGENT_ID`) and sends that agent's
+selector plus its runtime-session proof. It is self-scoped by construction — an
+agent reads its own IO and never another agent's. Team-wide aggregation stays on
+the member-authenticated Context Tree snapshot surface.
+
+Filters are `--chat`, `--action read|write`, `--since`, and `--until`
+(RFC 3339). `--limit` accepts 1-200 and defaults to 50. Results are newest
+first, paginated by an opaque `--cursor`; human mode prints the continuation
+cursor when more results exist. `--all` follows pagination automatically but
+stops after 50 pages and says so, so one invocation can never walk an unbounded
+feed.
+
+Human output is one line per event: timestamp, action, target kind, target
+path, and derivation source. JSON mode returns `{ items, nextCursor }`, adding
+`truncated: true` when `--all` hit its page bound. Each item carries
+`treeHeadCommit` when the runtime observed one, which identifies the candidate
+commit for recovering the node content that was read; it is not a claim that a
+dirty working file matched that commit.
 
 ## Environment variables
 

--- a/packages/client/src/__tests__/sdk-context-tree-io.test.ts
+++ b/packages/client/src/__tests__/sdk-context-tree-io.test.ts
@@ -66,6 +66,18 @@ describe("FirstTreeHubSDK.listAgentContextTreeIo", () => {
     expect(headers.get("authorization")).toBe("Bearer member-jwt");
   });
 
+  it("accepts a filter without an explicit limit and still defers to the server default", async () => {
+    const fetchMock = stubFeed();
+    // Regression: the options type must be the schema INPUT type. With the
+    // parsed output type, `limit` is required by its `.default(50)` and this
+    // call would not compile even though the server supplies the default.
+    await agentSdk().listAgentContextTreeIo({ action: "read" });
+
+    const url = requestedUrl(fetchMock);
+    expect(url.searchParams.get("action")).toBe("read");
+    expect(url.searchParams.has("limit")).toBe(false);
+  });
+
   it("omits the query string entirely when no filter is supplied", async () => {
     const fetchMock = stubFeed();
     await agentSdk().listAgentContextTreeIo();

--- a/packages/client/src/__tests__/sdk-context-tree-io.test.ts
+++ b/packages/client/src/__tests__/sdk-context-tree-io.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FirstTreeHubSDK } from "../sdk.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function stubFeed() {
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response(JSON.stringify({ items: [], nextCursor: null }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  globalThis.fetch = fetchMock;
+  return fetchMock;
+}
+
+function agentSdk() {
+  return new FirstTreeHubSDK({
+    serverUrl: "https://cloud.example",
+    getAccessToken: () => "member-jwt",
+    agentId: "agent/auditor",
+    runtimeSessionToken: "runtime-proof",
+  });
+}
+
+function requestedUrl(fetchMock: ReturnType<typeof stubFeed>): URL {
+  const [input] = fetchMock.mock.calls[0] ?? [];
+  return new URL(typeof input === "string" ? input : String(input));
+}
+
+describe("FirstTreeHubSDK.listAgentContextTreeIo", () => {
+  it("serializes every filter onto the request URL", async () => {
+    const fetchMock = stubFeed();
+    await agentSdk().listAgentContextTreeIo({
+      chatId: "chat-1",
+      action: "read",
+      since: "2026-07-01T00:00:00Z",
+      until: "2026-07-31T00:00:00Z",
+      limit: 25,
+      cursor: "cursor-1",
+    });
+
+    const url = requestedUrl(fetchMock);
+    expect(url.pathname).toBe("/api/v1/agent/context-tree/io");
+    expect(url.searchParams.get("chatId")).toBe("chat-1");
+    expect(url.searchParams.get("action")).toBe("read");
+    expect(url.searchParams.get("since")).toBe("2026-07-01T00:00:00Z");
+    expect(url.searchParams.get("until")).toBe("2026-07-31T00:00:00Z");
+    expect(url.searchParams.get("limit")).toBe("25");
+    expect(url.searchParams.get("cursor")).toBe("cursor-1");
+  });
+
+  it("sends the agent selector and runtime-session proof the Class D route requires", async () => {
+    const fetchMock = stubFeed();
+    await agentSdk().listAgentContextTreeIo({ limit: 10 });
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("x-agent-id")).toBe("agent/auditor");
+    expect(headers.get("x-agent-runtime-session")).toBe("runtime-proof");
+    expect(headers.get("authorization")).toBe("Bearer member-jwt");
+  });
+
+  it("omits the query string entirely when no filter is supplied", async () => {
+    const fetchMock = stubFeed();
+    await agentSdk().listAgentContextTreeIo();
+
+    const url = requestedUrl(fetchMock);
+    expect(url.search).toBe("");
+    expect(url.pathname).toBe("/api/v1/agent/context-tree/io");
+  });
+});

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -3,7 +3,7 @@ import {
   AGENT_RUNTIME_SESSION_HEADER,
   AGENT_SELECTOR_HEADER,
   type Agent,
-  type AgentContextTreeIoQuery,
+  type AgentContextTreeIoQueryInput,
   type AgentContextTreeIoResponse,
   type AgentRuntimeConfig,
   type AgentVisibility,
@@ -831,7 +831,7 @@ export class FirstTreeHubSDK {
    * answer "which nodes did this agent actually open, and when" for historical
    * work without scanning local runtime transcripts.
    */
-  async listAgentContextTreeIo(options?: AgentContextTreeIoQuery): Promise<AgentContextTreeIoResponse> {
+  async listAgentContextTreeIo(options?: AgentContextTreeIoQueryInput): Promise<AgentContextTreeIoResponse> {
     // Built here rather than through `queryString()`, which serializes only
     // `limit` / `cursor`. Every filter below must reach the server, otherwise
     // a caller that asked for one chat silently receives the whole feed.

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -3,6 +3,8 @@ import {
   AGENT_RUNTIME_SESSION_HEADER,
   AGENT_SELECTOR_HEADER,
   type Agent,
+  type AgentContextTreeIoQuery,
+  type AgentContextTreeIoResponse,
   type AgentRuntimeConfig,
   type AgentVisibility,
   type ArchiveChatResponse,
@@ -820,6 +822,17 @@ export class FirstTreeHubSDK {
   /** Read the live bound Tree plus Reviewer assignment as one runtime tuple. */
   async getAgentContextReviewConfig(): Promise<ContextReviewRuntimeConfig> {
     return this.requestJson<ContextReviewRuntimeConfig>("/api/v1/agent/context-tree/info");
+  }
+
+  /**
+   * Read this authenticated agent's own durable Context Tree read/write facts.
+   *
+   * `context_tree_io_events` outlives `session_events`, so a value audit can
+   * answer "which nodes did this agent actually open, and when" for historical
+   * work without scanning local runtime transcripts.
+   */
+  async listAgentContextTreeIo(options?: AgentContextTreeIoQuery): Promise<AgentContextTreeIoResponse> {
+    return this.requestJson<AgentContextTreeIoResponse>(`/api/v1/agent/context-tree/io${this.queryString(options)}`);
   }
 
   /** Bind Context Tree configuration for this SDK's authenticated agent organization. */

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -832,7 +832,18 @@ export class FirstTreeHubSDK {
    * work without scanning local runtime transcripts.
    */
   async listAgentContextTreeIo(options?: AgentContextTreeIoQuery): Promise<AgentContextTreeIoResponse> {
-    return this.requestJson<AgentContextTreeIoResponse>(`/api/v1/agent/context-tree/io${this.queryString(options)}`);
+    // Built here rather than through `queryString()`, which serializes only
+    // `limit` / `cursor`. Every filter below must reach the server, otherwise
+    // a caller that asked for one chat silently receives the whole feed.
+    const params = new URLSearchParams();
+    if (options?.chatId) params.set("chatId", options.chatId);
+    if (options?.action) params.set("action", options.action);
+    if (options?.since) params.set("since", options.since);
+    if (options?.until) params.set("until", options.until);
+    if (options?.limit !== undefined) params.set("limit", String(options.limit));
+    if (options?.cursor) params.set("cursor", options.cursor);
+    const query = params.toString();
+    return this.requestJson<AgentContextTreeIoResponse>(`/api/v1/agent/context-tree/io${query ? `?${query}` : ""}`);
   }
 
   /** Bind Context Tree configuration for this SDK's authenticated agent organization. */

--- a/packages/server/src/__tests__/agent-context-tree-io.test.ts
+++ b/packages/server/src/__tests__/agent-context-tree-io.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { chats } from "../db/schema/chats.js";
+import { contextTreeIoEvents } from "../db/schema/context-tree-io-events.js";
+import { listAgentContextTreeIoEvents } from "../services/context-tree-io.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+const TREE_REPO = "https://github.com/acme/first-tree-context.git";
+const getApp = useTestApp();
+
+type SeededEvent = {
+  chatId: string;
+  action: "read" | "write";
+  targetPath: string;
+  createdAt: Date;
+  headCommit?: string;
+};
+
+async function seedAgentWithEvents(events: SeededEvent[]) {
+  const app = getApp();
+  const seed = await createTestAgent(app);
+  const chatIds = [...new Set(events.map((event) => event.chatId))];
+  for (const chatId of chatIds) {
+    await app.db.insert(chats).values({ id: chatId, organizationId: seed.organizationId, type: "direct", topic: "io" });
+  }
+  let index = 0;
+  for (const event of events) {
+    index += 1;
+    await app.db.insert(contextTreeIoEvents).values({
+      id: `io-${seed.agent.uuid}-${index}`,
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      chatId: event.chatId,
+      sourceSessionEventId: `se-${seed.agent.uuid}-${index}`,
+      sourceIndex: 0,
+      runtimeProvider: "claude-code",
+      action: event.action,
+      source: event.action === "read" ? "claude_read_tool" : "claude_write_tool",
+      treeRepoUrl: TREE_REPO,
+      treeBranch: "main",
+      targetKind: "file",
+      targetPath: event.targetPath,
+      metadata: event.headCommit ? { repoHeadCommit: event.headCommit } : {},
+      createdAt: event.createdAt,
+    });
+  }
+  return seed;
+}
+
+const at = (iso: string) => new Date(iso);
+
+describe("agent-scoped Context Tree IO feed", () => {
+  it("returns only the calling agent's own events, newest first", async () => {
+    const app = getApp();
+    const chatId = `chat-${crypto.randomUUID()}`;
+    const seed = await seedAgentWithEvents([
+      { chatId, action: "read", targetPath: "system/a.md", createdAt: at("2026-07-01T10:00:00Z") },
+      { chatId, action: "read", targetPath: "system/b.md", createdAt: at("2026-07-01T12:00:00Z") },
+    ]);
+    // A second agent's events must never leak into the first agent's feed.
+    const other = await seedAgentWithEvents([
+      {
+        chatId: `chat-${crypto.randomUUID()}`,
+        action: "read",
+        targetPath: "other/x.md",
+        createdAt: at("2026-07-01T11:00:00Z"),
+      },
+    ]);
+    expect(other.agent.uuid).not.toBe(seed.agent.uuid);
+
+    const result = await listAgentContextTreeIoEvents(app.db, {
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      limit: 50,
+    });
+
+    expect(result.items.map((item) => item.targetPath)).toEqual(["system/b.md", "system/a.md"]);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("filters by chat, action, and time window", async () => {
+    const app = getApp();
+    const chatA = `chat-${crypto.randomUUID()}`;
+    const chatB = `chat-${crypto.randomUUID()}`;
+    const seed = await seedAgentWithEvents([
+      { chatId: chatA, action: "read", targetPath: "a/early.md", createdAt: at("2026-07-01T00:00:00Z") },
+      { chatId: chatA, action: "read", targetPath: "a/mid.md", createdAt: at("2026-07-05T00:00:00Z") },
+      { chatId: chatA, action: "write", targetPath: "a/written.md", createdAt: at("2026-07-05T01:00:00Z") },
+      { chatId: chatB, action: "read", targetPath: "b/other.md", createdAt: at("2026-07-05T02:00:00Z") },
+    ]);
+    const base = { organizationId: seed.organizationId, agentId: seed.agent.uuid, limit: 50 };
+
+    const byChat = await listAgentContextTreeIoEvents(app.db, { ...base, chatId: chatA });
+    expect(byChat.items).toHaveLength(3);
+
+    const readsOnly = await listAgentContextTreeIoEvents(app.db, { ...base, chatId: chatA, action: "read" });
+    expect(readsOnly.items.map((item) => item.targetPath)).toEqual(["a/mid.md", "a/early.md"]);
+
+    const windowed = await listAgentContextTreeIoEvents(app.db, {
+      ...base,
+      since: at("2026-07-02T00:00:00Z"),
+      until: at("2026-07-05T01:30:00Z"),
+    });
+    expect(windowed.items.map((item) => item.targetPath)).toEqual(["a/written.md", "a/mid.md"]);
+  });
+
+  it("paginates without dropping or repeating a row", async () => {
+    const app = getApp();
+    const chatId = `chat-${crypto.randomUUID()}`;
+    const seed = await seedAgentWithEvents(
+      Array.from({ length: 5 }, (_, index) => ({
+        chatId,
+        action: "read" as const,
+        targetPath: `n/${index}.md`,
+        createdAt: at(`2026-07-0${index + 1}T00:00:00Z`),
+      })),
+    );
+    const base = { organizationId: seed.organizationId, agentId: seed.agent.uuid };
+
+    const first = await listAgentContextTreeIoEvents(app.db, { ...base, limit: 2 });
+    expect(first.items).toHaveLength(2);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await listAgentContextTreeIoEvents(app.db, {
+      ...base,
+      limit: 10,
+      cursor: first.nextCursor ?? undefined,
+    });
+    const seen = [...first.items, ...second.items].map((item) => item.targetPath);
+    expect(seen).toEqual(["n/4.md", "n/3.md", "n/2.md", "n/1.md", "n/0.md"]);
+    expect(new Set(seen).size).toBe(5);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  it("surfaces the observed head commit only when it is a valid sha", async () => {
+    const app = getApp();
+    const chatId = `chat-${crypto.randomUUID()}`;
+    const commit = "0123456789abcdef0123456789abcdef01234567";
+    const seed = await seedAgentWithEvents([
+      { chatId, action: "read", targetPath: "with.md", createdAt: at("2026-07-02T00:00:00Z"), headCommit: commit },
+      { chatId, action: "read", targetPath: "without.md", createdAt: at("2026-07-01T00:00:00Z") },
+      { chatId, action: "read", targetPath: "bogus.md", createdAt: at("2026-06-30T00:00:00Z"), headCommit: "nope" },
+    ]);
+
+    const result = await listAgentContextTreeIoEvents(app.db, {
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      limit: 50,
+    });
+    expect(result.items.map((item) => [item.targetPath, item.treeHeadCommit])).toEqual([
+      ["with.md", commit],
+      ["without.md", null],
+      ["bogus.md", null],
+    ]);
+  });
+
+  it("rejects a malformed cursor instead of silently returning page one", async () => {
+    const app = getApp();
+    const seed = await createTestAgent(app);
+    await expect(
+      listAgentContextTreeIoEvents(app.db, {
+        organizationId: seed.organizationId,
+        agentId: seed.agent.uuid,
+        limit: 10,
+        cursor: "not-a-cursor",
+      }),
+    ).rejects.toThrow(/Invalid Context Tree IO cursor/);
+  });
+
+  it("serves the agent route and rejects an inverted time window", async () => {
+    const app = getApp();
+    const chatId = `chat-${crypto.randomUUID()}`;
+    const seed = await seedAgentWithEvents([
+      { chatId, action: "read", targetPath: "route/a.md", createdAt: at("2026-07-01T10:00:00Z") },
+    ]);
+
+    const ok = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/context-tree/io?limit=10",
+      headers: { authorization: `Bearer ${seed.accessToken}`, "x-agent-id": seed.agent.uuid },
+    });
+    expect(ok.statusCode).toBe(200);
+    const body = ok.json() as { items: Array<{ targetPath: string }>; nextCursor: string | null };
+    expect(body.items.map((item) => item.targetPath)).toEqual(["route/a.md"]);
+    expect(body.nextCursor).toBeNull();
+
+    const inverted = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/context-tree/io?since=2026-07-05T00:00:00Z&until=2026-07-01T00:00:00Z",
+      headers: { authorization: `Bearer ${seed.accessToken}`, "x-agent-id": seed.agent.uuid },
+    });
+    expect(inverted.statusCode).toBe(400);
+  });
+
+  it("requires agent authentication", async () => {
+    const app = getApp();
+    const res = await app.inject({ method: "GET", url: "/api/v1/agent/context-tree/io" });
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/packages/server/src/api/agent/context-tree-io.ts
+++ b/packages/server/src/api/agent/context-tree-io.ts
@@ -1,0 +1,43 @@
+import { agentContextTreeIoQuerySchema } from "@first-tree/shared";
+import type { FastifyInstance } from "fastify";
+import { BadRequestError } from "../../errors.js";
+import { requireAgent } from "../../middleware/require-identity.js";
+import { listAgentContextTreeIoEvents } from "../../services/context-tree-io.js";
+
+export async function agentContextTreeIoRoutes(app: FastifyInstance): Promise<void> {
+  /**
+   * Class D — `GET /api/v1/agent/context-tree/io`.
+   *
+   * The authenticated runtime agent's own durable Context Tree read/write
+   * facts, newest first. `context_tree_io_events` outlives `session_events`
+   * (dropped on session terminate / runtime switch), so this stays answerable
+   * for historical work whose surrounding decision stream is already gone.
+   *
+   * Deliberately self-scoped: an agent reads its own IO, never another
+   * agent's. Org-wide aggregation stays on the member-authenticated
+   * `/orgs/:orgId/context-tree/snapshot` endpoint.
+   */
+  app.get("/context-tree/io", async (request) => {
+    const identity = requireAgent(request);
+    const parsed = agentContextTreeIoQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      throw new BadRequestError(`Invalid Context Tree IO query: ${parsed.error.issues[0]?.message ?? "bad request"}`);
+    }
+    const query = parsed.data;
+    const since = query.since ? new Date(query.since) : undefined;
+    const until = query.until ? new Date(query.until) : undefined;
+    if (since && until && since > until) {
+      throw new BadRequestError("Context Tree IO `since` must not be after `until`");
+    }
+    return await listAgentContextTreeIoEvents(app.db, {
+      organizationId: identity.organizationId,
+      agentId: identity.uuid,
+      chatId: query.chatId,
+      action: query.action,
+      since,
+      until,
+      limit: query.limit,
+      cursor: query.cursor,
+    });
+  });
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -15,6 +15,7 @@ import { agentChatRoutes } from "./api/agent/chats.js";
 import { agentConfigRoutes as agentRuntimeConfigRoutes } from "./api/agent/config.js";
 import { agentContextReviewRunRoutes } from "./api/agent/context-review-runs.js";
 import { agentContextTreeInfoRoutes } from "./api/agent/context-tree-info.js";
+import { agentContextTreeIoRoutes } from "./api/agent/context-tree-io.js";
 import { agentCronJobRoutes } from "./api/agent/cron-jobs.js";
 import { agentDocumentRoutes } from "./api/agent/documents.js";
 import { agentGithubTaskRunRoutes } from "./api/agent/github-task-runs.js";
@@ -645,6 +646,7 @@ export async function buildApp(config: Config, options: BuildAppOptions = {}) {
           await scope.register(agentInboxRoutes, { prefix: "/inbox" });
           await scope.register(agentRuntimeConfigRoutes);
           await scope.register(agentContextTreeInfoRoutes);
+          await scope.register(agentContextTreeIoRoutes);
           if (config.docs.enabled) {
             await scope.register(agentDocumentRoutes);
           }

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -1,5 +1,6 @@
 import { posix } from "node:path";
 import {
+  type AgentContextTreeIoEvent,
   type ContextTreeIoAction,
   type ContextTreeIoBucket,
   type ContextTreeIoEvent,
@@ -18,13 +19,14 @@ import {
   type ToolFileRef,
   toolFileRefSchema,
 } from "@first-tree/shared";
-import { and, eq, gte, inArray, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lt, lte, or, type SQL, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { contextTreeIoEvents } from "../db/schema/context-tree-io-events.js";
 import { sessionEvents } from "../db/schema/session-events.js";
+import { BadRequestError } from "../errors.js";
 import { createLogger } from "../observability/index.js";
 import { type TimingSink, timeSyncWithSink, timeWithSink } from "../observability/timing.js";
 import { getOrgContextTreeBinding } from "./org-settings.js";
@@ -1218,4 +1220,112 @@ export async function buildContextTreeIoSummary(
     reconcileContextTreeWrites(db, organizationId, windowDays, gitWrites, downstreamOptions),
   );
   return { ...io, writes, writesTotal: writes.length };
+}
+
+/**
+ * Agent-scoped Context Tree IO feed.
+ *
+ * Returns only the calling agent's own durable IO facts, newest first. This is
+ * the read path a value audit uses instead of scanning local runtime
+ * transcripts: `context_tree_io_events` outlives `session_events` (which are
+ * dropped on session terminate / runtime switch), so historical exposure stays
+ * answerable even when the surrounding decision stream is gone.
+ *
+ * Org-wide aggregation deliberately stays on the member-authenticated snapshot
+ * endpoint — a runtime agent may read its own IO, never another agent's.
+ */
+export type AgentContextTreeIoListOptions = {
+  organizationId: string;
+  agentId: string;
+  chatId?: string;
+  action?: ContextTreeIoAction;
+  since?: Date;
+  until?: Date;
+  limit: number;
+  cursor?: string;
+};
+
+type AgentContextTreeIoCursor = { createdAt: Date; id: string };
+
+function encodeIoCursor(row: { createdAt: Date; id: string }): string {
+  return Buffer.from(`${row.createdAt.toISOString()}|${row.id}`, "utf8").toString("base64url");
+}
+
+function decodeIoCursor(cursor: string): AgentContextTreeIoCursor {
+  const raw = Buffer.from(cursor, "base64url").toString("utf8");
+  const separator = raw.indexOf("|");
+  if (separator <= 0) throw new BadRequestError("Invalid Context Tree IO cursor");
+  const createdAt = new Date(raw.slice(0, separator));
+  const id = raw.slice(separator + 1);
+  if (Number.isNaN(createdAt.getTime()) || id.length === 0) {
+    throw new BadRequestError("Invalid Context Tree IO cursor");
+  }
+  return { createdAt, id };
+}
+
+export async function listAgentContextTreeIoEvents(
+  db: Database,
+  options: AgentContextTreeIoListOptions,
+): Promise<{ items: AgentContextTreeIoEvent[]; nextCursor: string | null }> {
+  const filters = [
+    eq(contextTreeIoEvents.organizationId, options.organizationId),
+    eq(contextTreeIoEvents.agentId, options.agentId),
+  ];
+  if (options.chatId) filters.push(eq(contextTreeIoEvents.chatId, options.chatId));
+  if (options.action) filters.push(eq(contextTreeIoEvents.action, options.action));
+  if (options.since) filters.push(gte(contextTreeIoEvents.createdAt, options.since));
+  if (options.until) filters.push(lte(contextTreeIoEvents.createdAt, options.until));
+  if (options.cursor) {
+    // Keyset pagination over the same (created_at DESC, id DESC) order the
+    // query sorts by, so a row inserted mid-scan can never shift a page.
+    const cursor = decodeIoCursor(options.cursor);
+    filters.push(
+      or(
+        lt(contextTreeIoEvents.createdAt, cursor.createdAt),
+        and(eq(contextTreeIoEvents.createdAt, cursor.createdAt), lt(contextTreeIoEvents.id, cursor.id)),
+      ) as SQL,
+    );
+  }
+
+  const rows = await db
+    .select({
+      id: contextTreeIoEvents.id,
+      chatId: contextTreeIoEvents.chatId,
+      action: contextTreeIoEvents.action,
+      source: contextTreeIoEvents.source,
+      runtimeProvider: contextTreeIoEvents.runtimeProvider,
+      targetKind: contextTreeIoEvents.targetKind,
+      targetPath: contextTreeIoEvents.targetPath,
+      treeRepoUrl: contextTreeIoEvents.treeRepoUrl,
+      treeBranch: contextTreeIoEvents.treeBranch,
+      metadata: contextTreeIoEvents.metadata,
+      createdAt: contextTreeIoEvents.createdAt,
+    })
+    .from(contextTreeIoEvents)
+    .where(and(...filters))
+    .orderBy(desc(contextTreeIoEvents.createdAt), desc(contextTreeIoEvents.id))
+    .limit(options.limit + 1);
+
+  const hasMore = rows.length > options.limit;
+  const page = hasMore ? rows.slice(0, options.limit) : rows;
+  const last = page[page.length - 1];
+  return {
+    items: page.map((row) => {
+      const headCommit = row.metadata?.repoHeadCommit;
+      return {
+        id: row.id,
+        chatId: row.chatId,
+        action: row.action as ContextTreeIoAction,
+        source: row.source as ContextTreeIoSource,
+        runtimeProvider: row.runtimeProvider,
+        targetKind: row.targetKind as ContextTreeIoTargetKind,
+        targetPath: row.targetPath,
+        treeRepoUrl: row.treeRepoUrl,
+        treeBranch: row.treeBranch,
+        treeHeadCommit: typeof headCommit === "string" && /^[0-9a-f]{40}$/.test(headCommit) ? headCommit : null,
+        createdAt: row.createdAt.toISOString(),
+      };
+    }),
+    nextCursor: hasMore && last ? encodeIoCursor(last) : null,
+  };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -469,6 +469,7 @@ export {
 export {
   type AgentContextTreeIoEvent,
   type AgentContextTreeIoQuery,
+  type AgentContextTreeIoQueryInput,
   type AgentContextTreeIoResponse,
   agentContextTreeIoEventSchema,
   agentContextTreeIoQuerySchema,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -467,6 +467,12 @@ export {
   contextReviewerEnablementInputSchema,
 } from "./schemas/context-reviewer-settings.js";
 export {
+  type AgentContextTreeIoEvent,
+  type AgentContextTreeIoQuery,
+  type AgentContextTreeIoResponse,
+  agentContextTreeIoEventSchema,
+  agentContextTreeIoQuerySchema,
+  agentContextTreeIoResponseSchema,
   CONTEXT_TREE_CHANGE_TYPES,
   CONTEXT_TREE_EDGE_KINDS,
   CONTEXT_TREE_NODE_KINDS,

--- a/packages/shared/src/schemas/context-tree.ts
+++ b/packages/shared/src/schemas/context-tree.ts
@@ -487,6 +487,10 @@ export const agentContextTreeIoQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(200).default(50),
   cursor: z.string().min(1).optional(),
 });
+// Caller input: `limit` carries a schema default, so the parsed OUTPUT type
+// makes it required. Consumers building a query must be able to omit it.
+export type AgentContextTreeIoQueryInput = z.input<typeof agentContextTreeIoQuerySchema>;
+// Parsed output, where `limit` is always a concrete number.
 export type AgentContextTreeIoQuery = z.infer<typeof agentContextTreeIoQuerySchema>;
 
 export const agentContextTreeIoEventSchema = z.object({

--- a/packages/shared/src/schemas/context-tree.ts
+++ b/packages/shared/src/schemas/context-tree.ts
@@ -474,3 +474,44 @@ export const contextTreeInstallationInfoResponseSchema = z.object({
   suspended: z.boolean(),
 });
 export type ContextTreeInstallationInfoResponse = z.infer<typeof contextTreeInstallationInfoResponseSchema>;
+
+// Agent-scoped Context Tree IO feed. A runtime agent reads back its OWN
+// durable read/write facts so a value audit can join them against the work
+// that followed, without scanning local runtime transcripts. Org-wide
+// aggregation stays on the member-authenticated snapshot endpoint.
+export const agentContextTreeIoQuerySchema = z.object({
+  chatId: z.string().min(1).optional(),
+  action: contextTreeIoActionSchema.optional(),
+  since: z.string().datetime({ offset: true }).optional(),
+  until: z.string().datetime({ offset: true }).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  cursor: z.string().min(1).optional(),
+});
+export type AgentContextTreeIoQuery = z.infer<typeof agentContextTreeIoQuerySchema>;
+
+export const agentContextTreeIoEventSchema = z.object({
+  id: z.string(),
+  chatId: z.string(),
+  action: contextTreeIoActionSchema,
+  source: contextTreeIoSourceSchema,
+  runtimeProvider: z.string(),
+  targetKind: contextTreeIoTargetKindSchema,
+  targetPath: z.string(),
+  treeRepoUrl: z.string(),
+  treeBranch: z.string(),
+  // Local checkout HEAD observed for the event, when the client reported one.
+  // Identifies the candidate snapshot for recovering the node's content; it is
+  // not a claim that a dirty working file matched that commit.
+  treeHeadCommit: z
+    .string()
+    .regex(/^[0-9a-f]{40}$/)
+    .nullable(),
+  createdAt: z.string(),
+});
+export type AgentContextTreeIoEvent = z.infer<typeof agentContextTreeIoEventSchema>;
+
+export const agentContextTreeIoResponseSchema = z.object({
+  items: z.array(agentContextTreeIoEventSchema),
+  nextCursor: z.string().nullable(),
+});
+export type AgentContextTreeIoResponse = z.infer<typeof agentContextTreeIoResponseSchema>;


### PR DESCRIPTION
## Summary

A Context Tree **value audit** needs one fact: which tree nodes did an agent actually open, and when. Today the only way to recover that is to mine local runtime transcripts and statically parse shell commands — expensive, lossy, and limited to the runtimes whose transcripts are complete.

`context_tree_io_events` already records exactly that, durably, at tool-execution time, across every runtime. It is deliberately decoupled from `session_events` (which are dropped on session terminate / runtime switch) so the IO facts survive. It simply had no read path a runtime agent could reach.

This adds that read path.

## What changed

- **Server** — `GET /api/v1/agent/context-tree/io` (Class D, `agentSelector`, per `docs/development/http-path-conventions.md`).
- **Service** — `listAgentContextTreeIoEvents` with keyset pagination over `(created_at DESC, id DESC)`, so a row inserted mid-scan cannot shift a page.
- **Shared** — `agentContextTreeIoQuerySchema` / `agentContextTreeIoEventSchema` / response schema.
- **SDK** — `listAgentContextTreeIo`.
- **CLI** — `first-tree tree io` with `--chat`, `--action`, `--since`, `--until`, `--limit`, `--cursor`, and a bounded `--all`.

`treeHeadCommit` is surfaced (only when it is a valid 40-hex sha) so a consumer can recover the node content that was observed at read time.

## Scope decision

**Self-scoped on purpose:** an agent reads its own IO, never another agent's. Org-wide aggregation stays on the existing member-authenticated `/orgs/:orgId/context-tree/snapshot` endpoint. Filters are query parameters, not an authorization boundary — the boundary is the authenticated agent identity.

## Validation

- [x] `pnpm typecheck` — 11/11 packages
- [x] `pnpm exec biome check` — clean on all touched files
- [x] `pnpm --filter @first-tree/server exec vitest run src/__tests__/agent-context-tree-io.test.ts src/__tests__/context-tree-io.test.ts` — 42 passed (7 new + 35 existing regression)

New tests cover: cross-agent isolation, chat/action/time filtering, pagination with no drops or repeats, `treeHeadCommit` validation, malformed-cursor rejection (fails closed rather than silently returning page one), the HTTP route, inverted-window rejection, and unauthenticated rejection.

## QA risk

Read-only addition on an existing table behind the established Class D auth path. No migration, no write path, no change to how events are recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
