### PR TITLE
fix: stop one team adopting another team's Context Tree repo

### DIFF
--- a/packages/server/scripts/audit-shared-context-tree-repos.ts
+++ b/packages/server/scripts/audit-shared-context-tree-repos.ts
@@ -1,0 +1,76 @@
+/**
+ * Report Context Tree repos that more than one team is bound to.
+ *
+ * A Context Tree repo belongs to exactly one team. Provisioning used to derive
+ * the repo name from the team display name alone, and display names are
+ * deliberately not unique — every name without an ASCII alphanumeric slugified
+ * to the same `"team"` fallback. Two teams under one GitHub account therefore
+ * derived one repo name, and the adopt-on-conflict step handed the second team
+ * the first team's tree. Deriving the name per organization stops new
+ * collisions; it does not unpick bindings already written, which is what this
+ * reports.
+ *
+ * Read-only: it issues one SELECT and writes nothing. Repo URLs are printed so
+ * an operator can act on them, so treat the output as customer data.
+ *
+ * Run: DATABASE_URL=... pnpm --filter @first-tree/server tsx scripts/audit-shared-context-tree-repos.ts
+ */
+
+import { sql } from "drizzle-orm";
+import { connectDatabase } from "../src/db/connection.js";
+
+type SharedRepoRow = {
+  repo: string;
+  org_count: number;
+  organization_ids: string[];
+  display_names: string[];
+};
+
+async function main(): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("DATABASE_URL is required.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const db = connectDatabase(url);
+
+  const rows = await db.execute<SharedRepoRow>(sql`
+    SELECT
+      lower(s.value->>'repo')                       AS repo,
+      count(*)::int                                 AS org_count,
+      array_agg(s.organization_id ORDER BY s.organization_id) AS organization_ids,
+      array_agg(o.display_name ORDER BY s.organization_id)    AS display_names
+    FROM organization_settings s
+    JOIN organizations o ON o.id = s.organization_id
+    WHERE s.namespace = 'context_tree'
+      AND s.value->>'repo' IS NOT NULL
+    GROUP BY lower(s.value->>'repo')
+    HAVING count(*) > 1
+    ORDER BY count(*) DESC
+  `);
+
+  if (rows.length === 0) {
+    console.log("No Context Tree repo is bound to more than one team.");
+    await db.end();
+    return;
+  }
+
+  console.log(`${rows.length} Context Tree repo(s) bound to more than one team:\n`);
+  for (const row of rows) {
+    console.log(`${row.repo}  (${row.org_count} teams)`);
+    row.organization_ids.forEach((orgId, i) => {
+      console.log(`  - ${orgId}  ${row.display_names[i] ?? ""}`);
+    });
+    console.log("");
+  }
+  console.log("Each of these needs an owner decision: which team keeps the tree, and where the others' context goes.");
+  await db.end();
+  process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/packages/server/scripts/audit-shared-context-tree-repos.ts
+++ b/packages/server/scripts/audit-shared-context-tree-repos.ts
@@ -10,10 +10,12 @@
  * collisions; it does not unpick bindings already written, which is what this
  * reports.
  *
- * Grouping is on canonical repository identity, not on URL text: the binding
- * contract accepts HTTPS, `ssh://`, and scp-like SSH spellings with an optional
- * `.git`, so two teams can share one repository through two spellings and a
- * text grouping would report them as unrelated.
+ * Grouping uses the same repository identity the binding guard decides on, not
+ * URL text: the binding contract accepts HTTPS, `ssh://`, and scp-like SSH
+ * spellings with an optional `.git`, so two teams can share one repository
+ * through two spellings and a text grouping would report them as unrelated.
+ * That identity keeps a non-default port, so two self-managed forges on one
+ * host are not reported as a shared tree.
  *
  * Read-only: it issues one SELECT and writes nothing. Repo URLs are printed so
  * an operator can act on them, so treat the output as customer data.
@@ -21,9 +23,9 @@
  * Run: DATABASE_URL=... pnpm --filter @first-tree/server tsx scripts/audit-shared-context-tree-repos.ts
  */
 
-import { canonicalGitRepoUrl } from "@first-tree/shared";
 import { sql } from "drizzle-orm";
 import { connectDatabase } from "../src/db/connection.js";
+import { contextTreeRepoOwnershipKey } from "../src/services/org-settings.js";
 
 type BindingRow = {
   organization_id: string;
@@ -39,7 +41,7 @@ type SharedRepo = {
 function groupByCanonicalRepo(rows: BindingRow[]): SharedRepo[] {
   const byCanonical = new Map<string, SharedRepo>();
   for (const row of rows) {
-    const canonical = canonicalGitRepoUrl(row.repo);
+    const canonical = contextTreeRepoOwnershipKey(row.repo);
     if (!canonical || !row.repo) continue;
     const entry = byCanonical.get(canonical) ?? { canonical, teams: [] };
     entry.teams.push({

--- a/packages/server/scripts/audit-shared-context-tree-repos.ts
+++ b/packages/server/scripts/audit-shared-context-tree-repos.ts
@@ -14,8 +14,10 @@
  * URL text: the binding contract accepts HTTPS, `ssh://`, and scp-like SSH
  * spellings with an optional `.git`, so two teams can share one repository
  * through two spellings and a text grouping would report them as unrelated.
- * That identity keeps a non-default port, so two self-managed forges on one
- * host are not reported as a shared tree.
+ * Each row resolves through its own team's GitLab connection origin, so an SSH
+ * binding and an HTTPS binding on one self-managed forge group together while
+ * two forges on one host stay apart. A row whose forge cannot be classified has
+ * no establishable authority and is skipped rather than guessed at.
  *
  * Read-only: it issues one SELECT and writes nothing. Repo URLs are printed so
  * an operator can act on them, so treat the output as customer data.
@@ -25,33 +27,36 @@
 
 import { sql } from "drizzle-orm";
 import { connectDatabase } from "../src/db/connection.js";
-import { contextTreeRepoOwnershipKey } from "../src/services/org-settings.js";
+import { contextTreeRepoOwnershipIdentity } from "../src/services/org-settings.js";
 
 type BindingRow = {
   organization_id: string;
   display_name: string | null;
   repo: string | null;
+  provider: string | null;
+  instance_origin: string | null;
 };
 
 type SharedRepo = {
-  canonical: string;
+  identity: string;
   teams: Array<{ organizationId: string; displayName: string; repo: string }>;
 };
 
-function groupByCanonicalRepo(rows: BindingRow[]): SharedRepo[] {
-  const byCanonical = new Map<string, SharedRepo>();
+function groupBySharedRepo(rows: BindingRow[]): SharedRepo[] {
+  const byIdentity = new Map<string, SharedRepo>();
   for (const row of rows) {
-    const canonical = contextTreeRepoOwnershipKey(row.repo);
-    if (!canonical || !row.repo) continue;
-    const entry = byCanonical.get(canonical) ?? { canonical, teams: [] };
+    const provider = row.provider === "github" || row.provider === "gitlab" ? row.provider : undefined;
+    const identity = contextTreeRepoOwnershipIdentity(row.repo, provider, row.instance_origin);
+    if (!identity || !row.repo) continue;
+    const entry = byIdentity.get(identity) ?? { identity, teams: [] };
     entry.teams.push({
       organizationId: row.organization_id,
       displayName: row.display_name ?? "",
       repo: row.repo,
     });
-    byCanonical.set(canonical, entry);
+    byIdentity.set(identity, entry);
   }
-  return [...byCanonical.values()]
+  return [...byIdentity.values()]
     .filter((entry) => entry.teams.length > 1)
     .sort((a, b) => b.teams.length - a.teams.length);
 }
@@ -70,15 +75,18 @@ async function main(): Promise<void> {
       SELECT
         s.organization_id     AS organization_id,
         o.display_name        AS display_name,
-        s.value->>'repo'      AS repo
+        s.value->>'repo'      AS repo,
+        s.value->>'provider'  AS provider,
+        g.instance_origin     AS instance_origin
       FROM organization_settings s
       JOIN organizations o ON o.id = s.organization_id
+      LEFT JOIN gitlab_connections g ON g.organization_id = s.organization_id
       WHERE s.namespace = 'context_tree'
         AND s.value->>'repo' IS NOT NULL
       ORDER BY s.organization_id
     `);
 
-    const shared = groupByCanonicalRepo([...rows]);
+    const shared = groupBySharedRepo([...rows]);
     if (shared.length === 0) {
       console.log("No Context Tree repo is bound to more than one team.");
       return;
@@ -86,7 +94,7 @@ async function main(): Promise<void> {
 
     console.log(`${shared.length} Context Tree repo(s) bound to more than one team:\n`);
     for (const entry of shared) {
-      console.log(`${entry.canonical}  (${entry.teams.length} teams)`);
+      console.log(`${entry.identity}  (${entry.teams.length} teams)`);
       for (const team of entry.teams) {
         console.log(`  - ${team.organizationId}  ${team.displayName}  ${team.repo}`);
       }

--- a/packages/server/scripts/audit-shared-context-tree-repos.ts
+++ b/packages/server/scripts/audit-shared-context-tree-repos.ts
@@ -14,10 +14,11 @@
  * URL text: the binding contract accepts HTTPS, `ssh://`, and scp-like SSH
  * spellings with an optional `.git`, so two teams can share one repository
  * through two spellings and a text grouping would report them as unrelated.
- * Each row resolves through its own team's GitLab connection origin, so an SSH
- * binding and an HTTPS binding on one self-managed forge group together while
- * two forges on one host stay apart. A row whose forge cannot be classified has
- * no establishable authority and is skipped rather than guessed at.
+ * An HTTP(S) row carries its own web origin; an SSH row resolves through its
+ * own team's GitLab connection, so an SSH binding and an HTTPS binding on one
+ * self-managed forge group together while two forges on one host stay apart. An
+ * SSH row whose team has no connection has no establishable origin and is
+ * skipped rather than guessed at.
  *
  * Read-only: it issues one SELECT and writes nothing. Repo URLs are printed so
  * an operator can act on them, so treat the output as customer data.
@@ -33,7 +34,6 @@ type BindingRow = {
   organization_id: string;
   display_name: string | null;
   repo: string | null;
-  provider: string | null;
   instance_origin: string | null;
 };
 
@@ -45,8 +45,7 @@ type SharedRepo = {
 function groupBySharedRepo(rows: BindingRow[]): SharedRepo[] {
   const byIdentity = new Map<string, SharedRepo>();
   for (const row of rows) {
-    const provider = row.provider === "github" || row.provider === "gitlab" ? row.provider : undefined;
-    const identity = contextTreeRepoOwnershipIdentity(row.repo, provider, row.instance_origin);
+    const identity = contextTreeRepoOwnershipIdentity(row.repo, row.instance_origin);
     if (!identity || !row.repo) continue;
     const entry = byIdentity.get(identity) ?? { identity, teams: [] };
     entry.teams.push({
@@ -76,7 +75,6 @@ async function main(): Promise<void> {
         s.organization_id     AS organization_id,
         o.display_name        AS display_name,
         s.value->>'repo'      AS repo,
-        s.value->>'provider'  AS provider,
         g.instance_origin     AS instance_origin
       FROM organization_settings s
       JOIN organizations o ON o.id = s.organization_id

--- a/packages/server/scripts/audit-shared-context-tree-repos.ts
+++ b/packages/server/scripts/audit-shared-context-tree-repos.ts
@@ -10,21 +10,49 @@
  * collisions; it does not unpick bindings already written, which is what this
  * reports.
  *
+ * Grouping is on canonical repository identity, not on URL text: the binding
+ * contract accepts HTTPS, `ssh://`, and scp-like SSH spellings with an optional
+ * `.git`, so two teams can share one repository through two spellings and a
+ * text grouping would report them as unrelated.
+ *
  * Read-only: it issues one SELECT and writes nothing. Repo URLs are printed so
  * an operator can act on them, so treat the output as customer data.
  *
  * Run: DATABASE_URL=... pnpm --filter @first-tree/server tsx scripts/audit-shared-context-tree-repos.ts
  */
 
+import { canonicalGitRepoUrl } from "@first-tree/shared";
 import { sql } from "drizzle-orm";
 import { connectDatabase } from "../src/db/connection.js";
 
-type SharedRepoRow = {
-  repo: string;
-  org_count: number;
-  organization_ids: string[];
-  display_names: string[];
+type BindingRow = {
+  organization_id: string;
+  display_name: string | null;
+  repo: string | null;
 };
+
+type SharedRepo = {
+  canonical: string;
+  teams: Array<{ organizationId: string; displayName: string; repo: string }>;
+};
+
+function groupByCanonicalRepo(rows: BindingRow[]): SharedRepo[] {
+  const byCanonical = new Map<string, SharedRepo>();
+  for (const row of rows) {
+    const canonical = canonicalGitRepoUrl(row.repo);
+    if (!canonical || !row.repo) continue;
+    const entry = byCanonical.get(canonical) ?? { canonical, teams: [] };
+    entry.teams.push({
+      organizationId: row.organization_id,
+      displayName: row.display_name ?? "",
+      repo: row.repo,
+    });
+    byCanonical.set(canonical, entry);
+  }
+  return [...byCanonical.values()]
+    .filter((entry) => entry.teams.length > 1)
+    .sort((a, b) => b.teams.length - a.teams.length);
+}
 
 async function main(): Promise<void> {
   const url = process.env.DATABASE_URL;
@@ -35,39 +63,40 @@ async function main(): Promise<void> {
   }
 
   const db = connectDatabase(url);
+  try {
+    const rows = await db.execute<BindingRow>(sql`
+      SELECT
+        s.organization_id     AS organization_id,
+        o.display_name        AS display_name,
+        s.value->>'repo'      AS repo
+      FROM organization_settings s
+      JOIN organizations o ON o.id = s.organization_id
+      WHERE s.namespace = 'context_tree'
+        AND s.value->>'repo' IS NOT NULL
+      ORDER BY s.organization_id
+    `);
 
-  const rows = await db.execute<SharedRepoRow>(sql`
-    SELECT
-      lower(s.value->>'repo')                       AS repo,
-      count(*)::int                                 AS org_count,
-      array_agg(s.organization_id ORDER BY s.organization_id) AS organization_ids,
-      array_agg(o.display_name ORDER BY s.organization_id)    AS display_names
-    FROM organization_settings s
-    JOIN organizations o ON o.id = s.organization_id
-    WHERE s.namespace = 'context_tree'
-      AND s.value->>'repo' IS NOT NULL
-    GROUP BY lower(s.value->>'repo')
-    HAVING count(*) > 1
-    ORDER BY count(*) DESC
-  `);
+    const shared = groupByCanonicalRepo([...rows]);
+    if (shared.length === 0) {
+      console.log("No Context Tree repo is bound to more than one team.");
+      return;
+    }
 
-  if (rows.length === 0) {
-    console.log("No Context Tree repo is bound to more than one team.");
+    console.log(`${shared.length} Context Tree repo(s) bound to more than one team:\n`);
+    for (const entry of shared) {
+      console.log(`${entry.canonical}  (${entry.teams.length} teams)`);
+      for (const team of entry.teams) {
+        console.log(`  - ${team.organizationId}  ${team.displayName}  ${team.repo}`);
+      }
+      console.log("");
+    }
+    console.log(
+      "Each of these needs an owner decision: which team keeps the tree, and where the others' context goes.",
+    );
+    process.exitCode = 1;
+  } finally {
     await db.end();
-    return;
   }
-
-  console.log(`${rows.length} Context Tree repo(s) bound to more than one team:\n`);
-  for (const row of rows) {
-    console.log(`${row.repo}  (${row.org_count} teams)`);
-    row.organization_ids.forEach((orgId, i) => {
-      console.log(`  - ${orgId}  ${row.display_names[i] ?? ""}`);
-    });
-    console.log("");
-  }
-  console.log("Each of these needs an owner decision: which team keeps the tree, and where the others' context goes.");
-  await db.end();
-  process.exitCode = 1;
 }
 
 main().catch((err) => {

--- a/packages/server/scripts/audit-shared-context-tree-repos.ts
+++ b/packages/server/scripts/audit-shared-context-tree-repos.ts
@@ -26,39 +26,10 @@
  * Run: DATABASE_URL=... pnpm --filter @first-tree/server tsx scripts/audit-shared-context-tree-repos.ts
  */
 
+import { pathToFileURL } from "node:url";
 import { sql } from "drizzle-orm";
 import { connectDatabase } from "../src/db/connection.js";
-import { contextTreeRepoOwnershipIdentity } from "../src/services/org-settings.js";
-
-type BindingRow = {
-  organization_id: string;
-  display_name: string | null;
-  repo: string | null;
-  instance_origin: string | null;
-};
-
-type SharedRepo = {
-  identity: string;
-  teams: Array<{ organizationId: string; displayName: string; repo: string }>;
-};
-
-function groupBySharedRepo(rows: BindingRow[]): SharedRepo[] {
-  const byIdentity = new Map<string, SharedRepo>();
-  for (const row of rows) {
-    const identity = contextTreeRepoOwnershipIdentity(row.repo, row.instance_origin);
-    if (!identity || !row.repo) continue;
-    const entry = byIdentity.get(identity) ?? { identity, teams: [] };
-    entry.teams.push({
-      organizationId: row.organization_id,
-      displayName: row.display_name ?? "",
-      repo: row.repo,
-    });
-    byIdentity.set(identity, entry);
-  }
-  return [...byIdentity.values()]
-    .filter((entry) => entry.teams.length > 1)
-    .sort((a, b) => b.teams.length - a.teams.length);
-}
+import { auditBindings, type BindingRow } from "../src/services/context-tree-binding-audit.js";
 
 async function main(): Promise<void> {
   const url = process.env.DATABASE_URL;
@@ -84,13 +55,8 @@ async function main(): Promise<void> {
       ORDER BY s.organization_id
     `);
 
-    const shared = groupBySharedRepo([...rows]);
-    if (shared.length === 0) {
-      console.log("No Context Tree repo is bound to more than one team.");
-      return;
-    }
+    const { shared, unresolved } = auditBindings([...rows]);
 
-    console.log(`${shared.length} Context Tree repo(s) bound to more than one team:\n`);
     for (const entry of shared) {
       console.log(`${entry.identity}  (${entry.teams.length} teams)`);
       for (const team of entry.teams) {
@@ -98,16 +64,36 @@ async function main(): Promise<void> {
       }
       console.log("");
     }
-    console.log(
-      "Each of these needs an owner decision: which team keeps the tree, and where the others' context goes.",
-    );
+    if (shared.length > 0) {
+      console.log(`${shared.length} Context Tree repo(s) bound to more than one team.`);
+      console.log("Each needs an owner decision: which team keeps the tree, and where the others' context goes.\n");
+    }
+
+    if (unresolved.length > 0) {
+      console.log(`${unresolved.length} binding(s) whose forge could not be established:\n`);
+      for (const team of unresolved) {
+        console.log(`  - ${team.organizationId}  ${team.displayName}  ${team.repo}`);
+      }
+      console.log("\nThese were not compared against anything, so this run cannot tell you whether they are shared.");
+      console.log("Resolve them — connect the owning team's forge, or correct the binding — and run again.");
+    }
+
+    if (shared.length === 0 && unresolved.length === 0) {
+      console.log("No Context Tree repo is bound to more than one team, and every binding resolved.");
+      return;
+    }
+
     process.exitCode = 1;
   } finally {
     await db.end();
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
-});
+// Importing this module for its pure helpers must not open a database
+// connection, so only a direct run performs the audit.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/packages/server/src/__tests__/context-tree-binding-audit.test.ts
+++ b/packages/server/src/__tests__/context-tree-binding-audit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { auditBindings, type BindingRow } from "../services/context-tree-binding-audit.js";
+
+function row(organizationId: string, repo: string, instanceOrigin: string | null = null): BindingRow {
+  return {
+    organization_id: organizationId,
+    display_name: `Team ${organizationId}`,
+    repo,
+    instance_origin: instanceOrigin,
+  };
+}
+
+describe("audit-shared-context-tree-repos", () => {
+  it("groups transport spellings of one repository together", () => {
+    const origin = "https://git.internal:8443";
+    const { shared, unresolved } = auditBindings([
+      row("org-https", "https://git.internal:8443/group/tree.git", origin),
+      row("org-ssh", "ssh://git@git.internal:2222/group/tree.git", origin),
+      row("org-scp", "git@git.internal:group/tree.git", origin),
+    ]);
+
+    expect(unresolved).toEqual([]);
+    expect(shared).toHaveLength(1);
+    expect(shared[0]?.teams.map((team) => team.organizationId).sort()).toEqual(["org-https", "org-scp", "org-ssh"]);
+  });
+
+  it("keeps two self-managed instances on one host apart", () => {
+    const { shared } = auditBindings([
+      row("org-8443", "https://git.internal:8443/group/tree.git"),
+      row("org-9443", "https://git.internal:9443/group/tree.git"),
+    ]);
+
+    expect(shared).toEqual([]);
+  });
+
+  it("reports a binding whose forge cannot be established instead of dropping it", () => {
+    // A legacy or hand-edited row may keep a repo with no provider and no
+    // matching connection. Skipping it silently would let two affected teams go
+    // unlisted while the operator reads a clean result.
+    const { shared, unresolved } = auditBindings([
+      row("org-legacy", "git@git.internal:group/tree.git"),
+      row("org-other", "git@git.internal:group/tree.git"),
+    ]);
+
+    expect(shared).toEqual([]);
+    expect(unresolved.map((team) => team.organizationId)).toEqual(["org-legacy", "org-other"]);
+  });
+
+  it("separates unresolved rows from a genuine sharing report", () => {
+    const { shared, unresolved } = auditBindings([
+      row("org-a", "https://github.com/acme/tree.git"),
+      row("org-b", "git@github.com:acme/tree.git"),
+      row("org-legacy", "git@git.internal:group/tree.git"),
+    ]);
+
+    expect(shared).toHaveLength(1);
+    expect(shared[0]?.teams.map((team) => team.organizationId).sort()).toEqual(["org-a", "org-b"]);
+    expect(unresolved.map((team) => team.organizationId)).toEqual(["org-legacy"]);
+  });
+});

--- a/packages/server/src/__tests__/context-tree-initialize.test.ts
+++ b/packages/server/src/__tests__/context-tree-initialize.test.ts
@@ -648,39 +648,49 @@ owners: [${ACCOUNT_LOGIN}]
     });
   });
 
-  it("refuses to adopt a derived repo already bound to another team", async () => {
-    const app = getApp();
-    const admin = await createTestAdmin(app);
-    const installationId = await seedInstallation(app, admin.organizationId);
-    await renameOrg(app, admin.organizationId, "Acme Labs");
+  // A name only ever guesses at ownership; the binding table is the fact. The
+  // binding contract accepts HTTPS, ssh://, and scp-like SSH spellings with an
+  // optional `.git`, and every one of them names the same repository — so the
+  // conflict must be found through canonical identity, not URL text.
+  for (const spelling of ["clone URL", "HTTPS without .git", "ssh:// URL", "scp-like SSH"] as const) {
+    it(`refuses to adopt a derived repo another team holds as a ${spelling}`, async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const installationId = await seedInstallation(app, admin.organizationId);
+      await renameOrg(app, admin.organizationId, "Acme Labs");
 
-    // A name only ever guesses at ownership; the binding table is the fact.
-    // Park this exact repo on a different team and initialization must refuse
-    // rather than adopt a tree that already belongs to someone else.
-    const otherOrgId = await createOrganization(app, `other-${crypto.randomUUID().slice(0, 8)}`);
-    await putOrgSetting(
-      app.db,
-      otherOrgId,
-      "context_tree",
-      { repo: CLONE_URL, branch: "main" },
-      {
-        updatedBy: admin.userId,
-      },
-    );
+      const alias = {
+        "clone URL": CLONE_URL,
+        "HTTPS without .git": HTML_URL,
+        "ssh:// URL": `ssh://git@github.com/${ACCOUNT_LOGIN}/${REPO_NAME}.git`,
+        "scp-like SSH": `git@github.com:${ACCOUNT_LOGIN}/${REPO_NAME}.git`,
+      }[spelling];
 
-    const fetchSpy = mockFetch(async (url) => {
-      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
-      return new Response(`unexpected fetch ${url}`, { status: 500 });
+      const otherOrgId = await createOrganization(app, `other-${crypto.randomUUID().slice(0, 8)}`);
+      await putOrgSetting(
+        app.db,
+        otherOrgId,
+        "context_tree",
+        { repo: alias, branch: "main" },
+        {
+          updatedBy: admin.userId,
+        },
+      );
+
+      const fetchSpy = mockFetch(async (url) => {
+        if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+        return new Response(`unexpected fetch ${url}`, { status: 500 });
+      });
+
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(409);
+      expect(res.json()).toMatchObject({ code: "context_tree_repo_owned_by_other_org" });
+      // Only the installation token was minted — no repo was created or adopted.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(await getOrgContextTreeBinding(app.db, admin.organizationId)).toBeNull();
     });
-
-    const res = await initialize(app, admin);
-
-    expect(res.statusCode).toBe(409);
-    expect(res.json()).toMatchObject({ code: "context_tree_repo_owned_by_other_org" });
-    // Only the installation token was minted — no repo was created or adopted.
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(await getOrgContextTreeBinding(app.db, admin.organizationId)).toBeNull();
-  });
+  }
 
   it("returns 409 repo_unavailable when an existing deterministic repo is not readable by the installation", async () => {
     const app = getApp();

--- a/packages/server/src/__tests__/context-tree-initialize.test.ts
+++ b/packages/server/src/__tests__/context-tree-initialize.test.ts
@@ -6,6 +6,7 @@ import { authIdentities } from "../db/schema/auth-identities.js";
 import { members } from "../db/schema/members.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
 import { organizations } from "../db/schema/organizations.js";
+import { contextTreeRepoName } from "../services/context-tree-repo-provisioner.js";
 import { encryptValue } from "../services/crypto.js";
 import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
 import { createGitlabConnection } from "../services/gitlab-connections.js";
@@ -20,12 +21,16 @@ type FetchInit = Parameters<typeof globalThis.fetch>[1];
 const GITHUB_API_BASE = "https://api.github.com";
 const INSTALLATION_TOKEN = "ghs_installation_token";
 const ACCOUNT_LOGIN = "acme-github";
-const REPO_NAME = "acme-labs-context-tree";
-const CLONE_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}.git`;
-const HTML_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}`;
+// The repo name carries a per-organization discriminator, so it is only known
+// once a test has an org. `renameOrg` — which every test that reaches GitHub
+// already calls — recomputes these from the real derivation rather than
+// restating it here, so a change to the rule cannot pass by matching a copy.
+let REPO_NAME = "";
+let CLONE_URL = "";
+let HTML_URL = "";
 const USER_LOGIN = "octocat";
 const USER_GITHUB_ID = 4242;
-const USER_REPO_CLONE_URL = `https://github.com/${USER_LOGIN}/${REPO_NAME}.git`;
+let USER_REPO_CLONE_URL = "";
 const ROOT_NODE_PATH = "NODE.md";
 const VALIDATE_TREE_WORKFLOW_PATH = ".github/workflows/validate-tree.yml";
 const VALIDATE_TREE_WORKFLOW_CONTENT = `name: Validate Context Tree
@@ -641,6 +646,40 @@ owners: [${ACCOUNT_LOGIN}]
       repo: CLONE_URL,
       branch: "main",
     });
+  });
+
+  it("refuses to adopt a derived repo already bound to another team", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+
+    // A name only ever guesses at ownership; the binding table is the fact.
+    // Park this exact repo on a different team and initialization must refuse
+    // rather than adopt a tree that already belongs to someone else.
+    const otherOrgId = await createOrganization(app, `other-${crypto.randomUUID().slice(0, 8)}`);
+    await putOrgSetting(
+      app.db,
+      otherOrgId,
+      "context_tree",
+      { repo: CLONE_URL, branch: "main" },
+      {
+        updatedBy: admin.userId,
+      },
+    );
+
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({ code: "context_tree_repo_owned_by_other_org" });
+    // Only the installation token was minted — no repo was created or adopted.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(await getOrgContextTreeBinding(app.db, admin.organizationId)).toBeNull();
   });
 
   it("returns 409 repo_unavailable when an existing deterministic repo is not readable by the installation", async () => {
@@ -1354,6 +1393,10 @@ async function getInstallation(app: FastifyInstance, admin: Pick<TestAdmin, "org
 
 async function renameOrg(app: FastifyInstance, organizationId: string, displayName: string): Promise<void> {
   await app.db.update(organizations).set({ displayName }).where(eq(organizations.id, organizationId));
+  REPO_NAME = contextTreeRepoName(displayName, organizationId);
+  CLONE_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}.git`;
+  HTML_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}`;
+  USER_REPO_CLONE_URL = `https://github.com/${USER_LOGIN}/${REPO_NAME}.git`;
 }
 
 async function createOrganization(app: FastifyInstance, name: string): Promise<string> {

--- a/packages/server/src/__tests__/context-tree-repo-provisioner.test.ts
+++ b/packages/server/src/__tests__/context-tree-repo-provisioner.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { contextTreeRepoName } from "../services/context-tree-repo-provisioner.js";
 
 type ProvisionerContext = Awaited<ReturnType<typeof setupProvisioner>>;
 
@@ -196,5 +197,36 @@ describe("context tree repo provisioner edges", () => {
       ctx.ensureInstallationOwnedContextTreeRepo(input(ctx, { installation: userInstallation })),
     ).resolves.toBe(repo);
     expect(ctx.mocks.createUserRepo).not.toHaveBeenCalled();
+  });
+});
+
+describe("contextTreeRepoName", () => {
+  const ORG_A = "019fb647-c333-7dc2-8e8d-ba4701597d70";
+  const ORG_B = "019fb912-77a1-7b30-9e42-05c3d9f81b6a";
+
+  it("keeps the readable base and appends the org discriminator", () => {
+    expect(contextTreeRepoName("ACME Robotics", ORG_A)).toMatch(/^acme-robotics-[0-9a-f]{8}-context-tree$/);
+  });
+
+  it("separates teams whose display names derive the same base", () => {
+    // Names with no ASCII alphanumerics all fall back to the same `"team"`
+    // base, and display names are deliberately not unique, so the base alone
+    // cannot identify a team. Two teams sharing one repo name let the second
+    // adopt the first team's tree.
+    const collidingBases = [
+      ["电商平台", "设计团队"],
+      ["Design Team", "Design Team"],
+    ] as const;
+    for (const [left, right] of collidingBases) {
+      expect(contextTreeRepoName(left, ORG_A)).not.toBe(contextTreeRepoName(right, ORG_B));
+    }
+  });
+
+  it("is stable for one organization so a retry adopts its own repo", () => {
+    expect(contextTreeRepoName("Acme Labs", ORG_A)).toBe(contextTreeRepoName("Acme Labs", ORG_A));
+  });
+
+  it("does not exceed the GitHub repo name limit", () => {
+    expect(contextTreeRepoName("x".repeat(300), ORG_A).length).toBeLessThanOrEqual(100);
   });
 });

--- a/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
@@ -1,5 +1,13 @@
 import Fastify from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { contextTreeRepoName } from "../services/context-tree-repo-provisioner.js";
+
+// The repo name carries a per-organization discriminator. Derive the expected
+// names from the real rule so these route tests keep asserting error mapping
+// rather than a stale copy of the naming rule.
+const ORG_ID = "org-test";
+const REPO_NAME = contextTreeRepoName("Acme", ORG_ID);
+const RESEARCH_REPO_NAME = contextTreeRepoName("Acme Research Team", ORG_ID);
 
 type RouteMocks = Awaited<ReturnType<typeof setupRoute>>;
 
@@ -8,7 +16,7 @@ async function setupRoute() {
 
   const scope = {
     userId: "user-test",
-    organizationId: "org-test",
+    organizationId: ORG_ID,
     memberId: "member-test",
     role: "admin",
     humanAgentId: "human-test",
@@ -21,10 +29,10 @@ async function setupRoute() {
   };
   const repo = {
     ownerLogin: "acme",
-    name: "acme-context-tree",
-    fullName: "acme/acme-context-tree",
-    cloneUrl: "https://github.com/acme/acme-context-tree.git",
-    htmlUrl: "https://github.com/acme/acme-context-tree",
+    name: REPO_NAME,
+    fullName: `acme/${REPO_NAME}`,
+    cloneUrl: `https://github.com/acme/${REPO_NAME}.git`,
+    htmlUrl: `https://github.com/acme/${REPO_NAME}`,
   };
 
   class ContextTreeRepoProvisionError extends Error {
@@ -85,6 +93,7 @@ async function setupRoute() {
   const createRepoFileWithToken = vi.fn().mockResolvedValue({ content: { path: "NODE.md" } });
   const getOrgContextTreeBinding = vi.fn().mockResolvedValue(null);
   const getOrgContextTreeSettingState = vi.fn().mockResolvedValue({ kind: "unbound", branch: "main" });
+  const findOrgBoundToContextTreeRepo = vi.fn().mockResolvedValue(null);
   const getOrgContextReviewRuntime = vi.fn().mockResolvedValue({
     bindingState: "unbound",
     provider: null,
@@ -109,8 +118,14 @@ async function setupRoute() {
   });
 
   vi.doMock("../scope/require-org.js", () => ({ requireOrgAdmin, requireOrgMembership }));
+  const actualProvisioner = await vi.importActual<typeof import("../services/context-tree-repo-provisioner.js")>(
+    "../services/context-tree-repo-provisioner.js",
+  );
   vi.doMock("../services/context-tree-repo-provisioner.js", () => ({
     ContextTreeRepoProvisionError,
+    // Real derivation: these edge tests assert route error mapping, not repo
+    // naming, and a stubbed name would hide a break in the real rule.
+    contextTreeRepoName: actualProvisioner.contextTreeRepoName,
     ensureInstallationOwnedContextTreeRepo,
   }));
   vi.doMock("../services/context-tree-write-preflight.js", () => ({
@@ -126,6 +141,7 @@ async function setupRoute() {
   vi.doMock("../services/github-app-token.js", () => ({ mintContextTreeInstallationToken }));
   vi.doMock("../services/github-user-token.js", () => ({ GithubUserTokenError, getFreshGithubUserToken }));
   vi.doMock("../services/org-settings.js", () => ({
+    findOrgBoundToContextTreeRepo,
     getOrgContextTreeBinding,
     getOrgContextTreeSettingState,
     getOrgContextReviewRuntime,
@@ -395,7 +411,7 @@ describe("org context tree routes with mocked service edges", () => {
     { field: "HTTP HTML URL", repoOverride: { htmlUrl: "http://github.com/acme/tree" } },
     { field: "credentialed HTML URL", repoOverride: { htmlUrl: "https://user:secret@github.com/acme/tree" } },
     { field: "off-host HTML URL", repoOverride: { htmlUrl: "https://example.com/acme/tree" } },
-    { field: "off-host clone URL", repoOverride: { cloneUrl: "https://example.com/acme/acme-context-tree.git" } },
+    { field: "off-host clone URL", repoOverride: { cloneUrl: `https://example.com/acme/${REPO_NAME}.git` } },
     { field: "mismatched clone URL", repoOverride: { cloneUrl: "https://github.com/acme/other-tree.git" } },
     { field: "mismatched HTML URL", repoOverride: { htmlUrl: "https://github.com/acme/other-tree" } },
     { field: "mismatched full name", repoOverride: { fullName: "acme/other-tree" } },
@@ -421,10 +437,10 @@ describe("org context tree routes with mocked service edges", () => {
       field: "owner",
       repo: {
         ownerLogin: "other",
-        name: "acme-context-tree",
-        fullName: "other/acme-context-tree",
-        cloneUrl: "https://github.com/other/acme-context-tree.git",
-        htmlUrl: "https://github.com/other/acme-context-tree",
+        name: REPO_NAME,
+        fullName: `other/${REPO_NAME}`,
+        cloneUrl: `https://github.com/other/${REPO_NAME}.git`,
+        htmlUrl: `https://github.com/other/${REPO_NAME}`,
       },
     },
     {
@@ -473,7 +489,7 @@ describe("org context tree routes with mocked service edges", () => {
 
     expect(res.statusCode).toBe(409);
     expect(res.json()).toEqual({
-      error: "GitHub repo acme/acme-context-tree is not accessible to this team's GitHub App installation.",
+      error: `GitHub repo acme/${REPO_NAME} is not accessible to this team's GitHub App installation.`,
       code: "repo_unavailable",
     });
     expect(ctx.mocks.getRepoFileWithToken).toHaveBeenCalledTimes(2);
@@ -565,10 +581,10 @@ describe("org context tree routes with mocked service edges", () => {
     const ctx = await setupRoute();
     const expectedRepo = {
       ...ctx.repo,
-      name: "acme-research-team-context-tree",
-      fullName: "acme/acme-research-team-context-tree",
-      cloneUrl: "https://github.com/acme/acme-research-team-context-tree.git",
-      htmlUrl: "https://github.com/acme/acme-research-team-context-tree",
+      name: RESEARCH_REPO_NAME,
+      fullName: `acme/${RESEARCH_REPO_NAME}`,
+      cloneUrl: `https://github.com/acme/${RESEARCH_REPO_NAME}.git`,
+      htmlUrl: `https://github.com/acme/${RESEARCH_REPO_NAME}`,
     };
     ctx.mocks.getOrganization.mockResolvedValueOnce({
       id: ctx.scope.organizationId,
@@ -595,7 +611,7 @@ describe("org context tree routes with mocked service edges", () => {
       nodePath: "NODE.md",
     });
     expect(ctx.mocks.ensureInstallationOwnedContextTreeRepo).toHaveBeenCalledWith(
-      expect.objectContaining({ repoName: "acme-research-team-context-tree", teamName: "Àcme Research Team" }),
+      expect.objectContaining({ repoName: RESEARCH_REPO_NAME, teamName: "Àcme Research Team" }),
     );
     expect(ctx.mocks.createRepoFileWithToken).toHaveBeenCalledTimes(2);
     expect(ctx.mocks.createRepoFileWithToken).toHaveBeenNthCalledWith(

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -255,6 +255,37 @@ describe("org-settings service", () => {
     });
   }
 
+  it("putOrgSetting treats self-managed forges on different ports as different repos", async () => {
+    const app = getApp();
+    const first = await createTestAdmin(app);
+    const second = await createTestAdmin(app);
+    const secondOrgId = uuidv7();
+    await app.db
+      .insert(organizations)
+      .values({ id: secondOrgId, name: `port-${randomUUID().slice(0, 8)}`, displayName: "Other Instance" });
+
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      first.organizationId,
+      "context_tree",
+      { repo: "https://git.internal:8443/group/tree.git", branch: "main" },
+      { updatedBy: first.userId },
+    );
+
+    // Same host, different port — two separate self-managed instances. The
+    // provider-neutral canonical key drops the port, so comparing on it would
+    // refuse this team its own tree and make the audit report a shared tree
+    // that does not exist.
+    const out = await orgSettingsService.putOrgSetting(
+      app.db,
+      secondOrgId,
+      "context_tree",
+      { repo: "https://git.internal:9443/group/tree.git", branch: "main" },
+      { updatedBy: second.userId },
+    );
+    expect(out).toMatchObject({ repo: "https://git.internal:9443/group/tree.git" });
+  });
+
   it("putOrgSetting still lets a team rewrite its own binding", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -255,6 +255,22 @@ describe("org-settings service", () => {
     });
   }
 
+  it("contextTreeRepoOwnershipKey treats only an HTTP(S) port as forge authority", () => {
+    const key = orgSettingsService.contextTreeRepoOwnershipKey;
+
+    // A self-managed forge's Web port identifies which forge it is.
+    expect(key("https://git.internal:8443/group/tree.git")).toBe("git.internal:8443/group/tree");
+    expect(key("https://git.internal:9443/group/tree.git")).not.toBe(key("https://git.internal:8443/group/tree.git"));
+
+    // An ssh:// port is a transport detail of one checkout, not a forge, so it
+    // must not become authority — and both SSH spellings must agree.
+    expect(key("ssh://git@git.internal:2222/group/tree.git")).toBe("git.internal/group/tree");
+    expect(key("git@git.internal:group/tree.git")).toBe("git.internal/group/tree");
+
+    // GitHub carries no port in either spelling, so SSH and HTTPS match there.
+    expect(key("git@github.com:acme/tree.git")).toBe(key("https://github.com/acme/tree"));
+  });
+
   it("putOrgSetting treats self-managed forges on different ports as different repos", async () => {
     const app = getApp();
     const first = await createTestAdmin(app);

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -217,6 +217,67 @@ describe("org-settings service", () => {
     expect(re).toEqual(out);
   });
 
+  // A Context Tree repository backs one team, and the repository is the thing
+  // being claimed no matter which surface names it — so every binding write
+  // enforces exclusivity, not only the Cloud provisioner that derives a name.
+  for (const [spelling, alias] of [
+    ["clone URL", "https://github.com/example/shared-tree.git"],
+    ["HTTPS without .git", "https://github.com/example/shared-tree"],
+    ["ssh:// URL", "ssh://git@github.com/example/shared-tree.git"],
+    ["scp-like SSH", "git@github.com:example/shared-tree.git"],
+  ] as const) {
+    it(`putOrgSetting refuses a repo another team holds, given as a ${spelling}`, async () => {
+      const app = getApp();
+      const holder = await createTestAdmin(app);
+      const claimant = await createTestAdmin(app);
+      const claimantOrgId = uuidv7();
+      await app.db
+        .insert(organizations)
+        .values({ id: claimantOrgId, name: `claimant-${randomUUID().slice(0, 8)}`, displayName: "Claimant" });
+
+      await orgSettingsService.putOrgSetting(
+        app.db,
+        holder.organizationId,
+        "context_tree",
+        { repo: "https://github.com/example/shared-tree.git", branch: "main" },
+        { updatedBy: holder.userId },
+      );
+
+      await expect(
+        orgSettingsService.putOrgSetting(
+          app.db,
+          claimantOrgId,
+          "context_tree",
+          { repo: alias, branch: "main" },
+          { updatedBy: claimant.userId },
+        ),
+      ).rejects.toThrow(/already another team's Context Tree/i);
+    });
+  }
+
+  it("putOrgSetting still lets a team rewrite its own binding", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      { repo: "https://github.com/example/own-tree.git", branch: "main" },
+      { updatedBy: admin.userId },
+    );
+    // Same repository, different spelling: exclusivity is about *other* teams,
+    // so a team re-stating its own binding must not lock itself out.
+    const out = await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      { repo: "git@github.com:example/own-tree.git", branch: "v2" },
+      { updatedBy: admin.userId },
+    );
+    expect(out).toMatchObject({ branch: "v2" });
+  });
+
   it("putOrgSetting input semantics: undefined unchanged, null clears, value sets", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -6,6 +6,7 @@ import postgres from "postgres";
 import { describe, expect, it, vi } from "vitest";
 import { connectDatabase, sslOptions } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
+import { gitlabConnections } from "../db/schema/gitlab-connections.js";
 import { members } from "../db/schema/members.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
 import { organizations } from "../db/schema/organizations.js";
@@ -255,32 +256,32 @@ describe("org-settings service", () => {
     });
   }
 
-  it("contextTreeRepoOwnershipIdentity resolves GitLab references through the team's connection", () => {
+  it("contextTreeRepoOwnershipIdentity takes the web origin from wherever the reference states it", () => {
     const identity = orgSettingsService.contextTreeRepoOwnershipIdentity;
     const origin = "https://git.internal:8443";
+    const expected = "https://git.internal:8443/group/tree";
 
-    // One repository reached three ways by teams on the same forge. The SSH
-    // transport port is not a web port, so only the connection origin can say
-    // which forge an SSH reference belongs to.
-    const https = identity("https://git.internal:8443/group/tree.git", "gitlab", origin);
-    expect(https).toBe("https://git.internal:8443/group/tree");
-    expect(identity("ssh://git@git.internal:2222/group/tree.git", "gitlab", origin)).toBe(https);
-    expect(identity("git@git.internal:group/tree.git", "gitlab", origin)).toBe(https);
+    // An HTTP(S) reference states its own origin and needs no connection — a
+    // team that deletes its connection still owns the repository it is bound to.
+    expect(identity("https://git.internal:8443/group/tree.git", null)).toBe(expected);
+    expect(identity("https://git.internal:8443/group/tree.git", origin)).toBe(expected);
+
+    // SSH states no origin, so the owning team's connection supplies it. Its
+    // transport port is not a web port.
+    expect(identity("ssh://git@git.internal:2222/group/tree.git", origin)).toBe(expected);
+    expect(identity("git@git.internal:group/tree.git", origin)).toBe(expected);
+
+    // Without a usable connection an SSH reference has no establishable origin.
+    expect(identity("git@git.internal:group/tree.git", null)).toBeNull();
+    expect(identity("git@git.internal:group/tree.git", "https://git.elsewhere")).toBeNull();
 
     // A second instance on the same host is a different forge authority.
-    expect(identity("https://git.internal:9443/group/tree.git", "gitlab", "https://git.internal:9443")).not.toBe(https);
+    expect(identity("https://git.internal:9443/group/tree.git", null)).not.toBe(expected);
 
-    // An HTTPS reference whose origin is not the team's connection has no
-    // establishable authority, and neither does an unclassifiable host.
-    expect(identity("https://git.internal:9443/group/tree.git", "gitlab", origin)).toBeNull();
-    expect(identity("https://git.elsewhere/group/tree.git", undefined, null)).toBeNull();
-
-    // GitHub has one fixed origin and no port, so both spellings agree without
-    // any connection at all.
-    expect(identity("git@github.com:acme/tree.git", "github", null)).toBe(
-      identity("https://github.com/acme/tree", "github", null),
-    );
-    expect(identity("https://github.com/acme/tree.git", undefined, null)).toBe("github.com/acme/tree");
+    // GitHub has one fixed origin and no port, so its spellings agree with no
+    // connection at all.
+    expect(identity("git@github.com:acme/tree.git", null)).toBe(identity("https://github.com/acme/tree", null));
+    expect(identity("https://github.com/acme/tree.git", null)).toBe("github.com/acme/tree");
   });
 
   // The maintainer decision on first-tree#2122: SSH and HTTPS references to one
@@ -319,6 +320,55 @@ describe("org-settings service", () => {
         { provider: "gitlab", repo: "https://git.internal:8443/group/tree.git", branch: "main" },
         { updatedBy: holder.userId },
       );
+
+      await expect(
+        orgSettingsService.putOrgSetting(
+          app.db,
+          claimantOrgId,
+          "context_tree",
+          { provider: "gitlab", repo: alias, branch: "main" },
+          { updatedBy: claimant.userId },
+        ),
+      ).rejects.toThrow(/already another team's Context Tree/i);
+    });
+  }
+
+  // Deleting a GitLab connection does not clear `context_tree`, so a holder can
+  // outlive its connection. Its HTTPS binding already states the full web
+  // origin, and that binding still owns the repository.
+  for (const [spelling, alias] of [
+    ["HTTPS", "https://git.internal:8443/group/tree.git"],
+    ["scp-like SSH", "git@git.internal:group/tree.git"],
+  ] as const) {
+    it(`putOrgSetting refuses a repo held by a team with no connection, claimed over ${spelling}`, async () => {
+      const app = getApp();
+      const holder = await createTestAdmin(app);
+      const claimant = await createTestAdmin(app);
+      const claimantOrgId = uuidv7();
+      await app.db
+        .insert(organizations)
+        .values({ id: claimantOrgId, name: `noconn-${randomUUID().slice(0, 8)}`, displayName: "Claimant" });
+      for (const [orgId, memberId] of [
+        [holder.organizationId, holder.memberId],
+        [claimantOrgId, claimant.memberId],
+      ] as const) {
+        await createGitlabConnection(app.db, {
+          organizationId: orgId,
+          memberId,
+          displayName: "GitLab",
+          instanceOrigin: "https://git.internal:8443",
+        });
+      }
+
+      // The holder binds while connected, then loses its connection entirely.
+      await orgSettingsService.putOrgSetting(
+        app.db,
+        holder.organizationId,
+        "context_tree",
+        { provider: "gitlab", repo: "https://git.internal:8443/group/tree.git", branch: "main" },
+        { updatedBy: holder.userId },
+      );
+      await app.db.delete(gitlabConnections).where(eq(gitlabConnections.organizationId, holder.organizationId));
 
       await expect(
         orgSettingsService.putOrgSetting(

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -255,23 +255,84 @@ describe("org-settings service", () => {
     });
   }
 
-  it("contextTreeRepoOwnershipKey treats only an HTTP(S) port as forge authority", () => {
-    const key = orgSettingsService.contextTreeRepoOwnershipKey;
+  it("contextTreeRepoOwnershipIdentity resolves GitLab references through the team's connection", () => {
+    const identity = orgSettingsService.contextTreeRepoOwnershipIdentity;
+    const origin = "https://git.internal:8443";
 
-    // A self-managed forge's Web port identifies which forge it is.
-    expect(key("https://git.internal:8443/group/tree.git")).toBe("git.internal:8443/group/tree");
-    expect(key("https://git.internal:9443/group/tree.git")).not.toBe(key("https://git.internal:8443/group/tree.git"));
+    // One repository reached three ways by teams on the same forge. The SSH
+    // transport port is not a web port, so only the connection origin can say
+    // which forge an SSH reference belongs to.
+    const https = identity("https://git.internal:8443/group/tree.git", "gitlab", origin);
+    expect(https).toBe("https://git.internal:8443/group/tree");
+    expect(identity("ssh://git@git.internal:2222/group/tree.git", "gitlab", origin)).toBe(https);
+    expect(identity("git@git.internal:group/tree.git", "gitlab", origin)).toBe(https);
 
-    // An ssh:// port is a transport detail of one checkout, not a forge, so it
-    // must not become authority — and both SSH spellings must agree.
-    expect(key("ssh://git@git.internal:2222/group/tree.git")).toBe("git.internal/group/tree");
-    expect(key("git@git.internal:group/tree.git")).toBe("git.internal/group/tree");
+    // A second instance on the same host is a different forge authority.
+    expect(identity("https://git.internal:9443/group/tree.git", "gitlab", "https://git.internal:9443")).not.toBe(https);
 
-    // GitHub carries no port in either spelling, so SSH and HTTPS match there.
-    expect(key("git@github.com:acme/tree.git")).toBe(key("https://github.com/acme/tree"));
+    // An HTTPS reference whose origin is not the team's connection has no
+    // establishable authority, and neither does an unclassifiable host.
+    expect(identity("https://git.internal:9443/group/tree.git", "gitlab", origin)).toBeNull();
+    expect(identity("https://git.elsewhere/group/tree.git", undefined, null)).toBeNull();
+
+    // GitHub has one fixed origin and no port, so both spellings agree without
+    // any connection at all.
+    expect(identity("git@github.com:acme/tree.git", "github", null)).toBe(
+      identity("https://github.com/acme/tree", "github", null),
+    );
+    expect(identity("https://github.com/acme/tree.git", undefined, null)).toBe("github.com/acme/tree");
   });
 
-  it("putOrgSetting treats self-managed forges on different ports as different repos", async () => {
+  // The maintainer decision on first-tree#2122: SSH and HTTPS references to one
+  // self-managed repository must resolve to the same owner, which only each
+  // team's own GitLab connection origin can establish.
+  for (const [spelling, alias] of [
+    ["ssh:// with a transport port", "ssh://git@git.internal:2222/group/tree.git"],
+    ["scp-like SSH", "git@git.internal:group/tree.git"],
+    ["HTTPS on the connection origin", "https://git.internal:8443/group/tree.git"],
+  ] as const) {
+    it(`putOrgSetting refuses a GitLab repo another team holds, given as ${spelling}`, async () => {
+      const app = getApp();
+      const holder = await createTestAdmin(app);
+      const claimant = await createTestAdmin(app);
+      const claimantOrgId = uuidv7();
+      await app.db
+        .insert(organizations)
+        .values({ id: claimantOrgId, name: `gl-${randomUUID().slice(0, 8)}`, displayName: "Claimant" });
+      // Both teams are connected to the same self-managed instance.
+      for (const [orgId, memberId] of [
+        [holder.organizationId, holder.memberId],
+        [claimantOrgId, claimant.memberId],
+      ] as const) {
+        await createGitlabConnection(app.db, {
+          organizationId: orgId,
+          memberId,
+          displayName: "GitLab",
+          instanceOrigin: "https://git.internal:8443",
+        });
+      }
+
+      await orgSettingsService.putOrgSetting(
+        app.db,
+        holder.organizationId,
+        "context_tree",
+        { provider: "gitlab", repo: "https://git.internal:8443/group/tree.git", branch: "main" },
+        { updatedBy: holder.userId },
+      );
+
+      await expect(
+        orgSettingsService.putOrgSetting(
+          app.db,
+          claimantOrgId,
+          "context_tree",
+          { provider: "gitlab", repo: alias, branch: "main" },
+          { updatedBy: claimant.userId },
+        ),
+      ).rejects.toThrow(/already another team's Context Tree/i);
+    });
+  }
+
+  it("putOrgSetting keeps two self-managed instances on one host apart", async () => {
     const app = getApp();
     const first = await createTestAdmin(app);
     const second = await createTestAdmin(app);
@@ -279,24 +340,34 @@ describe("org-settings service", () => {
     await app.db
       .insert(organizations)
       .values({ id: secondOrgId, name: `port-${randomUUID().slice(0, 8)}`, displayName: "Other Instance" });
+    await createGitlabConnection(app.db, {
+      organizationId: first.organizationId,
+      memberId: first.memberId,
+      displayName: "GitLab",
+      instanceOrigin: "https://git.internal:8443",
+    });
+    await createGitlabConnection(app.db, {
+      organizationId: secondOrgId,
+      memberId: second.memberId,
+      displayName: "GitLab",
+      instanceOrigin: "https://git.internal:9443",
+    });
 
     await orgSettingsService.putOrgSetting(
       app.db,
       first.organizationId,
       "context_tree",
-      { repo: "https://git.internal:8443/group/tree.git", branch: "main" },
+      { provider: "gitlab", repo: "https://git.internal:8443/group/tree.git", branch: "main" },
       { updatedBy: first.userId },
     );
 
-    // Same host, different port — two separate self-managed instances. The
-    // provider-neutral canonical key drops the port, so comparing on it would
-    // refuse this team its own tree and make the audit report a shared tree
-    // that does not exist.
+    // Same host and path, different forge — a shared web origin is what makes
+    // two references one repository, and these do not share one.
     const out = await orgSettingsService.putOrgSetting(
       app.db,
       secondOrgId,
       "context_tree",
-      { repo: "https://git.internal:9443/group/tree.git", branch: "main" },
+      { provider: "gitlab", repo: "https://git.internal:9443/group/tree.git", branch: "main" },
       { updatedBy: second.userId },
     );
     expect(out).toMatchObject({ repo: "https://git.internal:9443/group/tree.git" });

--- a/packages/server/src/api/orgs/context-tree.ts
+++ b/packages/server/src/api/orgs/context-tree.ts
@@ -17,6 +17,7 @@ import { ConflictError } from "../../errors.js";
 import { requireOrgAdmin, requireOrgMembership } from "../../scope/require-org.js";
 import {
   ContextTreeRepoProvisionError,
+  contextTreeRepoName,
   ensureInstallationOwnedContextTreeRepo,
 } from "../../services/context-tree-repo-provisioner.js";
 import {
@@ -45,6 +46,7 @@ import {
   type TreeSetupRecoveryMessage,
 } from "../../services/onboarding-kickoff.js";
 import {
+  findOrgBoundToContextTreeRepo,
   getOrgContextReviewRuntime,
   getOrgContextTreeBinding,
   getOrgContextTreeSettingState,
@@ -73,8 +75,6 @@ jobs:
       - name: Validate Context Tree
         run: npx -p first-tree first-tree tree verify
 `;
-const REPO_SUFFIX = "-context-tree";
-const GITHUB_REPO_NAME_MAX_LENGTH = 100;
 const TREE_SETUP_TOPIC = "Set up shared context";
 const writePreflightRouteOptions = {
   // `undefined` intentionally preserves @fastify/rate-limit's global shared
@@ -288,8 +288,35 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
 
     const org = await getOrganization(app.db, scope.organizationId);
     const teamName = normalizeInlineText(org.displayName) || org.name;
-    const repoName = contextTreeRepoName(teamName);
+    const repoName = contextTreeRepoName(teamName, scope.organizationId);
     const expectedRepoFingerprint = fingerprintGithubRepository(`${installation.accountLogin}/${repoName}`);
+
+    // Provisioning adopts an existing repo when GitHub reports the name is
+    // taken, and adoption is only ever meant to recover this team's own
+    // half-created repo. The derived name is per-organization, so another team
+    // should not be able to reach this point — but a name is a guess about
+    // ownership and the binding table is the fact, so refuse rather than adopt
+    // a tree that already belongs to someone else.
+    const conflictingOrgId = await findOrgBoundToContextTreeRepo(
+      app.db,
+      scope.organizationId,
+      `https://github.com/${installation.accountLogin}/${repoName}.git`,
+    );
+    if (conflictingOrgId) {
+      app.log.warn(
+        {
+          event: "context_tree.initialize.repo_owned_by_other_org",
+          organizationId: scope.organizationId,
+          repoFingerprint: expectedRepoFingerprint,
+        },
+        "context tree initialize: derived repo already bound to another team",
+      );
+      return reply.status(409).send({
+        error:
+          "That GitHub repo is already the Context Tree of another team. Rename this team, or connect an existing repo from Settings → Context Tree.",
+        code: "context_tree_repo_owned_by_other_org",
+      });
+    }
     app.log.info(
       {
         event: "context_tree.initialize.start",
@@ -732,22 +759,6 @@ function mapUpstreamError(err: unknown, message: string): ContextTreeInitializeE
     return err;
   }
   return new ContextTreeInitializeError(502, "upstream", message);
-}
-
-function contextTreeRepoName(teamName: string): string {
-  const maxBaseLength = GITHUB_REPO_NAME_MAX_LENGTH - REPO_SUFFIX.length;
-  const base = slugifyRepoBase(teamName).slice(0, maxBaseLength).replace(/-+$/g, "") || "team";
-  return `${base}${REPO_SUFFIX}`;
-}
-
-function slugifyRepoBase(value: string): string {
-  const ascii = value.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
-  const slug = ascii
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .replace(/-{2,}/g, "-");
-  return slug || "team";
 }
 
 function initialRootNode(teamName: string, githubLogin: string): string {

--- a/packages/server/src/services/context-tree-binding-audit.ts
+++ b/packages/server/src/services/context-tree-binding-audit.ts
@@ -1,0 +1,61 @@
+import { contextTreeRepoOwnershipIdentity } from "./org-settings.js";
+
+/**
+ * Pure partitioning behind the shared-Context-Tree-repo audit. It lives beside
+ * the ownership rule it depends on so both are typechecked and tested with the
+ * rest of the service layer; the script under `scripts/` is only the runner
+ * that supplies rows and prints them.
+ */
+
+export type BindingRow = {
+  organization_id: string;
+  display_name: string | null;
+  repo: string | null;
+  instance_origin: string | null;
+};
+
+export type SharedRepo = {
+  identity: string;
+  teams: Array<{ organizationId: string; displayName: string; repo: string }>;
+};
+
+export type UnresolvedBinding = { organizationId: string; displayName: string; repo: string };
+
+export type AuditResult = { shared: SharedRepo[]; unresolved: UnresolvedBinding[] };
+
+/**
+ * Split bindings into repositories more than one team holds, and rows whose
+ * forge cannot be established.
+ *
+ * Unresolved rows are reported rather than dropped. Legacy and hand-edited
+ * bindings may keep a repo with no provider or no matching connection, and
+ * those are exactly the rows a remediation audit exists to surface — silently
+ * skipping them would let two affected teams go unlisted while the operator
+ * reads "no sharing" and stops looking.
+ */
+export function auditBindings(rows: BindingRow[]): AuditResult {
+  const byIdentity = new Map<string, SharedRepo>();
+  const unresolved: UnresolvedBinding[] = [];
+  for (const row of rows) {
+    if (!row.repo) continue;
+    const team = {
+      organizationId: row.organization_id,
+      displayName: row.display_name ?? "",
+      repo: row.repo,
+    };
+    const identity = contextTreeRepoOwnershipIdentity(row.repo, row.instance_origin);
+    if (!identity) {
+      unresolved.push(team);
+      continue;
+    }
+    const entry = byIdentity.get(identity) ?? { identity, teams: [] };
+    entry.teams.push(team);
+    byIdentity.set(identity, entry);
+  }
+  return {
+    shared: [...byIdentity.values()]
+      .filter((entry) => entry.teams.length > 1)
+      .sort((a, b) => b.teams.length - a.teams.length),
+    unresolved,
+  };
+}

--- a/packages/server/src/services/context-tree-repo-provisioner.ts
+++ b/packages/server/src/services/context-tree-repo-provisioner.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   createOrganizationRepo,
   GithubAppApiError,
@@ -27,6 +28,9 @@ import type { GithubUserToken } from "./github-user-token.js";
  * it has been granted access (always true for an "all repositories" install, but
  * a "selected repositories" install must add the freshly-created repo first).
  */
+
+const REPO_SUFFIX = "-context-tree";
+const GITHUB_REPO_NAME_MAX_LENGTH = 100;
 
 export class ContextTreeRepoProvisionError extends Error {
   constructor(
@@ -220,4 +224,36 @@ function mapUpstreamError(err: unknown, message: string): ContextTreeRepoProvisi
 
 function contextTreeRepoDescription(teamName: string): string {
   return `${teamName} Context Tree`;
+}
+
+/**
+ * Derive the Context Tree repo name for one team.
+ *
+ * The name carries a per-organization discriminator because it must be unique
+ * within the GitHub account that hosts it, while the team name it is derived
+ * from is not: display names are deliberately non-unique, and every name
+ * without ASCII alphanumerics — any all-CJK team name — slugifies to the same
+ * `"team"` fallback. Without the discriminator, two teams under one GitHub
+ * account derive one name and the adopt-on-conflict step above hands the
+ * second team the first team's tree.
+ *
+ * The discriminator hashes the organization id rather than slicing it: ids are
+ * opaque text, and a uuidv7's leading bytes are a timestamp, so same-day
+ * organizations would share any prefix taken from one.
+ */
+export function contextTreeRepoName(teamName: string, organizationId: string): string {
+  const discriminator = `-${createHash("sha256").update(organizationId).digest("hex").slice(0, 8)}`;
+  const maxBaseLength = GITHUB_REPO_NAME_MAX_LENGTH - REPO_SUFFIX.length - discriminator.length;
+  const base = slugifyRepoBase(teamName).slice(0, maxBaseLength).replace(/-+$/g, "") || "team";
+  return `${base}${discriminator}${REPO_SUFFIX}`;
+}
+
+function slugifyRepoBase(value: string): string {
+  const ascii = value.normalize("NFKD").replace(/[̀-ͯ]/g, "");
+  const slug = ascii
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+  return slug || "team";
 }

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -429,24 +429,35 @@ export async function getOrgContextTreeSettingState(db: Database, orgId: string)
  * arrives through another — a text comparison would report no conflict and hand
  * over a repository that is already someone's tree.
  *
- * Candidates are canonicalized in application code rather than SQL because the
- * canonical form is the shared cross-package rule; the scan is bounded by teams
- * that have a tree bound at all, and this runs once per initialization.
+ * Each side is resolved through its own team's GitLab connection, so an SSH
+ * reference and an HTTPS reference to one self-managed repository reduce to the
+ * same web identity. Resolution happens in application code rather than SQL
+ * because the identity rule is the shared cross-package one; the scan is
+ * bounded by teams that have a tree bound at all, and this runs once per write.
  */
 export async function findOrgBoundToContextTreeRepo(
   db: Database,
   excludeOrgId: string,
   repoUrl: string,
+  declaredProvider?: ContextTreeProvider,
 ): Promise<string | null> {
-  const target = contextTreeRepoOwnershipKey(repoUrl);
+  const [callerConnection] = await db
+    .select({ instanceOrigin: gitlabConnections.instanceOrigin })
+    .from(gitlabConnections)
+    .where(eq(gitlabConnections.organizationId, excludeOrgId))
+    .limit(1);
+  const target = contextTreeRepoOwnershipIdentity(repoUrl, declaredProvider, callerConnection?.instanceOrigin);
   if (!target) return null;
 
   const rows = await db
     .select({
       organizationId: organizationSettings.organizationId,
       repo: sql<string | null>`${organizationSettings.value}->>'repo'`,
+      provider: sql<string | null>`${organizationSettings.value}->>'provider'`,
+      instanceOrigin: gitlabConnections.instanceOrigin,
     })
     .from(organizationSettings)
+    .leftJoin(gitlabConnections, eq(gitlabConnections.organizationId, organizationSettings.organizationId))
     .where(
       and(
         eq(organizationSettings.namespace, "context_tree"),
@@ -455,7 +466,16 @@ export async function findOrgBoundToContextTreeRepo(
       ),
     );
 
-  return rows.find((row) => contextTreeRepoOwnershipKey(row.repo) === target)?.organizationId ?? null;
+  return (
+    rows.find(
+      (row) =>
+        contextTreeRepoOwnershipIdentity(row.repo, asContextTreeProvider(row.provider), row.instanceOrigin) === target,
+    )?.organizationId ?? null
+  );
+}
+
+function asContextTreeProvider(value: string | null): ContextTreeProvider | undefined {
+  return value === "github" || value === "gitlab" ? value : undefined;
 }
 
 /**
@@ -774,34 +794,39 @@ async function resolveStoredContextTreeProvider(
  * Identity two Context Tree bindings are compared on to decide whether they
  * name the same repository.
  *
- * `canonicalGitRepoUrl` deliberately drops transport detail, including the
- * HTTPS port — but a self-managed forge's port is part of which forge it is.
- * Two teams on `git.internal:8443` and `git.internal:9443` are on different
- * instances, and collapsing them would refuse a team its own tree and make the
- * audit report a shared tree that does not exist. So the port is kept whenever
- * the reference carries one.
+ * A repository reference alone is not enough to answer that. The binding
+ * contract accepts HTTPS, `ssh://`, and scp-like SSH spellings, and only the
+ * owning team's GitLab connection says which web origin an SSH reference
+ * belongs to — its transport port never doubles as the forge's web port. So a
+ * GitLab reference resolves through that team's own connection origin, and one
+ * repository reached over SSH by one team and HTTPS by another reduces to the
+ * same identity. Two teams on `git.internal:8443` and `git.internal:9443`
+ * stay distinct, because a non-default web port is part of which forge it is.
  *
- * Only an HTTP(S) port is authority. An `ssh://…:2222` port is a transport
- * detail of one checkout, not a forge, so SSH references — both `ssh://` and
- * scp-like — key on the host alone and therefore do not match a team bound
- * through a non-default web port. Resolving that would mean mapping each
- * team's SSH reference through its own GitLab connection origin. Until then
- * this direction fails open: a conflict goes unnoticed rather than a
- * legitimate binding being refused.
+ * GitHub needs no connection: it has one fixed origin and no port, so both
+ * spellings already agree under the shared canonical form.
+ *
+ * A reference that cannot be classified — a self-managed host with no
+ * connection, or one whose origin does not match its team's connection — has
+ * no establishable authority and returns null, which fails open. That is the
+ * safe direction: a conflict goes unnoticed rather than a legitimate binding
+ * being refused on a guess.
  */
-export function contextTreeRepoOwnershipKey(repo: string | null | undefined): string | null {
-  const canonical = canonicalGitRepoUrl(repo);
-  if (!canonical || !repo) return null;
-  try {
-    const { protocol, port } = new URL(repo.trim());
-    if (port && (protocol === "https:" || protocol === "http:")) {
-      const hostEnd = canonical.indexOf("/");
-      return `${canonical.slice(0, hostEnd)}:${port}${canonical.slice(hostEnd)}`;
-    }
-  } catch {
-    // scp-like or unparsable: the canonical form is the best available key.
+export function contextTreeRepoOwnershipIdentity(
+  repo: string | null | undefined,
+  declaredProvider: ContextTreeProvider | undefined,
+  gitlabInstanceOrigin: string | null | undefined,
+): string | null {
+  if (!repo) return null;
+  const resolution = resolveContextTreeProvider({ repo, declaredProvider, gitlabInstanceOrigin });
+  if (resolution.provider === "gitlab") {
+    const web = resolveGitLabRepositoryWebIdentity(repo, gitlabInstanceOrigin);
+    return web?.originMatchesConnection ? `${web.origin}/${web.path}` : null;
   }
-  return canonical;
+  if (resolution.provider === "github") {
+    return canonicalGitRepoUrl(repo);
+  }
+  return null;
 }
 
 /**
@@ -821,11 +846,11 @@ export function contextTreeRepoOwnershipKey(repo: string | null | undefined): st
 async function assertContextTreeRepoNotHeldByAnotherOrg(
   db: Database,
   orgId: string,
-  repo: string | undefined,
+  binding: OrgSettingStorage<"context_tree">,
 ): Promise<void> {
-  if (!repo || !contextTreeRepoOwnershipKey(repo)) return;
+  if (!binding.repo) return;
 
-  const holder = await findOrgBoundToContextTreeRepo(db, orgId, repo);
+  const holder = await findOrgBoundToContextTreeRepo(db, orgId, binding.repo, binding.provider);
   if (holder) {
     throw new ConflictError("That repository is already another team's Context Tree");
   }
@@ -836,7 +861,7 @@ export async function assertContextTreeBindingTargetAuthorized(
   orgId: string,
   binding: OrgSettingStorage<"context_tree">,
 ): Promise<void> {
-  await assertContextTreeRepoNotHeldByAnotherOrg(db, orgId, binding.repo);
+  await assertContextTreeRepoNotHeldByAnotherOrg(db, orgId, binding);
   if (!binding.provider || !binding.repo) return;
   const resolution = resolveContextTreeProvider({
     repo: binding.repo,

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -423,11 +423,11 @@ export async function getOrgContextTreeSettingState(db: Database, orgId: string)
  * one tree, and the second team silently reads and writes the first team's
  * decisions.
  *
- * Comparison is on canonical repository identity, never on URL text. The
- * binding contract accepts HTTPS, `ssh://`, and scp-like SSH spellings with an
- * optional `.git`, so a team bound through one transport must still be found
- * when the lookup arrives through another — a text comparison would report no
- * conflict and hand over a repository that is already someone's tree.
+ * Comparison is on repository identity, never on URL text. The binding contract
+ * accepts HTTPS, `ssh://`, and scp-like SSH spellings with an optional `.git`,
+ * so a team bound through one transport must still be found when the lookup
+ * arrives through another — a text comparison would report no conflict and hand
+ * over a repository that is already someone's tree.
  *
  * Candidates are canonicalized in application code rather than SQL because the
  * canonical form is the shared cross-package rule; the scan is bounded by teams
@@ -438,7 +438,7 @@ export async function findOrgBoundToContextTreeRepo(
   excludeOrgId: string,
   repoUrl: string,
 ): Promise<string | null> {
-  const target = canonicalGitRepoUrl(repoUrl);
+  const target = contextTreeRepoOwnershipKey(repoUrl);
   if (!target) return null;
 
   const rows = await db
@@ -455,7 +455,7 @@ export async function findOrgBoundToContextTreeRepo(
       ),
     );
 
-  return rows.find((row) => canonicalGitRepoUrl(row.repo) === target)?.organizationId ?? null;
+  return rows.find((row) => contextTreeRepoOwnershipKey(row.repo) === target)?.organizationId ?? null;
 }
 
 /**
@@ -771,6 +771,37 @@ async function resolveStoredContextTreeProvider(
 }
 
 /**
+ * Identity two Context Tree bindings are compared on to decide whether they
+ * name the same repository.
+ *
+ * `canonicalGitRepoUrl` deliberately drops transport detail, including the
+ * HTTPS port — but a self-managed forge's port is part of which forge it is.
+ * Two teams on `git.internal:8443` and `git.internal:9443` are on different
+ * instances, and collapsing them would refuse a team its own tree and make the
+ * audit report a shared tree that does not exist. So the port is kept whenever
+ * the reference carries one.
+ *
+ * scp-like SSH references have no web port to keep and fall back to the shared
+ * canonical form, so an SSH binding and an HTTPS binding on a non-default port
+ * do not compare equal. That direction fails open — a conflict goes unnoticed
+ * rather than a legitimate binding being refused.
+ */
+export function contextTreeRepoOwnershipKey(repo: string | null | undefined): string | null {
+  const canonical = canonicalGitRepoUrl(repo);
+  if (!canonical || !repo) return null;
+  try {
+    const { port } = new URL(repo.trim());
+    if (port) {
+      const hostEnd = canonical.indexOf("/");
+      return `${canonical.slice(0, hostEnd)}:${port}${canonical.slice(hostEnd)}`;
+    }
+  } catch {
+    // scp-like or unparsable: the canonical form is the best available key.
+  }
+  return canonical;
+}
+
+/**
  * Refuse a binding that would point this team at another team's Context Tree.
  *
  * A Context Tree repository backs one team: sharing one merges two teams'
@@ -789,7 +820,7 @@ async function assertContextTreeRepoNotHeldByAnotherOrg(
   orgId: string,
   repo: string | undefined,
 ): Promise<void> {
-  if (!repo || !canonicalGitRepoUrl(repo)) return;
+  if (!repo || !contextTreeRepoOwnershipKey(repo)) return;
 
   const holder = await findOrgBoundToContextTreeRepo(db, orgId, repo);
   if (holder) {

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -3,6 +3,7 @@ import {
   type ContextTreeActiveBinding,
   type ContextTreeProvider,
   type ContextTreeSettingState,
+  canonicalGitRepoUrl,
   classifyContextTreeSetting,
   contextTreeActiveBindingSchema,
   contextTreeBranchSchema,
@@ -421,24 +422,40 @@ export async function getOrgContextTreeSettingState(db: Database, orgId: string)
  * Without it, two teams whose names derive the same repo name end up sharing
  * one tree, and the second team silently reads and writes the first team's
  * decisions.
+ *
+ * Comparison is on canonical repository identity, never on URL text. The
+ * binding contract accepts HTTPS, `ssh://`, and scp-like SSH spellings with an
+ * optional `.git`, so a team bound through one transport must still be found
+ * when the lookup arrives through another — a text comparison would report no
+ * conflict and hand over a repository that is already someone's tree.
+ *
+ * Candidates are canonicalized in application code rather than SQL because the
+ * canonical form is the shared cross-package rule; the scan is bounded by teams
+ * that have a tree bound at all, and this runs once per initialization.
  */
 export async function findOrgBoundToContextTreeRepo(
   db: Database,
   excludeOrgId: string,
   repoUrl: string,
 ): Promise<string | null> {
-  const [row] = await db
-    .select({ organizationId: organizationSettings.organizationId })
+  const target = canonicalGitRepoUrl(repoUrl);
+  if (!target) return null;
+
+  const rows = await db
+    .select({
+      organizationId: organizationSettings.organizationId,
+      repo: sql<string | null>`${organizationSettings.value}->>'repo'`,
+    })
     .from(organizationSettings)
     .where(
       and(
         eq(organizationSettings.namespace, "context_tree"),
         ne(organizationSettings.organizationId, excludeOrgId),
-        sql`lower(${organizationSettings.value}->>'repo') = ${repoUrl.toLowerCase()}`,
+        sql`${organizationSettings.value}->>'repo' IS NOT NULL`,
       ),
-    )
-    .limit(1);
-  return row?.organizationId ?? null;
+    );
+
+  return rows.find((row) => canonicalGitRepoUrl(row.repo) === target)?.organizationId ?? null;
 }
 
 /**
@@ -753,11 +770,43 @@ async function resolveStoredContextTreeProvider(
   return { ...storage, provider: undefined };
 }
 
+/**
+ * Refuse a binding that would point this team at another team's Context Tree.
+ *
+ * A Context Tree repository backs one team: sharing one merges two teams'
+ * decisions, constraints, and ownership into a single tree. This runs on every
+ * binding write — Cloud provisioning, manual Settings binding, and the
+ * `tree init` callback alike — because the repository is the thing being
+ * claimed regardless of which surface names it.
+ *
+ * The advisory lock is what makes the check a decision rather than a guess.
+ * The caller already holds its own organization row, which does nothing to
+ * stop a *different* organization from passing this same check concurrently
+ * and committing a second binding to the same tree. Serializing on the
+ * repository identity closes that window; it is transaction-scoped, so it is
+ * released with the surrounding write either way.
+ */
+async function assertContextTreeRepoNotHeldByAnotherOrg(
+  db: Database,
+  orgId: string,
+  repo: string | undefined,
+): Promise<void> {
+  const canonical = canonicalGitRepoUrl(repo);
+  if (!canonical || !repo) return;
+
+  await db.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${canonical}))`);
+  const holder = await findOrgBoundToContextTreeRepo(db, orgId, repo);
+  if (holder) {
+    throw new ConflictError("That repository is already another team's Context Tree");
+  }
+}
+
 export async function assertContextTreeBindingTargetAuthorized(
   db: Database,
   orgId: string,
   binding: OrgSettingStorage<"context_tree">,
 ): Promise<void> {
+  await assertContextTreeRepoNotHeldByAnotherOrg(db, orgId, binding.repo);
   if (!binding.provider || !binding.repo) return;
   const resolution = resolveContextTreeProvider({
     repo: binding.repo,

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -781,17 +781,20 @@ async function resolveStoredContextTreeProvider(
  * audit report a shared tree that does not exist. So the port is kept whenever
  * the reference carries one.
  *
- * scp-like SSH references have no web port to keep and fall back to the shared
- * canonical form, so an SSH binding and an HTTPS binding on a non-default port
- * do not compare equal. That direction fails open — a conflict goes unnoticed
- * rather than a legitimate binding being refused.
+ * Only an HTTP(S) port is authority. An `ssh://…:2222` port is a transport
+ * detail of one checkout, not a forge, so SSH references — both `ssh://` and
+ * scp-like — key on the host alone and therefore do not match a team bound
+ * through a non-default web port. Resolving that would mean mapping each
+ * team's SSH reference through its own GitLab connection origin. Until then
+ * this direction fails open: a conflict goes unnoticed rather than a
+ * legitimate binding being refused.
  */
 export function contextTreeRepoOwnershipKey(repo: string | null | undefined): string | null {
   const canonical = canonicalGitRepoUrl(repo);
   if (!canonical || !repo) return null;
   try {
-    const { port } = new URL(repo.trim());
-    if (port) {
+    const { protocol, port } = new URL(repo.trim());
+    if (port && (protocol === "https:" || protocol === "http:")) {
       const hostEnd = canonical.indexOf("/");
       return `${canonical.slice(0, hostEnd)}:${port}${canonical.slice(hostEnd)}`;
     }

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -413,6 +413,35 @@ export async function getOrgContextTreeSettingState(db: Database, orgId: string)
 }
 
 /**
+ * Find another organization already bound to `repoUrl`, if any.
+ *
+ * A Context Tree repo belongs to exactly one team. Provisioning derives a repo
+ * name and adopts an existing repo when GitHub reports the name is taken, so
+ * "the name matches" is only ever a guess about ownership — this is the fact.
+ * Without it, two teams whose names derive the same repo name end up sharing
+ * one tree, and the second team silently reads and writes the first team's
+ * decisions.
+ */
+export async function findOrgBoundToContextTreeRepo(
+  db: Database,
+  excludeOrgId: string,
+  repoUrl: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ organizationId: organizationSettings.organizationId })
+    .from(organizationSettings)
+    .where(
+      and(
+        eq(organizationSettings.namespace, "context_tree"),
+        ne(organizationSettings.organizationId, excludeOrgId),
+        sql`lower(${organizationSettings.value}->>'repo') = ${repoUrl.toLowerCase()}`,
+      ),
+    )
+    .limit(1);
+  return row?.organizationId ?? null;
+}
+
+/**
  * Read the Context Tree binding plus row freshness. Onboarding recovery uses
  * `updatedAt` to distinguish a tree binding created after the user completed
  * the value-first work chat from an older, already-adopted team tree.

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -779,22 +779,18 @@ async function resolveStoredContextTreeProvider(
  * `tree init` callback alike — because the repository is the thing being
  * claimed regardless of which surface names it.
  *
- * The advisory lock is what makes the check a decision rather than a guess.
- * The caller already holds its own organization row, which does nothing to
- * stop a *different* organization from passing this same check concurrently
- * and committing a second binding to the same tree. Serializing on the
- * repository identity closes that window; it is transaction-scoped, so it is
- * released with the surrounding write either way.
+ * Two organizations binding the same repository at the same instant can still
+ * both pass this check: the caller holds its own organization row, which does
+ * not serialize a different organization's write. That window is left open
+ * rather than closed with a lock on the repository identity.
  */
 async function assertContextTreeRepoNotHeldByAnotherOrg(
   db: Database,
   orgId: string,
   repo: string | undefined,
 ): Promise<void> {
-  const canonical = canonicalGitRepoUrl(repo);
-  if (!canonical || !repo) return;
+  if (!repo || !canonicalGitRepoUrl(repo)) return;
 
-  await db.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${canonical}))`);
   const holder = await findOrgBoundToContextTreeRepo(db, orgId, repo);
   if (holder) {
     throw new ConflictError("That repository is already another team's Context Tree");

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -3,7 +3,7 @@ import {
   type ContextTreeActiveBinding,
   type ContextTreeProvider,
   type ContextTreeSettingState,
-  canonicalGitRepoUrl,
+  canonicalGitRepoIdentity,
   classifyContextTreeSetting,
   contextTreeActiveBindingSchema,
   contextTreeBranchSchema,
@@ -439,21 +439,19 @@ export async function findOrgBoundToContextTreeRepo(
   db: Database,
   excludeOrgId: string,
   repoUrl: string,
-  declaredProvider?: ContextTreeProvider,
 ): Promise<string | null> {
   const [callerConnection] = await db
     .select({ instanceOrigin: gitlabConnections.instanceOrigin })
     .from(gitlabConnections)
     .where(eq(gitlabConnections.organizationId, excludeOrgId))
     .limit(1);
-  const target = contextTreeRepoOwnershipIdentity(repoUrl, declaredProvider, callerConnection?.instanceOrigin);
+  const target = contextTreeRepoOwnershipIdentity(repoUrl, callerConnection?.instanceOrigin);
   if (!target) return null;
 
   const rows = await db
     .select({
       organizationId: organizationSettings.organizationId,
       repo: sql<string | null>`${organizationSettings.value}->>'repo'`,
-      provider: sql<string | null>`${organizationSettings.value}->>'provider'`,
       instanceOrigin: gitlabConnections.instanceOrigin,
     })
     .from(organizationSettings)
@@ -467,15 +465,9 @@ export async function findOrgBoundToContextTreeRepo(
     );
 
   return (
-    rows.find(
-      (row) =>
-        contextTreeRepoOwnershipIdentity(row.repo, asContextTreeProvider(row.provider), row.instanceOrigin) === target,
-    )?.organizationId ?? null
+    rows.find((row) => contextTreeRepoOwnershipIdentity(row.repo, row.instanceOrigin) === target)?.organizationId ??
+    null
   );
-}
-
-function asContextTreeProvider(value: string | null): ContextTreeProvider | undefined {
-  return value === "github" || value === "gitlab" ? value : undefined;
 }
 
 /**
@@ -794,39 +786,56 @@ async function resolveStoredContextTreeProvider(
  * Identity two Context Tree bindings are compared on to decide whether they
  * name the same repository.
  *
- * A repository reference alone is not enough to answer that. The binding
- * contract accepts HTTPS, `ssh://`, and scp-like SSH spellings, and only the
- * owning team's GitLab connection says which web origin an SSH reference
- * belongs to — its transport port never doubles as the forge's web port. So a
- * GitLab reference resolves through that team's own connection origin, and one
- * repository reached over SSH by one team and HTTPS by another reduces to the
- * same identity. Two teams on `git.internal:8443` and `git.internal:9443`
- * stay distinct, because a non-default web port is part of which forge it is.
+ * The identity is the repository's web origin and path. Where that origin comes
+ * from depends on the reference, because the binding contract accepts HTTPS,
+ * `ssh://`, and scp-like SSH spellings:
  *
- * GitHub needs no connection: it has one fixed origin and no port, so both
- * spellings already agree under the shared canonical form.
+ * - GitHub states it implicitly — one fixed origin, no port — so every
+ *   spelling already agrees under the shared canonical form.
+ * - An HTTP(S) reference states it outright, port included, and needs nothing
+ *   else. Asking for a connection here would discard the identity of a binding
+ *   whose team later deletes its connection, and that binding still owns its
+ *   repository.
+ * - An SSH or scp-like reference states no origin at all, and its transport
+ *   port is never the forge's, so only the owning team's GitLab connection can
+ *   supply one.
  *
- * A reference that cannot be classified — a self-managed host with no
- * connection, or one whose origin does not match its team's connection — has
- * no establishable authority and returns null, which fails open. That is the
- * safe direction: a conflict goes unnoticed rather than a legitimate binding
- * being refused on a guess.
+ * All three land on the same string for one repository, so a team on HTTPS and
+ * a team on SSH are seen to hold the same tree. Two self-managed instances on
+ * one host stay distinct, because a non-default web port is part of which
+ * forge it is.
+ *
+ * An SSH reference whose team has no connection, or whose host does not match
+ * it, has no establishable origin and returns null. That fails open on the safe
+ * side: a conflict goes unnoticed rather than a legitimate binding being
+ * refused on a guess.
  */
 export function contextTreeRepoOwnershipIdentity(
   repo: string | null | undefined,
-  declaredProvider: ContextTreeProvider | undefined,
   gitlabInstanceOrigin: string | null | undefined,
 ): string | null {
-  if (!repo) return null;
-  const resolution = resolveContextTreeProvider({ repo, declaredProvider, gitlabInstanceOrigin });
-  if (resolution.provider === "gitlab") {
-    const web = resolveGitLabRepositoryWebIdentity(repo, gitlabInstanceOrigin);
-    return web?.originMatchesConnection ? `${web.origin}/${web.path}` : null;
+  const identity = canonicalGitRepoIdentity(repo);
+  if (!identity || !repo) return null;
+
+  // GitHub has one fixed origin and no port, so every spelling already agrees.
+  if (identity.host === "github.com") return identity.canonical;
+
+  // An HTTP(S) reference states its own web origin, port included. Requiring a
+  // connection to read it would drop the identity of a binding whose team later
+  // deletes its connection — and that binding still owns its repository.
+  try {
+    const url = new URL(repo.trim());
+    if (url.protocol === "https:" || url.protocol === "http:") {
+      return `${url.origin.toLowerCase()}/${identity.path}`;
+    }
+  } catch {
+    // Not a URL — scp-like SSH, handled below.
   }
-  if (resolution.provider === "github") {
-    return canonicalGitRepoUrl(repo);
-  }
-  return null;
+
+  // SSH and scp-like references carry no web origin, and their transport port
+  // is never the forge's, so only the owning team's connection can supply one.
+  const web = resolveGitLabRepositoryWebIdentity(repo, gitlabInstanceOrigin);
+  return web?.originMatchesConnection ? `${web.origin}/${web.path}` : null;
 }
 
 /**
@@ -850,7 +859,7 @@ async function assertContextTreeRepoNotHeldByAnotherOrg(
 ): Promise<void> {
   if (!binding.repo) return;
 
-  const holder = await findOrgBoundToContextTreeRepo(db, orgId, binding.repo, binding.provider);
+  const holder = await findOrgBoundToContextTreeRepo(db, orgId, binding.repo);
   if (holder) {
     throw new ConflictError("That repository is already another team's Context Tree");
   }


### PR DESCRIPTION
Follow-up to #2115 / #2117. Same root cause — a derived identifier assuming display names are unique — but this one is reachable today and mixes two teams' context.

## Problem

`contextTreeRepoName` derived the Context Tree repo name from the team display name alone. `slugifyRepoBase` drops every character outside `[a-z0-9]`, so any display name without an ASCII alphanumeric falls back to the same `"team"` base:

```
"ACME Robotics"  ->  acme-robotics-context-tree
"电商平台"        ->  team-context-tree
"设计团队"        ->  team-context-tree
"销售部"          ->  team-context-tree
```

Display names are deliberately not unique, so this is not only a CJK problem — two teams both named "Design Team" under one GitHub account collide the same way. CJK just makes *every* name collide.

Provisioning then makes the collision silent. Both storage backends adopt an existing repo on the deterministic name: `ensureOrganizationRepo` falls back to adoption on `422 already exists`, and `ensureUserRepo` probes for the repo before creating anything. Neither asks whether the repo already belongs to a different team — `verifyInstallationCanAccess` only asks whether *this installation* can read it, which is trivially true for a sibling team under the same account.

Walked through, with two teams under `acme-inc`:

1. 电商平台 initializes → derives `team-context-tree` → creates it → binds it.
2. 设计团队 initializes → derives `team-context-tree` → create returns 422 → adopts → binds **the same repo**.

No error. Both teams now read and write one Context Tree, so each team's decisions, constraints and ownership are visible and writable by the other.

Adoption itself is not the bug. Initialization is gated on `existing.kind !== "unbound"`, so a team that already has a tree cannot reach this code; adoption exists to recover *this* team's repo when an earlier run created it but failed before persisting the binding. A colliding name is what turned "recover my own repo" into "take over someone else's".

## Change

**The name gets a per-organization discriminator**, so the collision cannot happen:

```
acme-robotics-2671b724-context-tree
team-4d0a91c7-context-tree
team-9f31ab05-context-tree
```

The discriminator hashes the organization id rather than slicing it — ids are opaque text, and a uuidv7's leading bytes are a timestamp, so same-day organizations would share any prefix taken from one. It stays stable for a given organization, so a retry still adopts its own repo, and it is included in the length budget so names stay under GitHub's 100-character limit.

**Every binding write refuses a repo another team holds**, so a collision cannot pass unnoticed if one occurs anyway. A name only guesses at ownership; `organization_settings` is the fact. The check lives in `assertContextTreeBindingTargetAuthorized`, the seam that Cloud provisioning, manual Settings binding, and the `tree init` callback all already call inside their transaction — the repository is the thing being claimed regardless of which surface names it. The initializer also keeps a pre-check so it fails before the GitHub round trip rather than creating a repo and rejecting the binding afterwards, returning 409 `context_tree_repo_owned_by_other_org`.

**Ownership is decided on the repository's web origin and path, not on URL text.** `context_tree.repo` accepts HTTPS, `ssh://`, and scp-like SSH spellings with an optional `.git`, and where that origin comes from depends on the reference. GitHub states it implicitly — one fixed origin, no port — so every spelling already agrees. An HTTP(S) reference states it outright, port included, and needs nothing else; requiring a connection there would discard the identity of a binding whose team later deletes its connection, and that binding still owns its repository. Only SSH and scp-like references, which carry no origin and whose transport port is never the forge's, resolve through the owning team's `gitlab_connections.instance_origin` — for the target and every stored candidate alike.

All three land on one identity for one repository, so a team on HTTPS and a team on SSH are seen to hold the same tree, while two self-managed instances on one host stay distinct.

An SSH reference whose team has no usable connection has no establishable origin. The guard leaves it unclaimed — a conflict goes unnoticed rather than a legitimate binding being refused on a guess — and the audit reports it rather than dropping it (below).

The audit groups on the same identity, so transport aliases of one repository are no longer reported as unrelated rows. Rows it cannot resolve are listed separately and make the run non-zero: legacy and hand-edited bindings may keep a repo with no provider and no matching connection, and dropping them would let two affected teams go unlisted while the operator reads a clean result. A clean result now means both that nothing is shared and that every binding resolved.

Both are needed. The discriminator alone would not cover repos created under the old naming, a repo somebody created by hand, or a leftover from a team that unbound its tree. The check alone would leave every collision to be recovered after a failed GitHub round trip.

`contextTreeRepoName` moves from the route file into `context-tree-repo-provisioner`, next to the adoption it constrains and where it can be tested directly.

## Existing data

The new rule does not unpick bindings already written. `packages/server/scripts/audit-shared-context-tree-repos.ts` reports every repo more than one team is bound to, plus every binding whose forge it could not establish. It is read-only — one SELECT, no writes — and each row it finds needs an owner decision about which team keeps the tree, so nothing is repaired automatically.

## Tests

- `context-tree-repo-provisioner.test.ts`: derivation unit tests — the readable base survives, two teams that derive the same base get different names (CJK pair and a duplicate English display name), the name is stable per organization, and it respects the 100-character limit.
- `context-tree-initialize.test.ts`: parking the derived repo on another team makes initialization return 409 `context_tree_repo_owned_by_other_org`, mint only the installation token, create or adopt nothing, and leave the caller unbound — covered for the clone URL, HTTPS without `.git`, `ssh://`, and scp-like SSH spellings.
- `org-settings.test.ts`: aliases of one repository are refused on the manual Settings write path, and a team re-stating its own binding through a different spelling is still allowed. For a team connected to web origin `:8443`, an HTTPS binding conflicts with `ssh://…:2222`, with scp-like SSH, and with the HTTPS spelling — each backed by a real connection row — while two teams connected to `:8443` and `:9443` bind the same host and path independently. A unit test pins the identity itself: the three GitLab spellings collapse to one web identity, a mismatched or unclassifiable origin yields none, and GitHub's SSH and HTTPS spellings agree without any connection.
- `context-tree-binding-audit.test.ts`: the audit groups HTTPS/`ssh://`/scp spellings of one repository together, keeps `:8443` and `:9443` apart, reports an unresolved legacy row instead of dropping it, and separates unresolved rows from a genuine sharing report.
- `context-tree-initialize.test.ts` / `context-tree-routes-mocked.test.ts`: expected repo names now come from the real derivation instead of hardcoded strings, so a change to the rule cannot pass by matching a stale copy.

`pnpm check`, `pnpm typecheck`, and the full server suite (2882) pass.

## Accepted limitation

The SSH-versus-web-port gap previously listed here is closed — connection-aware resolution was implemented per the maintainer decision on this PR. One limitation remains, and the paired tree node records it as a current constraint:

- **Concurrent cross-organization binding.** Two organizations binding the same repository at the same instant can both pass the check; the caller's own row lock does not serialize a different organization's write. Closing it needs serialization on the repository identity. Gandy2025 accepted this residual risk, so the rule is stated as holding between ordered writes rather than as race-safe.

## QA risk

This touches Context Tree provisioning and the GitHub App installation path, so it is worth formal QA. `packages/qa/cases/` has no case for two teams provisioning under one installation; happy to add one if you want it covered there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Context Tree

Paired tree change: agent-team-foundation/first-tree-context#871 (draft until this merges).


