### PR TITLE
docs: document OpenCode runtime setup

### DIFF
--- a/apps/cli/src/commands/_shared/doctor-checks.ts
+++ b/apps/cli/src/commands/_shared/doctor-checks.ts
@@ -17,11 +17,13 @@ import {
 } from "../../core/index.js";
 
 /**
- * Runtime-provider readiness: a launch-verified probe per built-in provider,
- * rendered one CheckResult per provider. This really launches each provider
- * (e.g. a 1-turn haiku query / a `codex doctor` handshake), so it is heavier
- * than the other checks — acceptable for a deliberate diagnostic. Probe
- * failures are captured per-provider (never thrown), so this never rejects.
+ * Runtime-provider readiness: a resolve-only capability detection per built-in
+ * provider, rendered one CheckResult per provider. Detection only locates each
+ * provider's executable and checks platform support — it never launches the
+ * provider, checks authentication, or makes model calls, so it stays cheap;
+ * provider credentials are validated on the first real provider turn.
+ * Detection failures are captured per-provider (never thrown), so this never
+ * rejects.
  */
 export async function checkRuntimeProviders(): Promise<CheckResult[]> {
   return runtimeProviderChecks(await probeCapabilities());

--- a/apps/cli/src/commands/daemon/probe.ts
+++ b/apps/cli/src/commands/daemon/probe.ts
@@ -13,18 +13,20 @@ import {
 import { isJsonMode, print } from "../../core/output.js";
 
 /**
- * `daemon probe` — run the launch-verified capability probes on demand.
+ * `daemon probe` — re-detect runtime-provider capabilities on demand.
  *
  * The daemon refreshes capabilities automatically (at startup, on every WS
  * reconnect, and via a bounded background poll while any provider is non-`ok`),
- * so installing / logging into a provider is normally noticed without operator
- * action. This command is the immediate, on-demand path — it forces a full
- * re-probe + upload right now (instead of waiting for the next backed-off poll)
- * and surfaces the real, verbatim probe result locally. Each probe really
- * launches its provider (a 1-turn haiku query / a `codex doctor` handshake), so
- * this is not free.
+ * so installing a provider is normally noticed without operator action. This
+ * command is the immediate, on-demand path — it forces a full re-detection +
+ * upload right now (instead of waiting for the next backed-off poll) and
+ * surfaces the real, verbatim detection result locally. Detection is
+ * resolve-only: it locates each provider's executable and checks platform
+ * support without launching the provider, checking authentication, or making
+ * model calls, so it is cheap and token-free. Provider credentials are
+ * validated later, on the first real provider turn.
  *
- * Probing is purely local and needs no First Tree credentials; only the
+ * Detection is purely local and needs no First Tree credentials; only the
  * (default) upload step requires a logged-in client. So `--no-upload` runs as
  * a credentials-free local diagnostic. `--json` (or the global `--json`) emits
  * the capability snapshot as the machine-readable `{ ok, data }` envelope on
@@ -33,17 +35,18 @@ import { isJsonMode, print } from "../../core/output.js";
 export function registerDaemonProbeCommand(daemon: Command): void {
   daemon
     .command("probe")
-    .description("Launch-probe local runtime providers and upload the result to the server")
-    .option("--no-upload", "Run the probes and print results without uploading to the server")
+    .description("Re-detect local runtime provider capabilities and upload the result to the server")
+    .option("--no-upload", "Run capability detection and print results without uploading to the server")
     .option("--json", "Emit the capability snapshot as a machine-readable JSON envelope on stdout")
     .action(async (options: { upload?: boolean; json?: boolean }) => {
       const binName = channelConfig.binName;
       const wantJson = options.json === true || isJsonMode();
 
-      // Probing is purely local — it needs no First Tree credentials or client
-      // config, so the local-only (`--no-upload`) path works on a machine that
-      // has never logged in.
-      if (!wantJson) print.line("\n  Probing runtime providers (each provider is launched for real)...\n\n");
+      // Detection is purely local — it needs no First Tree credentials or
+      // client config, so the local-only (`--no-upload`) path works on a
+      // machine that has never logged in.
+      if (!wantJson)
+        print.line("\n  Detecting runtime provider capabilities (resolve-only; no provider is launched)...\n\n");
       const capabilities = await probeCapabilities();
 
       // The human report renders immediately; the JSON success envelope is

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -241,13 +241,15 @@ needed if the daemon is already up.
 `--runtime` defaults to `claude-code`. The `opencode` runtime uses an
 operator-installed OpenCode CLI (`>=1.18.7 <2.0.0`) on macOS or Linux. Install
 it with `npm install -g opencode-ai@^1.18.7`, complete provider-owned
-authentication with `opencode auth login`, then run `first-tree daemon probe`
-to refresh the machine's advertised capabilities. First Tree never reads or
-relays OpenCode provider credentials. The capability probe resolves the
-executable and checks platform support; the first provider turn performs the
-compatible-version and database-readiness gates. Windows reports a resolved
-OpenCode binary for diagnostics but does not advertise it as available until
-the Client has the required pre-admission Job Object supervisor.
+authentication with `opencode auth login`, and run `first-tree daemon probe`
+after installation to force immediate artifact/platform re-detection and
+upload the machine's advertised capabilities. First Tree never reads or relays
+OpenCode provider credentials. The probe does not inspect authentication or
+provider reachability; the first provider turn validates credentials and
+performs the compatible-version and database-readiness gates. Windows reports
+a resolved OpenCode binary for diagnostics but does not advertise it as
+available until the Client has the required pre-admission Job Object
+supervisor.
 
 ### agent add
 
@@ -1018,9 +1020,9 @@ first-tree daemon
 | `stop` | Stop the service (preserves auto-start; bring it back with `start`). |
 | `restart` | Restart the service. |
 | `status` | Local service state + authoritative daemon owner + server binding + auth health. Runs in well under a second. |
-| `doctor` | Walk Node version, config, server reachability, WS, agent registrations, the installed service file, the authoritative daemon owner lock, **and the runtime providers** — each step reported. The runtime-provider rows run the real launch-verified probe (a 1-turn model call for `claude-code`, a `codex doctor` handshake for `codex`), so `doctor` makes live provider calls; it is a deliberate diagnostic, not a hot path. |
+| `doctor` | Walk Node version, config, server reachability, WS, agent registrations, the installed service file, the authoritative daemon owner lock, **and the runtime providers** — each step reported. Runtime-provider rows use the same artifact/platform capability detection as `daemon probe`; they do not launch providers, inspect authentication, or test provider reachability. |
 | `repair-ownership` | Reconcile an interrupted fenced ownership mutation. The command elects one repair process through per-instance ticket slots, atomically acquires a canonical repair guard, requires strict PID/start-identity proof that the exact fence owner is gone or reused, drains published startup entrants, and refuses live, malformed, unverifiable, changed, or ambiguous evidence. It never blindly deletes a fence. |
-| `probe` | Launch-probe the local runtime providers on demand and upload the result to the server (`PATCH /clients/:id/capabilities`). This is the manual refresh for a client's advertised capabilities after a provider is installed / logged in. Each probe really launches its provider. `--no-upload` runs a **credentials-free local-only** diagnostic (probe + print, no server auth needed). `--json` (or the global `--json`) emits the capability snapshot as the machine-readable `{ ok, data }` envelope on stdout. |
+| `probe` | Re-detect local runtime artifacts and platform execution support on demand, then upload the result to the server (`PATCH /clients/:id/capabilities`). This is the manual immediate refresh for a client's advertised capabilities after a provider is installed; it does not launch providers, inspect authentication, or test provider reachability. `--no-upload` runs a **credentials-free local-only** diagnostic (detect + print, no server auth needed). `--json` (or the global `--json`) emits the capability snapshot as the machine-readable `{ ok, data }` envelope on stdout. |
 | `install-codex` | Install the native Codex runtime engine on this machine (`npm install -g @openai/codex`). First Tree does not bundle the ~225MB native `codex` binary by default — the runtime resolves an external `codex` from PATH, known install locations, or the macOS ChatGPT/Codex desktop app — so this is the on-demand remediation when the `codex` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
 | `install-claude` | Install the native Claude Code runtime engine on this machine (`npm install -g @anthropic-ai/claude-code`). First Tree does not bundle the ~210MB native `claude` binary by default — the runtime resolves a system `claude` (env override / PATH / well-known install dirs) — so this is the on-demand remediation when the `claude-code` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
 
@@ -1111,24 +1113,19 @@ Files under `<home>/state/client-runtimes/` remain runtime markers for
 diagnostics, account-switch drain checks, and Windows supervisor lifecycle
 reporting. They are not daemon ownership or mutual-exclusion authority.
 
-**Capability refresh timing.** The daemon launch-probes runtime providers at
-startup and re-probes automatically on every WebSocket reconnect. A full real
-re-probe of all providers runs only when there is no prior snapshot or one is
-older than 24h; otherwise each provider is re-validated individually — a
-still-launchable, still-logged-in provider keeps its prior `ok` for free
-(resolve + auth re-checked, no session smoke re-run), a provider that lost its
-binary or login downgrades, and a non-ok provider is fully re-probed so it can
-recover. So a machine missing an optional provider (e.g. no tmux for
-`claude-code-tui`) does not re-smoke its healthy providers on every reconnect.
+**Capability refresh timing.** The daemon detects runtime artifacts and
+platform execution support at startup and again on every WebSocket reconnect.
+Detection is resolve-only: it does not launch providers, inspect
+authentication, or test provider reachability.
 
 **While the daemon stays connected**, it also runs a bounded background
-re-probe whenever any provider is not yet `ok` — so installing or logging into
-a provider is noticed within a bounded time without a restart or reconnect. The
-poll starts ~15s after the degraded state is seen and backs off to a 5-minute
-ceiling, re-probes only the non-`ok` providers (already-`ok` ones stay on the
-free cached path), uploads only when the snapshot actually changes, and stops
-once every provider is `ok`. `daemon probe` remains the manual, on-demand path
-to force an immediate full re-probe + upload.
+refresh whenever any provider is not yet `ok`, so installing a provider is
+noticed without a restart or reconnect. The poll starts ~15s after the degraded
+state is seen, backs off to a 5-minute ceiling, uploads only when the snapshot
+changes, and stops once every provider is `ok`. Authentication cannot change a
+capability row; credential failures are discovered when a provider turn runs.
+`daemon probe` remains the manual path to force an immediate full re-detection
+and upload.
 
 The top-level `first-tree status` is the cross-subsystem overview that
 calls `daemon status` internally and adds server/auth/agent rows.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -230,13 +230,24 @@ first-tree agent list --remote --org <id>  # cross-org view (multi-org operators
 ### agent create
 
 ```
-first-tree agent create <name> --type <human|agent> --client-id <thisClient> [--runtime claude-code|claude-code-tui|codex|cursor|kimi-code]
+first-tree agent create <name> --type <human|agent> --client-id <thisClient> [--runtime claude-code|claude-code-tui|codex|cursor|kimi-code|opencode]
 ```
 
 Creates the agent row on the server and binds it to the given client
 machine. The local `agents/<name>/agent.yaml` is written by the running
 daemon via the server-pushed `agent:pinned` frame; no second command
 needed if the daemon is already up.
+
+`--runtime` defaults to `claude-code`. The `opencode` runtime uses an
+operator-installed OpenCode CLI (`>=1.18.7 <2.0.0`) on macOS or Linux. Install
+it with `npm install -g opencode-ai@^1.18.7`, complete provider-owned
+authentication with `opencode auth login`, then run `first-tree daemon probe`
+to refresh the machine's advertised capabilities. First Tree never reads or
+relays OpenCode provider credentials. The capability probe resolves the
+executable and checks platform support; the first provider turn performs the
+compatible-version and database-readiness gates. Windows reports a resolved
+OpenCode binary for diagnostics but does not advertise it as available until
+the Client has the required pre-admission Job Object supervisor.
 
 ### agent add
 

--- a/docs/development/agent-workspace-state.md
+++ b/docs/development/agent-workspace-state.md
@@ -27,6 +27,7 @@ Each runtime discovers Skills from one workspace-relative root:
 | Codex | `.agents/skills/` |
 | Cursor | `.cursor/skills/` |
 | Kimi Code | `.kimi-code/skills/` |
+| OpenCode | `.opencode/skills/` |
 
 The reconciler projects both bundled Core Skills and Cloud-configured Team
 Skills into that one active root. It does not maintain cross-provider

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -73,6 +73,12 @@ FT_BIN="$HOME/.local/bin/first-tree" # Use first-tree-staging for staging.
 
 `--type` accepts `human` or `agent`. The `client-id` argument is required
 because an agent is permanently bound to exactly one client machine.
+`--runtime` accepts `claude-code`, `claude-code-tui`, `codex`, `cursor`,
+`kimi-code`, or `opencode`, and defaults to `claude-code`. OpenCode requires an
+operator-installed CLI (`npm install -g opencode-ai@^1.18.7`) plus
+provider-owned authentication (`opencode auth login`) on macOS or Linux.
+After installing or authenticating a provider, run `first-tree daemon probe`
+to refresh the machine's advertised capabilities.
 
 ## What `first-tree login` writes
 

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -77,8 +77,10 @@ because an agent is permanently bound to exactly one client machine.
 `kimi-code`, or `opencode`, and defaults to `claude-code`. OpenCode requires an
 operator-installed CLI (`npm install -g opencode-ai@^1.18.7`) plus
 provider-owned authentication (`opencode auth login`) on macOS or Linux.
-After installing or authenticating a provider, run `first-tree daemon probe`
-to refresh the machine's advertised capabilities.
+After installing a provider, run `first-tree daemon probe` to force immediate
+artifact/platform re-detection and upload the machine's advertised
+capabilities. The probe does not inspect authentication; credentials are
+validated when a provider turn runs.
 
 ## What `first-tree login` writes
 


### PR DESCRIPTION
## Summary

- add `opencode` to the documented `agent create --runtime` values
- document the supported OpenCode CLI version, host-local authentication, capability refresh, and platform gate
- add `.opencode/skills/` to the managed Skill discovery-path table
- keep the headless onboarding guide aligned with the public CLI surface

## Context

The OpenCode runtime shipped in #2077, but the source documentation still listed only the previous runtime providers. This restores the CLI documentation and managed-workspace source-of-truth required by the Context Tree change rules.

The shared session-fingerprint path-containment fix is intentionally being delivered in a separate code PR.

## Verification

- `git diff --check`
- documentation-only change; no formal QA or runtime acceptance run
