### PR TITLE
fix(client): hash session briefing fingerprint file keys to contain runtime artifacts

### DIFF
--- a/packages/client/src/__tests__/opencode-handler.test.ts
+++ b/packages/client/src/__tests__/opencode-handler.test.ts
@@ -1295,7 +1295,7 @@ describe("OpenCode V1 handler", () => {
     expect(inputs).toHaveLength(2);
     expect(inputs[0]).toContain("<first-tree-current-chat-context");
     expect(inputs[1]).toContain("<first-tree-current-chat-context");
-    expect(existsSync(join(root, ".first-tree-workspace", "session-briefings", "ses_new.json"))).toBe(true);
+    expect(readSessionBriefingFingerprint(root, "ses_new")).not.toBeNull();
     await manager.shutdown();
   });
 

--- a/packages/client/src/__tests__/session-briefing-fingerprint.test.ts
+++ b/packages/client/src/__tests__/session-briefing-fingerprint.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -11,6 +12,12 @@ import {
 } from "../runtime/session-briefing-fingerprint.js";
 
 const SESSION_ID = "019d9a97-90b0-716b-8317-a8c0be8430d7";
+
+/** Mirror of the module's storage key: sha256(sessionId) — the raw id must never be a path segment. */
+function fingerprintFilePath(workspace: string, sessionId: string): string {
+  const stem = createHash("sha256").update(sessionId, "utf8").digest("hex");
+  return join(workspace, SESSION_BRIEFINGS_DIR_REL, `${stem}.json`);
+}
 
 let workspace: string;
 
@@ -60,17 +67,61 @@ describe("read/write round-trip", () => {
 
 describe("readSessionBriefingFingerprint resilience", () => {
   it("returns null on malformed JSON", () => {
-    const path = join(workspace, SESSION_BRIEFINGS_DIR_REL, `${SESSION_ID}.json`);
     writeSessionBriefingFingerprint(workspace, SESSION_ID, "seed-so-dir-exists");
-    writeFileSync(path, "{not json", "utf-8");
+    writeFileSync(fingerprintFilePath(workspace, SESSION_ID), "{not json", "utf-8");
     expect(readSessionBriefingFingerprint(workspace, SESSION_ID)).toBeNull();
   });
 
   it("returns null for an unknown schema version (future writer)", () => {
-    const path = join(workspace, SESSION_BRIEFINGS_DIR_REL, `${SESSION_ID}.json`);
     writeSessionBriefingFingerprint(workspace, SESSION_ID, "seed");
-    writeFileSync(path, JSON.stringify({ schemaVersion: 2, fingerprint: "x" }), "utf-8");
+    writeFileSync(
+      fingerprintFilePath(workspace, SESSION_ID),
+      JSON.stringify({ schemaVersion: 2, fingerprint: "x" }),
+      "utf-8",
+    );
     expect(readSessionBriefingFingerprint(workspace, SESSION_ID)).toBeNull();
+  });
+});
+
+describe("path containment (opaque provider session ids)", () => {
+  // Ids satisfying each provider's loose id grammar but containing path
+  // segments: OpenCode only requires a `ses` prefix, and persisted/resumed
+  // ids are accepted as arbitrary non-empty strings.
+  const traversalId = "ses/../../../.first-tree/workspace";
+  const backslashId = "..\\..\\evil";
+  const hostileIds = [traversalId, "../../package", backslashId, "ses_/absolute/looking/path"];
+
+  it("round-trips hostile opaque ids without leaving the runtime dir", () => {
+    for (const [index, id] of hostileIds.entries()) {
+      const fp = computeBriefingFingerprint(`briefing-${index}`);
+      writeSessionBriefingFingerprint(workspace, id, fp);
+      expect(readSessionBriefingFingerprint(workspace, id)).toBe(fp);
+    }
+  });
+
+  it("keeps hostile-id fingerprints isolated per id (no sanitization collisions)", () => {
+    writeSessionBriefingFingerprint(workspace, traversalId, computeBriefingFingerprint("a"));
+    writeSessionBriefingFingerprint(workspace, backslashId, computeBriefingFingerprint("b"));
+    expect(readSessionBriefingFingerprint(workspace, traversalId)).toBe(computeBriefingFingerprint("a"));
+    expect(readSessionBriefingFingerprint(workspace, backslashId)).toBe(computeBriefingFingerprint("b"));
+  });
+
+  it("writes every artifact inside SESSION_BRIEFINGS_DIR_REL and never touches other workspace files", () => {
+    const workspaceJson = join(workspace, ".first-tree", "workspace.json");
+    mkdirSync(join(workspace, ".first-tree"), { recursive: true });
+    writeFileSync(workspaceJson, '{"sentinel":true}', "utf-8");
+    for (const id of hostileIds) {
+      writeSessionBriefingFingerprint(workspace, id, computeBriefingFingerprint(id));
+    }
+    const dir = join(workspace, SESSION_BRIEFINGS_DIR_REL);
+    const entries = readdirSync(dir);
+    expect(entries.length).toBe(hostileIds.length);
+    for (const entry of entries) {
+      expect(entry).toMatch(/^[0-9a-f]{64}\.json$/);
+    }
+    // nothing escaped: no files directly under the runtime dir or workspace root
+    expect(readdirSync(join(workspace, ".first-tree-workspace"))).toEqual(["session-briefings"]);
+    expect(readFileSync(workspaceJson, "utf-8")).toBe('{"sentinel":true}');
   });
 });
 

--- a/packages/client/src/runtime/session-briefing-fingerprint.ts
+++ b/packages/client/src/runtime/session-briefing-fingerprint.ts
@@ -47,8 +47,22 @@ export function computeBriefingFingerprint(briefing: string): string {
   return createHash("sha256").update(briefing, "utf8").digest("hex");
 }
 
+/**
+ * File-system-safe stem for a session's fingerprint file. The session id is a
+ * provider-owned opaque value with no documented character guarantee (and the
+ * OpenCode protocol even permits caller-supplied ids), so it must never become
+ * a path segment: `join` would happily resolve `..` out of the runtime dir and
+ * `renameSync` would then overwrite arbitrary workspace files. Hashing keeps
+ * every artifact inside `SESSION_BRIEFINGS_DIR_REL` while remaining a stable
+ * 1:1 key. Deliberately NOT a character-allowlist / basename sanitization —
+ * those can collide distinct ids.
+ */
+function sessionFingerprintStem(sessionId: string): string {
+  return createHash("sha256").update(sessionId, "utf8").digest("hex");
+}
+
 function sessionFingerprintPath(workspacePath: string, sessionId: string): string {
-  return join(workspacePath, SESSION_BRIEFINGS_DIR_REL, `${sessionId}.json`);
+  return join(workspacePath, SESSION_BRIEFINGS_DIR_REL, `${sessionFingerprintStem(sessionId)}.json`);
 }
 
 type SessionBriefingRecord = {
@@ -87,7 +101,7 @@ export function writeSessionBriefingFingerprint(workspacePath: string, sessionId
     mkdirSync(dir, { recursive: true });
     const record: SessionBriefingRecord = { schemaVersion: 1, fingerprint };
     const finalPath = sessionFingerprintPath(workspacePath, sessionId);
-    const tmpPath = join(dir, `.${sessionId}.${randomBytes(6).toString("hex")}.tmp`);
+    const tmpPath = join(dir, `.${sessionFingerprintStem(sessionId)}.${randomBytes(6).toString("hex")}.tmp`);
     writeFileSync(tmpPath, JSON.stringify(record), "utf-8");
     renameSync(tmpPath, finalPath);
   } catch {


### PR DESCRIPTION
## Summary

- Fixes a path-containment defect in the shared session-briefing fingerprint sink (`packages/client/src/runtime/session-briefing-fingerprint.ts`), used by the Claude Code, Codex, Cursor, and OpenCode handlers.
- The sink previously used the provider-owned opaque `sessionId` verbatim as the final file name (`${sessionId}.json`) and the atomic temp file name. The id has no enforced character guarantee: OpenCode's public schema only requires a `ses` prefix and permits caller-supplied ids, and First Tree's own parser / persisted-session recovery accept any non-empty string. `path.join` resolves `..` segments, so an id like `ses/../../../.first-tree/workspace` would normalize the final path to `<agent home>/.first-tree/workspace.json`, and `renameSync` would overwrite it — letting a runtime artifact escape `.first-tree-workspace/session-briefings/` and clobber workspace files.
- Fix: derive a `sha256(sessionId)` hex stem and use it for the read path, the final write path, and the atomic temp path. Hashing (not a character allowlist or `basename()`) keeps the key a stable 1:1 mapping with no collisions between distinct ids. No raw-id legacy fallback: a missing pre-fix fingerprint only triggers one briefing re-read notice on next resume, then a new safely-named file is written; provider sessions themselves are unaffected.
- Public function signatures and the best-effort (never-throws) read/write behavior are unchanged.

## Validation

- [ ] `pnpm check` (scoped: `biome check` on the 3 changed files — clean)
- [ ] `pnpm typecheck` (scoped: `tsc --noEmit` in `packages/client` — clean)
- [ ] `pnpm test` (scoped: `vitest run src/__tests__/session-briefing-fingerprint.test.ts src/__tests__/opencode-handler.test.ts` in `packages/client` — 48/48 passed)

Scoped checks only, per task instructions (no full QA / runtime acceptance). New deterministic regression coverage in `session-briefing-fingerprint.test.ts`:

- hostile opaque ids containing `/../`, backslashes, and absolute-looking segments still round-trip and stay isolated per id (no sanitization collisions);
- every written artifact matches `^[0-9a-f]{64}\.json$` inside `SESSION_BRIEFINGS_DIR_REL`, nothing is written directly under the runtime dir, and a pre-seeded `.first-tree/workspace.json` is untouched;
- the OpenCode handler test's raw `ses_new.json` filename assertion now goes through `readSessionBriefingFingerprint` instead of depending on the storage key format.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

None of the above — client-internal runtime storage only.

## Notes

- package or install behavior changes: none
- docs or tests updated to match: tests updated (see Validation); no user-visible behavior or docs impact
- follow-up work: the OpenCode parser could additionally reject over-long / control-character ids as protocol robustness, but that is defense-in-depth and not required for containment; documentation sync for the OpenCode runtime (cli-reference, workspace-state) is handled in a separate PR
