### PR TITLE
feat: add Grok Build runtime provider

### DIFF
--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -36,6 +36,7 @@ const allOk = (): ClientCapabilities => ({
   "claude-code-tui": ok(),
   codex: ok(),
   cursor: ok(),
+  grok: ok(),
   "kimi-code": ok(),
   opencode: ok(),
 });
@@ -45,6 +46,7 @@ const codexMissing = (): ClientCapabilities => ({
   "claude-code-tui": ok(),
   codex: missing(),
   cursor: ok(),
+  grok: ok(),
   "kimi-code": ok(),
   opencode: ok(),
 });
@@ -74,6 +76,7 @@ const codexPendingSnapshot = (): ClientCapabilities => ({
   "claude-code-tui": ok(),
   codex: codexPending(),
   cursor: ok(),
+  grok: ok(),
   "kimi-code": ok(),
   opencode: ok(),
 });
@@ -84,6 +87,7 @@ const codexUnauthSnapshot = (): ClientCapabilities => ({
   "claude-code-tui": ok(),
   codex: codexUnauth(),
   cursor: ok(),
+  grok: ok(),
   "kimi-code": ok(),
   opencode: ok(),
 });

--- a/apps/cli/src/__tests__/client-switch.test.ts
+++ b/apps/cli/src/__tests__/client-switch.test.ts
@@ -276,6 +276,14 @@ describe("client switch drain markers", () => {
     expect(isSwitchDrainEnvRequired("/home/op/.local/bin/agent -p --output-format stream-json")).toBe(true);
     expect(isSwitchDrainEnvRequired("cursor-agent login")).toBe(true);
   });
+
+  it("recognizes Grok Build CLI processes (grok binary)", () => {
+    // The drain must fail closed: a live grok turn spawned by the runtime must
+    // require the env envelope check. Grok's binary is `grok` — there is no
+    // generic-name special case like Cursor's `agent` basename.
+    expect(isSwitchDrainEnvRequired("/home/op/.local/bin/grok -p --output-format stream-json")).toBe(true);
+    expect(isSwitchDrainEnvRequired("grok login")).toBe(true);
+  });
 });
 
 describe("client runtime markers", () => {

--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -348,3 +348,73 @@ describe("runRuntimeAuthLogin — cursor (external-only binary)", () => {
     expect(h.calls.at(-1)?.entry.lastAuthError).toMatchObject({ reason: "exit-nonzero", message: "login failed" });
   });
 });
+
+describe("runRuntimeAuthLogin — grok (external-only binary)", () => {
+  function grokHarness(opts: {
+    resolveOk?: boolean;
+    outcome?: LoginOutcome;
+    fireAuthUrl?: string;
+    probeResult?: CapabilityEntry;
+  }) {
+    const calls: Recorded2[] = [];
+    const logs: string[] = [];
+    const loginCalls: string[] = [];
+    const deps = {
+      currentEntry: (): CapabilityEntry | undefined => undefined,
+      setProviderEntry: async (provider: string, entry: CapabilityEntry): Promise<void> => {
+        calls.push({ provider, entry });
+      },
+      log: (_symbol: string, msg: string): void => {
+        logs.push(msg);
+      },
+      now: (): number => NOW,
+      resolveGrokBinary: () =>
+        opts.resolveOk === false
+          ? ({ ok: false, error: "Grok Build CLI is missing on this machine.", transient: false } as const)
+          : ({ ok: true, binary: "/home/op/.local/bin/grok", version: "2026.07.09" } as const),
+      runGrokBrowser: async (o: { binary: string; onAuthUrl?: (url: string) => void }): Promise<LoginOutcome> => {
+        loginCalls.push(o.binary);
+        if (opts.fireAuthUrl) o.onAuthUrl?.(opts.fireAuthUrl);
+        await new Promise((r) => setTimeout(r, 0));
+        return opts.outcome ?? ({ ok: true } as const);
+      },
+      probeGrok: async (): Promise<CapabilityEntry> => opts.probeResult ?? installedEntry(),
+    };
+    return { calls, logs, loginCalls, deps };
+  }
+  type Recorded2 = { provider: string; entry: CapabilityEntry };
+
+  it("drives <resolved-binary> login and publishes pending → re-probed ok", async () => {
+    const h = grokHarness({ outcome: { ok: true }, probeResult: okEntry() });
+    await runRuntimeAuthLogin({ provider: "grok", ref: "rg1" }, h.deps);
+
+    expect(h.loginCalls).toEqual(["/home/op/.local/bin/grok"]);
+    expect(h.calls[0]?.provider).toBe("grok");
+    expect(h.calls[0]?.entry.pendingAuth).toMatchObject({ method: "browser" });
+    expect(h.calls.at(-1)?.entry.state).toBe("ok");
+    expect(h.calls.at(-1)?.entry.lastAuthError).toBeUndefined();
+  });
+
+  it("on unresolved/unverified binary, reflects a spawn-error lastAuthError and never logs in", async () => {
+    const h = grokHarness({
+      resolveOk: false,
+      probeResult: { ...installedEntry(), state: "missing", available: false },
+    });
+    await runRuntimeAuthLogin({ provider: "grok", ref: "rg2" }, h.deps);
+
+    expect(h.loginCalls).toEqual([]);
+    expect(h.calls).toHaveLength(1);
+    expect(h.calls[0]?.entry.state).toBe("missing");
+    expect(h.calls[0]?.entry.lastAuthError).toMatchObject({ reason: "spawn-error" });
+    expect(h.logs.some((l) => l.includes("grok binary unavailable"))).toBe(true);
+  });
+
+  it("stamps lastAuthError when the grok login fails", async () => {
+    const h = grokHarness({
+      outcome: { ok: false, reason: "exit-nonzero", error: "login failed" },
+      probeResult: installedEntry(),
+    });
+    await runRuntimeAuthLogin({ provider: "grok", ref: "rg3" }, h.deps);
+    expect(h.calls.at(-1)?.entry.lastAuthError).toMatchObject({ reason: "exit-nonzero", message: "login failed" });
+  });
+});

--- a/apps/cli/src/commands/agent/config/set-reasoning-effort.ts
+++ b/apps/cli/src/commands/agent/config/set-reasoning-effort.ts
@@ -7,7 +7,7 @@ export function registerAgentConfigSetReasoningEffortCommand(config: Command): v
   config
     .command("set-reasoning-effort <agent> <level>")
     .description(
-      'Set reasoning effort. claude-code: "" (inherit local) | low | medium | high | max. codex: low | medium | high | xhigh | max | ultra (model-dependent). Cursor, Kimi Code, and OpenCode have no separate effort field.',
+      'Set reasoning effort. claude-code: "" (inherit local) | low | medium | high | max. codex: low | medium | high | xhigh | max | ultra (model-dependent). Grok Build: "" (inherit local) | low | medium | high. Cursor, Kimi Code, and OpenCode have no separate effort field.',
     )
     .action(async (agentName: string, level: string) => {
       const serverUrl = resolveServerUrl(process.env.FIRST_TREE_SERVER_URL);

--- a/apps/cli/src/commands/agent/create.ts
+++ b/apps/cli/src/commands/agent/create.ts
@@ -16,7 +16,7 @@ export function registerAgentCreateCommand(agent: Command): void {
     )
     .option(
       "--runtime <runtime>",
-      "Runtime handler — one of: claude-code, claude-code-tui, codex, cursor, kimi-code, opencode (default: claude-code)",
+      "Runtime handler — one of: claude-code, claude-code-tui, codex, cursor, grok, kimi-code, opencode (default: claude-code)",
       "claude-code",
     )
     .option("--display-name <name>", "Display name")

--- a/apps/cli/src/core/client-switch.ts
+++ b/apps/cli/src/core/client-switch.ts
@@ -859,7 +859,7 @@ export function parseSwitchProcessEnvValue(envText: string, key: string): string
 
 function isKnownProviderCommand(command: string): boolean {
   if (
-    /(^|[/\s])(claude|codex|cursor-agent|opencode)(\s|$)/i.test(command) ||
+    /(^|[/\s])(claude|codex|cursor-agent|grok|opencode)(\s|$)/i.test(command) ||
     /@openai\/codex|claude-code|opencode-ai/i.test(command)
   ) {
     return true;

--- a/apps/cli/src/core/doctor.ts
+++ b/apps/cli/src/core/doctor.ts
@@ -336,7 +336,7 @@ export async function checkWebSocket(): Promise<CheckResult> {
 // `daemon probe`)
 // ---------------------------------------------------------------------------
 
-const RUNTIME_PROVIDER_ORDER = ["claude-code", "claude-code-tui", "codex", "cursor", "kimi-code", "opencode"];
+const RUNTIME_PROVIDER_ORDER = ["claude-code", "claude-code-tui", "codex", "cursor", "grok", "kimi-code", "opencode"];
 
 function formatCapabilityDetail(entry: CapabilityEntry): string {
   if (entry.state === "ok") {

--- a/apps/cli/src/core/runtime-auth-login.ts
+++ b/apps/cli/src/core/runtime-auth-login.ts
@@ -3,18 +3,22 @@ import {
   type ClaudeLoginInvocation,
   type CodexBinaryResolution,
   type CursorRuntimeBinaryResolution,
+  type GrokRuntimeBinaryResolution,
   type LoginOutcome,
   probeClaudeCodeCapability,
   probeClaudeCodeTuiCapability,
   probeCodexCapability,
   probeCursorCapability,
+  probeGrokCapability,
   type RuntimeAuthCommand,
   resolveClaudeLoginInvocation,
   resolveCodexRuntimeBinary,
   resolveCursorRuntimeBinary,
+  resolveGrokRuntimeBinary,
   runClaudeBrowserLogin,
   runCodexBrowserLogin,
   runCursorBrowserLogin,
+  runGrokBrowserLogin,
 } from "@first-tree/client";
 import {
   type CapabilityEntry,
@@ -56,6 +60,9 @@ export type RuntimeAuthLoginDeps = {
   resolveCursorBinary?: () => CursorRuntimeBinaryResolution;
   runCursorBrowser?: typeof runCursorBrowserLogin;
   probeCursor?: () => Promise<CapabilityEntry>;
+  resolveGrokBinary?: () => GrokRuntimeBinaryResolution;
+  runGrokBrowser?: typeof runGrokBrowserLogin;
+  probeGrok?: () => Promise<CapabilityEntry>;
   now?: () => number;
 };
 
@@ -145,6 +152,10 @@ export async function runRuntimeAuthLogin(command: RuntimeAuthCommand, deps: Run
     await runCursorRuntimeAuth(command, deps);
     return;
   }
+  if (command.provider === "grok") {
+    await runGrokRuntimeAuth(command, deps);
+    return;
+  }
   deps.log("⚠️", `runtime-auth: provider "${command.provider}" is not supported yet (ref ${command.ref})`);
 }
 
@@ -190,6 +201,53 @@ async function runCursorRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAu
 
   await reflect("after login", outcome.ok ? null : { reason: outcome.reason, message: outcome.error });
   logOutcome("cursor", command.ref, outcome, deps);
+}
+
+/** grok: `<grok-binary> login` (official browser OAuth on the host). */
+async function runGrokRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAuthLoginDeps): Promise<void> {
+  const now = deps.now ?? Date.now;
+  const resolveBinary = deps.resolveGrokBinary ?? resolveGrokRuntimeBinary;
+  const probeGrok = deps.probeGrok ?? probeGrokCapability;
+  const runGrokBrowser = deps.runGrokBrowser ?? runGrokBrowserLogin;
+
+  const reflect = async (label: string, failure: AuthFailure | null): Promise<void> => {
+    try {
+      await deps.setProviderEntry("grok", attachAuthError(await probeGrok(), failure, now()));
+    } catch (err) {
+      deps.log("⚠️", `runtime-auth: grok re-probe ${label} failed: ${message(err)}`);
+    }
+  };
+
+  deps.log("•", `runtime-auth: starting grok login (method=browser, ref ${command.ref})`);
+
+  // Login drives the SAME resolved binary the handler spawns (external-only),
+  // including its bounded `--version` smoke check — the first real use.
+  const resolved = resolveBinary();
+  if (!resolved.ok) {
+    deps.log("⚠️", `runtime-auth: grok binary unavailable: ${resolved.error}`);
+    await reflect("after unresolved binary", { reason: "spawn-error", message: resolved.error });
+    return;
+  }
+
+  const setPending = (authUrl?: string): Promise<void> =>
+    deps.setProviderEntry("grok", pendingEntry(deps.currentEntry("grok"), browserPending(now(), authUrl), now()));
+  await setPending();
+  deps.log("•", "runtime-auth: grok browser sign-in opened on this host");
+
+  let outcome: LoginOutcome;
+  try {
+    // `url` is annotated explicitly (unlike the cursor twin) because the
+    // `runGrokBrowserLogin` export has not landed in @first-tree/client yet,
+    // so there is no options type to infer from until it does.
+    outcome = await runGrokBrowser({ binary: resolved.binary, onAuthUrl: (url: string) => void setPending(url) });
+  } catch (err) {
+    deps.log("⚠️", `runtime-auth: grok login threw: ${message(err)}`);
+    await reflect("after login threw", { reason: "spawn-error", message: message(err) });
+    return;
+  }
+
+  await reflect("after login", outcome.ok ? null : { reason: outcome.reason, message: outcome.error });
+  logOutcome("grok", command.ref, outcome, deps);
 }
 
 async function runCodexRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAuthLoginDeps): Promise<void> {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -230,7 +230,7 @@ first-tree agent list --remote --org <id>  # cross-org view (multi-org operators
 ### agent create
 
 ```
-first-tree agent create <name> --type <human|agent> --client-id <thisClient> [--runtime claude-code|claude-code-tui|codex|cursor|kimi-code|opencode]
+first-tree agent create <name> --type <human|agent> --client-id <thisClient> [--runtime claude-code|claude-code-tui|codex|cursor|grok|kimi-code|opencode]
 ```
 
 Creates the agent row on the server and binds it to the given client
@@ -250,6 +250,15 @@ performs the compatible-version and database-readiness gates. Windows reports
 a resolved OpenCode binary for diagnostics but does not advertise it as
 available until the Client has the required pre-admission Job Object
 supervisor.
+
+The `grok` runtime drives an operator-installed Grok Build CLI
+(`>=0.2.117 <0.3.0`) over ACP on macOS or Linux. Install it with the official
+script (`curl -fsSL https://x.ai/cli/install.sh | bash`), complete
+provider-owned authentication with `grok login`, and run
+`first-tree daemon probe` after installation to force immediate
+artifact/platform re-detection. First Tree never reads or relays Grok
+credentials; the probe is install/platform-only and Windows is not advertised
+in V1.
 
 ### agent add
 

--- a/docs/development/agent-workspace-state.md
+++ b/docs/development/agent-workspace-state.md
@@ -26,6 +26,7 @@ Each runtime discovers Skills from one workspace-relative root:
 | Claude Code / Claude Code TUI | `.claude/skills/` |
 | Codex | `.agents/skills/` |
 | Cursor | `.cursor/skills/` |
+| Grok Build | `.grok/skills/` |
 | Kimi Code | `.kimi-code/skills/` |
 | OpenCode | `.opencode/skills/` |
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,6 +29,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "1.3.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.187",
     "@botiverse/kimi-code-sdk": "0.26.0-botiverse.2",
     "@openai/codex-sdk": "^0.144.1",
@@ -40,8 +41,8 @@
     "semver": "^7.6.3",
     "smol-toml": "^1.7.0",
     "ws": "^8.20.0",
-    "yauzl": "^3.4.0",
     "yaml": "^2.8.3",
+    "yauzl": "^3.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/client/src/__tests__/auth-error-hint.test.ts
+++ b/packages/client/src/__tests__/auth-error-hint.test.ts
@@ -3,6 +3,7 @@ import {
   formatAuthHint,
   isClaudeAuthError,
   isCodexAuthError,
+  isGrokAuthError,
   isOpenCodeAuthError,
 } from "../handlers/auth-error-hint.js";
 
@@ -98,6 +99,35 @@ describe("isClaudeAuthError", () => {
   });
 });
 
+describe("isGrokAuthError", () => {
+  it("matches every plausible logged-out Grok Build wording", () => {
+    const authMessages = [
+      "Error: not logged in. Run `grok login` to authenticate.",
+      "not authenticated — please run grok login",
+      "Error: authentication required",
+      "Provider returned 401 Unauthorized",
+      "Failed to read credentials from ~/.grok/auth.json",
+    ];
+    for (const msg of authMessages) {
+      expect(isGrokAuthError(msg), `expected auth-error: ${msg}`).toBe(true);
+    }
+  });
+
+  it("does NOT match unrelated failures (capacity / transport / input)", () => {
+    const nonAuth = [
+      "HTTP 429 Too Many Requests",
+      "rate limit exceeded",
+      "resource has been exhausted",
+      "fetch failed",
+      "context length exceeded",
+      "",
+    ];
+    for (const msg of nonAuth) {
+      expect(isGrokAuthError(msg), `expected NOT auth-error: ${msg}`).toBe(false);
+    }
+  });
+});
+
 describe("isOpenCodeAuthError", () => {
   it("matches provider-owned credential failures without treating capacity failures as auth", () => {
     expect(isOpenCodeAuthError("Provider returned 401 Unauthorized: invalid API key")).toBe(true);
@@ -127,6 +157,15 @@ describe("formatAuthHint", () => {
     expect(hint).toContain("Anthropic");
     expect(hint).toContain("not First Tree's");
     expect(hint).toContain("authentication_failed");
+  });
+
+  it("targets `grok login` for the grok runtime and names Grok Build", () => {
+    const hint = formatAuthHint("grok", "Error: not logged in. Run `grok login` to authenticate.");
+    expect(hint).toContain("grok");
+    expect(hint).toContain("`grok login`");
+    expect(hint).toContain("Grok Build");
+    expect(hint).toContain("not First Tree's");
+    expect(hint).toContain("not logged in");
   });
 
   it("keeps OpenCode authentication host-local and points at the provider-owned login", () => {

--- a/packages/client/src/__tests__/builtin-handlers.test.ts
+++ b/packages/client/src/__tests__/builtin-handlers.test.ts
@@ -84,6 +84,19 @@ describe("Built-in Handlers", () => {
     expect(typeof handler.shutdown).toBe("function");
   });
 
+  it("registers grok handler with a valid session-oriented shape", () => {
+    registerBuiltinHandlers();
+
+    const factory = getHandlerFactory("grok");
+    expect(typeof factory).toBe("function");
+    const handler = factory({ workspaceRoot: "/tmp/test", runtimeProvider: "grok" });
+    expect(typeof handler.start).toBe("function");
+    expect(typeof handler.resume).toBe("function");
+    expect(typeof handler.inject).toBe("function");
+    expect(typeof handler.suspend).toBe("function");
+    expect(typeof handler.shutdown).toBe("function");
+  });
+
   it("registers kimi-code handler with a valid session-oriented shape", () => {
     registerBuiltinHandlers();
 

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -736,6 +736,9 @@ describe("probeCapabilities (aggregator)", () => {
     vi.doMock("../runtime/capabilities/cursor.js", () => ({
       probeCursorCapability: vi.fn().mockResolvedValue(fakeEntry("ok")),
     }));
+    vi.doMock("../runtime/capabilities/grok.js", () => ({
+      probeGrokCapability: vi.fn().mockResolvedValue(fakeEntry("ok")),
+    }));
     vi.doMock("../runtime/capabilities/kimi-code.js", () => ({
       probeKimiCodeCapability: vi.fn().mockResolvedValue(fakeEntry("ok")),
     }));
@@ -748,11 +751,12 @@ describe("probeCapabilities (aggregator)", () => {
 
     // claude-code-tui is in DISABLED_RUNTIME_PROVIDERS — it is skipped, so it
     // gets no capability entry AND its probe is never called (no binary spawn).
-    expect(Object.keys(caps).sort()).toEqual(["claude-code", "codex", "cursor", "kimi-code", "opencode"]);
+    expect(Object.keys(caps).sort()).toEqual(["claude-code", "codex", "cursor", "grok", "kimi-code", "opencode"]);
     expect(caps["claude-code"]?.state).toBe("ok");
     expect(caps["claude-code-tui"]).toBeUndefined();
     expect(caps.codex?.state).toBe("ok");
     expect(caps.cursor?.state).toBe("ok");
+    expect(caps.grok?.state).toBe("ok");
     expect(caps["kimi-code"]?.state).toBe("ok");
     expect(caps.opencode?.state).toBe("ok");
     expect(tuiProbe).not.toHaveBeenCalled();
@@ -761,6 +765,7 @@ describe("probeCapabilities (aggregator)", () => {
     vi.doUnmock("../runtime/capabilities/claude-code-tui.js");
     vi.doUnmock("../runtime/capabilities/codex.js");
     vi.doUnmock("../runtime/capabilities/cursor.js");
+    vi.doUnmock("../runtime/capabilities/grok.js");
     vi.doUnmock("../runtime/capabilities/kimi-code.js");
     vi.doUnmock("../runtime/capabilities/opencode.js");
     vi.resetModules();
@@ -780,6 +785,9 @@ describe("probeCapabilities (aggregator)", () => {
     vi.doMock("../runtime/capabilities/cursor.js", () => ({
       probeCursorCapability: vi.fn().mockRejectedValue("cursor probe failed"),
     }));
+    vi.doMock("../runtime/capabilities/grok.js", () => ({
+      probeGrokCapability: vi.fn().mockRejectedValue("grok probe failed"),
+    }));
     vi.doMock("../runtime/capabilities/kimi-code.js", () => ({
       probeKimiCodeCapability: vi.fn().mockRejectedValue("kimi probe failed"),
     }));
@@ -797,6 +805,7 @@ describe("probeCapabilities (aggregator)", () => {
     });
     expect(caps.codex).toMatchObject({ state: "error", error: "codex probe failed" });
     expect(caps.cursor).toMatchObject({ state: "error", error: "cursor probe failed" });
+    expect(caps.grok).toMatchObject({ state: "error", error: "grok probe failed" });
     expect(caps["kimi-code"]).toMatchObject({ state: "error", error: "kimi probe failed" });
     expect(caps.opencode).toMatchObject({ state: "error", error: "opencode probe failed" });
     // Disabled provider is never probed, so no entry (not even an error one).
@@ -806,6 +815,7 @@ describe("probeCapabilities (aggregator)", () => {
     vi.doUnmock("../runtime/capabilities/codex.js");
     vi.doUnmock("../runtime/capabilities/claude-code-tui.js");
     vi.doUnmock("../runtime/capabilities/cursor.js");
+    vi.doUnmock("../runtime/capabilities/grok.js");
     vi.doUnmock("../runtime/capabilities/kimi-code.js");
     vi.doUnmock("../runtime/capabilities/opencode.js");
     vi.resetModules();

--- a/packages/client/src/__tests__/capability-reprobe.test.ts
+++ b/packages/client/src/__tests__/capability-reprobe.test.ts
@@ -79,6 +79,7 @@ describe("hasNonOkProvider", () => {
         "claude-code": okEntry(),
         codex: okEntry(),
         cursor: okEntry(),
+        grok: okEntry(),
         "kimi-code": okEntry(),
         opencode: okEntry(),
       }),

--- a/packages/client/src/__tests__/discover-models.test.ts
+++ b/packages/client/src/__tests__/discover-models.test.ts
@@ -100,10 +100,12 @@ describe("discoverProviderModels — grok", () => {
     },
   };
 
+  const resolvedOk = { ok: true as const, binary: "/fake/bin/grok", version: "0.2.117" };
+
   it("returns the provider-cli catalog parsed from the initialize _meta.modelState", async () => {
     const catalog = await discoverProviderModels("grok", {
       now: () => new Date("2026-07-31T00:00:00Z"),
-      findGrokBinary: () => "/fake/bin/grok",
+      resolveGrokBinary: () => resolvedOk,
       fetchGrokModelMeta: async () => ({ ok: true as const, meta: modelStateMeta }),
     });
     expect(catalog).toEqual({
@@ -120,15 +122,36 @@ describe("discoverProviderModels — grok", () => {
   });
 
   it("degrades to unavailable when the binary is missing", async () => {
-    const catalog = await discoverProviderModels("grok", { findGrokBinary: () => null });
+    const catalog = await discoverProviderModels("grok", {
+      resolveGrokBinary: () => ({ ok: false as const, error: "grok binary not found on this host", transient: false }),
+    });
     expect(catalog.source).toBe("unavailable");
     expect(catalog.models).toEqual([]);
     expect(catalog.error).toContain("not found");
   });
 
+  it("degrades to unavailable when the launch-verified version gate rejects the binary", async () => {
+    let spawned = false;
+    const catalog = await discoverProviderModels("grok", {
+      resolveGrokBinary: () => ({
+        ok: false as const,
+        error: "resolved grok failed validation: grok 0.1.0 is outside the supported range >=0.2.117 <0.3.0",
+        transient: false,
+      }),
+      fetchGrokModelMeta: async () => {
+        spawned = true;
+        return { ok: true as const, meta: modelStateMeta };
+      },
+    });
+    expect(catalog.source).toBe("unavailable");
+    expect(catalog.error).toContain("supported range");
+    // The gated binary must never be spawned for discovery.
+    expect(spawned).toBe(false);
+  });
+
   it("degrades to unavailable when the initialize handshake fails", async () => {
     const catalog = await discoverProviderModels("grok", {
-      findGrokBinary: () => "/fake/bin/grok",
+      resolveGrokBinary: () => resolvedOk,
       fetchGrokModelMeta: async () => ({ ok: false as const, error: "grok ACP model discovery timed out" }),
     });
     expect(catalog.source).toBe("unavailable");
@@ -137,7 +160,7 @@ describe("discoverProviderModels — grok", () => {
 
   it("degrades to unavailable when the response carries no model state", async () => {
     const catalog = await discoverProviderModels("grok", {
-      findGrokBinary: () => "/fake/bin/grok",
+      resolveGrokBinary: () => resolvedOk,
       fetchGrokModelMeta: async () => ({ ok: true as const, meta: null }),
     });
     expect(catalog.source).toBe("unavailable");

--- a/packages/client/src/__tests__/discover-models.test.ts
+++ b/packages/client/src/__tests__/discover-models.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  discoverProviderModels,
   parseCursorModelsOutput,
   parseKimiConfigModels,
   resolveKimiConfigPath,
@@ -83,5 +84,63 @@ display_name = "K3"
       ]),
     );
     expect(parsed.models).toHaveLength(2);
+  });
+});
+
+describe("discoverProviderModels — grok", () => {
+  const modelStateMeta = {
+    defaultAuthMethodId: "cached_token",
+    agentVersion: "0.2.117",
+    modelState: {
+      currentModelId: "grok-4",
+      availableModels: [
+        { modelId: "grok-4", name: "Grok 4", description: "" },
+        { modelId: "grok-3-mini", name: "Grok 3 Mini", description: "" },
+      ],
+    },
+  };
+
+  it("returns the provider-cli catalog parsed from the initialize _meta.modelState", async () => {
+    const catalog = await discoverProviderModels("grok", {
+      now: () => new Date("2026-07-31T00:00:00Z"),
+      findGrokBinary: () => "/fake/bin/grok",
+      fetchGrokModelMeta: async () => ({ ok: true as const, meta: modelStateMeta }),
+    });
+    expect(catalog).toEqual({
+      provider: "grok",
+      models: [
+        { id: "grok-4", label: "Grok 4", isDefault: true, hint: "default" },
+        { id: "grok-3-mini", label: "Grok 3 Mini" },
+      ],
+      defaultModelId: "grok-4",
+      fetchedAt: "2026-07-31T00:00:00.000Z",
+      source: "provider-cli",
+      error: null,
+    });
+  });
+
+  it("degrades to unavailable when the binary is missing", async () => {
+    const catalog = await discoverProviderModels("grok", { findGrokBinary: () => null });
+    expect(catalog.source).toBe("unavailable");
+    expect(catalog.models).toEqual([]);
+    expect(catalog.error).toContain("not found");
+  });
+
+  it("degrades to unavailable when the initialize handshake fails", async () => {
+    const catalog = await discoverProviderModels("grok", {
+      findGrokBinary: () => "/fake/bin/grok",
+      fetchGrokModelMeta: async () => ({ ok: false as const, error: "grok ACP model discovery timed out" }),
+    });
+    expect(catalog.source).toBe("unavailable");
+    expect(catalog.error).toContain("timed out");
+  });
+
+  it("degrades to unavailable when the response carries no model state", async () => {
+    const catalog = await discoverProviderModels("grok", {
+      findGrokBinary: () => "/fake/bin/grok",
+      fetchGrokModelMeta: async () => ({ ok: true as const, meta: null }),
+    });
+    expect(catalog.source).toBe("unavailable");
+    expect(catalog.error).toContain("no model state");
   });
 });

--- a/packages/client/src/__tests__/grok-acp-events.test.ts
+++ b/packages/client/src/__tests__/grok-acp-events.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeGrokSessionUpdate,
+  normalizeGrokXaiNotification,
+  parseGrokModelState,
+} from "../handlers/grok/events.js";
+import { grokShellCommandIsReadOnly, grokToolIsReadOnly } from "../handlers/grok/index.js";
+
+/**
+ * Pure normalization coverage for the Grok ACP wire shapes (locked against
+ * real Grok 0.2.117 traffic): standard session/update payloads, the x.ai
+ * extension channels, the `_meta["x.ai/tool"]` read-only ladder, and the
+ * initialize `_meta.modelState` catalog parsing.
+ */
+
+const SEARCH_REPLACE_TOOL_CALL = {
+  sessionId: "sess-1",
+  update: {
+    sessionUpdate: "tool_call",
+    toolCallId: "tc-1",
+    title: "search_replace",
+    rawInput: { path: "notes.md", old_str: "a", new_str: "b" },
+    _meta: {
+      "x.ai/tool": {
+        version: 1,
+        name: "search_replace",
+        kind: "edit",
+        namespace: "grok_build",
+        label: "Edit",
+        read_only: false,
+      },
+    },
+  },
+};
+
+describe("normalizeGrokSessionUpdate", () => {
+  it("normalizes agent_message_chunk into an assistant chunk", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello world" } },
+    });
+    expect(normalized).toEqual({ sessionId: "sess-1", event: { kind: "assistant_chunk", text: "Hello world" } });
+  });
+
+  it("normalizes agent_thought_chunk into a presence-only thought chunk", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "hmm" } },
+    });
+    expect(normalized).toEqual({ sessionId: "sess-1", event: { kind: "thought_chunk" } });
+  });
+
+  it("ignores user_message_chunk echoes", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: { sessionUpdate: "user_message_chunk", content: { type: "text", text: "my own prompt" } },
+    });
+    expect(normalized).toEqual({ sessionId: "sess-1", event: { kind: "user_echo" } });
+  });
+
+  it("normalizes tool_call with authoritative x.ai/tool metadata", () => {
+    const normalized = normalizeGrokSessionUpdate(SEARCH_REPLACE_TOOL_CALL);
+    expect(normalized?.sessionId).toBe("sess-1");
+    const event = normalized?.event;
+    if (event?.kind !== "tool_started") throw new Error("expected tool_started");
+    expect(event.tool.toolCallId).toBe("tc-1");
+    expect(event.tool.name).toBe("search_replace");
+    expect(event.tool.kind).toBe("edit");
+    expect(event.tool.readOnly).toBe(false);
+    expect(event.tool.command).toBeNull();
+  });
+
+  it("falls back to the raw title when x.ai/tool metadata is absent (unproven read-only)", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: { sessionUpdate: "tool_call", toolCallId: "tc-9", title: "read_file", rawInput: { path: "a.md" } },
+    });
+    const event = normalized?.event;
+    if (event?.kind !== "tool_started") throw new Error("expected tool_started");
+    expect(event.tool.name).toBe("read_file");
+    expect(event.tool.readOnly).toBeNull();
+  });
+
+  it("normalizes tool_call_update completed with diff + locations into a completed tool with paths", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-1",
+        kind: "edit",
+        title: "search_replace",
+        status: "completed",
+        content: [{ type: "diff", path: "notes.md", oldText: "a", newText: "b" }],
+        locations: [{ path: "notes.md" }, { path: "extra.md" }],
+        rawInput: { path: "notes.md" },
+        rawOutput: "edited notes.md",
+        _meta: { "x.ai/tool": { version: 1, name: "search_replace", kind: "edit", read_only: false } },
+      },
+    });
+    const event = normalized?.event;
+    if (event?.kind !== "tool_completed") throw new Error("expected tool_completed");
+    expect(event.ok).toBe(true);
+    expect(event.resultPreview).toBe("edited notes.md");
+    expect(event.tool.paths).toEqual(["notes.md", "extra.md"]);
+    expect(event.tool.argsSummary).toEqual({ path: "notes.md" });
+  });
+
+  it("maps a failed tool_call_update to ok=false", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: { sessionUpdate: "tool_call_update", toolCallId: "tc-2", status: "failed", rawOutput: "boom" },
+    });
+    const event = normalized?.event;
+    if (event?.kind !== "tool_completed") throw new Error("expected tool_completed");
+    expect(event.ok).toBe(false);
+    expect(event.resultPreview).toBe("boom");
+  });
+
+  it("ignores in-progress tool_call_update statuses", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: { sessionUpdate: "tool_call_update", toolCallId: "tc-2", status: "in_progress" },
+    });
+    expect(normalized?.event.kind).toBe("ignored");
+  });
+
+  it("extracts the shell command for run_terminal_cmd", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-3",
+        title: "run_terminal_cmd",
+        rawInput: { command: "cat context-tree/NODE.md" },
+        _meta: { "x.ai/tool": { version: 1, name: "run_terminal_cmd", kind: "execute", read_only: true } },
+      },
+    });
+    const event = normalized?.event;
+    if (event?.kind !== "tool_started") throw new Error("expected tool_started");
+    expect(event.tool.name).toBe("run_terminal_cmd");
+    expect(event.tool.command).toBe("cat context-tree/NODE.md");
+    expect(event.tool.argsSummary).toEqual({ command: "cat context-tree/NODE.md" });
+  });
+
+  it("keeps plan updates as a distinct log-only kind", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: { sessionUpdate: "plan", entries: [] },
+    });
+    expect(normalized?.event.kind).toBe("plan");
+  });
+
+  it("ignores available_commands_update and unknown kinds without throwing", () => {
+    expect(
+      normalizeGrokSessionUpdate({ sessionId: "s", update: { sessionUpdate: "available_commands_update" } })?.event
+        .kind,
+    ).toBe("ignored");
+    expect(
+      normalizeGrokSessionUpdate({ sessionId: "s", update: { sessionUpdate: "brand_new_kind" } })?.event.kind,
+    ).toBe("ignored");
+    expect(normalizeGrokSessionUpdate("not an object")).toBeNull();
+    expect(normalizeGrokSessionUpdate({ sessionId: "s" })).toBeNull();
+  });
+});
+
+describe("normalizeGrokXaiNotification", () => {
+  const TURN_COMPLETED = {
+    sessionId: "sess-1",
+    update: {
+      sessionUpdate: "turn_completed",
+      prompt_id: "prompt-1",
+      stop_reason: "end_turn",
+      usage: {
+        inputTokens: 42,
+        outputTokens: 7,
+        totalTokens: 49,
+        cachedReadTokens: 10,
+        cacheCreationTokens: 0,
+        reasoningTokens: 3,
+        modelCalls: 1,
+        apiDurationMs: 1200,
+        costUsdTicks: 55,
+      },
+    },
+  };
+
+  it("maps turn_completed usage with camelCase fields and log-only cost", () => {
+    const normalized = normalizeGrokXaiNotification(TURN_COMPLETED);
+    expect(normalized?.sessionId).toBe("sess-1");
+    const event = normalized?.event;
+    if (event?.kind !== "turn_completed") throw new Error("expected turn_completed");
+    expect(event.completed.promptId).toBe("prompt-1");
+    expect(event.completed.stopReason).toBe("end_turn");
+    expect(event.completed.usage).toEqual({ inputTokens: 42, outputTokens: 7, cachedReadTokens: 10 });
+    expect(event.completed.costUsdTicks).toBe(55);
+    expect(event.completed.modelCalls).toBe(1);
+    expect(event.completed.apiDurationMs).toBe(1200);
+  });
+
+  it("tolerates a turn_completed without usage", () => {
+    const normalized = normalizeGrokXaiNotification({
+      sessionId: "sess-1",
+      update: { sessionUpdate: "turn_completed", prompt_id: "p", stop_reason: "cancelled" },
+    });
+    const event = normalized?.event;
+    if (event?.kind !== "turn_completed") throw new Error("expected turn_completed");
+    expect(event.completed.usage).toBeNull();
+  });
+
+  it.each([
+    "response_completed",
+    "model_changed",
+    "tool_call_delta_chunk",
+    "pending_interaction",
+    "interaction_resolved",
+    "retry_state",
+    "session_summary_generated",
+  ])("ignores the %s extension kind (no double counting, log-only)", (sessionUpdate) => {
+    const normalized = normalizeGrokXaiNotification({
+      sessionId: "sess-1",
+      update: { sessionUpdate, usage: { input_tokens: 999, output_tokens: 999 } },
+    });
+    expect(normalized?.event.kind).toBe("ignored");
+    if (normalized?.event.kind !== "ignored") throw new Error("unreachable");
+    expect(normalized.event.note).toContain(sessionUpdate);
+  });
+
+  it("returns null for malformed envelopes", () => {
+    expect(normalizeGrokXaiNotification(null)).toBeNull();
+    expect(normalizeGrokXaiNotification({ update: "nope" })).toBeNull();
+  });
+});
+
+describe("read-only replay-safety ladder", () => {
+  const tool = (over: Record<string, unknown>) => ({
+    toolCallId: "t",
+    name: "tool",
+    kind: null,
+    readOnly: null,
+    command: null,
+    paths: [],
+    argsSummary: {},
+    ...over,
+  });
+
+  it("read_only === true on a non-shell tool is proven read-only", () => {
+    expect(grokToolIsReadOnly(tool({ name: "read_file", readOnly: true }))).toBe(true);
+  });
+
+  it("read_only false or absent is NEVER proven read-only", () => {
+    expect(grokToolIsReadOnly(tool({ readOnly: false }))).toBe(false);
+    expect(grokToolIsReadOnly(tool({}))).toBe(false);
+  });
+
+  it("a shell tool needs read_only AND a supported read classification", () => {
+    expect(grokToolIsReadOnly(tool({ name: "run_terminal_cmd", readOnly: true, command: "cat NODE.md" }))).toBe(true);
+    expect(grokToolIsReadOnly(tool({ name: "run_terminal_cmd", readOnly: true, command: "rm -rf x" }))).toBe(false);
+    expect(grokToolIsReadOnly(tool({ name: "run_terminal_cmd", readOnly: false, command: "cat NODE.md" }))).toBe(false);
+    expect(grokShellCommandIsReadOnly("git status")).toBe(false);
+    expect(grokShellCommandIsReadOnly(null)).toBe(false);
+  });
+});
+
+describe("parseGrokModelState", () => {
+  it("parses availableModels and marks the current model as default", () => {
+    const parsed = parseGrokModelState({
+      protocolVersion: 1,
+      _meta: {
+        defaultAuthMethodId: "cached_token",
+        agentVersion: "0.2.117",
+        modelState: {
+          currentModelId: "grok-4",
+          availableModels: [
+            {
+              modelId: "grok-4",
+              name: "Grok 4",
+              description: "flagship",
+              _meta: {
+                supportsReasoningEffort: true,
+                reasoningEffort: "medium",
+                reasoningEfforts: ["low", "medium", "high"],
+              },
+            },
+            { modelId: "grok-3-mini", name: "Grok 3 Mini", description: "" },
+          ],
+        },
+      },
+    });
+    expect(parsed.defaultModelId).toBe("grok-4");
+    expect(parsed.models).toEqual([
+      { id: "grok-4", label: "Grok 4", isDefault: true, hint: "default" },
+      { id: "grok-3-mini", label: "Grok 3 Mini" },
+    ]);
+  });
+
+  it("degrades to an empty catalog when modelState is absent or malformed", () => {
+    expect(parseGrokModelState({})).toEqual({ models: [], defaultModelId: null });
+    expect(parseGrokModelState(null)).toEqual({ models: [], defaultModelId: null });
+    expect(parseGrokModelState({ _meta: { modelState: { availableModels: [{ name: "no id" }] } } })).toEqual({
+      models: [],
+      defaultModelId: null,
+    });
+  });
+});

--- a/packages/client/src/__tests__/grok-acp-events.test.ts
+++ b/packages/client/src/__tests__/grok-acp-events.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   normalizeGrokSessionUpdate,
   normalizeGrokXaiNotification,
+  parseGrokModelChangedEcho,
   parseGrokModelState,
 } from "../handlers/grok/events.js";
 import { grokShellCommandIsReadOnly, grokToolIsReadOnly } from "../handlers/grok/index.js";
@@ -329,6 +330,34 @@ describe("read-only replay-safety ladder", () => {
     if (byKind?.event.kind !== "tool_started") throw new Error("expected tool_started");
     expect(byKind.event.tool.isShell).toBe(true);
     expect(grokToolIsReadOnly(byKind.event.tool)).toBe(false);
+  });
+});
+
+describe("parseGrokModelChangedEcho", () => {
+  it("locks the real snake_case wire shape from _x.ai/session_notification", () => {
+    // Captured live on Grok 0.2.117 after session/set_model.
+    const echo = parseGrokModelChangedEcho({
+      sessionId: "019fb8a6-80ad-75b1-a1eb-7f56e5767868",
+      update: { sessionUpdate: "model_changed", model_id: "grok-4.5", reasoning_effort: "low" },
+    });
+    expect(echo).toEqual({ modelId: "grok-4.5", reasoningEffort: "low" });
+  });
+
+  it("returns a null effort when the echo omits reasoning_effort (ignored override)", () => {
+    const echo = parseGrokModelChangedEcho({
+      sessionId: "s",
+      update: { sessionUpdate: "model_changed", model_id: "grok-4.5" },
+    });
+    expect(echo).toEqual({ modelId: "grok-4.5", reasoningEffort: null });
+  });
+
+  it("returns null for non-model_changed payloads", () => {
+    expect(parseGrokModelChangedEcho({ sessionId: "s", update: { sessionUpdate: "turn_completed" } })).toBeNull();
+    expect(parseGrokModelChangedEcho(null)).toBeNull();
+    expect(parseGrokModelChangedEcho({ sessionId: "s", update: { sessionUpdate: "model_changed" } })).toEqual({
+      modelId: null,
+      reasoningEffort: null,
+    });
   });
 });
 

--- a/packages/client/src/__tests__/grok-acp-events.test.ts
+++ b/packages/client/src/__tests__/grok-acp-events.test.ts
@@ -236,6 +236,7 @@ describe("read-only replay-safety ladder", () => {
     toolCallId: "t",
     name: "tool",
     kind: null,
+    isShell: false,
     readOnly: null,
     command: null,
     paths: [],
@@ -253,11 +254,81 @@ describe("read-only replay-safety ladder", () => {
   });
 
   it("a shell tool needs read_only AND a supported read classification", () => {
-    expect(grokToolIsReadOnly(tool({ name: "run_terminal_cmd", readOnly: true, command: "cat NODE.md" }))).toBe(true);
-    expect(grokToolIsReadOnly(tool({ name: "run_terminal_cmd", readOnly: true, command: "rm -rf x" }))).toBe(false);
-    expect(grokToolIsReadOnly(tool({ name: "run_terminal_cmd", readOnly: false, command: "cat NODE.md" }))).toBe(false);
+    expect(
+      grokToolIsReadOnly(tool({ name: "run_terminal_cmd", isShell: true, readOnly: true, command: "cat NODE.md" })),
+    ).toBe(true);
+    expect(
+      grokToolIsReadOnly(tool({ name: "run_terminal_cmd", isShell: true, readOnly: true, command: "rm -rf x" })),
+    ).toBe(false);
+    expect(
+      grokToolIsReadOnly(tool({ name: "run_terminal_cmd", isShell: true, readOnly: false, command: "cat NODE.md" })),
+    ).toBe(false);
     expect(grokShellCommandIsReadOnly("git status")).toBe(false);
     expect(grokShellCommandIsReadOnly(null)).toBe(false);
+  });
+
+  it("a shell tool with a MISSING command fails closed (unsafe) even with read_only true", () => {
+    expect(grokToolIsReadOnly(tool({ name: "run_terminal_cmd", isShell: true, readOnly: true, command: null }))).toBe(
+      false,
+    );
+  });
+
+  it("shell detection keys on kind execute even under a different name", () => {
+    expect(
+      grokToolIsReadOnly(
+        tool({ name: "shell_custom", kind: "execute", isShell: true, readOnly: true, command: "cat x" }),
+      ),
+    ).toBe(true);
+    expect(grokToolIsReadOnly(tool({ name: "shell_custom", kind: "execute", isShell: true, readOnly: true }))).toBe(
+      false,
+    );
+  });
+
+  it("reads the command from _meta x.ai/tool input when rawInput lacks it", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "s",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-meta",
+        title: "run_terminal_cmd",
+        rawInput: {},
+        _meta: {
+          "x.ai/tool": {
+            version: 1,
+            name: "run_terminal_cmd",
+            kind: "execute",
+            read_only: true,
+            input: { command: "cat NODE.md" },
+          },
+        },
+      },
+    });
+    const event = normalized?.event;
+    if (event?.kind !== "tool_started") throw new Error("expected tool_started");
+    expect(event.tool.command).toBe("cat NODE.md");
+    expect(event.tool.isShell).toBe(true);
+    expect(grokToolIsReadOnly(event.tool)).toBe(true);
+  });
+
+  it("marks run_terminal_cmd and kind execute as shell in normalized events", () => {
+    const byName = normalizeGrokSessionUpdate({
+      sessionId: "s",
+      update: { sessionUpdate: "tool_call", toolCallId: "t1", title: "run_terminal_cmd", rawInput: {} },
+    });
+    if (byName?.event.kind !== "tool_started") throw new Error("expected tool_started");
+    expect(byName.event.tool.isShell).toBe(true);
+    const byKind = normalizeGrokSessionUpdate({
+      sessionId: "s",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "t2",
+        title: "something_else",
+        _meta: { "x.ai/tool": { kind: "execute", read_only: true } },
+      },
+    });
+    if (byKind?.event.kind !== "tool_started") throw new Error("expected tool_started");
+    expect(byKind.event.tool.isShell).toBe(true);
+    expect(grokToolIsReadOnly(byKind.event.tool)).toBe(false);
   });
 });
 

--- a/packages/client/src/__tests__/grok-acp-session.test.ts
+++ b/packages/client/src/__tests__/grok-acp-session.test.ts
@@ -1,0 +1,155 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { fetchGrokAcpInitializeMeta } from "../handlers/grok/acp-session.js";
+
+/**
+ * Transport-level coverage for the model-discovery ACP handshake, against a
+ * REAL child process (a node script standing in for the grok binary). Locks
+ * the bounded EOF→close barrier: every path — success, non-zero exit, EOF
+ * ignored, initialize failure — must reclaim the process, and success
+ * requires a clean exit 0.
+ */
+
+const FAKE_AGENT_SCRIPT = `
+const fs = require("fs");
+const behavior = process.env.GROK_FAKE_DISCOVERY_BEHAVIOR || "success";
+const pidFile = process.env.GROK_FAKE_DISCOVERY_PID_FILE || "";
+if (pidFile) fs.writeFileSync(pidFile, String(process.pid));
+let buffer = "";
+function send(msg) { process.stdout.write(JSON.stringify(msg) + "\\n"); }
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let idx = buffer.indexOf("\\n");
+  while (idx >= 0) {
+    const line = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 1);
+    if (line.trim()) {
+      let req = null;
+      try { req = JSON.parse(line); } catch {}
+      if (req && req.method === "initialize" && req.id !== undefined) {
+        if (behavior === "init_error") {
+          send({ jsonrpc: "2.0", id: req.id, error: { code: -32000, message: "initialize rejected" } });
+        } else {
+          send({ jsonrpc: "2.0", id: req.id, result: { protocolVersion: 1, agentCapabilities: {}, _meta: { agentVersion: "0.2.117", modelState: { currentModelId: "grok-4", availableModels: [{ modelId: "grok-4", name: "Grok 4" }] } } } });
+        }
+      }
+    }
+    idx = buffer.indexOf("\\n");
+  }
+});
+process.stdin.on("end", () => {
+  if (behavior === "ignore_eof") return; // deliberately never exits
+  process.exit(behavior === "exit_nonzero" ? 3 : 0);
+});
+if (behavior === "ignore_eof") setInterval(() => {}, 1000);
+`;
+
+let dir: string;
+let binary: string;
+
+function pidFileFor(name: string): string {
+  return join(dir, `${name}.pid`);
+}
+
+function assertProcessGone(pidFile: string): void {
+  const pid = Number(readFileSync(pidFile, "utf8"));
+  expect(Number.isInteger(pid)).toBe(true);
+  let alive = true;
+  try {
+    process.kill(pid, 0);
+  } catch {
+    alive = false;
+  }
+  expect(alive).toBe(false);
+}
+
+function fetchMeta(behavior: string, pidFile: string, over: { timeoutMs?: number; eofCloseWaitMs?: number } = {}) {
+  return fetchGrokAcpInitializeMeta({
+    binary,
+    env: {
+      ...process.env,
+      GROK_FAKE_DISCOVERY_BEHAVIOR: behavior,
+      GROK_FAKE_DISCOVERY_PID_FILE: pidFile,
+    },
+    timeoutMs: over.timeoutMs ?? 5_000,
+    eofCloseWaitMs: over.eofCloseWaitMs ?? 300,
+    clientVersion: "0",
+  });
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "grok-acp-discovery-test-"));
+  binary = join(dir, "fake-grok");
+  writeFileSync(binary, `#!/usr/bin/env node\n${FAKE_AGENT_SCRIPT}`);
+  chmodSync(binary, 0o755);
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("fetchGrokAcpInitializeMeta — bounded EOF→close barrier", () => {
+  it("returns the initialize _meta on a clean exit 0", async () => {
+    const pidFile = pidFileFor("success");
+    const result = await fetchMeta("success", pidFile);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.meta).toMatchObject({ agentVersion: "0.2.117" });
+    assertProcessGone(pidFile);
+  });
+
+  it("fails (no silent success) when the child exits non-zero after initialize", async () => {
+    const pidFile = pidFileFor("nonzero");
+    const result = await fetchMeta("exit_nonzero", pidFile);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toContain("exited 3");
+    assertProcessGone(pidFile);
+  });
+
+  it("reclaims a child that ignores stdin EOF and reports failure", async () => {
+    const pidFile = pidFileFor("ignore-eof");
+    const startedAt = Date.now();
+    const result = await fetchMeta("ignore_eof", pidFile, { eofCloseWaitMs: 200 });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toContain("exit 0 required");
+    // The bounded barrier must terminate the child well under the overall timeout.
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+    assertProcessGone(pidFile);
+  });
+
+  it("reclaims the child when initialize fails while the child is still alive", async () => {
+    const pidFile = pidFileFor("init-error");
+    const result = await fetchMeta("init_error", pidFile);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toContain("initialize rejected");
+    assertProcessGone(pidFile);
+  });
+
+  it("times out and kills a child that never answers initialize", async () => {
+    const pidFile = pidFileFor("silent");
+    // A binary that reads stdin forever without answering anything.
+    const silent = join(dir, "fake-grok-silent");
+    writeFileSync(
+      silent,
+      `#!/usr/bin/env node\nconst fs = require("fs");fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));process.stdin.resume();setInterval(() => {}, 1000);\n`,
+    );
+    chmodSync(silent, 0o755);
+    const result = await fetchGrokAcpInitializeMeta({
+      binary: silent,
+      env: process.env,
+      timeoutMs: 1_000,
+      eofCloseWaitMs: 200,
+      clientVersion: "0",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toContain("timed out");
+    assertProcessGone(pidFile);
+  });
+});

--- a/packages/client/src/__tests__/grok-acp-session.test.ts
+++ b/packages/client/src/__tests__/grok-acp-session.test.ts
@@ -1,8 +1,10 @@
+import { spawn } from "node:child_process";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { fetchGrokAcpInitializeMeta } from "../handlers/grok/acp-session.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchGrokAcpInitializeMeta, runGrokAcpAttempt } from "../handlers/grok/acp-session.js";
+import type { ProviderProcessSupervisor } from "../runtime/provider-process-supervisor.js";
 
 /**
  * Transport-level coverage for the model-discovery ACP handshake, against a
@@ -33,18 +35,25 @@ process.stdin.on("data", (chunk) => {
         if (behavior === "init_error") {
           send({ jsonrpc: "2.0", id: req.id, error: { code: -32000, message: "initialize rejected" } });
         } else {
-          send({ jsonrpc: "2.0", id: req.id, result: { protocolVersion: 1, agentCapabilities: {}, _meta: { agentVersion: "0.2.117", modelState: { currentModelId: "grok-4", availableModels: [{ modelId: "grok-4", name: "Grok 4" }] } } } });
+          send({ jsonrpc: "2.0", id: req.id, result: { protocolVersion: behavior === "wrong_protocol" ? 2 : 1, agentCapabilities: {}, _meta: { agentVersion: "0.2.117", modelState: { currentModelId: "grok-4", availableModels: [{ modelId: "grok-4", name: "Grok 4" }] } } } });
         }
+      } else if (req && req.method === "session/new" && req.id !== undefined) {
+        send({ jsonrpc: "2.0", id: req.id, result: { sessionId: "s-probe", models: { currentModelId: "grok-4", availableModels: [] } } });
+      } else if (req && req.method === "session/set_model" && req.id !== undefined) {
+        send({ jsonrpc: "2.0", id: req.id, result: { _meta: { model: { Ok: req.params && req.params.modelId } } } });
+      } else if (req && req.method === "session/prompt" && req.id !== undefined) {
+        const clientPid = req.params && req.params._meta && typeof req.params._meta.promptId === "string" ? req.params._meta.promptId : "p1";
+        send({ jsonrpc: "2.0", id: req.id, result: { stopReason: "end_turn", _meta: { promptId: clientPid, modelId: "grok-4" } } });
       }
     }
     idx = buffer.indexOf("\\n");
   }
 });
 process.stdin.on("end", () => {
-  if (behavior === "ignore_eof") return; // deliberately never exits
+  if (behavior === "ignore_eof" || behavior === "hold_after_prompt") return; // deliberately never exits
   process.exit(behavior === "exit_nonzero" ? 3 : 0);
 });
-if (behavior === "ignore_eof") setInterval(() => {}, 1000);
+if (behavior === "ignore_eof" || behavior === "hold_after_prompt") setInterval(() => {}, 1000);
 `;
 
 let dir: string;
@@ -131,6 +140,15 @@ describe("fetchGrokAcpInitializeMeta — bounded EOF→close barrier", () => {
     assertProcessGone(pidFile);
   });
 
+  it("rejects an initialize response with an incompatible protocolVersion", async () => {
+    const pidFile = pidFileFor("wrong-protocol");
+    const result = await fetchMeta("wrong_protocol", pidFile);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error).toContain("protocolVersion 2");
+    assertProcessGone(pidFile);
+  });
+
   it("times out and kills a child that never answers initialize", async () => {
     const pidFile = pidFileFor("silent");
     // A binary that reads stdin forever without answering anything.
@@ -151,5 +169,144 @@ describe("fetchGrokAcpInitializeMeta — bounded EOF→close barrier", () => {
     if (result.ok) throw new Error("unreachable");
     expect(result.error).toContain("timed out");
     assertProcessGone(pidFile);
+  });
+});
+
+describe("runGrokAcpAttempt — teardown timer hygiene", () => {
+  it("reclaims a child with non-piped stdio and bounded-waits for its close", async () => {
+    if (process.platform === "win32") return; // POSIX process-group kill semantics
+    let childPid: number | undefined;
+    const supervisor: ProviderProcessSupervisor = {
+      spawn(spec) {
+        // stdio "ignore" yields null stdio streams — the defensive branch.
+        const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+          ...spec.options,
+          stdio: "ignore",
+        });
+        childPid = child.pid;
+        return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+      },
+    };
+    const outcome = await runGrokAcpAttempt({
+      supervisor,
+      binary,
+      args: [],
+      env: { PATH: process.env.PATH ?? "" },
+      cwd: dir,
+      abortSignal: new AbortController().signal,
+      label: "grok unpiped reclaim test",
+      clientVersion: "0",
+      resumeSessionId: null,
+      mcpServers: [],
+      model: "",
+      reasoningEffort: "",
+      promptText: "hi",
+      onSessionUpdate: () => {},
+      onXaiNotification: () => {},
+      log: () => {},
+    });
+
+    expect(outcome.spawnError?.message).toContain("not piped");
+    // The child was SIGKILLed and the branch waited for it to die.
+    if (!childPid) throw new Error("unreachable");
+    let alive = true;
+    try {
+      process.kill(childPid, 0);
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  });
+
+  it("a fast-closing non-piped child resolves well before the reclaim deadline", async () => {
+    if (process.platform === "win32") return; // POSIX process-group kill semantics
+    const supervisor: ProviderProcessSupervisor = {
+      spawn(spec) {
+        // Exits ~50ms after spawn with null stdio — the reclaim must catch the
+        // close via the pre-registered waiter, not wait the full 5s deadline.
+        const child = spawn(process.execPath, ["-e", "setTimeout(() => process.exit(0), 50)"], {
+          ...spec.options,
+          stdio: "ignore",
+        });
+        return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+      },
+    };
+    const startedAt = Date.now();
+    const outcome = await runGrokAcpAttempt({
+      supervisor,
+      binary,
+      args: [],
+      env: { PATH: process.env.PATH ?? "" },
+      cwd: dir,
+      abortSignal: new AbortController().signal,
+      label: "grok unpiped fast-close test",
+      clientVersion: "0",
+      resumeSessionId: null,
+      mcpServers: [],
+      model: "",
+      reasoningEffort: "",
+      promptText: "hi",
+      onSessionUpdate: () => {},
+      onXaiNotification: () => {},
+      log: () => {},
+    });
+
+    expect(outcome.spawnError?.message).toContain("not piped");
+    // The 5s reclaim deadline must NOT be hit: a fast close resolves almost immediately.
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it("clears pending SIGKILL timers once the terminated child closes (no post-close group kill)", async () => {
+    if (process.platform === "win32") return; // POSIX process-group kill semantics
+    const spy = vi.spyOn(process, "kill");
+    const supervisor: ProviderProcessSupervisor = {
+      spawn(spec) {
+        const child = spawn(binary, [], {
+          ...spec.options,
+          env: { ...spec.options.env, GROK_FAKE_DISCOVERY_BEHAVIOR: "hold_after_prompt" },
+        });
+        return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+      },
+    };
+    try {
+      const outcome = await runGrokAcpAttempt({
+        supervisor,
+        binary,
+        args: [],
+        env: Object.fromEntries(
+          Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+        ),
+        cwd: dir,
+        abortSignal: new AbortController().signal,
+        label: "grok timer-hygiene test",
+        clientVersion: "0",
+        resumeSessionId: null,
+        mcpServers: [],
+        model: "",
+        reasoningEffort: "",
+        promptText: "hi",
+        eofCloseWaitMs: 50,
+        killGraceMs: 50,
+        onSessionUpdate: () => {},
+        onXaiNotification: () => {},
+        log: () => {},
+      });
+
+      // The child answered the prompt, ignored EOF, and was reclaimed via
+      // SIGTERM — a non-clean exit, never a silent success.
+      expect(outcome.prompt).not.toBeNull();
+      expect(outcome.cleanExit).toBe(false);
+
+      // Wait well past the (shortened) hard-kill grace: if the close handler
+      // failed to clear the timers, a group SIGKILL would fire here against
+      // whatever now owns the PGID.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      const groupKills = spy.mock.calls.filter(([pid]) => typeof pid === "number" && pid < 0);
+      expect(groupKills.filter(([, signal]) => signal === "SIGTERM")).toHaveLength(1);
+      expect(groupKills.filter(([, signal]) => signal === "SIGKILL")).toEqual([]);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/client/src/__tests__/grok-binary.test.ts
+++ b/packages/client/src/__tests__/grok-binary.test.ts
@@ -1,0 +1,242 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  findGrokExecutableOnPath,
+  formatGrokBinaryMissingMessage,
+  GROK_INSTALL_COMMAND,
+  isGrokBinaryMissingError,
+  isGrokVersionSupported,
+  parseGrokVersion,
+  resolveGrokRuntimeBinary,
+  verifyGrokExecutable,
+} from "../runtime/grok-binary.js";
+
+let dir: string;
+
+function makeExecutable(path: string, body = "#!/bin/sh\nexit 0\n"): void {
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "grok-binary-test-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("findGrokExecutableOnPath — external-only resolution", () => {
+  it("resolves `grok` from the daemon PATH", () => {
+    const bin = join(dir, "bin");
+    mkdirSync(bin);
+    makeExecutable(join(bin, "grok"));
+    const found = findGrokExecutableOnPath(
+      { PATH: bin, HOME: dir },
+      { wellKnownDirs: () => [], loginShellPathDirs: () => [] },
+    );
+    expect(found).toBe(join(bin, "grok"));
+  });
+
+  it("falls back to the official `~/.grok/bin` install location when PATH misses", () => {
+    const grokBin = join(dir, ".grok", "bin");
+    mkdirSync(grokBin, { recursive: true });
+    makeExecutable(join(grokBin, "grok"));
+    // No wellKnownDirs injection: the default list must cover the official
+    // installer's `~/.grok/bin` target.
+    const found = findGrokExecutableOnPath({ PATH: join(dir, "nope"), HOME: dir }, { loginShellPathDirs: () => [] });
+    expect(found).toBe(join(grokBin, "grok"));
+  });
+
+  it("falls back to the `~/.local/bin` symlink location", () => {
+    const localBin = join(dir, ".local", "bin");
+    mkdirSync(localBin, { recursive: true });
+    makeExecutable(join(localBin, "grok"));
+    const found = findGrokExecutableOnPath({ PATH: join(dir, "nope"), HOME: dir }, { loginShellPathDirs: () => [] });
+    expect(found).toBe(join(localBin, "grok"));
+  });
+
+  it("falls back to the login-shell PATH last", () => {
+    const loginBin = join(dir, "login-bin");
+    mkdirSync(loginBin);
+    makeExecutable(join(loginBin, "grok"));
+    const found = findGrokExecutableOnPath(
+      { PATH: join(dir, "nope"), HOME: dir },
+      { wellKnownDirs: () => [], loginShellPathDirs: () => [loginBin] },
+    );
+    expect(found).toBe(join(loginBin, "grok"));
+  });
+
+  it("ignores directories and non-executables named grok", () => {
+    const bin = join(dir, "bin");
+    mkdirSync(bin);
+    mkdirSync(join(bin, "grok"));
+    const found = findGrokExecutableOnPath(
+      { PATH: bin, HOME: dir },
+      { wellKnownDirs: () => [], loginShellPathDirs: () => [] },
+    );
+    expect(found).toBeNull();
+  });
+
+  it("returns null when nothing resolves anywhere", () => {
+    expect(
+      findGrokExecutableOnPath(
+        { PATH: join(dir, "nope"), HOME: dir },
+        { wellKnownDirs: () => [], loginShellPathDirs: () => [] },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("verifyGrokExecutable — version parse + supported-range gate", () => {
+  const fakeGrok = (versionLine: string): string => {
+    const path = join(dir, `grok-${versionLine.replaceAll(/[^a-z0-9]+/gi, "-")}`);
+    makeExecutable(path, `#!/bin/sh\necho '${versionLine}'\nexit 0\n`);
+    return path;
+  };
+
+  it("parses the canonical `grok 0.2.117 (f1c06093089f)` output", () => {
+    expect(parseGrokVersion("grok 0.2.117 (f1c06093089f)")).toBe("0.2.117");
+    expect(parseGrokVersion("grok 0.2.117 (f1c06093089f)\n")).toBe("0.2.117");
+    expect(parseGrokVersion("some other tool 1.2.3")).toBeNull();
+  });
+
+  it("accepts a binary at the supported floor 0.2.117", () => {
+    const verification = verifyGrokExecutable(fakeGrok("grok 0.2.117 (f1c06093089f)"));
+    expect(verification).toMatchObject({ ok: true, version: "0.2.117" });
+  });
+
+  it("accepts a newer 0.2.x binary inside the range", () => {
+    const verification = verifyGrokExecutable(fakeGrok("grok 0.2.140 (abcd1234)"));
+    expect(verification).toMatchObject({ ok: true, version: "0.2.140" });
+  });
+
+  it("rejects 0.2.89 (below the floor) as deterministic, NOT transient", () => {
+    const verification = verifyGrokExecutable(fakeGrok("grok 0.2.89 (abcd1234)"));
+    expect(verification.ok).toBe(false);
+    if (verification.ok) throw new Error("unreachable");
+    expect(verification.transient).toBe(false);
+    expect(verification.reason).toContain("0.2.89");
+    expect(verification.reason).toContain("outside the supported range");
+  });
+
+  it("rejects 0.3.0 (the exclusive ceiling) as deterministic, NOT transient", () => {
+    const verification = verifyGrokExecutable(fakeGrok("grok 0.3.0 (abcd1234)"));
+    expect(verification.ok).toBe(false);
+    if (verification.ok) throw new Error("unreachable");
+    expect(verification.transient).toBe(false);
+    expect(verification.reason).toContain("outside the supported range");
+  });
+
+  it("isGrokVersionSupported pins the exact range boundaries", () => {
+    expect(isGrokVersionSupported("0.2.116")).toBe(false);
+    expect(isGrokVersionSupported("0.2.117")).toBe(true);
+    expect(isGrokVersionSupported("0.2.999")).toBe(true);
+    expect(isGrokVersionSupported("0.3.0")).toBe(false);
+    expect(isGrokVersionSupported("1.0.0")).toBe(false);
+  });
+
+  it("a clean exit with unparseable output is deterministic, NOT transient", () => {
+    const verification = verifyGrokExecutable(fakeGrok("hello world"));
+    expect(verification.ok).toBe(false);
+    if (verification.ok) throw new Error("unreachable");
+    expect(verification.transient).toBe(false);
+    expect(verification.reason).toContain("did not report a parseable version");
+  });
+
+  it("a non-zero exit is deterministic, NOT transient", () => {
+    const path = join(dir, "grok-broken");
+    makeExecutable(path, "#!/bin/sh\necho 'boom' >&2\nexit 2\n");
+    const verification = verifyGrokExecutable(path);
+    expect(verification.ok).toBe(false);
+    if (verification.ok) throw new Error("unreachable");
+    expect(verification.transient).toBe(false);
+    expect(verification.reason).toContain("exited 2");
+  });
+});
+
+describe("resolveGrokRuntimeBinary — spawn-time smoke split", () => {
+  it("missing binary → non-transient error carrying the official installer command", () => {
+    const resolution = resolveGrokRuntimeBinary({ PATH: join(dir, "nope"), HOME: dir }, { findOnPath: () => null });
+    expect(resolution.ok).toBe(false);
+    if (resolution.ok) throw new Error("unreachable");
+    expect(resolution.transient).toBe(false);
+    expect(resolution.error).toContain(GROK_INSTALL_COMMAND);
+    expect(isGrokBinaryMissingError(new Error(resolution.error))).toBe(true);
+  });
+
+  it("resolved binary whose smoke check flakes transiently is NOT missing (and is not cached)", () => {
+    // Distinct fake path per case: successful verifications are memoized per
+    // binary path, so sharing a path across cases would couple test order.
+    const resolution = resolveGrokRuntimeBinary(
+      { HOME: dir },
+      {
+        findOnPath: () => "/fake/transient/grok",
+        verifyPath: () => ({ ok: false, transient: true, reason: "`grok --version` timed out" }),
+      },
+    );
+    expect(resolution.ok).toBe(false);
+    if (resolution.ok) throw new Error("unreachable");
+    expect(resolution.transient).toBe(true);
+    expect(resolution.error).not.toMatch(/is missing/i);
+  });
+
+  it("clean broken-binary verdict is permanent (capability failure copy)", () => {
+    const resolution = resolveGrokRuntimeBinary(
+      { HOME: dir },
+      {
+        findOnPath: () => "/fake/broken/grok",
+        verifyPath: () => ({ ok: false, transient: false, reason: "`grok --version` exited 2" }),
+      },
+    );
+    expect(resolution.ok).toBe(false);
+    if (resolution.ok) throw new Error("unreachable");
+    expect(resolution.transient).toBe(false);
+    expect(resolution.error).toContain("Grok Build CLI is missing");
+  });
+
+  it("an out-of-range version is permanent and names the supported range", () => {
+    const resolution = resolveGrokRuntimeBinary(
+      { HOME: dir },
+      {
+        findOnPath: () => "/fake/old/grok",
+        verifyPath: () => ({
+          ok: false,
+          transient: false,
+          reason: "grok 0.2.89 is outside the supported range >=0.2.117 <0.3.0",
+        }),
+      },
+    );
+    expect(resolution.ok).toBe(false);
+    if (resolution.ok) throw new Error("unreachable");
+    expect(resolution.transient).toBe(false);
+    expect(resolution.error).toContain("outside the supported range");
+  });
+
+  it("verified binary reports the parsed version and memoizes the blocking smoke check", () => {
+    const verify = vi.fn(() => ({ ok: true as const, output: "grok 0.2.117 (f1c06093089f)", version: "0.2.117" }));
+    const deps = { findOnPath: () => "/fake/verified/grok", verifyPath: verify };
+    const resolution = resolveGrokRuntimeBinary({ HOME: dir }, deps);
+    expect(resolution).toMatchObject({
+      ok: true,
+      binary: "/fake/verified/grok",
+      version: "0.2.117",
+    });
+    // Second resolve of the same path must not spawn `--version` again.
+    const again = resolveGrokRuntimeBinary({ HOME: dir }, deps);
+    expect(again).toMatchObject({ ok: true, version: "0.2.117" });
+    expect(verify).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("formatGrokBinaryMissingMessage", () => {
+  it("names the external-only posture and the official installer", () => {
+    const message = formatGrokBinaryMissingMessage("nothing resolved");
+    expect(message).toContain("does not bundle or install the Grok engine");
+    expect(message).toContain(GROK_INSTALL_COMMAND);
+    expect(message).toContain("grok login");
+    expect(message).toContain("nothing resolved");
+  });
+});

--- a/packages/client/src/__tests__/grok-binary.test.ts
+++ b/packages/client/src/__tests__/grok-binary.test.ts
@@ -158,6 +158,15 @@ describe("verifyGrokExecutable — version parse + supported-range gate", () => 
 });
 
 describe("resolveGrokRuntimeBinary — spawn-time smoke split", () => {
+  it("win32 → refuses BEFORE any filesystem consult (central no-spawn gate)", () => {
+    const findOnPath = vi.fn(() => "/fake/grok");
+    const resolution = resolveGrokRuntimeBinary({ HOME: dir }, { platform: "win32", findOnPath });
+    expect(resolution).toMatchObject({ ok: false, transient: false });
+    if (resolution.ok) throw new Error("unreachable");
+    expect(resolution.error).toContain("not supported on Windows in V1");
+    expect(findOnPath).not.toHaveBeenCalled();
+  });
+
   it("missing binary → non-transient error carrying the official installer command", () => {
     const resolution = resolveGrokRuntimeBinary({ PATH: join(dir, "nope"), HOME: dir }, { findOnPath: () => null });
     expect(resolution.ok).toBe(false);
@@ -183,7 +192,7 @@ describe("resolveGrokRuntimeBinary — spawn-time smoke split", () => {
     expect(resolution.error).not.toMatch(/is missing/i);
   });
 
-  it("clean broken-binary verdict is permanent (capability failure copy)", () => {
+  it("clean broken-binary verdict is permanent and does NOT read as missing", () => {
     const resolution = resolveGrokRuntimeBinary(
       { HOME: dir },
       {
@@ -194,7 +203,11 @@ describe("resolveGrokRuntimeBinary — spawn-time smoke split", () => {
     expect(resolution.ok).toBe(false);
     if (resolution.ok) throw new Error("unreachable");
     expect(resolution.transient).toBe(false);
-    expect(resolution.error).toContain("Grok Build CLI is missing");
+    // "missing" is only for "no binary resolved" — a present-but-broken
+    // binary is an unsupported verdict with a deterministic classification.
+    expect(resolution.error).toContain("is not a supported Grok Build version");
+    expect(resolution.error).not.toMatch(/is missing/i);
+    expect(isGrokBinaryMissingError(new Error(resolution.error))).toBe(false);
   });
 
   it("an out-of-range version is permanent and names the supported range", () => {
@@ -213,6 +226,8 @@ describe("resolveGrokRuntimeBinary — spawn-time smoke split", () => {
     if (resolution.ok) throw new Error("unreachable");
     expect(resolution.transient).toBe(false);
     expect(resolution.error).toContain("outside the supported range");
+    expect(resolution.error).not.toMatch(/is missing/i);
+    expect(isGrokBinaryMissingError(new Error(resolution.error))).toBe(false);
   });
 
   it("verified binary reports the parsed version and memoizes the blocking smoke check", () => {

--- a/packages/client/src/__tests__/grok-capability.test.ts
+++ b/packages/client/src/__tests__/grok-capability.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeGrokCapability } from "../runtime/capabilities/grok.js";
+import { GROK_INSTALL_COMMAND } from "../runtime/grok-binary.js";
+
+describe("probeGrokCapability — install-only detection", () => {
+  it("resolved binary → ok with runtimeSource=path (existence only, never launched)", async () => {
+    const entry = await probeGrokCapability({ findOnPath: () => "/home/op/.grok/bin/grok" });
+    expect(entry).toMatchObject({
+      state: "ok",
+      available: true,
+      runtimeSource: "path",
+      runtimePath: "/home/op/.grok/bin/grok",
+    });
+  });
+
+  it("nothing resolved → missing with the official installer in the reason", async () => {
+    const entry = await probeGrokCapability({ findOnPath: () => null });
+    expect(entry).toMatchObject({ state: "missing", available: false });
+    expect(entry.error).toContain(GROK_INSTALL_COMMAND);
+  });
+
+  it("win32 → non-ok fail-closed WITHOUT consulting the filesystem or spawning", async () => {
+    // The platform gate must short-circuit BEFORE the resolver runs: no
+    // findOnPath call, no `grok` spawn, no credential / network inspection.
+    const findOnPath = vi.fn(() => "/fake/grok");
+    const entry = await probeGrokCapability({ platform: "win32", findOnPath });
+    expect(entry).toMatchObject({ state: "missing", available: false });
+    expect(entry.error).toContain("not supported on Windows");
+    expect(findOnPath).not.toHaveBeenCalled();
+  });
+
+  it("non-win32 platforms still resolve normally", async () => {
+    for (const platform of ["darwin", "linux"] as const) {
+      const entry = await probeGrokCapability({ platform, findOnPath: () => "/usr/local/bin/grok" });
+      expect(entry).toMatchObject({ state: "ok", available: true, runtimeSource: "path" });
+    }
+  });
+
+  it("a throwing resolver → error entry, never a rejection", async () => {
+    const entry = await probeGrokCapability({
+      findOnPath: () => {
+        throw new Error("resolver blew up");
+      },
+    });
+    expect(entry).toMatchObject({ state: "error", available: false, error: "resolver blew up" });
+  });
+});

--- a/packages/client/src/__tests__/grok-capability.test.ts
+++ b/packages/client/src/__tests__/grok-capability.test.ts
@@ -19,13 +19,15 @@ describe("probeGrokCapability — install-only detection", () => {
     expect(entry.error).toContain(GROK_INSTALL_COMMAND);
   });
 
-  it("win32 → non-ok fail-closed WITHOUT consulting the filesystem or spawning", async () => {
+  it("win32 → state error (NOT missing) fail-closed WITHOUT consulting the filesystem or spawning", async () => {
     // The platform gate must short-circuit BEFORE the resolver runs: no
     // findOnPath call, no `grok` spawn, no credential / network inspection.
+    // state `error` (not `missing`) keeps the Web setup cards from rendering
+    // the install command for a runtime V1 does not support on Windows.
     const findOnPath = vi.fn(() => "/fake/grok");
     const entry = await probeGrokCapability({ platform: "win32", findOnPath });
-    expect(entry).toMatchObject({ state: "missing", available: false });
-    expect(entry.error).toContain("not supported on Windows");
+    expect(entry).toMatchObject({ state: "error", available: false });
+    expect(entry.error).toContain("not supported on Windows in V1");
     expect(findOnPath).not.toHaveBeenCalled();
   });
 

--- a/packages/client/src/__tests__/grok-handler-engine.test.ts
+++ b/packages/client/src/__tests__/grok-handler-engine.test.ts
@@ -33,6 +33,7 @@ const releaseFile = process.env.GROK_FAKE_RELEASE_FILE || "";
 const replyText = process.env.GROK_FAKE_TEXT || "Hello world";
 const toolName = process.env.GROK_FAKE_TOOL || "";
 const toolPath = process.env.GROK_FAKE_TOOL_PATH || "notes.md";
+const stopReason = process.env.GROK_FAKE_STOP_REASON || "end_turn";
 const mcpHttp = process.env.GROK_FAKE_MCP_HTTP !== "0";
 const mcpSse = process.env.GROK_FAKE_MCP_SSE !== "0";
 let buffer = "";
@@ -65,7 +66,7 @@ function emitPromptNotifications(sid) {
 function finishPrompt(req) {
   const sid = req.params.sessionId;
   emitPromptNotifications(sid);
-  respond(req.id, { stopReason: scenario === "cancelled" ? "cancelled" : "end_turn", _meta: { sessionId: sid, promptId: "prompt-1", totalTokens: 49, inputTokens: 42, outputTokens: 7, cachedReadTokens: 10, modelId: "grok-4" } });
+  respond(req.id, { stopReason: scenario === "cancelled" ? "cancelled" : stopReason, _meta: { sessionId: sid, promptId: "prompt-1", totalTokens: 49, inputTokens: 42, outputTokens: 7, cachedReadTokens: 10, modelId: "grok-4" } });
 }
 function handle(req) {
   logRequest(req);
@@ -99,11 +100,21 @@ function handle(req) {
   }
   if (req.method === "session/prompt") {
     if (scenario === "prompt_error_rate_limit") { respondError(req.id, "429 Too Many Requests: the provider is overloaded, retry later"); return; }
+    if (scenario === "text_prompt_error_rate_limit") { emitPromptNotifications(req.params.sessionId); respondError(req.id, "429 Too Many Requests: the provider is overloaded, retry later"); return; }
+    if (scenario === "tool_unknown_death") { emitToolUpdates(req.params.sessionId); process.stderr.write("weird unclassified crash\\n"); process.exit(1); }
     if (scenario === "stderr_death") { process.stderr.write("fatal: backend unreachable\\n"); process.exit(1); }
+    if (scenario === "unknown_death") { process.stderr.write("weird unclassified crash\\n"); process.exit(1); }
     if (scenario === "hold") {
       const timer = setInterval(() => {
         if (releaseFile && fs.existsSync(releaseFile)) { clearInterval(timer); finishPrompt(req); }
       }, 25);
+      return;
+    }
+    if (scenario === "hold_after_prompt") {
+      // Answer the prompt, then never exit (ignores stdin EOF) — the bounded
+      // close barrier must reclaim this process.
+      finishPrompt(req);
+      setInterval(() => {}, 1000);
       return;
     }
     finishPrompt(req);
@@ -128,6 +139,7 @@ process.stdin.on("data", (chunk) => {
   }
 });
 process.stdin.on("end", () => {
+  if (scenario === "hold_after_prompt") return; // deliberately ignores EOF
   process.exit(scenario === "nonzero_exit" ? 3 : 0);
 });
 `;
@@ -481,7 +493,36 @@ describe("grok handler — per-turn ACP transport", () => {
     expect(token.completed.length + token.retried.length).toBeGreaterThan(0);
   });
 
-  it("non-zero exit AFTER a completed prompt lets the completed turn stand", async () => {
+  it.each([
+    "end_turn",
+    "max_tokens",
+    "max_turn_requests",
+    "refusal",
+  ])("stopReason %s with a clean exit settles the turn with the accumulated output", async (stopReason) => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor(`stop-${stopReason}`, { GROK_FAKE_STOP_REASON: stopReason });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+    const forwarded: string[] = [];
+
+    await handler.start(
+      makeMessage("m1", "hi"),
+      makeContext({ events, forwardResult: async (text) => void forwarded.push(text) }),
+      token,
+    );
+
+    expect(specs).toHaveLength(1);
+    expect(token.completed).toMatchObject([{ status: "success", terminal: true }]);
+    expect(forwarded).toEqual(["Hello world"]);
+    const assistantTexts = events.filter((e) => e.kind === "assistant_text");
+    expect(assistantTexts).toHaveLength(1);
+    expect(assistantTexts[0]?.payload.text).toBe("Hello world");
+    expect(events.some((e) => e.kind === "token_usage")).toBe(true);
+    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "success" } });
+  });
+
+  it("non-zero exit AFTER a completed prompt is a failure input, never a silent success", async () => {
     const events: SessionEvent[] = [];
     const logs: string[] = [];
     const specs: ProviderProcessSpec[] = [];
@@ -491,9 +532,73 @@ describe("grok handler — per-turn ACP transport", () => {
 
     await handler.start(makeMessage("m1", "hi"), makeContext({ events, logs }), token);
 
-    expect(token.completed).toMatchObject([{ status: "success" }]);
-    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "success" } });
-    expect(logs.some((line) => line.includes("completed turn stands"))).toBe(true);
+    // The full drain must exit 0: exit 3 after end_turn routes through
+    // ProviderAttempt — assistant text was already visible, so an unknown
+    // failure is an unsafe replay and settles consumed-terminal (no ACK of
+    // a success, no auto-retry of a dirty turn).
+    expect(token.completed).toMatchObject([{ status: "error", completion: "consumed", reason: "unsafe_replay" }]);
+    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "error" } });
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents[0]).toMatchObject({ event: "provider_failure_terminal", reasonCode: "unsafe_replay" });
+    expect(logs.some((line) => line.includes("completed turn stands"))).toBe(false);
+    // Billed usage from the completed prompt is still accounted.
+    expect(events.some((e) => e.kind === "token_usage")).toBe(true);
+  });
+
+  it("a process that answers the prompt but never exits is reclaimed and settled as a failure", async () => {
+    const events: SessionEvent[] = [];
+    const logs: string[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const children: SpawnedChild[] = [];
+    const fakeEnv = fakeEnvFor("eofignore", { GROK_FAKE_SCENARIO: "hold_after_prompt" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv, children), { grokEofCloseWaitMs: 200 });
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events, logs }), token);
+
+    expect(logs.some((line) => line.includes("did not exit after stdin EOF"))).toBe(true);
+    const child = children[0];
+    if (!child) throw new Error("unreachable");
+    if (child.exitCode === null && child.signalCode === null) {
+      await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    }
+    expect(child.signalCode).toBe("SIGTERM");
+    expect(token.completed).toMatchObject([{ status: "error", completion: "consumed" }]);
+    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "error" } });
+  });
+
+  it("a write-tool side effect forbids auto-replay of a later attempt's unknown failure", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("unsafeacross");
+    // Attempt 1: assistant text (user-visible) + retryable capacity failure →
+    // the policy grants one retry. Attempt 2: runs the write tool
+    // (search_replace) then dies with an unknown error — the unsafe state must
+    // forbid any further auto-replay.
+    const handler = makeHandler(
+      createFakeAcpSupervisor(specs, [
+        { ...fakeEnv, GROK_FAKE_SCENARIO: "text_prompt_error_rate_limit" },
+        { ...fakeEnv, GROK_FAKE_SCENARIO: "tool_unknown_death", GROK_FAKE_TOOL: "search_replace" },
+      ]),
+    );
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    // Exactly 2 attempts: attempt 2's unknown failure must NOT auto-replay —
+    // the write tool's side effect (tracked per attempt and carried across
+    // attempts) forces the unsafe_replay terminal stop.
+    expect(specs).toHaveLength(2);
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents.map((e) => e.event)).toEqual(["provider_retry_scheduled", "provider_failure_terminal"]);
+    expect(providerEvents[1]).toMatchObject({ reasonCode: "unsafe_replay", replaySafety: "unsafe" });
+    expect(token.completed).toMatchObject([{ status: "error", completion: "consumed", reason: "unsafe_replay" }]);
   });
 
   it("a cancelled stopReason settles as an aborted turn (redelivery, never consumed)", async () => {

--- a/packages/client/src/__tests__/grok-handler-engine.test.ts
+++ b/packages/client/src/__tests__/grok-handler-engine.test.ts
@@ -36,6 +36,7 @@ const toolPath = process.env.GROK_FAKE_TOOL_PATH || "notes.md";
 const stopReason = process.env.GROK_FAKE_STOP_REASON || "end_turn";
 const rejectSetModel = process.env.GROK_FAKE_REJECT_SET_MODEL === "1";
 const setModelResponse = process.env.GROK_FAKE_SET_MODEL_RESPONSE || "ok";
+const echoMode = process.env.GROK_FAKE_ECHO_MODE || "after";
 const replayMarked = process.env.GROK_FAKE_REPLAY_MARKED === "1";
 const mcpHttp = process.env.GROK_FAKE_MCP_HTTP !== "0";
 const mcpSse = process.env.GROK_FAKE_MCP_SSE !== "0";
@@ -119,12 +120,65 @@ function handle(req) {
     if (rejectSetModel) { respondError(req.id, "Invalid params", "unknown model id", -32602); return; }
     if (setModelResponse === "missing_key") { respond(req.id, { _meta: {} }); return; }
     if (setModelResponse === "wrong_value") { respond(req.id, { _meta: { model: { Ok: "some-other-model" } } }); return; }
+    const requestedEffort = req.params._meta && typeof req.params._meta.reasoningEffort === "string" ? req.params._meta.reasoningEffort : null;
+    const echo = (modelId, effort, extra) => {
+      notify("_x.ai/session_notification", { sessionId: req.params.sessionId, ...(extra || {}), update: { sessionUpdate: "model_changed", model_id: modelId, ...(effort === null ? {} : { reasoning_effort: effort }) } });
+    };
+    const correctEcho = () => {
+      if (echoMode === "none") return;
+      if (echoMode === "omit_effort") { echo(req.params.modelId, null); return; }
+      if (echoMode === "wrong_effort") { echo(req.params.modelId, "ultra"); return; }
+      echo(req.params.modelId, requestedEffort === null ? "high" : requestedEffort);
+    };
+    if (echoMode === "missing_session") {
+      // Valid shape + effort, but NO sessionId — must never confirm.
+      notify("_x.ai/session_notification", { update: { sessionUpdate: "model_changed", model_id: req.params.modelId, reasoning_effort: requestedEffort || "high" } });
+      respond(req.id, { _meta: { model: { Ok: req.params.modelId } } });
+      return;
+    }
+    if (echoMode === "foreign_session") {
+      notify("_x.ai/session_notification", { sessionId: "other-session", update: { sessionUpdate: "model_changed", model_id: req.params.modelId, reasoning_effort: requestedEffort || "high" } });
+      respond(req.id, { _meta: { model: { Ok: req.params.modelId } } });
+      return;
+    }
+    if (echoMode === "wrong_channel") {
+      // Identically-shaped payload on the _x.ai/session/update extension
+      // channel (accepted by the passthrough, enters routing) — must never
+      // confirm. The standard session/update schema would reject it at the
+      // SDK parser, which does not count as this implementation's test.
+      notify("_x.ai/session/update", { sessionId: req.params.sessionId, update: { sessionUpdate: "model_changed", model_id: req.params.modelId, reasoning_effort: requestedEffort || "high" } });
+      respond(req.id, { _meta: { model: { Ok: req.params.modelId } } });
+      return;
+    }
+    if (echoMode === "before") correctEcho();
     respond(req.id, { _meta: { model: { Ok: req.params.modelId } } });
+    if (echoMode === "stale_first") {
+      echo(req.params.modelId, requestedEffort || "high", { _meta: { isReplay: true } });
+      notify("_x.ai/session_notification", { sessionId: "other-session", update: { sessionUpdate: "model_changed", model_id: req.params.modelId, reasoning_effort: requestedEffort || "high" } });
+      echo("stale-old-model", requestedEffort || "high");
+      correctEcho();
+      return;
+    }
+    if (echoMode !== "before") correctEcho();
     return;
   }
   if (req.method === "session/load") {
     if (scenario === "load_fail") { respondError(req.id, "session not found"); return; }
     respond(req.id, { models: { currentModelId: "grok-4", availableModels: [{ modelId: "grok-4", name: "Grok 4" }] } });
+    if (process.env.GROK_FAKE_LEGACY_ECHO === "1") {
+      // UNMARKED same-session legacy model_changed from the persisted history —
+      // receipt-time fencing must stop it satisfying THIS turn's confirmation.
+      notify("_x.ai/session_notification", { sessionId: sessionId, update: { sessionUpdate: "model_changed", model_id: "grok-4", reasoning_effort: process.env.GROK_FAKE_LEGACY_ECHO_EFFORT || "low" } });
+    }
+    if (process.env.GROK_FAKE_LEGACY_STREAM === "1") {
+      // Continuous unmarked same-value legacy traffic: keeps the replay drain
+      // from ever going quiet (cap counter-example) and keeps arriving after it.
+      const effort = process.env.GROK_FAKE_LEGACY_ECHO_EFFORT || "low";
+      const timer = setInterval(() => {
+        notify("_x.ai/session_notification", { sessionId: sessionId, update: { sessionUpdate: "model_changed", model_id: "grok-4", reasoning_effort: effort } });
+      }, 10);
+      setTimeout(() => clearInterval(timer), 600);
+    }
     // Historical replay from prior turns — arrives BEFORE the current prompt
     // and must be dropped by the replay fence.
     notify("_x.ai/session_notification", { sessionId: sessionId, update: { sessionUpdate: "turn_completed", prompt_id: "old-prompt", stop_reason: "end_turn", usage: { inputTokens: 999, outputTokens: 999, totalTokens: 1998, cachedReadTokens: 0 } } });
@@ -824,6 +878,281 @@ describe("grok handler — per-turn ACP transport", () => {
     ]);
     expect(requests[2]?.params).toEqual({ sessionId: "grok-sess-1", modelId: "grok-4" });
     expect(requests[2]?.params).not.toHaveProperty("_meta");
+  });
+
+  it("a legacy unmarked model_changed from session/load never satisfies this turn's confirmation (timeout → terminal configuration)", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("legacy-echo-only", {
+      GROK_FAKE_LEGACY_ECHO: "1",
+      GROK_FAKE_LEGACY_ECHO_EFFORT: "low",
+      GROK_FAKE_ECHO_MODE: "none",
+    });
+    const payload = grokPayload({ reasoningEffort: "low" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      grokSetModelEchoWaitMs: 100,
+    });
+    const token = makeToken();
+
+    await handler.resume(makeMessage("m2", "continue"), "grok-sess-1", makeContext({ events }), token);
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).not.toContain("session/prompt");
+    expect(specs).toHaveLength(1);
+    expect(token.completed).toMatchObject([
+      { status: "error", completion: "consumed", reason: "provider_configuration_error" },
+    ]);
+    // Timeout diagnostics must NOT claim the pre-arm legacy echo was
+    // observed: only post-arm candidates are reported.
+    const sdkError = events.find((e) => e.kind === "error" && e.payload.source === "sdk");
+    if (sdkError?.kind !== "error") throw new Error("expected an sdk error event");
+    expect(sdkError.payload.message).toContain("no current model_changed echo received");
+  });
+
+  it("a legacy echo followed by this turn's correct echo confirms and runs the prompt", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("legacy-echo-then-correct", {
+      GROK_FAKE_LEGACY_ECHO: "1",
+      GROK_FAKE_LEGACY_ECHO_EFFORT: "low",
+    });
+    const payload = grokPayload({ reasoningEffort: "low" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+    const token = makeToken();
+
+    await handler.resume(makeMessage("m2", "continue"), "grok-sess-1", makeContext({ events }), token);
+
+    expect(token.completed).toMatchObject([{ status: "success" }]);
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).toEqual([
+      "initialize",
+      "session/load",
+      "session/set_model",
+      "session/prompt",
+    ]);
+  });
+
+  it.each([
+    { label: "missing sessionId", echoMode: "missing_session" },
+    { label: "foreign sessionId", echoMode: "foreign_session" },
+    { label: "wrong channel (_x.ai/session/update)", echoMode: "wrong_channel" },
+  ])("a $label echo alone never confirms — terminal configuration, no prompt", async ({ echoMode }) => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor(`echo-invalid-${echoMode}`, { GROK_FAKE_ECHO_MODE: echoMode });
+    const payload = grokPayload({ reasoningEffort: "low" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      grokSetModelEchoWaitMs: 100,
+    });
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).not.toContain("session/prompt");
+    expect(specs).toHaveLength(1);
+    expect(token.completed).toMatchObject([
+      { status: "error", completion: "consumed", reason: "provider_configuration_error" },
+    ]);
+  });
+
+  it("a replay drain that hits its cap fails closed for an explicit effort — no set_model, no prompt", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("drain-cap", {
+      GROK_FAKE_LEGACY_STREAM: "1",
+      GROK_FAKE_LEGACY_ECHO_EFFORT: "low",
+    });
+    const payload = grokPayload({ reasoningEffort: "low" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      grokReplayDrainCapMs: 150,
+    });
+    const token = makeToken();
+
+    await handler.resume(makeMessage("m2", "continue"), "grok-sess-1", makeContext({ events }), token);
+
+    // The unquiet drain is a provider/configuration mismatch terminal —
+    // never armed, never sent.
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).not.toContain("session/set_model");
+    expect(requests.map((r) => r.method)).not.toContain("session/prompt");
+    expect(specs).toHaveLength(1);
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toMatchObject([
+      { status: "error", completion: "consumed", reason: "provider_configuration_error" },
+    ]);
+  });
+
+  it("abort during the effort-echo wait returns well before the wait bound with no config settlement", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("abort-echo-wait", { GROK_FAKE_ECHO_MODE: "none" });
+    const payload = grokPayload({ reasoningEffort: "low" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      grokSetModelEchoWaitMs: 5_000,
+    });
+    const token = makeToken();
+    const ctx = makeContext({ events });
+
+    const startedAt = Date.now();
+    const startPromise = handler.start(makeMessage("m1", "hi"), ctx, token);
+    // Wait for the set_model response to have succeeded (the echo wait is
+    // now blocking), then abort mid-wait.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setInterval(() => {
+        if (readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "").some((r) => r.method === "session/set_model")) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 10);
+      setTimeout(() => reject(new Error("set_model never sent")), 5_000);
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+    await handler.suspend();
+    await startPromise;
+
+    // Settled long before the 5s echo-wait bound.
+    expect(Date.now() - startedAt).toBeLessThan(3_000);
+    // No configuration terminal, no completion, no retry — an aborted turn.
+    expect(token.completed).toEqual([]);
+    expect(token.retried).toEqual([]);
+    expect(
+      events.some(
+        (e) =>
+          e.kind === "error" &&
+          (parseProviderRetryEventMessage(e.payload.message)?.category === "configuration" ||
+            e.payload.message.includes("was not confirmed")),
+      ),
+    ).toBe(false);
+  });
+
+  it("effort echo arriving BEFORE the set_model JSON-RPC response still satisfies the confirmation", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("echo-before", { GROK_FAKE_ECHO_MODE: "before" });
+    const payload = grokPayload({ reasoningEffort: "high" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).toEqual(["initialize", "session/new", "session/set_model", "session/prompt"]);
+    expect(token.completed).toMatchObject([{ status: "success" }]);
+  });
+
+  it("empty effort accepts the provider default (echo carries the default effort) without failure", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("echo-default-effort");
+    const payload = grokPayload({ model: "", reasoningEffort: "" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(token.completed).toMatchObject([{ status: "success" }]);
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).toContain("session/prompt");
+  });
+
+  it("stale/foreign/replay-marked echos do not satisfy the confirmation — only the correct echo does", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("echo-stale-first", { GROK_FAKE_ECHO_MODE: "stale_first" });
+    const payload = grokPayload({ reasoningEffort: "low" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+    const token = makeToken();
+
+    await handler.resume(makeMessage("m2", "continue"), "grok-sess-1", makeContext({ events }), token);
+
+    expect(token.completed).toMatchObject([{ status: "success" }]);
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).toEqual([
+      "initialize",
+      "session/load",
+      "session/set_model",
+      "session/prompt",
+    ]);
+  });
+
+  it.each([
+    {
+      label: "omits reasoning_effort",
+      echoMode: "omit_effort",
+      expectedDetail: "effort (none)",
+    },
+    {
+      label: "carries the wrong effort value",
+      echoMode: "wrong_effort",
+      expectedDetail: "ultra",
+    },
+    {
+      label: "never arrives (bounded timeout)",
+      echoMode: "none",
+      expectedDetail: "no current model_changed echo received",
+    },
+  ])("a set_model echo that $label — terminal notice trigger before turn_end/token.complete; no prompt, no retry, no success", async ({
+    echoMode,
+    expectedDetail,
+  }) => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor(`echo-fail-${echoMode}`, { GROK_FAKE_ECHO_MODE: echoMode });
+    const payload = grokPayload({ reasoningEffort: "low" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      grokSetModelEchoWaitMs: 100,
+    });
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).not.toContain("session/prompt");
+    expect(specs).toHaveLength(1);
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toMatchObject([
+      { status: "error", completion: "consumed", reason: "provider_configuration_error" },
+    ]);
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents[0]).toMatchObject({ event: "provider_failure_terminal", category: "configuration" });
+    // Notice-TRIGGER ordering at the handler boundary: the provider.retry
+    // notice-trigger SessionEvent (a live trace / notice trigger, NOT the
+    // durable chat notice) is emitted strictly BEFORE the turn_end that
+    // gates token.complete. The durable chat notice write itself lives in
+    // SessionManager/token.complete and is covered by the generic
+    // SessionManager failure-post tests — this test makes no claim about it.
+    const noticeIndex = events.findIndex(
+      (e) => e.kind === "error" && parseProviderRetryEventMessage(e.payload.message) !== null,
+    );
+    const turnEndIndex = events.findIndex((e) => e.kind === "turn_end");
+    expect(noticeIndex).toBeGreaterThanOrEqual(0);
+    expect(turnEndIndex).toBeGreaterThan(noticeIndex);
+    const sdkError = events.find((e) => e.kind === "error" && e.payload.source === "sdk");
+    if (sdkError?.kind !== "error") throw new Error("expected an sdk error event");
+    expect(sdkError.payload.message).toContain('"low"');
+    expect(sdkError.payload.message).toContain(expectedDetail);
+    expect(sdkError.payload.message).not.toContain("ignored the effort override");
+    // The config confirmation must never surface as a user-facing session event.
+    expect(events.some((e) => e.kind === "tool_call")).toBe(false);
   });
 
   it("a prompt response with a mismatched promptId fails closed", async () => {

--- a/packages/client/src/__tests__/grok-handler-engine.test.ts
+++ b/packages/client/src/__tests__/grok-handler-engine.test.ts
@@ -34,6 +34,9 @@ const replyText = process.env.GROK_FAKE_TEXT || "Hello world";
 const toolName = process.env.GROK_FAKE_TOOL || "";
 const toolPath = process.env.GROK_FAKE_TOOL_PATH || "notes.md";
 const stopReason = process.env.GROK_FAKE_STOP_REASON || "end_turn";
+const rejectSetModel = process.env.GROK_FAKE_REJECT_SET_MODEL === "1";
+const setModelResponse = process.env.GROK_FAKE_SET_MODEL_RESPONSE || "ok";
+const replayMarked = process.env.GROK_FAKE_REPLAY_MARKED === "1";
 const mcpHttp = process.env.GROK_FAKE_MCP_HTTP !== "0";
 const mcpSse = process.env.GROK_FAKE_MCP_SSE !== "0";
 let buffer = "";
@@ -41,7 +44,11 @@ let buffer = "";
 function send(msg) { process.stdout.write(JSON.stringify(msg) + "\\n"); }
 function notify(method, params) { send({ jsonrpc: "2.0", method: method, params: params }); }
 function respond(id, result) { send({ jsonrpc: "2.0", id: id, result: result }); }
-function respondError(id, message) { send({ jsonrpc: "2.0", id: id, error: { code: -32000, message: message } }); }
+function respondError(id, message, data, code) { send({ jsonrpc: "2.0", id: id, error: { code: code === undefined ? -32000 : code, message: message, ...(data === undefined ? {} : { data: data }) } }); }
+function clientPromptId(req) {
+  const meta = req.params && req.params._meta;
+  return meta && typeof meta.promptId === "string" ? meta.promptId : "prompt-1";
+}
 function logRequest(req) {
   if (!logFile) return;
   try { fs.appendFileSync(logFile, JSON.stringify({ method: req.method, params: req.params }) + "\\n"); } catch {}
@@ -54,19 +61,38 @@ function emitToolUpdates(sid) {
   notify("session/update", { sessionId: sid, update: { sessionUpdate: "tool_call", toolCallId: "tc-1", title: toolName, rawInput: rawInput, _meta: { "x.ai/tool": meta } } });
   notify("session/update", { sessionId: sid, update: { sessionUpdate: "tool_call_update", toolCallId: "tc-1", title: toolName, status: "completed", content: toolName === "search_replace" ? [{ type: "diff", path: toolPath, oldText: "a", newText: "b" }] : [], locations: [{ path: toolPath }], rawInput: rawInput, rawOutput: toolName + " done", _meta: { "x.ai/tool": meta } } });
 }
-function emitPromptNotifications(sid) {
+function emitPromptNotifications(sid, pid) {
   notify("session/update", { sessionId: sid, update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "thinking" } } });
   emitToolUpdates(sid);
   const half = Math.ceil(replyText.length / 2);
   notify("session/update", { sessionId: sid, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: replyText.slice(0, half) } } });
   notify("session/update", { sessionId: sid, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: replyText.slice(half) } } });
-  notify("_x.ai/session_notification", { sessionId: sid, update: { sessionUpdate: "turn_completed", prompt_id: "prompt-1", stop_reason: "end_turn", usage: { inputTokens: 42, outputTokens: 7, totalTokens: 49, cachedReadTokens: 10, cacheCreationTokens: 0, reasoningTokens: 0, modelCalls: 1, apiDurationMs: 1200, costUsdTicks: 55 } } });
+  notify("_x.ai/session_notification", { sessionId: sid, update: { sessionUpdate: "turn_completed", prompt_id: pid, stop_reason: "end_turn", usage: { inputTokens: 42, outputTokens: 7, totalTokens: 49, cachedReadTokens: 10, cacheCreationTokens: 0, reasoningTokens: 0, modelCalls: 1, apiDurationMs: 1200, costUsdTicks: 55 } } });
   notify("_x.ai/session_notification", { sessionId: sid, update: { sessionUpdate: "response_completed", usage: { input_tokens: 999, output_tokens: 999 } } });
 }
 function finishPrompt(req) {
   const sid = req.params.sessionId;
-  emitPromptNotifications(sid);
-  respond(req.id, { stopReason: scenario === "cancelled" ? "cancelled" : stopReason, _meta: { sessionId: sid, promptId: "prompt-1", totalTokens: 49, inputTokens: 42, outputTokens: 7, cachedReadTokens: 10, modelId: "grok-4" } });
+  const pid = clientPromptId(req);
+  emitPromptNotifications(sid, pid);
+  if (replayMarked) {
+    // Replay-marked traffic arriving INSIDE the prompt window (e.g. after the
+    // quiet-window cap) must still be dropped via _meta.isReplay.
+    notify("session/update", { sessionId: sid, _meta: { isReplay: true }, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "REPLAY MARKED TEXT" } } });
+    notify("_x.ai/session_notification", { sessionId: sid, _meta: { isReplay: true }, update: { sessionUpdate: "turn_completed", prompt_id: "old-prompt", stop_reason: "end_turn", usage: { inputTokens: 999, outputTokens: 999, totalTokens: 1998, cachedReadTokens: 0 } } });
+  }
+  respond(req.id, { stopReason: scenario === "cancelled" ? "cancelled" : stopReason, _meta: { sessionId: sid, promptId: pid, totalTokens: 49, inputTokens: 42, outputTokens: 7, cachedReadTokens: 10, modelId: "grok-4" } });
+}
+function finishPromptLateEvents(req) {
+  // Prompt response FIRST; the tool/usage notifications land next tick, and
+  // the process only exits on stdin EOF. The settle barrier must not lose
+  // them (exit code comes from the shared end handler below).
+  const sid = req.params.sessionId;
+  const pid = clientPromptId(req);
+  respond(req.id, { stopReason: "end_turn", _meta: { sessionId: sid, promptId: pid, totalTokens: 49, modelId: "grok-4" } });
+  setImmediate(() => {
+    emitToolUpdates(sid);
+    notify("_x.ai/session_notification", { sessionId: sid, update: { sessionUpdate: "turn_completed", prompt_id: pid, stop_reason: "end_turn", usage: { inputTokens: 42, outputTokens: 7, totalTokens: 49, cachedReadTokens: 10 } } });
+  });
 }
 function handle(req) {
   logRequest(req);
@@ -86,12 +112,19 @@ function handle(req) {
   }
   if (req.method === "session/new") {
     if (scenario === "prompt_error_auth") { respondError(req.id, "Error: not logged in. Run grok login to authenticate."); return; }
-    respond(req.id, { sessionId: sessionId });
+    respond(req.id, { sessionId: sessionId, models: { currentModelId: "grok-4", availableModels: [{ modelId: "grok-4", name: "Grok 4" }] } });
+    return;
+  }
+  if (req.method === "session/set_model") {
+    if (rejectSetModel) { respondError(req.id, "Invalid params", "unknown model id", -32602); return; }
+    if (setModelResponse === "missing_key") { respond(req.id, { _meta: {} }); return; }
+    if (setModelResponse === "wrong_value") { respond(req.id, { _meta: { model: { Ok: "some-other-model" } } }); return; }
+    respond(req.id, { _meta: { model: { Ok: req.params.modelId } } });
     return;
   }
   if (req.method === "session/load") {
     if (scenario === "load_fail") { respondError(req.id, "session not found"); return; }
-    respond(req.id, {});
+    respond(req.id, { models: { currentModelId: "grok-4", availableModels: [{ modelId: "grok-4", name: "Grok 4" }] } });
     // Historical replay from prior turns — arrives BEFORE the current prompt
     // and must be dropped by the replay fence.
     notify("_x.ai/session_notification", { sessionId: sessionId, update: { sessionUpdate: "turn_completed", prompt_id: "old-prompt", stop_reason: "end_turn", usage: { inputTokens: 999, outputTokens: 999, totalTokens: 1998, cachedReadTokens: 0 } } });
@@ -100,6 +133,7 @@ function handle(req) {
   }
   if (req.method === "session/prompt") {
     if (scenario === "prompt_error_rate_limit") { respondError(req.id, "429 Too Many Requests: the provider is overloaded, retry later"); return; }
+    if (scenario === "tool_prompt_error_rate_limit") { emitToolUpdates(req.params.sessionId); respondError(req.id, "429 Too Many Requests: the provider is overloaded, retry later"); return; }
     if (scenario === "text_prompt_error_rate_limit") { emitPromptNotifications(req.params.sessionId); respondError(req.id, "429 Too Many Requests: the provider is overloaded, retry later"); return; }
     if (scenario === "tool_unknown_death") { emitToolUpdates(req.params.sessionId); process.stderr.write("weird unclassified crash\\n"); process.exit(1); }
     if (scenario === "stderr_death") { process.stderr.write("fatal: backend unreachable\\n"); process.exit(1); }
@@ -115,6 +149,28 @@ function handle(req) {
       // close barrier must reclaim this process.
       finishPrompt(req);
       setInterval(() => {}, 1000);
+      return;
+    }
+    if (scenario === "prompt_id_mismatch") {
+      // Respond with a DIFFERENT promptId than the client supplied — the
+      // transport must fail closed.
+      respond(req.id, { stopReason: "end_turn", _meta: { sessionId: req.params.sessionId, promptId: "not-the-client-prompt-id", modelId: "grok-4" } });
+      return;
+    }
+    if (scenario === "prompt_id_missing") {
+      // Respond with NO promptId at all — equally fail closed.
+      respond(req.id, { stopReason: "end_turn", _meta: { sessionId: req.params.sessionId, modelId: "grok-4" } });
+      return;
+    }
+    if (scenario === "prompt_error_then_tool") {
+      // Retryable prompt error FIRST; the write-tool effect lands next tick
+      // and must still be observed before settlement (no truncation).
+      respondError(req.id, "429 Too Many Requests: the provider is overloaded, retry later");
+      setImmediate(() => emitToolUpdates(req.params.sessionId));
+      return;
+    }
+    if (scenario === "late_events_success" || scenario === "late_events_dirty_exit") {
+      finishPromptLateEvents(req);
       return;
     }
     finishPrompt(req);
@@ -140,7 +196,7 @@ process.stdin.on("data", (chunk) => {
 });
 process.stdin.on("end", () => {
   if (scenario === "hold_after_prompt") return; // deliberately ignores EOF
-  process.exit(scenario === "nonzero_exit" ? 3 : 0);
+  process.exit(scenario === "nonzero_exit" || scenario === "late_events_dirty_exit" ? 3 : 0);
 });
 `;
 
@@ -319,13 +375,21 @@ describe("grok handler — per-turn ACP transport", () => {
 
     const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
     const methods = requests.map((r) => r.method);
-    expect(methods).toEqual(["initialize", "session/new", "session/prompt"]);
+    expect(methods).toEqual(["initialize", "session/new", "session/set_model", "session/prompt"]);
     const init = requests[0];
     expect(init?.params).toMatchObject({ protocolVersion: 1, clientCapabilities: {} });
     const newSession = requests[1];
     expect(newSession?.params).toMatchObject({ cwd: workspaceRoot, _meta: { yoloMode: true } });
-    const prompt = requests[2];
+    // Empty config re-asserts the INITIALIZE-advertised current model and
+    // OMITS `_meta` entirely (a null effort meta is not the same as absent).
+    const setModel = requests[2];
+    expect(setModel?.params).toEqual({ sessionId: "grok-sess-1", modelId: "grok-4" });
+    expect(setModel?.params).not.toHaveProperty("_meta");
+    const prompt = requests[3];
     expect(prompt?.params).toMatchObject({ sessionId: "grok-sess-1" });
+    // The prompt carries a client-generated correlation promptId.
+    const promptMeta = prompt?.params._meta;
+    expect(typeof (promptMeta as Record<string, unknown> | undefined)?.promptId).toBe("string");
     const promptBlocks = prompt?.params.prompt;
     expect(Array.isArray(promptBlocks)).toBe(true);
     const promptText = Array.isArray(promptBlocks)
@@ -364,10 +428,14 @@ describe("grok handler — per-turn ACP transport", () => {
 
     const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
     const methods = requests.map((r) => r.method);
-    expect(methods).toEqual(["initialize", "session/load", "session/prompt"]);
+    expect(methods).toEqual(["initialize", "session/load", "session/set_model", "session/prompt"]);
     expect(methods).not.toContain("session/new");
     const load = requests[1];
-    expect(load?.params).toMatchObject({ sessionId: "grok-sess-1", cwd: workspaceRoot, _meta: { yoloMode: true } });
+    expect(load?.params).toMatchObject({
+      sessionId: "grok-sess-1",
+      cwd: workspaceRoot,
+      _meta: { yoloMode: true, noReplay: true },
+    });
 
     // The replayed OLD chunk and OLD turn_completed (999 tokens) never land.
     const assistantTexts = events.filter((e) => e.kind === "assistant_text");
@@ -570,14 +638,45 @@ describe("grok handler — per-turn ACP transport", () => {
     expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "error" } });
   });
 
-  it("a write-tool side effect forbids auto-replay of a later attempt's unknown failure", async () => {
+  it("attempt 1 write tool + retryable capacity failure: the side effect is remembered and nothing auto-replays", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("unsafe-attempt1");
+    // Attempt 1: write tool starts (replay-unsafe) then a known retryable
+    // capacity failure. The retry policy's unsafe guard
+    // (provider-retry-policy decideProviderRetry) stops BEFORE granting a
+    // retry — a side-effecting attempt is never replayed, so no second
+    // attempt ever runs. The scripted second spawn must stay unused.
+    const handler = makeHandler(
+      createFakeAcpSupervisor(specs, [
+        { ...fakeEnv, GROK_FAKE_SCENARIO: "tool_prompt_error_rate_limit", GROK_FAKE_TOOL: "search_replace" },
+        { ...fakeEnv, GROK_FAKE_SCENARIO: "unknown_death" },
+      ]),
+    );
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(specs).toHaveLength(1);
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents.map((e) => e.event)).toEqual(["provider_failure_terminal"]);
+    expect(providerEvents[0]).toMatchObject({ reasonCode: "unsafe_replay", replaySafety: "unsafe" });
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toMatchObject([{ status: "error", completion: "consumed", reason: "unsafe_replay" }]);
+  });
+
+  it("a write tool in a retried attempt forbids a further auto-replay of its unknown failure", async () => {
     const events: SessionEvent[] = [];
     const specs: ProviderProcessSpec[] = [];
     const fakeEnv = fakeEnvFor("unsafeacross");
     // Attempt 1: assistant text (user-visible) + retryable capacity failure →
     // the policy grants one retry. Attempt 2: runs the write tool
-    // (search_replace) then dies with an unknown error — the unsafe state must
-    // forbid any further auto-replay.
+    // (search_replace) then dies with an unknown error — the unsafe state
+    // (seeded per attempt and carried across attempts via anyToolEffect)
+    // must forbid any further auto-replay.
     const handler = makeHandler(
       createFakeAcpSupervisor(specs, [
         { ...fakeEnv, GROK_FAKE_SCENARIO: "text_prompt_error_rate_limit" },
@@ -588,9 +687,7 @@ describe("grok handler — per-turn ACP transport", () => {
 
     await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
 
-    // Exactly 2 attempts: attempt 2's unknown failure must NOT auto-replay —
-    // the write tool's side effect (tracked per attempt and carried across
-    // attempts) forces the unsafe_replay terminal stop.
+    // Exactly 2 attempts: attempt 2's unknown failure must NOT auto-replay.
     expect(specs).toHaveLength(2);
     const providerEvents = events
       .filter((e) => e.kind === "error")
@@ -601,7 +698,283 @@ describe("grok handler — per-turn ACP transport", () => {
     expect(token.completed).toMatchObject([{ status: "error", completion: "consumed", reason: "unsafe_replay" }]);
   });
 
-  it("a cancelled stopReason settles as an aborted turn (redelivery, never consumed)", async () => {
+  it("applies the configured model+effort via session/set_model after session/new, before prompt", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("setmodel-new");
+    const payload = grokPayload({ model: "grok-4-fast", reasoningEffort: "high" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), makeToken());
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).toEqual(["initialize", "session/new", "session/set_model", "session/prompt"]);
+    const setModel = requests[2];
+    expect(setModel?.params).toEqual({
+      sessionId: "grok-sess-1",
+      modelId: "grok-4-fast",
+      _meta: { reasoningEffort: "high" },
+    });
+  });
+
+  it("applies a changed model+effort via session/set_model after session/load on an existing session", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("setmodel-load");
+    const payload = grokPayload({ model: "grok-4-fast", reasoningEffort: "low" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+
+    await handler.resume(makeMessage("m2", "continue"), "grok-sess-1", makeContext({ events }), makeToken());
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).toEqual([
+      "initialize",
+      "session/load",
+      "session/set_model",
+      "session/prompt",
+    ]);
+    expect(requests[1]?.params).toMatchObject({ _meta: { yoloMode: true, noReplay: true } });
+    expect(requests[2]?.params).toEqual({
+      sessionId: "grok-sess-1",
+      modelId: "grok-4-fast",
+      _meta: { reasoningEffort: "low" },
+    });
+  });
+
+  it("effort-only config sends session/set_model with the session's reported current model", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("setmodel-effortonly");
+    const payload = grokPayload({ model: "", reasoningEffort: "low" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), makeToken());
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    const setModel = requests.find((r) => r.method === "session/set_model");
+    expect(setModel?.params).toEqual({
+      sessionId: "grok-sess-1",
+      modelId: "grok-4",
+      _meta: { reasoningEffort: "low" },
+    });
+  });
+
+  it("a session/set_model rejection classifies configuration, preserves the error data, and never reaches the prompt", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("setmodel-reject", { GROK_FAKE_REJECT_SET_MODEL: "1" });
+    const payload = grokPayload({ model: "not-a-real-model" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).not.toContain("session/prompt");
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents[0]).toMatchObject({
+      event: "provider_failure_terminal",
+      category: "configuration",
+      reasonCode: "provider_configuration_error",
+    });
+    // The ACP RequestError's `data` ("unknown model id" under -32602 Invalid
+    // params) is preserved on the user-facing classification surface.
+    const sdkError = events.find((e) => e.kind === "error" && e.payload.source === "sdk");
+    if (sdkError?.kind !== "error") throw new Error("expected an sdk error event");
+    expect(sdkError.payload.message).toContain("unknown model id");
+    // No silent fallback: exactly one attempt, no retry, no success ACK.
+    expect(specs).toHaveLength(1);
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toMatchObject([
+      { status: "error", completion: "consumed", reason: "provider_configuration_error" },
+    ]);
+  });
+
+  it("empty config on an existing session still sends set_model with the initialize default and no effort meta", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("setmodel-empty-override");
+    // Existing session previously ran model A / effort high; the operator
+    // cleared both (""/""). The resumed turn must re-assert the provider
+    // default via set_model — the persisted selection is never silently kept.
+    const payload = grokPayload({ model: "", reasoningEffort: "" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+
+    await handler.resume(makeMessage("m2", "continue"), "grok-sess-1", makeContext({ events }), makeToken());
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).toEqual([
+      "initialize",
+      "session/load",
+      "session/set_model",
+      "session/prompt",
+    ]);
+    expect(requests[2]?.params).toEqual({ sessionId: "grok-sess-1", modelId: "grok-4" });
+    expect(requests[2]?.params).not.toHaveProperty("_meta");
+  });
+
+  it("a prompt response with a mismatched promptId fails closed", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("promptid-mismatch", { GROK_FAKE_SCENARIO: "prompt_id_mismatch" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(token.completed).not.toMatchObject([{ status: "success" }]);
+    const sdkError = events.find((e) => e.kind === "error" && e.payload.source === "sdk");
+    if (sdkError?.kind !== "error") throw new Error("expected an sdk error event");
+    expect(sdkError.payload.message).toContain("promptId");
+  });
+
+  it("settle barrier: notifications arriving AFTER the prompt response are not lost (clean exit)", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("late-success", {
+      GROK_FAKE_SCENARIO: "late_events_success",
+      GROK_FAKE_TOOL: "read_file",
+    });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(token.completed).toMatchObject([{ status: "success" }]);
+    // The late tool + usage notifications landed before settlement was read.
+    expect(events.some((e) => e.kind === "tool_call" && e.payload.status === "ok")).toBe(true);
+    expect(events.some((e) => e.kind === "token_usage")).toBe(true);
+    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "success" } });
+  });
+
+  it("settle barrier: late write-tool notifications turn a dirty exit into an unsafe settlement (no retry)", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("late-dirty", {
+      GROK_FAKE_SCENARIO: "late_events_dirty_exit",
+      GROK_FAKE_TOOL: "search_replace",
+    });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    // The write tool's side effect was seen before settlement — the dirty
+    // exit after a completed prompt settles consumed-terminal unsafe_replay,
+    // never a retry and never a silent success.
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toMatchObject([{ status: "error", completion: "consumed", reason: "unsafe_replay" }]);
+    expect(events.some((e) => e.kind === "tool_call" && e.payload.name === "search_replace")).toBe(true);
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents[0]).toMatchObject({ reasonCode: "unsafe_replay", replaySafety: "unsafe" });
+  });
+
+  it.each([
+    { label: "missing _meta.model key", setModelResponse: "missing_key" },
+    { label: "wrong _meta.model.Ok value", setModelResponse: "wrong_value" },
+  ])("a set_model response with $label fails closed as configuration and never prompts", async ({
+    setModelResponse,
+  }) => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor(`setmodel-shape-${setModelResponse}`, {
+      GROK_FAKE_SET_MODEL_RESPONSE: setModelResponse,
+    });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).not.toContain("session/prompt");
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents[0]).toMatchObject({
+      event: "provider_failure_terminal",
+      category: "configuration",
+    });
+    expect(token.completed).toMatchObject([
+      { status: "error", completion: "consumed", reason: "provider_configuration_error" },
+    ]);
+  });
+
+  it("a prompt response with NO promptId fails closed", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("promptid-missing", { GROK_FAKE_SCENARIO: "prompt_id_missing" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(token.completed).not.toMatchObject([{ status: "success" }]);
+    const sdkError = events.find((e) => e.kind === "error" && e.payload.source === "sdk");
+    if (sdkError?.kind !== "error") throw new Error("expected an sdk error event");
+    expect(sdkError.payload.message).toContain("promptId");
+  });
+
+  it("a write-tool effect arriving the tick AFTER a retryable prompt error is observed and settles unsafe (no retry)", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("error-then-tool", {
+      GROK_FAKE_SCENARIO: "prompt_error_then_tool",
+      GROK_FAKE_TOOL: "search_replace",
+    });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    // The failure path must not truncate the late notification: the side
+    // effect is seen, so the retryable capacity error still settles unsafe
+    // with NO retry and no silent success.
+    expect(specs).toHaveLength(1);
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toMatchObject([{ status: "error", completion: "consumed", reason: "unsafe_replay" }]);
+    expect(events.some((e) => e.kind === "tool_call" && e.payload.name === "search_replace")).toBe(true);
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents.map((e) => e.event)).toEqual(["provider_failure_terminal"]);
+    expect(providerEvents[0]).toMatchObject({ reasonCode: "unsafe_replay", replaySafety: "unsafe" });
+  });
+
+  it("replay-marked notifications inside the prompt window are always dropped", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("replay-marked", { GROK_FAKE_REPLAY_MARKED: "1" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+
+    await handler.resume(makeMessage("m2", "continue"), "grok-sess-1", makeContext({ events }), makeToken());
+
+    const assistantTexts = events.filter((e) => e.kind === "assistant_text");
+    expect(assistantTexts).toHaveLength(1);
+    expect(assistantTexts[0]?.payload.text).toBe("Hello world");
+    expect(JSON.stringify(events)).not.toContain("REPLAY MARKED TEXT");
+    const usage = events.find((e) => e.kind === "token_usage");
+    expect(usage).toMatchObject({ kind: "token_usage", payload: { inputTokens: 42 } });
+  });
+
+  it("a cancelled stopReason routes through ProviderAttempt/replay-safety like any abnormal end", async () => {
     const events: SessionEvent[] = [];
     const specs: ProviderProcessSpec[] = [];
     const fakeEnv = fakeEnvFor("cancelled", { GROK_FAKE_SCENARIO: "cancelled" });
@@ -610,9 +983,33 @@ describe("grok handler — per-turn ACP transport", () => {
 
     await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
 
-    expect(token.completed).toEqual([]);
-    expect(token.retried).toEqual(["grok_turn_cancelled"]);
-    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "success" } });
+    // Assistant text was already user-visible, so the unknown classification
+    // of a provider-side cancel stops as unsafe_replay — consumed terminal,
+    // never an unconditional success/redelivery.
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toMatchObject([{ status: "error", completion: "consumed", reason: "unsafe_replay" }]);
+    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "error" } });
+  });
+
+  it("a cancelled stopReason after a write tool settles consumed terminal (unsafe)", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("cancelled-tool", {
+      GROK_FAKE_SCENARIO: "cancelled",
+      GROK_FAKE_TOOL: "search_replace",
+    });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toMatchObject([{ status: "error", completion: "consumed", reason: "unsafe_replay" }]);
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents[0]).toMatchObject({ event: "provider_failure_terminal", reasonCode: "unsafe_replay" });
   });
 
   it("passes the operator model + effort verbatim and delivers mapped MCP servers in session/new", async () => {
@@ -701,9 +1098,11 @@ describe("grok handler — per-turn ACP transport", () => {
     expect(requests.map((r) => r.method)).toEqual([
       "initialize",
       "session/new",
+      "session/set_model",
       "session/prompt",
       "initialize",
       "session/load",
+      "session/set_model",
       "session/prompt",
     ]);
   });
@@ -770,7 +1169,12 @@ describe("grok handler — per-turn ACP transport", () => {
     });
     expect(specs).toHaveLength(1);
     const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
-    expect(requests.map((r) => r.method)).toEqual(["initialize", "session/load", "session/prompt"]);
+    expect(requests.map((r) => r.method)).toEqual([
+      "initialize",
+      "session/load",
+      "session/set_model",
+      "session/prompt",
+    ]);
     expect(token.completed).toMatchObject([{ status: "success" }]);
   });
 
@@ -835,7 +1239,7 @@ describe("grok handler — per-turn ACP transport", () => {
     const specs: ProviderProcessSpec[] = [];
     const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnvFor("win32")), { grokPlatform: "win32" });
     await expect(handler.start(makeMessage("m1", "hi"), makeContext({ events: [] }), makeToken())).rejects.toThrow(
-      /does not support Windows/,
+      /not supported on Windows in V1/,
     );
     expect(specs).toHaveLength(0);
   });

--- a/packages/client/src/__tests__/grok-handler-engine.test.ts
+++ b/packages/client/src/__tests__/grok-handler-engine.test.ts
@@ -1,0 +1,754 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildGrokTurnArgs, createGrokHandler, GROK_PENDING_SESSION_PREFIX } from "../handlers/grok/index.js";
+import type { DeliveryToken, SessionContext, SessionMessage, TurnOutcome } from "../runtime/handler.js";
+import type { ProviderProcessSpec, ProviderProcessSupervisor } from "../runtime/provider-process-supervisor.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+/**
+ * Handler-integration coverage for the per-turn Grok ACP transport, on a fake
+ * provider seam — a real `node -e` child speaking NDJSON JSON-RPC (ACP v1)
+ * over piped stdio, spawned through the injected ProviderProcessSupervisor.
+ * Locks the canonical spawn contract (argv / cwd / prompt-on-stdin), the
+ * session/new → session/load lifecycle, the replay fence, usage mapping, and
+ * the settlement barrier.
+ */
+
+/**
+ * Fake Grok ACP agent. Answers initialize / session/new / session/load /
+ * session/prompt and streams canned session/update + _x.ai/* notifications.
+ * Behavior is driven by env vars (see GROK_FAKE_* below). Every request is
+ * appended as one JSON line to GROK_FAKE_REQUEST_LOG.
+ */
+const FAKE_ACP_AGENT_SCRIPT = `
+const fs = require("fs");
+const scenario = process.env.GROK_FAKE_SCENARIO || "success";
+const sessionId = process.env.GROK_FAKE_SESSION_ID || "grok-sess-1";
+const logFile = process.env.GROK_FAKE_REQUEST_LOG || "";
+const releaseFile = process.env.GROK_FAKE_RELEASE_FILE || "";
+const replyText = process.env.GROK_FAKE_TEXT || "Hello world";
+const toolName = process.env.GROK_FAKE_TOOL || "";
+const toolPath = process.env.GROK_FAKE_TOOL_PATH || "notes.md";
+const mcpHttp = process.env.GROK_FAKE_MCP_HTTP !== "0";
+const mcpSse = process.env.GROK_FAKE_MCP_SSE !== "0";
+let buffer = "";
+
+function send(msg) { process.stdout.write(JSON.stringify(msg) + "\\n"); }
+function notify(method, params) { send({ jsonrpc: "2.0", method: method, params: params }); }
+function respond(id, result) { send({ jsonrpc: "2.0", id: id, result: result }); }
+function respondError(id, message) { send({ jsonrpc: "2.0", id: id, error: { code: -32000, message: message } }); }
+function logRequest(req) {
+  if (!logFile) return;
+  try { fs.appendFileSync(logFile, JSON.stringify({ method: req.method, params: req.params }) + "\\n"); } catch {}
+}
+function emitToolUpdates(sid) {
+  if (!toolName) return;
+  const meta = { version: 1, name: toolName, kind: toolName === "read_file" ? "read" : toolName === "run_terminal_cmd" ? "execute" : "edit", namespace: "grok_build", label: toolName, read_only: toolName !== "search_replace" };
+  const rawInput = toolName === "run_terminal_cmd" ? { command: "cat " + toolPath } : { path: toolPath };
+  meta.input = rawInput;
+  notify("session/update", { sessionId: sid, update: { sessionUpdate: "tool_call", toolCallId: "tc-1", title: toolName, rawInput: rawInput, _meta: { "x.ai/tool": meta } } });
+  notify("session/update", { sessionId: sid, update: { sessionUpdate: "tool_call_update", toolCallId: "tc-1", title: toolName, status: "completed", content: toolName === "search_replace" ? [{ type: "diff", path: toolPath, oldText: "a", newText: "b" }] : [], locations: [{ path: toolPath }], rawInput: rawInput, rawOutput: toolName + " done", _meta: { "x.ai/tool": meta } } });
+}
+function emitPromptNotifications(sid) {
+  notify("session/update", { sessionId: sid, update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "thinking" } } });
+  emitToolUpdates(sid);
+  const half = Math.ceil(replyText.length / 2);
+  notify("session/update", { sessionId: sid, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: replyText.slice(0, half) } } });
+  notify("session/update", { sessionId: sid, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: replyText.slice(half) } } });
+  notify("_x.ai/session_notification", { sessionId: sid, update: { sessionUpdate: "turn_completed", prompt_id: "prompt-1", stop_reason: "end_turn", usage: { inputTokens: 42, outputTokens: 7, totalTokens: 49, cachedReadTokens: 10, cacheCreationTokens: 0, reasoningTokens: 0, modelCalls: 1, apiDurationMs: 1200, costUsdTicks: 55 } } });
+  notify("_x.ai/session_notification", { sessionId: sid, update: { sessionUpdate: "response_completed", usage: { input_tokens: 999, output_tokens: 999 } } });
+}
+function finishPrompt(req) {
+  const sid = req.params.sessionId;
+  emitPromptNotifications(sid);
+  respond(req.id, { stopReason: scenario === "cancelled" ? "cancelled" : "end_turn", _meta: { sessionId: sid, promptId: "prompt-1", totalTokens: 49, inputTokens: 42, outputTokens: 7, cachedReadTokens: 10, modelId: "grok-4" } });
+}
+function handle(req) {
+  logRequest(req);
+  if (req.id === undefined || req.id === null) return; // notification (e.g. session/cancel)
+  if (req.method === "initialize") {
+    respond(req.id, {
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: true, mcpCapabilities: { http: mcpHttp, sse: mcpSse } },
+      authMethods: [{ id: "cached_token", name: "Cached token" }, { id: "grok.com", name: "grok.com" }],
+      _meta: {
+        defaultAuthMethodId: "cached_token",
+        agentVersion: "0.2.117",
+        modelState: { currentModelId: "grok-4", availableModels: [{ modelId: "grok-4", name: "Grok 4", description: "", _meta: { supportsReasoningEffort: true, reasoningEffort: "medium", reasoningEfforts: ["low", "medium", "high"] } }] },
+      },
+    });
+    return;
+  }
+  if (req.method === "session/new") {
+    if (scenario === "prompt_error_auth") { respondError(req.id, "Error: not logged in. Run grok login to authenticate."); return; }
+    respond(req.id, { sessionId: sessionId });
+    return;
+  }
+  if (req.method === "session/load") {
+    if (scenario === "load_fail") { respondError(req.id, "session not found"); return; }
+    respond(req.id, {});
+    // Historical replay from prior turns — arrives BEFORE the current prompt
+    // and must be dropped by the replay fence.
+    notify("_x.ai/session_notification", { sessionId: sessionId, update: { sessionUpdate: "turn_completed", prompt_id: "old-prompt", stop_reason: "end_turn", usage: { inputTokens: 999, outputTokens: 999, totalTokens: 1998, cachedReadTokens: 0 } } });
+    notify("session/update", { sessionId: sessionId, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "OLD REPLAYED TEXT" } } });
+    return;
+  }
+  if (req.method === "session/prompt") {
+    if (scenario === "prompt_error_rate_limit") { respondError(req.id, "429 Too Many Requests: the provider is overloaded, retry later"); return; }
+    if (scenario === "stderr_death") { process.stderr.write("fatal: backend unreachable\\n"); process.exit(1); }
+    if (scenario === "hold") {
+      const timer = setInterval(() => {
+        if (releaseFile && fs.existsSync(releaseFile)) { clearInterval(timer); finishPrompt(req); }
+      }, 25);
+      return;
+    }
+    finishPrompt(req);
+    return;
+  }
+  respondError(req.id, "unknown method " + req.method);
+}
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let idx = buffer.indexOf("\\n");
+  while (idx >= 0) {
+    const line = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 1);
+    if (line.trim()) {
+      let req = null;
+      try { req = JSON.parse(line); } catch {}
+      if (req && req.method) handle(req);
+    }
+    idx = buffer.indexOf("\\n");
+  }
+});
+process.stdin.on("end", () => {
+  process.exit(scenario === "nonzero_exit" ? 3 : 0);
+});
+`;
+
+type SpawnedChild = ReturnType<typeof spawn>;
+
+function createFakeAcpSupervisor(
+  specs: ProviderProcessSpec[],
+  fakeEnv: Record<string, string> | Record<string, string>[],
+  children: SpawnedChild[] = [],
+): ProviderProcessSupervisor {
+  return {
+    spawn(spec) {
+      specs.push(spec);
+      const env = Array.isArray(fakeEnv) ? (fakeEnv[specs.length - 1] ?? fakeEnv.at(-1) ?? {}) : fakeEnv;
+      const child = spawn(process.execPath, ["-e", FAKE_ACP_AGENT_SCRIPT], {
+        ...spec.options,
+        env: { ...spec.options.env, ...env },
+      });
+      children.push(child);
+      return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+    },
+  };
+}
+
+type LoggedRequest = { method: string; params: Record<string, unknown> };
+
+function readRequestLog(logFile: string): LoggedRequest[] {
+  if (!existsSync(logFile)) return [];
+  return readFileSync(logFile, "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as LoggedRequest);
+}
+
+function makeToken(): DeliveryToken & { completed: TurnOutcome[]; retried: string[] } {
+  const completed: TurnOutcome[] = [];
+  const retried: string[] = [];
+  return {
+    completed,
+    retried,
+    processingStarted: () => {},
+    complete: async (_messages, outcome) => {
+      completed.push(outcome);
+    },
+    retry: (_messages, reason) => {
+      retried.push(reason);
+    },
+    terminalRejected: async () => {},
+  };
+}
+
+function makeMessage(id: string, content: string): SessionMessage {
+  return { id, chatId: "chat-grok", senderId: "human-1", format: "text", content, metadata: {} };
+}
+
+let workspaceRoot: string;
+
+function makeContext(opts: {
+  events: SessionEvent[];
+  logs?: string[];
+  forwardResult?: (text: string) => Promise<void>;
+  replaceSessionId?: (sessionId: string, reason: string) => void;
+}): SessionContext {
+  const sendMessage = async () => ({});
+  const plumbing = mockCtxPlumbing({ sendMessage }, "chat-grok");
+  return {
+    agent: {
+      agentId: "agent-grok-1",
+      inboxId: "inbox_agent-grok-1",
+      displayName: "grok-assistant",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    // fetchChatContext failures are logged and tolerated — a throwing fake sdk
+    // exercises that path without network.
+    sdk: { sendMessage } as unknown as SessionContext["sdk"],
+    chatId: "chat-grok",
+    log: (msg) => {
+      opts.logs?.push(msg);
+    },
+    recordProviderActivity: () => {},
+    emitEvent: (event) => {
+      opts.events.push(event);
+    },
+    ...plumbing,
+    ...(opts.forwardResult ? { forwardResult: opts.forwardResult } : {}),
+    ...(opts.replaceSessionId ? { replaceSessionId: opts.replaceSessionId } : {}),
+  };
+}
+
+function grokPayload(over: Record<string, unknown> = {}) {
+  return {
+    kind: "grok" as const,
+    prompt: { append: "" },
+    model: "",
+    mcpServers: [],
+    env: [],
+    gitRepos: [],
+    resourceSkills: [],
+    reasoningEffort: "" as const,
+    ...over,
+  };
+}
+
+function makeHandler(supervisor: ProviderProcessSupervisor, extraConfig: Record<string, unknown> = {}) {
+  return createGrokHandler({
+    workspaceRoot,
+    runtimeProvider: "grok",
+    providerProcessSupervisor: supervisor,
+    grokBinaryResolver: () => ({ ok: true, binary: "/fake/bin/grok", version: "0.2.117" }),
+    grokRetrySleep: async () => {},
+    ...extraConfig,
+  });
+}
+
+function fakeEnvFor(testName: string, over: Record<string, string> = {}): Record<string, string> {
+  return { GROK_FAKE_REQUEST_LOG: join(workspaceRoot, `requests-${testName}.jsonl`), ...over };
+}
+
+beforeEach(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "grok-handler-test-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("buildGrokTurnArgs — canonical spawn contract", () => {
+  it("omits --model/--effort when unconfigured and appends them verbatim when set", () => {
+    expect(buildGrokTurnArgs({ model: "", reasoningEffort: "" })).toEqual([
+      "--no-auto-update",
+      "agent",
+      "--no-leader",
+      "--always-approve",
+      "stdio",
+    ]);
+    expect(buildGrokTurnArgs({ model: "grok-4-fast", reasoningEffort: "high" })).toEqual([
+      "--no-auto-update",
+      "agent",
+      "--no-leader",
+      "--always-approve",
+      "--model",
+      "grok-4-fast",
+      "--effort",
+      "high",
+      "stdio",
+    ]);
+  });
+});
+
+describe("grok handler — per-turn ACP transport", () => {
+  it("start: canonical argv, session/new id capture, single assistant_text, usage, turn_end", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("start");
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+    const forwarded: string[] = [];
+
+    const result = await handler.start(
+      makeMessage("m1", "do the thing"),
+      makeContext({ events, forwardResult: async (text) => void forwarded.push(text) }),
+      token,
+    );
+
+    expect(specs).toHaveLength(1);
+    const spec = specs[0];
+    if (!spec) throw new Error("unreachable");
+    expect(spec.command).toBe("/fake/bin/grok");
+    expect(spec.args).toEqual(["--no-auto-update", "agent", "--no-leader", "--always-approve", "stdio"]);
+    expect(spec.options).toMatchObject({ cwd: workspaceRoot, shell: false });
+    // The prompt never rides argv.
+    expect(spec.args.join(" ")).not.toContain("do the thing");
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    const methods = requests.map((r) => r.method);
+    expect(methods).toEqual(["initialize", "session/new", "session/prompt"]);
+    const init = requests[0];
+    expect(init?.params).toMatchObject({ protocolVersion: 1, clientCapabilities: {} });
+    const newSession = requests[1];
+    expect(newSession?.params).toMatchObject({ cwd: workspaceRoot, _meta: { yoloMode: true } });
+    const prompt = requests[2];
+    expect(prompt?.params).toMatchObject({ sessionId: "grok-sess-1" });
+    const promptBlocks = prompt?.params.prompt;
+    expect(Array.isArray(promptBlocks)).toBe(true);
+    const promptText = Array.isArray(promptBlocks)
+      ? (promptBlocks as Array<{ text?: string }>).map((b) => b.text ?? "").join("")
+      : "";
+    expect(promptText).toContain("do the thing");
+    // Provider-neutral runtime output contract precedes the inbound message.
+    expect(promptText.indexOf("do the thing")).toBeGreaterThan(0);
+
+    expect(result).toMatchObject({ sessionId: "grok-sess-1", route: { kind: "owned", mode: "processing" } });
+    expect(token.completed).toMatchObject([{ status: "success", terminal: true }]);
+    expect(forwarded).toEqual(["Hello world"]);
+
+    // Chunks concatenate into ONE assistant_text (no per-chunk emission).
+    const assistantTexts = events.filter((e) => e.kind === "assistant_text");
+    expect(assistantTexts).toHaveLength(1);
+    expect(assistantTexts[0]?.payload.text).toBe("Hello world");
+    expect(events.some((e) => e.kind === "thinking")).toBe(true);
+    const usage = events.find((e) => e.kind === "token_usage");
+    expect(usage).toMatchObject({
+      kind: "token_usage",
+      payload: { provider: "grok", model: "grok-4", inputTokens: 42, cachedInputTokens: 10, outputTokens: 7 },
+    });
+    // response_completed (per-model-call) must not double the usage events.
+    expect(events.filter((e) => e.kind === "token_usage")).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "success" } });
+  });
+
+  it("resume with a confirmed id runs session/load and the replay fence drops historical updates", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("resume");
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+
+    await handler.resume(makeMessage("m2", "continue"), "grok-sess-1", makeContext({ events }), makeToken());
+
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    const methods = requests.map((r) => r.method);
+    expect(methods).toEqual(["initialize", "session/load", "session/prompt"]);
+    expect(methods).not.toContain("session/new");
+    const load = requests[1];
+    expect(load?.params).toMatchObject({ sessionId: "grok-sess-1", cwd: workspaceRoot, _meta: { yoloMode: true } });
+
+    // The replayed OLD chunk and OLD turn_completed (999 tokens) never land.
+    const assistantTexts = events.filter((e) => e.kind === "assistant_text");
+    expect(assistantTexts).toHaveLength(1);
+    expect(assistantTexts[0]?.payload.text).toBe("Hello world");
+    expect(JSON.stringify(events)).not.toContain("OLD REPLAYED TEXT");
+    const usage = events.find((e) => e.kind === "token_usage");
+    expect(usage).toMatchObject({ kind: "token_usage", payload: { inputTokens: 42 } });
+  });
+
+  it("session/load failure never falls back to session/new and settles through bounded retry", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("loadfail", { GROK_FAKE_SCENARIO: "load_fail" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.resume(makeMessage("m2", "continue"), "grok-sess-1", makeContext({ events }), token);
+
+    // 1 initial + 2 retries, every attempt is session/load — never session/new.
+    expect(specs).toHaveLength(3);
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).not.toContain("session/new");
+    expect(requests.filter((r) => r.method === "session/load")).toHaveLength(3);
+
+    // The load failure settles consumed-terminal through ProviderAttempt after
+    // the bounded retries exhaust (initialize completed, so the replay ladder
+    // is past pre_provider and the delivery is NOT redelivered).
+    expect(token.retried).toEqual([]);
+    expect(token.completed).toMatchObject([
+      { status: "error", completion: "consumed", reason: "provider_retry_exhausted" },
+    ]);
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents.map((e) => e.event)).toEqual([
+      "provider_retry_scheduled",
+      "provider_retry_scheduled",
+      "provider_retry_exhausted",
+    ]);
+  });
+
+  it("first-turn auth failure settles consumed-terminal, returns a synthetic id, and upgrades on the next turn", async () => {
+    const events: SessionEvent[] = [];
+    const replaceCalls: Array<{ id: string; reason: string }> = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("auth");
+    // First spawn fails session/new with an auth error (no provider id ever
+    // exists); the second spawn (the recovery turn) succeeds.
+    const handler = makeHandler(
+      createFakeAcpSupervisor(specs, [
+        { ...fakeEnv, GROK_FAKE_SCENARIO: "prompt_error_auth" },
+        { ...fakeEnv, GROK_FAKE_SCENARIO: "success" },
+      ]),
+    );
+    const token = makeToken();
+    const ctx = makeContext({ events, replaceSessionId: (id, reason) => void replaceCalls.push({ id, reason }) });
+
+    const started = await handler.start(makeMessage("m1", "hi"), ctx, token);
+    if (typeof started === "string") throw new Error("expected a start receipt");
+    expect(token.completed).toMatchObject([{ status: "error", completion: "consumed" }]);
+    expect(started.sessionId.startsWith(GROK_PENDING_SESSION_PREFIX)).toBe(true);
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents[0]).toMatchObject({ event: "provider_failure_terminal", category: "credential" });
+    // The user-facing error is reframed with the grok login hint.
+    expect(
+      events.some((e) => e.kind === "error" && e.payload.source === "sdk" && /grok login/.test(e.payload.message)),
+    ).toBe(true);
+
+    // Resuming with the synthetic id must NOT session/load it; the fresh
+    // session/new id upgrades the mapping via replaceSessionId.
+    const token2 = makeToken();
+    await handler.resume(makeMessage("m2", "again"), started.sessionId, ctx, token2);
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    const loadParams = requests.filter((r) => r.method === "session/load").map((r) => r.params.sessionId);
+    expect(loadParams).not.toContain(started.sessionId);
+    expect(replaceCalls).toMatchObject([{ id: "grok-sess-1", reason: "grok_session_id_confirmed" }]);
+    expect(token2.completed).toMatchObject([{ status: "success" }]);
+  });
+
+  it("429-style prompt failure classifies capacity, retries with visible bounds, then exhausts", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("ratelimit", { GROK_FAKE_SCENARIO: "prompt_error_rate_limit" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(specs).toHaveLength(3);
+    const providerEvents = events
+      .filter((e) => e.kind === "error")
+      .map((e) => parseProviderRetryEventMessage(e.payload.message))
+      .filter((e) => e !== null);
+    expect(providerEvents.map((e) => e.event)).toEqual([
+      "provider_retry_scheduled",
+      "provider_retry_scheduled",
+      "provider_retry_exhausted",
+    ]);
+    expect(providerEvents.every((e) => e.category === "provider_capacity")).toBe(true);
+    expect(token.completed).toMatchObject([
+      { status: "error", completion: "consumed", reason: "provider_retry_exhausted" },
+    ]);
+  });
+
+  it("non-zero exit without a completed prompt classifies from the stderr tail", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("stderrdeath", { GROK_FAKE_SCENARIO: "stderr_death" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(specs.length).toBeGreaterThan(0);
+    const sdkError = events.find((e) => e.kind === "error" && e.payload.source === "sdk");
+    if (sdkError?.kind !== "error") throw new Error("expected an sdk error event");
+    expect(sdkError.payload.message).toContain("backend unreachable");
+    expect(token.completed.length + token.retried.length).toBeGreaterThan(0);
+  });
+
+  it("non-zero exit AFTER a completed prompt lets the completed turn stand", async () => {
+    const events: SessionEvent[] = [];
+    const logs: string[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("nonzero", { GROK_FAKE_SCENARIO: "nonzero_exit" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events, logs }), token);
+
+    expect(token.completed).toMatchObject([{ status: "success" }]);
+    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "success" } });
+    expect(logs.some((line) => line.includes("completed turn stands"))).toBe(true);
+  });
+
+  it("a cancelled stopReason settles as an aborted turn (redelivery, never consumed)", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("cancelled", { GROK_FAKE_SCENARIO: "cancelled" });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token = makeToken();
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events }), token);
+
+    expect(token.completed).toEqual([]);
+    expect(token.retried).toEqual(["grok_turn_cancelled"]);
+    expect(events.at(-1)).toMatchObject({ kind: "turn_end", payload: { status: "success" } });
+  });
+
+  it("passes the operator model + effort verbatim and delivers mapped MCP servers in session/new", async () => {
+    const events: SessionEvent[] = [];
+    const logs: string[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("mcp", { GROK_FAKE_MCP_SSE: "0" });
+    const payload = grokPayload({
+      model: "grok-4-fast",
+      reasoningEffort: "high",
+      mcpServers: [
+        { name: "docs", transport: "stdio", command: "docs-server", args: ["--stdio"] },
+        { name: "remote", transport: "http", url: "https://mcp.example.test/rpc", headers: { "X-Test": "1" } },
+        { name: "events", transport: "sse", url: "https://mcp.example.test/events" },
+      ],
+    });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+    });
+
+    await handler.start(makeMessage("m1", "hi"), makeContext({ events, logs }), makeToken());
+
+    const spec = specs[0];
+    expect(spec?.args).toEqual([
+      "--no-auto-update",
+      "agent",
+      "--no-leader",
+      "--always-approve",
+      "--model",
+      "grok-4-fast",
+      "--effort",
+      "high",
+      "stdio",
+    ]);
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    const newSession = requests.find((r) => r.method === "session/new");
+    // The sse server is dropped (agent advertised mcpCapabilities.sse=false);
+    // stdio and http map to the ACP schema.
+    expect(newSession?.params.mcpServers).toEqual([
+      { name: "docs", command: "docs-server", args: ["--stdio"], env: [] },
+      { name: "remote", type: "http", url: "https://mcp.example.test/rpc", headers: [{ name: "X-Test", value: "1" }] },
+    ]);
+    expect(logs.some((line) => line.includes('dropping MCP server "events"'))).toBe(true);
+  });
+
+  it("inject while a turn is active queues and drains as an ordered session/load batch afterwards", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const releaseFile = join(workspaceRoot, "release-first");
+    const fakeEnv = fakeEnvFor("queued", { GROK_FAKE_SCENARIO: "hold", GROK_FAKE_RELEASE_FILE: releaseFile });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+    const token1 = makeToken();
+    const ctx = makeContext({ events });
+
+    const startPromise = handler.start(makeMessage("m1", "long turn"), ctx, token1);
+    // Wait for the first prompt to be in flight, then inject mid-turn.
+    await new Promise<void>((resolve) => {
+      const timer = setInterval(() => {
+        if (readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "").some((r) => r.method === "session/prompt")) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 10);
+    });
+    const token2 = makeToken();
+    const receipt = handler.inject(makeMessage("m2", "queued message"), token2);
+    expect(receipt).toMatchObject({ kind: "owned", mode: "queued" });
+
+    writeFileSync(releaseFile, "go");
+    await startPromise;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setInterval(() => {
+        if (token2.completed.length > 0) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 10);
+      setTimeout(() => reject(new Error("queued turn never settled")), 5000);
+    });
+
+    expect(specs).toHaveLength(2);
+    expect(token1.completed).toMatchObject([{ status: "success" }]);
+    expect(token2.completed).toMatchObject([{ status: "success" }]);
+    // The queued turn resumed the now-confirmed session id via session/load.
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).toEqual([
+      "initialize",
+      "session/new",
+      "session/prompt",
+      "initialize",
+      "session/load",
+      "session/prompt",
+    ]);
+  });
+
+  it("suspend mid-turn aborts the child, retries the queued batch, and never completes the in-flight token", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const children: SpawnedChild[] = [];
+    const fakeEnv = fakeEnvFor("suspend", {
+      GROK_FAKE_SCENARIO: "hold",
+      GROK_FAKE_RELEASE_FILE: join(workspaceRoot, "never-released"),
+    });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv, children));
+    const token1 = makeToken();
+    const ctx = makeContext({ events });
+
+    const startPromise = handler.start(makeMessage("m1", "long turn"), ctx, token1);
+    await new Promise<void>((resolve) => {
+      const timer = setInterval(() => {
+        if (readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "").some((r) => r.method === "session/prompt")) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 10);
+    });
+    const token2 = makeToken();
+    handler.inject(makeMessage("m2", "queued message"), token2);
+
+    await handler.suspend();
+    await startPromise;
+
+    expect(token1.completed).toEqual([]);
+    expect(token2.retried).toEqual(["grok_suspend_before_terminal"]);
+    // The abort path SIGTERMs the process group; the held child must be dead.
+    const child = children[0];
+    if (!child) throw new Error("unreachable");
+    if (child.exitCode === null && child.signalCode === null) {
+      await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    }
+    expect(child.signalCode).toBe("SIGTERM");
+  });
+
+  it("admin resume (no message) clears the bring-up guard so later injects still drain", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const fakeEnv = fakeEnvFor("adminresume");
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv));
+
+    const receipt = await handler.resume(undefined, "grok-sess-1", makeContext({ events }), makeToken());
+    if (typeof receipt === "string") throw new Error("expected a resume receipt");
+    expect(receipt.route).toBeNull();
+
+    const token = makeToken();
+    const injectReceipt = handler.inject(makeMessage("m-post-admin", "hello"), token);
+    expect(injectReceipt).toMatchObject({ kind: "owned", mode: "queued" });
+    await new Promise<void>((resolve, reject) => {
+      const timer = setInterval(() => {
+        if (token.completed.length > 0) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 10);
+      setTimeout(() => reject(new Error("queued turn never settled")), 5000);
+    });
+    expect(specs).toHaveLength(1);
+    const requests = readRequestLog(fakeEnv.GROK_FAKE_REQUEST_LOG ?? "");
+    expect(requests.map((r) => r.method)).toEqual(["initialize", "session/load", "session/prompt"]);
+    expect(token.completed).toMatchObject([{ status: "success" }]);
+  });
+
+  it("tool completion emits tool_call events with repo-qualified Context Tree refs", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const contextTreePath = join(workspaceRoot, "context-tree");
+    const toolPath = join(contextTreePath, "system", "NODE.md");
+    const fakeEnv = fakeEnvFor("toolturn", { GROK_FAKE_TOOL: "search_replace", GROK_FAKE_TOOL_PATH: toolPath });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      contextTreePath,
+      contextTreeRepoUrl: "https://github.com/acme/tree.git",
+      contextTreeBranch: "main",
+    });
+
+    await handler.start(makeMessage("m1", "edit the node"), makeContext({ events }), makeToken());
+
+    const pending = events.find((e) => e.kind === "tool_call" && e.payload.status === "pending");
+    expect(pending).toMatchObject({
+      kind: "tool_call",
+      payload: { toolUseId: "tc-1", name: "search_replace", status: "pending" },
+    });
+    const completed = events.find((e) => e.kind === "tool_call" && e.payload.status === "ok");
+    if (completed?.kind !== "tool_call") throw new Error("expected an ok tool_call event");
+    expect(completed.payload.name).toBe("search_replace");
+    expect(completed.payload.resultPreview).toBe("search_replace done");
+    expect(completed.payload.toolFileRefs).toMatchObject([
+      {
+        origin: "file_change",
+        repoUrl: "https://github.com/acme/tree.git",
+        repoBranch: "main",
+        repoRelativePath: "system/NODE.md",
+      },
+    ]);
+  });
+
+  it("a proven read-only shell tool emits a tool_arg ref and keeps the turn replay-safe", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const contextTreePath = join(workspaceRoot, "context-tree");
+    const fakeEnv = fakeEnvFor("shellturn", {
+      GROK_FAKE_TOOL: "run_terminal_cmd",
+      GROK_FAKE_TOOL_PATH: join(contextTreePath, "NODE.md"),
+    });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      contextTreePath,
+      contextTreeRepoUrl: "https://github.com/acme/tree.git",
+      contextTreeBranch: "main",
+    });
+
+    await handler.start(makeMessage("m1", "read the node"), makeContext({ events }), makeToken());
+
+    const completed = events.find((e) => e.kind === "tool_call" && e.payload.status === "ok");
+    if (completed?.kind !== "tool_call") throw new Error("expected an ok tool_call event");
+    expect(completed.payload.name).toBe("run_terminal_cmd");
+    expect(completed.payload.toolFileRefs).toMatchObject([
+      { origin: "tool_arg", repoUrl: "https://github.com/acme/tree.git", repoRelativePath: "NODE.md" },
+    ]);
+  });
+
+  it("fails closed on win32 before any spawn", async () => {
+    const specs: ProviderProcessSpec[] = [];
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnvFor("win32")), { grokPlatform: "win32" });
+    await expect(handler.start(makeMessage("m1", "hi"), makeContext({ events: [] }), makeToken())).rejects.toThrow(
+      /does not support Windows/,
+    );
+    expect(specs).toHaveLength(0);
+  });
+
+  it("fails closed for landing campaign trial agents (app-server-only contract)", async () => {
+    const specs: ProviderProcessSpec[] = [];
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnvFor("trial")));
+    const ctx = makeContext({ events: [] });
+    ctx.agent.metadata = {
+      landingCampaignTrial: true,
+      campaign: "production-scan",
+      skillSetId: "production-scan",
+      skillSetVersion: "2026.07.02.1",
+      repo: { url: "https://github.com/acme/backend", canonicalKey: "github.com/acme/backend" },
+    };
+    await expect(handler.start(makeMessage("m1", "hi"), ctx, makeToken())).rejects.toThrow(
+      /landing campaign trial agents require the codex app-server/,
+    );
+    expect(specs).toHaveLength(0);
+  });
+});

--- a/packages/client/src/__tests__/grok-login.test.ts
+++ b/packages/client/src/__tests__/grok-login.test.ts
@@ -32,6 +32,16 @@ function fakeSpawn(child: FakeChild): {
 }
 
 describe("runGrokBrowserLogin", () => {
+  it("win32 → refuses without spawning", async () => {
+    const child = new FakeChild();
+    const { spawnFn, calls } = fakeSpawn(child);
+    const outcome = await runGrokBrowserLogin({ binary: "/x/grok", spawnFn, platform: "win32" });
+    expect(outcome).toMatchObject({ ok: false, reason: "spawn-error" });
+    if (outcome.ok) throw new Error("unreachable");
+    expect(outcome.error).toContain("not supported on Windows in V1");
+    expect(calls).toEqual([]);
+  });
+
   it("spawns `<binary> login` and resolves ok on exit 0 (Grok writes its own credential store)", async () => {
     const child = new FakeChild();
     const { spawnFn, calls } = fakeSpawn(child);

--- a/packages/client/src/__tests__/grok-login.test.ts
+++ b/packages/client/src/__tests__/grok-login.test.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { runGrokBrowserLogin } from "../runtime/grok-login.js";
+
+/** Minimal stand-in for a spawned child: stdout/stderr emitters + kill(). */
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  killed = false;
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+  emitStdout(text: string): void {
+    this.stdout.emit("data", Buffer.from(text, "utf-8"));
+  }
+  close(code: number): void {
+    this.emit("close", code);
+  }
+}
+
+function fakeSpawn(child: FakeChild): {
+  spawnFn: typeof import("node:child_process").spawn;
+  calls: Array<{ command: string; args: string[] }>;
+} {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const spawnFn = ((command: string, args: string[]) => {
+    calls.push({ command, args });
+    return child;
+  }) as unknown as typeof import("node:child_process").spawn;
+  return { spawnFn, calls };
+}
+
+describe("runGrokBrowserLogin", () => {
+  it("spawns `<binary> login` and resolves ok on exit 0 (Grok writes its own credential store)", async () => {
+    const child = new FakeChild();
+    const { spawnFn, calls } = fakeSpawn(child);
+    const urls: string[] = [];
+    const run = runGrokBrowserLogin({
+      binary: "/home/op/.grok/bin/grok",
+      onAuthUrl: (u) => urls.push(u),
+      spawnFn,
+    });
+
+    child.emitStdout("Opening browser…\nIf it didn't open, visit https://accounts.x.ai/oauth/authorize?x=1\n");
+    child.close(0);
+
+    await expect(run).resolves.toEqual({ ok: true });
+    expect(calls).toEqual([{ command: "/home/op/.grok/bin/grok", args: ["login"] }]);
+    expect(urls).toEqual(["https://accounts.x.ai/oauth/authorize?x=1"]);
+  });
+
+  it("never passes --device-auth (that flow stays operator-run)", async () => {
+    const child = new FakeChild();
+    const { spawnFn, calls } = fakeSpawn(child);
+    const run = runGrokBrowserLogin({ binary: "/x/grok", spawnFn });
+
+    child.close(0);
+
+    await expect(run).resolves.toEqual({ ok: true });
+    expect(calls).toEqual([{ command: "/x/grok", args: ["login"] }]);
+  });
+
+  it("reports exit-nonzero with the provider's own failure text", async () => {
+    const child = new FakeChild();
+    const { spawnFn } = fakeSpawn(child);
+    const run = runGrokBrowserLogin({ binary: "/x/grok", spawnFn });
+
+    child.stderr.emit("data", Buffer.from("login failed: network unreachable\n", "utf-8"));
+    child.close(1);
+
+    const outcome = await run;
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) throw new Error("unreachable");
+    expect(outcome.reason).toBe("exit-nonzero");
+    expect(outcome.error).toContain("network unreachable");
+  });
+});

--- a/packages/client/src/__tests__/managed-skills.test.ts
+++ b/packages/client/src/__tests__/managed-skills.test.ts
@@ -44,6 +44,7 @@ const PROVIDERS: readonly RuntimeProvider[] = [
   "claude-code-tui",
   "codex",
   "cursor",
+  "grok",
   "kimi-code",
   "opencode",
 ];
@@ -179,6 +180,7 @@ describe("managed Skill reconciler", () => {
       ["claude-code-tui", ".claude/skills"],
       ["codex", ".agents/skills"],
       ["cursor", ".cursor/skills"],
+      ["grok", ".grok/skills"],
       ["kimi-code", ".kimi-code/skills"],
       ["opencode", ".opencode/skills"],
     ]);

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -193,6 +193,78 @@ describe("classifyProviderFailure", () => {
     ).toMatchObject({ action: "retry" });
   });
 
+  it("classifies Grok Build logged-out phrasings as credential, grok-gated", () => {
+    for (const message of [
+      "Error: not logged in. Run `grok login` to authenticate.",
+      "Failed to read credentials from ~/.grok/auth.json",
+    ]) {
+      const c = classifyProviderFailure(new Error(message), {
+        provider: "grok",
+        scope: "provider_turn",
+        source: "sdk",
+      });
+      expect(c, message).toMatchObject({ category: "credential" });
+      expect(
+        decideProviderRetry({ classification: c, scope: "provider_turn", attempt: 1, replaySafety: "pre_provider" }),
+      ).toMatchObject({ action: "stop", terminalKind: "needs_operator" });
+    }
+    // The same wording under ANOTHER provider must not trip the grok-only
+    // branch (the in-chat re-login CTA keys off category=credential).
+    const other = classifyProviderFailure(new Error("not logged in"), {
+      provider: "codex",
+      scope: "provider_turn",
+      source: "sdk",
+    });
+    expect(other.category).not.toBe("credential");
+  });
+
+  it("classifies Grok Build 429 / exhaustion phrasings as provider capacity, grok-gated", () => {
+    for (const message of [
+      "HTTP 429 Too Many Requests",
+      "Error: resource has been exhausted (rate limit budget spent)",
+    ]) {
+      const c = classifyProviderFailure(new Error(message), {
+        provider: "grok",
+        scope: "provider_turn",
+        source: "sdk",
+      });
+      expect(c, message).toMatchObject({ category: "provider_capacity", reasonCode: "provider_rate_limited" });
+    }
+    // "resource has been exhausted" is not reserved capacity-speak for other
+    // providers — the branch stays grok-only.
+    const other = classifyProviderFailure(new Error("resource has been exhausted"), {
+      provider: "codex",
+      scope: "provider_turn",
+      source: "sdk",
+    });
+    expect(other.category).not.toBe("provider_capacity");
+  });
+
+  it("a transient grok --version verify flake is retried at session start, NOT a terminal capability failure", () => {
+    const err = new Error(
+      "grok --version smoke check did not complete (transient host condition); will retry. Detail: `grok --version` timed out",
+    );
+    err.name = "GrokBinaryVerifyTransientError";
+    const c = classifyProviderFailure(err, { provider: "grok", scope: "session_start", source: "session" });
+    expect(c.category).toBe("transient_transport");
+    expect(c.reasonCode).toBe("grok_verify_transient");
+    expect(
+      decideProviderRetry({ classification: c, scope: "session_start", attempt: 1, replaySafety: "pre_provider" }),
+    ).toMatchObject({ action: "retry" });
+  });
+
+  it("a genuinely missing grok binary stays terminal needs_operator (no false retry)", () => {
+    const err = new Error(
+      "Grok Build CLI is missing on this machine. First Tree does not bundle or install the Grok engine.",
+    );
+    const c = classifyProviderFailure(err, { provider: "grok", scope: "session_start", source: "session" });
+    expect(c.category).toBe("capability");
+    expect(c.reasonCode).toBe("grok_binary_missing");
+    expect(
+      decideProviderRetry({ classification: c, scope: "session_start", attempt: 1, replaySafety: "pre_provider" }),
+    ).toMatchObject({ action: "stop", terminalKind: "needs_operator" });
+  });
+
   it("a codex backend AbortSignal.timeout is transient_transport and retried", () => {
     const err = new DOMException("The operation was aborted due to timeout", "TimeoutError");
     const c = classifyProviderFailure(err, { provider: "codex", scope: "provider_turn", source: "sdk" });

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -406,6 +406,42 @@ describe("classifyProviderFailure", () => {
       }),
     ).toMatchObject({ category: "deterministic_input", reasonCode: "provider_deterministic_input" });
   });
+
+  it("grok win32 fail-closed classifies capability/grok_platform_unsupported with a deterministic stop", () => {
+    const c = classifyProviderFailure(
+      new Error("the grok provider is not supported on Windows in V1 (macOS/Linux only)"),
+      { provider: "grok", scope: "provider_turn" },
+    );
+    expect(c.category).not.toBe("unknown");
+    expect(c.reasonCode).not.toBe("grok_binary_missing");
+    expect(c).toMatchObject({ category: "capability", reasonCode: "grok_platform_unsupported" });
+    expect(
+      decideProviderRetry({ classification: c, scope: "provider_turn", attempt: 1, replaySafety: "pre_provider" }),
+    ).toMatchObject({ action: "stop" });
+  });
+
+  it("grok out-of-range binary classifies capability/grok_binary_unsupported (never unknown, never binary_missing)", () => {
+    const c = classifyProviderFailure(
+      new Error(
+        "Grok Build CLI at /home/op/.local/bin/grok is not a supported Grok Build version: `grok --version` " +
+          "reported 0.2.89 (supported range >=0.2.117 <0.3.0).",
+      ),
+      { provider: "grok", scope: "provider_turn" },
+    );
+    expect(c.category).not.toBe("unknown");
+    expect(c.reasonCode).not.toBe("grok_binary_missing");
+    expect(c).toMatchObject({ category: "capability", reasonCode: "grok_binary_unsupported" });
+    expect(
+      decideProviderRetry({ classification: c, scope: "provider_turn", attempt: 1, replaySafety: "pre_provider" }),
+    ).toMatchObject({ action: "stop" });
+    // The grok gates stay provider-scoped: the same text under another
+    // provider must not take the grok reason codes.
+    const other = classifyProviderFailure(new Error("not supported on Windows in V1"), {
+      provider: "cursor",
+      scope: "provider_turn",
+    });
+    expect(other.reasonCode).not.toBe("grok_platform_unsupported");
+  });
 });
 
 describe("decideProviderRetry", () => {

--- a/packages/client/src/handlers/auth-error-hint.ts
+++ b/packages/client/src/handlers/auth-error-hint.ts
@@ -13,7 +13,7 @@
  * CLI. The hint reframes the message so the next step is obvious.
  */
 
-type Runtime = "codex" | "claude-code" | "cursor" | "kimi-code" | "opencode";
+type Runtime = "codex" | "claude-code" | "cursor" | "grok" | "kimi-code" | "opencode";
 
 /**
  * Substring keywords used to detect codex's auth-refresh failures. Codex's
@@ -69,6 +69,29 @@ export function isCursorAuthError(message: string): boolean {
   return CURSOR_AUTH_KEYWORDS.some((kw) => lower.includes(kw));
 }
 
+/**
+ * Grok Build CLI auth-failure phrases. The CLI exposes no typed error code —
+ * a logged-out turn fails with prose along the lines of "Error: not logged
+ * in. Run `grok login` to authenticate." or an unauthorized response, and a
+ * corrupt credential store is reported by naming `auth.json`. First Tree
+ * never opens `~/.grok/auth.json`; detection is purely output substring
+ * matching, mirroring the cursor approach.
+ */
+const GROK_AUTH_KEYWORDS: readonly string[] = [
+  "not logged in",
+  "not authenticated",
+  "authentication required",
+  "unauthorized",
+  "grok login",
+  "auth.json",
+];
+
+export function isGrokAuthError(message: string): boolean {
+  if (message.length === 0) return false;
+  const lower = message.toLowerCase();
+  return GROK_AUTH_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
 export function isKimiCodeAuthError(codeOrMessage: string): boolean {
   const lower = codeOrMessage.toLowerCase();
   return (
@@ -122,21 +145,25 @@ export function formatAuthHint(runtime: Runtime, originalMessage: string): strin
       ? "`codex login`"
       : runtime === "cursor"
         ? "`cursor-agent login`"
-        : runtime === "opencode"
-          ? "`opencode auth login`"
-          : runtime === "kimi-code"
-            ? "`kimi` and then `/login`"
-            : "`claude auth login`";
+        : runtime === "grok"
+          ? "`grok login`"
+          : runtime === "opencode"
+            ? "`opencode auth login`"
+            : runtime === "kimi-code"
+              ? "`kimi` and then `/login`"
+              : "`claude auth login`";
   const provider =
     runtime === "codex"
       ? "OpenAI"
       : runtime === "cursor"
         ? "Cursor"
-        : runtime === "opencode"
-          ? "OpenCode's selected provider"
-          : runtime === "kimi-code"
-            ? "Kimi"
-            : "Anthropic";
+        : runtime === "grok"
+          ? "Grok Build"
+          : runtime === "opencode"
+            ? "OpenCode's selected provider"
+            : runtime === "kimi-code"
+              ? "Kimi"
+              : "Anthropic";
   // Cap the appended raw message so an upstream stack-trace envelope (codex
   // wraps its `event.error.message` in surprising ways) doesn't bloat the
   // hint into a wall of text on the chat timeline.

--- a/packages/client/src/handlers/grok/acp-session.ts
+++ b/packages/client/src/handlers/grok/acp-session.ts
@@ -1,0 +1,554 @@
+/**
+ * Thin ACP (Agent Client Protocol v1) transport for the Grok Build CLI.
+ *
+ * One short-lived `grok ... stdio` process per provider turn; this module
+ * owns the child lifecycle and the JSON-RPC sequence:
+ *
+ *   spawn → ndJsonStream over stdio → initialize (EMPTY clientCapabilities,
+ *   so Grok keeps file/terminal ops on its own local backends) →
+ *   session/new (first turn) or session/load (resume; NEVER silently falls
+ *   back to session/new on failure — replay safety) → session/prompt →
+ *   drain queued notification handlers → end stdin → require exit 0.
+ *
+ * Auth is deliberately NOT negotiated: Grok auto-selects its
+ * `defaultAuthMethodId`, and an explicit `authenticate(cached_token)` can
+ * fall through to the interactive grok.com flow. Auth failures surface as
+ * prompt/JSON-RPC errors and classify through the retry policy.
+ *
+ * Replay fence: after `session/load`, Grok replays historical updates from
+ * prior turns. The wrapper drains the replay before sending the current
+ * prompt (bounded quiet-window — the SDK dispatches notification handlers
+ * asynchronously, so a naive "prompt sent" boolean races the replay), drops
+ * every notification that arrives before the current `session/prompt`
+ * request has been sent, and drops routed updates whose sessionId
+ * contradicts the active session. Prompt-id correlation of
+ * `turn_completed` usage stays in the handler (events.ts + index.ts).
+ *
+ * The defensive `session/request_permission` handler always denies: under
+ * `--always-approve` + yoloMode it must never fire, and auto-approving would
+ * silently widen the approval posture.
+ */
+
+import { spawn } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+import type { InitializeResponse, McpServer, NewSessionResponse } from "@agentclientprotocol/sdk";
+import { client, ndJsonStream } from "@agentclientprotocol/sdk";
+import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
+import type { ProviderProcessSupervisor } from "../../runtime/provider-process-supervisor.js";
+import { grokNotificationSessionId } from "./events.js";
+
+export const GROK_ACP_PROTOCOL_VERSION = 1;
+
+/** Canonical argv prefix shared by turn spawns and model discovery. */
+export const GROK_ACP_BASE_ARGS: readonly string[] = ["--no-auto-update", "agent", "--no-leader", "--always-approve"];
+
+/**
+ * Canonical turn argv (exported so tests can lock the spawn contract).
+ * `--model` / `--effort` are omitted when the config values are empty so
+ * Grok falls back to its local defaults; the prompt NEVER rides argv.
+ */
+export function buildGrokTurnArgs(input: { model: string; reasoningEffort: string }): string[] {
+  const args = [...GROK_ACP_BASE_ARGS];
+  if (input.model) args.push("--model", input.model);
+  if (input.reasoningEffort) args.push("--effort", input.reasoningEffort);
+  args.push("stdio");
+  return args;
+}
+
+/** Bounded stderr tail kept for failure classification (never persisted raw). */
+const STDERR_TAIL_LIMIT = 8_192;
+/** Grace between SIGTERM and SIGKILL on abort, and the final close wait. */
+const KILL_GRACE_MS = 5_000;
+const FINAL_CLOSE_WAIT_MS = 10_000;
+/** Pre-prompt (replay-fence) drops are logged a bounded number of times. */
+const REPLAY_DROP_LOG_LIMIT = 3;
+/**
+ * Post-session/load replay drain: historical updates stream in right after
+ * the load response; the prompt is sent only after the inbound channel has
+ * been quiet for REPLAY_QUIET_MS (hard-capped at REPLAY_DRAIN_CAP_MS). The
+ * SDK dispatches notification handlers asynchronously, so without the drain
+ * a replayed chunk can be dispatched after our continuation has already
+ * marked the prompt as sent.
+ */
+export const GROK_ACP_REPLAY_QUIET_MS = 25;
+export const GROK_ACP_REPLAY_DRAIN_CAP_MS = 2_000;
+
+export type GrokAcpMcpCapabilities = { http: boolean; sse: boolean };
+
+function headerRecordToArray(headers: Record<string, string> | undefined): Array<{ name: string; value: string }> {
+  return Object.entries(headers ?? {}).map(([name, value]) => ({ name, value }));
+}
+
+/**
+ * Map First Tree managed MCP servers to the ACP schema. HTTP/SSE entries are
+ * dropped (with one log line per server) when the agent did not advertise the
+ * transport in its initialize response — never claim a transport the agent
+ * did not offer.
+ */
+export function mapGrokAcpMcpServers(
+  servers: AgentRuntimeConfigPayload["mcpServers"],
+  capabilities: GrokAcpMcpCapabilities,
+  log: (message: string) => void,
+): McpServer[] {
+  const mapped: McpServer[] = [];
+  for (const server of servers) {
+    if (server.transport === "stdio") {
+      mapped.push({ name: server.name, command: server.command, args: server.args ?? [], env: [] });
+      continue;
+    }
+    if (!capabilities[server.transport]) {
+      log(
+        `grok ACP: dropping MCP server "${server.name}" — agent did not advertise mcpCapabilities.${server.transport}`,
+      );
+      continue;
+    }
+    mapped.push({
+      name: server.name,
+      type: server.transport,
+      url: server.url,
+      headers: headerRecordToArray(server.headers),
+    });
+  }
+  return mapped;
+}
+
+export type GrokAcpFailurePhase = "initialize" | "session_new" | "session_load" | "prompt";
+
+export type GrokAcpAttemptInput = {
+  supervisor: ProviderProcessSupervisor;
+  binary: string;
+  args: string[];
+  env: Record<string, string>;
+  cwd: string;
+  abortSignal: AbortSignal;
+  label: string;
+  /** Advertised as clientInfo.version ("0" when the build has no shared version). */
+  clientVersion: string;
+  /** Confirmed provider session id to `session/load`; null runs `session/new`. */
+  resumeSessionId: string | null;
+  mcpServers: AgentRuntimeConfigPayload["mcpServers"];
+  promptText: string;
+  /** Fired once initialize completed and capabilities validated (replay-ladder "saw provider" rung). */
+  onInitialized?: () => void;
+  /** Fired as soon as session/new or session/load confirms the active session id. */
+  onSessionId?: (sessionId: string) => void;
+  onSessionUpdate: (params: unknown) => void;
+  onXaiNotification: (params: unknown) => void;
+  log: (message: string) => void;
+};
+
+export type GrokAcpAttemptOutcome = {
+  /** Session id confirmed by session/new (or the loaded id); null when the attempt died earlier. */
+  sessionId: string | null;
+  /** session/prompt response; null when the prompt never completed. */
+  prompt: { stopReason: string; meta: Record<string, unknown> | null } | null;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stderrTail: string;
+  /** True only when the process closed with exit code 0 after stdin EOF. */
+  cleanExit: boolean;
+  spawnError?: Error;
+  failure?: { phase: GrokAcpFailurePhase; error: Error };
+};
+
+function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+function asMeta(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+/**
+ * Run one ACP turn attempt against a fresh Grok process. Never throws: every
+ * failure mode lands in the returned outcome for the handler to classify
+ * (spawn error / protocol failure phase / stderr tail + exit status).
+ */
+export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<GrokAcpAttemptOutcome> {
+  let supervised: ReturnType<ProviderProcessSupervisor["spawn"]>;
+  try {
+    supervised = input.supervisor.spawn({
+      command: input.binary,
+      args: input.args,
+      label: input.label,
+      options: {
+        cwd: input.cwd,
+        env: input.env,
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+        // POSIX: own process group so abort kills the whole tree (mirrors the
+        // opencode handler's terminate path).
+        ...(process.platform === "win32" ? {} : { detached: true }),
+      },
+    });
+  } catch (err) {
+    return {
+      sessionId: null,
+      prompt: null,
+      exitCode: null,
+      signal: null,
+      stderrTail: "",
+      cleanExit: false,
+      spawnError: toError(err),
+    };
+  }
+  const child = supervised.child;
+  if (!child.stdin || !child.stdout || !child.stderr) {
+    return {
+      sessionId: null,
+      prompt: null,
+      exitCode: null,
+      signal: null,
+      stderrTail: "",
+      cleanExit: false,
+      spawnError: new Error("grok ACP child stdio is not piped"),
+    };
+  }
+  const childStdin = child.stdin;
+  const childStdout = child.stdout;
+  const childStderr = child.stderr;
+
+  let stderrTail = "";
+  let spawnError: Error | undefined;
+  let closed: { exitCode: number | null; signal: NodeJS.Signals | null } | null = null;
+  let terminated = false;
+  let resolveClose: () => void = () => {};
+  const closeWait = new Promise<void>((resolve) => {
+    resolveClose = resolve;
+  });
+
+  const killTree = (signal: NodeJS.Signals): void => {
+    try {
+      if (process.platform !== "win32" && child.pid) process.kill(-child.pid, signal);
+      else child.kill(signal);
+    } catch {
+      // The process may already be gone.
+    }
+  };
+
+  const terminate = (): void => {
+    if (terminated) return;
+    terminated = true;
+    killTree("SIGTERM");
+    const hardKill = setTimeout(() => killTree("SIGKILL"), KILL_GRACE_MS);
+    hardKill.unref?.();
+    const finalDeadline = setTimeout(() => {
+      closed ??= { exitCode: null, signal: "SIGKILL" };
+      resolveClose();
+    }, KILL_GRACE_MS + FINAL_CLOSE_WAIT_MS);
+    finalDeadline.unref?.();
+  };
+
+  childStderr.setEncoding("utf8");
+  childStderr.on("data", (chunk: string) => {
+    stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_LIMIT);
+  });
+  childStderr.on("error", () => {
+    /* tail stays best-effort */
+  });
+  child.on("error", (err) => {
+    spawnError = toError(err);
+    closed ??= { exitCode: null, signal: null };
+    resolveClose();
+  });
+  child.on("close", (exitCode, signal) => {
+    closed = { exitCode, signal };
+    resolveClose();
+  });
+
+  // Replay-fence state (see module doc): only notifications that belong to
+  // the CURRENT prompt may reach the handler. `lastInboundAt` is stamped by
+  // the notification PARSERS — the SDK runs them synchronously at receipt,
+  // while handlers dispatch asynchronously (a post-load replay message is
+  // often dispatched only after our continuation already resumed), so the
+  // fence cannot key off handler-dispatch order alone.
+  let currentSessionId: string | null = null;
+  let promptSent = false;
+  let replayDrops = 0;
+  let lastInboundAt = 0;
+  const pendingNotifications = new Set<Promise<void>>();
+
+  const routeNotification = (params: unknown, deliver: (value: unknown) => void, channel: string): void => {
+    if (!promptSent) {
+      if (replayDrops < REPLAY_DROP_LOG_LIMIT) {
+        input.log(`grok ACP: dropped pre-prompt ${channel} notification (session/load replay fence)`);
+      }
+      replayDrops++;
+      return;
+    }
+    const routedSessionId = grokNotificationSessionId(params);
+    if (currentSessionId && routedSessionId && routedSessionId !== currentSessionId) {
+      input.log(`grok ACP: dropped ${channel} notification for foreign session ${routedSessionId}`);
+      return;
+    }
+    const tracked = Promise.resolve()
+      .then(() => deliver(params))
+      .then(
+        () => {},
+        (err: unknown) => {
+          input.log(`grok ACP: ${channel} notification handling failed: ${toError(err).message}`);
+        },
+      );
+    pendingNotifications.add(tracked);
+    void tracked.then(() => pendingNotifications.delete(tracked));
+  };
+
+  // The passthrough parser keeps raw params so events.ts owns ALL tolerant
+  // normalization in one tested layer; the SDK's generated schemas must not
+  // silently strip `_meta` (x.ai tool metadata) or reject unknown update kinds.
+  const passthrough = (params: unknown): unknown => {
+    lastInboundAt = Date.now();
+    return params;
+  };
+  const app = client({ name: "first-tree" })
+    .onNotification("session/update", passthrough, (context) =>
+      routeNotification(context.params, input.onSessionUpdate, "session/update"),
+    )
+    .onNotification("_x.ai/session_notification", passthrough, (context) =>
+      routeNotification(context.params, input.onXaiNotification, "_x.ai/session_notification"),
+    )
+    .onNotification("_x.ai/session/update", passthrough, (context) =>
+      routeNotification(context.params, input.onXaiNotification, "_x.ai/session/update"),
+    )
+    .onRequest("session/request_permission", () => {
+      // Must never fire under --always-approve + yoloMode. Fail closed:
+      // cancel, never auto-approve.
+      input.log(
+        "grok ACP: refused unexpected session/request_permission under --always-approve (provider misbehavior)",
+      );
+      return { outcome: { outcome: "cancelled" as const } };
+    });
+
+  const stream = ndJsonStream(Writable.toWeb(childStdin), Readable.toWeb(childStdout));
+  const connection = app.connect(stream);
+  const agent = connection.agent;
+
+  let promptInFlight = false;
+  const onAbort = (): void => {
+    if (promptInFlight && currentSessionId) {
+      // Best-effort cooperative cancel BEFORE the SIGTERM path.
+      void agent.notify("session/cancel", { sessionId: currentSessionId }).catch(() => {});
+    }
+    terminate();
+  };
+  input.abortSignal.addEventListener("abort", onAbort, { once: true });
+
+  const outcome = (): GrokAcpAttemptOutcome => ({
+    sessionId: currentSessionId,
+    prompt: promptResult,
+    exitCode: closed?.exitCode ?? null,
+    signal: closed?.signal ?? null,
+    stderrTail,
+    cleanExit: closed?.exitCode === 0,
+    ...(spawnError ? { spawnError } : {}),
+    ...(failure ? { failure } : {}),
+  });
+
+  const failAndDrain = async (phase: GrokAcpFailurePhase, err: unknown): Promise<GrokAcpAttemptOutcome> => {
+    failure = { phase, error: toError(err) };
+    try {
+      childStdin.end();
+    } catch {
+      /* already gone */
+    }
+    terminate();
+    await closeWait;
+    return outcome();
+  };
+
+  let failure: { phase: GrokAcpFailurePhase; error: Error } | undefined;
+  let promptResult: GrokAcpAttemptOutcome["prompt"] = null;
+
+  try {
+    // 1. initialize — deliberately EMPTY clientCapabilities (see module doc).
+    let initResponse: InitializeResponse;
+    try {
+      initResponse = await agent.request("initialize", {
+        protocolVersion: GROK_ACP_PROTOCOL_VERSION,
+        clientCapabilities: {},
+        clientInfo: { name: "first-tree", version: input.clientVersion },
+      });
+    } catch (err) {
+      return await failAndDrain("initialize", err);
+    }
+    if (initResponse.protocolVersion !== GROK_ACP_PROTOCOL_VERSION) {
+      return await failAndDrain(
+        "initialize",
+        new Error(
+          `grok provider mismatch: ACP protocolVersion ${String(initResponse.protocolVersion)} ` +
+            `(expected ${GROK_ACP_PROTOCOL_VERSION})`,
+        ),
+      );
+    }
+    const agentCapabilities = initResponse.agentCapabilities;
+    if (input.resumeSessionId && agentCapabilities?.loadSession !== true) {
+      return await failAndDrain(
+        "initialize",
+        new Error("grok provider mismatch: agent does not advertise session/load capability required for resume"),
+      );
+    }
+    const mcpCapabilities: GrokAcpMcpCapabilities = {
+      http: agentCapabilities?.mcpCapabilities?.http === true,
+      sse: agentCapabilities?.mcpCapabilities?.sse === true,
+    };
+    input.onInitialized?.();
+
+    // 2. session/new (first turn) or session/load (resume). A session/load
+    // failure is terminal for the attempt — never silently re-run as
+    // session/new (a fresh session could re-execute side effects).
+    const mappedServers = mapGrokAcpMcpServers(input.mcpServers, mcpCapabilities, input.log);
+    if (input.resumeSessionId) {
+      try {
+        await agent.request("session/load", {
+          sessionId: input.resumeSessionId,
+          cwd: input.cwd,
+          mcpServers: mappedServers,
+          _meta: { yoloMode: true },
+        });
+      } catch (err) {
+        return await failAndDrain("session_load", err);
+      }
+      currentSessionId = input.resumeSessionId;
+    } else {
+      let newSessionResponse: NewSessionResponse;
+      try {
+        newSessionResponse = await agent.request("session/new", {
+          cwd: input.cwd,
+          mcpServers: mappedServers,
+          _meta: { yoloMode: true },
+        });
+      } catch (err) {
+        return await failAndDrain("session_new", err);
+      }
+      currentSessionId = newSessionResponse.sessionId;
+    }
+    input.onSessionId?.(currentSessionId);
+
+    if (input.resumeSessionId) {
+      // Replay drain: historical updates arrive right after the load
+      // response; wait until the inbound channel goes quiet before sending
+      // the current prompt. Everything received during the drain is dropped
+      // by the pre-prompt fence above.
+      lastInboundAt = Date.now();
+      const drainStart = lastInboundAt;
+      for (;;) {
+        const quietFor = Date.now() - lastInboundAt;
+        if (quietFor >= GROK_ACP_REPLAY_QUIET_MS) break;
+        if (Date.now() - drainStart >= GROK_ACP_REPLAY_DRAIN_CAP_MS) {
+          input.log("grok ACP: replay drain hit its cap; proceeding with the prompt");
+          break;
+        }
+        if (input.abortSignal.aborted) break;
+        await new Promise((resolve) => {
+          setTimeout(resolve, Math.min(GROK_ACP_REPLAY_QUIET_MS - quietFor, 25));
+        });
+      }
+      if (replayDrops > 0) {
+        input.log(`grok ACP: replay fence dropped ${replayDrops} historical notification(s) after session/load`);
+      }
+    }
+
+    // 3. session/prompt — the replay fence opens only now.
+    promptSent = true;
+    promptInFlight = true;
+    try {
+      const promptResponse = await agent.request("session/prompt", {
+        sessionId: currentSessionId,
+        prompt: [{ type: "text", text: input.promptText }],
+      });
+      promptResult = { stopReason: promptResponse.stopReason, meta: asMeta(promptResponse._meta) };
+    } catch (err) {
+      return await failAndDrain("prompt", err);
+    } finally {
+      promptInFlight = false;
+    }
+
+    // 4. Settlement barrier: drain queued notification handlers, then end
+    // stdin and require the process to close (Grok exits 0 on clean EOF).
+    while (pendingNotifications.size > 0) {
+      await Promise.all([...pendingNotifications]);
+    }
+    childStdin.end();
+    if (input.abortSignal.aborted) terminate();
+    await closeWait;
+    return outcome();
+  } finally {
+    input.abortSignal.removeEventListener("abort", onAbort);
+    if (!closed) terminate();
+  }
+}
+
+export type GrokAcpModelStateFetch = { ok: true; meta: Record<string, unknown> | null } | { ok: false; error: string };
+
+/**
+ * Initialize-only ACP handshake for model discovery: spawn the CLI, run
+ * `initialize` (unauthenticated metadata — never touches credentials),
+ * capture the response `_meta`, end stdin, and await exit with a bounded
+ * timeout. Discovery never reaches session/new.
+ */
+export async function fetchGrokAcpInitializeMeta(input: {
+  binary: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+  clientVersion: string;
+}): Promise<GrokAcpModelStateFetch> {
+  return await new Promise<GrokAcpModelStateFetch>((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(input.binary, [...GROK_ACP_BASE_ARGS, "stdio"], {
+        env: input.env,
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (err) {
+      resolve({ ok: false, error: toError(err).message });
+      return;
+    }
+    if (!child.stdin || !child.stdout) {
+      resolve({ ok: false, error: "grok ACP child stdio is not piped" });
+      return;
+    }
+    let stderrTail = "";
+    let settled = false;
+    const finish = (result: GrokAcpModelStateFetch): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+      finish({ ok: false, error: `grok ACP model discovery timed out after ${input.timeoutMs}ms` });
+    }, input.timeoutMs);
+    timer.unref?.();
+
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_LIMIT);
+    });
+    child.on("error", (err) => finish({ ok: false, error: toError(err).message }));
+
+    const stream = ndJsonStream(Writable.toWeb(child.stdin), Readable.toWeb(child.stdout));
+    const connection = client({ name: "first-tree" }).connect(stream);
+    void (async () => {
+      try {
+        const initResponse = await connection.agent.request("initialize", {
+          protocolVersion: GROK_ACP_PROTOCOL_VERSION,
+          clientCapabilities: {},
+          clientInfo: { name: "first-tree", version: input.clientVersion },
+        });
+        const meta = asMeta(initResponse._meta);
+        child.stdin?.end();
+        finish({ ok: true, meta });
+      } catch (err) {
+        finish({ ok: false, error: stderrTail.trim() || toError(err).message });
+      }
+    })();
+  });
+}

--- a/packages/client/src/handlers/grok/acp-session.ts
+++ b/packages/client/src/handlers/grok/acp-session.ts
@@ -7,10 +7,13 @@
  *   spawn → ndJsonStream over stdio → initialize (EMPTY clientCapabilities,
  *   so Grok keeps file/terminal ops on its own local backends) →
  *   session/new (first turn) or session/load (resume; NEVER silently falls
- *   back to session/new on failure — replay safety) → session/set_model
- *   (after EVERY session open, every turn: session/load restores the
- *   session's PERSISTED selection, so even an empty config re-asserts the
- *   initialize default model; empty effort OMITS `_meta` entirely) →
+ *   back to session/new on failure — replay safety) → legacy replay drain →
+ *   session/set_model (after EVERY session open, every turn: session/load
+ *   restores the session's PERSISTED selection, so even an empty config
+ *   re-asserts the initialize default model; empty effort OMITS `_meta`
+ *   entirely; a non-empty effort is confirmed by requiring THIS set_model's
+ *   non-replay, same-session `model_changed` echo with the effective
+ *   model_id + reasoning_effort — the waiter arms BEFORE the request) →
  *   session/prompt (client-generated `_meta.promptId`) → settle barrier:
  *   stdin EOF → bounded wait for real close + connection.closed → stable
  *   drain of the routed-handler queue → only then read settlement state →
@@ -45,7 +48,12 @@ import type { InitializeResponse, McpServer, NewSessionResponse } from "@agentcl
 import { client, ndJsonStream } from "@agentclientprotocol/sdk";
 import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
 import type { ProviderProcessSupervisor } from "../../runtime/provider-process-supervisor.js";
-import { grokNotificationIsReplay, grokNotificationSessionId, parseGrokModelState } from "./events.js";
+import {
+  grokNotificationIsReplay,
+  grokNotificationSessionId,
+  parseGrokModelChangedEcho,
+  parseGrokModelState,
+} from "./events.js";
 
 export const GROK_ACP_PROTOCOL_VERSION = 1;
 
@@ -82,6 +90,12 @@ const REPLAY_DROP_LOG_LIMIT = 3;
  */
 export const GROK_ACP_REPLAY_QUIET_MS = 25;
 export const GROK_ACP_REPLAY_DRAIN_CAP_MS = 2_000;
+/**
+ * Bounded wait for THIS set_model's `model_changed` effort echo. The echo is
+ * local state (no model call), so it should land within milliseconds; the
+ * bound only guards a misbehaving build.
+ */
+export const GROK_SET_MODEL_ECHO_WAIT_MS = 2_000;
 
 export type GrokAcpMcpCapabilities = { http: boolean; sse: boolean };
 
@@ -154,6 +168,10 @@ export type GrokAcpAttemptInput = {
   eofCloseWaitMs?: number;
   /** Grace between SIGTERM and SIGKILL on the terminate path (tests shorten this). */
   killGraceMs?: number;
+  /** Bounded wait for the model_changed effort echo after set_model (tests shorten this). */
+  setModelEchoWaitMs?: number;
+  /** Bounded cap for the legacy replay drain after session/load (tests shorten this). */
+  replayDrainCapMs?: number;
   /** Fired once initialize completed and capabilities validated (replay-ladder "saw provider" rung). */
   onInitialized?: () => void;
   /** Fired as soon as session/new or session/load confirms the active session id. */
@@ -239,6 +257,11 @@ async function reclaimUnpipedChild(child: {
 
 function asMeta(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+/** Strict same-session gate for config-confirmation echos: a MISSING session id rejects. */
+function routedSessionIdEqualsCurrent(routedSessionId: string | null, currentSessionId: string | null): boolean {
+  return routedSessionId !== null && currentSessionId !== null && routedSessionId === currentSessionId;
 }
 
 /**
@@ -390,9 +413,31 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
   let lastInboundAt = 0;
   /** Client-generated correlation id for the in-flight prompt (null until sent). */
   let attemptPromptId: string | null = null;
+  /**
+   * Latest `model_changed` echo, tagged with its RECEIPT-TIME ingress
+   * sequence. Internal config confirmation ONLY — intercepted here and never
+   * delivered to the handler, so it cannot become a user-facing event or
+   * advance replay-safety state.
+   */
+  let modelChangedEcho: { modelId: string | null; reasoningEffort: string | null; seq: number } | null = null;
+  const echoWaiters = new Set<() => void>();
+  let cancelEchoWait: (() => void) | null = null;
+  /**
+   * Monotonic receipt clock, stamped by the notification PARSERS — the SDK
+   * runs them synchronously at ingress, while handlers dispatch
+   * asynchronously. The echo confirmation baseline is taken from THIS clock,
+   * so a legacy echo received before the waiter armed can never satisfy it,
+   * even when its dispatch lands after arming.
+   */
+  let ingressSeq = 0;
   const pendingNotifications = new Set<Promise<void>>();
 
-  const routeNotification = (params: unknown, deliver: (value: unknown) => void, channel: string): void => {
+  const routeNotification = (
+    envelope: { params: unknown; seq: number },
+    deliver: (value: unknown) => void,
+    channel: string,
+  ): void => {
+    const { params, seq } = envelope;
     // Exact replay contract (Grok's own headless uses it): a notification
     // marked `_meta.isReplay === true` is ALWAYS historical, regardless of
     // when it arrives — drop it even inside the prompt window.
@@ -403,16 +448,29 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
       replayDrops++;
       return;
     }
+    // Config-confirmation echo: capture ONLY the exact
+    // `_x.ai/session_notification` channel with a STRICT same-session id
+    // (missing sessionId = reject), wake any armed waiter, and never deliver
+    // onward. Identically-shaped payloads on other channels continue through
+    // the normal fence/normalization — they never confirm configuration.
+    if (channel === "_x.ai/session_notification") {
+      const echo = parseGrokModelChangedEcho(params);
+      if (echo && routedSessionIdEqualsCurrent(grokNotificationSessionId(params), currentSessionId)) {
+        modelChangedEcho = { ...echo, seq };
+        for (const waiter of [...echoWaiters]) waiter();
+        return;
+      }
+    }
+    const routedSessionId = grokNotificationSessionId(params);
+    if (currentSessionId && routedSessionId && routedSessionId !== currentSessionId) {
+      input.log(`grok ACP: dropped ${channel} notification for foreign session ${routedSessionId}`);
+      return;
+    }
     if (!promptSent) {
       if (replayDrops < REPLAY_DROP_LOG_LIMIT) {
         input.log(`grok ACP: dropped pre-prompt ${channel} notification (session/load replay fence)`);
       }
       replayDrops++;
-      return;
-    }
-    const routedSessionId = grokNotificationSessionId(params);
-    if (currentSessionId && routedSessionId && routedSessionId !== currentSessionId) {
-      input.log(`grok ACP: dropped ${channel} notification for foreign session ${routedSessionId}`);
       return;
     }
     // Prompt correlation: anything stamped with a DIFFERENT prompt id than
@@ -434,12 +492,72 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
     void tracked.then(() => pendingNotifications.delete(tracked));
   };
 
+  /**
+   * Bounded wait for THIS set_model's effective-value `model_changed` echo.
+   * The arm-time baseline is the ingress receipt clock: only an echo RECEIVED
+   * after arming can satisfy, and it must match BOTH the effective model and
+   * the requested effort. Diagnostics report only POST-arm candidates — a
+   * pre-arm stale echo is never claimed as "observed". `cancel` cleans up
+   * AND settles with an explicit cancelled outcome (used by the abort path
+   * and every config-phase failure exit; no lingering timer/closure).
+   */
+  const waitForModelChangedEcho = (
+    expectedModelId: string,
+    expectedEffort: string,
+  ): { promise: Promise<{ ok: true } | { ok: false; observed: string }>; cancel: () => void } => {
+    const armSeq = ingressSeq;
+    let lastPostArmCandidate: { modelId: string | null; reasoningEffort: string | null } | null = null;
+    let settled = false;
+    let settle: (result: { ok: true } | { ok: false; observed: string }) => void = () => {};
+    const promise = new Promise<{ ok: true } | { ok: false; observed: string }>((resolve) => {
+      settle = resolve;
+    });
+    const finish = (result: { ok: true } | { ok: false; observed: string }): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      echoWaiters.delete(check);
+      settle(result);
+    };
+    const matches = (): boolean =>
+      modelChangedEcho !== null &&
+      modelChangedEcho.seq > armSeq &&
+      modelChangedEcho.modelId === expectedModelId &&
+      modelChangedEcho.reasoningEffort === expectedEffort;
+    const deadline = setTimeout(() => {
+      finish({
+        ok: false,
+        observed: lastPostArmCandidate
+          ? `echo reported model ${lastPostArmCandidate.modelId ?? "(none)"} effort ${lastPostArmCandidate.reasoningEffort ?? "(none)"}`
+          : "no current model_changed echo received",
+      });
+    }, input.setModelEchoWaitMs ?? GROK_SET_MODEL_ECHO_WAIT_MS);
+    deadline.unref?.();
+    const check = (): void => {
+      if (modelChangedEcho && modelChangedEcho.seq > armSeq) {
+        lastPostArmCandidate = modelChangedEcho;
+      }
+      if (!matches()) return;
+      finish({ ok: true });
+    };
+    echoWaiters.add(check);
+    check();
+    return {
+      promise,
+      cancel: () => finish({ ok: false, observed: "echo wait cancelled" }),
+    };
+  };
+
   // The passthrough parser keeps raw params so events.ts owns ALL tolerant
   // normalization in one tested layer; the SDK's generated schemas must not
-  // silently strip `_meta` (x.ai tool metadata) or reject unknown update kinds.
-  const passthrough = (params: unknown): unknown => {
+  // silently strip `_meta` (x.ai tool metadata) or reject unknown update
+  // kinds. The parser ALSO stamps the ingress receipt clock — it runs
+  // synchronously at receipt, so this is the trustworthy time boundary (the
+  // handler dispatch that follows is asynchronous).
+  const passthrough = (params: unknown): { params: unknown; seq: number } => {
     lastInboundAt = Date.now();
-    return params;
+    ingressSeq++;
+    return { params, seq: ingressSeq };
   };
   const app = client({ name: "first-tree" })
     .onNotification("session/update", passthrough, (context) =>
@@ -466,6 +584,10 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
 
   let promptInFlight = false;
   const onAbort = (): void => {
+    // Cancel any armed echo wait FIRST — an abort must never linger behind a
+    // config-confirmation timeout, and the settled-cancel path upstream
+    // ensures NO configuration terminal/ACK is produced.
+    cancelEchoWait?.();
     if (promptInFlight && currentSessionId) {
       // Best-effort cooperative cancel BEFORE the SIGTERM path.
       void agent.notify("session/cancel", { sessionId: currentSessionId }).catch(() => {});
@@ -616,6 +738,45 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
     }
     input.onSessionId?.(currentSessionId);
 
+    if (input.resumeSessionId) {
+      // Replay drain: historical updates arrive right after the load
+      // response; wait until the inbound channel goes quiet before arming
+      // the model_changed confirmation and sending the current prompt.
+      // Everything received during the drain is dropped by the pre-prompt
+      // fence above, so no stale echo can satisfy the confirmation.
+      lastInboundAt = Date.now();
+      const drainStart = lastInboundAt;
+      const drainCapMs = input.replayDrainCapMs ?? GROK_ACP_REPLAY_DRAIN_CAP_MS;
+      for (;;) {
+        const quietFor = Date.now() - lastInboundAt;
+        if (quietFor >= GROK_ACP_REPLAY_QUIET_MS) break;
+        if (Date.now() - drainStart >= drainCapMs) {
+          if (input.reasoningEffort) {
+            // Fail closed: the wire has no request/event id, so a drain that
+            // never went quiet cannot prove a late same-value echo belongs to
+            // THIS turn's set_model — an unproven drain is a configuration
+            // mismatch, never a completed quiet drain.
+            return await failAndDrain(
+              "session_load",
+              new Error(
+                `grok provider mismatch: session/load replay drain did not go quiet within ${drainCapMs}ms; ` +
+                  "cannot trust effort confirmation for an explicit effort",
+              ),
+            );
+          }
+          input.log("grok ACP: replay drain hit its cap; proceeding with the prompt");
+          break;
+        }
+        if (input.abortSignal.aborted) break;
+        await new Promise((resolve) => {
+          setTimeout(resolve, Math.min(GROK_ACP_REPLAY_QUIET_MS - quietFor, 25));
+        });
+      }
+      if (replayDrops > 0) {
+        input.log(`grok ACP: replay fence dropped ${replayDrops} historical notification(s) after session/load`);
+      }
+    }
+
     // 2b. Apply model/effort after EVERY session open, every turn (Grok's
     // headless apply_headless_model_and_effort does the same after
     // open_session): session/load restores the session's PERSISTED
@@ -632,6 +793,14 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
         new Error("grok provider mismatch: the provider advertised no current model to apply for this turn"),
       );
     }
+    // Arm the effort-echo waiter BEFORE the request — the model_changed echo
+    // can precede the JSON-RPC response (observed same-millisecond on the
+    // live wire). Empty effort keeps "remove override" semantics: the
+    // provider default may itself carry an effort, so no echo is required.
+    const effortEchoWait = input.reasoningEffort
+      ? waitForModelChangedEcho(effectiveModelId, input.reasoningEffort)
+      : null;
+    cancelEchoWait = effortEchoWait?.cancel ?? null;
     try {
       const setModelResponse: unknown = await agent.request("session/set_model", {
         sessionId: currentSessionId,
@@ -647,6 +816,8 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
       const setModelResult = asMeta(asMeta(asMeta(setModelResponse)?._meta)?.model);
       const appliedModelId = typeof setModelResult?.Ok === "string" ? setModelResult.Ok : null;
       if (appliedModelId !== effectiveModelId) {
+        cancelEchoWait?.();
+        cancelEchoWait = null;
         return await failAndDrain(
           "set_model",
           new Error(
@@ -656,6 +827,8 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
         );
       }
     } catch (err) {
+      cancelEchoWait?.();
+      cancelEchoWait = null;
       return await failAndDrain(
         "set_model",
         new Error(
@@ -664,28 +837,27 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
         ),
       );
     }
-
-    if (input.resumeSessionId) {
-      // Replay drain: historical updates arrive right after the load
-      // response; wait until the inbound channel goes quiet before sending
-      // the current prompt. Everything received during the drain is dropped
-      // by the pre-prompt fence above.
-      lastInboundAt = Date.now();
-      const drainStart = lastInboundAt;
-      for (;;) {
-        const quietFor = Date.now() - lastInboundAt;
-        if (quietFor >= GROK_ACP_REPLAY_QUIET_MS) break;
-        if (Date.now() - drainStart >= GROK_ACP_REPLAY_DRAIN_CAP_MS) {
-          input.log("grok ACP: replay drain hit its cap; proceeding with the prompt");
-          break;
-        }
-        if (input.abortSignal.aborted) break;
-        await new Promise((resolve) => {
-          setTimeout(resolve, Math.min(GROK_ACP_REPLAY_QUIET_MS - quietFor, 25));
-        });
+    if (effortEchoWait) {
+      // model_switch.rs (upstream dd04f397): when the selected model does not
+      // support reasoning effort, set_model IGNORES the override but still
+      // returns a successful _meta.model.Ok — only the effective-value
+      // model_changed echo proves the effort was applied.
+      const echoConfirmation = await effortEchoWait.promise;
+      cancelEchoWait = null; // settled either way; the waiter's own cleanup ran
+      if (input.abortSignal.aborted) {
+        // Abort raced the confirmation (onAbort settled the wait): tear the
+        // transport down, but the upstream abort gate ensures NO
+        // configuration terminal/ACK lands from this path.
+        return await failAndDrain("prompt", new Error("grok ACP attempt aborted during effort confirmation"));
       }
-      if (replayDrops > 0) {
-        input.log(`grok ACP: replay fence dropped ${replayDrops} historical notification(s) after session/load`);
+      if (!echoConfirmation.ok) {
+        return await failAndDrain(
+          "set_model",
+          new Error(
+            `grok provider mismatch: reasoning effort "${input.reasoningEffort}" was not confirmed on model ` +
+              `"${effectiveModelId}" (observed: ${echoConfirmation.observed})`,
+          ),
+        );
       }
     }
 
@@ -731,6 +903,7 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
     return outcome();
   } finally {
     input.abortSignal.removeEventListener("abort", onAbort);
+    cancelEchoWait?.();
     if (!closed) terminate();
   }
 }

--- a/packages/client/src/handlers/grok/acp-session.ts
+++ b/packages/client/src/handlers/grok/acp-session.ts
@@ -128,6 +128,8 @@ export type GrokAcpAttemptInput = {
   resumeSessionId: string | null;
   mcpServers: AgentRuntimeConfigPayload["mcpServers"];
   promptText: string;
+  /** Bounded wait for process close after stdin EOF on the success path. */
+  eofCloseWaitMs?: number;
   /** Fired once initialize completed and capabilities validated (replay-ladder "saw provider" rung). */
   onInitialized?: () => void;
   /** Fired as soon as session/new or session/load confirms the active session id. */
@@ -465,13 +467,22 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
     }
 
     // 4. Settlement barrier: drain queued notification handlers, then end
-    // stdin and require the process to close (Grok exits 0 on clean EOF).
+    // stdin and require the process to close with exit 0 (Grok exits 0 on
+    // clean EOF). The close wait is BOUNDED: a process that answered the
+    // prompt but never exits is reclaimed through the terminate path and
+    // lands as a non-clean exit (a failure input, never a silent success).
     while (pendingNotifications.size > 0) {
       await Promise.all([...pendingNotifications]);
     }
     childStdin.end();
     if (input.abortSignal.aborted) terminate();
+    const eofDeadline = setTimeout(() => {
+      input.log("grok ACP: process did not exit after stdin EOF; terminating the process tree");
+      terminate();
+    }, input.eofCloseWaitMs ?? FINAL_CLOSE_WAIT_MS);
+    eofDeadline.unref?.();
     await closeWait;
+    clearTimeout(eofDeadline);
     return outcome();
   } finally {
     input.abortSignal.removeEventListener("abort", onAbort);
@@ -484,71 +495,131 @@ export type GrokAcpModelStateFetch = { ok: true; meta: Record<string, unknown> |
 /**
  * Initialize-only ACP handshake for model discovery: spawn the CLI, run
  * `initialize` (unauthenticated metadata — never touches credentials),
- * capture the response `_meta`, end stdin, and await exit with a bounded
- * timeout. Discovery never reaches session/new.
+ * capture the response `_meta`, then reclaim the process through a bounded
+ * EOF→close barrier. EVERY path reclaims the child: stdin EOF, then a
+ * bounded wait, then process-tree terminate. Success requires a clean
+ * exit 0 — an early return after initialize would leak the process and ACK
+ * a catalog whose transport never drained.
  */
 export async function fetchGrokAcpInitializeMeta(input: {
   binary: string;
   env: NodeJS.ProcessEnv;
   timeoutMs: number;
   clientVersion: string;
+  /** Bounded wait for process close after stdin EOF (tests shorten this). */
+  eofCloseWaitMs?: number;
 }): Promise<GrokAcpModelStateFetch> {
-  return await new Promise<GrokAcpModelStateFetch>((resolve) => {
-    let child: ReturnType<typeof spawn>;
-    try {
-      child = spawn(input.binary, [...GROK_ACP_BASE_ARGS, "stdio"], {
-        env: input.env,
-        shell: false,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      });
-    } catch (err) {
-      resolve({ ok: false, error: toError(err).message });
-      return;
-    }
-    if (!child.stdin || !child.stdout) {
-      resolve({ ok: false, error: "grok ACP child stdio is not piped" });
-      return;
-    }
-    let stderrTail = "";
-    let settled = false;
-    const finish = (result: GrokAcpModelStateFetch): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(result);
-    };
-    const timer = setTimeout(() => {
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        /* already gone */
-      }
-      finish({ ok: false, error: `grok ACP model discovery timed out after ${input.timeoutMs}ms` });
-    }, input.timeoutMs);
-    timer.unref?.();
-
-    child.stderr?.setEncoding("utf8");
-    child.stderr?.on("data", (chunk: string) => {
-      stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_LIMIT);
+  const eofCloseWaitMs = input.eofCloseWaitMs ?? FINAL_CLOSE_WAIT_MS;
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(input.binary, [...GROK_ACP_BASE_ARGS, "stdio"], {
+      env: input.env,
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      ...(process.platform === "win32" ? {} : { detached: true }),
     });
-    child.on("error", (err) => finish({ ok: false, error: toError(err).message }));
+  } catch (err) {
+    return { ok: false, error: toError(err).message };
+  }
+  if (!child.stdin || !child.stdout) {
+    return { ok: false, error: "grok ACP child stdio is not piped" };
+  }
+  const childStdin = child.stdin;
+  const childStdout = child.stdout;
 
-    const stream = ndJsonStream(Writable.toWeb(child.stdin), Readable.toWeb(child.stdout));
-    const connection = client({ name: "first-tree" }).connect(stream);
-    void (async () => {
-      try {
-        const initResponse = await connection.agent.request("initialize", {
-          protocolVersion: GROK_ACP_PROTOCOL_VERSION,
-          clientCapabilities: {},
-          clientInfo: { name: "first-tree", version: input.clientVersion },
-        });
-        const meta = asMeta(initResponse._meta);
-        child.stdin?.end();
-        finish({ ok: true, meta });
-      } catch (err) {
-        finish({ ok: false, error: stderrTail.trim() || toError(err).message });
-      }
-    })();
+  let stderrTail = "";
+  let spawnError: Error | undefined;
+  let closed: { exitCode: number | null; signal: NodeJS.Signals | null } | null = null;
+  let resolveClose: () => void = () => {};
+  const closeWait = new Promise<void>((resolve) => {
+    resolveClose = resolve;
   });
+  const killTree = (signal: NodeJS.Signals): void => {
+    try {
+      if (process.platform !== "win32" && child.pid) process.kill(-child.pid, signal);
+      else child.kill(signal);
+    } catch {
+      // The process may already be gone.
+    }
+  };
+  let terminated = false;
+  const terminate = (): void => {
+    if (terminated) return;
+    terminated = true;
+    killTree("SIGTERM");
+    const hardKill = setTimeout(() => killTree("SIGKILL"), KILL_GRACE_MS);
+    hardKill.unref?.();
+    const finalDeadline = setTimeout(() => {
+      closed ??= { exitCode: null, signal: "SIGKILL" };
+      resolveClose();
+    }, KILL_GRACE_MS + FINAL_CLOSE_WAIT_MS);
+    finalDeadline.unref?.();
+  };
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    terminate();
+  }, input.timeoutMs);
+  timer.unref?.();
+
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_LIMIT);
+  });
+  child.on("error", (err) => {
+    spawnError = toError(err);
+    closed ??= { exitCode: null, signal: null };
+    resolveClose();
+  });
+  child.on("close", (exitCode, signal) => {
+    closed = { exitCode, signal };
+    resolveClose();
+  });
+
+  const stream = ndJsonStream(Writable.toWeb(childStdin), Readable.toWeb(childStdout));
+  const connection = client({ name: "first-tree" }).connect(stream);
+
+  let meta: Record<string, unknown> | null = null;
+  let initError: Error | null = null;
+  try {
+    const initResponse = await connection.agent.request("initialize", {
+      protocolVersion: GROK_ACP_PROTOCOL_VERSION,
+      clientCapabilities: {},
+      clientInfo: { name: "first-tree", version: input.clientVersion },
+    });
+    meta = asMeta(initResponse._meta);
+  } catch (err) {
+    initError = toError(err);
+  }
+
+  // Reclaim the process on EVERY path: EOF first, bounded wait, then
+  // process-tree terminate. Never resolve while the child is still running.
+  try {
+    childStdin.end();
+  } catch {
+    /* already gone */
+  }
+  const eofDeadline = setTimeout(() => terminate(), eofCloseWaitMs);
+  eofDeadline.unref?.();
+  await closeWait;
+  clearTimeout(eofDeadline);
+  clearTimeout(timer);
+
+  if (timedOut) return { ok: false, error: `grok ACP model discovery timed out after ${input.timeoutMs}ms` };
+  if (spawnError) return { ok: false, error: spawnError.message };
+  if (initError) return { ok: false, error: stderrTail.trim() || initError.message };
+  // `closed` is assigned from event callbacks; read it through a function so
+  // TS does not narrow it to null from the initializer (microsoft/TypeScript#9998).
+  const finalClose = ((): { exitCode: number | null; signal: NodeJS.Signals | null } | null => closed)();
+  if (finalClose?.exitCode !== 0) {
+    return {
+      ok: false,
+      error:
+        `grok ACP model discovery process exited ${finalClose?.exitCode ?? `signal ${finalClose?.signal ?? "unknown"}`} ` +
+        "after initialize (exit 0 required)",
+    };
+  }
+  return { ok: true, meta };
 }

--- a/packages/client/src/handlers/grok/acp-session.ts
+++ b/packages/client/src/handlers/grok/acp-session.ts
@@ -7,22 +7,31 @@
  *   spawn → ndJsonStream over stdio → initialize (EMPTY clientCapabilities,
  *   so Grok keeps file/terminal ops on its own local backends) →
  *   session/new (first turn) or session/load (resume; NEVER silently falls
- *   back to session/new on failure — replay safety) → session/prompt →
- *   drain queued notification handlers → end stdin → require exit 0.
+ *   back to session/new on failure — replay safety) → session/set_model
+ *   (after EVERY session open, every turn: session/load restores the
+ *   session's PERSISTED selection, so even an empty config re-asserts the
+ *   initialize default model; empty effort OMITS `_meta` entirely) →
+ *   session/prompt (client-generated `_meta.promptId`) → settle barrier:
+ *   stdin EOF → bounded wait for real close + connection.closed → stable
+ *   drain of the routed-handler queue → only then read settlement state →
+ *   require exit 0.
  *
  * Auth is deliberately NOT negotiated: Grok auto-selects its
  * `defaultAuthMethodId`, and an explicit `authenticate(cached_token)` can
  * fall through to the interactive grok.com flow. Auth failures surface as
  * prompt/JSON-RPC errors and classify through the retry policy.
  *
- * Replay fence: after `session/load`, Grok replays historical updates from
- * prior turns. The wrapper drains the replay before sending the current
- * prompt (bounded quiet-window — the SDK dispatches notification handlers
- * asynchronously, so a naive "prompt sent" boolean races the replay), drops
- * every notification that arrives before the current `session/prompt`
- * request has been sent, and drops routed updates whose sessionId
- * contradicts the active session. Prompt-id correlation of
- * `turn_completed` usage stays in the handler (events.ts + index.ts).
+ * Replay fence: `session/load` is sent with `_meta.noReplay: true` (Grok's
+ * own headless resume contract), any notification stamped
+ * `_meta.isReplay === true` is ALWAYS dropped regardless of arrival time,
+ * and as a legacy fallback for builds without the marker the wrapper drains
+ * the post-load replay before sending the current prompt (bounded
+ * quiet-window — the SDK dispatches notification handlers asynchronously, so
+ * a naive "prompt sent" boolean races the replay) and drops every
+ * notification that arrives before the current `session/prompt` request has
+ * been sent. Routed updates whose sessionId contradicts the active session
+ * are dropped. Prompt-id correlation of `turn_completed` usage stays in the
+ * handler (events.ts + index.ts).
  *
  * The defensive `session/request_permission` handler always denies: under
  * `--always-approve` + yoloMode it must never fire, and auto-approving would
@@ -30,12 +39,13 @@
  */
 
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { Readable, Writable } from "node:stream";
 import type { InitializeResponse, McpServer, NewSessionResponse } from "@agentclientprotocol/sdk";
 import { client, ndJsonStream } from "@agentclientprotocol/sdk";
 import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
 import type { ProviderProcessSupervisor } from "../../runtime/provider-process-supervisor.js";
-import { grokNotificationSessionId } from "./events.js";
+import { grokNotificationIsReplay, grokNotificationSessionId, parseGrokModelState } from "./events.js";
 
 export const GROK_ACP_PROTOCOL_VERSION = 1;
 
@@ -112,7 +122,7 @@ export function mapGrokAcpMcpServers(
   return mapped;
 }
 
-export type GrokAcpFailurePhase = "initialize" | "session_new" | "session_load" | "prompt";
+export type GrokAcpFailurePhase = "initialize" | "session_new" | "session_load" | "set_model" | "prompt";
 
 export type GrokAcpAttemptInput = {
   supervisor: ProviderProcessSupervisor;
@@ -127,9 +137,23 @@ export type GrokAcpAttemptInput = {
   /** Confirmed provider session id to `session/load`; null runs `session/new`. */
   resumeSessionId: string | null;
   mcpServers: AgentRuntimeConfigPayload["mcpServers"];
+  /**
+   * Operator-configured model / reasoning effort for this turn ("" = provider
+   * default / no override). Applied via ACP `session/set_model` after EVERY
+   * session open (new AND load) because `session/load` restores the session's
+   * PERSISTED selection — mirroring Grok's own headless
+   * `apply_headless_model_and_effort`. An explicit model is always re-applied;
+   * an empty effort omits the effort meta; an empty model resolves to the
+   * initialize-advertised default model, so "" resets to the provider default
+   * rather than inheriting the load-restored value.
+   */
+  model: string;
+  reasoningEffort: string;
   promptText: string;
   /** Bounded wait for process close after stdin EOF on the success path. */
   eofCloseWaitMs?: number;
+  /** Grace between SIGTERM and SIGKILL on the terminate path (tests shorten this). */
+  killGraceMs?: number;
   /** Fired once initialize completed and capabilities validated (replay-ladder "saw provider" rung). */
   onInitialized?: () => void;
   /** Fired as soon as session/new or session/load confirms the active session id. */
@@ -157,8 +181,79 @@ function toError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err));
 }
 
+/** Cap on the JSON-RPC error `data` payload preserved in classification text. */
+const ACP_ERROR_DATA_CAP = 256;
+
+/**
+ * Error message for classification/log surfaces, preserving the ACP
+ * RequestError's `data` payload (length-capped, never the whole object
+ * graph). The real unknown-model failure is `Invalid params` (-32602) with
+ * the actual reason only in `data` ("unknown model id").
+ */
+function acpErrorDetail(err: unknown): string {
+  const base = toError(err).message;
+  if (!err || typeof err !== "object" || !("data" in err)) return base;
+  const data = err.data;
+  if (data === undefined || data === null) return base;
+  const text = typeof data === "string" ? data : JSON.stringify(data) || "";
+  const capped = text.trim().slice(0, ACP_ERROR_DATA_CAP);
+  return capped.length > 0 ? `${base} (data: ${capped})` : base;
+}
+
+/** Bounded wait for a reclaimed non-piped child to die after SIGKILL. */
+const UNPIPED_RECLAIM_WAIT_MS = 5_000;
+
+/**
+ * Reclaim a spawned child whose stdio turned out not to be piped (defensive
+ * branch — a non-piped child cannot be negotiated with). Fail closed with an
+ * immediate process-tree SIGKILL, then bounded-wait for the close so the
+ * caller never returns while the process is still running. The close waiter
+ * is registered BEFORE the kill (and an already-exited child short-circuits)
+ * so a fast close is never missed behind the full deadline.
+ */
+async function reclaimUnpipedChild(child: {
+  pid?: number | undefined;
+  exitCode?: number | null;
+  signalCode?: NodeJS.Signals | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  once(event: "close", listener: () => void): unknown;
+}): Promise<void> {
+  const waiter = new Promise<void>((resolve) => {
+    const deadline = setTimeout(resolve, UNPIPED_RECLAIM_WAIT_MS);
+    deadline.unref?.();
+    child.once("close", () => {
+      clearTimeout(deadline);
+      resolve();
+    });
+  });
+  if (child.exitCode !== null && child.exitCode !== undefined) return;
+  if (child.signalCode !== null && child.signalCode !== undefined) return;
+  try {
+    if (process.platform !== "win32" && child.pid) process.kill(-child.pid, "SIGKILL");
+    else child.kill("SIGKILL");
+  } catch {
+    // The process may already be gone.
+  }
+  await waiter;
+}
+
 function asMeta(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+/**
+ * Prompt correlation id carried on a routed notification, when present:
+ * `_meta.promptId` (extension envelopes) or the snake/camel `prompt_id` on
+ * the update payload (e.g. `turn_completed`).
+ */
+function notificationPromptId(params: unknown): string | null {
+  const record = asMeta(params);
+  const meta = asMeta(record?._meta);
+  if (typeof meta?.promptId === "string") return meta.promptId;
+  const update = asMeta(record?.update);
+  if (typeof update?.prompt_id === "string") return update.prompt_id;
+  if (typeof update?.promptId === "string") return update.promptId;
+  return null;
 }
 
 /**
@@ -197,6 +292,7 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
   }
   const child = supervised.child;
   if (!child.stdin || !child.stdout || !child.stderr) {
+    await reclaimUnpipedChild(child);
     return {
       sessionId: null,
       prompt: null,
@@ -215,6 +311,8 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
   let spawnError: Error | undefined;
   let closed: { exitCode: number | null; signal: NodeJS.Signals | null } | null = null;
   let terminated = false;
+  let hardKill: NodeJS.Timeout | null = null;
+  let finalDeadline: NodeJS.Timeout | null = null;
   let resolveClose: () => void = () => {};
   const closeWait = new Promise<void>((resolve) => {
     resolveClose = resolve;
@@ -229,16 +327,35 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
     }
   };
 
+  /**
+   * The SIGKILL/final-deadline timers MUST be cancelled once the child really
+   * closes: on POSIX the kill targets a PGID, and a stale timer can fire
+   * against a REUSED PGID under short-process high concurrency, killing an
+   * unrelated later turn.
+   */
+  const clearTerminateTimers = (): void => {
+    if (hardKill) {
+      clearTimeout(hardKill);
+      hardKill = null;
+    }
+    if (finalDeadline) {
+      clearTimeout(finalDeadline);
+      finalDeadline = null;
+    }
+  };
+
+  const killGraceMs = input.killGraceMs ?? KILL_GRACE_MS;
+
   const terminate = (): void => {
     if (terminated) return;
     terminated = true;
     killTree("SIGTERM");
-    const hardKill = setTimeout(() => killTree("SIGKILL"), KILL_GRACE_MS);
+    hardKill = setTimeout(() => killTree("SIGKILL"), killGraceMs);
     hardKill.unref?.();
-    const finalDeadline = setTimeout(() => {
+    finalDeadline = setTimeout(() => {
       closed ??= { exitCode: null, signal: "SIGKILL" };
       resolveClose();
-    }, KILL_GRACE_MS + FINAL_CLOSE_WAIT_MS);
+    }, killGraceMs + FINAL_CLOSE_WAIT_MS);
     finalDeadline.unref?.();
   };
 
@@ -252,10 +369,12 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
   child.on("error", (err) => {
     spawnError = toError(err);
     closed ??= { exitCode: null, signal: null };
+    clearTerminateTimers();
     resolveClose();
   });
   child.on("close", (exitCode, signal) => {
     closed = { exitCode, signal };
+    clearTerminateTimers();
     resolveClose();
   });
 
@@ -269,9 +388,21 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
   let promptSent = false;
   let replayDrops = 0;
   let lastInboundAt = 0;
+  /** Client-generated correlation id for the in-flight prompt (null until sent). */
+  let attemptPromptId: string | null = null;
   const pendingNotifications = new Set<Promise<void>>();
 
   const routeNotification = (params: unknown, deliver: (value: unknown) => void, channel: string): void => {
+    // Exact replay contract (Grok's own headless uses it): a notification
+    // marked `_meta.isReplay === true` is ALWAYS historical, regardless of
+    // when it arrives — drop it even inside the prompt window.
+    if (grokNotificationIsReplay(params)) {
+      if (replayDrops < REPLAY_DROP_LOG_LIMIT) {
+        input.log(`grok ACP: dropped replay-marked ${channel} notification (_meta.isReplay)`);
+      }
+      replayDrops++;
+      return;
+    }
     if (!promptSent) {
       if (replayDrops < REPLAY_DROP_LOG_LIMIT) {
         input.log(`grok ACP: dropped pre-prompt ${channel} notification (session/load replay fence)`);
@@ -282,6 +413,13 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
     const routedSessionId = grokNotificationSessionId(params);
     if (currentSessionId && routedSessionId && routedSessionId !== currentSessionId) {
       input.log(`grok ACP: dropped ${channel} notification for foreign session ${routedSessionId}`);
+      return;
+    }
+    // Prompt correlation: anything stamped with a DIFFERENT prompt id than
+    // the in-flight prompt belongs to another prompt (e.g. history) — drop.
+    const correlatedPromptId = notificationPromptId(params);
+    if (attemptPromptId && correlatedPromptId && correlatedPromptId !== attemptPromptId) {
+      input.log(`grok ACP: dropped ${channel} notification for foreign prompt ${correlatedPromptId}`);
       return;
     }
     const tracked = Promise.resolve()
@@ -347,15 +485,62 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
     ...(failure ? { failure } : {}),
   });
 
-  const failAndDrain = async (phase: GrokAcpFailurePhase, err: unknown): Promise<GrokAcpAttemptOutcome> => {
-    failure = { phase, error: toError(err) };
+  /**
+   * Drain the routed-handler queue to a STABLE empty. The SDK dispatches
+   * notification handlers asynchronously, so after the connection closes a
+   * dispatch chain may still be queued behind a macrotask; settlement state
+   * must not be read until every routed notification has landed.
+   */
+  const drainPendingNotifications = async (): Promise<void> => {
+    for (let idlePasses = 0, guard = 0; guard < 50; guard++) {
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      if (pendingNotifications.size === 0) {
+        idlePasses++;
+        if (idlePasses >= 2) return;
+        continue;
+      }
+      idlePasses = 0;
+      await Promise.all([...pendingNotifications]);
+    }
+  };
+
+  /**
+   * Unified transport-settle barrier (success AND failure paths):
+   * EOF/terminate FIRST, then a bounded wait for the real child close and
+   * the connection teardown, then drain the routed-handler queue — only
+   * then may the caller read settlement state.
+   */
+  const settleBarrier = async (): Promise<void> => {
     try {
       childStdin.end();
     } catch {
       /* already gone */
     }
-    terminate();
+    if (input.abortSignal.aborted) terminate();
+    const eofDeadline = setTimeout(() => {
+      input.log("grok ACP: process did not exit after stdin EOF; terminating the process tree");
+      terminate();
+    }, input.eofCloseWaitMs ?? FINAL_CLOSE_WAIT_MS);
+    eofDeadline.unref?.();
     await closeWait;
+    clearTimeout(eofDeadline);
+    try {
+      await connection.closed;
+    } catch {
+      // Connection teardown errors carry no extra settlement signal.
+    }
+    await drainPendingNotifications();
+  };
+
+  const failAndDrain = async (phase: GrokAcpFailurePhase, err: unknown): Promise<GrokAcpAttemptOutcome> => {
+    failure = { phase, error: new Error(acpErrorDetail(err)) };
+    // Same settle barrier as the success path: EOF first, bounded close
+    // wait, connection teardown, stable handler drain. terminate only fires
+    // on abort or when the EOF grace expires — so write/usage notifications
+    // dispatched on the tick AFTER a JSON-RPC error are not cut off.
+    await settleBarrier();
     return outcome();
   };
 
@@ -395,10 +580,14 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
       sse: agentCapabilities?.mcpCapabilities?.sse === true,
     };
     input.onInitialized?.();
+    const initializeModelState = parseGrokModelState(initResponse);
 
     // 2. session/new (first turn) or session/load (resume). A session/load
     // failure is terminal for the attempt — never silently re-run as
     // session/new (a fresh session could re-execute side effects).
+    // `_meta.noReplay: true` is the exact replay contract Grok's own headless
+    // resume sends; historical traffic is additionally dropped via the
+    // `_meta.isReplay` marker and (legacy fallback) the pre-prompt fence.
     const mappedServers = mapGrokAcpMcpServers(input.mcpServers, mcpCapabilities, input.log);
     if (input.resumeSessionId) {
       try {
@@ -406,7 +595,7 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
           sessionId: input.resumeSessionId,
           cwd: input.cwd,
           mcpServers: mappedServers,
-          _meta: { yoloMode: true },
+          _meta: { yoloMode: true, noReplay: true },
         });
       } catch (err) {
         return await failAndDrain("session_load", err);
@@ -426,6 +615,55 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
       currentSessionId = newSessionResponse.sessionId;
     }
     input.onSessionId?.(currentSessionId);
+
+    // 2b. Apply model/effort after EVERY session open, every turn (Grok's
+    // headless apply_headless_model_and_effort does the same after
+    // open_session): session/load restores the session's PERSISTED
+    // selection, so even an EMPTY config must re-assert the default — empty
+    // model = the INITIALIZE-advertised current model (NOT the load-restored
+    // one), empty effort = no effort meta (provider default). A set_model
+    // rejection is a configuration failure — never silently fall back to the
+    // persisted selection. Fail closed when the provider advertised no
+    // current model to apply.
+    const effectiveModelId = input.model || initializeModelState.defaultModelId;
+    if (!effectiveModelId) {
+      return await failAndDrain(
+        "set_model",
+        new Error("grok provider mismatch: the provider advertised no current model to apply for this turn"),
+      );
+    }
+    try {
+      const setModelResponse: unknown = await agent.request("session/set_model", {
+        sessionId: currentSessionId,
+        modelId: effectiveModelId,
+        // Empty effort must OMIT `_meta` entirely — serializing null is not
+        // the same as omitting the effort meta (it would not restore the
+        // provider default).
+        ...(input.reasoningEffort ? { _meta: { reasoningEffort: input.reasoningEffort } } : {}),
+      });
+      // The success shape (verified live on 0.2.117) is
+      // `_meta.model.Ok === <applied modelId>`; anything else is provider
+      // misbehavior — fail closed, never prompt under an unverified model.
+      const setModelResult = asMeta(asMeta(asMeta(setModelResponse)?._meta)?.model);
+      const appliedModelId = typeof setModelResult?.Ok === "string" ? setModelResult.Ok : null;
+      if (appliedModelId !== effectiveModelId) {
+        return await failAndDrain(
+          "set_model",
+          new Error(
+            `grok provider mismatch: session/set_model response did not confirm model "${effectiveModelId}" ` +
+              `(got ${appliedModelId ?? "no _meta.model.Ok"})`,
+          ),
+        );
+      }
+    } catch (err) {
+      return await failAndDrain(
+        "set_model",
+        new Error(
+          `grok provider mismatch: session/set_model rejected model "${effectiveModelId}"` +
+            `${input.reasoningEffort ? ` with effort "${input.reasoningEffort}"` : ""}: ${acpErrorDetail(err)}`,
+        ),
+      );
+    }
 
     if (input.resumeSessionId) {
       // Replay drain: historical updates arrive right after the load
@@ -451,38 +689,45 @@ export async function runGrokAcpAttempt(input: GrokAcpAttemptInput): Promise<Gro
       }
     }
 
-    // 3. session/prompt — the replay fence opens only now.
+    // 3. session/prompt — the replay fence opens only now. A client-generated
+    // promptId rides `_meta.promptId` (Grok honors it); notifications and the
+    // prompt RESPONSE are correlated against it.
+    attemptPromptId = randomUUID();
     promptSent = true;
     promptInFlight = true;
     try {
       const promptResponse = await agent.request("session/prompt", {
         sessionId: currentSessionId,
         prompt: [{ type: "text", text: input.promptText }],
+        _meta: { promptId: attemptPromptId },
       });
-      promptResult = { stopReason: promptResponse.stopReason, meta: asMeta(promptResponse._meta) };
+      const responseMeta = asMeta(promptResponse._meta);
+      const responsePromptId = typeof responseMeta?.promptId === "string" ? responseMeta.promptId : null;
+      if (responsePromptId !== attemptPromptId) {
+        // Exact-correlation contract: the response MUST echo the client
+        // promptId — a missing or different one fails closed.
+        return await failAndDrain(
+          "prompt",
+          new Error(
+            `grok provider mismatch: prompt response carried promptId ${responsePromptId ?? "(none)"} ` +
+              `(expected ${attemptPromptId})`,
+          ),
+        );
+      }
+      promptResult = { stopReason: promptResponse.stopReason, meta: responseMeta };
     } catch (err) {
       return await failAndDrain("prompt", err);
     } finally {
       promptInFlight = false;
     }
 
-    // 4. Settlement barrier: drain queued notification handlers, then end
-    // stdin and require the process to close with exit 0 (Grok exits 0 on
-    // clean EOF). The close wait is BOUNDED: a process that answered the
-    // prompt but never exits is reclaimed through the terminate path and
-    // lands as a non-clean exit (a failure input, never a silent success).
-    while (pendingNotifications.size > 0) {
-      await Promise.all([...pendingNotifications]);
-    }
-    childStdin.end();
-    if (input.abortSignal.aborted) terminate();
-    const eofDeadline = setTimeout(() => {
-      input.log("grok ACP: process did not exit after stdin EOF; terminating the process tree");
-      terminate();
-    }, input.eofCloseWaitMs ?? FINAL_CLOSE_WAIT_MS);
-    eofDeadline.unref?.();
-    await closeWait;
-    clearTimeout(eofDeadline);
+    // 4. Settlement barrier: EOF first, then a bounded wait for the real
+    // close + connection teardown, then drain the routed-handler queue to a
+    // stable empty — settlement state is read only after late-dispatched
+    // notifications have landed. A process that answered the prompt but
+    // never exits is reclaimed through the terminate path and lands as a
+    // non-clean exit (a failure input, never a silent success).
+    await settleBarrier();
     return outcome();
   } finally {
     input.abortSignal.removeEventListener("abort", onAbort);
@@ -523,6 +768,7 @@ export async function fetchGrokAcpInitializeMeta(input: {
     return { ok: false, error: toError(err).message };
   }
   if (!child.stdin || !child.stdout) {
+    await reclaimUnpipedChild(child);
     return { ok: false, error: "grok ACP child stdio is not piped" };
   }
   const childStdin = child.stdin;
@@ -544,13 +790,27 @@ export async function fetchGrokAcpInitializeMeta(input: {
     }
   };
   let terminated = false;
+  let hardKill: NodeJS.Timeout | null = null;
+  let finalDeadline: NodeJS.Timeout | null = null;
+  /** Cancel pending kill timers once the child really closes (see the turn
+   * transport: a stale timer can SIGKILL a REUSED PGID under concurrency). */
+  const clearTerminateTimers = (): void => {
+    if (hardKill) {
+      clearTimeout(hardKill);
+      hardKill = null;
+    }
+    if (finalDeadline) {
+      clearTimeout(finalDeadline);
+      finalDeadline = null;
+    }
+  };
   const terminate = (): void => {
     if (terminated) return;
     terminated = true;
     killTree("SIGTERM");
-    const hardKill = setTimeout(() => killTree("SIGKILL"), KILL_GRACE_MS);
+    hardKill = setTimeout(() => killTree("SIGKILL"), KILL_GRACE_MS);
     hardKill.unref?.();
-    const finalDeadline = setTimeout(() => {
+    finalDeadline = setTimeout(() => {
       closed ??= { exitCode: null, signal: "SIGKILL" };
       resolveClose();
     }, KILL_GRACE_MS + FINAL_CLOSE_WAIT_MS);
@@ -571,10 +831,12 @@ export async function fetchGrokAcpInitializeMeta(input: {
   child.on("error", (err) => {
     spawnError = toError(err);
     closed ??= { exitCode: null, signal: null };
+    clearTerminateTimers();
     resolveClose();
   });
   child.on("close", (exitCode, signal) => {
     closed = { exitCode, signal };
+    clearTerminateTimers();
     resolveClose();
   });
 
@@ -589,7 +851,16 @@ export async function fetchGrokAcpInitializeMeta(input: {
       clientCapabilities: {},
       clientInfo: { name: "first-tree", version: input.clientVersion },
     });
-    meta = asMeta(initResponse._meta);
+    if (initResponse.protocolVersion !== GROK_ACP_PROTOCOL_VERSION) {
+      // The turn handler would reject the same build; the UI must not publish
+      // a model catalog from an incompatible protocol.
+      initError = new Error(
+        `grok provider mismatch: ACP protocolVersion ${String(initResponse.protocolVersion)} ` +
+          `(expected ${GROK_ACP_PROTOCOL_VERSION})`,
+      );
+    } else {
+      meta = asMeta(initResponse._meta);
+    }
   } catch (err) {
     initError = toError(err);
   }

--- a/packages/client/src/handlers/grok/events.ts
+++ b/packages/client/src/handlers/grok/events.ts
@@ -1,0 +1,274 @@
+/**
+ * Pure, tolerant normalization of Grok Build ACP wire traffic into internal
+ * events. Two inbound channels are covered:
+ *
+ *   - the standard `session/update` notification (`params.update`), and
+ *   - x.ai's extension notifications `_x.ai/session_notification` and
+ *     `_x.ai/session/update`, which carry snake_case payloads such as
+ *     `turn_completed` usage.
+ *
+ * Tolerance contract (same as the cursor stream parser): unknown update
+ * kinds, missing optional fields, and malformed payloads NEVER throw — they
+ * degrade to `{ kind: "ignored" }` carrying a diagnostic note. The handler
+ * decides what is a protocol failure; this module only reads.
+ *
+ * Wire shapes locked against real Grok 0.2.117 traffic.
+ */
+
+import type { ProviderModelOption } from "@first-tree/shared";
+
+/** Usage carried by `_x.ai/session_notification` `turn_completed` (one per prompt). */
+export type GrokUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cachedReadTokens: number;
+};
+
+export type GrokTurnCompleted = {
+  /** Correlates this completion with the prompt response `_meta.promptId`. */
+  promptId: string | null;
+  stopReason: string | null;
+  usage: GrokUsage | null;
+  /** Provider cost accounting has no SessionEvent field — log-only. */
+  costUsdTicks: number | null;
+  modelCalls: number | null;
+  apiDurationMs: number | null;
+};
+
+/**
+ * One tool invocation, normalized from `tool_call` / `tool_call_update`.
+ * `readOnly` is tri-state: `true` only when the provider's
+ * `_meta["x.ai/tool"].read_only` explicitly says so; anything else (false,
+ * absent, malformed) is unproven and must count as a side effect on the
+ * replay-safety ladder.
+ */
+export type GrokToolInfo = {
+  toolCallId: string;
+  /** `_meta["x.ai/tool"].name` when present, else the raw `title`, else a tagged unknown. */
+  name: string;
+  kind: string | null;
+  readOnly: boolean | null;
+  /** Shell command for `run_terminal_cmd` (from `rawInput.command`). */
+  command: string | null;
+  /** Candidate file paths: `_meta["x.ai/tool"].input.path`, locations, diff content. */
+  paths: string[];
+  argsSummary: Record<string, unknown>;
+};
+
+export type GrokNormalizedEvent =
+  | { kind: "assistant_chunk"; text: string }
+  | { kind: "thought_chunk" }
+  | { kind: "user_echo" }
+  | { kind: "tool_started"; tool: GrokToolInfo }
+  | { kind: "tool_completed"; tool: GrokToolInfo; ok: boolean; resultPreview: string | null }
+  | { kind: "plan" }
+  | { kind: "turn_completed"; completed: GrokTurnCompleted }
+  | { kind: "ignored"; note: string };
+
+const RESULT_PREVIEW_LIMIT = 400;
+const XAI_TOOL_META_KEY = "x.ai/tool";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function contentText(content: unknown): string {
+  const record = asRecord(content);
+  if (record?.type === "text" && typeof record.text === "string") return record.text;
+  return "";
+}
+
+function xaiToolMeta(update: Record<string, unknown>): Record<string, unknown> | null {
+  const meta = asRecord(update._meta);
+  return meta ? asRecord(meta[XAI_TOOL_META_KEY]) : null;
+}
+
+function pushPath(paths: string[], seen: Set<string>, value: unknown): void {
+  if (typeof value !== "string" || value.length === 0 || seen.has(value)) return;
+  seen.add(value);
+  paths.push(value);
+}
+
+function extractToolPaths(update: Record<string, unknown>, meta: Record<string, unknown> | null): string[] {
+  const paths: string[] = [];
+  const seen = new Set<string>();
+  const metaInput = meta ? asRecord(meta.input) : null;
+  pushPath(paths, seen, metaInput?.path);
+  const locations = update.locations;
+  if (Array.isArray(locations)) {
+    for (const location of locations) pushPath(paths, seen, asRecord(location)?.path);
+  }
+  const content = update.content;
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      const record = asRecord(block);
+      if (record?.type === "diff") pushPath(paths, seen, record.path);
+    }
+  }
+  return paths;
+}
+
+function toolArgsSummary(command: string | null, paths: string[]): Record<string, unknown> {
+  if (command) return { command };
+  const path = paths[0];
+  if (path) return { path };
+  return {};
+}
+
+function extractTool(update: Record<string, unknown>): GrokToolInfo | null {
+  const toolCallId = asString(update.toolCallId);
+  if (!toolCallId) return null;
+  const meta = xaiToolMeta(update);
+  const rawInput = asRecord(update.rawInput);
+  const command = asString(rawInput?.command);
+  const title = asString(update.title);
+  const metaName = meta ? asString(meta.name) : null;
+  const readOnly = meta && typeof meta.read_only === "boolean" ? meta.read_only : null;
+  const paths = extractToolPaths(update, meta);
+  return {
+    toolCallId,
+    name: metaName ?? title ?? "grok:unknown",
+    kind: meta ? asString(meta.kind) : null,
+    readOnly,
+    command,
+    paths,
+    argsSummary: toolArgsSummary(command, paths),
+  };
+}
+
+function extractUsage(usage: unknown): GrokUsage | null {
+  const record = asRecord(usage);
+  if (!record) return null;
+  const inputTokens = asFiniteNumber(record.inputTokens);
+  const outputTokens = asFiniteNumber(record.outputTokens);
+  const cachedReadTokens = asFiniteNumber(record.cachedReadTokens);
+  if (inputTokens === null && outputTokens === null && cachedReadTokens === null) return null;
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    cachedReadTokens: cachedReadTokens ?? 0,
+  };
+}
+
+/** Session id carried on a routed ACP notification, when present. */
+export function grokNotificationSessionId(params: unknown): string | null {
+  return asString(asRecord(params)?.sessionId);
+}
+
+/**
+ * Normalize one standard `session/update` notification. Returns null when the
+ * payload has no recognizable envelope at all.
+ */
+export function normalizeGrokSessionUpdate(params: unknown): {
+  sessionId: string | null;
+  event: GrokNormalizedEvent;
+} | null {
+  const record = asRecord(params);
+  const update = asRecord(record?.update);
+  if (!record || !update) return null;
+  const sessionId = asString(record.sessionId);
+  const sessionUpdate = asString(update.sessionUpdate);
+
+  switch (sessionUpdate) {
+    case "agent_message_chunk":
+      return { sessionId, event: { kind: "assistant_chunk", text: contentText(update.content) } };
+    case "agent_thought_chunk":
+      return { sessionId, event: { kind: "thought_chunk" } };
+    case "user_message_chunk":
+      return { sessionId, event: { kind: "user_echo" } };
+    case "tool_call": {
+      const tool = extractTool(update);
+      if (!tool) return { sessionId, event: { kind: "ignored", note: "tool_call without toolCallId" } };
+      return { sessionId, event: { kind: "tool_started", tool } };
+    }
+    case "tool_call_update": {
+      const tool = extractTool(update);
+      if (!tool) return { sessionId, event: { kind: "ignored", note: "tool_call_update without toolCallId" } };
+      const status = asString(update.status);
+      if (status !== "completed" && status !== "failed") {
+        return { sessionId, event: { kind: "ignored", note: `tool_call_update status ${status ?? "unknown"}` } };
+      }
+      const rawOutput = asString(update.rawOutput);
+      const preview = rawOutput && rawOutput.trim().length > 0 ? rawOutput.slice(0, RESULT_PREVIEW_LIMIT) : null;
+      return { sessionId, event: { kind: "tool_completed", tool, ok: status === "completed", resultPreview: preview } };
+    }
+    case "plan":
+      return { sessionId, event: { kind: "plan" } };
+    default:
+      return { sessionId, event: { kind: "ignored", note: `sessionUpdate kind ${sessionUpdate ?? "unknown"}` } };
+  }
+}
+
+/**
+ * Normalize one x.ai extension notification (`_x.ai/session_notification` or
+ * `_x.ai/session/update`). The only payload with event semantics is
+ * `turn_completed` — THE per-prompt usage source. `response_completed` is
+ * per-model-call with snake_case fields and must never be summed in, so it
+ * degrades to ignored like every other extension kind.
+ */
+export function normalizeGrokXaiNotification(params: unknown): {
+  sessionId: string | null;
+  event: GrokNormalizedEvent;
+} | null {
+  const record = asRecord(params);
+  const update = asRecord(record?.update);
+  if (!record || !update) return null;
+  const sessionId = asString(record.sessionId);
+  const sessionUpdate = asString(update.sessionUpdate);
+
+  if (sessionUpdate === "turn_completed") {
+    return {
+      sessionId,
+      event: {
+        kind: "turn_completed",
+        completed: {
+          promptId: asString(update.prompt_id),
+          stopReason: asString(update.stop_reason),
+          usage: extractUsage(update.usage),
+          costUsdTicks: asFiniteNumber(update.usage ? asRecord(update.usage)?.costUsdTicks : null),
+          modelCalls: asFiniteNumber(update.usage ? asRecord(update.usage)?.modelCalls : null),
+          apiDurationMs: asFiniteNumber(update.usage ? asRecord(update.usage)?.apiDurationMs : null),
+        },
+      },
+    };
+  }
+  return { sessionId, event: { kind: "ignored", note: `x.ai sessionUpdate kind ${sessionUpdate ?? "unknown"}` } };
+}
+
+/**
+ * Parse the initialize response `_meta.modelState` into a model catalog
+ * (shared by model discovery and the handler's default-model bookkeeping).
+ * `currentModelId` marks the provider's current/default entry.
+ */
+export function parseGrokModelState(initializeResponse: unknown): {
+  models: ProviderModelOption[];
+  defaultModelId: string | null;
+} {
+  const meta = asRecord(asRecord(initializeResponse)?._meta);
+  const modelState = asRecord(meta?.modelState);
+  if (!modelState) return { models: [], defaultModelId: null };
+  const currentModelId = asString(modelState.currentModelId);
+  const available = Array.isArray(modelState.availableModels) ? modelState.availableModels : [];
+  const models: ProviderModelOption[] = [];
+  for (const entry of available) {
+    const record = asRecord(entry);
+    const modelId = asString(record?.modelId);
+    if (!modelId) continue;
+    const name = asString(record?.name);
+    const isDefault = currentModelId !== null && modelId === currentModelId;
+    models.push({
+      id: modelId,
+      label: name && name.length > 0 ? name : modelId,
+      ...(isDefault ? { isDefault: true, hint: "default" } : {}),
+    });
+  }
+  return { models, defaultModelId: currentModelId };
+}

--- a/packages/client/src/handlers/grok/events.ts
+++ b/packages/client/src/handlers/grok/events.ts
@@ -47,8 +47,14 @@ export type GrokToolInfo = {
   /** `_meta["x.ai/tool"].name` when present, else the raw `title`, else a tagged unknown. */
   name: string;
   kind: string | null;
+  /**
+   * True for the shell/execute tool (`run_terminal_cmd` or kind "execute"),
+   * keyed on name/kind — NOT on the presence of a command. A shell tool whose
+   * command is missing must fail CLOSED (unsafe), never inherit read-only.
+   */
+  isShell: boolean;
   readOnly: boolean | null;
-  /** Shell command for `run_terminal_cmd` (from `rawInput.command`). */
+  /** Shell command: `rawInput.command`, else `_meta["x.ai/tool"].input.command`. */
   command: string | null;
   /** Candidate file paths: `_meta["x.ai/tool"].input.path`, locations, diff content. */
   paths: string[];
@@ -127,16 +133,20 @@ function extractTool(update: Record<string, unknown>): GrokToolInfo | null {
   const toolCallId = asString(update.toolCallId);
   if (!toolCallId) return null;
   const meta = xaiToolMeta(update);
+  const metaInput = meta ? asRecord(meta.input) : null;
   const rawInput = asRecord(update.rawInput);
-  const command = asString(rawInput?.command);
+  const command = asString(rawInput?.command) ?? asString(metaInput?.command);
   const title = asString(update.title);
   const metaName = meta ? asString(meta.name) : null;
+  const kind = meta ? asString(meta.kind) : null;
+  const name = metaName ?? title ?? "grok:unknown";
   const readOnly = meta && typeof meta.read_only === "boolean" ? meta.read_only : null;
   const paths = extractToolPaths(update, meta);
   return {
     toolCallId,
-    name: metaName ?? title ?? "grok:unknown",
-    kind: meta ? asString(meta.kind) : null,
+    name,
+    kind,
+    isShell: name === "run_terminal_cmd" || kind === "execute",
     readOnly,
     command,
     paths,
@@ -161,6 +171,15 @@ function extractUsage(usage: unknown): GrokUsage | null {
 /** Session id carried on a routed ACP notification, when present. */
 export function grokNotificationSessionId(params: unknown): string | null {
   return asString(asRecord(params)?.sessionId);
+}
+
+/**
+ * The exact replay marker (`params._meta.isReplay === true`) Grok stamps on
+ * historical traffic. A marked notification is ALWAYS replay, no matter when
+ * it arrives — the marker, not arrival timing, is the correctness boundary.
+ */
+export function grokNotificationIsReplay(params: unknown): boolean {
+  return asRecord(asRecord(params)?._meta)?.isReplay === true;
 }
 
 /**

--- a/packages/client/src/handlers/grok/events.ts
+++ b/packages/client/src/handlers/grok/events.ts
@@ -174,6 +174,25 @@ export function grokNotificationSessionId(params: unknown): string | null {
 }
 
 /**
+ * Parse the `_x.ai/session_notification` `model_changed` echo Grok emits in
+ * response to `session/set_model` (real 0.2.117 wire shape, snake_case):
+ * `{sessionId, update: {sessionUpdate: "model_changed", model_id, reasoning_effort?}}`.
+ * Returns null for any other payload. `reasoningEffort` is null when the
+ * echo omits the field (e.g. the provider ignored the override).
+ */
+export function parseGrokModelChangedEcho(params: unknown): {
+  modelId: string | null;
+  reasoningEffort: string | null;
+} | null {
+  const update = asRecord(asRecord(params)?.update);
+  if (asString(update?.sessionUpdate) !== "model_changed") return null;
+  return {
+    modelId: asString(update?.model_id),
+    reasoningEffort: asString(update?.reasoning_effort),
+  };
+}
+
+/**
  * The exact replay marker (`params._meta.isReplay === true`) Grok stamps on
  * historical traffic. A marked notification is ALWAYS replay, no matter when
  * it arrives — the marker, not arrival timing, is the correctness boundary.

--- a/packages/client/src/handlers/grok/index.ts
+++ b/packages/client/src/handlers/grok/index.ts
@@ -196,6 +196,14 @@ export const createGrokHandler: HandlerFactory = (config) => {
     typeof config.grokEofCloseWaitMs === "number" && config.grokEofCloseWaitMs > 0
       ? config.grokEofCloseWaitMs
       : undefined;
+  const setModelEchoWaitMs =
+    typeof config.grokSetModelEchoWaitMs === "number" && config.grokSetModelEchoWaitMs > 0
+      ? config.grokSetModelEchoWaitMs
+      : undefined;
+  const replayDrainCapMs =
+    typeof config.grokReplayDrainCapMs === "number" && config.grokReplayDrainCapMs > 0
+      ? config.grokReplayDrainCapMs
+      : undefined;
 
   let cwd: string | null = null;
   let ctx: SessionContext | null = null;
@@ -654,6 +662,8 @@ export const createGrokHandler: HandlerFactory = (config) => {
           reasoningEffort,
           promptText: providerInput,
           ...(eofCloseWaitMs ? { eofCloseWaitMs } : {}),
+          ...(setModelEchoWaitMs ? { setModelEchoWaitMs } : {}),
+          ...(replayDrainCapMs ? { replayDrainCapMs } : {}),
           onInitialized: () => {
             if (turnGeneration === generation && !abort.signal.aborted) state.sawInit = true;
           },

--- a/packages/client/src/handlers/grok/index.ts
+++ b/packages/client/src/handlers/grok/index.ts
@@ -114,6 +114,19 @@ export function isGrokPendingSessionId(sessionId: string): boolean {
  */
 const GROK_CLIENT_VERSION = "0";
 
+/**
+ * ACP v1 stop reasons that are prompt COMPLETIONS: the provider finished the
+ * turn and the accumulated output is the turn's result. Only `cancelled`
+ * takes the abort/redelivery path; any OTHER unknown value stays a provider
+ * error (conservative against future wire additions).
+ */
+const GROK_COMPLETION_STOP_REASONS: ReadonlySet<string> = new Set([
+  "end_turn",
+  "max_tokens",
+  "max_turn_requests",
+  "refusal",
+]);
+
 type GrokRetrySleep = (delayMs: number, signal: AbortSignal) => Promise<void>;
 
 function defaultGrokRetrySleep(delayMs: number, signal: AbortSignal): Promise<void> {
@@ -178,6 +191,10 @@ export const createGrokHandler: HandlerFactory = (config) => {
   const resolveBinary =
     (config.grokBinaryResolver as typeof resolveGrokRuntimeBinary | undefined) ?? resolveGrokRuntimeBinary;
   const retrySleep = (config.grokRetrySleep as GrokRetrySleep | undefined) ?? defaultGrokRetrySleep;
+  const eofCloseWaitMs =
+    typeof config.grokEofCloseWaitMs === "number" && config.grokEofCloseWaitMs > 0
+      ? config.grokEofCloseWaitMs
+      : undefined;
 
   let cwd: string | null = null;
   let ctx: SessionContext | null = null;
@@ -592,6 +609,12 @@ export const createGrokHandler: HandlerFactory = (config) => {
     let retryStatus: "success" | "error" = "error";
     let providerCompleted = false;
     let anyUserVisible = false;
+    /**
+     * Carried across attempts exactly like anyUserVisible: a side effect from
+     * an earlier attempt must keep EVERY later attempt's replay-safety at
+     * unsafe — resetting it per attempt could auto-replay after a write.
+     */
+    let anyToolEffect = false;
 
     const promise = (async () => {
       for (let attempt = 0; ; attempt++) {
@@ -599,7 +622,7 @@ export const createGrokHandler: HandlerFactory = (config) => {
           attempt: new ProviderAttempt({ provider: runtimeProvider, scope: "provider_turn", source: "stream" }),
           sawInit: false,
           userVisibleEmitted: anyUserVisible,
-          toolEffectStarted: false,
+          toolEffectStarted: anyToolEffect,
           thinkingEmitted: false,
           assistantText: "",
           turnCompleted: null,
@@ -627,6 +650,7 @@ export const createGrokHandler: HandlerFactory = (config) => {
           resumeSessionId: providerSessionId,
           mcpServers: turnPayload.mcpServers,
           promptText: providerInput,
+          ...(eofCloseWaitMs ? { eofCloseWaitMs } : {}),
           onInitialized: () => {
             if (turnGeneration === generation && !abort.signal.aborted) state.sawInit = true;
           },
@@ -648,6 +672,7 @@ export const createGrokHandler: HandlerFactory = (config) => {
         if (abort.signal.aborted || turnGeneration !== generation) return;
 
         anyUserVisible = anyUserVisible || state.userVisibleEmitted;
+        anyToolEffect = anyToolEffect || state.toolEffectStarted;
         // Billed tokens are billed regardless of how the turn settles — keep
         // the latest usage the provider reported so failed/consumed turns
         // still emit token_usage.
@@ -679,13 +704,14 @@ export const createGrokHandler: HandlerFactory = (config) => {
         };
 
         const prompt = outcome.prompt;
-        if (prompt && prompt.stopReason === "end_turn" && !outcome.spawnError && !outcome.failure) {
-          if (!outcome.cleanExit) {
-            // Non-zero exit AFTER a successful prompt response: the completed
-            // turn stands (verified Grok quirk on some builds).
+        const isCompletionStop = prompt !== null && GROK_COMPLETION_STOP_REASONS.has(prompt.stopReason);
+        if (prompt && isCompletionStop && !outcome.spawnError && !outcome.failure && outcome.cleanExit) {
+          // Every ACP v1 completion stop reason (end_turn / max_tokens /
+          // max_turn_requests / refusal) settles the turn with the
+          // accumulated output — the full drain MUST have exited 0.
+          if (prompt.stopReason !== "end_turn") {
             sessionCtx.log(
-              `grok process exited ${outcome.exitCode ?? `signal ${outcome.signal ?? "unknown"}`} ` +
-                "after a completed prompt; the completed turn stands",
+              `grok turn completed with stopReason "${prompt.stopReason}"; settling the accumulated output`,
             );
           }
           // Prompt-id correlation: discard replayed usage that belongs to a
@@ -716,23 +742,35 @@ export const createGrokHandler: HandlerFactory = (config) => {
         // Failure path. Auth / capacity / protocol failures commonly produce
         // NO prompt response — classify from the failure phase error, the
         // stopReason, or the stderr tail + exit status (mirror cursor's
-        // failureText assembly).
+        // failureText assembly). A COMPLETED prompt whose process did not
+        // exit 0 is a failure input too: the "full drain exits 0" boundary
+        // never silently ACKs a dirty exit as success.
         updateReplaySafety(state);
         const stderrText = outcome.stderrTail.trim();
         const phaseErrorText = outcome.failure ? outcome.failure.error.message.trim() : "";
-        const stopReasonText = prompt ? `grok turn stopped with stopReason "${prompt.stopReason}"` : "";
+        const dirtyExitText =
+          prompt && isCompletionStop
+            ? `grok process exited ${outcome.exitCode ?? `signal ${outcome.signal ?? "unknown"}`} ` +
+              "after a completed prompt (exit 0 required)"
+            : "";
+        const stopReasonText =
+          prompt && !isCompletionStop ? `grok turn stopped with stopReason "${prompt.stopReason}"` : "";
         const failureText =
           outcome.spawnError?.message ??
           (phaseErrorText
             ? stderrText
               ? `${phaseErrorText}\nstderr: ${stderrText}`
               : phaseErrorText
-            : stopReasonText
+            : dirtyExitText
               ? stderrText
-                ? `${stopReasonText}\nstderr: ${stderrText}`
-                : stopReasonText
-              : stderrText ||
-                `grok exited ${outcome.exitCode ?? `signal ${outcome.signal ?? "unknown"}`} without completing the prompt`);
+                ? `${dirtyExitText}\nstderr: ${stderrText}`
+                : dirtyExitText
+              : stopReasonText
+                ? stderrText
+                  ? `${stopReasonText}\nstderr: ${stderrText}`
+                  : stopReasonText
+                : stderrText ||
+                  `grok exited ${outcome.exitCode ?? `signal ${outcome.signal ?? "unknown"}`} without completing the prompt`);
         const failureError =
           outcome.spawnError && (outcome.spawnError as NodeJS.ErrnoException).code === "ENOENT"
             ? new Error(formatGrokBinaryMissingMessage(`the bound grok binary disappeared: ${activeBinary}`))

--- a/packages/client/src/handlers/grok/index.ts
+++ b/packages/client/src/handlers/grok/index.ts
@@ -154,13 +154,14 @@ export function grokShellCommandIsReadOnly(command: string | null): boolean {
 /**
  * True when a tool invocation is PROVEN read-only. The provider's
  * `_meta["x.ai/tool"].read_only === true` is required; a shell tool
- * (`run_terminal_cmd`, detected by its `command` input) must additionally
- * classify as a supported read. Anything else — read_only false, absent, or
- * unknown — is an unproven side effect and ends automatic replay.
+ * (`run_terminal_cmd` / kind "execute", keyed on name/kind) must
+ * additionally carry a command that classifies as a supported read — a
+ * missing command fails CLOSED (unsafe). Anything else — read_only false,
+ * absent, or unknown — is an unproven side effect and ends automatic replay.
  */
 export function grokToolIsReadOnly(tool: GrokToolInfo): boolean {
   if (tool.readOnly !== true) return false;
-  if (tool.command !== null) return grokShellCommandIsReadOnly(tool.command);
+  if (tool.isShell) return grokShellCommandIsReadOnly(tool.command);
   return true;
 }
 
@@ -364,8 +365,8 @@ export const createGrokHandler: HandlerFactory = (config) => {
   }
 
   function providerRefsForTool(tool: GrokToolInfo): ToolFileRef[] {
-    if (tool.command) {
-      return cwd
+    if (tool.isShell) {
+      return tool.command && cwd
         ? toolFileRefsFromShellCommand({
             command: tool.command,
             cwd,
@@ -649,6 +650,8 @@ export const createGrokHandler: HandlerFactory = (config) => {
           // turn (and any turn after a synthetic placeholder) runs session/new.
           resumeSessionId: providerSessionId,
           mcpServers: turnPayload.mcpServers,
+          model,
+          reasoningEffort,
           promptText: providerInput,
           ...(eofCloseWaitMs ? { eofCloseWaitMs } : {}),
           onInitialized: () => {
@@ -731,20 +734,14 @@ export const createGrokHandler: HandlerFactory = (config) => {
           providerCompleted = true;
           return;
         }
-        if (prompt && prompt.stopReason === "cancelled") {
-          // Provider-side cancel without a local abort settles as an aborted
-          // turn: redeliver, never consume.
-          retryReason = "grok_turn_cancelled";
-          retryStatus = "success";
-          return;
-        }
-
         // Failure path. Auth / capacity / protocol failures commonly produce
         // NO prompt response — classify from the failure phase error, the
-        // stopReason, or the stderr tail + exit status (mirror cursor's
-        // failureText assembly). A COMPLETED prompt whose process did not
-        // exit 0 is a failure input too: the "full drain exits 0" boundary
-        // never silently ACKs a dirty exit as success.
+        // stopReason (including a provider-side `cancelled`, which is an
+        // abnormal end, NOT an unconditional redelivery), or the stderr
+        // tail + exit status (mirror cursor's failureText assembly). A
+        // COMPLETED prompt whose process did not exit 0 is a failure input
+        // too: the "full drain exits 0" boundary never silently ACKs a dirty
+        // exit as success.
         updateReplaySafety(state);
         const stderrText = outcome.stderrTail.trim();
         const phaseErrorText = outcome.failure ? outcome.failure.error.message.trim() : "";
@@ -1005,7 +1002,8 @@ export const createGrokHandler: HandlerFactory = (config) => {
     // spawn deterministically if a stale config ever routes here).
     if (platform === "win32") {
       throw new Error(
-        "the grok provider does not support Windows: the Grok Build ACP runtime is supervised macOS/Linux-only",
+        "the grok provider is not supported on Windows in V1 (macOS/Linux only); " +
+          "the Grok Build ACP runtime is supervised macOS/Linux-only",
       );
     }
     // Landing campaign trials require the codex app-server workspace-only

--- a/packages/client/src/handlers/grok/index.ts
+++ b/packages/client/src/handlers/grok/index.ts
@@ -1,0 +1,1200 @@
+import { randomUUID } from "node:crypto";
+import { isAbsolute, join, resolve } from "node:path";
+import {
+  type AgentRuntimeConfig,
+  type AgentRuntimeConfigPayload,
+  classifyShellCommandIo,
+  encodeProviderRetryEventMessage,
+  isLandingCampaignTrialAgentMetadata,
+  runtimeProviderSchema,
+  type ToolFileRef,
+} from "@first-tree/shared";
+import { ensureAgentBootstrap } from "../../runtime/agent-bootstrap.js";
+import { buildAgentBriefing } from "../../runtime/agent-briefing.js";
+import type { AgentConfigCache } from "../../runtime/agent-config-cache.js";
+import { writeAgentBriefing } from "../../runtime/bootstrap.js";
+import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
+import { renderChatContextPrompt, renderRuntimeOutputContract } from "../../runtime/chat-context-section.js";
+import {
+  type ContextTreeAttribution,
+  resolveContextTreeRelativePath,
+  toolFileRefsFromShellCommand,
+} from "../../runtime/context-tree-file-refs.js";
+import {
+  type ContextTreeGitWriteTracker,
+  createContextTreeGitWriteTracker,
+} from "../../runtime/context-tree-git-status.js";
+import {
+  formatGrokBinaryMissingMessage,
+  GrokBinaryVerifyTransientError,
+  resolveGrokRuntimeBinary,
+} from "../../runtime/grok-binary.js";
+import type {
+  AgentHandler,
+  DeliveryToken,
+  HandlerFactory,
+  SessionContext,
+  SessionMessage,
+  TurnConsumedErrorReason,
+} from "../../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../../runtime/handler.js";
+import {
+  isManagedSkillsUnsafeDiscoveryError,
+  type ReconciledTeamSkill,
+  reconcileManagedSkillsForConfig,
+} from "../../runtime/managed-skills.js";
+import { ProviderAttempt, type ProviderAttemptSettlement } from "../../runtime/provider-attempt.js";
+import {
+  createDefaultProviderProcessSupervisor,
+  type ProviderProcessSupervisor,
+} from "../../runtime/provider-process-supervisor.js";
+import { maxProviderTurnRetryAttempts } from "../../runtime/provider-retry-policy.js";
+import {
+  buildBriefingUpdateNotice,
+  computeBriefingFingerprint,
+  readSessionBriefingFingerprint,
+  writeSessionBriefingFingerprint,
+} from "../../runtime/session-briefing-fingerprint.js";
+import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../../runtime/source-repos.js";
+import { teamSkillBundleResolverFromSdk } from "../../runtime/team-skill-bundle-resolver.js";
+import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
+import { chunkAssistantText } from "../assistant-text.js";
+import { formatAuthHint, isGrokAuthError } from "../auth-error-hint.js";
+import { resolveTurnSettlement } from "../turn-settlement.js";
+import { buildGrokTurnArgs, runGrokAcpAttempt } from "./acp-session.js";
+import {
+  type GrokNormalizedEvent,
+  type GrokToolInfo,
+  type GrokTurnCompleted,
+  normalizeGrokSessionUpdate,
+  normalizeGrokXaiNotification,
+} from "./events.js";
+
+export { buildGrokTurnArgs } from "./acp-session.js";
+
+/**
+ * Grok Build handler — drives the EXTERNAL Grok Build CLI over ACP (Agent
+ * Client Protocol) v1, one short-lived process per provider turn:
+ *
+ *   inbox delivery → prepareTurn → spawn grok process → initialize →
+ *     session/new | session/load → session/prompt (prompt on ACP stdin only)
+ *     → session/update + _x.ai/* notification stream → prompt response →
+ *     notification drain → stdin EOF → exit 0 → settle DeliveryToken →
+ *     next queued batch
+ *
+ * Canonical spawn contract (mirrors the cursor/opencode safety posture):
+ *   grok --no-auto-update agent --no-leader --always-approve
+ *        [--model <exact-operator-value>] [--effort <low|medium|high>] stdio
+ *
+ * Hard constraints enforced here, not by prompt:
+ *   - process cwd = agent home; prompt rides ACP stdin only (never argv);
+ *   - args go to the supervisor as an array with `shell: false`;
+ *   - MCP servers are delivered via session/new|load params (filtered by the
+ *     advertised mcpCapabilities) — there is NO file-projection layer;
+ *   - `session/load` only ever carries a stream-confirmed provider session
+ *     id, and a load failure NEVER falls back to session/new (replay
+ *     safety); synthetic pending ids stay runtime-local;
+ *   - settlement waits for the prompt response, the notification-handler
+ *     drain, and process close (non-zero exit without a completed prompt is
+ *     a first-class failure input, classified from the stderr tail);
+ *   - Windows fails closed in prepareSession (the capability probe already
+ *     hides the provider; this is belt-and-braces).
+ */
+
+/** Prefix for runtime-local pending session ids (never sent to session/load). */
+export const GROK_PENDING_SESSION_PREFIX = "grok-pending-";
+
+export function isGrokPendingSessionId(sessionId: string): boolean {
+  return sessionId.startsWith(GROK_PENDING_SESSION_PREFIX);
+}
+
+/**
+ * No shared build-version constant is wired into the client package yet, so
+ * the ACP clientInfo advertises "0" (the value is informational only).
+ */
+const GROK_CLIENT_VERSION = "0";
+
+type GrokRetrySleep = (delayMs: number, signal: AbortSignal) => Promise<void>;
+
+function defaultGrokRetrySleep(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.reject(new DOMException("Aborted", "AbortError"));
+  return new Promise((resolvePromise, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolvePromise();
+    }, delayMs);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/** True when a shell command is PROVEN read-only (replay-safe). */
+export function grokShellCommandIsReadOnly(command: string | null): boolean {
+  if (!command) return false;
+  const classification = classifyShellCommandIo(command);
+  return classification.supported && classification.action === "read";
+}
+
+/**
+ * True when a tool invocation is PROVEN read-only. The provider's
+ * `_meta["x.ai/tool"].read_only === true` is required; a shell tool
+ * (`run_terminal_cmd`, detected by its `command` input) must additionally
+ * classify as a supported read. Anything else — read_only false, absent, or
+ * unknown — is an unproven side effect and ends automatic replay.
+ */
+export function grokToolIsReadOnly(tool: GrokToolInfo): boolean {
+  if (tool.readOnly !== true) return false;
+  if (tool.command !== null) return grokShellCommandIsReadOnly(tool.command);
+  return true;
+}
+
+type TurnAcpState = {
+  attempt: ProviderAttempt;
+  sawInit: boolean;
+  userVisibleEmitted: boolean;
+  toolEffectStarted: boolean;
+  thinkingEmitted: boolean;
+  /** Accumulated agent_message_chunk text — the canonical final turn text. */
+  assistantText: string;
+  turnCompleted: GrokTurnCompleted | null;
+  ignoredCount: number;
+};
+
+export const createGrokHandler: HandlerFactory = (config) => {
+  const workspaceRoot = config.workspaceRoot as string;
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider ?? "grok");
+  const providerTurnMaxRetries = maxProviderTurnRetryAttempts();
+  const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
+  const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
+  const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
+  const contextTreeBranch = (config.contextTreeBranch as string | undefined) ?? null;
+  const platform = (config.grokPlatform as NodeJS.Platform | undefined) ?? process.platform;
+  const processSupervisor =
+    (config.providerProcessSupervisor as ProviderProcessSupervisor | undefined) ??
+    createDefaultProviderProcessSupervisor(platform);
+  const resolveBinary =
+    (config.grokBinaryResolver as typeof resolveGrokRuntimeBinary | undefined) ?? resolveGrokRuntimeBinary;
+  const retrySleep = (config.grokRetrySleep as GrokRetrySleep | undefined) ?? defaultGrokRetrySleep;
+
+  let cwd: string | null = null;
+  let ctx: SessionContext | null = null;
+  let activePayload: AgentRuntimeConfigPayload | null = null;
+  let reconciledTeamSkills: readonly ReconciledTeamSkill[] = [];
+  let binary: string | null = null;
+  /** Provider-confirmed session id — the ONLY value session/load may carry. */
+  let providerSessionId: string | null = null;
+  /** Runtime-local placeholder returned when the first turn settled before session/new. */
+  let pendingSyntheticId: string | null = null;
+  /**
+   * Session-liveness fence for the run-to-completion transport. True from the
+   * end of prepareSession until suspend()/shutdown(). Queued drains and
+   * runTurn refuse to spawn while false, so a drain that raced past its gates
+   * before suspend cannot start a provider process on a suspended session,
+   * and an inject landing during prepareSession's awaits cannot run ahead of
+   * the session's own first turn.
+   */
+  let sessionActive = false;
+  let currentAbort: AbortController | null = null;
+  let currentTurnPromise: Promise<void> | null = null;
+  /**
+   * Turn/identity fence: emit, settlement, the child slot, and finally-cleanup
+   * all capture the generation they belong to; a stale continuation (late
+   * timeout, delayed close) must never touch a newer turn's state.
+   */
+  let turnGeneration = 0;
+  let drainScheduled = false;
+  let drainInProgress = false;
+  let initialTurnPreparing = false;
+  const queuedMessages: Array<{ message: SessionMessage; token: DeliveryToken }> = [];
+  /**
+   * One-shot provider context. Grok has no system-prompt channel in the ACP
+   * session contract we use, so the runtime output contract + escaped Current
+   * Chat Context + any briefing re-read notice ride the next messageful
+   * provider turn's prompt text, then clear. Queued injects must not consume
+   * it before a turn actually enters the provider.
+   */
+  let pendingChatContextPrompt: string | null = null;
+  let sourceReposForPrompt: ReturnType<typeof declaredSourceRepos> = [];
+  const gitWriteTracker: ContextTreeGitWriteTracker = createContextTreeGitWriteTracker({
+    contextTreePath,
+    contextTreeRepoUrl,
+    contextTreeBranch,
+    log: (message) => ctx?.log(message),
+  });
+
+  function emitProviderTurnSettlementEvent(sessionCtx: SessionContext, settlement: ProviderAttemptSettlement): void {
+    sessionCtx.emitEvent({
+      kind: "error",
+      payload: {
+        source: "runtime",
+        message: encodeProviderRetryEventMessage(settlement.eventPayload),
+      },
+    });
+  }
+
+  function buildEnv(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload): Record<string, string> {
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (typeof v === "string") env[k] = v;
+    }
+    for (const e of payload.env) env[e.key] = e.value;
+    // The First Tree envelope injects the runtime-session token FILE PATH and
+    // identity ids — never a token value.
+    const merged = sessionCtx.buildAgentEnv(env);
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(merged)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  }
+
+  function formatGrokError(message: string): string {
+    if (isGrokAuthError(message)) return formatAuthHint("grok", message);
+    return message;
+  }
+
+  function buildBriefing(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload, workspaceCwd: string): string {
+    return buildAgentBriefing({
+      identity: sessionCtx.agent,
+      payload,
+      workspacePath: workspaceCwd,
+      sourceRepos: sourceReposForPrompt,
+      contextTreePath,
+      contextTreeRepoUrl,
+      contextTreeBranch,
+      teamSkills: reconciledTeamSkills,
+    });
+  }
+
+  async function fetchChatContextOrLog(sessionCtx: SessionContext): Promise<ChatContext | undefined> {
+    try {
+      return await fetchChatContext(sessionCtx.sdk, sessionCtx.chatId, sessionCtx.agent);
+    } catch (err) {
+      sessionCtx.log(`fetchChatContext failed: ${err instanceof Error ? err.message : String(err)}`);
+      return undefined;
+    }
+  }
+
+  function consumePendingChatContext(input: string): string {
+    const chatPrompt = pendingChatContextPrompt;
+    pendingChatContextPrompt = null;
+    // Same provider-neutral runtime output contract as the other run-to-
+    // completion providers — Grok gets no persistent system-prompt channel,
+    // so the contract rides every turn's prompt ahead of any chat-context
+    // block. Chat-context field values are labelled data and escaped
+    // upstream; they cannot re-address the turn or forge prompt sections.
+    const contract = renderRuntimeOutputContract();
+    const prefix = chatPrompt ? `${contract}\n\n${chatPrompt}` : contract;
+    return `${prefix}\n\n${input}`;
+  }
+
+  function declareSourceRepos(payload: AgentRuntimeConfigPayload, workspaceCwd: string): void {
+    sourceReposForPrompt = declaredSourceRepos(workspaceCwd, payload);
+  }
+
+  function grokNativePathRefs(filePath: string, origin: "tool_arg" | "file_change"): ToolFileRef[] {
+    if (!cwd) return [];
+    const attribution: ContextTreeAttribution = { contextTreePath, contextTreeRepoUrl };
+    const absolutePath = isAbsolute(filePath) ? resolve(filePath) : resolve(cwd, filePath);
+    const repoRelativePath = resolveContextTreeRelativePath(absolutePath, attribution);
+    return [
+      {
+        origin,
+        localPath: filePath,
+        pathKind: "file",
+        ...(contextTreeRepoUrl && repoRelativePath && repoRelativePath !== "/"
+          ? {
+              repoUrl: contextTreeRepoUrl,
+              ...(contextTreeBranch ? { repoBranch: contextTreeBranch } : {}),
+              repoRelativePath,
+            }
+          : {}),
+      },
+    ];
+  }
+
+  /** Terminal-tool ref assembly: provider-derived refs + git-status-delta refs. */
+  function refsForCompletedTool(input: {
+    ok: boolean;
+    readOnly: boolean;
+    providerRefs: ToolFileRef[];
+    toolName: string;
+    toolUseId: string;
+  }): ToolFileRef[] | undefined {
+    // A PROVEN read-only tool cannot have moved the tree's git status — skip
+    // the per-tool `git status` spawn entirely (tool-heavy read turns would
+    // otherwise stall the event loop once per read). Any accumulated dirty
+    // paths stay attributed to the next non-read-only tool.
+    if (input.readOnly) {
+      return input.providerRefs.length > 0 ? input.providerRefs : undefined;
+    }
+    if (!input.ok) {
+      // A failed tool still moves the baseline so the NEXT successful tool
+      // does not swallow this one's dirty paths.
+      gitWriteTracker.captureBaseline();
+      return undefined;
+    }
+    const gitStatusRefs = gitWriteTracker.refsForSuccessfulToolCall({
+      toolName: input.toolName,
+      toolUseId: input.toolUseId,
+      existingRefs: input.providerRefs,
+    });
+    const refs = [...input.providerRefs, ...gitStatusRefs];
+    return refs.length > 0 ? refs : undefined;
+  }
+
+  function providerRefsForTool(tool: GrokToolInfo): ToolFileRef[] {
+    if (tool.command) {
+      return cwd
+        ? toolFileRefsFromShellCommand({
+            command: tool.command,
+            cwd,
+            contextTreePath,
+            contextTreeRepoUrl,
+            contextTreeBranch,
+          })
+        : [];
+    }
+    const origin = tool.readOnly === true ? "tool_arg" : "file_change";
+    return tool.paths.flatMap((filePath) => grokNativePathRefs(filePath, origin));
+  }
+
+  /**
+   * Replay-safety ladder: user-visible assistant output and any non-read-only
+   * tool effect both end automatic replay; pure thinking / read-only activity
+   * stays retryable; nothing from the provider yet (pre-initialize) is
+   * pre_provider.
+   */
+  function updateReplaySafety(state: TurnAcpState): void {
+    if (state.toolEffectStarted) {
+      state.attempt.setReplaySafety("unsafe");
+    } else if (state.userVisibleEmitted) {
+      state.attempt.markUserVisibleOutput();
+    } else if (state.sawInit) {
+      state.attempt.setReplaySafety("pre_visible");
+    } else {
+      state.attempt.setReplaySafety("pre_provider");
+    }
+  }
+
+  function adoptProviderSessionId(sessionCtx: SessionContext, confirmedSessionId: string): void {
+    if (providerSessionId === confirmedSessionId) return;
+    const hadSynthetic = pendingSyntheticId !== null && providerSessionId === null;
+    const syntheticId = pendingSyntheticId;
+    providerSessionId = confirmedSessionId;
+    if (hadSynthetic && syntheticId) {
+      // Atomically upgrade the runtime-local placeholder to the real provider
+      // id without dropping inbox custody.
+      sessionCtx.replaceSessionId?.(confirmedSessionId, "grok_session_id_confirmed");
+      pendingSyntheticId = null;
+      // Migrate the briefing-fingerprint baseline to the real id (see cursor).
+      if (cwd) {
+        try {
+          const baseline = readSessionBriefingFingerprint(cwd, syntheticId);
+          if (baseline) writeSessionBriefingFingerprint(cwd, confirmedSessionId, baseline);
+        } catch (err) {
+          sessionCtx.log(
+            `briefing fingerprint migration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+  }
+
+  function handleNormalizedEvent(event: GrokNormalizedEvent, state: TurnAcpState, sessionCtx: SessionContext): void {
+    sessionCtx.recordProviderActivity();
+    switch (event.kind) {
+      case "assistant_chunk":
+        // There is no separate result message: the concatenation of
+        // agent_message_chunk text IS the canonical final text, emitted ONCE
+        // as assistant_text at successful turn end (never per chunk).
+        state.assistantText += event.text;
+        if (event.text.trim()) state.userVisibleEmitted = true;
+        break;
+      case "thought_chunk":
+        // Presence-only marker, at most one per turn (per-chunk emission
+        // would flood the event stream).
+        if (!state.thinkingEmitted) {
+          state.thinkingEmitted = true;
+          sessionCtx.emitEvent({ kind: "thinking", payload: {} });
+        }
+        break;
+      case "user_echo":
+        break;
+      case "tool_started": {
+        if (!grokToolIsReadOnly(event.tool)) state.toolEffectStarted = true;
+        sessionCtx.emitEvent({
+          kind: "tool_call",
+          payload: {
+            toolUseId: event.tool.toolCallId,
+            name: event.tool.name,
+            args: event.tool.argsSummary,
+            status: "pending",
+          },
+        });
+        break;
+      }
+      case "tool_completed": {
+        const ok = event.ok;
+        const readOnly = grokToolIsReadOnly(event.tool);
+        if (!readOnly) state.toolEffectStarted = true;
+        const providerRefs = ok ? providerRefsForTool(event.tool) : [];
+        const toolFileRefs = refsForCompletedTool({
+          ok,
+          readOnly,
+          providerRefs,
+          toolName: event.tool.name,
+          toolUseId: event.tool.toolCallId,
+        });
+        sessionCtx.emitEvent({
+          kind: "tool_call",
+          payload: {
+            toolUseId: event.tool.toolCallId,
+            name: event.tool.name,
+            args: event.tool.argsSummary,
+            status: ok ? "ok" : "error",
+            ...(event.resultPreview ? { resultPreview: event.resultPreview } : {}),
+            ...(toolFileRefs ? { toolFileRefs } : {}),
+          },
+        });
+        break;
+      }
+      case "plan":
+        // The SessionEvent schema has no plan kind — log-only.
+        sessionCtx.log("grok ACP: plan update received (no plan event kind; not emitted)");
+        break;
+      case "turn_completed":
+        // THE per-prompt usage source. Kept for turn-end emission; the
+        // prompt-id correlation check runs once the prompt response meta is
+        // known. `response_completed` (per-model-call) never reaches here —
+        // events.ts degrades it to ignored so usage is never double-counted.
+        state.turnCompleted = event.completed;
+        break;
+      case "ignored":
+        if (state.ignoredCount < 5) {
+          sessionCtx.log(`grok ACP tolerant-parse diagnostic: ${event.note}`);
+        }
+        state.ignoredCount++;
+        break;
+    }
+  }
+
+  /**
+   * Run one provider turn (possibly several attempts). Returns whether the
+   * turn was delivered (settled complete) — the briefing-fingerprint baseline
+   * and queued-drain scheduling key off this.
+   */
+  async function runTurn(
+    input: string,
+    sessionCtx: SessionContext,
+    messages: readonly SessionMessage[],
+    token: DeliveryToken,
+  ): Promise<boolean> {
+    const workspaceCwd = cwd;
+    const fallbackPayload = activePayload;
+    if (!workspaceCwd || !binary || !fallbackPayload || !sessionActive) {
+      // `sessionActive` closes the drain-vs-lifecycle race (see cursor).
+      token.retry(messages, sessionActive ? "grok_missing_workspace_or_binary" : "grok_session_inactive");
+      return false;
+    }
+
+    const activeBinary = binary;
+    // One immutable per-turn snapshot drives model, effort, MCP delivery, and
+    // env. SessionManager refreshes the cache before dispatch, so an active
+    // chat converges on its very next turn.
+    const turnPayload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload ?? fallbackPayload;
+    const model = turnPayload.model;
+    const reasoningEffort = turnPayload.kind === "grok" ? turnPayload.reasoningEffort : "";
+    const env = buildEnv(sessionCtx, turnPayload);
+    const generation = ++turnGeneration;
+    const abort = new AbortController();
+    currentAbort = abort;
+    const turnPromise = runTurnAttempts(
+      input,
+      sessionCtx,
+      messages,
+      token,
+      workspaceCwd,
+      activeBinary,
+      turnPayload,
+      model,
+      reasoningEffort,
+      env,
+      generation,
+      abort,
+    ).catch((err: unknown) => {
+      if (abort.signal.aborted || turnGeneration !== generation) return false;
+      throw err;
+    });
+    currentTurnPromise = turnPromise.then(
+      () => {},
+      () => {},
+    );
+    try {
+      return await turnPromise;
+    } finally {
+      if (turnGeneration === generation) {
+        currentAbort = null;
+        currentTurnPromise = null;
+        scheduleQueuedMessagesDrain();
+      }
+    }
+  }
+
+  async function runTurnAttempts(
+    input: string,
+    sessionCtx: SessionContext,
+    messages: readonly SessionMessage[],
+    token: DeliveryToken,
+    workspaceCwd: string,
+    activeBinary: string,
+    turnPayload: AgentRuntimeConfigPayload,
+    model: string,
+    reasoningEffort: string,
+    env: Record<string, string>,
+    generation: number,
+    abort: AbortController,
+  ): Promise<boolean> {
+    if (
+      abort.signal.aborted ||
+      turnGeneration !== generation ||
+      cwd !== workspaceCwd ||
+      binary !== activeBinary ||
+      !sessionActive
+    ) {
+      return false;
+    }
+
+    // One-shot payload snapshot: a non-delivered exit (abort, retry-path
+    // settlement) must put the chat-context/notice back so the redelivery
+    // still carries it.
+    const promptSnapshot = pendingChatContextPrompt;
+    const providerInput = consumePendingChatContext(input);
+    const restorePendingChatContext = (): void => {
+      if (pendingChatContextPrompt === null) pendingChatContextPrompt = promptSnapshot;
+    };
+
+    token.processingStarted(messages);
+    gitWriteTracker.captureBaseline();
+
+    const turnStartedAt = Date.now();
+
+    let finalText = "";
+    // Box so TS control-flow analysis survives the assignment living inside
+    // the async IIFE below (microsoft/TypeScript#9998).
+    const usageBox: { value: GrokTurnCompleted | null } = { value: null };
+    let usedModel = model;
+    let consumedErrorReason: TurnConsumedErrorReason | null = null;
+    let retryReason: string | null = null;
+    let retryStatus: "success" | "error" = "error";
+    let providerCompleted = false;
+    let anyUserVisible = false;
+
+    const promise = (async () => {
+      for (let attempt = 0; ; attempt++) {
+        const state: TurnAcpState = {
+          attempt: new ProviderAttempt({ provider: runtimeProvider, scope: "provider_turn", source: "stream" }),
+          sawInit: false,
+          userVisibleEmitted: anyUserVisible,
+          toolEffectStarted: false,
+          thinkingEmitted: false,
+          assistantText: "",
+          turnCompleted: null,
+          ignoredCount: 0,
+        };
+        consumedErrorReason = null;
+        retryReason = null;
+        retryStatus = "error";
+        let retryRequested = false;
+        let retryDelay = 0;
+
+        const args = buildGrokTurnArgs({ model, reasoningEffort });
+
+        const outcome = await runGrokAcpAttempt({
+          supervisor: processSupervisor,
+          binary: activeBinary,
+          args,
+          env,
+          cwd: workspaceCwd,
+          abortSignal: abort.signal,
+          label: `grok turn ${sessionCtx.chatId}`,
+          clientVersion: GROK_CLIENT_VERSION,
+          // Only a provider-confirmed id ever reaches session/load; the first
+          // turn (and any turn after a synthetic placeholder) runs session/new.
+          resumeSessionId: providerSessionId,
+          mcpServers: turnPayload.mcpServers,
+          promptText: providerInput,
+          onInitialized: () => {
+            if (turnGeneration === generation && !abort.signal.aborted) state.sawInit = true;
+          },
+          onSessionId: (sessionId) => {
+            if (turnGeneration === generation && !abort.signal.aborted) {
+              adoptProviderSessionId(sessionCtx, sessionId);
+            }
+          },
+          onSessionUpdate: (params) => {
+            const normalized = normalizeGrokSessionUpdate(params);
+            if (normalized) handleNormalizedEvent(normalized.event, state, sessionCtx);
+          },
+          onXaiNotification: (params) => {
+            const normalized = normalizeGrokXaiNotification(params);
+            if (normalized) handleNormalizedEvent(normalized.event, state, sessionCtx);
+          },
+          log: (message) => sessionCtx.log(message),
+        });
+        if (abort.signal.aborted || turnGeneration !== generation) return;
+
+        anyUserVisible = anyUserVisible || state.userVisibleEmitted;
+        // Billed tokens are billed regardless of how the turn settles — keep
+        // the latest usage the provider reported so failed/consumed turns
+        // still emit token_usage.
+        if (state.turnCompleted?.usage) usageBox.value = state.turnCompleted;
+
+        const applySettlement = (settlement: ProviderAttemptSettlement, reasonPrefix: string): void => {
+          if (settlement.decision.action === "retry") {
+            retryRequested = true;
+            retryDelay = settlement.decision.delayMs;
+            retryReason = `${reasonPrefix} (${settlement.classification.category}): ${settlement.messagePreview}`;
+            emitProviderTurnSettlementEvent(sessionCtx, settlement);
+            return;
+          }
+          emitProviderTurnSettlementEvent(sessionCtx, settlement);
+          if (settlement.decision.replaySafety === "pre_provider" && settlement.decision.terminalKind === "exhausted") {
+            retryReason = settlement.decision.reasonCode;
+          } else {
+            consumedErrorReason =
+              settlement.decision.terminalKind === "capacity_wait_required"
+                ? "capacity_wait_required"
+                : settlement.decision.terminalKind === "exhausted"
+                  ? "provider_retry_exhausted"
+                  : settlement.decision.reasonCode;
+          }
+          sessionCtx.emitEvent({
+            kind: "error",
+            payload: { source: "sdk", message: formatGrokError(settlement.messagePreview) },
+          });
+        };
+
+        const prompt = outcome.prompt;
+        if (prompt && prompt.stopReason === "end_turn" && !outcome.spawnError && !outcome.failure) {
+          if (!outcome.cleanExit) {
+            // Non-zero exit AFTER a successful prompt response: the completed
+            // turn stands (verified Grok quirk on some builds).
+            sessionCtx.log(
+              `grok process exited ${outcome.exitCode ?? `signal ${outcome.signal ?? "unknown"}`} ` +
+                "after a completed prompt; the completed turn stands",
+            );
+          }
+          // Prompt-id correlation: discard replayed usage that belongs to a
+          // different prompt than the one this response settles.
+          const responsePromptId = typeof prompt.meta?.promptId === "string" ? prompt.meta.promptId : null;
+          const captured = usageBox.value;
+          if (responsePromptId && captured?.promptId && captured.promptId !== responsePromptId) {
+            sessionCtx.log(
+              `grok ACP: discarded turn_completed usage for foreign prompt_id ${captured.promptId} ` +
+                `(current prompt ${responsePromptId})`,
+            );
+            usageBox.value = null;
+          }
+          const metaModelId = typeof prompt.meta?.modelId === "string" ? prompt.meta.modelId : "";
+          if (metaModelId) usedModel = metaModelId;
+          finalText = state.assistantText;
+          providerCompleted = true;
+          return;
+        }
+        if (prompt && prompt.stopReason === "cancelled") {
+          // Provider-side cancel without a local abort settles as an aborted
+          // turn: redeliver, never consume.
+          retryReason = "grok_turn_cancelled";
+          retryStatus = "success";
+          return;
+        }
+
+        // Failure path. Auth / capacity / protocol failures commonly produce
+        // NO prompt response — classify from the failure phase error, the
+        // stopReason, or the stderr tail + exit status (mirror cursor's
+        // failureText assembly).
+        updateReplaySafety(state);
+        const stderrText = outcome.stderrTail.trim();
+        const phaseErrorText = outcome.failure ? outcome.failure.error.message.trim() : "";
+        const stopReasonText = prompt ? `grok turn stopped with stopReason "${prompt.stopReason}"` : "";
+        const failureText =
+          outcome.spawnError?.message ??
+          (phaseErrorText
+            ? stderrText
+              ? `${phaseErrorText}\nstderr: ${stderrText}`
+              : phaseErrorText
+            : stopReasonText
+              ? stderrText
+                ? `${stopReasonText}\nstderr: ${stderrText}`
+                : stopReasonText
+              : stderrText ||
+                `grok exited ${outcome.exitCode ?? `signal ${outcome.signal ?? "unknown"}`} without completing the prompt`);
+        const failureError =
+          outcome.spawnError && (outcome.spawnError as NodeJS.ErrnoException).code === "ENOENT"
+            ? new Error(formatGrokBinaryMissingMessage(`the bound grok binary disappeared: ${activeBinary}`))
+            : new Error(failureText);
+        state.attempt.recordSignal({
+          kind: outcome.spawnError ? "local_error" : "provider_error",
+          error: failureError,
+        });
+        const settlement = state.attempt.settle({ attempt: attempt + 1 });
+        if (settlement) applySettlement(settlement, outcome.spawnError ? "spawn failed" : "provider failed");
+
+        if (!retryRequested) return;
+        sessionCtx.log(
+          `grok turn retry ${attempt + 1}/${providerTurnMaxRetries + 1} after ${retryDelay}ms; ${retryReason}`,
+        );
+        try {
+          await retrySleep(retryDelay, abort.signal);
+        } catch {
+          return; // suspend/shutdown raced ahead
+        }
+      }
+    })();
+
+    await promise;
+
+    if (abort.signal.aborted || turnGeneration !== generation) {
+      // Suspend/shutdown/preemption raced ahead — not a delivered turn; the
+      // chat-context/notice payload must survive for the redelivery.
+      restorePendingChatContext();
+      return false;
+    }
+
+    let forwardFailed = false;
+    if (providerCompleted && consumedErrorReason === null && retryReason === null) {
+      // The canonical final text lands as chunked assistant_text FIRST, then
+      // the completion hook runs (fires on every success — including silent /
+      // tool-only turns with empty text).
+      if (finalText.trim()) {
+        for (const chunk of chunkAssistantText(finalText)) {
+          sessionCtx.emitEvent({ kind: "assistant_text", payload: { text: chunk } });
+        }
+      }
+      try {
+        await sessionCtx.forwardResult(finalText);
+      } catch (err) {
+        forwardFailed = true;
+        const msg = err instanceof Error ? err.message : String(err);
+        sessionCtx.emitEvent({
+          kind: "error",
+          payload: { source: "runtime", message: `forwardResult failed: ${msg}` },
+        });
+      }
+    }
+
+    const capturedUsage = usageBox.value;
+    if (capturedUsage?.usage) {
+      try {
+        sessionCtx.emitEvent({
+          kind: "token_usage",
+          payload: {
+            provider: "grok",
+            model: usedModel || "grok-default",
+            inputTokens: capturedUsage.usage.inputTokens,
+            cachedInputTokens: capturedUsage.usage.cachedReadTokens,
+            outputTokens: capturedUsage.usage.outputTokens,
+          },
+        });
+      } catch (err) {
+        sessionCtx.log(`Failed to emit token_usage: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    const settlement = resolveTurnSettlement({ retryReason, retryStatus, consumedErrorReason, forwardFailed });
+    if (settlement.action.kind === "complete") {
+      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: settlement.status } });
+      const completion = await token.complete(messages, settlement.action.outcome);
+      if (completion === "retry") {
+        // Completion deliberately retained server custody (a durable notice
+        // could not be posted): the one-shot payload must ride the redelivery.
+        restorePendingChatContext();
+        return false;
+      }
+    } else {
+      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: settlement.status } });
+      // Retry-path settlement: the delivery goes back for redelivery, so the
+      // one-shot chat-context/notice must be available to it again.
+      restorePendingChatContext();
+      token.retry(messages, settlement.action.reason);
+    }
+
+    if (capturedUsage?.usage) {
+      sessionCtx.log(
+        `grok usage chatId=${sessionCtx.chatId} duration_ms=${Date.now() - turnStartedAt} ` +
+          `input_tokens=${capturedUsage.usage.inputTokens} cache_read_tokens=${capturedUsage.usage.cachedReadTokens} ` +
+          `output_tokens=${capturedUsage.usage.outputTokens} ` +
+          (capturedUsage.costUsdTicks !== null ? `cost_usd_ticks=${capturedUsage.costUsdTicks} ` : "") +
+          `status=${settlement.status}`,
+      );
+    }
+
+    return settlement.action.kind === "complete";
+  }
+
+  function scheduleQueuedMessagesDrain(): void {
+    if (drainScheduled || drainInProgress) return;
+    if (queuedMessages.length === 0 || !ctx || !cwd || !sessionActive || currentTurnPromise || initialTurnPreparing) {
+      return;
+    }
+
+    drainScheduled = true;
+    setImmediate(() => {
+      drainScheduled = false;
+      if (
+        drainInProgress ||
+        queuedMessages.length === 0 ||
+        !ctx ||
+        !cwd ||
+        !sessionActive ||
+        currentTurnPromise ||
+        initialTurnPreparing
+      ) {
+        scheduleQueuedMessagesDrain();
+        return;
+      }
+      const drained = queuedMessages.splice(0);
+      const sessionCtx = ctx;
+      drainInProgress = true;
+      void mergeAndRun(drained, sessionCtx)
+        .catch((err) => {
+          sessionCtx.log(`grok queued turn failed: ${err instanceof Error ? err.message : String(err)}`);
+          for (const queued of drained) queued.token.retry(queued.message, "grok_queued_turn_failed");
+        })
+        .finally(() => {
+          drainInProgress = false;
+          scheduleQueuedMessagesDrain();
+        });
+    });
+  }
+
+  /**
+   * Active-session briefing hot-switch before an injected turn (same contract
+   * as the cursor handler): rebuild from the latest cached config; when
+   * changed, rewrite AGENTS.md and report so the caller prepends the one-time
+   * re-read notice. Never throws on the drain path.
+   */
+  async function refreshBriefingForActiveTurn(
+    sessionCtx: SessionContext,
+  ): Promise<{ fingerprint: string; changed: boolean } | null> {
+    const sessionKey = providerSessionId ?? pendingSyntheticId;
+    if (!agentConfigCache || !cwd || !sessionKey) return null;
+    try {
+      const runtimeConfig = agentConfigCache.get(sessionCtx.agent.agentId);
+      if (!runtimeConfig) return null;
+      const payload = runtimeConfig.payload;
+      reconciledTeamSkills = (
+        await reconcileManagedSkillsForConfig(
+          cwd,
+          runtimeProvider,
+          runtimeConfig,
+          sessionCtx.log,
+          teamSkillBundleResolverFromSdk(sessionCtx.sdk),
+        )
+      ).teamSkills;
+      const briefing = buildBriefing(sessionCtx, payload, cwd);
+      const fingerprint = computeBriefingFingerprint(briefing);
+      if (readSessionBriefingFingerprint(cwd, sessionKey) === fingerprint) return { fingerprint, changed: false };
+      writeAgentBriefing(cwd, briefing);
+      return { fingerprint, changed: true };
+    } catch (err) {
+      if (isManagedSkillsUnsafeDiscoveryError(err)) throw err;
+      sessionCtx.log(
+        `active-session briefing refresh failed, delivering under prior briefing: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+
+  async function mergeAndRun(
+    drained: Array<{ message: SessionMessage; token: DeliveryToken }>,
+    sessionCtx: SessionContext,
+  ): Promise<void> {
+    const inputs: string[] = [];
+    const messages = drained.map((entry) => entry.message);
+    const token = drained[0]?.token;
+    if (!token) return;
+    let hadFormatFailure = false;
+    for (const m of messages) {
+      try {
+        inputs.push(await sessionCtx.formatInboundContent(m));
+      } catch (err) {
+        hadFormatFailure = true;
+        sessionCtx.log(`grok inject formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (hadFormatFailure || inputs.length === 0) {
+      for (const queued of drained) queued.token.retry(queued.message, "grok_queued_turn_format_failed");
+      return;
+    }
+    const refreshed = await refreshBriefingForActiveTurn(sessionCtx);
+    if (refreshed?.changed && cwd) {
+      const notice = buildBriefingUpdateNotice(join(cwd, "AGENTS.md"));
+      pendingChatContextPrompt = pendingChatContextPrompt ? `${notice}\n\n${pendingChatContextPrompt}` : notice;
+      sessionCtx.log(`Active session briefing changed — prepending re-read notice (${providerSessionId})`);
+    }
+    const delivered = await runTurn(inputs.join("\n\n"), sessionCtx, messages, token);
+    const sessionKey = providerSessionId ?? pendingSyntheticId;
+    if (refreshed?.changed && delivered && cwd && sessionKey) {
+      writeSessionBriefingFingerprint(cwd, sessionKey, refreshed.fingerprint);
+    }
+  }
+
+  function retryQueuedMessages(reason: string): void {
+    const drained = queuedMessages.splice(0);
+    for (const queued of drained) {
+      queued.token.retry(queued.message, reason);
+    }
+  }
+
+  /**
+   * Session bring-up shared by start/resume: platform + trial gates, payload
+   * refresh, chat context, skills, briefing, workspace bootstrap, binary
+   * resolution (transient smoke-check flakes reschedule; a genuinely absent
+   * binary is a permanent capability failure).
+   */
+  async function prepareSession(sessionCtx: SessionContext): Promise<{
+    payload: AgentRuntimeConfigPayload;
+    briefing: string;
+    workspaceCwd: string;
+  }> {
+    // Platform gate: the Grok ACP transport is supervised POSIX-only (the
+    // capability probe already hides the provider on win32; this refuses the
+    // spawn deterministically if a stale config ever routes here).
+    if (platform === "win32") {
+      throw new Error(
+        "the grok provider does not support Windows: the Grok Build ACP runtime is supervised macOS/Linux-only",
+      );
+    }
+    // Landing campaign trials require the codex app-server workspace-only
+    // runtime (managed sandbox + confirmed turn-completion records). The grok
+    // handler implements neither — fail closed instead of running a trial
+    // without its guarantees.
+    if (isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata)) {
+      throw new Error(
+        "landing campaign trial agents require the codex app-server workspace-only runtime; the grok provider does not support trials",
+      );
+    }
+    ctx = sessionCtx;
+    const workspaceCwd = acquireAgentHome(workspaceRoot);
+    cwd = workspaceCwd;
+
+    let runtimeConfig: AgentRuntimeConfig | null = null;
+    let payload: AgentRuntimeConfigPayload | null = null;
+    if (agentConfigCache) {
+      runtimeConfig = await agentConfigCache.refresh(sessionCtx.agent.agentId);
+      payload = runtimeConfig.payload;
+    }
+    const payloadResolved = payload !== null;
+    if (!payload) {
+      payload = {
+        kind: "grok",
+        prompt: { append: "" },
+        model: "",
+        mcpServers: [],
+        env: [],
+        gitRepos: [],
+        resourceSkills: [],
+        reasoningEffort: "",
+      };
+    }
+
+    const chatContext = await fetchChatContextOrLog(sessionCtx);
+    pendingChatContextPrompt = renderChatContextPrompt(chatContext);
+
+    declareSourceRepos(payload, workspaceCwd);
+    reconciledTeamSkills = (
+      await reconcileManagedSkillsForConfig(
+        workspaceCwd,
+        runtimeProvider,
+        runtimeConfig,
+        sessionCtx.log,
+        teamSkillBundleResolverFromSdk(sessionCtx.sdk),
+      )
+    ).teamSkills;
+
+    const briefing = buildBriefing(sessionCtx, payload, workspaceCwd);
+    ensureAgentBootstrap({
+      workspace: workspaceCwd,
+      sessionCtx,
+      contextTreePath,
+      briefing,
+      currentSourceRepoNames: currentSourceRepoNamesFromPayload(payload, payloadResolved),
+    });
+    markWorkspaceInitComplete(workspaceCwd);
+
+    const resolution = resolveBinary(process.env);
+    if (!resolution.ok) {
+      if (resolution.transient) throw new GrokBinaryVerifyTransientError(resolution.error);
+      throw new Error(resolution.error);
+    }
+    binary = resolution.binary;
+    sessionCtx.log(`grok binary: ${resolution.binary}${resolution.version ? ` (version ${resolution.version})` : ""}`);
+
+    activePayload = payload;
+    sessionActive = true;
+    return { payload, briefing, workspaceCwd };
+  }
+
+  return {
+    async start(message, sessionCtx, token) {
+      const hasExplicitDeliveryToken = token !== undefined;
+      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+
+      // Guard the whole bring-up: an inject landing while prepareSession is
+      // awaiting must queue, not race ahead of the session's first turn.
+      initialTurnPreparing = true;
+      let initialTurnCompleted = false;
+      let briefing: string;
+      let workspaceCwd: string;
+      try {
+        ({ briefing, workspaceCwd } = await prepareSession(sessionCtx));
+        const input = await sessionCtx.formatInboundContent(message);
+        await runTurn(input, sessionCtx, [message], deliveryToken);
+        initialTurnCompleted = true;
+      } finally {
+        initialTurnPreparing = false;
+        if (initialTurnCompleted) scheduleQueuedMessagesDrain();
+      }
+
+      if (!providerSessionId) {
+        // First turn settled (e.g. auth/quota terminal consumed) before
+        // session/new ever confirmed a provider id. Return a runtime-local
+        // placeholder so SessionManager does not re-process the already
+        // settled delivery; the next confirmed id upgrades it atomically via
+        // replaceSessionId.
+        pendingSyntheticId = `${GROK_PENDING_SESSION_PREFIX}${randomUUID()}`;
+      }
+      const sessionId = providerSessionId ?? pendingSyntheticId;
+      if (!sessionId) throw new Error("grok session id unresolved after first turn");
+      writeSessionBriefingFingerprint(workspaceCwd, sessionId, computeBriefingFingerprint(briefing));
+      return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "processing" } } : sessionId;
+    },
+
+    async resume(message, sessionId, sessionCtx, token) {
+      const hasExplicitDeliveryToken = token !== undefined;
+      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+
+      // Guard the whole bring-up (see start()).
+      initialTurnPreparing = true;
+      let briefing: string;
+      let workspaceCwd: string;
+      try {
+        ({ briefing, workspaceCwd } = await prepareSession(sessionCtx));
+      } catch (err) {
+        initialTurnPreparing = false;
+        throw err;
+      }
+
+      // A synthetic pending id is runtime-local bookkeeping: it must NEVER be
+      // sent to session/load. The turn below runs start-shaped (session/new);
+      // the confirmed id it captures upgrades the mapping via replaceSessionId.
+      if (isGrokPendingSessionId(sessionId)) {
+        pendingSyntheticId = sessionId;
+        providerSessionId = null;
+      } else {
+        providerSessionId = sessionId;
+        pendingSyntheticId = null;
+      }
+
+      // Briefing-staleness notice — same contract as cursor: a resumed Grok
+      // session read AGENTS.md at its original init and does not reliably
+      // re-read it, so a changed briefing gets a one-time re-read notice on
+      // the next messageful turn; the baseline advances only after that turn
+      // is actually delivered.
+      const briefingFingerprint = computeBriefingFingerprint(briefing);
+      const briefingChanged =
+        Boolean(message) && readSessionBriefingFingerprint(workspaceCwd, sessionId) !== briefingFingerprint;
+      if (briefingChanged) {
+        const notice = buildBriefingUpdateNotice(join(workspaceCwd, "AGENTS.md"));
+        pendingChatContextPrompt = pendingChatContextPrompt ? `${notice}\n\n${pendingChatContextPrompt}` : notice;
+        sessionCtx.log(`Resume: briefing changed since last turn — prepending re-read notice (${sessionId})`);
+      }
+
+      if (message) {
+        let initialTurnCompleted = false;
+        let turnDelivered = false;
+        try {
+          const input = await sessionCtx.formatInboundContent(message);
+          turnDelivered = await runTurn(input, sessionCtx, [message], deliveryToken);
+          initialTurnCompleted = true;
+        } finally {
+          initialTurnPreparing = false;
+          if (initialTurnCompleted) scheduleQueuedMessagesDrain();
+        }
+        const sessionKey = providerSessionId ?? pendingSyntheticId ?? sessionId;
+        if (turnDelivered) writeSessionBriefingFingerprint(workspaceCwd, sessionKey, briefingFingerprint);
+      } else {
+        // Admin-triggered resume carries no message (handler contract). The
+        // bring-up guard must still clear, or every later inject would queue
+        // forever behind a drain gate that never reopens.
+        initialTurnPreparing = false;
+        scheduleQueuedMessagesDrain();
+      }
+
+      const effectiveId = providerSessionId ?? pendingSyntheticId ?? sessionId;
+      return hasExplicitDeliveryToken
+        ? { sessionId: effectiveId, route: message ? { kind: "owned", mode: "processing" } : null }
+        : effectiveId;
+    },
+
+    inject(message, token) {
+      // Grok turns are run-to-completion; there is no mid-turn interject in
+      // v1. Every inject queues and drains as an ordered fused batch after
+      // the active turn settles.
+      if (!ctx) return { kind: "rejected", reason: "no_active_context", retryable: true };
+      const deliveryToken = token ?? deliveryTokenFromSessionContext(ctx);
+      queuedMessages.push({ message, token: deliveryToken });
+      scheduleQueuedMessagesDrain();
+      return { kind: "owned", mode: "queued" };
+    },
+
+    async suspend() {
+      // Flip the liveness fence FIRST: a drain already past its gates (or a
+      // mergeAndRun awaiting formatInboundContent) re-checks sessionActive at
+      // runTurn entry and retries its batch instead of spawning post-suspend.
+      sessionActive = false;
+      retryQueuedMessages("grok_suspend_before_terminal");
+      turnGeneration++;
+      currentAbort?.abort();
+      try {
+        await currentTurnPromise;
+      } catch {
+        /* abort path */
+      }
+      currentAbort = null;
+      currentTurnPromise = null;
+      activePayload = null;
+      initialTurnPreparing = false;
+      pendingChatContextPrompt = null;
+    },
+
+    async shutdown(reason?: string) {
+      sessionActive = false;
+      retryQueuedMessages(reason ?? "grok_shutdown_before_terminal");
+      turnGeneration++;
+      currentAbort?.abort();
+      try {
+        await currentTurnPromise;
+      } catch {
+        /* ignore */
+      }
+      currentAbort = null;
+      currentTurnPromise = null;
+      activePayload = null;
+      // cwd is the persistent agent home — never removed by the runtime.
+      cwd = null;
+      binary = null;
+      providerSessionId = null;
+      pendingSyntheticId = null;
+      ctx = null;
+      initialTurnPreparing = false;
+      pendingChatContextPrompt = null;
+      queuedMessages.length = 0;
+    },
+  } satisfies AgentHandler;
+};

--- a/packages/client/src/handlers/index.ts
+++ b/packages/client/src/handlers/index.ts
@@ -5,6 +5,7 @@ import { createClaudeCodeTuiHandler } from "./claude-code-tui/index.js";
 import { type ClaudeExecutableResolution, resolveClaudeCodeExecutable } from "./claude-executable.js";
 import { createCodexHandler } from "./codex/index.js";
 import { createCursorHandler } from "./cursor/index.js";
+import { createGrokHandler } from "./grok/index.js";
 import { createKimiCodeHandler } from "./kimi-code.js";
 import { createOpenCodeHandler } from "./opencode/index.js";
 
@@ -51,6 +52,10 @@ export function registerBuiltinHandlers(deps: RegisterBuiltinHandlersDeps = {}):
   // handler resolves `cursor-agent` / `agent` lazily at session start (with
   // the login-shell probe) and spawns one CLI process per provider turn.
   registerHandler("cursor", (config) => createCursorHandler(config));
+  // Grok Build is external-only: the handler resolves the operator-installed
+  // `grok` binary lazily at session start and drives one ACP (stdio) process
+  // per provider turn. Windows stays fail-closed (POSIX-only supervision).
+  registerHandler("grok", (config) => createGrokHandler(config));
   // Kimi Code is driven through the bundled Node SDK. It reuses the host's
   // ~/.kimi-code credential/config and does not add a First Tree login flow.
   registerHandler("kimi-code", (config) => createKimiCodeHandler(config));

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -56,6 +56,7 @@ export {
   parseCursorModelsOutput,
   parseKimiConfigModels,
 } from "./runtime/capabilities/discover-models.js";
+export { probeGrokCapability } from "./runtime/capabilities/grok.js";
 export {
   CAPABILITY_REFRESH_BASE_MS,
   CAPABILITY_REFRESH_MAX_MS,
@@ -103,6 +104,14 @@ export type { AttachmentUploader, SelfFence, WorkspaceFence } from "./runtime/do
 export { buildMessageDocumentSnapshots } from "./runtime/doc-snapshots.js";
 export type { Classification, ErrorKind, ErrorSource, RetryStrategy } from "./runtime/error-taxonomy.js";
 export { clampRetryAttempt, classify, ERROR_KINDS, nextRetryDelayMs } from "./runtime/error-taxonomy.js";
+export {
+  findGrokExecutableOnPath,
+  formatGrokBinaryMissingMessage,
+  GROK_INSTALL_COMMAND,
+  type GrokRuntimeBinaryResolution,
+  resolveGrokRuntimeBinary,
+} from "./runtime/grok-binary.js";
+export { type GrokBrowserLoginOptions, runGrokBrowserLogin } from "./runtime/grok-login.js";
 export type {
   AgentHandler,
   HandlerConfig,

--- a/packages/client/src/runtime/capabilities/discover-models.ts
+++ b/packages/client/src/runtime/capabilities/discover-models.ts
@@ -3,11 +3,16 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ProviderModelCatalog, ProviderModelOption, RuntimeProvider } from "@first-tree/shared";
 import { parse as parseToml } from "smol-toml";
+import { fetchGrokAcpInitializeMeta } from "../../handlers/grok/acp-session.js";
+import { parseGrokModelState } from "../../handlers/grok/events.js";
 import { findCursorExecutableOnPath } from "../cursor-binary.js";
+import { findGrokExecutableOnPath } from "../grok-binary.js";
 import { runCommand } from "./launch-probe.js";
 
 /** Ceiling for `agent models` — account catalog fetch can be network-bound. */
 const CURSOR_MODELS_TIMEOUT_MS = 20_000;
+/** Ceiling for the initialize-only ACP handshake behind grok model discovery. */
+const GROK_MODELS_TIMEOUT_MS = 20_000;
 
 export type DiscoverModelsDeps = {
   env?: NodeJS.ProcessEnv;
@@ -17,6 +22,11 @@ export type DiscoverModelsDeps = {
     binary: string,
     env: NodeJS.ProcessEnv,
   ) => Promise<{ ok: boolean; stdout: string; stderr: string }>;
+  findGrokBinary?: (env?: Record<string, string | undefined>) => string | null;
+  fetchGrokModelMeta?: (
+    binary: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<{ ok: true; meta: Record<string, unknown> | null } | { ok: false; error: string }>;
   readKimiConfig?: () => Promise<string | null>;
   kimiConfigPath?: string;
 };
@@ -191,6 +201,46 @@ async function discoverKimiModels(deps: DiscoverModelsDeps): Promise<ProviderMod
 }
 
 /**
+ * Grok model discovery: spawn the CLI in ACP stdio mode and run ONLY the
+ * `initialize` handshake (empty clientCapabilities, unauthenticated metadata
+ * — never touches credentials), then parse `_meta.modelState` from the
+ * response. The catalog marks the provider's current model as the default.
+ */
+async function discoverGrokModels(deps: DiscoverModelsDeps): Promise<ProviderModelCatalog> {
+  const env = deps.env ?? process.env;
+  const findBinary = deps.findGrokBinary ?? findGrokExecutableOnPath;
+  const binary = findBinary(env);
+  if (!binary) {
+    return unavailable("grok", "grok binary not found on this host", deps);
+  }
+  const fetchMeta =
+    deps.fetchGrokModelMeta ??
+    ((bin, processEnv) =>
+      fetchGrokAcpInitializeMeta({
+        binary: bin,
+        env: processEnv,
+        timeoutMs: GROK_MODELS_TIMEOUT_MS,
+        clientVersion: "0",
+      }));
+  const result = await fetchMeta(binary, env);
+  if (!result.ok) {
+    return unavailable("grok", result.error.slice(0, 500), deps);
+  }
+  const parsed = parseGrokModelState({ _meta: result.meta });
+  if (parsed.models.length === 0) {
+    return unavailable("grok", "grok initialize response carried no model state", deps);
+  }
+  return {
+    provider: "grok",
+    models: parsed.models,
+    defaultModelId: parsed.defaultModelId,
+    fetchedAt: fetchedAt(deps),
+    source: "provider-cli",
+    error: null,
+  };
+}
+
+/**
  * Discover the model catalog for a runtime provider from the host-local
  * provider. Phase 1 implements Cursor + Kimi; other providers return
  * `source: "unavailable"` so the web can keep its curated/fallback UI.
@@ -202,6 +252,8 @@ export async function discoverProviderModels(
   switch (provider) {
     case "cursor":
       return discoverCursorModels(deps);
+    case "grok":
+      return discoverGrokModels(deps);
     case "kimi-code":
       return discoverKimiModels(deps);
     case "opencode":

--- a/packages/client/src/runtime/capabilities/discover-models.ts
+++ b/packages/client/src/runtime/capabilities/discover-models.ts
@@ -6,7 +6,7 @@ import { parse as parseToml } from "smol-toml";
 import { fetchGrokAcpInitializeMeta } from "../../handlers/grok/acp-session.js";
 import { parseGrokModelState } from "../../handlers/grok/events.js";
 import { findCursorExecutableOnPath } from "../cursor-binary.js";
-import { findGrokExecutableOnPath } from "../grok-binary.js";
+import { type GrokRuntimeBinaryResolution, resolveGrokRuntimeBinary } from "../grok-binary.js";
 import { runCommand } from "./launch-probe.js";
 
 /** Ceiling for `agent models` — account catalog fetch can be network-bound. */
@@ -22,7 +22,12 @@ export type DiscoverModelsDeps = {
     binary: string,
     env: NodeJS.ProcessEnv,
   ) => Promise<{ ok: boolean; stdout: string; stderr: string }>;
-  findGrokBinary?: (env?: Record<string, string | undefined>) => string | null;
+  /**
+   * Launch-verified grok resolution (supported version range gate). Discovery
+   * spawns the binary, so it must go through `resolveGrokRuntimeBinary`
+   * semantics — never the existence-only probe path.
+   */
+  resolveGrokBinary?: (env: NodeJS.ProcessEnv) => GrokRuntimeBinaryResolution;
   fetchGrokModelMeta?: (
     binary: string,
     env: NodeJS.ProcessEnv,
@@ -201,17 +206,21 @@ async function discoverKimiModels(deps: DiscoverModelsDeps): Promise<ProviderMod
 }
 
 /**
- * Grok model discovery: spawn the CLI in ACP stdio mode and run ONLY the
- * `initialize` handshake (empty clientCapabilities, unauthenticated metadata
- * — never touches credentials), then parse `_meta.modelState` from the
- * response. The catalog marks the provider's current model as the default.
+ * Grok model discovery: resolve the binary through the SAME launch-verified
+ * resolution the handler uses (`resolveGrokRuntimeBinary` — the capability
+ * probe stays install-only, but discovery actually spawns, so the supported
+ * version range must gate it and probe/discovery/handler agree on the same
+ * binary), then run ONLY the `initialize` handshake (empty
+ * clientCapabilities, unauthenticated metadata — never touches credentials)
+ * and parse `_meta.modelState` from the response. The catalog marks the
+ * provider's current model as the default.
  */
 async function discoverGrokModels(deps: DiscoverModelsDeps): Promise<ProviderModelCatalog> {
   const env = deps.env ?? process.env;
-  const findBinary = deps.findGrokBinary ?? findGrokExecutableOnPath;
-  const binary = findBinary(env);
-  if (!binary) {
-    return unavailable("grok", "grok binary not found on this host", deps);
+  const resolveBinary = deps.resolveGrokBinary ?? ((processEnv) => resolveGrokRuntimeBinary(processEnv));
+  const resolution = resolveBinary(env);
+  if (!resolution.ok) {
+    return unavailable("grok", resolution.error.slice(0, 500), deps);
   }
   const fetchMeta =
     deps.fetchGrokModelMeta ??
@@ -222,7 +231,7 @@ async function discoverGrokModels(deps: DiscoverModelsDeps): Promise<ProviderMod
         timeoutMs: GROK_MODELS_TIMEOUT_MS,
         clientVersion: "0",
       }));
-  const result = await fetchMeta(binary, env);
+  const result = await fetchMeta(resolution.binary, env);
   if (!result.ok) {
     return unavailable("grok", result.error.slice(0, 500), deps);
   }

--- a/packages/client/src/runtime/capabilities/grok.ts
+++ b/packages/client/src/runtime/capabilities/grok.ts
@@ -22,8 +22,11 @@ export type GrokProbeDeps = {
  * `"path"` for grok.
  *
  * Platform gate: Grok Build V1 supports macOS and Linux only. On Windows the
- * probe fails closed — it reports the provider unusable WITHOUT spawning
- * anything or consulting the filesystem.
+ * probe fails closed with state `error` (NOT `missing`): a `missing` entry
+ * makes the Web setup cards render the official install command in a loop
+ * for a runtime First Tree explicitly does not support on that platform.
+ * The gate short-circuits BEFORE the resolver — no filesystem consult, no
+ * spawn.
  */
 export async function probeGrokCapability(deps: GrokProbeDeps = {}): Promise<CapabilityEntry> {
   const env = deps.env ?? process.env;
@@ -32,12 +35,10 @@ export async function probeGrokCapability(deps: GrokProbeDeps = {}): Promise<Cap
 
   return runDetect(async (): Promise<DetectOutcome> => {
     if (platform === "win32") {
-      return {
-        installed: false,
-        error:
-          "Grok Build is not supported on Windows — the Grok Build CLI supports macOS and Linux only. " +
+      throw new Error(
+        "Grok Build provider is not supported on Windows in V1 (macOS/Linux only). " +
           "First Tree fails closed on this platform and will not spawn `grok` here.",
-      };
+      );
     }
     const pathBinary = findOnPath(env);
     if (pathBinary) {

--- a/packages/client/src/runtime/capabilities/grok.ts
+++ b/packages/client/src/runtime/capabilities/grok.ts
@@ -1,0 +1,51 @@
+import type { CapabilityEntry } from "@first-tree/shared";
+import { findGrokExecutableOnPath, formatGrokBinaryMissingMessage } from "../grok-binary.js";
+import { type DetectOutcome, runDetect } from "./detect.js";
+
+/** Injectable seams — production callers pass nothing. */
+export type GrokProbeDeps = {
+  findOnPath?: (env?: Record<string, string | undefined>) => string | null;
+  env?: NodeJS.ProcessEnv;
+  /** Test-only platform override; production reads `process.platform`. */
+  platform?: NodeJS.Platform;
+};
+
+/**
+ * Install-only probe for the `grok` (Grok Build) runtime.
+ *
+ * Grok Build is external-only — there is no bundled fallback, so the probe
+ * answers exactly one question: does an operator-installed `grok` exist on
+ * this host? Existence only: no `--version`, no credential or network
+ * judgment (the probe never reads `~/.grok/auth.json` either). A logged-out
+ * or unreachable Grok Build is discovered when a session actually runs and
+ * surfaced as an in-chat credential failure. `runtimeSource` is always
+ * `"path"` for grok.
+ *
+ * Platform gate: Grok Build V1 supports macOS and Linux only. On Windows the
+ * probe fails closed — it reports the provider unusable WITHOUT spawning
+ * anything or consulting the filesystem.
+ */
+export async function probeGrokCapability(deps: GrokProbeDeps = {}): Promise<CapabilityEntry> {
+  const env = deps.env ?? process.env;
+  const platform = deps.platform ?? process.platform;
+  const findOnPath = deps.findOnPath ?? findGrokExecutableOnPath;
+
+  return runDetect(async (): Promise<DetectOutcome> => {
+    if (platform === "win32") {
+      return {
+        installed: false,
+        error:
+          "Grok Build is not supported on Windows — the Grok Build CLI supports macOS and Linux only. " +
+          "First Tree fails closed on this platform and will not spawn `grok` here.",
+      };
+    }
+    const pathBinary = findOnPath(env);
+    if (pathBinary) {
+      return { installed: true, runtimeSource: "path", runtimePath: pathBinary };
+    }
+    return {
+      installed: false,
+      error: formatGrokBinaryMissingMessage("no grok binary resolved on this host"),
+    };
+  });
+}

--- a/packages/client/src/runtime/capabilities/index.ts
+++ b/packages/client/src/runtime/capabilities/index.ts
@@ -8,6 +8,7 @@ import { probeClaudeCodeCapability } from "./claude-code.js";
 import { probeClaudeCodeTuiCapability } from "./claude-code-tui.js";
 import { probeCodexCapability } from "./codex.js";
 import { probeCursorCapability } from "./cursor.js";
+import { probeGrokCapability } from "./grok.js";
 import { probeKimiCodeCapability } from "./kimi-code.js";
 import { probeOpenCodeCapability } from "./opencode.js";
 
@@ -20,7 +21,7 @@ export const REPROBE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
  * temporarily disabled. Drives whether a daemon's advertised snapshot still has
  * a provider worth re-probing (see {@link hasNonOkProvider}). */
 export const PROBED_RUNTIME_PROVIDERS: readonly RuntimeProvider[] = (
-  ["claude-code", "claude-code-tui", "codex", "cursor", "kimi-code", "opencode"] as const
+  ["claude-code", "claude-code-tui", "codex", "cursor", "grok", "kimi-code", "opencode"] as const
 ).filter((p) => isRuntimeProviderEnabled(p));
 
 /** First delay before the daemon-side degraded-capability re-probe fires. Short
@@ -92,6 +93,7 @@ export async function probeCapabilities(): Promise<ClientCapabilities> {
   if (isRuntimeProviderEnabled("claude-code-tui")) probes.push(["claude-code-tui", probeClaudeCodeTuiCapability()]);
   if (isRuntimeProviderEnabled("codex")) probes.push(["codex", probeCodexCapability()]);
   if (isRuntimeProviderEnabled("cursor")) probes.push(["cursor", probeCursorCapability()]);
+  if (isRuntimeProviderEnabled("grok")) probes.push(["grok", probeGrokCapability()]);
   if (isRuntimeProviderEnabled("kimi-code")) probes.push(["kimi-code", probeKimiCodeCapability()]);
   if (isRuntimeProviderEnabled("opencode")) probes.push(["opencode", probeOpenCodeCapability()]);
   return aggregate(probes);

--- a/packages/client/src/runtime/error-taxonomy.ts
+++ b/packages/client/src/runtime/error-taxonomy.ts
@@ -21,6 +21,7 @@
 
 import { isCodexBinaryMissingError } from "./codex-binary.js";
 import { isCursorBinaryMissingError } from "./cursor-binary.js";
+import { isGrokBinaryMissingError } from "./grok-binary.js";
 
 export const ERROR_KINDS = {
   TRANSIENT: "transient",
@@ -309,6 +310,25 @@ export function classify(err: unknown, context?: { source?: ErrorSource }): Clas
       strategy: NONE,
       reasonCode: "cursor_binary_missing",
       message: shape.message ?? "Cursor Agent CLI binary missing",
+    };
+  }
+  // Same present-but-flaky vs genuinely-missing split for the external Grok
+  // Build CLI: a smoke-check flake retries, a resolved-nothing / clean-broken
+  // / unsupported-version binary is a permanent capability failure.
+  if (shape.name === "GrokBinaryVerifyTransientError") {
+    return {
+      kind: ERROR_KINDS.TRANSIENT,
+      strategy: TRANSIENT_FAST,
+      reasonCode: "grok_verify_transient",
+      message: shape.message ?? "grok --version smoke check did not complete (transient)",
+    };
+  }
+  if (isGrokBinaryMissingError(err)) {
+    return {
+      kind: ERROR_KINDS.PERMANENT,
+      strategy: NONE,
+      reasonCode: "grok_binary_missing",
+      message: shape.message ?? "Grok Build CLI binary missing",
     };
   }
   // `AbortSignal.timeout()` aborts with a `DOMException` whose `name` is

--- a/packages/client/src/runtime/grok-binary.ts
+++ b/packages/client/src/runtime/grok-binary.ts
@@ -240,6 +240,8 @@ export type GrokRuntimeBinaryResolution =
 export type GrokRuntimeResolveDeps = {
   findOnPath?: (env?: Record<string, string | undefined>) => string | null;
   verifyPath?: (path: string, env?: Record<string, string | undefined>) => GrokExecutableVerification;
+  /** Test-only platform override; production reads `process.platform`. */
+  platform?: NodeJS.Platform;
 };
 
 /**
@@ -262,6 +264,19 @@ export function resolveGrokRuntimeBinary(
   env: NodeJS.ProcessEnv = process.env,
   deps: GrokRuntimeResolveDeps = {},
 ): GrokRuntimeBinaryResolution {
+  // Central fail-closed platform gate: EVERY spawn entry point (turn
+  // transport, model discovery, runtime auth) resolves through here, so one
+  // refusal covers them all. Short-circuits before any filesystem consult.
+  const platform = deps.platform ?? process.platform;
+  if (platform === "win32") {
+    return {
+      ok: false,
+      error:
+        "Grok Build provider is not supported on Windows in V1 (macOS/Linux only); " +
+        "First Tree fails closed and will not resolve or spawn `grok` on this platform.",
+      transient: false,
+    };
+  }
   const findOnPath = deps.findOnPath ?? findGrokExecutableOnPath;
   const verifyPath = deps.verifyPath ?? verifyGrokExecutable;
 
@@ -288,7 +303,14 @@ export function resolveGrokRuntimeBinary(
     }
     return {
       ok: false,
-      error: formatGrokBinaryMissingMessage(`resolved grok failed validation: ${verification.reason}`),
+      // A resolved-but-UNSUPPORTED binary (out of range / failed verification)
+      // is NOT "missing": the message must not match the missing-binary
+      // patterns, and the retry policy maps it to the deterministic
+      // `grok_binary_unsupported` capability stop.
+      error:
+        `Grok Build CLI at ${binary} is not a supported Grok Build version: ${verification.reason} ` +
+        `(supported range >=${GROK_MIN_SUPPORTED_VERSION} <${GROK_MAX_EXCLUSIVE_VERSION}). ` +
+        `Upgrade with the official installer (\`${GROK_INSTALL_COMMAND}\`).`,
       transient: false,
     };
   }

--- a/packages/client/src/runtime/grok-binary.ts
+++ b/packages/client/src/runtime/grok-binary.ts
@@ -1,0 +1,326 @@
+import { spawnSync } from "node:child_process";
+import { accessSync, constants, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, isAbsolute, join, resolve } from "node:path";
+import { wellKnownBinDirs } from "./install-locations.js";
+import { getLoginShellPathDirs } from "./login-shell-path.js";
+
+/**
+ * Grok Build CLI binary resolution. Grok Build is EXTERNAL-ONLY: First Tree
+ * never bundles the Grok engine, never downloads it, and never reads Grok
+ * internals (`~/.grok/auth.json` included) — the runtime resolves the
+ * operator-installed CLI and spawns it with `shell: false`. The official
+ * installer (`curl -fsSL https://x.ai/cli/install.sh | bash`) drops the
+ * binary at `~/.grok/bin/grok` and commonly links it into `~/.local/bin/grok`;
+ * it is NOT an npm package, so no node_modules resolution is attempted.
+ */
+
+/** Official install command surfaced in missing-binary copy and setup UI. */
+export const GROK_INSTALL_COMMAND = "curl -fsSL https://x.ai/cli/install.sh | bash";
+
+/**
+ * Supported Grok Build CLI range for this integration. Verified against
+ * `grok 0.2.117 (f1c06093089f)`; a resolved binary outside the range is a
+ * deterministic configuration failure, never a transient one.
+ */
+export const GROK_MIN_SUPPORTED_VERSION = "0.2.117";
+export const GROK_MAX_EXCLUSIVE_VERSION = "0.3.0";
+
+/**
+ * `grok --version` smoke-check ceiling. Mirrors the cursor bound: a cold
+ * binary or a loaded machine can take seconds to respond, and a tight bound
+ * would turn a present, working binary into a spurious failure.
+ */
+const GROK_VERSION_VERIFY_TIMEOUT_MS = 10_000;
+
+/**
+ * Spawn errnos that mean "the machine couldn't run the check right now", NOT
+ * "the binary is broken/absent". These map to a transient verification failure
+ * (→ retry), never to a missing-binary verdict.
+ */
+const TRANSIENT_SPAWN_CODES: ReadonlySet<string> = new Set(["ETIMEDOUT", "EAGAIN", "ENOMEM", "ETXTBSY"]);
+
+/**
+ * Kill signals that mean "the binary crashed deterministically" — a broken /
+ * incompatible install that will fault the same way on every retry. Any OTHER
+ * signal (the timeout's SIGTERM/SIGKILL, an OOM kill) is a host condition and
+ * stays transient.
+ */
+const DETERMINISTIC_CRASH_SIGNALS: ReadonlySet<NodeJS.Signals> = new Set([
+  "SIGSEGV",
+  "SIGABRT",
+  "SIGILL",
+  "SIGBUS",
+  "SIGFPE",
+]);
+
+export type GrokExecutableVerification =
+  | { ok: true; output?: string; version: string | null }
+  | { ok: false; reason: string; transient: boolean };
+
+/**
+ * A resolved grok binary that EXISTS but whose `--version` smoke check did
+ * not complete for a transient reason (timeout / host pressure). Carries a
+ * distinct `name` the error taxonomy maps to `transient`, so a flaky check
+ * reschedules bring-up instead of surfacing as a permanent missing-binary
+ * terminal failure.
+ */
+export class GrokBinaryVerifyTransientError extends Error {
+  constructor(reason: string) {
+    super(`grok --version smoke check did not complete (transient host condition); will retry. Detail: ${reason}`);
+    this.name = "GrokBinaryVerifyTransientError";
+  }
+}
+
+const GROK_BINARY_MISSING_PATTERNS: readonly RegExp[] = [
+  /grok build cli is missing/i,
+  /grok.*not (?:found|installed)/i,
+];
+
+export function isGrokBinaryMissingError(input: unknown): boolean {
+  const text = errorSearchText(input);
+  return GROK_BINARY_MISSING_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function formatGrokBinaryMissingMessage(input: unknown): string {
+  const original = errorText(input).trim();
+  const suffix = original ? ` Original error: ${original}` : "";
+  return (
+    "Grok Build CLI is missing on this machine. " +
+    "First Tree does not bundle or install the Grok engine — it resolves the operator-installed `grok` from PATH, well-known install directories, or the login-shell PATH. " +
+    `Install it with the official installer (\`${GROK_INSTALL_COMMAND}\`), then sign in with \`grok login\` and re-run capability detection.` +
+    suffix
+  );
+}
+
+/** Injectable seams so probe tests stay hermetic (no real shell spawn / no host install dirs). */
+export type FindGrokExecutableDeps = {
+  /** Returns the user's interactive-login-shell PATH dirs; defaults to the memoized probe. */
+  loginShellPathDirs?: () => string[];
+  /** Returns the curated well-known bin dirs; defaults to the real host list. */
+  wellKnownDirs?: () => string[];
+  platform?: NodeJS.Platform;
+  pathDelimiter?: string;
+};
+
+/**
+ * Resolve the Grok Build CLI the runtime would spawn. Existence-only — never
+ * launches the binary; `verifyGrokExecutable` owns the spawn-time smoke check.
+ *
+ * Directory order mirrors the other external providers — daemon PATH →
+ * curated well-known install dirs (the official installer targets
+ * `~/.grok/bin` and commonly links into `~/.local/bin`) → login-shell PATH
+ * (may spawn a shell, so consulted last).
+ */
+export function findGrokExecutableOnPath(
+  env: Record<string, string | undefined> = process.env,
+  deps: FindGrokExecutableDeps = {},
+): string | null {
+  const platform = deps.platform ?? process.platform;
+  const pathDelimiter = deps.pathDelimiter ?? (platform === "win32" ? ";" : delimiter);
+  const loginShellPathDirs = deps.loginShellPathDirs ?? getLoginShellPathDirs;
+  const home = env.HOME && env.HOME.length > 0 ? env.HOME : homedir();
+  const wellKnownDirs = deps.wellKnownDirs ?? (() => [join(home, ".grok", "bin"), ...wellKnownBinDirs(home)]);
+  const name = grokExecutableName(platform);
+  const seen = new Set<string>();
+
+  const search = (dirs: readonly string[]): string | null => {
+    for (const dir of dirs) {
+      if (!dir) continue;
+      const base = isAbsolute(dir) ? dir : resolve(dir);
+      if (seen.has(base)) continue;
+      seen.add(base);
+      const candidate = join(base, name);
+      if (isExecutableFile(candidate, platform)) return candidate;
+    }
+    return null;
+  };
+
+  const pathValue = env.PATH ?? env.Path ?? env.path ?? "";
+  const pathDirs = pathValue ? pathValue.split(pathDelimiter) : [];
+  return search(pathDirs) ?? search(wellKnownDirs()) ?? search(loginShellPathDirs());
+}
+
+/**
+ * Parse the semver out of `grok --version` output, e.g.
+ * `grok 0.2.117 (f1c06093089f)` → `0.2.117`. Returns null when the output
+ * does not carry the canonical `grok <semver>` token.
+ */
+export function parseGrokVersion(output: string): string | null {
+  const match = output.match(/grok (\d+\.\d+\.\d+)/);
+  return match?.[1] ?? null;
+}
+
+/** Compare two `x.y.z` versions: negative / zero / positive. */
+function compareSemver(left: string, right: string): number {
+  const a = left.split(".").map(Number);
+  const b = right.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/** True when `version` falls inside the supported `>=min <maxExclusive` range. */
+export function isGrokVersionSupported(version: string): boolean {
+  return (
+    compareSemver(version, GROK_MIN_SUPPORTED_VERSION) >= 0 && compareSemver(version, GROK_MAX_EXCLUSIVE_VERSION) < 0
+  );
+}
+
+/**
+ * Bounded `--version` smoke check run at first REAL use of the binary
+ * (handler spawn / login) — never by the install-only capability probe.
+ * Timeout / spawn-pressure outcomes are transient; a clean non-zero exit, a
+ * deterministic crash signal, an unparseable version, or a version outside
+ * the supported range is a genuine broken / unsupported-binary verdict.
+ */
+export function verifyGrokExecutable(
+  path: string,
+  env: Record<string, string | undefined> = process.env,
+): GrokExecutableVerification {
+  const result = spawnSync(path, ["--version"], {
+    env: { ...process.env, ...env },
+    encoding: "utf-8",
+    shell: false,
+    timeout: GROK_VERSION_VERIFY_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  if (result.error) {
+    const code = (result.error as NodeJS.ErrnoException).code;
+    const timedOut = code === "ETIMEDOUT";
+    const transient = timedOut || (typeof code === "string" && TRANSIENT_SPAWN_CODES.has(code));
+    return { ok: false, transient, reason: timedOut ? "`grok --version` timed out" : result.error.message };
+  }
+  if (result.signal) {
+    const crashed = DETERMINISTIC_CRASH_SIGNALS.has(result.signal);
+    return { ok: false, transient: !crashed, reason: `\`grok --version\` killed by ${result.signal}` };
+  }
+  if (result.status !== 0) {
+    const detail = [result.stderr, result.stdout]
+      .filter((text): text is string => typeof text === "string" && text.trim().length > 0)
+      .join(" ")
+      .trim();
+    return {
+      ok: false,
+      transient: false,
+      reason: `\`grok --version\` exited ${result.status}${detail ? `: ${detail}` : ""}`,
+    };
+  }
+  const output = [result.stdout, result.stderr]
+    .filter((text): text is string => typeof text === "string" && text.trim().length > 0)
+    .join(" ")
+    .trim();
+  const version = parseGrokVersion(output);
+  if (!version) {
+    return {
+      ok: false,
+      transient: false,
+      reason: `\`grok --version\` did not report a parseable version (output: ${output.slice(0, 200)})`,
+    };
+  }
+  if (!isGrokVersionSupported(version)) {
+    return {
+      ok: false,
+      transient: false,
+      reason:
+        `grok ${version} is outside the supported range ` +
+        `>=${GROK_MIN_SUPPORTED_VERSION} <${GROK_MAX_EXCLUSIVE_VERSION}; upgrade with \`${GROK_INSTALL_COMMAND}\``,
+    };
+  }
+  return { ok: true, output, version };
+}
+
+export type GrokRuntimeBinaryResolution =
+  | { ok: true; binary: string; version: string | null }
+  | { ok: false; error: string; transient: boolean };
+
+/** Injectable seams for `resolveGrokRuntimeBinary` (tests only). */
+export type GrokRuntimeResolveDeps = {
+  findOnPath?: (env?: Record<string, string | undefined>) => string | null;
+  verifyPath?: (path: string, env?: Record<string, string | undefined>) => GrokExecutableVerification;
+};
+
+/**
+ * Successful smoke-check verdicts, keyed by binary path. `verifyGrokExecutable`
+ * is a BLOCKING spawnSync on the daemon main thread; without this cache every
+ * session start/resume of every grok agent would stall the event loop for
+ * the `--version` round-trip. Only successes are cached — a transient flake
+ * must stay retryable, and a broken binary should re-report its reason. A
+ * binary that later disappears is caught by the spawn-time ENOENT path.
+ */
+const verifiedGrokBinaries = new Map<string, string | null>();
+
+/**
+ * Resolve + launch-verify the grok binary the handler / login is about to
+ * spawn. The capability probe does NOT use this (it is install-only); both
+ * share `findGrokExecutableOnPath`, so the probe's existence verdict is a
+ * strict subset of this resolution.
+ */
+export function resolveGrokRuntimeBinary(
+  env: NodeJS.ProcessEnv = process.env,
+  deps: GrokRuntimeResolveDeps = {},
+): GrokRuntimeBinaryResolution {
+  const findOnPath = deps.findOnPath ?? findGrokExecutableOnPath;
+  const verifyPath = deps.verifyPath ?? verifyGrokExecutable;
+
+  const binary = findOnPath(env);
+  if (!binary) {
+    return {
+      ok: false,
+      error: formatGrokBinaryMissingMessage("no grok binary resolved"),
+      transient: false,
+    };
+  }
+  if (verifiedGrokBinaries.has(binary)) {
+    return { ok: true, binary, version: verifiedGrokBinaries.get(binary) ?? null };
+  }
+  const verification = verifyPath(binary, env);
+  if (!verification.ok) {
+    if (verification.transient) {
+      // A present binary that only flaked its smoke check is NOT missing.
+      return {
+        ok: false,
+        error: `grok resolved at ${binary} but \`--version\` did not complete (transient host condition): ${verification.reason}`,
+        transient: true,
+      };
+    }
+    return {
+      ok: false,
+      error: formatGrokBinaryMissingMessage(`resolved grok failed validation: ${verification.reason}`),
+      transient: false,
+    };
+  }
+  verifiedGrokBinaries.set(binary, verification.version);
+  return { ok: true, binary, version: verification.version };
+}
+
+function grokExecutableName(platform: NodeJS.Platform): string {
+  return platform === "win32" ? "grok.exe" : "grok";
+}
+
+function isExecutableFile(filePath: string, platform: NodeJS.Platform): boolean {
+  try {
+    if (!statSync(filePath).isFile()) return false;
+    accessSync(filePath, platform === "win32" ? constants.F_OK : constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function errorText(input: unknown): string {
+  if (input instanceof Error) return input.message;
+  if (typeof input === "string") return input;
+  if (input && typeof input === "object") {
+    const maybe = input as { message?: unknown };
+    if (typeof maybe.message === "string") return maybe.message;
+  }
+  return String(input);
+}
+
+function errorSearchText(input: unknown): string {
+  if (input instanceof Error) return `${input.name} ${input.message}`;
+  return errorText(input);
+}

--- a/packages/client/src/runtime/grok-login.ts
+++ b/packages/client/src/runtime/grok-login.ts
@@ -23,10 +23,21 @@ export type GrokBrowserLoginOptions = {
   signal?: AbortSignal;
   timeoutMs?: number;
   spawnFn?: typeof spawn;
+  /** Test-only platform override; production reads `process.platform`. */
+  platform?: NodeJS.Platform;
 };
 
 /** Spawn `<grok-binary> login` (official browser OAuth on the host). */
 export function runGrokBrowserLogin(options: GrokBrowserLoginOptions): Promise<LoginOutcome> {
+  // Fail closed on Windows before any spawn (belt-and-braces next to the
+  // resolver gate — this function is also reachable from the CLI auth flow).
+  if ((options.platform ?? process.platform) === "win32") {
+    return Promise.resolve({
+      ok: false,
+      reason: "spawn-error",
+      error: "Grok Build login is not supported on Windows in V1 (macOS/Linux only); First Tree fails closed.",
+    });
+  }
   return runBrowserLogin({
     command: options.binary,
     args: ["login"],

--- a/packages/client/src/runtime/grok-login.ts
+++ b/packages/client/src/runtime/grok-login.ts
@@ -1,0 +1,41 @@
+import type { spawn } from "node:child_process";
+import { BROWSER_LOGIN_TIMEOUT_MS, type LoginOutcome, runBrowserLogin } from "./runtime-login.js";
+
+/**
+ * Grok Build browser-OAuth login on top of the shared {@link runBrowserLogin}
+ * plumbing: `<grok-binary> login` opens the provider's sign-in page on the
+ * host, Grok's own callback completes the exchange, and the CLI writes its
+ * local credential store itself. First Tree never sees the token; it only
+ * observes the process outcome and re-probes capabilities. (`grok login
+ * --device-auth` exists for headless hosts but stays operator-run; the
+ * in-product flow always drives the browser path.)
+ */
+
+export type GrokBrowserLoginOptions = {
+  /** Absolute path to the grok binary the runtime resolved (external-only). */
+  binary: string;
+  /** Environment for the child; defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Fired at most once with a fallback auth URL parsed from output. */
+  onAuthUrl?: (url: string) => void;
+  /** Raw, ANSI-stripped output, for diagnostics. */
+  onRawOutput?: (chunk: string) => void;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  spawnFn?: typeof spawn;
+};
+
+/** Spawn `<grok-binary> login` (official browser OAuth on the host). */
+export function runGrokBrowserLogin(options: GrokBrowserLoginOptions): Promise<LoginOutcome> {
+  return runBrowserLogin({
+    command: options.binary,
+    args: ["login"],
+    label: "grok login",
+    env: options.env,
+    onAuthUrl: options.onAuthUrl,
+    onRawOutput: options.onRawOutput,
+    signal: options.signal,
+    timeoutMs: options.timeoutMs ?? BROWSER_LOGIN_TIMEOUT_MS,
+    spawnFn: options.spawnFn,
+  });
+}

--- a/packages/client/src/runtime/managed-skills.ts
+++ b/packages/client/src/runtime/managed-skills.ts
@@ -63,6 +63,7 @@ const PROVIDER_SKILL_ROOTS: Readonly<Record<RuntimeProvider, string>> = {
   "claude-code-tui": ".claude/skills",
   codex: ".agents/skills",
   cursor: ".cursor/skills",
+  grok: ".grok/skills",
   "kimi-code": ".kimi-code/skills",
   opencode: ".opencode/skills",
 };

--- a/packages/client/src/runtime/managed-state.ts
+++ b/packages/client/src/runtime/managed-state.ts
@@ -374,6 +374,7 @@ function isSafePersistedTarget(target: string): boolean {
     root === ".agents/skills" ||
     root === ".claude/skills" ||
     root === ".cursor/skills" ||
+    root === ".grok/skills" ||
     root === ".kimi-code/skills" ||
     root === ".opencode/skills" ||
     root === ".first-tree/resources/skills";

--- a/packages/client/src/runtime/provider-retry-policy.ts
+++ b/packages/client/src/runtime/provider-retry-policy.ts
@@ -120,7 +120,7 @@ export function classifyProviderFailure(
       sourceKind: base.kind,
     };
   }
-  if (isCapacity(text, base, retryAfterMs)) {
+  if (isCapacity(text, base, retryAfterMs, context.provider)) {
     return {
       category: "provider_capacity",
       reasonCode: capacityReason(text, base),
@@ -442,7 +442,12 @@ function isCredential(
   // Cursor" CTA renders only for category=credential, so a wording variant
   // that drops the word "authentication" must still classify credential —
   // without leaking these generic phrases into other providers' traffic.
-  return provider === "cursor" && /not logged in|agent login|cursor_api_key/.test(text);
+  if (provider === "cursor" && /not logged in|agent login|cursor_api_key/.test(text)) return true;
+  // Grok Build CLI logged-out phrasings (kept in sync with isGrokAuthError in
+  // handlers/auth-error-hint.ts). Same provider-gating rationale as cursor:
+  // "not logged in" / "grok login" / "auth.json" carry no generic auth token
+  // the shared classifier already covers, so they need a grok-only branch.
+  return provider === "grok" && /not logged in|grok login|auth\.json/.test(text);
 }
 
 function credentialReason(base: Classification): string {
@@ -498,11 +503,20 @@ function deterministicReason(base: Classification): string {
   return base.reasonCode === "unknown" ? "provider_deterministic_input" : base.reasonCode;
 }
 
-function isCapacity(text: string, base: Classification, retryAfterMs: number | undefined): boolean {
+function isCapacity(
+  text: string,
+  base: Classification,
+  retryAfterMs: number | undefined,
+  provider: RuntimeProvider,
+): boolean {
   return (
     retryAfterMs !== undefined ||
     base.reasonCode.includes("rate_limit") ||
-    /rate.?limit|usage limit|session limit|quota|insufficient_quota|overloaded|capacity/.test(text)
+    /rate.?limit|usage limit|session limit|quota|insufficient_quota|overloaded|capacity/.test(text) ||
+    // Grok Build surfaces HTTP 429 with these phrasings after its internal
+    // retry budget is exhausted. Provider-gated like the cursor configuration
+    // branch: the words alone are not reserved capacity-speak elsewhere.
+    (provider === "grok" && /too many requests|resource has been exhausted/.test(text))
   );
 }
 
@@ -518,7 +532,12 @@ function isTransportText(text: string): boolean {
 function capacityReason(text: string, base: Classification): string {
   if (/usage limit|session limit|quota|insufficient_quota/.test(text)) return "provider_usage_limit";
   if (/overloaded|capacity/.test(text)) return "provider_overloaded";
-  if (/rate.?limit/.test(text) || base.reasonCode.includes("rate_limit")) return "provider_rate_limited";
+  if (
+    /rate.?limit|too many requests|resource has been exhausted/.test(text) ||
+    base.reasonCode.includes("rate_limit")
+  ) {
+    return "provider_rate_limited";
+  }
   return base.reasonCode === "unknown" ? "provider_capacity" : base.reasonCode;
 }
 

--- a/packages/client/src/runtime/provider-retry-policy.ts
+++ b/packages/client/src/runtime/provider-retry-policy.ts
@@ -93,6 +93,30 @@ export function classifyProviderFailure(
       sourceKind: base.kind,
     };
   }
+  // Grok deterministic capability gates, produced by the win32 fail-closed
+  // path (handler bring-up / resolveGrokRuntimeBinary refusal) and the
+  // resolved-but-unsupported binary verdict (out-of-range / failed
+  // verification). Both must stop deterministically — never the unknown
+  // retry path, never the binary_missing reason code (that one is reserved
+  // for "no binary resolved").
+  if (context.provider === "grok" && /not supported on windows in v1/.test(text)) {
+    return {
+      category: "capability",
+      reasonCode: "grok_platform_unsupported",
+      message: base.message,
+      retryAfterMs,
+      sourceKind: base.kind,
+    };
+  }
+  if (context.provider === "grok" && /is not a supported grok build version/.test(text)) {
+    return {
+      category: "capability",
+      reasonCode: "grok_binary_unsupported",
+      message: base.message,
+      retryAfterMs,
+      sourceKind: base.kind,
+    };
+  }
   if (isCapability(text, base)) {
     return {
       category: "capability",

--- a/packages/client/src/runtime/runtime-notice.ts
+++ b/packages/client/src/runtime/runtime-notice.ts
@@ -41,6 +41,8 @@ function providerLabel(provider: RuntimeProvider): string {
       return "Claude Code";
     case "cursor":
       return "Cursor";
+    case "grok":
+      return "Grok Build";
     case "kimi-code":
       return "Kimi Code";
     case "opencode":

--- a/packages/qa/cases/runtime/grok-provider.md
+++ b/packages/qa/cases/runtime/grok-provider.md
@@ -35,8 +35,8 @@ that case and the run-local plan, not this one.
 - Capability: with the CLI absent, the computer card shows setup-incomplete for Grok Build with the official installer
   command (`curl -fsSL https://x.ai/cli/install.sh | bash`) and no npm install copy; after installing and re-probing,
   the entry turns `ok` with a `path` runtime source. Detection must never launch the binary or judge login state.
-- Provider selection: a new agent can be created on `grok` only when the bound client advertises it; the binding is
-  immutable afterwards, matching the other providers.
+- Provider selection: a new agent can be created on `grok` only when the bound client advertises it; afterwards the
+  provider changes only via the explicit runtime-switch flow, matching the other providers.
 - Auth recovery: with the CLI logged out, a real turn fails as a credential failure; the chat surfaces a durable
   runtime notice plus a "Log in to Grok Build" action before the delivery is acked. Driving the login runs the
   provider's official login on the host (`grok login`); progress rides `pendingAuth` / `lastAuthError` on the
@@ -59,8 +59,29 @@ that case and the run-local plan, not this one.
 - Free-form model: set an exact model id through Web (free-form input with the `auto (Grok default)` hint), confirm it
   round-trips and reaches the next turn's spawn as `--model`; an id the provider rejects must fail visibly as a
   configuration failure with no silent fallback, and recover after an explicit config change.
+- Model/effort on an EXISTING session: with a chat that already has a persisted Grok session, change the model and/or
+  effort in Web and send the next message — the resumed turn must apply the new selection via ACP `session/set_model`
+  after `session/load` and before the prompt (session/load restores the session's persisted model/effort, so argv-only
+  selection would silently keep the old values). An invalid model must be visibly rejected by `session/set_model` as a
+  configuration failure — never a silent fallback to the persisted selection.
 - Reasoning effort: the effort control is shown for Grok Build with inherit/low/medium/high. Round-trip each value:
-  inherit sends no `--effort` flag; low/medium/high reach the next turn's spawn as `--effort <value>`.
+  low/medium/high reach the next turn's spawn as `--effort <value>` and are re-applied after every session open via
+  `session/set_model` (`_meta.reasoningEffort`). An explicit model is always re-applied with it; clearing only the
+  effort removes just the effort override (no effort meta is sent) while the explicit model is still re-applied —
+  only when the model is ALSO empty does the next turn's `session/set_model` carry the initialize-advertised default
+  model, resetting the session to the provider default. An existing session's persisted selection is never silently
+  kept.
+- Replay contract on resume: a resumed turn sends `session/load` with `_meta.noReplay: true`, and any historical
+  notification stamped `_meta.isReplay` is dropped even when it arrives inside the active prompt window — the resumed
+  turn's visible output and `token_usage` must reflect only the current prompt.
+- Terminal stop reasons: a turn ending with an ACP completion stop reason other than `end_turn` (`max_tokens` or
+  `refusal`) still completes the turn with the accumulated assistant text and usage preserved — it must not surface
+  as a provider failure. A provider-side `cancelled` is an abnormal end routed through ProviderAttempt/replay-safety
+  like any other failure: redelivery only when the turn is replay-safe, consumed-terminal when user-visible output
+  or tool side effects already happened — never an unconditional abort/redelivery.
+- Discovery version gate: host-local model discovery resolves the binary through the launch-verified supported range
+  (`>=0.2.117 <0.3.0`), never the existence-only probe path; an out-of-range `grok` degrades the catalog to
+  `unavailable` instead of spawning the ACP handshake.
 - Context Tree I/O: in a chat whose agent has a bound Context Tree, have the agent read a tree node and edit a tree
   file; the Context tab must record repo-qualified read/write evidence for the native Grok file tools
   (`read_file`, `write`, `search_replace`) and for the shell-read path (`git_status_delta` may carry the write).
@@ -74,16 +95,20 @@ that case and the run-local plan, not this one.
 
 `PASS` means the live branches above were exercised with real product evidence: an authenticated Grok turn completed
 end to end under the canonical posture, credential failure surfaced the durable notice + login action and recovered
-in-product, ACP session new/load continuity held across turns and a daemon restart, same-cwd parallel chats stayed
-isolated, a First Tree-managed MCP tool was delivered via `mcpServers` and called, model and effort config
-round-tripped (including the visible model-rejection branch), 429 capacity produced a visible retry, and Context Tree
-I/O evidence appeared for both native-tool and shell-read paths.
+in-product, ACP session new/load continuity held across turns and a daemon restart, model/effort changes on an
+existing session were applied via `session/set_model` after `session/load` (invalid model visibly rejected, no silent
+fallback), replay-marked traffic on resume was filtered, terminal stop reasons completed with preserved text,
+discovery stayed behind the version gate, same-cwd parallel chats stayed isolated, a First Tree-managed MCP tool was
+delivered via `mcpServers` and called, model and effort config round-tripped, 429 capacity produced a visible retry,
+and Context Tree I/O evidence appeared for both native-tool and shell-read paths.
 
-`FAIL` means a reproducible product issue: e.g. prompt in argv, a session id resumed in the wrong chat, a lingering
-process after turn completion, a terminal failure acked without a durable chat notice, silent model or effort
-fallback, managed MCP leaking into provider-side config files or surviving removal, cross-chat session-dir
-interleaving, a 429 surfaced as terminal without retry, missing Context Tree I/O evidence, or a drain that misses a
-live `grok` process.
+`FAIL` means a reproducible product issue: e.g. prompt in argv, a session id resumed in the wrong chat, a resumed turn
+silently keeping the session's persisted model/effort instead of the configured one, replayed history leaking into a
+resumed turn's output or usage, a terminal stop reason surfaced as a provider failure, model discovery spawning an
+out-of-range binary, a lingering process after turn completion, a terminal failure acked without a durable chat
+notice, silent model or effort fallback, managed MCP leaking into provider-side config files or surviving removal,
+cross-chat session-dir interleaving, a 429 surfaced as terminal without retry, missing Context Tree I/O evidence, or a
+drain that misses a live `grok` process.
 
 `BLOCKED` means the CLI, account, entitlement, network, platform (Windows), or run-cell topology prevented a live
 branch — never a product `FAIL`. `INCONCLUSIVE` means turns ran but the evidence cannot distinguish the claimed

--- a/packages/qa/cases/runtime/grok-provider.md
+++ b/packages/qa/cases/runtime/grok-provider.md
@@ -65,12 +65,16 @@ that case and the run-local plan, not this one.
   selection would silently keep the old values). An invalid model must be visibly rejected by `session/set_model` as a
   configuration failure — never a silent fallback to the persisted selection.
 - Reasoning effort: the effort control is shown for Grok Build with inherit/low/medium/high. Round-trip each value:
-  low/medium/high reach the next turn's spawn as `--effort <value>` and are re-applied after every session open via
-  `session/set_model` (`_meta.reasoningEffort`). An explicit model is always re-applied with it; clearing only the
-  effort removes just the effort override (no effort meta is sent) while the explicit model is still re-applied —
-  only when the model is ALSO empty does the next turn's `session/set_model` carry the initialize-advertised default
-  model, resetting the session to the provider default. An existing session's persisted selection is never silently
-  kept.
+  low/medium/high reach the next turn's spawn as `--effort <value>` and are re-applied AND confirmed after every
+  session open via `session/set_model` (`_meta.reasoningEffort`). An explicit model is always re-applied with it;
+  clearing only the effort removes just the effort override (no effort meta is sent) while the explicit model is
+  still re-applied — only when the model is ALSO empty does the next turn's `session/set_model` carry the
+  initialize-advertised default model, resetting the session to the provider default. An existing session's
+  persisted selection is never silently kept. Confirmation: a configured effort runs the prompt ONLY when the
+  provider's `model_changed` echo carries the effective model+effort — a missing echo, an omitted effort field, or
+  a different effort value fails as a configuration failure and the turn does not run (a model without
+  reasoning-effort support silently ignores the override upstream while still returning a successful model
+  response, so the response alone cannot prove the effort was applied).
 - Replay contract on resume: a resumed turn sends `session/load` with `_meta.noReplay: true`, and any historical
   notification stamped `_meta.isReplay` is dropped even when it arrives inside the active prompt window — the resumed
   turn's visible output and `token_usage` must reflect only the current prompt.

--- a/packages/qa/cases/runtime/grok-provider.md
+++ b/packages/qa/cases/runtime/grok-provider.md
@@ -1,0 +1,99 @@
+---
+id: grok-provider
+description: Validate the Grok Build CLI runtime provider end to end — external binary, ACP sessions, managed MCP, real turns, free-form model and reasoning effort, and Context Tree I/O evidence.
+areas: [runtime]
+surfaces: [web, cli, server, client]
+---
+
+# Grok Build Runtime Provider
+
+## Goal
+
+Confirm that an agent bound to the `grok` provider runs real turns through the external Grok Build CLI over ACP with
+the canonical runtime posture, that credential and capacity failures surface through the existing recovery paths, and
+that cross-surface behavior (capability cards, managed MCP, model and reasoning-effort inputs, client switch, Context
+Tree I/O) matches the shipped contract. Deterministic parser/handler behavior is covered by product tests; this case
+validates the live judgment slices those tests cannot prove.
+
+Use this case when the grok handler, capability probe, runtime-auth dispatch, or provider selection surfaces change.
+Pair it with the runtime-provider readiness case when the same run must also prove that existing Claude Code / Codex
+agents on the client keep probing, binding, and completing turns — that cross-provider regression question belongs to
+that case and the run-local plan, not this one.
+
+## Preconditions
+
+- Run in the isolated QA run cell selected by the plan (Docker + temporary git worktree; never the operator checkout).
+- The run cell host has the official external Grok Build CLI installed (`grok`, via
+  `curl -fsSL https://x.ai/cli/install.sh | bash`); First Tree must not bundle, download, or install it for you — if it
+  is absent, exercise only the install-hint branch and mark live branches `BLOCKED`. V1 supports macOS/Linux only.
+- A Grok account the run may authenticate on that host. Login state is host-OS-user-scoped and operator-owned; do not
+  copy credential files between users or machines, and do not drive `grok login` outside the operator-approved flow.
+- Do not modify the tested product object; config and fixtures change only inside the run cell.
+
+## Checklist
+
+- Capability: with the CLI absent, the computer card shows setup-incomplete for Grok Build with the official installer
+  command (`curl -fsSL https://x.ai/cli/install.sh | bash`) and no npm install copy; after installing and re-probing,
+  the entry turns `ok` with a `path` runtime source. Detection must never launch the binary or judge login state.
+- Provider selection: a new agent can be created on `grok` only when the bound client advertises it; the binding is
+  immutable afterwards, matching the other providers.
+- Auth recovery: with the CLI logged out, a real turn fails as a credential failure; the chat surfaces a durable
+  runtime notice plus a "Log in to Grok Build" action before the delivery is acked. Driving the login runs the
+  provider's official login on the host (`grok login`); progress rides `pendingAuth` / `lastAuthError` on the
+  capability entry, and after success a fresh turn completes. First Tree must never see or store the token.
+- Real turn posture: during an authenticated turn, verify the spawned process runs from the agent workspace root with
+  the canonical arguments (`grok --no-auto-update agent --no-leader --always-approve stdio`, plus `--model` only when
+  the operator set one and `--effort` only when a non-inherit effort is set) — the prompt must arrive on stdin only,
+  never in argv. The process is short-lived per turn; no daemon or lingering process survives turn completion.
+- ACP session continuity: a follow-up message in the same chat must resume the same Grok session — the session ID is
+  persisted per chat and the next turn's process resumes it via ACP `session/load`; a fresh chat starts with
+  `session/new`. A restarted daemon must still resume the persisted session id.
+- Parallel isolation: two chats bound to agents in the SAME workspace cwd run in parallel without cross-talk — each
+  turn gets an isolated Grok session directory, and neither turn observes the other's session state or file locks.
+- Managed MCP: configure a disposable local MCP server through First Tree, then verify the client passes it to the
+  Grok turn through the ACP `mcpServers` session payload (no provider-side config file mutation), and the
+  authenticated Grok turn calls one of its tools. Removing the managed server must drop it from the next turn's
+  `mcpServers` payload with no residue. Do not inspect or archive literal secret headers.
+- Managed skills: with managed skills configured, verify the reconciler projects them into
+  `<agent workspace>/.grok/skills/` and a turn can invoke one.
+- Free-form model: set an exact model id through Web (free-form input with the `auto (Grok default)` hint), confirm it
+  round-trips and reaches the next turn's spawn as `--model`; an id the provider rejects must fail visibly as a
+  configuration failure with no silent fallback, and recover after an explicit config change.
+- Reasoning effort: the effort control is shown for Grok Build with inherit/low/medium/high. Round-trip each value:
+  inherit sends no `--effort` flag; low/medium/high reach the next turn's spawn as `--effort <value>`.
+- Context Tree I/O: in a chat whose agent has a bound Context Tree, have the agent read a tree node and edit a tree
+  file; the Context tab must record repo-qualified read/write evidence for the native Grok file tools
+  (`read_file`, `write`, `search_replace`) and for the shell-read path (`git_status_delta` may carry the write).
+- Capacity retry: on a free-tier account, drive turns until Grok answers 429 capacity; the retry must be visible as a
+  transient retry (not a terminal failure), ride the provider-turn retry budget, and the turn must complete once
+  capacity returns — or fail with the standard terminal provider event and durable runtime notice after exhaustion.
+- Client switch: with a Grok turn in flight, a local client switch/logout drain must detect the running `grok`
+  process (First Tree env envelope scoped) and fail closed rather than moving root state.
+
+## Expected Result
+
+`PASS` means the live branches above were exercised with real product evidence: an authenticated Grok turn completed
+end to end under the canonical posture, credential failure surfaced the durable notice + login action and recovered
+in-product, ACP session new/load continuity held across turns and a daemon restart, same-cwd parallel chats stayed
+isolated, a First Tree-managed MCP tool was delivered via `mcpServers` and called, model and effort config
+round-tripped (including the visible model-rejection branch), 429 capacity produced a visible retry, and Context Tree
+I/O evidence appeared for both native-tool and shell-read paths.
+
+`FAIL` means a reproducible product issue: e.g. prompt in argv, a session id resumed in the wrong chat, a lingering
+process after turn completion, a terminal failure acked without a durable chat notice, silent model or effort
+fallback, managed MCP leaking into provider-side config files or surviving removal, cross-chat session-dir
+interleaving, a 429 surfaced as terminal without retry, missing Context Tree I/O evidence, or a drain that misses a
+live `grok` process.
+
+`BLOCKED` means the CLI, account, entitlement, network, platform (Windows), or run-cell topology prevented a live
+branch — never a product `FAIL`. `INCONCLUSIVE` means turns ran but the evidence cannot distinguish the claimed
+behavior (e.g. cannot observe the spawned argv or the ACP wire payloads in the run cell).
+
+## Evidence
+
+Keep the capability snapshots (before/after install and login), the spawned process argv/cwd observation, the failing
+turn's runtime notice and the login action, the ACP session new/load ids across two turns and across a daemon
+restart, the parallel same-cwd isolation observation, sanitized `mcpServers` session payloads (add and remove), the
+`.grok/skills` projection listing, the model and effort config writes/readbacks plus the rejection surface, the 429
+retry sequence, the Context tab I/O rows, and the drain classification result. Keep the ACP wire logs; redact tokens,
+headers, account identifiers, and private chat content; never copy Grok credential files into artifacts.

--- a/packages/server/src/__tests__/admin-agent-config.test.ts
+++ b/packages/server/src/__tests__/admin-agent-config.test.ts
@@ -253,6 +253,48 @@ describe("Admin agent-config API (Step 2)", () => {
     expect(effort.json<{ error: string }>().error).toContain("not supported");
   });
 
+  it("accepts reasoningEffort and rejects serviceTier writes for grok agents", async () => {
+    const app = getApp();
+    const req = await authedRequest(app);
+    const agent = await (await seedAgentFactory(app))({
+      name: `cfg-grok-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+      runtimeProvider: "grok",
+    });
+
+    // The grok payload variant HAS an effort channel — a fresh agent defaults
+    // to the "" inherit sentinel and a valid value is accepted and persisted.
+    const before = await req("GET", `/api/v1/agents/${agent.uuid}/config`);
+    expect(before.json().payload).toMatchObject({ kind: "grok", reasoningEffort: "" });
+
+    const ok = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
+      expectedVersion: 1,
+      payload: { reasoningEffort: "high" },
+    });
+    expect(ok.statusCode).toBe(200);
+    expect(ok.json().payload.reasoningEffort).toBe("high");
+    await app.configService.flush(agent.uuid);
+
+    const after = await req("GET", `/api/v1/agents/${agent.uuid}/config`);
+    expect(after.json().payload.reasoningEffort).toBe("high");
+
+    // A codex-only value is rejected: the merged payload fails the grok
+    // variant's enum on the tagged-union re-parse.
+    const badEffort = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
+      expectedVersion: 2,
+      payload: { reasoningEffort: "xhigh" },
+    });
+    expect(badEffort.statusCode).toBe(400);
+
+    // serviceTier is codex-only — grok has no such channel.
+    const badTier = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
+      expectedVersion: 2,
+      payload: { serviceTier: "fast" },
+    });
+    expect(badTier.statusCode).toBe(400);
+    expect(badTier.json<{ error: string }>().error).toContain("only supported by the Codex");
+  });
+
   it("persists model-dependent max and ultra values for codex agents", async () => {
     const app = getApp();
     const req = await authedRequest(app);

--- a/packages/server/src/__tests__/clients-provider-models.test.ts
+++ b/packages/server/src/__tests__/clients-provider-models.test.ts
@@ -93,6 +93,43 @@ describe("GET /clients/:clientId/providers/:provider/models", () => {
     }
   });
 
+  it("forwards provider-models:list for grok and returns the daemon catalog", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `pm-${crypto.randomUUID().slice(0, 6)}` });
+    await markClientOnInstance(app, admin.clientId, app.config.instanceId);
+    const ws = { readyState: 1, send: vi.fn(), close: vi.fn() };
+    setClientConnection(admin.clientId, ws as unknown as WebSocket);
+    try {
+      const pending = app.inject({
+        method: "GET",
+        url: `/api/v1/clients/${admin.clientId}/providers/grok/models`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+
+      await vi.waitFor(() => {
+        expect(ws.send).toHaveBeenCalled();
+      });
+      const frame = JSON.parse(String(ws.send.mock.calls[0]?.[0]));
+      expect(frame).toMatchObject({ type: "provider-models:list", provider: "grok" });
+
+      const catalog = {
+        provider: "grok" as const,
+        models: [{ id: "grok-code-fast-1", label: "grok-code-fast-1", isDefault: true }],
+        defaultModelId: "grok-code-fast-1",
+        fetchedAt: new Date().toISOString(),
+        source: "provider-cli" as const,
+        error: null,
+      };
+      expect(resolveClientReply(admin.clientId, frame.ref, catalog)).toBe(true);
+
+      const res = await pending;
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject(catalog);
+    } finally {
+      removeClientConnection(admin.clientId, ws as unknown as WebSocket);
+    }
+  });
+
   it("returns 502 when the daemon is not connected", async () => {
     const app = getApp();
     const admin = await createAdminContext(app, { username: `pm-${crypto.randomUUID().slice(0, 6)}` });

--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -551,6 +551,133 @@ describe("context-tree IO service", () => {
     ).toEqual({ recordable: false, reason: "unsupported_tool" });
   });
 
+  it("derives grok read/write IO from tool names, gated on runtimeProvider=grok", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+
+    const mkEvent = (toolUseId: string, name: string, path: string, origin: "tool_arg" | "file_change") => ({
+      kind: "tool_call" as const,
+      payload: {
+        toolUseId,
+        name,
+        args: { path: `/tmp/context-tree/${path}` },
+        status: "ok" as const,
+        toolFileRefs: [
+          { origin, repoUrl: TREE_REPO, repoBranch: "main", repoRelativePath: path, pathKind: "file" as const },
+        ],
+      },
+    });
+
+    const readEvent = await appendEvent(
+      app.db,
+      seed.agent.uuid,
+      seed.chatId,
+      mkEvent("tu-g-read", "read_file", "NODE.md", "tool_arg"),
+    );
+    const writeEvent = await appendEvent(
+      app.db,
+      seed.agent.uuid,
+      seed.chatId,
+      mkEvent("tu-g-write", "write", "practices/new.md", "file_change"),
+    );
+    const editEvent = await appendEvent(
+      app.db,
+      seed.agent.uuid,
+      seed.chatId,
+      mkEvent("tu-g-edit", "search_replace", "system/NODE.md", "file_change"),
+    );
+
+    for (const sessionEvent of [readEvent, writeEvent, editEvent]) {
+      await recordFromSessionEvent(app.db, {
+        organizationId: seed.organizationId,
+        agentId: seed.agent.uuid,
+        chatId: seed.chatId,
+        runtimeProvider: "grok",
+        sessionEvent,
+      });
+    }
+
+    const rows = await app.db.select().from(contextTreeIoEvents).where(eq(contextTreeIoEvents.chatId, seed.chatId));
+    expect(
+      rows
+        .map((row) => ({ action: row.action, source: row.source, targetPath: row.targetPath }))
+        .sort((a, b) => a.targetPath.localeCompare(b.targetPath)),
+    ).toEqual([
+      { action: "read", source: "grok_read_tool", targetPath: "NODE.md" },
+      { action: "write", source: "grok_write_tool", targetPath: "practices/new.md" },
+      { action: "write", source: "grok_write_tool", targetPath: "system/NODE.md" },
+    ]);
+
+    // Provider gating both ways: grok's names mean nothing to other providers,
+    // and codex's `command` means nothing to grok.
+    expect(
+      explainContextTreeIoDecision({ runtimeProvider: "codex", sessionEvent: readEvent, bindingRepo: TREE_REPO }),
+    ).toEqual({ recordable: false, reason: "unsupported_tool" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "grok",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "tu-x",
+            name: "command",
+            args: { command: "cat /tmp/context-tree/NODE.md" },
+            status: "ok",
+          },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "unsupported_tool" });
+  });
+
+  it("derives grok shell (run_terminal_cmd) reads via shell_command classification", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+
+    const shellEvent = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-g-shell",
+        name: "run_terminal_cmd",
+        args: { command: "cat context-tree/NODE.md" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            localPath: "context-tree/NODE.md",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+
+    await recordFromSessionEvent(app.db, {
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      chatId: seed.chatId,
+      runtimeProvider: "grok",
+      sessionEvent: shellEvent,
+    });
+
+    const rows = await app.db.select().from(contextTreeIoEvents).where(eq(contextTreeIoEvents.chatId, seed.chatId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      runtimeProvider: "grok",
+      action: "read",
+      source: "shell_command",
+      treeRepoUrl: TREE_REPO,
+      targetPath: "NODE.md",
+    });
+
+    // run_terminal_cmd is grok-only: the same event under cursor is unsupported.
+    expect(
+      explainContextTreeIoDecision({ runtimeProvider: "cursor", sessionEvent: shellEvent, bindingRepo: TREE_REPO }),
+    ).toEqual({ recordable: false, reason: "unsupported_tool" });
+  });
+
   it("derives Kimi Read/Write IO and gates the shared capitalized names by provider", async () => {
     const read = {
       kind: "tool_call",

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -42,6 +42,11 @@ const CLAUDE_WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"
 // collide with claude's capitalized tools or codex's `command`/`file_change`.
 const CURSOR_READ_TOOLS = new Set(["read"]);
 const CURSOR_WRITE_TOOLS = new Set(["edit", "write"]);
+// Grok Build's handler-emitted tool names (ACP tool_call titles are the raw
+// tool ids). Interpreted ONLY when `runtimeProvider === "grok"` — same
+// no-collision reasoning as cursor's lowercase names above.
+const GROK_READ_TOOLS = new Set(["read_file"]);
+const GROK_WRITE_TOOLS = new Set(["write", "search_replace"]);
 const KIMI_READ_TOOLS = new Set(["Read", "Grep", "Glob"]);
 const KIMI_WRITE_TOOLS = new Set(["Write", "Edit"]);
 const OPENCODE_READ_TOOLS = new Set(["read", "grep", "glob"]);
@@ -60,6 +65,9 @@ const CONTEXT_TREE_IO_TOOL_NAMES = [
   "edit",
   "file_change",
   "read",
+  "read_file",
+  "run_terminal_cmd",
+  "search_replace",
   "shell",
   "write",
   "bash",
@@ -203,6 +211,7 @@ function isShellTool(runtimeProvider: string, toolName: string): boolean {
   return (
     (runtimeProvider === "codex" && toolName === "command") ||
     (runtimeProvider === "cursor" && toolName === "shell") ||
+    (runtimeProvider === "grok" && toolName === "run_terminal_cmd") ||
     (runtimeProvider === "kimi-code" && toolName === "Bash") ||
     (runtimeProvider === "opencode" && toolName === "bash") ||
     (isClaudeRuntime(runtimeProvider) && toolName === "Bash")
@@ -240,6 +249,9 @@ function skippedDecisionFastPathForNoRefs(
   if (runtimeProvider === "cursor" && (CURSOR_READ_TOOLS.has(toolName) || CURSOR_WRITE_TOOLS.has(toolName))) {
     return { handled: true, decision: { recordable: false, reason: "no_tool_file_refs" }, toolName };
   }
+  if (runtimeProvider === "grok" && (GROK_READ_TOOLS.has(toolName) || GROK_WRITE_TOOLS.has(toolName))) {
+    return { handled: true, decision: { recordable: false, reason: "no_tool_file_refs" }, toolName };
+  }
   if (runtimeProvider === "kimi-code" && (KIMI_READ_TOOLS.has(toolName) || KIMI_WRITE_TOOLS.has(toolName))) {
     return { handled: true, decision: { recordable: false, reason: "no_tool_file_refs" }, toolName };
   }
@@ -275,6 +287,12 @@ function deriveEventIo(event: SessionEvent, runtimeProvider: string): EventIoDer
   }
   if (runtimeProvider === "cursor" && CURSOR_WRITE_TOOLS.has(toolName)) {
     return { action: "write", source: "cursor_write_tool" };
+  }
+  if (runtimeProvider === "grok" && GROK_READ_TOOLS.has(toolName)) {
+    return { action: "read", source: "grok_read_tool" };
+  }
+  if (runtimeProvider === "grok" && GROK_WRITE_TOOLS.has(toolName)) {
+    return { action: "write", source: "grok_write_tool" };
   }
   if (runtimeProvider === "kimi-code" && KIMI_READ_TOOLS.has(toolName)) {
     return { action: "read", source: "kimi_read_tool" };

--- a/packages/shared/src/__tests__/agent-runtime-config.test.ts
+++ b/packages/shared/src/__tests__/agent-runtime-config.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD,
   DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD,
   DEFAULT_CURSOR_RUNTIME_CONFIG_PAYLOAD,
+  DEFAULT_GROK_RUNTIME_CONFIG_PAYLOAD,
   DEFAULT_KIMI_CODE_RUNTIME_CONFIG_PAYLOAD,
   DEFAULT_OPENCODE_RUNTIME_CONFIG_PAYLOAD,
   defaultRuntimeConfigPayload,
@@ -255,6 +256,40 @@ describe("agent runtime config — cursor variant", () => {
     // effort field into a provider that has no effort channel.
     const parsed = agentRuntimeConfigPayloadSchema.parse({ kind: "cursor", reasoningEffort: "high" });
     expect("reasoningEffort" in parsed).toBe(false);
+  });
+});
+
+/**
+ * Grok Build is a free-form-model provider WITH a separate effort channel:
+ * `model` is an exact provider-native id passed through verbatim (empty =
+ * omit `--model`, Grok picks its local default), and `reasoningEffort` maps
+ * to the CLI's `--effort <low|medium|high>` flag with `""` as the inherit
+ * sentinel (the flag is omitted).
+ */
+describe("agent runtime config — grok variant", () => {
+  it("DEFAULT_GROK_RUNTIME_CONFIG_PAYLOAD is kind=grok with an empty model and the effort inherit sentinel", () => {
+    expect(DEFAULT_GROK_RUNTIME_CONFIG_PAYLOAD).toMatchObject({ kind: "grok", model: "", reasoningEffort: "" });
+  });
+
+  it("defaultRuntimeConfigPayload('grok') selects the grok variant", () => {
+    expect(defaultRuntimeConfigPayload("grok")).toMatchObject({ kind: "grok", model: "", reasoningEffort: "" });
+  });
+
+  it("schema accepts an explicit grok payload with a free-form model id and a supported effort", () => {
+    const parsed = agentRuntimeConfigPayloadSchema.parse({
+      kind: "grok",
+      model: "grok-4.5",
+      reasoningEffort: "medium",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+    });
+    expect(parsed).toMatchObject({ kind: "grok", model: "grok-4.5", reasoningEffort: "medium" });
+  });
+
+  it("schema rejects effort values outside the Grok CLI's --effort channel", () => {
+    expect(() => agentRuntimeConfigPayloadSchema.parse({ kind: "grok", reasoningEffort: "max" })).toThrow();
+    expect(() => agentRuntimeConfigPayloadSchema.parse({ kind: "grok", reasoningEffort: "xhigh" })).toThrow();
   });
 });
 

--- a/packages/shared/src/__tests__/runtime-provider-schemas.test.ts
+++ b/packages/shared/src/__tests__/runtime-provider-schemas.test.ts
@@ -25,6 +25,7 @@ describe("runtimeProviderSchema", () => {
     expect(runtimeProviderSchema.parse("claude-code-tui")).toBe("claude-code-tui");
     expect(runtimeProviderSchema.parse("codex")).toBe("codex");
     expect(runtimeProviderSchema.parse("cursor")).toBe("cursor");
+    expect(runtimeProviderSchema.parse("grok")).toBe("grok");
     expect(runtimeProviderSchema.parse("kimi-code")).toBe("kimi-code");
     expect(runtimeProviderSchema.parse("opencode")).toBe("opencode");
   });
@@ -39,6 +40,7 @@ describe("runtimeProviderSchema", () => {
     expect(runtimeProviderSchema.parse(RUNTIME_PROVIDERS.CLAUDE_CODE_TUI)).toBe("claude-code-tui");
     expect(runtimeProviderSchema.parse(RUNTIME_PROVIDERS.CODEX)).toBe("codex");
     expect(runtimeProviderSchema.parse(RUNTIME_PROVIDERS.CURSOR)).toBe("cursor");
+    expect(runtimeProviderSchema.parse(RUNTIME_PROVIDERS.GROK)).toBe("grok");
     expect(runtimeProviderSchema.parse(RUNTIME_PROVIDERS.KIMI_CODE)).toBe("kimi-code");
     expect(runtimeProviderSchema.parse(RUNTIME_PROVIDERS.OPENCODE)).toBe("opencode");
   });
@@ -51,6 +53,7 @@ describe("runtimeProviderSchema", () => {
     expect(isRuntimeProviderEnabled("claude-code")).toBe(true);
     expect(isRuntimeProviderEnabled("codex")).toBe(true);
     expect(isRuntimeProviderEnabled("cursor")).toBe(true);
+    expect(isRuntimeProviderEnabled("grok")).toBe(true);
     expect(isRuntimeProviderEnabled("kimi-code")).toBe(true);
     expect(isRuntimeProviderEnabled("opencode")).toBe(true);
     expect(isRuntimeProviderEnabled("claude-code-tui")).toBe(false);

--- a/packages/shared/src/schemas/agent-runtime-config.ts
+++ b/packages/shared/src/schemas/agent-runtime-config.ts
@@ -321,9 +321,14 @@ const grokRuntimeConfigPayloadShape = agentRuntimeConfigPayloadShape.extend({
   kind: z.literal("grok"),
   // Maps to the Grok Build CLI `--effort <low|medium|high>` flag. The empty
   // string is an "inherit" sentinel: when set, the handler omits `--effort`
-  // so Grok falls back to its own local default. A non-empty value is passed
-  // through verbatim as one argv entry. An empty `model` likewise omits
-  // `--model` and lets Grok pick its local/default model.
+  // AND sends no effort meta — but it still calls `session/set_model` after
+  // every session open (new or load), so an EMPTY effort only removes the
+  // override; it never silently keeps a resumed session's persisted effort.
+  // A non-empty value is passed through verbatim as one argv entry. An empty
+  // `model` likewise omits `--model`; after every session open the handler
+  // then applies the INITIALIZE-advertised current/default model via
+  // `session/set_model` — the resumed session's persisted model is never
+  // silently inherited.
   reasoningEffort: z.enum(["", "low", "medium", "high"]).default(""),
 });
 
@@ -495,9 +500,11 @@ export const DEFAULT_OPENCODE_RUNTIME_CONFIG_PAYLOAD: AgentRuntimeConfigPayload 
 
 /**
  * Default payload for a fresh grok agent. `model` is empty by default so the
- * spawn omits `--model` and the Grok Build CLI picks its local default;
- * `reasoningEffort` defaults to the inherit sentinel so `--effort` is omitted
- * as well. A non-empty operator value for either is passed through verbatim.
+ * spawn omits `--model`; `reasoningEffort` defaults to the inherit sentinel
+ * so `--effort` is omitted as well. Empty values do NOT inherit a resumed
+ * session's persisted selection: after every session open the handler still
+ * calls `session/set_model` (initialize default model, no effort meta when
+ * unset). A non-empty operator value for either is passed through verbatim.
  */
 export const DEFAULT_GROK_RUNTIME_CONFIG_PAYLOAD: AgentRuntimeConfigPayload = {
   kind: "grok",

--- a/packages/shared/src/schemas/agent-runtime-config.ts
+++ b/packages/shared/src/schemas/agent-runtime-config.ts
@@ -317,11 +317,22 @@ const opencodeRuntimeConfigPayloadShape = agentRuntimeConfigPayloadShape.extend(
   // configuration; non-empty values are forwarded as one argv entry.
 });
 
+const grokRuntimeConfigPayloadShape = agentRuntimeConfigPayloadShape.extend({
+  kind: z.literal("grok"),
+  // Maps to the Grok Build CLI `--effort <low|medium|high>` flag. The empty
+  // string is an "inherit" sentinel: when set, the handler omits `--effort`
+  // so Grok falls back to its own local default. A non-empty value is passed
+  // through verbatim as one argv entry. An empty `model` likewise omits
+  // `--model` and lets Grok pick its local/default model.
+  reasoningEffort: z.enum(["", "low", "medium", "high"]).default(""),
+});
+
 const taggedPayloadUnion = z.discriminatedUnion("kind", [
   claudeRuntimeConfigPayloadShape,
   claudeCodeTuiRuntimeConfigPayloadShape,
   codexRuntimeConfigPayloadShape,
   cursorRuntimeConfigPayloadShape,
+  grokRuntimeConfigPayloadShape,
   kimiCodeRuntimeConfigPayloadShape,
   opencodeRuntimeConfigPayloadShape,
 ]);
@@ -483,6 +494,23 @@ export const DEFAULT_OPENCODE_RUNTIME_CONFIG_PAYLOAD: AgentRuntimeConfigPayload 
 };
 
 /**
+ * Default payload for a fresh grok agent. `model` is empty by default so the
+ * spawn omits `--model` and the Grok Build CLI picks its local default;
+ * `reasoningEffort` defaults to the inherit sentinel so `--effort` is omitted
+ * as well. A non-empty operator value for either is passed through verbatim.
+ */
+export const DEFAULT_GROK_RUNTIME_CONFIG_PAYLOAD: AgentRuntimeConfigPayload = {
+  kind: "grok",
+  prompt: { append: "" },
+  model: "",
+  mcpServers: [],
+  env: [],
+  gitRepos: [],
+  resourceSkills: [],
+  reasoningEffort: "",
+};
+
+/**
  * Default payload selector by runtime provider.
  */
 export function defaultRuntimeConfigPayload(
@@ -493,6 +521,8 @@ export function defaultRuntimeConfigPayload(
       return { ...DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD };
     case "cursor":
       return { ...DEFAULT_CURSOR_RUNTIME_CONFIG_PAYLOAD };
+    case "grok":
+      return { ...DEFAULT_GROK_RUNTIME_CONFIG_PAYLOAD };
     case "kimi-code":
       return { ...DEFAULT_KIMI_CODE_RUNTIME_CONFIG_PAYLOAD };
     case "opencode":

--- a/packages/shared/src/schemas/context-tree.ts
+++ b/packages/shared/src/schemas/context-tree.ts
@@ -187,6 +187,8 @@ export const contextTreeIoSourceSchema = z.enum([
   "codex_file_change",
   "cursor_read_tool",
   "cursor_write_tool",
+  "grok_read_tool",
+  "grok_write_tool",
   "kimi_read_tool",
   "kimi_write_tool",
   "opencode_read_tool",

--- a/packages/shared/src/schemas/runtime-auth.ts
+++ b/packages/shared/src/schemas/runtime-auth.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
  * rather than returning `started: true` for a provider that will never publish
  * pending auth.
  */
-export const runtimeAuthProviderSchema = z.enum(["claude-code", "codex", "cursor"]);
+export const runtimeAuthProviderSchema = z.enum(["claude-code", "codex", "cursor", "grok"]);
 export type RuntimeAuthProvider = z.infer<typeof runtimeAuthProviderSchema>;
 
 /**

--- a/packages/shared/src/schemas/runtime-provider.ts
+++ b/packages/shared/src/schemas/runtime-provider.ts
@@ -10,6 +10,7 @@ export const RUNTIME_PROVIDERS = {
   CLAUDE_CODE_TUI: "claude-code-tui",
   CODEX: "codex",
   CURSOR: "cursor",
+  GROK: "grok",
   KIMI_CODE: "kimi-code",
   OPENCODE: "opencode",
 } as const;
@@ -19,6 +20,7 @@ export const runtimeProviderSchema = z.enum([
   "claude-code-tui",
   "codex",
   "cursor",
+  "grok",
   "kimi-code",
   "opencode",
 ]);

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -146,6 +146,7 @@ function asRuntimeProvider(provider: string): RuntimeProvider | null {
     provider === "claude-code-tui" ||
     provider === "codex" ||
     provider === "cursor" ||
+    provider === "grok" ||
     provider === "kimi-code" ||
     provider === "opencode"
   ) {
@@ -171,6 +172,7 @@ function pickPreferredRuntime(caps: ClientCapabilities): RuntimeProvider | null 
   // Same central-switch guard as the TUI line: a stale `ok` snapshot from a
   // daemon must not auto-pick a provider that has since been disabled.
   if (isRuntimeProviderEnabled("cursor") && caps.cursor?.state === "ok") return "cursor";
+  if (isRuntimeProviderEnabled("grok") && caps.grok?.state === "ok") return "grok";
   if (isRuntimeProviderEnabled("opencode") && caps.opencode?.state === "ok") return "opencode";
   // Any other provider (incl. one still disabled in a stale snapshot) is only
   // auto-picked when enabled.
@@ -188,6 +190,7 @@ function prettyRuntimeLabel(provider: RuntimeProvider): string {
   if (provider === "claude-code-tui") return "Claude Code CLI";
   if (provider === "codex") return "Codex";
   if (provider === "cursor") return "Cursor";
+  if (provider === "grok") return "Grok Build";
   if (provider === "kimi-code") return "Kimi Code";
   if (provider === "opencode") return "OpenCode";
   return provider;

--- a/packages/web/src/pages/agent-detail/__tests__/model-section-catalog.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/model-section-catalog.test.tsx
@@ -64,6 +64,17 @@ const CURSOR_CATALOG: ProviderModelCatalog = {
   source: "provider-cli",
 };
 
+const GROK_CATALOG: ProviderModelCatalog = {
+  provider: "grok",
+  models: [
+    { id: "grok-4-heavy", label: "Grok 4 Heavy" },
+    { id: "grok-code-fast-1", label: "Grok Code Fast", hint: "fast", isDefault: true },
+  ],
+  defaultModelId: "grok-code-fast-1",
+  fetchedAt: "2026-07-17T00:00:00.000Z",
+  source: "provider-cli",
+};
+
 describe("buildCatalogModelOptions", () => {
   it("lists unset (with local default hint), discovered models, current custom value, and the custom entry", () => {
     const items = buildCatalogModelOptions(CURSOR_CATALOG, "my-account-model");
@@ -313,5 +324,50 @@ describe("ModelSection — daemon catalog", () => {
     });
     // Empty string = no override → the host provider's local default applies.
     expect(saved).toEqual([""]);
+  });
+
+  it("renders the grok catalog in the select, marking the local default", async () => {
+    providerModelsMocks.getProviderModels.mockResolvedValue(GROK_CATALOG);
+    const el = await renderWithQuery(
+      <ModelSection value="grok-4-heavy" onChange={() => {}} provider="grok" clientId="c1" />,
+    );
+
+    await flushUntil(
+      () => el.querySelector('button[aria-label="Model"]')?.textContent?.includes("Grok 4 Heavy") ?? false,
+    );
+    const trigger = el.querySelector<HTMLButtonElement>('button[aria-label="Model"]');
+    expect(trigger?.textContent).toContain("Grok 4 Heavy");
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const body = document.body.textContent ?? "";
+    expect(body).toContain("(unset — inherits local)");
+    expect(body).toContain("default: grok-code-fast-1");
+    expect(body).toContain("Grok Code Fast");
+    expect(body).toContain("Custom model id…");
+  });
+
+  it("saves a grok catalog pick verbatim", async () => {
+    providerModelsMocks.getProviderModels.mockResolvedValue(GROK_CATALOG);
+    const saved: string[] = [];
+    const el = await renderWithQuery(
+      <ModelSection value="" onChange={(v) => saved.push(v)} provider="grok" clientId="c1" />,
+    );
+
+    await flushUntil(() => {
+      const b = el.querySelector<HTMLButtonElement>('button[aria-label="Model"]');
+      return !!b && !b.disabled;
+    });
+    await act(async () => {
+      el.querySelector('button[aria-label="Model"]')?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const option = Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')).find((b) =>
+      b.textContent?.includes("Grok Code Fast"),
+    );
+    await act(async () => {
+      option?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(saved).toEqual(["grok-code-fast-1"]);
   });
 });

--- a/packages/web/src/pages/agent-detail/__tests__/reasoning-effort-section-options.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/reasoning-effort-section-options.test.ts
@@ -16,6 +16,12 @@ describe("grok reasoning effort help copy", () => {
     expect(copy).toContain("explicit model is still re-applied");
     expect(copy).toContain("with model also unset");
   });
+
+  it("states the re-applied AND confirmed semantics for an explicit effort", () => {
+    const copy = EFFORT_HELP_BY_PROVIDER.grok;
+    expect(copy).toContain("re-applied AND confirmed");
+    expect(copy).toContain("does not run if the provider does not confirm");
+  });
 });
 
 describe("Codex reasoning effort options", () => {

--- a/packages/web/src/pages/agent-detail/__tests__/reasoning-effort-section-options.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/reasoning-effort-section-options.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { CODEX_EFFORT_OPTIONS } from "../reasoning-effort-section.js";
+import { CODEX_EFFORT_OPTIONS, EFFORT_HELP_BY_PROVIDER } from "../reasoning-effort-section.js";
+
+describe("grok reasoning effort help copy", () => {
+  it("describes next-turn existing-session semantics (set_model), never new-sessions-only", () => {
+    const copy = EFFORT_HELP_BY_PROVIDER.grok;
+    expect(copy).not.toContain("Applies to new sessions");
+    expect(copy).toContain("next turn");
+    expect(copy).toContain("existing sessions");
+    expect(copy).toContain("session/set_model");
+  });
+
+  it("unset removes only the effort override — it does not imply clearing an explicit model", () => {
+    const copy = EFFORT_HELP_BY_PROVIDER.grok;
+    expect(copy).toContain("removes only the effort override");
+    expect(copy).toContain("explicit model is still re-applied");
+    expect(copy).toContain("with model also unset");
+  });
+});
 
 describe("Codex reasoning effort options", () => {
   it("orders the provider-native levels through max and ultra", () => {

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -81,6 +81,7 @@ const MODEL_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, ModelOption[]> = {
   "claude-code-tui": CLAUDE_MODEL_OPTIONS,
   codex: CODEX_MODEL_OPTIONS,
   cursor: [],
+  grok: [],
   "kimi-code": [],
   opencode: [],
 };
@@ -91,6 +92,7 @@ const MODEL_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
   codex: "Applies to new sessions immediately. Unset lets the CLI pick by auth mode.",
   cursor:
     "Options come from this computer's Cursor CLI when reachable. The id is passed through verbatim on the next turn — one your account can't use fails visibly, no silent fallback. Unset uses the Cursor default (auto).",
+  grok: "Options come from this computer's Grok Build CLI when reachable. The id is passed through verbatim on the next turn — one your account can't use fails visibly, no silent fallback. Unset uses the Grok default (auto).",
   "kimi-code":
     "Options come from this computer's ~/.kimi-code config when reachable. Passed to new sessions. Unset uses the model configured in ~/.kimi-code.",
   opencode:
@@ -457,11 +459,13 @@ function FreeFormModelInput({
       placeholder={
         provider === "kimi-code"
           ? "local Kimi default"
-          : provider === "opencode"
-            ? "local OpenCode default"
-            : provider === "cursor"
-              ? "auto (Cursor default)"
-              : "provider default"
+          : provider === "grok"
+            ? "auto (Grok default)"
+            : provider === "opencode"
+              ? "local OpenCode default"
+              : provider === "cursor"
+                ? "auto (Cursor default)"
+                : "provider default"
       }
       className="font-mono"
       aria-label="Model"

--- a/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
+++ b/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
@@ -11,6 +11,8 @@ import { ConfigRow } from "./flat-section.js";
  *   - codex maps to its provider-native effort (low/medium/high/xhigh/max/ultra).
  *     The higher values are model-dependent; "minimal" is excluded because it
  *     breaks the default tool set.
+ *   - grok maps to the Grok Build CLI `--effort` flag (low/medium/high), plus
+ *     an "" inherit option that omits the flag so Grok uses its local default.
  */
 
 const CLAUDE_EFFORT_OPTIONS: SelectOption[] = [
@@ -30,6 +32,16 @@ export const CODEX_EFFORT_OPTIONS: SelectOption[] = [
   { value: "ultra", label: "ultra", hint: "deepest; model-dependent" },
 ];
 
+// Grok's effort channel mirrors claude's minus "max": an "" inherit option
+// (the `--effort` flag is omitted and Grok uses its local default) plus
+// low/medium/high.
+const GROK_EFFORT_OPTIONS: SelectOption[] = [
+  { value: "", label: "(unset — inherits local)" },
+  { value: "low", label: "low", hint: "fastest" },
+  { value: "medium", label: "medium" },
+  { value: "high", label: "high", hint: "default" },
+];
+
 const EFFORT_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, SelectOption[]> = {
   "claude-code": CLAUDE_EFFORT_OPTIONS,
   // claude-code-tui drives the same `claude` CLI as claude-code, so it shares
@@ -40,6 +52,7 @@ const EFFORT_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, SelectOption[]> = {
   // in the model id itself, so RuntimeTab hides this section entirely for
   // cursor agents. The empty entry keeps the Record exhaustive.
   cursor: [],
+  grok: GROK_EFFORT_OPTIONS,
   "kimi-code": [],
   opencode: [],
 };
@@ -49,6 +62,7 @@ const EFFORT_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
   "claude-code-tui": "Applies to new sessions. Unset inherits the local ~/.claude effortLevel; setting it overrides.",
   codex: "Applies to new sessions. Higher means more reasoning per turn; max and ultra require a compatible model.",
   cursor: "Cursor encodes effort in the model id; there is no separate control.",
+  grok: "Applies to new sessions. Unset omits the effort flag so Grok uses its local default; setting it overrides.",
   "kimi-code": "Kimi thinking configuration is inherited from the local Kimi configuration.",
   opencode: "OpenCode model variants are provider-native; there is no separate First Tree effort control.",
 };

--- a/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
+++ b/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
@@ -62,7 +62,7 @@ export const EFFORT_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
   "claude-code-tui": "Applies to new sessions. Unset inherits the local ~/.claude effortLevel; setting it overrides.",
   codex: "Applies to new sessions. Higher means more reasoning per turn; max and ultra require a compatible model.",
   cursor: "Cursor encodes effort in the model id; there is no separate control.",
-  grok: "Applies from the next turn, on new and existing sessions (re-applied via session/set_model after every session open). Unset removes only the effort override — an explicit model is still re-applied; with model also unset, the next turn resets to Grok's default model.",
+  grok: "Applies from the next turn, on new and existing sessions (re-applied AND confirmed via session/set_model after every session open — the turn does not run if the provider does not confirm the effective effort). Unset removes only the effort override — an explicit model is still re-applied; with model also unset, the next turn resets to Grok's default model.",
   "kimi-code": "Kimi thinking configuration is inherited from the local Kimi configuration.",
   opencode: "OpenCode model variants are provider-native; there is no separate First Tree effort control.",
 };

--- a/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
+++ b/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
@@ -57,12 +57,12 @@ const EFFORT_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, SelectOption[]> = {
   opencode: [],
 };
 
-const EFFORT_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
+export const EFFORT_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
   "claude-code": "Applies to new sessions. Unset inherits the local ~/.claude effortLevel; setting it overrides.",
   "claude-code-tui": "Applies to new sessions. Unset inherits the local ~/.claude effortLevel; setting it overrides.",
   codex: "Applies to new sessions. Higher means more reasoning per turn; max and ultra require a compatible model.",
   cursor: "Cursor encodes effort in the model id; there is no separate control.",
-  grok: "Applies to new sessions. Unset omits the effort flag so Grok uses its local default; setting it overrides.",
+  grok: "Applies from the next turn, on new and existing sessions (re-applied via session/set_model after every session open). Unset removes only the effort override — an explicit model is still re-applied; with model also unset, the next turn resets to Grok's default model.",
   "kimi-code": "Kimi thinking configuration is inherited from the local Kimi configuration.",
   opencode: "OpenCode model variants are provider-native; there is no separate First Tree effort control.",
 };

--- a/packages/web/src/pages/agent-detail/runtime-section.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-section.tsx
@@ -31,6 +31,7 @@ const RUNTIME_NAME: Record<RuntimeProvider, string> = {
   "claude-code-tui": "Claude Code CLI",
   codex: "Codex",
   cursor: "Cursor",
+  grok: "Grok Build",
   "kimi-code": "Kimi Code",
   opencode: "OpenCode",
 };

--- a/packages/web/src/pages/clients/__tests__/grok-provider-surfaces.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/grok-provider-surfaces.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+
+import type { CapabilityEntry } from "@first-tree/shared";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { ModelSection } from "../../agent-detail/model-section.js";
+import {
+  buildInstallCommand,
+  GROK_INSTALL_COMMAND,
+  PROVIDER_LABEL,
+  providerInstallHint,
+  runtimeProviderLabel,
+} from "../cards/shared/providers.js";
+import { installBoxView } from "../cards/shared/runtime-install-box.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+async function render(element: React.ReactElement): Promise<HTMLElement> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(element);
+  });
+  if (!container) throw new Error("container missing");
+  return container;
+}
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("grok provider — setup card surfaces", () => {
+  it("labels the provider Grok Build", () => {
+    expect(PROVIDER_LABEL.grok).toBe("Grok Build");
+    expect(runtimeProviderLabel("grok")).toBe("Grok Build");
+  });
+
+  it("install command is the official installer script + login, never npm", () => {
+    const command = buildInstallCommand("grok", "darwin");
+    expect(command).toBe(`${GROK_INSTALL_COMMAND}\ngrok login`);
+    expect(command).not.toContain("npm install");
+  });
+
+  it("install hint names the official installer for a missing grok", () => {
+    const hint = providerInstallHint("grok", "darwin");
+    expect(hint).toContain(GROK_INSTALL_COMMAND);
+    expect(hint).toContain("Mac");
+  });
+
+  it("probe-error install box falls back to the official installer, not an npm spec", () => {
+    const entry: CapabilityEntry = {
+      state: "error",
+      available: false,
+      error: "detection threw",
+      detectedAt: "2026-07-14T00:00:00.000Z",
+    };
+    const view = installBoxView(entry, "grok", "devbox");
+    expect(view.command).toBe(GROK_INSTALL_COMMAND);
+    expect(view.headline).toContain("Grok Build probe failed");
+  });
+});
+
+describe("grok provider — DEFAULT + Custom model picker", () => {
+  it("exposes unset + custom entry and commits an exact id via Custom", async () => {
+    const saved: string[] = [];
+    const el = await render(<ModelSection value="" onChange={(v) => saved.push(v)} provider="grok" />);
+
+    const trigger = el.querySelector<HTMLButtonElement>('button[aria-label="Model"]');
+    expect(trigger).not.toBeNull();
+    expect(el.querySelector('input[aria-label="Model"]')).toBeNull();
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const body = document.body.textContent ?? "";
+    expect(body).toContain("(unset — inherits local)");
+    expect(body).toContain("Custom model id…");
+
+    const custom = Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')).find((b) =>
+      b.textContent?.includes("Custom model id…"),
+    );
+    await act(async () => {
+      custom?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(saved).toEqual([]);
+
+    const input = el.querySelector<HTMLInputElement>('input[aria-label="Model"]');
+    expect(input).not.toBeNull();
+    if (!input) throw new Error("unreachable");
+    expect(input.placeholder).toContain("auto");
+
+    await act(async () => {
+      // React tracks the value setter — go through the native prototype setter
+      // so the synthetic onChange fires for a controlled input.
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(input, " grok-4-heavy ");
+      input.dispatchEvent(new InputEvent("input", { bubbles: true, data: " grok-4-heavy ", inputType: "insertText" }));
+    });
+    // No save yet — the field commits on Enter/blur, not per keystroke.
+    expect(saved).toEqual([]);
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    // Trimmed exact id, committed once; custom mode then returns to the Select.
+    expect(saved).toEqual(["grok-4-heavy"]);
+    expect(el.querySelector('button[aria-label="Model"]')).not.toBeNull();
+  });
+
+  it("keeps the dropdown for claude/codex providers (no free-form regression)", async () => {
+    const el = await render(<ModelSection value="opus" onChange={() => {}} provider="claude-code" />);
+    expect(el.querySelector('input[aria-label="Model"]')).toBeNull();
+  });
+});

--- a/packages/web/src/pages/clients/__tests__/grok-provider-surfaces.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/grok-provider-surfaces.test.tsx
@@ -12,7 +12,7 @@ import {
   providerInstallHint,
   runtimeProviderLabel,
 } from "../cards/shared/providers.js";
-import { installBoxView } from "../cards/shared/runtime-install-box.js";
+import { installBoxView, RuntimeInstallBox } from "../cards/shared/runtime-install-box.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -67,6 +67,33 @@ describe("grok provider — setup card surfaces", () => {
     const view = installBoxView(entry, "grok", "devbox");
     expect(view.command).toBe(GROK_INSTALL_COMMAND);
     expect(view.headline).toContain("Grok Build probe failed");
+  });
+
+  it("grok on Windows renders the unsupported status with NO install command", async () => {
+    const entry: CapabilityEntry = {
+      // The exact shape the win32 probe now produces (state error, not missing).
+      state: "error",
+      available: false,
+      error:
+        "Grok Build provider is not supported on Windows in V1 (macOS/Linux only). First Tree fails closed on this platform and will not spawn `grok` here.",
+      detectedAt: "2026-07-14T00:00:00.000Z",
+    };
+    const view = installBoxView(entry, "grok", "devbox", "win32");
+    expect(view.command).toBeNull();
+    expect(view.headline).toContain("not supported on Windows in V1");
+    expect(view.headline).not.toContain(GROK_INSTALL_COMMAND);
+
+    // The rendered box shows the status and no setup command box at all.
+    const el = await render(<RuntimeInstallBox provider="grok" entry={entry} hostname="devbox" os="win32" />);
+    expect(el.textContent).toContain("not supported on Windows in V1");
+    expect(el.textContent).not.toContain(GROK_INSTALL_COMMAND);
+    expect(el.querySelector("pre")).toBeNull();
+  });
+
+  it("grok on Windows still renders the install box for other providers / platforms unchanged", async () => {
+    const el = await render(<RuntimeInstallBox provider="grok" entry={null} hostname="devbox" os="darwin" />);
+    expect(el.textContent).toContain(GROK_INSTALL_COMMAND);
+    expect(el.querySelector("pre")).not.toBeNull();
   });
 });
 

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -20,6 +20,7 @@ export const PROVIDER_ORDER: RuntimeProvider[] = [
   RUNTIME_PROVIDERS.CLAUDE_CODE_TUI,
   RUNTIME_PROVIDERS.CODEX,
   RUNTIME_PROVIDERS.CURSOR,
+  RUNTIME_PROVIDERS.GROK,
   RUNTIME_PROVIDERS.KIMI_CODE,
   RUNTIME_PROVIDERS.OPENCODE,
 ].filter((p) => isRuntimeProviderEnabled(p));
@@ -29,6 +30,7 @@ export const PROVIDER_LABEL: Record<RuntimeProvider, string> = {
   "claude-code-tui": "Claude Code CLI",
   codex: "Codex",
   cursor: "Cursor",
+  grok: "Grok Build",
   "kimi-code": "Kimi Code",
   opencode: "OpenCode",
 };
@@ -70,6 +72,9 @@ export const PROVIDER_NPM_PACKAGE: Record<RuntimeProvider, string | null> = {
   // Cursor is not distributed via npm — its official installer script is the
   // only supported install path (see CURSOR_INSTALL_COMMAND).
   cursor: null,
+  // Grok Build is not distributed via npm either — same installer-script
+  // pattern as Cursor (see GROK_INSTALL_COMMAND).
+  grok: null,
   // Runtime execution is bundled, but the official CLI remains the supported
   // operator login/recovery surface for the shared ~/.kimi-code credential.
   "kimi-code": "@moonshot-ai/kimi-code",
@@ -86,6 +91,26 @@ export const PROVIDER_NPM_PACKAGE: Record<RuntimeProvider, string | null> = {
 export const CURSOR_INSTALL_COMMAND = "curl https://cursor.com/install -fsS | bash";
 
 /**
+ * Grok Build's official installer. Same posture as Cursor: external-only, the
+ * card renders it for the operator to run. Mirrors `GROK_INSTALL_COMMAND` in
+ * `@first-tree/client`'s grok-binary module (web cannot import the client
+ * package, so the string is duplicated deliberately; update both together).
+ */
+export const GROK_INSTALL_COMMAND = "curl -fsSL https://x.ai/cli/install.sh | bash";
+
+/**
+ * The single install command line for a provider: the `npm install -g` spec
+ * when one exists, otherwise the provider's official installer script. Shared
+ * by `buildInstallCommand` and the install-box probe-error path so non-npm
+ * providers never fall back to another provider's installer.
+ */
+export function providerInstallCommand(provider: RuntimeProvider): string {
+  const npmPackage = PROVIDER_NPM_PACKAGE[provider];
+  if (npmPackage) return `npm install -g ${npmPackage}`;
+  return provider === "grok" ? GROK_INSTALL_COMMAND : CURSOR_INSTALL_COMMAND;
+}
+
+/**
  * Per-runtime login command shown after install. Codex prints
  * `codex login`; Claude Code prints `claude auth login`. Both accept
  * `--api-key` flavored alternatives the user discovers on the install
@@ -97,6 +122,7 @@ export const PROVIDER_LOGIN_COMMAND: Record<RuntimeProvider, string> = {
   "claude-code-tui": "claude auth login",
   codex: "codex login",
   cursor: "cursor-agent login",
+  grok: "grok login",
   "kimi-code": "kimi # then run /login",
   opencode: "opencode auth login",
 };
@@ -108,9 +134,7 @@ export const PROVIDER_LOGIN_COMMAND: Record<RuntimeProvider, string> = {
  * box with a copy button per box.
  */
 export function buildInstallCommand(provider: RuntimeProvider, os?: string | null): string {
-  const npmPackage = PROVIDER_NPM_PACKAGE[provider];
-  const installLine = npmPackage ? `npm install -g ${npmPackage}` : CURSOR_INSTALL_COMMAND;
-  const base = `${installLine}\n${PROVIDER_LOGIN_COMMAND[provider]}`;
+  const base = `${providerInstallCommand(provider)}\n${PROVIDER_LOGIN_COMMAND[provider]}`;
   if (provider === "claude-code-tui") {
     // The tmux-driven runtime additionally needs tmux (>= 3.0). tmux is not an
     // npm package, so emit the command for the host's actual package manager
@@ -217,6 +241,9 @@ export function providerInstallHint(
   }
   if (provider === "cursor") {
     return `Run \`${CURSOR_INSTALL_COMMAND}\` on this ${device} (official Cursor installer).`;
+  }
+  if (provider === "grok") {
+    return `Run \`${GROK_INSTALL_COMMAND}\` on this ${device} (official Grok Build installer).`;
   }
   if (provider === "kimi-code") {
     return `Install the official Kimi CLI with \`npm install -g @moonshot-ai/kimi-code\` on this ${device}, run \`kimi\`, then \`/login\`. First Tree still executes through its bundled Kimi SDK.`;

--- a/packages/web/src/pages/clients/cards/shared/runtime-auth-view.test.ts
+++ b/packages/web/src/pages/clients/cards/shared/runtime-auth-view.test.ts
@@ -168,6 +168,7 @@ describe("deriveRuntimeAuthView", () => {
     expect(providerSupportsInProductAuth("codex")).toBe(true);
     expect(providerSupportsInProductAuth("claude-code")).toBe(true);
     expect(providerSupportsInProductAuth("cursor")).toBe(true);
+    expect(providerSupportsInProductAuth("grok")).toBe(true);
     expect(providerSupportsInProductAuth("claude-code-tui")).toBe(false);
   });
 

--- a/packages/web/src/pages/clients/cards/shared/runtime-auth-view.ts
+++ b/packages/web/src/pages/clients/cards/shared/runtime-auth-view.ts
@@ -30,9 +30,10 @@ export type RuntimeAuthView =
 /** Providers whose login the daemon can drive in-product today. */
 export function providerSupportsInProductAuth(provider: RuntimeProvider): boolean {
   // Consistent browser-OAuth Connect: codex (`codex login`), claude-code
-  // (`claude auth login`), and cursor (`cursor-agent login`). `claude-code-tui`
-  // shares Claude Code's credentials but isn't a distinct Connect target.
-  return provider === "codex" || provider === "claude-code" || provider === "cursor";
+  // (`claude auth login`), cursor (`cursor-agent login`), and grok
+  // (`grok login`). `claude-code-tui` shares Claude Code's credentials but
+  // isn't a distinct Connect target.
+  return provider === "codex" || provider === "claude-code" || provider === "cursor" || provider === "grok";
 }
 
 /**

--- a/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
@@ -54,7 +54,7 @@ export function RuntimeInstallBox({ provider, entry, hostname, os }: RuntimeInst
       <p className="text-caption" style={{ margin: 0, color: "var(--fg-3)" }}>
         {renderHeadlineWithCode(headline)}
       </p>
-      <InlineCommand command={command} ariaLabel={`${label} setup command`} />
+      {command !== null && <InlineCommand command={command} ariaLabel={`${label} setup command`} />}
     </div>
   );
 }
@@ -83,14 +83,26 @@ function renderHeadlineWithCode(text: string): ReactNode {
 /**
  * Pure helper — returns `{headline, command}` for a given capability
  * entry. Extracted for testability so the install-box's per-state
- * branching is unit-tested without DOM.
+ * branching is unit-tested without DOM. `command` is null when the
+ * platform makes installation impossible (grok on Windows): the caller
+ * renders the status headline only, never an install command.
  */
 export function installBoxView(
   entry: CapabilityEntry | null,
   provider: RuntimeProvider,
   hostname: string,
   os?: string | null,
-): { headline: string; command: string } {
+): { headline: string; command: string | null } {
+  // Grok Build is macOS/Linux-only in V1. The probe reports this as state
+  // `error` on win32; rendering the generic probe-error branch would print
+  // the official install command in a loop for a runtime First Tree does
+  // not support on this platform. Fail closed with a status instead.
+  if (provider === "grok" && (os === "win32" || os === "windows")) {
+    return {
+      headline: `${PROVIDER_LABEL[provider]} is not supported on Windows in V1 (macOS/Linux only). Nothing to install on ${hostname}.`,
+      command: null,
+    };
+  }
   if (!entry || entry.state === "missing") {
     // `claude-code-tui` needs the `claude` CLI AND tmux (>= 3.0); name the tmux
     // requirement explicitly so the box isn't read as a CLI-only install (the

--- a/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
@@ -1,13 +1,7 @@
 import type { CapabilityEntry, RuntimeProvider } from "@first-tree/shared";
 import type { ReactNode } from "react";
 import { InlineCommand } from "./inline-command.js";
-import {
-  buildInstallCommand,
-  CURSOR_INSTALL_COMMAND,
-  PROVIDER_LABEL,
-  PROVIDER_LOGIN_COMMAND,
-  PROVIDER_NPM_PACKAGE,
-} from "./providers.js";
+import { buildInstallCommand, PROVIDER_LABEL, PROVIDER_LOGIN_COMMAND, providerInstallCommand } from "./providers.js";
 
 type RuntimeInstallBoxProps = {
   provider: RuntimeProvider;
@@ -108,10 +102,9 @@ export function installBoxView(
     return { headline, command: buildInstallCommand(provider, os) };
   }
   if (entry.state === "error") {
-    const npmPackage = PROVIDER_NPM_PACKAGE[provider];
     return {
       headline: `${PROVIDER_LABEL[provider]} probe failed: ${entry.error ?? "unknown error"}. Reinstall on ${hostname}:`,
-      command: npmPackage ? `npm install -g ${npmPackage}` : CURSOR_INSTALL_COMMAND,
+      command: providerInstallCommand(provider),
     };
   }
   // `ok` should not reach here — the Setup-incomplete card filters such

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
 
   packages/client:
     dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: 1.3.0
+        version: 1.3.0(zod@4.3.6)
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.187
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
@@ -456,6 +459,11 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
+
+  '@agentclientprotocol/sdk@1.3.0':
+    resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -5463,6 +5471,10 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@agentclientprotocol/sdk@1.3.0(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
 
   '@ampproject/remapping@2.3.0':
     dependencies:


### PR DESCRIPTION
# Add Grok Build runtime provider

Adds `grok` ([Grok Build](https://github.com/xai-org/grok-build)) as a new runtime provider, driving the official `grok` CLI over **ACP v1** (stdio / NDJSON) via the official `@agentclientprotocol/sdk@1.3.0`.

## Adopted V1 design

- **Short-lived process per provider turn.** Each turn spawns `grok --no-auto-update agent --no-leader --always-approve [--model <id>] [--effort <low|medium|high>] stdio`, runs `initialize → session/new|session/load → session/prompt → full notification/response barrier → stdin EOF → drained exit 0`, then exits. One persisted Grok session ID per `(agent, chat)`; same-chat turns serialize through the existing handler queue; different chats run in parallel — including on a shared workspace cwd, since Grok keys session storage by session ID under the encoded cwd. No shared cross-chat process, no mid-turn interject in V1 (active-turn `inject` queues for the next turn).
- **Empty client fs/terminal capabilities by design.** `initialize` advertises `clientCapabilities: {}` so Grok keeps using its own local filesystem/terminal backends. Declaring those capabilities would force First Tree to implement reverse fs/terminal proxy methods — deliberately out of scope. A defensive `session/request_permission` handler fails closed (it never fires under `--always-approve` + `yoloMode`).
- **Auth/token boundary.** First Tree never reads, copies, or relays Grok tokens. Ordinary turns do not send ACP `authenticate` — Grok auto-selects its initialize-advertised `defaultAuthMethodId`; a credential failure classifies as `credential`, persists the existing durable runtime notice before ACK, and offers the explicit in-product browser-login action, which runs the official `grok login` on the daemon host. Headless device auth / API keys remain provider-owned host configuration.
- **Session integrity.** Only stream-confirmed Grok session IDs are persisted (synthetic `grok-pending-*` placeholder upgrades via `replaceSessionId`). `session/load` must match the persisted ID and **never silently falls back to a fresh session** (replay safety). The replay contract is exact, not time-based: `session/load` carries `_meta.noReplay: true`, replay-marked notifications (`params._meta.isReplay === true`) are dropped on every route regardless of arrival time, and each attempt mints a `session/prompt` `_meta.promptId` — updates, `turn_completed`, and the prompt response must correlate to it (mismatch or missing fails closed). A legacy quiet-window fence remains only as a fallback for builds without the markers.
- **Model/effort are re-applied after EVERY session open.** Because `session/load` restores the session's persisted model/effort, argv-only selection would silently keep stale values on resumed sessions. After every `session/new` or `session/load` and before the prompt, the handler sends `session/set_model` (`{ sessionId, modelId, _meta: { reasoningEffort } }`) and requires the response to carry `_meta.model.Ok === effectiveModelId`. An explicit model is always re-applied; an empty effort omits the `_meta` key entirely (override removed); an empty model resets to the initialize-advertised default model. A `set_model` rejection classifies as `configuration` and no prompt is sent — no silent fallback.
- **Explicit effort is also verified effective before prompting.** Grok silently ignores an effort override the selected model does not support while still returning the successful model response, so a non-empty `reasoningEffort` additionally requires THIS set_model's effective echo: a non-replay `_x.ai/session_notification` `model_changed` on the exact session, received after the waiter's receipt-time ingress baseline (stale/foreign/wrong-channel/replay-marked echos never satisfy), with `model_id === effectiveModelId` and `reasoning_effort === requestedEffort`. Missing/omitted/wrong/timed-out confirmations, and a replay drain that fails to go quiet before an explicit effort, are deterministic configuration terminals — 1 spawn, no retry, no prompt, no success ACK (the SessionManager-owned durable notice still precedes the consumed ACK). The once-settled echo waiter is cancelled on response failure, confirmation, and abort; diagnostics report only post-arm candidates. Empty effort keeps remove-override semantics (the provider default effort is accepted without an echo requirement). Verified against live Grok 0.2.117 for the wire shape/order/provider default; the unsupported-model ignored-override branch is covered by upstream-source-derived fake regressions (not live-tested — this account's catalog only lists effort-capable models).
- **Settlement boundaries.** Success and failure paths share one settle barrier: EOF → bounded child close + `connection.closed` → stable notification-handler drain → then settlement state is read (post-response write/usage notifications cannot be truncated). A completed prompt requires a clean exit 0; non-zero exits and EOF timeouts route into `ProviderAttempt` per replay-safety/custody (terminate timers are cleared on real close so a reused PGID can never be killed; non-piped stdio branches reclaim with a bounded close wait). ACP terminal stop reasons `max_tokens` / `max_turn_requests` / `refusal` are completions (assistant text and usage preserved); only `cancelled` is abnormal and it too flows through `ProviderAttempt`/replay-safety rather than unconditional redelivery. Replay-safety state accumulates across attempts. JSON-RPC error `data` is preserved length-capped in failure classification.
- **Events.** Standard ACP `agent_message_chunk` (accumulated, emitted once as chunked `assistant_text` at successful turn end), `agent_thought_chunk` (presence-only `thinking`), `tool_call` / `tool_call_update` mapped with `_meta["x.ai/tool"]` metadata (`read_file` / `write` / `search_replace` / `run_terminal_cmd`) into tool events with Context Tree file refs; usage parsed from `_x.ai/session_notification` `turn_completed` into one `token_usage` event per turn; replay safety advances when assistant output or a non-proven-read-only tool begins.
- **MCP / models / effort.** Managed MCP servers map into ACP `session/new|load` params, filtered by the transports the agent advertises. `model` is a free-form exact ID (empty = Grok local default); `reasoningEffort` maps to `--effort` with `""` as the inherit sentinel. Model catalog discovery runs a bounded initialize-only ACP handshake and parses `_meta.modelState`, degrading to the free-form input when unavailable.
- **Managed skills** project to `.grok/skills`.

## Supported range and platform gate

- Grok Build **>= 0.2.117 < 0.3.0** (validated against 0.2.117); the bounded `grok --version` compatibility gate runs at first real provider use against the exact binary the handler will spawn.
- **macOS / Linux only in V1.** The capability probe is install/platform-only (never launches the CLI, never inspects credentials, never touches the network) and Windows fails closed at EVERY entry point — probe, binary resolver, model discovery, runtime auth, and the Web install box (which renders an unsupported status instead of an install command on win32).
- **Deterministic unsupported classification.** win32 bring-up and resolved-but-out-of-range/invalid binaries classify as `capability`/`configuration` (`grok_platform_unsupported` / `grok_binary_unsupported`) with an immediate stop — never the unknown-retry path; `grok_binary_missing` is reserved for an unresolved binary.
- 429s surface after Grok's internal retry budget and classify as `provider_rate_limited` capacity with bounded visible retry; free-tier rate limits are not hardcoded into the provider.

## Prior live validation (research/QA pass, Grok 0.2.117)

Parallel `session/new`/`session/load` on one cwd, isolated session directories, clean EOF exit 0, single-side failure isolation, real `grok-4.5` prompts, cross-process local tool read/write, and two concurrent chat-like tool turns all passed. The only live transient observed was a recoverable HTTP 429.

## Verification

- `pnpm check` — clean (2122 files).
- `pnpm typecheck` — clean across all packages.
- `pnpm test` — 12/12 turbo tasks succeeded on the final head `d3a70a7c3`. Focused grok suites on this head: `grok-handler-engine` 51 tests; the reviewer's independent run over the 5 adversarial/settlement suites (engine/events/ACP session/provider policy/SessionManager) is 145/145; Web grok suites 13/13.
- One environment-sensitive CLI case (`core-attention-update-extra.test.ts` `detectInstallMode`) was observed failing on this machine on a clean baseline as well (returns `portable` instead of `npx` depending on install mode); it is unrelated to this change and passed in the final full-suite run.
- `git diff --check` clean; lockfile change is limited to `@agentclientprotocol/sdk@1.3.0`.

## QA

Formal live-provider QA is **pending** (not yet executed): this adds a new provider across runtime/auth surfaces. `packages/qa/cases/runtime/grok-provider.md` covers the live boundary (install-only probe, auth recovery with durable notice + `grok login`, ACP spawn posture, same-cwd parallel chats, session new/load resume with set_model re-apply + replay-marker filtering, terminal stop reasons, MCP/skills projection, model + effort round-trips including the empty-config reset, Context Tree I/O evidence, 429 capacity retry, discovery version gate, client-switch drain).
