### PR TITLE
feat: add agent template adoption

### DIFF
--- a/packages/server/src/__tests__/agent-template-adoption.test.ts
+++ b/packages/server/src/__tests__/agent-template-adoption.test.ts
@@ -988,6 +988,134 @@ describe("Agent Template adoption", () => {
         await app.db.select().from(agentResourceBindings).where(eq(agentResourceBindings.agentId, agent.uuid)),
       ).toHaveLength(0);
     });
+
+    it("never deadlocks an existing-agent adoption against Template-backed creation", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const bundleId = await uploadZip(app, publisher, skillZip("dual-entry-skill"));
+      const template = await publishTemplate(app, publisher, `de-${crypto.randomUUID().slice(0, 6)}`, [
+        { key: "dual-entry-skill", type: "skill", bundleAttachmentId: bundleId },
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const existingAgent = await createAgentRow({ name: `de-old-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `de-${crypto.randomUUID().slice(0, 8)}` });
+      const [configBefore] = await app.db
+        .select()
+        .from(agentConfigs)
+        .where(eq(agentConfigs.agentId, existingAgent.uuid));
+
+      const url = process.env.DATABASE_URL ?? "";
+      const blocker = postgres(url, { max: 1, ...sslOptions(url) });
+      const probe = postgres(url, { max: 1, ...sslOptions(url) });
+      let patchReply: Awaited<ReturnType<typeof call>> | undefined;
+      let postReply: Awaited<ReturnType<typeof call>> | undefined;
+      let patchPromise: ReturnType<typeof call> | undefined;
+      let postPromise: ReturnType<typeof call> | undefined;
+      let blockerInTransaction = false;
+      const withTimeout = async <T>(promise: Promise<T>, label: string): Promise<T> => {
+        let timer: NodeJS.Timeout | undefined;
+        try {
+          return await Promise.race([
+            promise,
+            new Promise<T>((_, reject) => {
+              timer = setTimeout(() => reject(new Error(`${label} timed out — possible deadlock`)), 15_000);
+            }),
+          ]);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
+      };
+      const waitForSkillWaiters = async (expected: number, deadline: number, label: string): Promise<void> => {
+        for (;;) {
+          const [row] = await probe`SELECT count(*)::int AS waiters FROM pg_locks
+            WHERE locktype = 'advisory' AND objsubid = 2 AND NOT granted
+              AND classid::bigint = (hashtext('team_skill_name')::bigint & 4294967295)
+              AND objid::bigint = (hashtext(${admin.organizationId})::bigint & 4294967295)`;
+          if (row && row.waiters >= expected) return;
+          if (Date.now() > deadline) throw new Error(`${label} did not reach ${expected} waiter(s) in time`);
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+      };
+      try {
+        await blocker`BEGIN`;
+        await blocker`SELECT pg_advisory_xact_lock(hashtext('team_skill_name'), hashtext(${admin.organizationId}))`;
+        blockerInTransaction = true;
+
+        patchPromise = call(app, admin, "PATCH", `/api/v1/agents/${existingAgent.uuid}/templates`, {
+          expectedVersion: configBefore?.version ?? 1,
+          templateIds: [template.id],
+        });
+        await waitForSkillWaiters(1, Date.now() + 10_000, "existing-agent adoption");
+
+        const newName = `de-new-${crypto.randomUUID().slice(0, 6)}`;
+        postPromise = call(app, admin, "POST", `/api/v1/orgs/${admin.organizationId}/agents`, {
+          name: newName,
+          displayName: "Dual Entry",
+          type: "agent",
+          templateIds: [template.id],
+        });
+        await waitForSkillWaiters(2, Date.now() + 10_000, "Template-backed create");
+
+        // Both entries are parked behind the Team Skill lock, so neither
+        // may hold the Team+Template advisory yet.
+        const [lockRow] = await probe`SELECT count(*)::int AS granted_count FROM pg_locks
+          WHERE locktype = 'advisory' AND objsubid = 2 AND granted
+            AND classid::bigint = (hashtext(${admin.organizationId})::bigint & 4294967295)
+            AND objid::bigint = (hashtext(${template.id})::bigint & 4294967295)`;
+        expect(lockRow?.granted_count).toBe(0);
+
+        await blocker`ROLLBACK`;
+        blockerInTransaction = false;
+
+        patchReply = await withTimeout(patchPromise, "existing-agent adoption");
+        postReply = await withTimeout(postPromise, "Template-backed create");
+      } finally {
+        if (blockerInTransaction) await blocker`ROLLBACK`.catch(() => undefined);
+        await Promise.allSettled([patchPromise, postPromise].filter((promise) => promise !== undefined));
+        await blocker.end({ timeout: 1 }).catch(() => undefined);
+        await probe.end({ timeout: 1 }).catch(() => undefined);
+      }
+
+      expect(patchReply?.statusCode).toBe(200);
+      expect(postReply?.statusCode).toBe(201);
+
+      // One Team copy; both Agents bound to it; config versions exact.
+      const rows = await provenanceResources(app, template.id);
+      expect(rows).toHaveLength(1);
+      // Exactly one byte copy behind the single Skill Resource.
+      const copies = await app.db
+        .select()
+        .from(attachments)
+        .where(
+          and(eq(attachments.organizationId, admin.organizationId), eq(attachments.uploadedBy, admin.humanAgentUuid)),
+        );
+      expect(copies).toHaveLength(1);
+      expect(rows[0]?.bundleAttachmentId).toBe(copies[0]?.id);
+      const created = postReply?.json<{ uuid: string }>();
+      const existingBindings = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(eq(agentResourceBindings.agentId, existingAgent.uuid));
+      expect(existingBindings.map((binding) => binding.resourceId)).toEqual([rows[0]?.id]);
+      const newBindings = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(eq(agentResourceBindings.agentId, created?.uuid ?? ""));
+      expect(newBindings.map((binding) => binding.resourceId)).toEqual([rows[0]?.id]);
+
+      const [configAfter] = await app.db
+        .select()
+        .from(agentConfigs)
+        .where(eq(agentConfigs.agentId, existingAgent.uuid));
+      expect(configAfter?.version).toBe((configBefore?.version ?? 1) + 1);
+      expect(configAfter?.templateIds).toEqual([template.id]);
+      const [newConfig] = await app.db
+        .select()
+        .from(agentConfigs)
+        .where(eq(agentConfigs.agentId, created?.uuid ?? ""));
+      expect(newConfig?.version).toBe(1);
+      expect(newConfig?.templateIds).toEqual([template.id]);
+    });
   });
 
   describe("MCP durable name uniqueness", () => {

--- a/packages/server/src/__tests__/agent-template-adoption.test.ts
+++ b/packages/server/src/__tests__/agent-template-adoption.test.ts
@@ -1,7 +1,9 @@
 import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER } from "@first-tree/shared";
 import { and, eq } from "drizzle-orm";
 import { strToU8, zipSync } from "fflate";
+import postgres from "postgres";
 import { describe, expect, it } from "vitest";
+import { sslOptions } from "../db/connection.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
 import { agentTemplates } from "../db/schema/agent-templates.js";
@@ -853,6 +855,138 @@ describe("Agent Template adoption", () => {
       const reply = await adopt(app, admin, agent.uuid, config?.version ?? 1, [first.id, second.id]);
       expect(reply.statusCode).toBe(409);
       expect(await copiesOf(app, admin)).toBe(copiesBefore);
+    });
+  });
+
+  describe("lock ordering with ordinary Team Skill writes", () => {
+    it("never deadlocks adoption against a recommended Team Skill create", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `lo-${crypto.randomUUID().slice(0, 6)}`, [
+        {
+          key: "lock-skill",
+          type: "skill",
+          bundleAttachmentId: await uploadZip(app, publisher, skillZip("lock-skill")),
+        },
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `lo-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `lo-${crypto.randomUUID().slice(0, 8)}` });
+
+      // The Team's own ready bundle for the ordinary recommended create.
+      const teamUpload = await app.inject({
+        method: "POST",
+        url: `/api/v1/orgs/${admin.organizationId}/attachments`,
+        headers: {
+          authorization: `Bearer ${admin.accessToken}`,
+          "content-type": "application/octet-stream",
+          [ATTACHMENT_MIME_HEADER]: "application/zip",
+          [ATTACHMENT_FILENAME_HEADER]: "skill.zip",
+        },
+        payload: skillZip("team-skill"),
+      });
+      expect(teamUpload.statusCode).toBe(201);
+      const teamBundleId = teamUpload.json<{ id: string }>().id;
+      const adoptionCopiesBefore = (
+        await app.db
+          .select({ id: attachments.id })
+          .from(attachments)
+          .where(eq(attachments.uploadedBy, admin.humanAgentUuid))
+      ).length;
+
+      const [configBefore] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      const url = process.env.DATABASE_URL ?? "";
+      const blocker = postgres(url, { max: 1, ...sslOptions(url) });
+      const probe = postgres(url, { max: 1, ...sslOptions(url) });
+      let ordinaryReply: Awaited<ReturnType<typeof call>> | undefined;
+      let adoptionReply: Awaited<ReturnType<typeof call>> | undefined;
+      let ordinaryPromise: ReturnType<typeof call> | undefined;
+      let adoptionPromise: ReturnType<typeof call> | undefined;
+      const withTimeout = async <T>(promise: Promise<T>, label: string): Promise<T> => {
+        let timer: NodeJS.Timeout | undefined;
+        try {
+          return await Promise.race([
+            promise,
+            new Promise<T>((_, reject) => {
+              timer = setTimeout(() => reject(new Error(`${label} timed out — possible deadlock`)), 15_000);
+            }),
+          ]);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
+      };
+      let blockerInTransaction = false;
+      try {
+        await blocker`BEGIN`;
+        blockerInTransaction = true;
+        await blocker`SELECT id FROM attachments WHERE id = ${teamBundleId} FOR UPDATE`;
+
+        ordinaryPromise = call(app, admin, "POST", `/api/v1/orgs/${admin.organizationId}/resources`, {
+          type: "skill",
+          bundleAttachmentId: teamBundleId,
+          defaultEnabled: "recommended",
+        });
+
+        // Wait until the ordinary write provably holds team_skill_name
+        // (autocommit probe statements release immediately when the try succeeds).
+        const deadline = Date.now() + 10_000;
+        for (;;) {
+          const [row] =
+            await probe`SELECT pg_try_advisory_xact_lock(hashtext('team_skill_name'), hashtext(${admin.organizationId})) AS acquired`;
+          if (!row?.acquired) break;
+          if (Date.now() > deadline) throw new Error("ordinary write did not take the advisory lock in time");
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+
+        adoptionPromise = call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/templates`, {
+          expectedVersion: configBefore?.version ?? 1,
+          templateIds: [template.id],
+        });
+        // Wait until the adoption provably waits on the same two-key
+        // advisory lock, then unblock the ordinary write.
+        const adoptionDeadline = Date.now() + 10_000;
+        for (;;) {
+          const [row] = await probe`SELECT count(*)::int AS waiters FROM pg_locks
+            WHERE locktype = 'advisory' AND objsubid = 2 AND NOT granted
+              AND classid::bigint = (hashtext('team_skill_name')::bigint & 4294967295)
+              AND objid::bigint = (hashtext(${admin.organizationId})::bigint & 4294967295)`;
+          if (row && row.waiters > 0) break;
+          if (Date.now() > adoptionDeadline) throw new Error("adoption did not reach the advisory lock wait in time");
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        await blocker`ROLLBACK`;
+        blockerInTransaction = false;
+
+        ordinaryReply = await withTimeout(ordinaryPromise, "ordinary Team Skill create");
+        adoptionReply = await withTimeout(adoptionPromise, "Template adoption");
+      } finally {
+        if (blockerInTransaction) await blocker`ROLLBACK`.catch(() => undefined);
+        // Both HTTP promises must converge even on error paths — no
+        // unhandled rejections or dangling work past the test.
+        await Promise.allSettled([ordinaryPromise, adoptionPromise].filter((promise) => promise !== undefined));
+        await blocker.end({ timeout: 1 }).catch(() => undefined);
+        await probe.end({ timeout: 1 }).catch(() => undefined);
+      }
+
+      expect(ordinaryReply?.statusCode).toBe(201);
+      expect(adoptionReply?.statusCode).toBe(409);
+
+      // Only the ordinary bump landed; the adoption left nothing behind.
+      const [configAfter] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect(configAfter?.version).toBe((configBefore?.version ?? 1) + 1);
+      expect(configAfter?.templateIds).toEqual([]);
+      expect(await provenanceResources(app, template.id)).toHaveLength(0);
+      expect(
+        (
+          await app.db
+            .select({ id: attachments.id })
+            .from(attachments)
+            .where(eq(attachments.uploadedBy, admin.humanAgentUuid))
+        ).length,
+      ).toBe(adoptionCopiesBefore);
+      expect(
+        await app.db.select().from(agentResourceBindings).where(eq(agentResourceBindings.agentId, agent.uuid)),
+      ).toHaveLength(0);
     });
   });
 

--- a/packages/server/src/__tests__/agent-template-adoption.test.ts
+++ b/packages/server/src/__tests__/agent-template-adoption.test.ts
@@ -602,29 +602,10 @@ describe("Agent Template adoption", () => {
   });
 
   describe("shared bundles, conflicts, and lifecycle edges", () => {
-    it("shares one target attachment when two adopted Templates use the same source ZIP", async () => {
-      const app = getApp();
-      const publisher = await createPublisherAdmin(app);
-      const bundleId = await uploadZip(app, publisher, skillZip("shared-zip"));
-      const first = await publishTemplate(app, publisher, `sh1-${crypto.randomUUID().slice(0, 6)}`, [
-        { key: "shared-zip", type: "skill", bundleAttachmentId: bundleId },
-      ]);
-      const second = await publishTemplate(app, publisher, `sh2-${crypto.randomUUID().slice(0, 6)}`, [
-        { key: "shared-zip", type: "skill", bundleAttachmentId: bundleId },
-      ]);
-      const createAgentRow = await seedAgentFactory(app);
-      const agent = await createAgentRow({ name: `sh-${crypto.randomUUID().slice(0, 6)}` });
-      const admin = await createTestAdmin(app, { username: `sh-${crypto.randomUUID().slice(0, 8)}` });
-      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
-
-      const reply = await adopt(app, admin, agent.uuid, config?.version ?? 1, [first.id, second.id]);
-      expect(reply.statusCode).toBe(200);
-      const rows = [...(await provenanceResources(app, first.id)), ...(await provenanceResources(app, second.id))];
-      expect(rows).toHaveLength(2);
-      expect(rows[0]?.bundleAttachmentId).toBeTruthy();
-      expect(rows[0]?.bundleAttachmentId).toBe(rows[1]?.bundleAttachmentId);
-      expect(rows[0]?.bundleAttachmentId).not.toBe(bundleId);
-    });
+    // Two Templates sharing one source ZIP always declare the same Skill
+    // name (the name is derived from that ZIP), so the Team Skill name
+    // invariant below rejects that combination instead of importing it — see
+    // "rejects duplicate Skill names across Templates inside one adoption".
 
     it("rejects adoption when a replace binding targets the Resource in either direction", async () => {
       const app = getApp();
@@ -797,6 +778,158 @@ describe("Agent Template adoption", () => {
       const [otherConfig] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, other.uuid));
       const reply = await adopt(app, admin, other.uuid, otherConfig?.version ?? 1, [template.id]);
       expect(reply.statusCode).toBe(409);
+    });
+  });
+
+  describe("Team Skill name invariant", () => {
+    async function copiesOf(app: TestApp, admin: Admin): Promise<number> {
+      return (
+        await app.db
+          .select({ id: attachments.id })
+          .from(attachments)
+          .where(eq(attachments.uploadedBy, admin.humanAgentUuid))
+      ).length;
+    }
+
+    it("rejects a first-import Skill whose name already exists in the Team, before any copy", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const admin = await createTestAdmin(app, { username: `sn-${crypto.randomUUID().slice(0, 8)}` });
+
+      // The Team already owns an active Skill with this exact name.
+      const teamZip = skillZip("adopt-skill");
+      const teamBundle = await app.inject({
+        method: "POST",
+        url: `/api/v1/orgs/${admin.organizationId}/attachments`,
+        headers: {
+          authorization: `Bearer ${admin.accessToken}`,
+          "content-type": "application/octet-stream",
+          [ATTACHMENT_MIME_HEADER]: "application/zip",
+          [ATTACHMENT_FILENAME_HEADER]: "skill.zip",
+        },
+        payload: teamZip,
+      });
+      expect(teamBundle.statusCode).toBe(201);
+      const created = await call(app, admin, "POST", `/api/v1/orgs/${admin.organizationId}/resources`, {
+        type: "skill",
+        bundleAttachmentId: teamBundle.json<{ id: string }>().id,
+        defaultEnabled: "available",
+      });
+      expect(created.statusCode).toBe(201);
+
+      const templateBundle = await uploadZip(app, publisher, skillZip("Adopt-Skill"));
+      const template = await publishTemplate(app, publisher, `snc-${crypto.randomUUID().slice(0, 6)}`, [
+        { key: "adopt-skill", type: "skill", bundleAttachmentId: templateBundle },
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `sn-${crypto.randomUUID().slice(0, 6)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      const copiesBefore = await copiesOf(app, admin);
+
+      const reply = await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id]);
+      expect(reply.statusCode).toBe(409);
+      // The name check runs before Phase 3: nothing was copied.
+      expect(await copiesOf(app, admin)).toBe(copiesBefore);
+      expect(await provenanceResources(app, template.id)).toHaveLength(0);
+    });
+
+    it("rejects duplicate Skill names across Templates inside one adoption", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const bundleA = await uploadZip(app, publisher, skillZip("dup-skill"));
+      const bundleB = await uploadZip(app, publisher, skillZip("Dup-Skill"));
+      const first = await publishTemplate(app, publisher, `sd1-${crypto.randomUUID().slice(0, 6)}`, [
+        { key: "dup-skill", type: "skill", bundleAttachmentId: bundleA },
+      ]);
+      const second = await publishTemplate(app, publisher, `sd2-${crypto.randomUUID().slice(0, 6)}`, [
+        { key: "dup-skill", type: "skill", bundleAttachmentId: bundleB },
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `sd-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `sd-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      const copiesBefore = await copiesOf(app, admin);
+
+      const reply = await adopt(app, admin, agent.uuid, config?.version ?? 1, [first.id, second.id]);
+      expect(reply.statusCode).toBe(409);
+      expect(await copiesOf(app, admin)).toBe(copiesBefore);
+    });
+  });
+
+  describe("MCP durable name uniqueness", () => {
+    async function expectBothMcpUnavailable(app: TestApp, agentUuid: string) {
+      const effective = await app.resourcesService.resolveEffectiveResources(agentUuid);
+      const enabledNames = effective.mcp.filter((row) => row.mode === "enabled");
+      expect(enabledNames).toHaveLength(0);
+      const unavailableRows = effective.mcp.filter((row) => row.mode === "unavailable");
+      expect(unavailableRows.length).toBeGreaterThanOrEqual(2);
+      for (const row of unavailableRows) expect(row.unavailableReason).toBe("duplicate_mcp_name");
+      const reasons = effective.unavailable.filter((entry) => entry.type === "mcp").map((entry) => entry.reason);
+      expect(reasons.length).toBeGreaterThanOrEqual(2);
+      for (const reason of reasons) expect(reason).toBe("duplicate_mcp_name");
+
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agentUuid));
+      if (!config) throw new Error("agent config missing");
+      const resolved = await app.resourcesService.resolveRuntimeConfig({
+        agentId: agentUuid,
+        version: config.version,
+        payload: config.payload,
+        updatedAt: config.updatedAt.toISOString(),
+        updatedBy: config.updatedBy,
+      });
+      const projected = resolved.payload.mcpServers.map((server) =>
+        typeof server.name === "string" ? server.name.toLowerCase() : "",
+      );
+      expect(projected).not.toContain("github");
+    }
+
+    it("marks both rows unavailable when Team maintenance adds a same-name recommended MCP", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `mdu-${crypto.randomUUID().slice(0, 6)}`, [
+        mcpComponent("mdu-mcp", "github"),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `mdu-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `md-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+
+      const created = await call(app, admin, "POST", `/api/v1/orgs/${admin.organizationId}/resources`, {
+        type: "mcp",
+        name: "GitHub Team MCP",
+        defaultEnabled: "recommended",
+        payload: { name: "GitHub", transport: "http", url: "https://mcp.example/github" },
+      });
+      expect(created.statusCode).toBe(201);
+      await expectBothMcpUnavailable(app, agent.uuid);
+    });
+
+    it("marks both rows unavailable when Team maintenance renames an MCP payload to a collision", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `mup-${crypto.randomUUID().slice(0, 6)}`, [
+        mcpComponent("mup-mcp", "github"),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `mup-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `mu-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+
+      const other = await call(app, admin, "POST", `/api/v1/orgs/${admin.organizationId}/resources`, {
+        type: "mcp",
+        name: "Other MCP",
+        defaultEnabled: "available",
+        payload: { name: "other", transport: "http", url: "https://mcp.example/other" },
+      });
+      expect(other.statusCode).toBe(201);
+      const updated = await call(app, admin, "PATCH", `/api/v1/resources/${other.json<{ id: string }>().id}`, {
+        payload: { name: "GitHub", transport: "http", url: "https://mcp.example/other" },
+        defaultEnabled: "recommended",
+      });
+      expect(updated.statusCode).toBe(200);
+      await expectBothMcpUnavailable(app, agent.uuid);
     });
   });
 

--- a/packages/server/src/__tests__/agent-template-adoption.test.ts
+++ b/packages/server/src/__tests__/agent-template-adoption.test.ts
@@ -1,0 +1,1086 @@
+import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER } from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
+import { strToU8, zipSync } from "fflate";
+import { describe, expect, it } from "vitest";
+import { agentConfigs } from "../db/schema/agent-configs.js";
+import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
+import { agentTemplates } from "../db/schema/agent-templates.js";
+import { agents } from "../db/schema/agents.js";
+import { attachments } from "../db/schema/attachments.js";
+import { members } from "../db/schema/members.js";
+import { organizations } from "../db/schema/organizations.js";
+import { resources } from "../db/schema/resources.js";
+import { createAgent } from "../services/agent.js";
+import { uuidv7 } from "../uuid.js";
+import { createTestAdmin, createTestAgent, seedAgentFactory, useTestApp } from "./helpers.js";
+
+const PUBLISHER_ORG_ID = "agent-template-publisher-org-test";
+const INTERNAL_URL = "/api/v1/internal/agent-templates";
+
+type Admin = Awaited<ReturnType<typeof createTestAdmin>>;
+type TestApp = ReturnType<ReturnType<typeof useTestApp>>;
+
+function skillZip(name: string, entries: Record<string, Uint8Array> = {}): Buffer {
+  return Buffer.from(
+    zipSync({
+      "SKILL.md": strToU8(`---\nname: ${name}\ndescription: ${name} description\n---\n\n# ${name}\n\nRun carefully.`),
+      ...entries,
+    }),
+  );
+}
+
+async function seedPublisherMembership(
+  app: TestApp,
+  userId: string,
+  role: "admin" | "member",
+): Promise<{ memberId: string }> {
+  await app.db
+    .insert(organizations)
+    .values({ id: PUBLISHER_ORG_ID, name: "official-publisher", displayName: "Official Publisher" })
+    .onConflictDoNothing();
+  const memberId = uuidv7();
+  await app.db.transaction(async (tx) => {
+    const human = await createAgent(tx as unknown as typeof app.db, {
+      name: `publisher-human-${crypto.randomUUID().slice(0, 6)}`,
+      type: "human",
+      displayName: "Publisher Human",
+      managerId: memberId,
+      organizationId: PUBLISHER_ORG_ID,
+    });
+    await tx.insert(members).values({
+      id: memberId,
+      userId,
+      organizationId: PUBLISHER_ORG_ID,
+      agentId: human.uuid,
+      role,
+    });
+  });
+  return { memberId };
+}
+
+async function createPublisherAdmin(app: TestApp): Promise<Admin> {
+  const admin = await createTestAdmin(app, { username: `pub-${crypto.randomUUID().slice(0, 8)}` });
+  await seedPublisherMembership(app, admin.userId, "admin");
+  return admin;
+}
+
+async function uploadZip(app: TestApp, admin: Admin, bytes: Buffer): Promise<string> {
+  const reply = await app.inject({
+    method: "POST",
+    url: `/api/v1/orgs/${PUBLISHER_ORG_ID}/attachments`,
+    headers: {
+      authorization: `Bearer ${admin.accessToken}`,
+      "content-type": "application/octet-stream",
+      [ATTACHMENT_MIME_HEADER]: "application/zip",
+      [ATTACHMENT_FILENAME_HEADER]: "skill.zip",
+    },
+    payload: bytes,
+  });
+  expect(reply.statusCode).toBe(201);
+  return reply.json<{ id: string }>().id;
+}
+
+function validPublicProfile() {
+  return {
+    tagline: "t",
+    purpose: "p",
+    targetUsers: "u",
+    userValue: "v",
+    instructionsSummary: "i",
+    toolsAndSkillsSummary: "s",
+  };
+}
+
+function promptComponent(key = "instructions") {
+  return {
+    key,
+    type: "prompt",
+    name: `${key} prompt`,
+    payload: { body: `You follow ${key}.`, description: "core" },
+  };
+}
+
+function mcpComponent(key = "github-mcp", name = "github") {
+  return {
+    key,
+    type: "mcp",
+    name: `${name} mcp`,
+    payload: { name, transport: "http", url: `https://mcp.example/${name}` },
+  };
+}
+
+async function publishTemplate(
+  app: TestApp,
+  publisher: Admin,
+  slug: string,
+  components: unknown[],
+): Promise<{ id: string; slug: string; updatedAt: string }> {
+  const created = await app.inject({
+    method: "POST",
+    url: INTERNAL_URL,
+    headers: { authorization: `Bearer ${publisher.accessToken}` },
+    payload: { slug, name: slug, public: validPublicProfile(), components },
+  });
+  expect(created.statusCode).toBe(201);
+  const draft = created.json<{ id: string; updatedAt: string }>();
+  const published = await app.inject({
+    method: "POST",
+    url: `${INTERNAL_URL}/${draft.id}/publish`,
+    headers: { authorization: `Bearer ${publisher.accessToken}` },
+    payload: { expectedUpdatedAt: draft.updatedAt },
+  });
+  expect(published.statusCode).toBe(200);
+  return { id: draft.id, slug, updatedAt: published.json<{ updatedAt: string }>().updatedAt };
+}
+
+function call(
+  app: TestApp,
+  admin: { accessToken: string } | null,
+  method: "GET" | "POST" | "PATCH" | "DELETE",
+  url: string,
+  payload?: Record<string, unknown>,
+) {
+  return app.inject({
+    method,
+    url,
+    ...(admin ? { headers: { authorization: `Bearer ${admin.accessToken}` } } : {}),
+    ...(payload !== undefined ? { payload } : {}),
+  });
+}
+
+describe("Agent Template adoption", () => {
+  const getApp = useTestApp({ agentTemplatePublisherOrgId: PUBLISHER_ORG_ID });
+
+  async function getResources(app: TestApp, admin: Admin, agentUuid: string) {
+    const reply = await call(app, admin, "GET", `/api/v1/agents/${agentUuid}/resources`);
+    expect(reply.statusCode).toBe(200);
+    return reply.json<{
+      version: number;
+      templateIds: string[];
+      bindings: Array<Record<string, unknown>>;
+      effective: { mcp: Array<{ name: string }> };
+    }>();
+  }
+
+  async function adopt(app: TestApp, admin: Admin, agentUuid: string, expectedVersion: number, templateIds: string[]) {
+    return call(app, admin, "PATCH", `/api/v1/agents/${agentUuid}/templates`, { expectedVersion, templateIds });
+  }
+
+  async function provenanceResources(app: TestApp, templateId: string) {
+    return app.db.select().from(resources).where(eq(resources.originTemplateId, templateId));
+  }
+
+  describe("permissions and write guards", () => {
+    it("still allows a real manager after demotion from org admin", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `mgr-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const manager = await createTestAgent(app, { name: `mgr-agent-${crypto.randomUUID().slice(0, 6)}` });
+      await app.db
+        .update(members)
+        .set({ role: "member" })
+        .where(and(eq(members.userId, manager.userId), eq(members.organizationId, manager.organizationId)));
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, manager.agent.uuid));
+      const reply = await call(
+        app,
+        { accessToken: manager.accessToken },
+        "PATCH",
+        `/api/v1/agents/${manager.agent.uuid}/templates`,
+        { expectedVersion: config?.version ?? 1, templateIds: [template.id] },
+      );
+      expect(reply.statusCode).toBe(200);
+    });
+
+    it("allows the manager and an org admin, rejects others", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `perm-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `perm-agent-${crypto.randomUUID().slice(0, 6)}` });
+
+      // The factory admin is not this agent's manager; find the managing admin.
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect(config).toBeDefined();
+
+      const outsider = await createTestAdmin(app, { username: `out-${crypto.randomUUID().slice(0, 8)}` });
+      await app.db
+        .update(members)
+        .set({ role: "member" })
+        .where(and(eq(members.userId, outsider.userId), eq(members.organizationId, outsider.organizationId)));
+      const denied = await adopt(app, outsider, agent.uuid, config?.version ?? 1, [template.id]);
+      expect(denied.statusCode).toBe(404);
+
+      const orgAdmin = await createTestAdmin(app, { username: `adm-${crypto.randomUUID().slice(0, 8)}` });
+      const asAdmin = await adopt(app, orgAdmin, agent.uuid, config?.version ?? 1, [template.id]);
+      expect(asAdmin.statusCode).toBe(200);
+      expect(asAdmin.json<{ version: number }>().version).toBe((config?.version ?? 1) + 1);
+    });
+
+    it("rejects cross-org callers with 404", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `xo-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `xo-agent-${crypto.randomUUID().slice(0, 6)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+
+      // A caller whose only membership is in another org.
+      const stranger = await createTestAdmin(app, { username: `str-${crypto.randomUUID().slice(0, 8)}` });
+      const otherOrgId = `org-other-${crypto.randomUUID().slice(0, 6)}`;
+      const otherMemberId = uuidv7();
+      await app.db.transaction(async (tx) => {
+        await tx.insert(organizations).values({ id: otherOrgId, name: otherOrgId, displayName: "Other Org" });
+        const human = await createAgent(tx as unknown as typeof app.db, {
+          name: `stranger-human-${crypto.randomUUID().slice(0, 6)}`,
+          type: "human",
+          displayName: "Stranger",
+          managerId: otherMemberId,
+          organizationId: otherOrgId,
+        });
+        await tx.insert(members).values({
+          id: otherMemberId,
+          userId: stranger.userId,
+          organizationId: otherOrgId,
+          agentId: human.uuid,
+          role: "admin",
+        });
+        // No active membership left in the agent's org.
+        await tx.update(members).set({ status: "left" }).where(eq(members.id, stranger.memberId));
+      });
+      const reply = await adopt(app, stranger, agent.uuid, config?.version ?? 1, [template.id]);
+      expect(reply.statusCode).toBe(404);
+    });
+
+    it("rejects Human agents, landing trial agents, and runtime-switch agents", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `guard-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const admin = await createTestAdmin(app, { username: `g-${crypto.randomUUID().slice(0, 8)}` });
+      const [humanConfig] = await app.db
+        .select()
+        .from(agentConfigs)
+        .where(eq(agentConfigs.agentId, admin.humanAgentUuid));
+      const human = await adopt(app, admin, admin.humanAgentUuid, humanConfig?.version ?? 1, [template.id]);
+      expect(human.statusCode).toBe(400);
+
+      const createAgentRow = await seedAgentFactory(app);
+      const trialAgent = await createAgentRow({ name: `trial-${crypto.randomUUID().slice(0, 6)}` });
+      await app.db
+        .update(agents)
+        .set({
+          metadata: { landingCampaignTrial: true, campaign: "production-scan", skillSetId: "s", skillSetVersion: "1" },
+        })
+        .where(eq(agents.uuid, trialAgent.uuid));
+      const trialAdmin = await createTestAdmin(app, { username: `ta-${crypto.randomUUID().slice(0, 8)}` });
+      const [trialConfig] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, trialAgent.uuid));
+      const trial = await adopt(app, trialAdmin, trialAgent.uuid, trialConfig?.version ?? 1, [template.id]);
+      expect(trial.statusCode).toBe(403);
+
+      const switchAgent = await createAgentRow({ name: `switch-${crypto.randomUUID().slice(0, 6)}` });
+      await app.db
+        .update(agents)
+        .set({ metadata: { runtimeSwitch: { claimId: "claim-1" } } })
+        .where(eq(agents.uuid, switchAgent.uuid));
+      const [switchConfig] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, switchAgent.uuid));
+      const switching = await adopt(app, trialAdmin, switchAgent.uuid, switchConfig?.version ?? 1, [template.id]);
+      expect(switching.statusCode).toBe(409);
+    });
+  });
+
+  describe("first import and reuse", () => {
+    it("imports prompt, mcp, and a byte-identical skill copy with provenance and bindings", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const zipBytes = skillZip("adopt-skill", { "scripts/run.sh": strToU8("echo ok") });
+      const sourceBundle = await uploadZip(app, publisher, zipBytes);
+      const template = await publishTemplate(app, publisher, `import-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+        mcpComponent(),
+        { key: "adopt-skill", type: "skill", bundleAttachmentId: sourceBundle },
+      ]);
+
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `import-agent-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `im-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+
+      const reply = await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id]);
+      expect(reply.statusCode).toBe(200);
+      const body = reply.json<{ version: number; templateIds: string[] }>();
+      expect(body.version).toBe((config?.version ?? 1) + 1);
+      expect(body.templateIds).toEqual([template.id]);
+
+      const rows = await provenanceResources(app, template.id);
+      expect(rows).toHaveLength(3);
+      for (const row of rows) {
+        expect(row.organizationId).toBe(agent.organizationId);
+        expect(row.scope).toBe("team");
+        expect(row.defaultEnabled).toBe("available");
+        expect(row.status).toBe("active");
+        expect(row.originTemplateId).toBe(template.id);
+        expect(row.originComponentKey).toBeTruthy();
+        expect(row.originContentDigest).toMatch(/^[0-9a-f]{64}$/);
+      }
+      const skillRow = rows.find((row) => row.type === "skill");
+      expect(skillRow?.bundleAttachmentId).toBeTruthy();
+      expect(skillRow?.bundleAttachmentId).not.toBe(sourceBundle);
+      const [copied] = await app.db
+        .select()
+        .from(attachments)
+        .where(eq(attachments.id, skillRow?.bundleAttachmentId ?? ""));
+      expect(copied?.organizationId).toBe(agent.organizationId);
+      expect(copied?.data?.equals(zipBytes)).toBe(true);
+      // The restricted action keeps the caller's audit identity.
+      expect(copied?.uploadedBy).toBe(admin.humanAgentUuid);
+      for (const row of rows) {
+        expect(row.createdBy).toBe(admin.memberId);
+        expect(row.updatedBy).toBe(admin.memberId);
+      }
+
+      const bindings = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(eq(agentResourceBindings.agentId, agent.uuid));
+      expect(bindings).toHaveLength(3);
+      for (const binding of bindings) {
+        expect(binding.mode).toBe("include");
+        expect(binding.originTemplateId).toBe(template.id);
+        expect(binding.originComponentKey).toBeTruthy();
+      }
+    });
+
+    it("reuses the Team copy for the second Agent and never re-syncs or revives", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `reuse-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const firstAgent = await createAgentRow({ name: `reuse-a-${crypto.randomUUID().slice(0, 6)}` });
+      const secondAgent = await createAgentRow({ name: `reuse-b-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `re-${crypto.randomUUID().slice(0, 8)}` });
+
+      const [configA] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, firstAgent.uuid));
+      expect((await adopt(app, admin, firstAgent.uuid, configA?.version ?? 1, [template.id])).statusCode).toBe(200);
+      const [imported] = await provenanceResources(app, template.id);
+
+      // The Team customizes its copy afterwards.
+      await app.db
+        .update(resources)
+        .set({ payload: { body: "Team-edited instructions.", description: "edited" } })
+        .where(eq(resources.id, imported?.id ?? ""));
+
+      const [configB] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, secondAgent.uuid));
+      expect((await adopt(app, admin, secondAgent.uuid, configB?.version ?? 1, [template.id])).statusCode).toBe(200);
+
+      // Still exactly one Team Resource; the second Agent reuses it.
+      expect(await provenanceResources(app, template.id)).toHaveLength(1);
+      const secondBindings = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(eq(agentResourceBindings.agentId, secondAgent.uuid));
+      expect(secondBindings).toHaveLength(1);
+      expect(secondBindings[0]?.resourceId).toBe(imported?.id);
+
+      // The official Template gains a new component afterwards — the already
+      // imported Team does not receive it.
+      const detail = await call(app, publisher, "GET", `${INTERNAL_URL}/${template.id}`);
+      const current = detail.json<{ updatedAt: string; payload: { components: unknown[] } }>();
+      const updated = await call(app, publisher, "PATCH", `${INTERNAL_URL}/${template.id}`, {
+        expectedUpdatedAt: current.updatedAt,
+        components: [...current.payload.components, promptComponent("extra")],
+      });
+      expect(updated.statusCode).toBe(200);
+
+      const thirdAgent = await createAgentRow({ name: `reuse-c-${crypto.randomUUID().slice(0, 6)}` });
+      const [configC] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, thirdAgent.uuid));
+      expect((await adopt(app, admin, thirdAgent.uuid, configC?.version ?? 1, [template.id])).statusCode).toBe(200);
+      expect(await provenanceResources(app, template.id)).toHaveLength(1);
+
+      // A retired Team Resource stays retired — adoption does not revive it.
+      await app.db
+        .update(resources)
+        .set({ status: "retired" })
+        .where(eq(resources.id, imported?.id ?? ""));
+      const fourthAgent = await createAgentRow({ name: `reuse-d-${crypto.randomUUID().slice(0, 6)}` });
+      const [configD] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, fourthAgent.uuid));
+      expect((await adopt(app, admin, fourthAgent.uuid, configD?.version ?? 1, [template.id])).statusCode).toBe(200);
+      expect(
+        await app.db.select().from(agentResourceBindings).where(eq(agentResourceBindings.agentId, fourthAgent.uuid)),
+      ).toHaveLength(0);
+    });
+
+    it("serializes concurrent first imports into one Team copy", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const zipBytes = skillZip("concurrent-skill");
+      const bundleId = await uploadZip(app, publisher, zipBytes);
+      const template = await publishTemplate(app, publisher, `conc-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+        { key: "concurrent-skill", type: "skill", bundleAttachmentId: bundleId },
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agentA = await createAgentRow({ name: `conc-a-${crypto.randomUUID().slice(0, 6)}` });
+      const agentB = await createAgentRow({ name: `conc-b-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `cc-${crypto.randomUUID().slice(0, 8)}` });
+      const [configA] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agentA.uuid));
+      const [configB] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agentB.uuid));
+
+      const [replyA, replyB] = await Promise.all([
+        adopt(app, admin, agentA.uuid, configA?.version ?? 1, [template.id]),
+        adopt(app, admin, agentB.uuid, configB?.version ?? 1, [template.id]),
+      ]);
+      expect(replyA.statusCode).toBe(200);
+      expect(replyB.statusCode).toBe(200);
+      // Exactly one Team copy — one prompt + one skill Resource, and a
+      // single byte-copy attachment behind the skill.
+      const rows = await provenanceResources(app, template.id);
+      expect(rows).toHaveLength(2);
+      const skillRow = rows.find((row) => row.type === "skill");
+      expect(skillRow?.bundleAttachmentId).toBeTruthy();
+      expect(skillRow?.bundleAttachmentId).not.toBe(bundleId);
+      const [copy] = await app.db
+        .select()
+        .from(attachments)
+        .where(eq(attachments.id, skillRow?.bundleAttachmentId ?? ""));
+      expect(copy?.data?.equals(zipBytes)).toBe(true);
+    });
+  });
+
+  describe("replace-set semantics", () => {
+    it("is an idempotent no-op for the same set and 409s on stale versions", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `noop-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `noop-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `no-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+      const adopted = await getResources(app, admin, agent.uuid);
+
+      const noop = await adopt(app, admin, agent.uuid, adopted.version, [template.id]);
+      expect(noop.statusCode).toBe(200);
+      expect(noop.json<{ version: number }>().version).toBe(adopted.version);
+
+      const stale = await adopt(app, admin, agent.uuid, (config?.version ?? 1) + 99, [template.id]);
+      expect(stale.statusCode).toBe(409);
+    });
+
+    it("removes only auto bindings on removal and keeps manual ones", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `rem-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `rem-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `rm-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+      const [imported] = await provenanceResources(app, template.id);
+
+      // Turn the auto binding into a manual one by round-tripping with an
+      // inline prompt replacement on the same row, then adopt + remove again.
+      const withResources = await getResources(app, admin, agent.uuid);
+      const manualReply = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/resources`, {
+        expectedVersion: withResources.version,
+        bindings: [...withResources.bindings, { type: "prompt", mode: "include", inlinePromptBody: "manual note" }],
+      });
+      expect(manualReply.statusCode).toBe(200);
+      const afterManual = await getResources(app, admin, agent.uuid);
+
+      const removed = await adopt(app, admin, agent.uuid, afterManual.version, []);
+      expect(removed.statusCode).toBe(200);
+      const remaining = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(eq(agentResourceBindings.agentId, agent.uuid));
+      // Only the manual inline prompt binding survives.
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]?.inlinePromptBody).toBe("manual note");
+      expect(remaining[0]?.originTemplateId).toBeNull();
+      // The Team Resource itself is never deleted by adoption removal.
+      const [stillThere] = await app.db
+        .select()
+        .from(resources)
+        .where(eq(resources.id, imported?.id ?? ""));
+      expect(stillThere).toBeDefined();
+    });
+
+    it("does not duplicate a manual include and rejects conflicting disable choices", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `dup-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `dup-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `du-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+      const [imported] = await provenanceResources(app, template.id);
+
+      // Convert the auto binding to manual by re-adding the same include
+      // through the resources API (drops provenance), then remove the
+      // Template and re-adopt: no duplicate binding appears.
+      const withResources = await getResources(app, admin, agent.uuid);
+      const autoBinding = withResources.bindings.find((binding) => binding.resourceId === imported?.id);
+      const manual = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/resources`, {
+        expectedVersion: withResources.version,
+        bindings: [{ type: "prompt", mode: "include", resourceId: imported?.id }],
+      });
+      expect(manual.statusCode).toBe(200);
+      const afterManual = await getResources(app, admin, agent.uuid);
+      expect((await adopt(app, admin, agent.uuid, afterManual.version, [])).statusCode).toBe(200);
+      const cleared = await getResources(app, admin, agent.uuid);
+      const reAdopted = await adopt(app, admin, agent.uuid, cleared.version, [template.id]);
+      expect(reAdopted.statusCode).toBe(200);
+      const bindingsForResource = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(
+          and(eq(agentResourceBindings.agentId, agent.uuid), eq(agentResourceBindings.resourceId, imported?.id ?? "")),
+        );
+      expect(bindingsForResource).toHaveLength(1);
+      void autoBinding;
+
+      // A disable choice against the Resource blocks re-adoption with 409.
+      const afterReAdopt = await getResources(app, admin, agent.uuid);
+      const disabled = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/resources`, {
+        expectedVersion: afterReAdopt.version,
+        bindings: [{ type: "prompt", mode: "disable", resourceId: imported?.id }],
+      });
+      expect(disabled.statusCode).toBe(200);
+      const afterDisable = await getResources(app, admin, agent.uuid);
+      const cleared2 = await adopt(app, admin, agent.uuid, afterDisable.version, []);
+      expect(cleared2.statusCode).toBe(200);
+      const afterClear = await getResources(app, admin, agent.uuid);
+      const conflict = await adopt(app, admin, agent.uuid, afterClear.version, [template.id]);
+      expect(conflict.statusCode).toBe(409);
+    });
+
+    it("rejects MCP server names that collide case-insensitively", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `mcpc-${crypto.randomUUID().slice(0, 6)}`, [
+        mcpComponent("collide-mcp", "github"),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `mcpc-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `mc-${crypto.randomUUID().slice(0, 8)}` });
+
+      // A recommended Team MCP already provides "GitHub" to every Agent.
+      await app.db.insert(resources).values({
+        id: uuidv7(),
+        organizationId: agent.organizationId,
+        type: "mcp",
+        scope: "team",
+        name: "GitHub MCP",
+        defaultEnabled: "recommended",
+        status: "active",
+        payload: { name: "GitHub", transport: "http", url: "https://mcp.example/github" },
+        createdBy: "qa",
+        updatedBy: "qa",
+      });
+
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      const conflict = await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id]);
+      expect(conflict.statusCode).toBe(409);
+    });
+  });
+
+  describe("shared bundles, conflicts, and lifecycle edges", () => {
+    it("shares one target attachment when two adopted Templates use the same source ZIP", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const bundleId = await uploadZip(app, publisher, skillZip("shared-zip"));
+      const first = await publishTemplate(app, publisher, `sh1-${crypto.randomUUID().slice(0, 6)}`, [
+        { key: "shared-zip", type: "skill", bundleAttachmentId: bundleId },
+      ]);
+      const second = await publishTemplate(app, publisher, `sh2-${crypto.randomUUID().slice(0, 6)}`, [
+        { key: "shared-zip", type: "skill", bundleAttachmentId: bundleId },
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `sh-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `sh-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+
+      const reply = await adopt(app, admin, agent.uuid, config?.version ?? 1, [first.id, second.id]);
+      expect(reply.statusCode).toBe(200);
+      const rows = [...(await provenanceResources(app, first.id)), ...(await provenanceResources(app, second.id))];
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.bundleAttachmentId).toBeTruthy();
+      expect(rows[0]?.bundleAttachmentId).toBe(rows[1]?.bundleAttachmentId);
+      expect(rows[0]?.bundleAttachmentId).not.toBe(bundleId);
+    });
+
+    it("rejects adoption when a replace binding targets the Resource in either direction", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `rep-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `rep-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `rp-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+      const [imported] = await provenanceResources(app, template.id);
+
+      // Manual replace that targets the imported Resource.
+      const withResources = await getResources(app, admin, agent.uuid);
+      const replaced = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/resources`, {
+        expectedVersion: withResources.version,
+        bindings: [
+          { type: "prompt", mode: "replace", replacesResourceId: imported?.id, inlinePromptBody: "manual override" },
+        ],
+      });
+      expect(replaced.statusCode).toBe(200);
+
+      // Removing the Template keeps the manual replace binding; re-adopting
+      // must then conflict with it instead of silently overriding.
+      const afterReplace = await getResources(app, admin, agent.uuid);
+      expect((await adopt(app, admin, agent.uuid, afterReplace.version, [])).statusCode).toBe(200);
+      const after = await getResources(app, admin, agent.uuid);
+      const conflict = await adopt(app, admin, agent.uuid, after.version, [template.id]);
+      expect(conflict.statusCode).toBe(409);
+    });
+
+    it("re-adopts cleanly over a manual MCP include without self-conflict or duplicates", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `mcpi-${crypto.randomUUID().slice(0, 6)}`, [
+        mcpComponent("manual-mcp", "github"),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `mcpi-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `mi-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+      const [imported] = await provenanceResources(app, template.id);
+
+      // Remove the Template, then include the Resource manually.
+      const afterAdopt = await getResources(app, admin, agent.uuid);
+      expect((await adopt(app, admin, agent.uuid, afterAdopt.version, [])).statusCode).toBe(200);
+      const afterRemove = await getResources(app, admin, agent.uuid);
+      const manual = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/resources`, {
+        expectedVersion: afterRemove.version,
+        bindings: [{ type: "mcp", mode: "include", resourceId: imported?.id }],
+      });
+      expect(manual.statusCode).toBe(200);
+
+      const afterManual = await getResources(app, admin, agent.uuid);
+      const reAdopted = await adopt(app, admin, agent.uuid, afterManual.version, [template.id]);
+      expect(reAdopted.statusCode).toBe(200);
+      const rows = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(
+          and(eq(agentResourceBindings.agentId, agent.uuid), eq(agentResourceBindings.resourceId, imported?.id ?? "")),
+        );
+      expect(rows).toHaveLength(1);
+    });
+
+    it("still conflicts when the same-name MCP is explicitly bound despite a disable row", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `xmd-${crypto.randomUUID().slice(0, 6)}`, [
+        mcpComponent("xmd-mcp", "github"),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `xmd-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `xm-${crypto.randomUUID().slice(0, 8)}` });
+      const teamMcpId = uuidv7();
+      await app.db.insert(resources).values({
+        id: teamMcpId,
+        organizationId: agent.organizationId,
+        type: "mcp",
+        scope: "team",
+        name: "GitHub MCP",
+        defaultEnabled: "available",
+        status: "active",
+        payload: { name: "GitHub", transport: "http", url: "https://mcp.example/github" },
+        createdBy: "qa",
+        updatedBy: "qa",
+      });
+
+      // The replace-set API allows an include and a disable on the same
+      // Resource; the effective projection still keeps the include row
+      // enabled, so adoption must conflict, not pass.
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      const manual = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/resources`, {
+        expectedVersion: config?.version ?? 1,
+        bindings: [
+          { type: "mcp", mode: "include", resourceId: teamMcpId },
+          { type: "mcp", mode: "disable", resourceId: teamMcpId },
+        ],
+      });
+      expect(manual.statusCode).toBe(200);
+      const after = await getResources(app, admin, agent.uuid);
+      const conflict = await adopt(app, admin, agent.uuid, after.version, [template.id]);
+      expect(conflict.statusCode).toBe(409);
+    });
+
+    it("swaps same-name MCP Templates atomically in one replace-set", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const templateA = await publishTemplate(app, publisher, `swa-${crypto.randomUUID().slice(0, 6)}`, [
+        mcpComponent("swap-a-mcp", "github"),
+      ]);
+      const templateB = await publishTemplate(app, publisher, `swb-${crypto.randomUUID().slice(0, 6)}`, [
+        mcpComponent("swap-b-mcp", "github"),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `swap-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `sw-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [templateA.id])).statusCode).toBe(200);
+      const [resourceA] = await provenanceResources(app, templateA.id);
+
+      const afterA = await getResources(app, admin, agent.uuid);
+      const swapped = await adopt(app, admin, agent.uuid, afterA.version, [templateB.id]);
+      expect(swapped.statusCode).toBe(200);
+      const body = swapped.json<{ version: number; templateIds: string[] }>();
+      expect(body.version).toBe(afterA.version + 1);
+      expect(body.templateIds).toEqual([templateB.id]);
+
+      const bindings = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(eq(agentResourceBindings.agentId, agent.uuid));
+      expect(bindings.filter((binding) => binding.resourceId === resourceA?.id)).toHaveLength(0);
+      const [resourceB] = await provenanceResources(app, templateB.id);
+      expect(bindings.filter((binding) => binding.resourceId === resourceB?.id)).toHaveLength(1);
+      expect(bindings.find((binding) => binding.resourceId === resourceB?.id)?.originTemplateId).toBe(templateB.id);
+    });
+
+    it("keeps a retired-after-adoption Template in place, removable, but never newly adoptable", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `ret-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `ret-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `rt-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+
+      // Retire the Template afterwards.
+      const detail = await call(app, publisher, "GET", `${INTERNAL_URL}/${template.id}`);
+      const retired = await call(app, publisher, "POST", `${INTERNAL_URL}/${template.id}/retire`, {
+        expectedUpdatedAt: detail.json<{ updatedAt: string }>().updatedAt,
+      });
+      expect(retired.statusCode).toBe(200);
+
+      // Same set is still a no-op; removal still works.
+      const afterAdopt = await getResources(app, admin, agent.uuid);
+      const noop = await adopt(app, admin, agent.uuid, afterAdopt.version, [template.id]);
+      expect(noop.statusCode).toBe(200);
+      expect(noop.json<{ version: number }>().version).toBe(afterAdopt.version);
+      expect((await adopt(app, admin, agent.uuid, afterAdopt.version, [])).statusCode).toBe(200);
+
+      // A retired Template can never be newly adopted by another Agent.
+      const other = await createAgentRow({ name: `ret-b-${crypto.randomUUID().slice(0, 6)}` });
+      const [otherConfig] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, other.uuid));
+      const reply = await adopt(app, admin, other.uuid, otherConfig?.version ?? 1, [template.id]);
+      expect(reply.statusCode).toBe(409);
+    });
+  });
+
+  describe("creation with templates", () => {
+    it("creates the Agent, imports, and binds atomically at version 1", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const zipBytes = skillZip("create-skill");
+      const bundleId = await uploadZip(app, publisher, zipBytes);
+      const template = await publishTemplate(app, publisher, `create-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+        { key: "create-skill", type: "skill", bundleAttachmentId: bundleId },
+      ]);
+      const admin = await createTestAdmin(app, { username: `cr-${crypto.randomUUID().slice(0, 8)}` });
+      const name = `create-agent-${crypto.randomUUID().slice(0, 6)}`;
+
+      const reply = await call(app, admin, "POST", `/api/v1/orgs/${admin.organizationId}/agents`, {
+        name,
+        displayName: "Created With Template",
+        type: "agent",
+        templateIds: [template.id],
+      });
+      expect(reply.statusCode).toBe(201);
+      const created = reply.json<{ uuid: string }>();
+
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, created.uuid));
+      expect(config?.version).toBe(1);
+      expect(config?.templateIds).toEqual([template.id]);
+      const imported = await provenanceResources(app, template.id);
+      expect(imported).toHaveLength(2);
+      const skillRow = imported.find((row) => row.type === "skill");
+      const [copied] = await app.db
+        .select()
+        .from(attachments)
+        .where(eq(attachments.id, skillRow?.bundleAttachmentId ?? ""));
+      expect(copied?.uploadedBy).toBe(admin.humanAgentUuid);
+      for (const row of imported) {
+        expect(row.createdBy).toBe(admin.memberId);
+        expect(row.updatedBy).toBe(admin.memberId);
+      }
+      const bindings = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(eq(agentResourceBindings.agentId, created.uuid));
+      expect(bindings).toHaveLength(2);
+      for (const binding of bindings) {
+        expect(binding.originTemplateId).toBe(template.id);
+        expect(binding.createdBy).toBe(admin.memberId);
+      }
+    });
+
+    it("leaves zero residue when the adoption fails mid-create", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `resid-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const admin = await createTestAdmin(app, { username: `rs-${crypto.randomUUID().slice(0, 8)}` });
+      const name = `residue-${crypto.randomUUID().slice(0, 6)}`;
+      const missingTemplateId = crypto.randomUUID();
+      const copiesBefore = (
+        await app.db
+          .select({ id: attachments.id })
+          .from(attachments)
+          .where(eq(attachments.uploadedBy, "system:agent-template-import"))
+      ).length;
+
+      const reply = await call(app, admin, "POST", `/api/v1/orgs/${admin.organizationId}/agents`, {
+        name,
+        displayName: "Residue Check",
+        type: "agent",
+        templateIds: [template.id, missingTemplateId],
+      });
+      expect([400, 404, 409]).toContain(reply.statusCode);
+
+      const agentRows = await app.db.select().from(agents).where(eq(agents.name, name));
+      expect(agentRows).toHaveLength(0);
+      expect(await provenanceResources(app, template.id)).toHaveLength(0);
+      // The failed adoption produced no new byte copies.
+      const copiesAfter = (
+        await app.db
+          .select({ id: attachments.id })
+          .from(attachments)
+          .where(eq(attachments.uploadedBy, "system:agent-template-import"))
+      ).length;
+      expect(copiesAfter).toBe(copiesBefore);
+
+      // A plain create without templates is unaffected.
+      const plain = await call(app, admin, "POST", `/api/v1/orgs/${admin.organizationId}/agents`, {
+        name,
+        displayName: "Residue Check",
+        type: "agent",
+      });
+      expect(plain.statusCode).toBe(201);
+    });
+
+    it("rolls back the Skill copy and imports when the MCP name guard fails after import", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const bundleId = await uploadZip(app, publisher, skillZip("rollback-skill"));
+      // The Template carries a real Skill ZIP and an MCP whose name is
+      // already effective for the new Agent through a recommended Team MCP —
+      // so the copy and the Resource import happen before the guard fails.
+      const template = await publishTemplate(app, publisher, `rb-${crypto.randomUUID().slice(0, 6)}`, [
+        { key: "rollback-skill", type: "skill", bundleAttachmentId: bundleId },
+        mcpComponent("rollback-mcp", "github"),
+      ]);
+      const admin = await createTestAdmin(app, { username: `rb-${crypto.randomUUID().slice(0, 8)}` });
+      await app.db.insert(resources).values({
+        id: uuidv7(),
+        organizationId: admin.organizationId,
+        type: "mcp",
+        scope: "team",
+        name: "GitHub MCP",
+        defaultEnabled: "recommended",
+        status: "active",
+        payload: { name: "GitHub", transport: "http", url: "https://mcp.example/github" },
+        createdBy: "qa",
+        updatedBy: "qa",
+      });
+      const name = `rollback-${crypto.randomUUID().slice(0, 6)}`;
+      const agentsBefore = (await app.db.select({ uuid: agents.uuid }).from(agents)).length;
+      const configsBefore = (await app.db.select({ agentId: agentConfigs.agentId }).from(agentConfigs)).length;
+      const copiesBefore = (
+        await app.db
+          .select({ id: attachments.id })
+          .from(attachments)
+          .where(eq(attachments.uploadedBy, admin.humanAgentUuid))
+      ).length;
+
+      const reply = await call(app, admin, "POST", `/api/v1/orgs/${admin.organizationId}/agents`, {
+        name,
+        displayName: "Rollback Check",
+        type: "agent",
+        templateIds: [template.id],
+      });
+      expect(reply.statusCode).toBe(409);
+
+      // The whole creation transaction rolled back: no Agent, no config, no
+      // delegate, no imported Resources, no byte copy, no bindings.
+      expect((await app.db.select({ uuid: agents.uuid }).from(agents)).length).toBe(agentsBefore);
+      expect((await app.db.select({ agentId: agentConfigs.agentId }).from(agentConfigs)).length).toBe(configsBefore);
+      const [human] = await app.db.select().from(agents).where(eq(agents.uuid, admin.humanAgentUuid));
+      expect(human?.delegateMention).toBeNull();
+      expect(await provenanceResources(app, template.id)).toHaveLength(0);
+      const copiesAfter = (
+        await app.db
+          .select({ id: attachments.id })
+          .from(attachments)
+          .where(eq(attachments.uploadedBy, admin.humanAgentUuid))
+      ).length;
+      expect(copiesAfter).toBe(copiesBefore);
+      const bindings = await app.db.select().from(agentResourceBindings);
+      expect(bindings.filter((binding) => binding.originTemplateId === template.id)).toHaveLength(0);
+    });
+  });
+
+  describe("resources round-trip provenance", () => {
+    it("keeps provenance for unchanged rows and clears it on semantic changes", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `rt-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `rt-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `rt-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+
+      // Unchanged round-trip: provenance survives.
+      const first = await getResources(app, admin, agent.uuid);
+      const roundTrip = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/resources`, {
+        expectedVersion: first.version,
+        bindings: first.bindings,
+      });
+      expect(roundTrip.statusCode).toBe(200);
+      let rows = await app.db.select().from(agentResourceBindings).where(eq(agentResourceBindings.agentId, agent.uuid));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.originTemplateId).toBe(template.id);
+
+      // Semantic change: the row becomes manual with cleared provenance.
+      const second = await getResources(app, admin, agent.uuid);
+      const changed = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/resources`, {
+        expectedVersion: second.version,
+        bindings: second.bindings.map((binding) => ({
+          ...binding,
+          inlinePromptBody: "edited inline",
+          resourceId: null,
+        })),
+      });
+      expect(changed.statusCode).toBe(200);
+      rows = await app.db.select().from(agentResourceBindings).where(eq(agentResourceBindings.agentId, agent.uuid));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.originTemplateId).toBeNull();
+      expect(rows[0]?.inlinePromptBody).toBe("edited inline");
+    });
+
+    it("treats a pure reorder as a semantic change and protects the row from Template removal", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const template = await publishTemplate(app, publisher, `ord-${crypto.randomUUID().slice(0, 6)}`, [
+        promptComponent(),
+      ]);
+      const createAgentRow = await seedAgentFactory(app);
+      const agent = await createAgentRow({ name: `ord-${crypto.randomUUID().slice(0, 6)}` });
+      const admin = await createTestAdmin(app, { username: `or-${crypto.randomUUID().slice(0, 8)}` });
+      const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+      expect((await adopt(app, admin, agent.uuid, config?.version ?? 1, [template.id])).statusCode).toBe(200);
+
+      const first = await getResources(app, admin, agent.uuid);
+      const reordered = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/resources`, {
+        expectedVersion: first.version,
+        bindings: first.bindings.map((binding) => ({ ...binding, order: 99 })),
+      });
+      expect(reordered.statusCode).toBe(200);
+      const rows = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(eq(agentResourceBindings.agentId, agent.uuid));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.originTemplateId).toBeNull();
+
+      const after = await getResources(app, admin, agent.uuid);
+      expect((await adopt(app, admin, agent.uuid, after.version, [])).statusCode).toBe(200);
+      const remaining = await app.db
+        .select()
+        .from(agentResourceBindings)
+        .where(eq(agentResourceBindings.agentId, agent.uuid));
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]?.order).toBe(99);
+    });
+  });
+});
+
+describe("Agent Template adoption without publisher config", () => {
+  const getApp = useTestApp();
+
+  it("rejects adoption of even a prompt-only Template with zero writes", async () => {
+    const app = getApp();
+    const templateId = uuidv7();
+    await app.db.insert(agentTemplates).values({
+      id: templateId,
+      slug: "prompt-only-template",
+      name: "Prompt Only",
+      status: "active",
+      payload: {
+        schemaVersion: 1,
+        public: {
+          tagline: "t",
+          purpose: "p",
+          targetUsers: "u",
+          userValue: "v",
+          instructionsSummary: "i",
+          toolsAndSkillsSummary: "s",
+        },
+        components: [
+          {
+            key: "instructions",
+            type: "prompt",
+            name: "Instructions",
+            payload: { body: "You are helpful.", description: "d" },
+          },
+        ],
+      },
+      createdBy: "qa",
+      updatedBy: "qa",
+    });
+    const createAgentRow = await seedAgentFactory(app);
+    const agent = await createAgentRow({ name: `npc-${crypto.randomUUID().slice(0, 6)}` });
+    const admin = await createTestAdmin(app, { username: `np-${crypto.randomUUID().slice(0, 8)}` });
+    const [config] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+
+    const reply = await call(app, admin, "PATCH", `/api/v1/agents/${agent.uuid}/templates`, {
+      expectedVersion: config?.version ?? 1,
+      templateIds: [templateId],
+    });
+    expect(reply.statusCode).toBe(403);
+    const [after] = await app.db.select().from(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+    expect(after?.templateIds).toEqual([]);
+    expect(after?.version).toBe(config?.version);
+    expect(await app.db.select().from(resources).where(eq(resources.originTemplateId, templateId))).toHaveLength(0);
+    expect(
+      await app.db.select().from(agentResourceBindings).where(eq(agentResourceBindings.agentId, agent.uuid)),
+    ).toHaveLength(0);
+  });
+});

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -167,6 +167,7 @@ function makeApp(extra: Record<string, unknown> = {}): { app: unknown; routes: R
   const routes: RegisteredRoute[] = [];
   const app = {
     db: { name: "db" },
+    config: {},
     addContentTypeParser: vi.fn(),
     delete(path: string, optionsOrHandler: unknown, maybeHandler?: unknown): void {
       addRoute(routes, "DELETE", path, optionsOrHandler, maybeHandler);

--- a/packages/server/src/__tests__/service-branch-defaults.test.ts
+++ b/packages/server/src/__tests__/service-branch-defaults.test.ts
@@ -865,10 +865,12 @@ describe("service branch defaults", () => {
     const notifier = resourceNotifier();
     const selectRows = [
       [{ uuid: "agent_1", organizationId: "org_1", status: "active" }],
+      [],
       [{ uuid: "agent_1", organizationId: "org_1", status: "active" }],
       [{ version: 2 }],
       [],
       [],
+      [{ templateIds: [] }],
       [],
       [],
     ];

--- a/packages/server/src/api/agents-resources.ts
+++ b/packages/server/src/api/agents-resources.ts
@@ -1,7 +1,9 @@
-import { updateAgentResourcesSchema } from "@first-tree/shared";
+import { AGENT_TYPES, updateAgentResourcesSchema, updateAgentTemplatesSchema } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
+import { BadRequestError } from "../errors.js";
 import { requireAgentAccess } from "../scope/require-resource.js";
 import { assertNoRuntimeSwitchInProgress } from "../services/agent-runtime-switch.js";
+import { adoptAgentTemplates } from "../services/agent-template-adoption.js";
 import { assertMutableAgentIsNotLandingCampaignTrial } from "../services/landing-campaigns/guards.js";
 
 export async function agentResourcesRoutes(app: FastifyInstance): Promise<void> {
@@ -16,5 +18,30 @@ export async function agentResourcesRoutes(app: FastifyInstance): Promise<void> 
     assertNoRuntimeSwitchInProgress(agent);
     const body = updateAgentResourcesSchema.parse(request.body);
     return app.resourcesService.replaceAgentResources(request.params.uuid, body, scope.memberId);
+  });
+
+  /**
+   * Full replace-set write of the Agent's adopted official Templates. The
+   * read side lives in `GET /:uuid/resources` (`templateIds` + `version`).
+   */
+  app.patch<{ Params: { uuid: string } }>("/:uuid/templates", async (request) => {
+    const { agent, scope } = await requireAgentAccess(request, app.db, "manage");
+    assertMutableAgentIsNotLandingCampaignTrial(agent);
+    assertNoRuntimeSwitchInProgress(agent);
+    if (agent.type === AGENT_TYPES.HUMAN) {
+      throw new BadRequestError("Human Agents cannot adopt Agent Templates");
+    }
+    const body = updateAgentTemplatesSchema.parse(request.body);
+    await adoptAgentTemplates(
+      app.db,
+      app.attachmentBlobStore,
+      app.config.agentTemplates?.publisherOrgId,
+      app.notifier,
+      agent,
+      scope.memberId,
+      scope.humanAgentId,
+      body,
+    );
+    return app.resourcesService.getAgentResources(request.params.uuid);
   });
 }

--- a/packages/server/src/api/orgs/agents.ts
+++ b/packages/server/src/api/orgs/agents.ts
@@ -159,7 +159,13 @@ export async function orgAgentRoutes(app: FastifyInstance): Promise<void> {
         source: body.source ?? "admin-api",
         managerId,
       },
-      { adoptAsDelegateIfFirst: managerId === scope.memberId },
+      {
+        adoptAsDelegateIfFirst: managerId === scope.memberId,
+        attachmentBlobStore: app.attachmentBlobStore,
+        templatePublisherOrgId: app.config.agentTemplates?.publisherOrgId,
+        templateActorMemberId: scope.memberId,
+        templateActorHumanAgentId: scope.humanAgentId,
+      },
     );
     notifyClientAgentPinned(agent);
     return reply.status(201).send({

--- a/packages/server/src/services/agent-template-adoption.ts
+++ b/packages/server/src/services/agent-template-adoption.ts
@@ -1,0 +1,483 @@
+import { createHash } from "node:crypto";
+import {
+  AGENT_STATUSES,
+  AGENT_TYPES,
+  type AgentTemplateComponent,
+  type AgentTemplatePayload,
+  agentTemplatePayloadSchema,
+  type UpdateAgentTemplates,
+} from "@first-tree/shared";
+import { and, asc, eq, inArray, or, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agentConfigs } from "../db/schema/agent-configs.js";
+import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
+import { agentTemplates } from "../db/schema/agent-templates.js";
+import { agents } from "../db/schema/agents.js";
+import { resources } from "../db/schema/resources.js";
+import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { uuidv7 } from "../uuid.js";
+import { assertNoRuntimeSwitchInProgress } from "./agent-runtime-switch.js";
+import { assertSkillComponentMatchesBundle } from "./agent-templates.js";
+import { copyAttachmentForOrganization } from "./attachment.js";
+import type { AttachmentBlobStore } from "./attachment-blob-store.js";
+import { assertMutableAgentIsNotLandingCampaignTrial } from "./landing-campaigns/guards.js";
+import type { Notifier } from "./notifier.js";
+
+/**
+ * Agent Template adoption: turn an Agent's adopted Template set into
+ * Team-owned configuration in one bounded, atomic write.
+ *
+ * Boundaries (frozen design):
+ * - First adoption in a Team imports every component as Team-owned
+ *   `available` Resources; later adoptions in the same Team reuse whatever
+ *   provenance Resources the Team currently keeps — no re-sync, no repair.
+ * - Bindings created by adoption carry Template/component provenance so a
+ *   later removal deletes exactly those auto-bindings and nothing else.
+ * - The write shares the existing `agent_configs.version` optimistic lock
+ *   and emits exactly one config-change notification after commit.
+ */
+
+type AgentRow = { uuid: string; organizationId: string; type: string };
+type ResourceRow = typeof resources.$inferSelect;
+
+export type AdoptAgentTemplatesResult = {
+  version: number;
+  templateIds: string[];
+};
+
+/** Deterministic provenance digest for one imported component. */
+function templateComponentDigest(component: AgentTemplateComponent, zipBytes?: Buffer): string {
+  const hash = createHash("sha256");
+  hash.update("agent-template-component:v1\n");
+  hash.update(JSON.stringify(component));
+  if (zipBytes) {
+    hash.update("\nzip-bytes\n");
+    hash.update(zipBytes);
+  }
+  return hash.digest("hex");
+}
+
+function skillBundleIds(components: readonly AgentTemplateComponent[]): string[] {
+  return components.flatMap((component) => (component.type === "skill" ? [component.bundle.attachmentId] : []));
+}
+
+/**
+ * Lock and fully verify an official Template row for adoption: present,
+ * currently active, strictly valid payload with at least one component, and
+ * every Skill bundle still available to the Publisher Team with a matching
+ * projection.
+ */
+async function lockAndVerifyTemplate(
+  db: Database,
+  blobStore: AttachmentBlobStore,
+  publisherOrgId: string,
+  templateId: string,
+): Promise<{ id: string; payload: AgentTemplatePayload }> {
+  const [row] = await db
+    .select({ id: agentTemplates.id, status: agentTemplates.status, payload: agentTemplates.payload })
+    .from(agentTemplates)
+    .where(eq(agentTemplates.id, templateId))
+    .for("update")
+    .limit(1);
+  if (!row) throw new NotFoundError(`Agent Template "${templateId}" not found`);
+  if (row.status !== "active") {
+    throw new ConflictError(`Agent Template "${templateId}" is not active and cannot be adopted`);
+  }
+  const parsed = agentTemplatePayloadSchema.safeParse(row.payload);
+  if (!parsed.success) {
+    throw new ConflictError(`Agent Template "${templateId}" is not valid and cannot be adopted`);
+  }
+  if (parsed.data.components.length === 0) {
+    throw new ConflictError(`Agent Template "${templateId}" has no components and cannot be adopted`);
+  }
+  for (const component of parsed.data.components) {
+    if (component.type !== "skill") continue;
+    await assertSkillComponentMatchesBundle(db, blobStore, publisherOrgId, component);
+  }
+  return { id: row.id, payload: parsed.data };
+}
+
+/** First-time import of every component into the adopting Team. */
+async function importTemplateComponents(
+  db: Database,
+  organizationId: string,
+  templateId: string,
+  payload: AgentTemplatePayload,
+  actorId: string,
+  bundleTargetBySourceId: ReadonlyMap<string, string>,
+  digestByComponentKey: ReadonlyMap<string, string>,
+): Promise<ResourceRow[]> {
+  const created: ResourceRow[] = [];
+  for (const component of payload.components) {
+    const base = {
+      id: uuidv7(),
+      organizationId,
+      scope: "team" as const,
+      ownerAgentId: null,
+      name: component.name,
+      repoCanonicalKey: null,
+      bundleAttachmentId: null,
+      defaultEnabled: "available" as const,
+      status: "active" as const,
+      createdBy: actorId,
+      updatedBy: actorId,
+      originTemplateId: templateId,
+      originComponentKey: component.key,
+    };
+    if (component.type === "skill") {
+      const targetAttachmentId = bundleTargetBySourceId.get(component.bundle.attachmentId);
+      const digest = digestByComponentKey.get(`${templateId}:${component.key}`);
+      if (!targetAttachmentId || !digest) {
+        throw new Error(`Missing copied bundle for source attachment "${component.bundle.attachmentId}"`);
+      }
+      const [row] = await db
+        .insert(resources)
+        .values({
+          ...base,
+          type: "skill",
+          bundleAttachmentId: targetAttachmentId,
+          payload: component.payload,
+          originContentDigest: digest,
+        })
+        .returning();
+      if (!row) throw new Error("Template Skill Resource insert returned no row");
+      created.push(row);
+      continue;
+    }
+    const [row] = await db
+      .insert(resources)
+      .values({
+        ...base,
+        type: component.type,
+        payload: component.payload,
+        originContentDigest: templateComponentDigest(component),
+      })
+      .returning();
+    if (!row) throw new Error("Template Resource insert returned no row");
+    created.push(row);
+  }
+  return created;
+}
+
+/** Create provenance-carrying include bindings, respecting manual choices. */
+async function bindAdoptedResources(
+  db: Database,
+  agent: AgentRow,
+  rows: readonly ResourceRow[],
+  actorId: string,
+): Promise<void> {
+  for (const row of rows) {
+    const existing = await db
+      .select()
+      .from(agentResourceBindings)
+      .where(
+        and(
+          eq(agentResourceBindings.agentId, agent.uuid),
+          or(eq(agentResourceBindings.resourceId, row.id), eq(agentResourceBindings.replacesResourceId, row.id)),
+        ),
+      );
+    // A disable, or a replace in either direction, is a deliberate manual
+    // choice the adoption must not silently override.
+    if (existing.some((binding) => binding.mode === "disable" || binding.mode === "replace")) {
+      throw new ConflictError(
+        `Agent "${agent.uuid}" already has a manual choice for Resource "${row.name}"; resolve it before adopting this Template`,
+      );
+    }
+    if (existing.some((binding) => binding.mode === "include" && binding.resourceId === row.id)) continue;
+    await db.insert(agentResourceBindings).values({
+      id: uuidv7(),
+      organizationId: agent.organizationId,
+      agentId: agent.uuid,
+      type: row.type,
+      mode: "include",
+      resourceId: row.id,
+      order: 0,
+      originTemplateId: row.originTemplateId,
+      originComponentKey: row.originComponentKey,
+      createdBy: actorId,
+      updatedBy: actorId,
+    });
+  }
+}
+
+/**
+ * Small deterministic guard: newly adopted MCP Resources must not collide
+ * (case-insensitively) with the Agent's currently effective MCP names. The
+ * newly adopted Resources themselves are excluded from the "existing" scan
+ * so a manual include of the same Resource cannot report against itself.
+ */
+async function assertNewMcpNamesAvailable(
+  db: Database,
+  agent: AgentRow,
+  newRows: readonly ResourceRow[],
+): Promise<void> {
+  const newNames = newRows.flatMap((row) =>
+    row.type === "mcp" && typeof (row.payload as { name?: unknown }).name === "string"
+      ? [(row.payload as { name: string }).name.toLowerCase()]
+      : [],
+  );
+  if (newNames.length === 0) return;
+  if (new Set(newNames).size !== newNames.length) {
+    throw new ConflictError("The adopted Templates provide duplicate MCP server names");
+  }
+  const newResourceIds = new Set(newRows.map((row) => row.id));
+  const bindings = await db
+    .select({
+      mode: agentResourceBindings.mode,
+      resourceId: agentResourceBindings.resourceId,
+      replacesResourceId: agentResourceBindings.replacesResourceId,
+    })
+    .from(agentResourceBindings)
+    .where(eq(agentResourceBindings.agentId, agent.uuid));
+  const disabled = new Set(bindings.flatMap((b) => (b.mode === "disable" && b.resourceId ? [b.resourceId] : [])));
+  const replaced = new Set(
+    bindings.flatMap((b) => (b.mode === "replace" && b.replacesResourceId ? [b.replacesResourceId] : [])),
+  );
+  // Same explicit-enable rule as the effective-resource resolver.
+  const explicitlyBound = new Set(
+    bindings.flatMap((b) => (b.mode !== "disable" && b.resourceId ? [b.resourceId] : [])),
+  );
+  const candidates = await db
+    .select()
+    .from(resources)
+    .where(
+      and(
+        eq(resources.organizationId, agent.organizationId),
+        eq(resources.type, "mcp"),
+        inArray(resources.status, ["active", "stale"]),
+      ),
+    );
+  for (const row of candidates) {
+    if (newResourceIds.has(row.id)) continue;
+    // Mirrors the effective-resource resolver: an explicit include/replace
+    // binding always yields an enabled row, while disable/replace only
+    // suppress the default recommended row.
+    const effective =
+      explicitlyBound.has(row.id) ||
+      (row.scope === "team" && row.defaultEnabled === "recommended" && !disabled.has(row.id) && !replaced.has(row.id));
+    if (!effective) continue;
+    const name =
+      typeof (row.payload as { name?: unknown }).name === "string"
+        ? (row.payload as { name: string }).name.toLowerCase()
+        : null;
+    if (name && newNames.includes(name)) {
+      throw new ConflictError(`MCP server name "${name}" is already in use by Agent "${agent.uuid}"`);
+    }
+  }
+}
+
+async function adoptTemplatesInTransaction(
+  db: Database,
+  blobStore: AttachmentBlobStore,
+  publisherOrgId: string | undefined,
+  agent: AgentRow,
+  addedTemplateIds: readonly string[],
+  actorId: string,
+  attachmentUploader: string,
+): Promise<void> {
+  if (addedTemplateIds.length === 0) return;
+  if (!publisherOrgId) {
+    throw new ForbiddenError("Agent Template publishing is not configured on this deployment.");
+  }
+
+  // Phase 1 — lock (Team + Template, stable order) and verify every added Template.
+  const templates: Array<{ id: string; payload: AgentTemplatePayload }> = [];
+  for (const templateId of addedTemplateIds) {
+    await db.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${agent.organizationId}), hashtext(${templateId}))`);
+    templates.push(await lockAndVerifyTemplate(db, blobStore, publisherOrgId, templateId));
+  }
+
+  // Phase 2 — decide first-time import vs reuse per Template, based only on
+  // Resource provenance (any status) in this Team.
+  const plan: Array<{ template: (typeof templates)[number]; firstImport: boolean; reusable: ResourceRow[] }> = [];
+  for (const template of templates) {
+    const provenanceRows = await db
+      .select()
+      .from(resources)
+      .where(and(eq(resources.organizationId, agent.organizationId), eq(resources.originTemplateId, template.id)))
+      .orderBy(asc(resources.createdAt), asc(resources.id));
+    plan.push({
+      template,
+      firstImport: provenanceRows.length === 0,
+      reusable: provenanceRows.filter((row) => row.status === "active" || row.status === "stale"),
+    });
+  }
+
+  // Phase 3 — copy every distinct source bundle once, in stable source-id
+  // order, across the whole transaction.
+  const sourceBundleIds = [
+    ...new Set(plan.flatMap((entry) => (entry.firstImport ? skillBundleIds(entry.template.payload.components) : []))),
+  ].sort();
+  // Digest right after each copy while the bytes are still a short-lived
+  // local — the maps only keep small ids/digests, so a large adoption never
+  // holds every ZIP buffer at once. The digest rule is unchanged (canonical
+  // component plus the complete ZIP bytes).
+  const bundleTargetBySourceId = new Map<string, string>();
+  const digestByComponentKey = new Map<string, string>();
+  for (const sourceId of sourceBundleIds) {
+    const attachment = await copyAttachmentForOrganization(
+      db,
+      blobStore,
+      sourceId,
+      agent.organizationId,
+      attachmentUploader,
+    );
+    if (!attachment.data) throw new Error("Attachment copy has no PostgreSQL bytes");
+    bundleTargetBySourceId.set(sourceId, attachment.id);
+    const zipBytes = attachment.data;
+    for (const entry of plan) {
+      if (!entry.firstImport) continue;
+      for (const component of entry.template.payload.components) {
+        if (component.type !== "skill" || component.bundle.attachmentId !== sourceId) continue;
+        digestByComponentKey.set(`${entry.template.id}:${component.key}`, templateComponentDigest(component, zipBytes));
+      }
+    }
+  }
+
+  // Phase 4 — import first-time components, then bind everything.
+  const toBind: ResourceRow[] = [];
+  for (const entry of plan) {
+    if (entry.firstImport) {
+      toBind.push(
+        ...(await importTemplateComponents(
+          db,
+          agent.organizationId,
+          entry.template.id,
+          entry.template.payload,
+          actorId,
+          bundleTargetBySourceId,
+          digestByComponentKey,
+        )),
+      );
+    } else {
+      toBind.push(...entry.reusable);
+    }
+  }
+  await assertNewMcpNamesAvailable(db, agent, toBind);
+  await bindAdoptedResources(db, agent, toBind, actorId);
+}
+
+/**
+ * Initialize a freshly-created Agent's adopted Templates inside the caller's
+ * creation transaction. The initial config stays version 1 and nothing
+ * notifies — the create flow owns its own post-commit signal.
+ */
+export async function initializeAdoptedTemplates(
+  db: Database,
+  blobStore: AttachmentBlobStore,
+  publisherOrgId: string | undefined,
+  agent: AgentRow,
+  templateIds: readonly string[],
+  actorId: string,
+  attachmentUploader: string,
+): Promise<void> {
+  if (agent.type === AGENT_TYPES.HUMAN) {
+    throw new BadRequestError("Human Agents cannot adopt Agent Templates");
+  }
+  await adoptTemplatesInTransaction(db, blobStore, publisherOrgId, agent, templateIds, actorId, attachmentUploader);
+  // The freshly-inserted config stays version 1; only the adopted set is recorded.
+  await db
+    .update(agentConfigs)
+    .set({ templateIds: [...templateIds] })
+    .where(eq(agentConfigs.agentId, agent.uuid));
+}
+
+/**
+ * Full replace-set write of an existing Agent's adopted Templates. The
+ * transaction re-locks the Agent row before the config row and re-checks
+ * lifecycle guards against the locked row — route-level guards are only a
+ * fast path. Same set is an idempotent no-op: the version is checked but
+ * never bumped and no notification is sent.
+ */
+export async function adoptAgentTemplates(
+  db: Database,
+  blobStore: AttachmentBlobStore,
+  publisherOrgId: string | undefined,
+  notifier: Notifier,
+  agent: AgentRow,
+  actorId: string,
+  attachmentUploader: string,
+  input: UpdateAgentTemplates,
+): Promise<AdoptAgentTemplatesResult> {
+  const result = await db.transaction(async (tx) => {
+    const targetDb = tx as unknown as Database;
+    const [lockedAgent] = await targetDb
+      .select()
+      .from(agents)
+      .where(eq(agents.uuid, agent.uuid))
+      .for("update")
+      .limit(1);
+    if (!lockedAgent || lockedAgent.status === AGENT_STATUSES.DELETED) {
+      throw new NotFoundError(`Agent "${agent.uuid}" not found`);
+    }
+    if (lockedAgent.type === AGENT_TYPES.HUMAN) {
+      throw new BadRequestError("Human Agents cannot adopt Agent Templates");
+    }
+    assertMutableAgentIsNotLandingCampaignTrial(lockedAgent);
+    assertNoRuntimeSwitchInProgress(lockedAgent);
+    const effectiveAgent: AgentRow = {
+      uuid: lockedAgent.uuid,
+      organizationId: lockedAgent.organizationId,
+      type: lockedAgent.type,
+    };
+
+    const [config] = await targetDb
+      .select({ version: agentConfigs.version, templateIds: agentConfigs.templateIds })
+      .from(agentConfigs)
+      .where(eq(agentConfigs.agentId, effectiveAgent.uuid))
+      .for("update")
+      .limit(1);
+    if (!config) throw new NotFoundError(`Agent config "${effectiveAgent.uuid}" not found`);
+    if (config.version !== input.expectedVersion) {
+      throw new ConflictError(
+        `Agent templates "${effectiveAgent.uuid}" version mismatch: expected ${input.expectedVersion}, got ${config.version}`,
+      );
+    }
+    const current = [...config.templateIds].sort();
+    const target = [...input.templateIds].sort();
+    if (current.length === target.length && current.every((id, index) => id === target[index])) {
+      return { version: config.version, templateIds: target, changed: false };
+    }
+
+    const added = target.filter((id) => !current.includes(id));
+    const removed = current.filter((id) => !target.includes(id));
+    // Remove first: the MCP effective-name guard below must see the target
+    // replace-set's final binding baseline (a same-name A→B swap is legal),
+    // and a failure anywhere rolls the removals back with the transaction.
+    if (removed.length > 0) {
+      await targetDb
+        .delete(agentResourceBindings)
+        .where(
+          and(
+            eq(agentResourceBindings.agentId, effectiveAgent.uuid),
+            inArray(agentResourceBindings.originTemplateId, removed),
+          ),
+        );
+    }
+    await adoptTemplatesInTransaction(
+      targetDb,
+      blobStore,
+      publisherOrgId,
+      effectiveAgent,
+      added,
+      actorId,
+      attachmentUploader,
+    );
+    const [updated] = await targetDb
+      .update(agentConfigs)
+      .set({
+        version: sql`${agentConfigs.version} + 1`,
+        templateIds: target,
+        updatedBy: actorId,
+        updatedAt: new Date(),
+      })
+      .where(eq(agentConfigs.agentId, effectiveAgent.uuid))
+      .returning({ version: agentConfigs.version });
+    if (!updated) throw new Error("Agent config update returned no row");
+    return { version: updated.version, templateIds: target, changed: true };
+  });
+  if (result.changed) {
+    await notifier.notifyConfigChange(`agent:${agent.uuid}`);
+  }
+  return { version: result.version, templateIds: result.templateIds };
+}

--- a/packages/server/src/services/agent-template-adoption.ts
+++ b/packages/server/src/services/agent-template-adoption.ts
@@ -281,6 +281,15 @@ async function adoptTemplatesInTransaction(
     throw new ForbiddenError("Agent Template publishing is not configured on this deployment.");
   }
 
+  // Shared single lock boundary for both adoption entry points (existing
+  // PATCH and Template-backed create): the Team Skill lock always comes
+  // before any Team+Template or attachment lock —
+  // `team_skill_name → Team+Template → attachment`. The existing adoption
+  // pre-acquires it before the config row lock, so this is a same-tx
+  // idempotent re-acquire there; the Template-backed create relies on this
+  // call. Accepting it for prompt/MCP-only adoptions keeps one clear order.
+  await lockTeamSkillNames(db, agent.organizationId);
+
   // Phase 1 — lock (Team + Template, stable order) and verify every added Template.
   const templates: Array<{ id: string; payload: AgentTemplatePayload }> = [];
   for (const templateId of addedTemplateIds) {
@@ -304,17 +313,16 @@ async function adoptTemplatesInTransaction(
     });
   }
 
-  // Phase 2.5 — Team Skill name invariant, taken before any attachment
-  // quota or source-row lock (lock order matches ordinary Team Skill
-  // creation). Rejects collisions with existing Team Skills and duplicates
-  // inside this adoption; reusable Skills are untouched either way.
+  // Phase 2.5 — Team Skill name invariant. The shared entry already holds
+  // the Team Skill lock (see above), so this only re-checks collisions
+  // with existing Team Skills and duplicates inside this adoption;
+  // reusable Skills are untouched either way.
   const firstImportSkillNames = plan.flatMap((entry) =>
     entry.firstImport
       ? entry.template.payload.components.flatMap((component) => (component.type === "skill" ? [component.name] : []))
       : [],
   );
   if (firstImportSkillNames.length > 0) {
-    await lockTeamSkillNames(db, agent.organizationId);
     const seen = new Set<string>();
     for (const name of firstImportSkillNames) {
       const identity = name.toLowerCase();

--- a/packages/server/src/services/agent-template-adoption.ts
+++ b/packages/server/src/services/agent-template-adoption.ts
@@ -444,6 +444,16 @@ export async function adoptAgentTemplates(
       type: lockedAgent.type,
     };
 
+    // Global lock order: team_skill_name → agent_configs. Ordinary Team
+    // Skill writes take the advisory lock first and bump agent config
+    // versions inside the same transaction, so an adoption that writes any
+    // Template set must take it before the config row lock. An empty target
+    // set never reaches the Skill import path and needs no lock. Phase 2.5
+    // re-acquires it harmlessly (same-transaction advisory locks nest).
+    if (input.templateIds.length > 0) {
+      await lockTeamSkillNames(targetDb, effectiveAgent.organizationId);
+    }
+
     const [config] = await targetDb
       .select({ version: agentConfigs.version, templateIds: agentConfigs.templateIds })
       .from(agentConfigs)

--- a/packages/server/src/services/agent-template-adoption.ts
+++ b/packages/server/src/services/agent-template-adoption.ts
@@ -22,6 +22,7 @@ import { copyAttachmentForOrganization } from "./attachment.js";
 import type { AttachmentBlobStore } from "./attachment-blob-store.js";
 import { assertMutableAgentIsNotLandingCampaignTrial } from "./landing-campaigns/guards.js";
 import type { Notifier } from "./notifier.js";
+import { assertTeamSkillNameAvailable, lockTeamSkillNames } from "./resources.js";
 
 /**
  * Agent Template adoption: turn an Agent's adopted Template set into
@@ -301,6 +302,28 @@ async function adoptTemplatesInTransaction(
       firstImport: provenanceRows.length === 0,
       reusable: provenanceRows.filter((row) => row.status === "active" || row.status === "stale"),
     });
+  }
+
+  // Phase 2.5 — Team Skill name invariant, taken before any attachment
+  // quota or source-row lock (lock order matches ordinary Team Skill
+  // creation). Rejects collisions with existing Team Skills and duplicates
+  // inside this adoption; reusable Skills are untouched either way.
+  const firstImportSkillNames = plan.flatMap((entry) =>
+    entry.firstImport
+      ? entry.template.payload.components.flatMap((component) => (component.type === "skill" ? [component.name] : []))
+      : [],
+  );
+  if (firstImportSkillNames.length > 0) {
+    await lockTeamSkillNames(db, agent.organizationId);
+    const seen = new Set<string>();
+    for (const name of firstImportSkillNames) {
+      const identity = name.toLowerCase();
+      if (seen.has(identity)) {
+        throw new ConflictError(`The adopted Templates provide duplicate Skill names ("${name}")`);
+      }
+      seen.add(identity);
+      await assertTeamSkillNameAvailable(db, agent.organizationId, name);
+    }
   }
 
   // Phase 3 — copy every distinct source bundle once, in stable source-id

--- a/packages/server/src/services/agent-templates.ts
+++ b/packages/server/src/services/agent-templates.ts
@@ -250,7 +250,7 @@ async function compileTemplateComponents(
  * the persisted projection. Fails closed on any drift — a schema-valid row
  * whose summary no longer matches its bytes must never become adoptable.
  */
-async function assertSkillComponentMatchesBundle(
+export async function assertSkillComponentMatchesBundle(
   db: Database,
   blobStore: AttachmentBlobStore,
   publisherOrgId: string,

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -37,6 +37,8 @@ import {
   agentNotLandingCampaignTrialCondition,
   agentVisibilityCondition,
 } from "./access-control.js";
+import { initializeAdoptedTemplates } from "./agent-template-adoption.js";
+import type { AttachmentBlobStore } from "./attachment-blob-store.js";
 import { resolveDefaultOrgId } from "./organization.js";
 import { recomputeWatchersForAgent } from "./watcher.js";
 
@@ -417,7 +419,14 @@ async function resolveFallbackManagerId(db: Database, orgId: string): Promise<st
 export async function createAgent(
   db: Database,
   data: CreateAgent & { managerId?: string },
-  options: { force?: boolean; adoptAsDelegateIfFirst?: boolean } = {},
+  options: {
+    force?: boolean;
+    adoptAsDelegateIfFirst?: boolean;
+    attachmentBlobStore?: AttachmentBlobStore;
+    templatePublisherOrgId?: string;
+    templateActorMemberId?: string;
+    templateActorHumanAgentId?: string;
+  } = {},
 ) {
   const uuid = uuidv7();
   const name = data.name ?? null;
@@ -619,6 +628,25 @@ export async function createAgent(
           updatedBy: "system",
         })
         .onConflictDoNothing();
+
+      // Adopted official Agent Templates import into Team Resources and bind
+      // inside this same transaction — the new Agent, its config, the Team
+      // copies, and the bindings are all-or-nothing.
+      if (data.templateIds && data.templateIds.length > 0) {
+        if (!options.attachmentBlobStore) throw new Error("attachmentBlobStore is required for Template adoption");
+        if (!options.templateActorMemberId || !options.templateActorHumanAgentId) {
+          throw new Error("Template actor identity is required for Template adoption");
+        }
+        await initializeAdoptedTemplates(
+          tx as unknown as Database,
+          options.attachmentBlobStore,
+          options.templatePublisherOrgId,
+          { uuid: row.uuid, organizationId: orgId, type: data.type },
+          data.templateIds,
+          options.templateActorMemberId,
+          options.templateActorHumanAgentId,
+        );
+      }
 
       // First-agent → delegate adoption. When a member creates their FIRST
       // non-human agent and hasn't picked a delegate yet, adopt it as their

--- a/packages/server/src/services/attachment.ts
+++ b/packages/server/src/services/attachment.ts
@@ -205,6 +205,66 @@ async function assertOrganizationQuota(
 /** Everything in `AttachmentRow` except the PostgreSQL payload and legacy pointer. */
 export type AttachmentMeta = Omit<AttachmentRow, "data" | "objectKey">;
 
+/**
+ * Copy a ready attachment's bytes into another organization as a brand-new
+ * ready row, inside the caller's transaction. Used by Agent Template
+ * adoption: the adopting Team gets its own byte copy of the official Skill
+ * bundle, so the Publisher Team's attachment lifecycle can never break an
+ * adopted Resource. Quota accounting follows the normal upload path; a
+ * failing copy rolls back with the surrounding transaction and leaves no
+ * orphan.
+ */
+export async function copyAttachmentForOrganization(
+  db: Database,
+  blobStore: AttachmentBlobStore,
+  sourceId: string,
+  targetOrganizationId: string,
+  uploadedBy: string,
+): Promise<AttachmentRow> {
+  // Quota-first, matching the normal upload path: the target Team's advisory
+  // lock is always taken before any source row lock, so concurrent
+  // adoptions cannot interleave source-lock → quota-lock into a cycle.
+  await lockOrganizationAttachmentQuota(db, targetOrganizationId);
+  const [source] = await db.select().from(attachments).where(eq(attachments.id, sourceId)).for("update").limit(1);
+  if (!source || source.lifecycleState !== "ready" || (source.data === null && source.objectKey === null)) {
+    throw new BadRequestError("Source attachment is not a ready attachment with available bytes");
+  }
+  let bytes: Buffer;
+  if (source.data) {
+    if (source.data.byteLength !== source.sizeBytes) {
+      throw new BadRequestError("Source attachment byte length does not match its metadata");
+    }
+    bytes = source.data;
+  } else if (source.objectKey) {
+    // Legacy external-store row: read through the blob store and persist the
+    // copy PostgreSQL-backed like every new upload.
+    bytes = await readAttachmentBody(await blobStore.get(source.objectKey), source.sizeBytes);
+  } else {
+    throw new BadRequestError("Source attachment bytes are unavailable");
+  }
+  await assertOrganizationQuota(db, targetOrganizationId, {
+    additionalObjects: 1,
+    additionalBytes: bytes.byteLength,
+  });
+  const id = randomUUID();
+  const [row] = await db
+    .insert(attachments)
+    .values({
+      id,
+      organizationId: targetOrganizationId,
+      objectKey: null,
+      lifecycleState: "ready",
+      mimeType: source.mimeType,
+      filename: source.filename,
+      sizeBytes: bytes.byteLength,
+      data: bytes,
+      uploadedBy,
+    })
+    .returning();
+  if (!row) throw new Error("Attachment copy insert returned no row");
+  return row;
+}
+
 export type AttachmentReader = Pick<Database, "select">;
 
 export async function loadAttachmentMeta(db: AttachmentReader, id: string): Promise<AttachmentMeta | null> {

--- a/packages/server/src/services/resources.ts
+++ b/packages/server/src/services/resources.ts
@@ -104,6 +104,42 @@ export type ResourcesServiceOptions = {
   attachmentBlobStore?: AttachmentBlobStore;
 };
 
+/**
+ * Serialize Team Skill name checks for one Team. Held for the whole
+ * transaction by Team Skill create/update and by Template adoption imports,
+ * always before any attachment quota or source-row lock.
+ */
+export async function lockTeamSkillNames(targetDb: Database, organizationId: string): Promise<void> {
+  await targetDb.execute(sql`SELECT pg_advisory_xact_lock(hashtext('team_skill_name'), hashtext(${organizationId}))`);
+}
+
+/**
+ * Reject an active/stale Team Skill with the same case-insensitive name.
+ * Must be called while holding `lockTeamSkillNames`.
+ */
+export async function assertTeamSkillNameAvailable(
+  targetDb: Database,
+  organizationId: string,
+  name: string,
+  excludeResourceId = "",
+): Promise<void> {
+  const [existing] = await targetDb
+    .select({ id: resources.id })
+    .from(resources)
+    .where(
+      and(
+        eq(resources.organizationId, organizationId),
+        eq(resources.scope, "team"),
+        eq(resources.type, "skill"),
+        inArray(resources.status, ["active", "stale"]),
+        ne(resources.id, excludeResourceId),
+        sql`lower(${resources.name}) = lower(${name})`,
+      ),
+    )
+    .limit(1);
+  if (existing) throw new ConflictError(`A Team Skill named "${name}" already exists`);
+}
+
 export function createResourcesService(opts: ResourcesServiceOptions): ResourcesService {
   const { db, notifier } = opts;
   const attachmentBlobStore = opts.attachmentBlobStore ?? createUnavailableAttachmentBlobStore();
@@ -228,33 +264,6 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
     if (!row) {
       throw new BadRequestError("Skill bundle attachment must be a ready attachment owned by this organization");
     }
-  }
-
-  async function lockTeamSkillNames(targetDb: Database, organizationId: string): Promise<void> {
-    await targetDb.execute(sql`SELECT pg_advisory_xact_lock(hashtext('team_skill_name'), hashtext(${organizationId}))`);
-  }
-
-  async function assertTeamSkillNameAvailable(
-    targetDb: Database,
-    organizationId: string,
-    name: string,
-    excludeResourceId = "",
-  ): Promise<void> {
-    const [existing] = await targetDb
-      .select({ id: resources.id })
-      .from(resources)
-      .where(
-        and(
-          eq(resources.organizationId, organizationId),
-          eq(resources.scope, "team"),
-          eq(resources.type, "skill"),
-          inArray(resources.status, ["active", "stale"]),
-          ne(resources.id, excludeResourceId),
-          sql`lower(${resources.name}) = lower(${name})`,
-        ),
-      )
-      .limit(1);
-    if (existing) throw new ConflictError(`A Team Skill named "${name}" already exists`);
   }
 
   function makePreviewTeamResource(args: {
@@ -649,6 +658,7 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
     applyRepoLocalPathDedup(repos, unavailable);
     await applySkillBundleAvailability(skills, resourceRows, agent.organizationId, unavailable);
     applyPayloadValidation(skills, mcp, unavailable);
+    applyMcpNameDedup(mcp, unavailable);
 
     return {
       version,
@@ -701,6 +711,35 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
         });
       }
       seen.add(localPath);
+    }
+  }
+
+  function applyMcpNameDedup(rows: EffectiveResourceRow[], unavailable: EffectiveAgentResources["unavailable"]): void {
+    // Provider adapters key MCP servers by name, so a name collision can
+    // never reach the runtime: every row in a duplicate group becomes
+    // unavailable instead of silently picking a winner. This holds no matter
+    // which ordinary Resource/binding mutation produced the overlap.
+    const groups = new Map<string, EffectiveResourceRow[]>();
+    for (const row of rows) {
+      if (row.mode !== "enabled") continue;
+      const payload = row.payload as { name?: unknown } | null;
+      const name = typeof payload?.name === "string" ? payload.name.toLowerCase() : null;
+      if (!name) continue;
+      const group = groups.get(name) ?? [];
+      group.push(row);
+      groups.set(name, group);
+    }
+    for (const group of groups.values()) {
+      if (group.length < 2) continue;
+      for (const row of group) {
+        row.mode = "unavailable";
+        row.unavailableReason = "duplicate_mcp_name";
+        unavailable.push({
+          type: "mcp",
+          id: row.resourceId ?? row.bindingId ?? row.id,
+          reason: "duplicate_mcp_name",
+        });
+      }
     }
   }
 

--- a/packages/server/src/services/resources.ts
+++ b/packages/server/src/services/resources.ts
@@ -1362,6 +1362,11 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
     async getAgentResources(agentId) {
       const agent = await loadAgent(agentId);
       const effective = await resolveEffectiveResources(agentId);
+      const [configRow] = await db
+        .select({ templateIds: agentConfigs.templateIds })
+        .from(agentConfigs)
+        .where(eq(agentConfigs.agentId, agentId))
+        .limit(1);
       const bindingRows = await db
         .select()
         .from(agentResourceBindings)
@@ -1380,6 +1385,7 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
         .orderBy(resources.type, resources.name);
       return {
         version: effective.version,
+        templateIds: configRow?.templateIds ?? [],
         effective,
         bindings: bindingRows.map(bindingToInput),
         availableTeamResources: availableTeamResources.map(rowToResource),
@@ -1411,6 +1417,11 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
             `Agent resources "${agentId}" version mismatch: expected ${input.expectedVersion}, got ${current?.version ?? "missing"}`,
           );
         }
+        const existingBindings = await targetDb
+          .select()
+          .from(agentResourceBindings)
+          .where(eq(agentResourceBindings.agentId, agentId));
+        const existingById = new Map(existingBindings.map((row) => [row.id, row]));
         await targetDb.delete(agentResourceBindings).where(eq(agentResourceBindings.agentId, agentId));
         for (let idx = 0; idx < input.bindings.length; idx++) {
           const binding = input.bindings[idx];
@@ -1419,8 +1430,24 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
           const resourceId = binding.agentExtraRepo
             ? await findOrCreateAgentRepoResource(targetDb, agentId, agent.organizationId, binding, actorId)
             : (binding.resourceId ?? null);
+          // Preserve the original row — including Template provenance — when
+          // the caller round-trips an unchanged binding (order included). A
+          // semantic change turns the row into a fresh manual binding with
+          // no provenance.
+          const nextOrder = binding.order ?? idx + 1;
+          const prior = binding.id ? existingById.get(binding.id) : undefined;
+          const carryProvenance =
+            prior !== undefined &&
+            prior.type === binding.type &&
+            prior.mode === binding.mode &&
+            prior.resourceId === resourceId &&
+            prior.replacesResourceId === (binding.replacesResourceId ?? null) &&
+            prior.inlinePromptBody === (binding.inlinePromptBody ?? null) &&
+            prior.repoRef === (binding.repoRef ?? null) &&
+            prior.repoLocalPath === (binding.repoLocalPath ?? null) &&
+            prior.order === nextOrder;
           await targetDb.insert(agentResourceBindings).values({
-            id: uuidv7(),
+            id: carryProvenance ? prior.id : uuidv7(),
             organizationId: agent.organizationId,
             agentId,
             type: binding.type,
@@ -1430,14 +1457,23 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
             inlinePromptBody: binding.inlinePromptBody ?? null,
             repoRef: binding.repoRef ?? null,
             repoLocalPath: binding.repoLocalPath ?? null,
-            order: binding.order ?? idx + 1,
-            createdBy: actorId,
-            updatedBy: actorId,
+            order: nextOrder,
+            originTemplateId: carryProvenance ? prior.originTemplateId : null,
+            originComponentKey: carryProvenance ? prior.originComponentKey : null,
+            createdBy: carryProvenance ? prior.createdBy : actorId,
+            updatedBy: carryProvenance ? prior.updatedBy : actorId,
+            createdAt: carryProvenance ? prior.createdAt : undefined,
+            updatedAt: carryProvenance ? prior.updatedAt : undefined,
           });
         }
       });
       await notifyAgents([agentId]);
       const effective = await resolveEffectiveResources(agentId);
+      const [configRow] = await db
+        .select({ templateIds: agentConfigs.templateIds })
+        .from(agentConfigs)
+        .where(eq(agentConfigs.agentId, agentId))
+        .limit(1);
       const bindingRows = await db
         .select()
         .from(agentResourceBindings)
@@ -1456,6 +1492,7 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
         .orderBy(resources.type, resources.name);
       return {
         version: effective.version,
+        templateIds: configRow?.templateIds ?? [],
         effective,
         bindings: bindingRows.map(bindingToInput),
         availableTeamResources: availableTeamResources.map(rowToResource),

--- a/packages/shared/src/__tests__/agent-template-schema.test.ts
+++ b/packages/shared/src/__tests__/agent-template-schema.test.ts
@@ -16,6 +16,7 @@ import {
   publishAgentTemplateSchema,
   retireAgentTemplateSchema,
   updateAgentTemplateSchema,
+  updateAgentTemplatesSchema,
 } from "../schemas/agent-template.js";
 import { PROMPT_RESOURCE_BODY_MAX_CHARS } from "../schemas/resource.js";
 
@@ -679,5 +680,52 @@ describe("PostgreSQL text compatibility", () => {
       agentTemplatePayloadSchema.safeParse({ schemaVersion: 1, public: VALID_PUBLIC_PROFILE, components: [literal] })
         .success,
     ).toBe(true);
+  });
+});
+
+describe("agent template replace-set write", () => {
+  it("accepts a strict expectedVersion + canonical templateIds body", () => {
+    const ok = updateAgentTemplatesSchema.safeParse({
+      expectedVersion: 3,
+      templateIds: [TEMPLATE_ID_B, TEMPLATE_ID_A],
+    });
+    expect(ok.success).toBe(true);
+    if (ok.success) {
+      expect(ok.data.templateIds).toEqual([TEMPLATE_ID_A, TEMPLATE_ID_B]);
+    }
+
+    expect(updateAgentTemplatesSchema.safeParse({ expectedVersion: 0, templateIds: [] }).success).toBe(false);
+    expect(updateAgentTemplatesSchema.safeParse({ expectedVersion: 1.5, templateIds: [] }).success).toBe(false);
+    expect(
+      updateAgentTemplatesSchema.safeParse({ expectedVersion: 1, templateIds: [TEMPLATE_ID_A, TEMPLATE_ID_A] }).success,
+    ).toBe(false);
+    expect(
+      updateAgentTemplatesSchema.safeParse({
+        expectedVersion: 1,
+        templateIds: [TEMPLATE_ID_A, TEMPLATE_ID_B, TEMPLATE_ID_C, TEMPLATE_ID_D],
+      }).success,
+    ).toBe(false);
+    expect(
+      updateAgentTemplatesSchema.safeParse({ expectedVersion: 1, templateIds: [], add: [TEMPLATE_ID_A] }).success,
+    ).toBe(false);
+  });
+});
+
+describe("createAgentSchema templateIds", () => {
+  it("canonicalizes, dedupes, and caps adopted Templates on create", async () => {
+    const { createAgentSchema } = await import("../schemas/agent.js");
+    const base = { type: "agent", displayName: "Templated" };
+    const ok = createAgentSchema.safeParse({ ...base, templateIds: [TEMPLATE_ID_B, TEMPLATE_ID_A] });
+    expect(ok.success).toBe(true);
+    if (ok.success) expect(ok.data.templateIds).toEqual([TEMPLATE_ID_A, TEMPLATE_ID_B]);
+
+    expect(createAgentSchema.safeParse({ ...base, templateIds: [TEMPLATE_ID_A, TEMPLATE_ID_A] }).success).toBe(false);
+    expect(
+      createAgentSchema.safeParse({
+        ...base,
+        templateIds: [TEMPLATE_ID_A, TEMPLATE_ID_B, TEMPLATE_ID_C, TEMPLATE_ID_D],
+      }).success,
+    ).toBe(false);
+    expect(createAgentSchema.safeParse(base).success).toBe(true);
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -246,7 +246,9 @@ export {
   type RetireAgentTemplate,
   retireAgentTemplateSchema,
   type UpdateAgentTemplate,
+  type UpdateAgentTemplates,
   updateAgentTemplateSchema,
+  updateAgentTemplatesSchema,
 } from "./schemas/agent-template.js";
 export {
   ATTACHMENT_FILENAME_HEADER,

--- a/packages/shared/src/schemas/agent-template.ts
+++ b/packages/shared/src/schemas/agent-template.ts
@@ -510,6 +510,19 @@ export const retireAgentTemplateSchema = z
   .strict();
 export type RetireAgentTemplate = z.infer<typeof retireAgentTemplateSchema>;
 
+/**
+ * Full replace-set write for an Agent's adopted Templates against the
+ * shared `agent_configs.version` optimistic lock. No add/remove/order API —
+ * the caller always submits the complete target set.
+ */
+export const updateAgentTemplatesSchema = z
+  .object({
+    expectedVersion: z.number().int().positive(),
+    templateIds: agentTemplateIdsSchema,
+  })
+  .strict();
+export type UpdateAgentTemplates = z.infer<typeof updateAgentTemplatesSchema>;
+
 /** Safe replacement pointer on a retired Template's public detail. */
 export const agentTemplateReplacementSummarySchema = z
   .object({

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { agentTemplateIdsSchema } from "./agent-template.js";
 import { paginationQuerySchema } from "./common.js";
 import { presenceStatusSchema, runtimeStateSchema } from "./presence.js";
 import { runtimeProviderSchema } from "./runtime-provider.js";
@@ -166,6 +167,12 @@ export const createAgentSchema = z.object({
    * pinned client's reported capabilities (or be force-overridden).
    */
   runtimeProvider: runtimeProviderSchema.optional(),
+  /**
+   * Official Agent Templates to adopt atomically with creation. The server
+   * imports their components into Team Resources and creates explicit
+   * bindings inside the same transaction; omit for a plain create.
+   */
+  templateIds: agentTemplateIdsSchema.optional(),
 });
 export type CreateAgent = z.infer<typeof createAgentSchema>;
 

--- a/packages/shared/src/schemas/resource.ts
+++ b/packages/shared/src/schemas/resource.ts
@@ -412,6 +412,8 @@ export type EffectiveAgentResources = z.infer<typeof effectiveAgentResourcesSche
 
 export const agentResourcesOutputSchema = z.object({
   version: z.number().int().positive(),
+  /** Adopted official Agent Template ids (0-3, canonical order). */
+  templateIds: z.array(z.string().uuid()),
   effective: effectiveAgentResourcesSchema,
   bindings: z.array(agentResourceBindingInputSchema),
   availableTeamResources: z.array(resourceRowSchema),

--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -39,6 +39,7 @@ const UUID = "agent-preview";
 
 const RESOURCES: AgentResourcesOutput = {
   version: 7,
+  templateIds: [],
   effective: {
     version: 7,
     repos: [

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -195,6 +195,7 @@ function promptRow(overrides: Partial<EffectivePromptRow> = {}): EffectivePrompt
 function agentResources(overrides: Partial<AgentResourcesOutput> = {}): AgentResourcesOutput {
   return {
     version: overrides.version ?? 9,
+    templateIds: overrides.templateIds ?? [],
     effective: overrides.effective ?? {
       version: overrides.version ?? 9,
       repos: [],

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -177,6 +177,7 @@ function config(overrides: Partial<AgentRuntimeConfig> = {}): AgentRuntimeConfig
 function agentResources(overrides: Partial<AgentResourcesOutput> = {}): AgentResourcesOutput {
   return {
     version: overrides.version ?? 7,
+    templateIds: overrides.templateIds ?? [],
     effective: overrides.effective ?? {
       version: overrides.version ?? 7,
       repos: [],

--- a/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
@@ -68,6 +68,7 @@ function config(): AgentRuntimeConfig {
 function agentResources(overrides: Partial<AgentResourcesOutput> = {}): AgentResourcesOutput {
   return {
     version: overrides.version ?? 3,
+    templateIds: overrides.templateIds ?? [],
     effective: overrides.effective ?? {
       version: overrides.version ?? 3,
       repos: [],


### PR DESCRIPTION
## Summary

- add a strict CAS replace-set API for an agent's canonical 0–3 Template IDs and expose the set through the existing resources read model
- import official Prompt, MCP, and complete Skill bundles once as Team-owned `available` Resources, then reuse the Team's current provenance copies for later agents
- create explicit Template-origin bindings, remove only those automatic bindings, and preserve provenance through unchanged generic resource round-trips
- make Template-backed Agent creation atomic at config version 1, including attachment copy, Resource import, bindings, and rollback
- serialize first imports and use stable quota/source lock ordering without adding a table, migration, synchronization loop, repair flow, or diagnostic state machine

This completes the deliberately small Task 3 adoption boundary. Runtime projection, Client materialization, Template UI, seed content, and automatic synchronization remain outside this change.

## Validation

- [x] `pnpm check` — passed; 16 pre-existing warnings, no errors
- [x] `pnpm typecheck` — 11/11 tasks passed
- [x] `pnpm test` — 12/12 tasks passed; Server 257 files / 2931 tests
- [x] focused Shared schema — 49/49
- [x] focused Server adoption — 23/23
- [x] independent QA on exact head `6ecacd643e721157782ff9c603cd52d2524768a1`
- [x] production Server + PostgreSQL 17 probe — 56 authenticated HTTP requests matched expected behavior
- [x] forced no-cache production build — 5/5 tasks passed

Independent QA also exercised real row-lock revalidation, first-import concurrency, byte-identical shared ZIP copying, config notification count, same-name MCP replacement, and post-copy/post-import rollback. No product defect was found.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: Shared/server contract and integration tests added; existing Web resource fixtures updated for the new required read-model field
- database changes: none; no schema or Drizzle migration changes
- Context Tree: existing one-time import, Team-resource authority, provenance-removal, and no-auto-sync decisions already cover this source change; no Tree diff is needed
- follow-up work: runtime/Client/Web projection and Template seed work remain separate later tasks
