### PR TITLE
fix(client): preserve Kimi background work through turn completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,15 @@ jobs:
       # all 233 tests passed. Building before vitest starts keeps the
       # heavy work outside the worker IPC window.
       - run: pnpm build
+      # The npm release surface packs with a bundled Kimi SDK; npm's
+      # trusted-publishing client is pinned to the exact version QA qualifies
+      # (a floated range already broke this boundary upstream). Smoke the real
+      # pack → empty-consumer install → public CLI → patched SDK chain on
+      # every CLI-affecting PR.
+      - name: Pin trusted-publishing npm client
+        run: npm install -g npm@11.5.1
+      - name: Release pack smoke (bundled Kimi SDK)
+        run: node scripts/release-pack-smoke.mjs
       # Keep the CLI behind Turbo so an unchanged first-tree-dev#test task can
       # use cache while its package script releases heap between batches.
       - run: pnpm exec turbo run test --filter=first-tree-dev --concurrency=1

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -60,7 +60,7 @@ jobs:
           cache: "pnpm"
 
       - name: Ensure trusted publishing npm version
-        run: npm install -g npm@^11.5.1
+        run: npm install -g npm@11.5.1
 
       - name: Validate stable release tag
         id: release
@@ -281,7 +281,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Ensure trusted publishing npm version
-        run: npm install -g npm@^11.5.1
+        run: npm install -g npm@11.5.1
 
       - name: Resolve staging version
         id: version
@@ -485,7 +485,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Ensure trusted publishing npm version
-        run: npm install -g npm@^11.5.1
+        run: npm install -g npm@11.5.1
 
       - name: Resolve alpha version
         id: version

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /app
 
 # Copy package manifests for dependency layer caching. Only the packages
 # needed to build + run the SaaS server image: shared, server, web.
+# pnpm-workspace.yaml declares patchedDependencies, so the patch files must
+# be present before any pnpm install.
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY patches/ patches/
 COPY packages/shared/package.json packages/shared/
 COPY packages/server/package.json packages/server/
 COPY packages/web/package.json packages/web/

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -49,6 +49,9 @@
     "postinstall": "node scripts/prune-codex-runtime-binary.mjs && node scripts/prune-claude-runtime-binary.mjs && node scripts/prune-claude-sdk-deps.mjs"
   },
   "license": "Apache-2.0",
+  "bundleDependencies": [
+    "@botiverse/kimi-code-sdk"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/agent-team-foundation/first-tree.git",
@@ -60,6 +63,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.187",
     "@botiverse/kimi-code-sdk": "0.26.0-botiverse.2",
+    "@antfu/utils": "^9.3.0",
     "@inquirer/prompts": "^8.3.0",
     "@openai/codex-sdk": "^0.144.1",
     "commander": "^13.1.0",
@@ -69,8 +73,10 @@
     "jose": "^6.0.0",
     "mdast-util-from-markdown": "^2.0.3",
     "semver": "^7.6.3",
+    "smol-toml": "^1.6.1",
     "ws": "^8.20.0",
     "yaml": "^2.8.3",
+    "yazl": "^3.3.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -123,3 +123,26 @@ describe("workspace dependency-patch distribution", () => {
     expect(dockerignore).not.toMatch(/^patches\/?$/m);
   });
 });
+
+describe("trusted-publishing npm toolchain contract", () => {
+  const PUBLISH_WORKFLOW = join(REPO_ROOT, ".github", "workflows", "publish-npm-package.yml");
+  const CI_WORKFLOW = join(REPO_ROOT, ".github", "workflows", "ci.yml");
+
+  it("pins every trusted-publishing npm install to the exact QA-qualified version, with no moving selector", () => {
+    const workflow = readText(PUBLISH_WORKFLOW);
+    const installs = [...workflow.matchAll(/npm install -g npm@(\S+)/g)].map((match) => match[1]);
+    // prod CLI, staging CLI, and shared alpha must all be covered.
+    expect(installs.length).toBeGreaterThanOrEqual(3);
+    for (const selector of installs) {
+      expect(selector).toBe("11.5.1");
+    }
+    expect(workflow).not.toMatch(/npm@(latest|next|\^|~)/);
+  });
+
+  it("runs a real release-pack smoke under the pinned client on CLI-affecting PRs", () => {
+    const ci = readText(CI_WORKFLOW);
+    expect(ci).toContain("npm install -g npm@11.5.1");
+    expect(ci).toContain("node scripts/release-pack-smoke.mjs");
+    expect(existsSync(join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"))).toBe(true);
+  });
+});

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -80,4 +80,46 @@ describe("npm package metadata", () => {
 
     expect(dependencies["fs-native-extensions"]).toBe("^1.5.0");
   });
+
+  it("bundles the patched Kimi SDK and declares its runtime dependencies for consumers", () => {
+    const pkg = readJson(join(CLI_ROOT, "package.json")) as Record<string, unknown>;
+    // The workspace pins the Kimi SDK through a pnpm patch (see
+    // pnpm-workspace.yaml). npm consumers cannot apply that patch, so the
+    // tarball must carry the patched artifact as a bundled dependency, and
+    // the SDK's own runtime deps must be regular CLI dependencies so the
+    // bundled copy resolves them from the consumer's top-level node_modules.
+    expect(pkg.bundleDependencies).toEqual(["@botiverse/kimi-code-sdk"]);
+    const dependencies = packageDependencies(pkg);
+    for (const sdkRuntimeDep of ["@antfu/utils", "smol-toml", "yazl"]) {
+      expect(dependencies[sdkRuntimeDep]).toBeDefined();
+    }
+    expect(dependencies["@botiverse/kimi-code-sdk"]).toBe("0.26.0-botiverse.2");
+  });
+});
+
+describe("workspace dependency-patch distribution", () => {
+  it("copies the pnpm patch files into the Docker dependency stage before install", () => {
+    const dockerfile = readText(join(REPO_ROOT, "Dockerfile"));
+    const copyPatches = dockerfile.indexOf("COPY patches/ patches/");
+    const install = dockerfile.indexOf("pnpm install --frozen-lockfile");
+    expect(copyPatches).toBeGreaterThan(-1);
+    expect(install).toBeGreaterThan(-1);
+    expect(copyPatches).toBeLessThan(install);
+  });
+
+  it("points every patchedDependencies entry at a patch file that exists and ships to Docker", () => {
+    const workspaceYaml = readText(join(REPO_ROOT, "pnpm-workspace.yaml"));
+    const match = workspaceYaml.match(/patchedDependencies:\n((?:[ \t]+\S.*\n?)+)/);
+    expect(match).not.toBeNull();
+    if (!match) throw new Error("patchedDependencies block missing from pnpm-workspace.yaml");
+    const entries = [...match[1].matchAll(/^\s+(['"]?)([^'":]+)\1:\s*(.+?)\s*$/gm)];
+    expect(entries.length).toBeGreaterThan(0);
+    const dockerignore = readText(join(REPO_ROOT, ".dockerignore"));
+    for (const entry of entries) {
+      const patchPath = entry[3];
+      expect(patchPath.startsWith("patches/")).toBe(true);
+      expect(existsSync(join(REPO_ROOT, patchPath))).toBe(true);
+    }
+    expect(dockerignore).not.toMatch(/^patches\/?$/m);
+  });
 });

--- a/apps/cli/tests/portable-builder.test.ts
+++ b/apps/cli/tests/portable-builder.test.ts
@@ -37,6 +37,7 @@ import {
   portableBuildRoots,
   portableTarCreateArgs,
   readWorkspacePackageManager,
+  readWorkspacePatchedDependencies,
   relativizeInternalSymlinks,
   renderInstallerForChannel,
   resolveNodeVersion,
@@ -304,6 +305,47 @@ describe("portable builder helpers", () => {
     expect(() => readWorkspacePackageManager({ packageManager: "pnpm@^10" })).toThrow(/exact pnpm version/);
     expect(() => readWorkspacePackageManager({})).toThrow(/exact pnpm version/);
     expect(readWorkspacePackageManager()).toMatch(/^pnpm@\d+\.\d+\.\d+$/);
+  });
+
+  it("carries workspace patchedDependencies into the portable app manifest", () => {
+    const patched = readWorkspacePatchedDependencies();
+    // The Kimi SDK resume-drain patch must reach the synthetic portable app;
+    // without it the app's generated lockfile resolves the unpatched SDK.
+    expect(patched).toHaveProperty(
+      "@botiverse/kimi-code-sdk@0.26.0-botiverse.2",
+      "patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch",
+    );
+    for (const patchPath of Object.values(patched)) {
+      expect(patchPath.startsWith("patches/")).toBe(true);
+      expect(existsSync(join(REPO_ROOT, patchPath))).toBe(true);
+    }
+
+    const appPackage = packageJsonForApp({
+      channelConfig: { packageName: "first-tree", binName: "first-tree", aliasName: "ft" },
+      version: "1.2.3",
+      dependencies: { commander: "13.1.0" },
+      sourcePackage: {
+        description: "First Tree CLI",
+        license: "MIT",
+        repository: { type: "git", url: "https://example.test/first-tree.git" },
+        engines: { node: ">=22.13" },
+      },
+      patchedDependencies: patched,
+    });
+    expect(appPackage.pnpm).toEqual({ patchedDependencies: patched });
+
+    const unpatched = packageJsonForApp({
+      channelConfig: { packageName: "first-tree", binName: "first-tree", aliasName: "ft" },
+      version: "1.2.3",
+      dependencies: { commander: "13.1.0" },
+      sourcePackage: {
+        description: "First Tree CLI",
+        license: "MIT",
+        repository: { type: "git", url: "https://example.test/first-tree.git" },
+        engines: { node: ">=22.13" },
+      },
+    });
+    expect(unpatched).not.toHaveProperty("pnpm");
   });
 
   it("fails when a portable dependency is missing from locked pnpm output", () => {

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -30,6 +30,7 @@ type FakeSessionState = {
   >;
   applyStaleChatIds: ReturnType<typeof vi.fn<(chatIds: string[]) => void>>;
   noteBindRecoveryComplete: ReturnType<typeof vi.fn<() => void>>;
+  reconcileReplayFencesWithServer: ReturnType<typeof vi.fn<() => Promise<void>>>;
   updateTransport: ReturnType<typeof vi.fn<(sdk: unknown, agentConfigCache?: unknown) => void>>;
   shutdown: ReturnType<typeof vi.fn<(reason?: string, opts?: unknown) => Promise<void>>>;
 };
@@ -244,6 +245,7 @@ function installMocks(
           handleCommand: vi.fn(async () => {}),
           applyStaleChatIds: vi.fn(),
           noteBindRecoveryComplete: vi.fn(),
+          reconcileReplayFencesWithServer: vi.fn(async () => {}),
           updateTransport: vi.fn(),
           shutdown: vi.fn(async () => {}),
         };
@@ -287,6 +289,10 @@ function installMocks(
 
       noteBindRecoveryComplete(): void {
         this.state.noteBindRecoveryComplete();
+      }
+
+      reconcileReplayFencesWithServer(): Promise<void> {
+        return this.state.reconcileReplayFencesWithServer();
       }
 
       updateTransport(sdk: unknown, agentConfigCache?: unknown): void {
@@ -750,6 +756,7 @@ describe("AgentSlot", () => {
 
     const nextSdk = makeSdk({ activeRuntimeChatIds: ["chat-2"] });
     vi.mocked(sdk.listActiveRuntimeChatIds).mockClear();
+    session.reconcileReplayFencesWithServer.mockClear();
 
     connection.emit("agent:bound", {
       agentId: "agent-1",
@@ -766,6 +773,7 @@ describe("AgentSlot", () => {
     expect(vi.mocked(sdk.listActiveRuntimeChatIds)).not.toHaveBeenCalled();
     expect(session.updateTransport).toHaveBeenCalledWith(nextSdk, expect.anything());
     expect(session.noteBindRecoveryComplete).toHaveBeenCalled();
+    expect(session.reconcileReplayFencesWithServer).toHaveBeenCalledTimes(1);
 
     await slot.stop();
   });

--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -294,7 +294,7 @@ describe("ClientConnection — additional branch coverage", () => {
 
     await expect(eventPromise).resolves.toBeUndefined();
     await expect(ackPromise).resolves.toBeUndefined();
-    await expect(recoverPromise).resolves.toBe(2);
+    await expect(recoverPromise).resolves.toEqual({ resetCount: 2, unackedOutstanding: undefined });
   });
 
   it("times out confirmed session events and keeps later rejection frames from double-settling", async () => {

--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -294,7 +294,7 @@ describe("ClientConnection — additional branch coverage", () => {
 
     await expect(eventPromise).resolves.toBeUndefined();
     await expect(ackPromise).resolves.toBeUndefined();
-    await expect(recoverPromise).resolves.toBeUndefined();
+    await expect(recoverPromise).resolves.toBe(2);
   });
 
   it("times out confirmed session events and keeps later rejection frames from double-settling", async () => {

--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -610,8 +610,9 @@ describe("ClientConnection — WebSocket edge coverage", () => {
       agentId: "agent-1",
       chatId: "chat-1",
       resetCount: 1,
+      unackedOutstanding: 3,
     });
-    await expect(accepted).resolves.toBe(1);
+    await expect(accepted).resolves.toEqual({ resetCount: 1, unackedOutstanding: 3 });
 
     const rejected = connection.sendInboxRecover("agent-1", "chat-2");
     const rejectFrame = parseSent(socket, socket.sent.length - 1);

--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -627,6 +627,55 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     expect(socket.closeCalls).toHaveLength(0);
   });
 
+  it("sends fence probes and settles on accepted or rejected frames without any destructive effect", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const bindPromise = internal.sendBind("agent-1", "codex");
+    const bindFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "agent:bound",
+      ref: bindFrame.ref,
+      agentId: "agent-1",
+      displayName: "Agent One",
+      agentType: "agent",
+    });
+    await bindPromise;
+
+    const accepted = connection.sendInboxFenceProbe("agent-1", "chat-1", ["msg-1", "msg-2"]);
+    const probeFrame = parseSent(socket, socket.sent.length - 1);
+    expect(probeFrame).toMatchObject({
+      type: "inbox:fence-probe",
+      agentId: "agent-1",
+      chatId: "chat-1",
+      messageIds: ["msg-1", "msg-2"],
+    });
+    expect(typeof probeFrame.ref).toBe("string");
+
+    socket.emitMessage({
+      type: "inbox:fence-probe:accepted",
+      ref: probeFrame.ref,
+      agentId: "agent-1",
+      chatId: "chat-1",
+      settledMessageIds: ["msg-1"],
+    });
+    await expect(accepted).resolves.toEqual({ settledMessageIds: ["msg-1"] });
+
+    const rejected = connection.sendInboxFenceProbe("agent-1", "chat-2", ["msg-3"]);
+    const rejectFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "inbox:fence-probe:rejected",
+      ref: rejectFrame.ref,
+      agentId: "agent-1",
+      chatId: "chat-2",
+      reason: "agent_not_bound",
+    });
+    await expect(rejected).rejects.toThrow("agent_not_bound");
+    // Read-only probe: a rejection never tears down the socket.
+    expect(socket.closeCalls).toHaveLength(0);
+  });
+
   it("forces a reconnect when an inbox recovery confirmation times out", async () => {
     vi.useFakeTimers();
     const connection = await makeConnection();

--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -611,7 +611,7 @@ describe("ClientConnection — WebSocket edge coverage", () => {
       chatId: "chat-1",
       resetCount: 1,
     });
-    await expect(accepted).resolves.toBeUndefined();
+    await expect(accepted).resolves.toBe(1);
 
     const rejected = connection.sendInboxRecover("agent-1", "chat-2");
     const rejectFrame = parseSent(socket, socket.sent.length - 1);

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -44,12 +44,42 @@ class FakeSession {
     const events = this.scripts.shift();
     if (!events) throw new Error("fake Kimi session called more times than scripted");
     for (const event of events) {
+      await invokeAuthorizeHook(this.id, event);
       for (const listener of this.listeners) listener(event);
     }
   }
 
   async getUsage(): Promise<SessionUsage> {
     return this.usage;
+  }
+}
+
+type GlobalBeforeToolCall = (info: {
+  sessionId?: string;
+  agentId?: string;
+  toolName: string;
+  toolCallId: string;
+  args: unknown;
+}) => Promise<void> | void;
+
+// Invokes the handler-registered global pre-effect hook exactly where the
+// patched SDK's awaited authorizeToolExecution boundary would call it:
+// before the tool task starts. Returns false when the hook blocked the call.
+async function invokeAuthorizeHook(sessionId: string, value: KimiEvent): Promise<boolean> {
+  if (value.type !== "tool.call.started") return true;
+  const hook = (globalThis as { __firstTreeBeforeToolCall?: GlobalBeforeToolCall }).__firstTreeBeforeToolCall;
+  if (!hook) return true;
+  try {
+    await hook({
+      sessionId,
+      agentId: value.agentId,
+      toolName: value.name,
+      toolCallId: value.toolCallId,
+      args: value.args,
+    });
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -68,6 +98,7 @@ class GatedFakeSession extends FakeSession {
   }
 
   emit(value: KimiEvent): void {
+    void invokeAuthorizeHook(this.id, value);
     for (const listener of this.listeners) listener(value);
   }
 
@@ -83,12 +114,11 @@ async function flushAsyncWork(): Promise<void> {
   }
 }
 
-// Models the patched SDK's tool-dispatch contract: the live-event listener
-// runs BEFORE the tool effect starts; unmarked listener errors are swallowed,
-// while errors marked `__firstTreeReplayFenceBlock` abort the dispatch so the
-// effect never runs. This mirrors `prepareToolCall` awaiting the tool.call
-// dispatch before creating the runnable task, plus the First Tree patch that
-// rethrows marked errors out of `safeEmitLive`.
+// Models the patched SDK's pre-effect contract: the awaited authorize hook
+// runs BEFORE the tool task starts; a hook throw blocks the tool so its
+// effect never runs (the blocked call still emits its tool.call event, like
+// the SDK's settleError path), while an allowed unsafe call counts as an
+// executed effect.
 class EffectGateFakeSession extends FakeSession {
   effectCount = 0;
   private readonly scriptEvents: KimiEvent[];
@@ -101,24 +131,11 @@ class EffectGateFakeSession extends FakeSession {
   override async prompt(input: string): Promise<void> {
     this.prompts.push(input);
     for (const value of this.scriptEvents) {
-      try {
-        for (const listener of this.listeners) {
-          listener(value);
-        }
-      } catch (error) {
-        // Swallow unmarked listener errors like the SDK's safeEmitLive;
-        // rethrow only the replay-fence block marker.
-        if (
-          typeof error === "object" &&
-          error !== null &&
-          (error as { __firstTreeReplayFenceBlock?: boolean }).__firstTreeReplayFenceBlock === true
-        ) {
-          throw error;
-        }
-      }
-      if (value.type === "tool.call.started" && !kimiToolIsReadOnly(value.name, value.args)) {
+      const allowed = await invokeAuthorizeHook(this.id, value);
+      if (value.type === "tool.call.started" && allowed && !kimiToolIsReadOnly(value.name, value.args)) {
         this.effectCount += 1;
       }
+      for (const listener of this.listeners) listener(value);
     }
   }
 }
@@ -802,9 +819,10 @@ describe("Kimi background subagent lifecycle", () => {
     expect(source).toMatch(
       /getReadyAgent\("main"\);\s*\n\s*if \(main !== void 0 && this\.options\.drainAgentTasksOnStop\)/,
     );
-    // safeEmitLive must rethrow marked replay-fence block errors instead of
-    // swallowing them, so a failed fence write aborts the tool dispatch.
-    expect(source).toContain("__firstTreeReplayFenceBlock");
+    // The awaited authorize boundary must invoke the host pre-effect hook,
+    // and agents must carry session/agent identity for hook routing.
+    expect(source).toContain("__firstTreeBeforeToolCall");
+    expect(source).toContain("agent.sessionId = this.options.id");
   });
 });
 

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -83,6 +83,46 @@ async function flushAsyncWork(): Promise<void> {
   }
 }
 
+// Models the patched SDK's tool-dispatch contract: the live-event listener
+// runs BEFORE the tool effect starts; unmarked listener errors are swallowed,
+// while errors marked `__firstTreeReplayFenceBlock` abort the dispatch so the
+// effect never runs. This mirrors `prepareToolCall` awaiting the tool.call
+// dispatch before creating the runnable task, plus the First Tree patch that
+// rethrows marked errors out of `safeEmitLive`.
+class EffectGateFakeSession extends FakeSession {
+  effectCount = 0;
+  private readonly scriptEvents: KimiEvent[];
+
+  constructor(id: string, scriptEvents: KimiEvent[]) {
+    super(id, []);
+    this.scriptEvents = scriptEvents;
+  }
+
+  override async prompt(input: string): Promise<void> {
+    this.prompts.push(input);
+    for (const value of this.scriptEvents) {
+      try {
+        for (const listener of this.listeners) {
+          listener(value);
+        }
+      } catch (error) {
+        // Swallow unmarked listener errors like the SDK's safeEmitLive;
+        // rethrow only the replay-fence block marker.
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          (error as { __firstTreeReplayFenceBlock?: boolean }).__firstTreeReplayFenceBlock === true
+        ) {
+          throw error;
+        }
+      }
+      if (value.type === "tool.call.started" && !kimiToolIsReadOnly(value.name, value.args)) {
+        this.effectCount += 1;
+      }
+    }
+  }
+}
+
 function event(sessionId: string, value: Record<string, unknown>): KimiEvent {
   return { agentId: "main", sessionId, ...value } as KimiEvent;
 }
@@ -126,14 +166,19 @@ function failedTurn(
   ];
 }
 
-function makeToken(): DeliveryToken & { completed: TurnOutcome[]; retried: string[] } {
+function makeToken(
+  opts: { completeResult?: "settled" | "retry" } = {},
+): DeliveryToken & { completed: TurnOutcome[]; retried: string[] } {
   const completed: TurnOutcome[] = [];
   const retried: string[] = [];
   return {
     completed,
     retried,
     processingStarted: () => {},
-    complete: async (_messages, outcome) => void completed.push(outcome),
+    complete: async (_messages, outcome) => {
+      completed.push(outcome);
+      return opts.completeResult;
+    },
     retry: (_messages, reason) => void retried.push(reason),
     terminalRejected: async () => {},
   };
@@ -757,6 +802,9 @@ describe("Kimi background subagent lifecycle", () => {
     expect(source).toMatch(
       /getReadyAgent\("main"\);\s*\n\s*if \(main !== void 0 && this\.options\.drainAgentTasksOnStop\)/,
     );
+    // safeEmitLive must rethrow marked replay-fence block errors instead of
+    // swallowing them, so a failed fence write aborts the tool dispatch.
+    expect(source).toContain("__firstTreeReplayFenceBlock");
   });
 });
 
@@ -865,45 +913,93 @@ describe("Kimi replay fence", () => {
     expect(fence.entries).toHaveLength(1);
   });
 
-  it("settles as a terminal consumed error when the fence cannot be persisted", async () => {
+  it("blocks the unsafe effect and retains custody when the fence cannot be persisted", async () => {
     const id = "kimi-session-fence-failure";
     const fence = makeFence();
     fence.fence.mockImplementation(() => {
       throw new Error("disk full");
     });
-    const fakeSession = new FakeSession(id, [unsafeWriteTurn(id)]);
+    const fakeSession = new EffectGateFakeSession(id, unsafeWriteTurn(id));
     const handler = makeHandler(fakeSession, {}, { replayFence: fence });
     const events: SessionEvent[] = [];
     const token = makeToken();
 
     await handler.start(message("m1", "write the marker"), makeContext(events), token);
 
-    expect(token.completed).toEqual([
-      { status: "error", completion: "consumed", reason: "replay_fence_persist_failed" },
-    ]);
+    // The marked throw aborts the SDK tool dispatch before the effect runs,
+    // and the retryable classification retains delivery custody instead of
+    // ACKing: redelivery is safe because effect count is provably zero.
+    expect(fakeSession.effectCount).toBe(0);
+    expect(token.completed).toEqual([]);
+    expect(token.retried).toContain("replay_fence_persist_failed");
     expect(events.some((item) => item.kind === "assistant_text")).toBe(false);
-    expect(events).toContainEqual({
-      kind: "error",
-      payload: { source: "runtime", message: "replay fence persistence failed: disk full" },
+    expect(events.filter((item) => item.kind === "turn_end")).toEqual([]);
+  });
+
+  it("settles through the durable-notice pipeline when the fence failure is non-retryable", async () => {
+    const id = "kimi-session-fence-config";
+    const fence = makeFence();
+    fence.fence.mockImplementation(() => {
+      throw new Error("bad config: replay fence store layout unsupported");
     });
+    const fakeSession = new EffectGateFakeSession(id, unsafeWriteTurn(id));
+    const handler = makeHandler(fakeSession, {}, { replayFence: fence });
+    const events: SessionEvent[] = [];
+    const token = makeToken();
+
+    await handler.start(message("m1", "write the marker"), makeContext(events), token);
+
+    expect(fakeSession.effectCount).toBe(0);
+    // Terminal settlement goes through the provider-attempt pipeline: the
+    // provider.retry event is what SessionManager turns into the durable
+    // chat-visible runtime notice before the consumed ACK.
+    expect(
+      events.some(
+        (item) =>
+          item.kind === "error" &&
+          item.payload.source === "runtime" &&
+          item.payload.message.startsWith("provider.retry:"),
+      ),
+    ).toBe(true);
+    expect(events.some((item) => item.kind === "assistant_text")).toBe(false);
     expect(events.filter((item) => item.kind === "turn_end")).toEqual([
       { kind: "turn_end", payload: { status: "error" } },
     ]);
+    expect(token.completed).toEqual([
+      { status: "error", completion: "consumed", reason: "replay_fence_persist_failed" },
+    ]);
   });
 
-  it("fails closed when no replay fence store is configured, while read-only turns still run", async () => {
+  it("retains custody when no replay fence store is configured", async () => {
     const id = "kimi-session-fence-missing";
-    const fakeSession = new FakeSession(id, [unsafeWriteTurn(id), successfulTurn(id, "read only ok")]);
+    const fakeSession = new EffectGateFakeSession(id, unsafeWriteTurn(id));
     const handler = makeHandler(fakeSession, {}, { replayFence: undefined });
     const events: SessionEvent[] = [];
     const token = makeToken();
 
     await handler.start(message("m1", "write the marker"), makeContext(events), token);
 
-    expect(token.completed).toEqual([
-      { status: "error", completion: "consumed", reason: "replay_fence_persist_failed" },
-    ]);
+    expect(fakeSession.effectCount).toBe(0);
+    expect(token.completed).toEqual([]);
+    expect(token.retried).toContain("replay_fence_persist_failed");
     expect(events.some((item) => item.kind === "assistant_text")).toBe(false);
+  });
+
+  it("keeps the fence when the completion disposition retains server custody", async () => {
+    const id = "kimi-session-fence-ack-retry";
+    const fence = makeFence();
+    const fakeSession = new FakeSession(id, [unsafeWriteTurn(id)]);
+    const handler = makeHandler(fakeSession, {}, { replayFence: fence });
+    const token = makeToken({ completeResult: "retry" });
+
+    await handler.start(message("m1", "write the marker"), makeContext([]), token);
+
+    // The ACK did not commit (disposition "retry"), so the fence must
+    // survive: a later crash-redelivery of this delivery would otherwise
+    // replay the write.
+    expect(token.completed).toEqual([{ status: "success" }]);
+    expect(fence.clear).not.toHaveBeenCalled();
+    expect(fence.entries).toHaveLength(1);
   });
 
   it("does not require the fence store for a read-only turn", async () => {

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -52,6 +52,36 @@ class FakeSession {
   }
 }
 
+// Test-controlled session: `prompt()` records the input and returns without
+// emitting anything; tests push events through `emit()` to model subagent
+// streams that outlive the prompt call, which a synchronous script cannot.
+class GatedFakeSession extends FakeSession {
+  private promptSeenResolve: () => void = () => {};
+  readonly promptSeen: Promise<void>;
+
+  constructor(id: string) {
+    super(id, []);
+    this.promptSeen = new Promise((resolvePromise) => {
+      this.promptSeenResolve = resolvePromise;
+    });
+  }
+
+  emit(value: KimiEvent): void {
+    for (const listener of this.listeners) listener(value);
+  }
+
+  override async prompt(input: string): Promise<void> {
+    this.prompts.push(input);
+    this.promptSeenResolve();
+  }
+}
+
+async function flushAsyncWork(): Promise<void> {
+  for (let index = 0; index < 5; index += 1) {
+    await new Promise((resolvePromise) => setImmediate(resolvePromise));
+  }
+}
+
 function event(sessionId: string, value: Record<string, unknown>): KimiEvent {
   return { agentId: "main", sessionId, ...value } as KimiEvent;
 }
@@ -545,6 +575,47 @@ describe("Kimi background subagent lifecycle", () => {
         payload: expect.objectContaining({ toolUseId: "sub-1:child-tool-1", status: "ok" }),
       }),
     );
+    expect(events.filter((item) => item.kind === "turn_end")).toEqual([
+      { kind: "turn_end", payload: { status: "success" } },
+    ]);
+    expect(token.completed).toEqual([{ status: "success" }]);
+  });
+
+  it("keeps the delivery pending when a child turn.ended arrives before any main terminal event", async () => {
+    const id = "kimi-session-subagent-gate";
+    const fakeSession = new GatedFakeSession(id);
+    const handler = makeHandler(fakeSession, {});
+    const events: SessionEvent[] = [];
+    const token = makeToken();
+    let settled = false;
+    const startPromise = handler
+      .start(message("m1", "run a background subagent"), makeContext(events), token)
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+
+    await fakeSession.promptSeen;
+    fakeSession.emit(childEvent(id, "sub-1", { type: "turn.started", turnId: 2 }));
+    fakeSession.emit(childEvent(id, "sub-1", { type: "assistant.delta", turnId: 2, delta: "child text" }));
+    fakeSession.emit(childEvent(id, "sub-1", { type: "turn.ended", turnId: 2, reason: "completed" }));
+    // The prompt call has returned and every emitted event has been processed;
+    // a handler that lets child completion settle the attempt would resolve here.
+    await flushAsyncWork();
+
+    expect(settled).toBe(false);
+    expect(token.completed).toEqual([]);
+    expect(token.retried).toEqual([]);
+    expect(events.filter((item) => item.kind === "turn_end")).toEqual([]);
+    expect(events.some((item) => item.kind === "assistant_text")).toBe(false);
+
+    fakeSession.emit(event(id, { type: "assistant.delta", turnId: 1, delta: "parent answer" }));
+    fakeSession.emit(event(id, { type: "turn.ended", turnId: 1, reason: "completed" }));
+    const result = await startPromise;
+
+    expect(result).toMatchObject({ sessionId: id, route: { kind: "owned", mode: "processing" } });
+    const assistantTexts = events.filter((item) => item.kind === "assistant_text").map((item) => item.payload.text);
+    expect(assistantTexts).toEqual(["parent answer"]);
     expect(events.filter((item) => item.kind === "turn_end")).toEqual([
       { kind: "turn_end", payload: { status: "success" } },
     ]);

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -53,6 +54,10 @@ class FakeSession {
 
 function event(sessionId: string, value: Record<string, unknown>): KimiEvent {
   return { agentId: "main", sessionId, ...value } as KimiEvent;
+}
+
+function childEvent(sessionId: string, agentId: string, value: Record<string, unknown>): KimiEvent {
+  return { agentId, sessionId, ...value } as KimiEvent;
 }
 
 function successfulTurn(sessionId: string, text = "done"): KimiEvent[] {
@@ -181,6 +186,7 @@ describe("Kimi Code handler", () => {
     expect(captures.create).toMatchObject({
       workDir: workspaceRoot,
       permission: "yolo",
+      drainAgentTasksOnStop: true,
     });
     expect(captures.create).not.toHaveProperty("model");
     expect(captures.create).not.toHaveProperty("mcpServers");
@@ -284,7 +290,7 @@ describe("Kimi Code handler", () => {
 
     await handler.resume(message("m2", "continue"), "kimi-session-2", makeContext([]), makeToken());
 
-    expect(captures.resume).toMatchObject({ id: "kimi-session-2" });
+    expect(captures.resume).toMatchObject({ id: "kimi-session-2", drainAgentTasksOnStop: true });
     expect(captures.resume).toHaveProperty("mcpServers", {
       docs: { transport: "stdio", command: "docs-server" },
     });
@@ -494,6 +500,154 @@ describe("Kimi Code handler", () => {
         outputTokens: 6,
       },
     });
+  });
+});
+
+describe("Kimi background subagent lifecycle", () => {
+  it("holds the parent turn open across a child stream and completes exactly once", async () => {
+    const id = "kimi-session-subagent";
+    const fakeSession = new FakeSession(id, [
+      [
+        event(id, { type: "turn.started", turnId: 1 }),
+        childEvent(id, "sub-1", { type: "turn.started", turnId: 2 }),
+        childEvent(id, "sub-1", { type: "thinking.delta", turnId: 2, delta: "child reasoning" }),
+        childEvent(id, "sub-1", { type: "assistant.delta", turnId: 2, delta: "child leaked text" }),
+        childEvent(id, "sub-1", {
+          type: "tool.call.started",
+          turnId: 2,
+          toolCallId: "child-tool-1",
+          name: "Write",
+          args: { path: "child-out.txt", content: "from child" },
+        }),
+        childEvent(id, "sub-1", { type: "tool.result", turnId: 2, toolCallId: "child-tool-1", output: "ok" }),
+        // The child ends first; this must not settle the parent attempt.
+        childEvent(id, "sub-1", { type: "turn.ended", turnId: 2, reason: "completed" }),
+        event(id, { type: "assistant.delta", turnId: 1, delta: "parent answer" }),
+        event(id, { type: "turn.ended", turnId: 1, reason: "completed" }),
+      ],
+    ]);
+    const handler = makeHandler(fakeSession, {});
+    const events: SessionEvent[] = [];
+    const token = makeToken();
+
+    await handler.start(message("m1", "run a background subagent"), makeContext(events), token);
+
+    const assistantTexts = events.filter((item) => item.kind === "assistant_text").map((item) => item.payload.text);
+    expect(assistantTexts).toEqual(["parent answer"]);
+    const toolCalls = events.filter((item) => item.kind === "tool_call");
+    expect(toolCalls).toContainEqual(
+      expect.objectContaining({
+        payload: expect.objectContaining({ toolUseId: "sub-1:child-tool-1", name: "Write", status: "pending" }),
+      }),
+    );
+    expect(toolCalls).toContainEqual(
+      expect.objectContaining({
+        payload: expect.objectContaining({ toolUseId: "sub-1:child-tool-1", status: "ok" }),
+      }),
+    );
+    expect(events.filter((item) => item.kind === "turn_end")).toEqual([
+      { kind: "turn_end", payload: { status: "success" } },
+    ]);
+    expect(token.completed).toEqual([{ status: "success" }]);
+  });
+
+  it("keeps parallel child tool-call ids collision-safe while main ids stay raw", async () => {
+    const id = "kimi-session-parallel-subagents";
+    const fakeSession = new FakeSession(id, [
+      [
+        event(id, { type: "turn.started", turnId: 1 }),
+        childEvent(id, "sub-a", {
+          type: "tool.call.started",
+          turnId: 2,
+          toolCallId: "dup",
+          name: "Write",
+          args: { path: "a.txt", content: "a" },
+        }),
+        childEvent(id, "sub-b", {
+          type: "tool.call.started",
+          turnId: 3,
+          toolCallId: "dup",
+          name: "Write",
+          args: { path: "b.txt", content: "b" },
+        }),
+        event(id, {
+          type: "tool.call.started",
+          turnId: 1,
+          toolCallId: "main-1",
+          name: "Read",
+          args: { path: "a.txt" },
+        }),
+        childEvent(id, "sub-a", { type: "tool.result", turnId: 2, toolCallId: "dup", output: "ok a" }),
+        childEvent(id, "sub-b", { type: "tool.result", turnId: 3, toolCallId: "dup", output: "ok b" }),
+        event(id, { type: "tool.result", turnId: 1, toolCallId: "main-1", output: "a" }),
+        childEvent(id, "sub-a", { type: "turn.ended", turnId: 2, reason: "completed" }),
+        childEvent(id, "sub-b", { type: "turn.ended", turnId: 3, reason: "completed" }),
+        event(id, { type: "assistant.delta", turnId: 1, delta: "both done" }),
+        event(id, { type: "turn.ended", turnId: 1, reason: "completed" }),
+      ],
+    ]);
+    const handler = makeHandler(fakeSession, {});
+    const events: SessionEvent[] = [];
+    const token = makeToken();
+
+    await handler.start(message("m1", "run two background subagents"), makeContext(events), token);
+
+    const settled = events.flatMap((item) =>
+      item.kind === "tool_call" && item.payload.status === "ok"
+        ? [[item.payload.toolUseId, item.payload.resultPreview]]
+        : [],
+    );
+    expect(settled).toEqual([
+      ["sub-a:dup", "ok a"],
+      ["sub-b:dup", "ok b"],
+      ["main-1", "a"],
+    ]);
+    expect(events.filter((item) => item.kind === "turn_end")).toEqual([
+      { kind: "turn_end", payload: { status: "success" } },
+    ]);
+    expect(token.completed).toEqual([{ status: "success" }]);
+  });
+
+  it("ignores a child failure for parent settlement when the main turn still completes", async () => {
+    const id = "kimi-session-subagent-failure";
+    const failure = { code: "provider.rate_limit", message: "child rate limited", retryable: false };
+    const fakeSession = new FakeSession(id, [
+      [
+        event(id, { type: "turn.started", turnId: 1 }),
+        childEvent(id, "sub-1", { type: "error", ...failure }),
+        childEvent(id, "sub-1", { type: "turn.ended", turnId: 2, reason: "failed", error: failure }),
+        event(id, { type: "assistant.delta", turnId: 1, delta: "parent survived" }),
+        event(id, { type: "turn.ended", turnId: 1, reason: "completed" }),
+      ],
+    ]);
+    const handler = makeHandler(fakeSession, {});
+    const events: SessionEvent[] = [];
+    const token = makeToken();
+
+    await handler.start(message("m1", "tolerate a failed subagent"), makeContext(events), token);
+
+    expect(events).toContainEqual({ kind: "assistant_text", payload: { text: "parent survived" } });
+    expect(events.some((item) => item.kind === "error")).toBe(false);
+    expect(events.filter((item) => item.kind === "turn_end")).toEqual([
+      { kind: "turn_end", payload: { status: "success" } },
+    ]);
+    expect(token.completed).toEqual([{ status: "success" }]);
+  });
+
+  it("installs the dependency patch that applies drainAgentTasksOnStop on resume", () => {
+    // The pinned SDK only honors drainAgentTasksOnStop on the create path; the
+    // pnpm patch makes resume symmetrical. The SDK core session cannot be
+    // constructed without a full runtime, so this guard resolves the exact
+    // installed artifact the client package loads and pins the two behavior
+    // sites: threading the flag into the resumed core session options and
+    // applying it to the resumed main agent.
+    const require = createRequire(import.meta.url);
+    const sdkEntry = require.resolve("@botiverse/kimi-code-sdk");
+    const source = readFileSync(sdkEntry, "utf8");
+    expect(source).toContain("drainAgentTasksOnStop: input.drainAgentTasksOnStop");
+    expect(source).toMatch(
+      /getReadyAgent\("main"\);\s*\n\s*if \(main !== void 0 && this\.options\.drainAgentTasksOnStop\)/,
+    );
   });
 });
 

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -954,6 +954,115 @@ describe("Kimi replay fence", () => {
     expect(events.filter((item) => item.kind === "turn_end")).toEqual([]);
   });
 
+  it("keeps blocking every later unsafe call after a fence persistence failure", async () => {
+    const id = "kimi-session-fence-double";
+    const fence = makeFence();
+    fence.fence.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    const fakeSession = new EffectGateFakeSession(id, [
+      event(id, { type: "turn.started", turnId: 1 }),
+      event(id, {
+        type: "tool.call.started",
+        turnId: 1,
+        toolCallId: "write-1",
+        name: "Write",
+        args: { path: "one.txt", content: "one" },
+      }),
+      event(id, { type: "tool.result", turnId: 1, toolCallId: "write-1", isError: true, output: "blocked" }),
+      // The model reacts to the blocked result with a second unsafe call:
+      // without the fail-closed guard this would take the fast path and run.
+      event(id, {
+        type: "tool.call.started",
+        turnId: 1,
+        toolCallId: "write-2",
+        name: "Write",
+        args: { path: "two.txt", content: "two" },
+      }),
+      event(id, { type: "tool.result", turnId: 1, toolCallId: "write-2", isError: true, output: "blocked" }),
+      event(id, { type: "assistant.delta", turnId: 1, delta: "both blocked" }),
+      event(id, { type: "turn.ended", turnId: 1, reason: "completed" }),
+    ]);
+    const handler = makeHandler(fakeSession, {}, { replayFence: fence });
+    const token = makeToken();
+
+    await handler.start(message("m1", "write twice"), makeContext([]), token);
+
+    expect(fakeSession.effectCount).toBe(0);
+    // The second call hit the fenceError fast path and never attempted a
+    // write again — proof it did not silently become "authorized".
+    expect(fence.fence).toHaveBeenCalledTimes(1);
+    expect(token.completed).toEqual([]);
+    expect(token.retried).toContain("replay_fence_persist_failed");
+  });
+
+  it("rolls back a partial fence so a failed multi-message persist authorizes nothing", async () => {
+    const id = "kimi-session-fence-partial";
+    const fence = makeFence();
+    const originalFence = fence.fence.getMockImplementation();
+    fence.fence.mockImplementation((entry: ReplayFenceEntry) => {
+      if (entry.messageId === "m3") throw new Error("disk full on second message");
+      originalFence?.(entry);
+    });
+    const fakeSession = new GatedFakeSession(id);
+    const handler = makeHandler(fakeSession, {}, { replayFence: fence });
+    const events: SessionEvent[] = [];
+    const token1 = makeToken();
+    const token2 = makeToken();
+    const token3 = makeToken();
+    const startPromise = handler.start(message("m1", "first turn"), makeContext(events), token1);
+
+    await fakeSession.promptSeen;
+    // Two more deliveries arrive while the first turn is active; they merge
+    // into ONE fused turn whose messages share a single fence batch.
+    expect(handler.inject(message("m2", "queued two"), token2)).toEqual({ kind: "owned", mode: "queued" });
+    expect(handler.inject(message("m3", "queued three"), token3)).toEqual({ kind: "owned", mode: "queued" });
+    fakeSession.emit(event(id, { type: "turn.started", turnId: 1 }));
+    fakeSession.emit(event(id, { type: "assistant.delta", turnId: 1, delta: "first done" }));
+    fakeSession.emit(event(id, { type: "turn.ended", turnId: 1, reason: "completed" }));
+    await startPromise;
+    expect(token1.completed).toEqual([{ status: "success" }]);
+
+    // The fused turn's prompt arrives after the drain; drive its events
+    // explicitly: an unsafe call whose fence persists for m2 but fails for
+    // m3 — the m2 entry must be rolled back, and the following unsafe call
+    // must stay blocked.
+    await vi.waitFor(() => expect(fakeSession.prompts).toHaveLength(2));
+    fakeSession.emit(event(id, { type: "turn.started", turnId: 2 }));
+    fakeSession.emit(
+      event(id, {
+        type: "tool.call.started",
+        turnId: 2,
+        toolCallId: "write-1",
+        name: "Write",
+        args: { path: "partial.txt", content: "x" },
+      }),
+    );
+    fakeSession.emit(
+      event(id, { type: "tool.result", turnId: 2, toolCallId: "write-1", isError: true, output: "blocked" }),
+    );
+    fakeSession.emit(
+      event(id, {
+        type: "tool.call.started",
+        turnId: 2,
+        toolCallId: "write-2",
+        name: "Write",
+        args: { path: "partial2.txt", content: "x" },
+      }),
+    );
+    fakeSession.emit(
+      event(id, { type: "tool.result", turnId: 2, toolCallId: "write-2", isError: true, output: "blocked" }),
+    );
+    fakeSession.emit(event(id, { type: "turn.ended", turnId: 2, reason: "completed" }));
+    await flushAsyncWork();
+
+    expect(fence.clear).toHaveBeenCalledWith("chat-kimi", "m2");
+    expect(fence.entries).toEqual([]);
+    expect(token2.completed).toEqual([]);
+    expect(token2.retried).toContain("replay_fence_persist_failed");
+    expect(token3.completed).toEqual([]);
+  });
+
   it("settles through the durable-notice pipeline when the fence failure is non-retryable", async () => {
     const id = "kimi-session-fence-config";
     const fence = makeFence();

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -13,6 +13,7 @@ import type { AgentRuntimeConfigPayload, SessionEvent } from "@first-tree/shared
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createKimiCodeHandler, formatKimiCodeError, kimiToolIsReadOnly } from "../handlers/kimi-code.js";
 import type { DeliveryToken, SessionContext, SessionMessage, TurnOutcome } from "../runtime/handler.js";
+import type { ReplayFenceEntry } from "../runtime/replay-fence.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 class FakeSession {
@@ -187,6 +188,7 @@ function makeHandler(
     workspaceRoot,
     runtimeProvider: "kimi-code",
     kimiKaosFactory: async () => fakeKaos,
+    replayFence: makeFence(),
     kimiHarnessFactory: () => ({
       createSession: async (options: CreateSessionOptions) => {
         captures.create = options;
@@ -200,6 +202,42 @@ function makeHandler(
     }),
     ...extraConfig,
   });
+}
+
+type FakeFence = {
+  entries: ReplayFenceEntry[];
+  fence: ReturnType<typeof vi.fn>;
+  clear: ReturnType<typeof vi.fn>;
+};
+
+function makeFence(): FakeFence {
+  const fence: FakeFence = {
+    entries: [],
+    fence: vi.fn((entry: ReplayFenceEntry) => {
+      fence.entries.push(entry);
+    }),
+    clear: vi.fn((chatId: string, messageId: string) => {
+      const index = fence.entries.findIndex((entry) => entry.chatId === chatId && entry.messageId === messageId);
+      if (index >= 0) fence.entries.splice(index, 1);
+    }),
+  };
+  return fence;
+}
+
+function unsafeWriteTurn(sessionId: string, text = "wrote file"): KimiEvent[] {
+  return [
+    event(sessionId, { type: "turn.started", turnId: 1 }),
+    event(sessionId, {
+      type: "tool.call.started",
+      turnId: 1,
+      toolCallId: "write-1",
+      name: "Write",
+      args: { path: "marker.txt", content: "INTERRUPT_UNSAFE_ONCE" },
+    }),
+    event(sessionId, { type: "tool.result", turnId: 1, toolCallId: "write-1", output: "ok" }),
+    event(sessionId, { type: "assistant.delta", turnId: 1, delta: text }),
+    event(sessionId, { type: "turn.ended", turnId: 1, reason: "completed" }),
+  ];
 }
 
 describe("Kimi Code handler", () => {
@@ -719,6 +757,164 @@ describe("Kimi background subagent lifecycle", () => {
     expect(source).toMatch(
       /getReadyAgent\("main"\);\s*\n\s*if \(main !== void 0 && this\.options\.drainAgentTasksOnStop\)/,
     );
+  });
+});
+
+describe("Kimi replay fence", () => {
+  it("fences the delivery at the first unsafe tool start and clears it after settled completion", async () => {
+    const id = "kimi-session-fence-success";
+    const fence = makeFence();
+    const fakeSession = new FakeSession(id, [unsafeWriteTurn(id)]);
+    const handler = makeHandler(fakeSession, {}, { replayFence: fence });
+    const token = makeToken();
+
+    await handler.start(message("m1", "write the marker"), makeContext([]), token);
+
+    expect(fence.fence).toHaveBeenCalledTimes(1);
+    expect(fence.clear).toHaveBeenCalledWith("chat-kimi", "m1");
+    expect(fence.entries).toEqual([]);
+    expect(token.completed).toEqual([{ status: "success" }]);
+  });
+
+  it("fences on the resume path with the same create/resume custody", async () => {
+    const id = "kimi-session-fence-resume";
+    const fence = makeFence();
+    const fakeSession = new FakeSession(id, [unsafeWriteTurn(id)]);
+    const handler = makeHandler(fakeSession, {}, { replayFence: fence });
+    const token = makeToken();
+
+    await handler.resume(message("m2", "continue writing"), id, makeContext([]), token);
+
+    expect(fence.fence).toHaveBeenCalledTimes(1);
+    expect(fence.clear).toHaveBeenCalledWith("chat-kimi", "m2");
+    expect(fence.entries).toEqual([]);
+    expect(token.completed).toEqual([{ status: "success" }]);
+  });
+
+  it("records the child-prefixed tool id when a subagent's write starts first", async () => {
+    const id = "kimi-session-fence-child";
+    const fence = makeFence();
+    const fakeSession = new FakeSession(id, [
+      [
+        event(id, { type: "turn.started", turnId: 1 }),
+        childEvent(id, "agent-0", {
+          type: "tool.call.started",
+          turnId: 2,
+          toolCallId: "tool_childwrite",
+          name: "Bash",
+          args: { command: "echo INTERRUPT_UNSAFE_ONCE >> marker.txt" },
+        }),
+        childEvent(id, "agent-0", { type: "tool.result", turnId: 2, toolCallId: "tool_childwrite", output: "ok" }),
+        childEvent(id, "agent-0", { type: "turn.ended", turnId: 2, reason: "completed" }),
+        event(id, { type: "assistant.delta", turnId: 1, delta: "child wrote" }),
+        event(id, { type: "turn.ended", turnId: 1, reason: "completed" }),
+      ],
+    ]);
+    const handler = makeHandler(fakeSession, {}, { replayFence: fence });
+    const token = makeToken();
+
+    await handler.start(message("m1", "run a background writer"), makeContext([]), token);
+
+    expect(fence.fence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat-kimi",
+        messageId: "m1",
+        provider: "kimi-code",
+        toolName: "Bash",
+        toolUseId: "agent-0:tool_childwrite",
+      }),
+    );
+    expect(fence.entries).toEqual([]);
+    expect(token.completed).toEqual([{ status: "success" }]);
+  });
+
+  it("keeps the fence when the turn is interrupted instead of settled", async () => {
+    const id = "kimi-session-fence-interrupt";
+    const fence = makeFence();
+    const fakeSession = new GatedFakeSession(id);
+    fakeSession.cancel.mockImplementation(async () => {
+      fakeSession.emit(event(id, { type: "turn.ended", turnId: 1, reason: "cancelled" }));
+    });
+    const handler = makeHandler(fakeSession, {}, { replayFence: fence });
+    const events: SessionEvent[] = [];
+    const token = makeToken();
+    const startPromise = handler.start(message("m1", "write then hang"), makeContext(events), token);
+
+    await fakeSession.promptSeen;
+    fakeSession.emit(event(id, { type: "turn.started", turnId: 1 }));
+    fakeSession.emit(
+      event(id, {
+        type: "tool.call.started",
+        turnId: 1,
+        toolCallId: "write-1",
+        name: "Write",
+        args: { path: "marker.txt", content: "INTERRUPT_UNSAFE_ONCE" },
+      }),
+    );
+    await flushAsyncWork();
+    expect(fence.entries).toHaveLength(1);
+
+    await handler.suspend("process_crash_simulation");
+    await startPromise;
+
+    // No settlement happened, so nothing may clear the fence and nothing may
+    // be ACKed: the delivery stays recovery debt for the restart gate.
+    expect(token.completed).toEqual([]);
+    expect(token.retried).toContain("kimi_turn_cancelled");
+    expect(fence.clear).not.toHaveBeenCalled();
+    expect(fence.entries).toHaveLength(1);
+  });
+
+  it("settles as a terminal consumed error when the fence cannot be persisted", async () => {
+    const id = "kimi-session-fence-failure";
+    const fence = makeFence();
+    fence.fence.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    const fakeSession = new FakeSession(id, [unsafeWriteTurn(id)]);
+    const handler = makeHandler(fakeSession, {}, { replayFence: fence });
+    const events: SessionEvent[] = [];
+    const token = makeToken();
+
+    await handler.start(message("m1", "write the marker"), makeContext(events), token);
+
+    expect(token.completed).toEqual([
+      { status: "error", completion: "consumed", reason: "replay_fence_persist_failed" },
+    ]);
+    expect(events.some((item) => item.kind === "assistant_text")).toBe(false);
+    expect(events).toContainEqual({
+      kind: "error",
+      payload: { source: "runtime", message: "replay fence persistence failed: disk full" },
+    });
+    expect(events.filter((item) => item.kind === "turn_end")).toEqual([
+      { kind: "turn_end", payload: { status: "error" } },
+    ]);
+  });
+
+  it("fails closed when no replay fence store is configured, while read-only turns still run", async () => {
+    const id = "kimi-session-fence-missing";
+    const fakeSession = new FakeSession(id, [unsafeWriteTurn(id), successfulTurn(id, "read only ok")]);
+    const handler = makeHandler(fakeSession, {}, { replayFence: undefined });
+    const events: SessionEvent[] = [];
+    const token = makeToken();
+
+    await handler.start(message("m1", "write the marker"), makeContext(events), token);
+
+    expect(token.completed).toEqual([
+      { status: "error", completion: "consumed", reason: "replay_fence_persist_failed" },
+    ]);
+    expect(events.some((item) => item.kind === "assistant_text")).toBe(false);
+  });
+
+  it("does not require the fence store for a read-only turn", async () => {
+    const id = "kimi-session-fence-readonly";
+    const fakeSession = new FakeSession(id, [successfulTurn(id, "read only ok")]);
+    const handler = makeHandler(fakeSession, {}, { replayFence: undefined });
+    const token = makeToken();
+
+    await handler.start(message("m1", "read things"), makeContext([]), token);
+
+    expect(token.completed).toEqual([{ status: "success" }]);
   });
 });
 

--- a/packages/client/src/__tests__/kimi-sdk-authorize-hook.test.ts
+++ b/packages/client/src/__tests__/kimi-sdk-authorize-hook.test.ts
@@ -1,9 +1,14 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_KIMI_CODE_RUNTIME_CONFIG_PAYLOAD } from "@first-tree/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createKimiCodeHandler } from "../handlers/kimi-code.js";
+import type { DeliveryToken, SessionContext, SessionMessage, TurnOutcome } from "../runtime/handler.js";
+import { ReplayFenceStore } from "../runtime/replay-fence.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
 
 /**
  * End-to-end regression through the REAL patched `@botiverse/kimi-code-sdk`
@@ -23,7 +28,8 @@ class MockOpenAIProvider {
   requests: Array<{ stream: boolean; toolNames: string[] }> = [];
   private step = 0;
 
-  constructor(private readonly toolCall: ToolCallSpec) {}
+  /** Tool calls to emit, one per LLM request; later requests get plain text. */
+  constructor(private readonly toolCalls: ToolCallSpec[]) {}
 
   async start(): Promise<void> {
     const server = createServer((req, res) => void this.handle(req, res));
@@ -55,24 +61,24 @@ class MockOpenAIProvider {
       toolNames: (parsed.tools ?? []).map((tool) => tool.function?.name ?? ""),
     });
     this.step += 1;
-    const withToolCall = this.step === 1;
+    const toolCall = this.toolCalls[this.step - 1];
     if (parsed.stream === true) {
-      this.respondSse(res, withToolCall);
+      this.respondSse(res, toolCall);
     } else {
-      this.respondJson(res, withToolCall);
+      this.respondJson(res, toolCall);
     }
   }
 
-  private respondJson(res: ServerResponse, withToolCall: boolean): void {
-    const message = withToolCall
+  private respondJson(res: ServerResponse, toolCall: ToolCallSpec | undefined): void {
+    const message = toolCall
       ? {
           role: "assistant",
           content: null,
           tool_calls: [
             {
-              id: this.toolCall.id,
+              id: toolCall.id,
               type: "function",
-              function: { name: this.toolCall.name, arguments: this.toolCall.arguments },
+              function: { name: toolCall.name, arguments: toolCall.arguments },
             },
           ],
         }
@@ -84,13 +90,13 @@ class MockOpenAIProvider {
         object: "chat.completion",
         created: 0,
         model: "mock-model",
-        choices: [{ index: 0, message, finish_reason: withToolCall ? "tool_calls" : "stop" }],
+        choices: [{ index: 0, message, finish_reason: toolCall ? "tool_calls" : "stop" }],
         usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
       }),
     );
   }
 
-  private respondSse(res: ServerResponse, withToolCall: boolean): void {
+  private respondSse(res: ServerResponse, toolCall: ToolCallSpec | undefined): void {
     res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
     const chunk = (delta: Record<string, unknown>, finish: string | null) =>
       `data: ${JSON.stringify({
@@ -100,7 +106,7 @@ class MockOpenAIProvider {
         model: "mock-model",
         choices: [{ index: 0, delta, finish_reason: finish }],
       })}\n\n`;
-    if (withToolCall) {
+    if (toolCall) {
       res.write(chunk({ role: "assistant", content: "" }, null));
       res.write(
         chunk(
@@ -108,16 +114,16 @@ class MockOpenAIProvider {
             tool_calls: [
               {
                 index: 0,
-                id: this.toolCall.id,
+                id: toolCall.id,
                 type: "function",
-                function: { name: this.toolCall.name, arguments: "" },
+                function: { name: toolCall.name, arguments: "" },
               },
             ],
           },
           null,
         ),
       );
-      res.write(chunk({ tool_calls: [{ index: 0, function: { arguments: this.toolCall.arguments } }] }, null));
+      res.write(chunk({ tool_calls: [{ index: 0, function: { arguments: toolCall.arguments } }] }, null));
       res.write(chunk({}, "tool_calls"));
     } else {
       res.write(chunk({ role: "assistant", content: "turn done" }, null));
@@ -181,11 +187,13 @@ const MARKER_NAME = "authorize-hook-effect-marker.txt";
 beforeEach(async () => {
   homeDir = mkdtempSync(join(tmpdir(), "kimi-sdk-hook-home-"));
   workDir = mkdtempSync(join(tmpdir(), "kimi-sdk-hook-work-"));
-  provider = new MockOpenAIProvider({
-    id: "call_bash_marker",
-    name: "Bash",
-    arguments: JSON.stringify({ command: `touch ${MARKER_NAME}` }),
-  });
+  provider = new MockOpenAIProvider([
+    {
+      id: "call_bash_marker",
+      name: "Bash",
+      arguments: JSON.stringify({ command: `touch ${MARKER_NAME}` }),
+    },
+  ]);
   await provider.start();
   writeFileSync(
     join(homeDir, "config.toml"),
@@ -235,6 +243,74 @@ async function createHarness(): Promise<SdkHarness> {
   });
 }
 
+/** Repoint the mock provider at a new tool-call script (config.toml rewrite). */
+async function reconfigureProvider(toolCalls: ToolCallSpec[]): Promise<void> {
+  await provider.stop();
+  provider = new MockOpenAIProvider(toolCalls);
+  await provider.start();
+  writeFileSync(
+    join(homeDir, "config.toml"),
+    [
+      'default_provider = "mock"',
+      'default_model = "mock-model"',
+      "telemetry = false",
+      "",
+      "[providers.mock]",
+      'type = "openai"',
+      `base_url = "http://127.0.0.1:${provider.port}/v1"`,
+      'api_key = "mock-key"',
+      "",
+      '[models."mock-model"]',
+      'provider = "mock"',
+      'model = "mock-model"',
+      "max_context_size = 131072",
+      'capabilities = ["tool_use"]',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function handlerMessage(id: string, content: string): SessionMessage {
+  return { id, chatId: "chat-e2e", senderId: "human-1", format: "text", content, metadata: {} };
+}
+
+function handlerToken(): DeliveryToken & { completed: TurnOutcome[]; retried: string[] } {
+  const completed: TurnOutcome[] = [];
+  const retried: string[] = [];
+  return {
+    completed,
+    retried,
+    processingStarted: () => {},
+    complete: async (_messages, outcome) => {
+      completed.push(outcome);
+    },
+    retry: (_messages, reason) => void retried.push(reason),
+    terminalRejected: async () => {},
+  };
+}
+
+function handlerContext(): SessionContext {
+  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  return {
+    agent: {
+      agentId: "agent-e2e",
+      inboxId: "inbox-e2e",
+      displayName: "e2e-agent",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { sendMessage } as unknown as SessionContext["sdk"],
+    chatId: "chat-e2e",
+    log: () => {},
+    recordProviderActivity: () => {},
+    emitEvent: () => {},
+    ...mockCtxPlumbing({ sendMessage }, "chat-e2e"),
+  };
+}
+
 describe("patched SDK authorize boundary (real bundle + mock provider)", () => {
   it("invokes the host hook with session/agent identity and blocks the unsafe effect when it throws", async () => {
     const hookCalls: Array<{ sessionId?: string; agentId?: string; toolName: string }> = [];
@@ -272,5 +348,54 @@ describe("patched SDK authorize boundary (real bundle + mock provider)", () => {
     await session.close();
 
     expect(existsSync(join(workDir, MARKER_NAME))).toBe(true);
+  }, 60_000);
+
+  it("blocks BOTH unsafe calls across a real handler turn when the fence store keeps failing", async () => {
+    await reconfigureProvider([
+      { id: "call_bash_one", name: "Bash", arguments: JSON.stringify({ command: "touch marker-one.txt" }) },
+      { id: "call_bash_two", name: "Bash", arguments: JSON.stringify({ command: "touch marker-two.txt" }) },
+    ]);
+    // Real fence store in an unwritable directory: every persist fails.
+    const fenceDir = mkdtempSync(join(tmpdir(), "kimi-sdk-fence-blocked-"));
+    chmodSync(fenceDir, 0o500);
+    const fenceStore = new ReplayFenceStore(join(fenceDir, "fence.json"));
+    fenceStore.load();
+    const require = createRequire(import.meta.url);
+    const sdk = (await import(
+      require.resolve("@botiverse/kimi-code-sdk", { paths: [join(process.cwd(), "src", "__tests__")] })
+    )) as {
+      createKimiHarness(options: Record<string, unknown>): SdkHarness;
+    };
+
+    const handler = createKimiCodeHandler({
+      workspaceRoot: workDir,
+      runtimeProvider: "kimi-code",
+      agentConfigCache: {
+        refresh: async () => ({ payload: DEFAULT_KIMI_CODE_RUNTIME_CONFIG_PAYLOAD }),
+        get: () => ({ payload: DEFAULT_KIMI_CODE_RUNTIME_CONFIG_PAYLOAD }),
+      },
+      kimiHarnessFactory: () =>
+        sdk.createKimiHarness({
+          identity: { userAgentProduct: "first-tree-test", version: "0.0.0" },
+          uiMode: "first-tree",
+          homeDir,
+        }),
+      replayFence: fenceStore,
+    });
+    const token = handlerToken();
+
+    await handler.start(handlerMessage("m1", "run two bash writes"), handlerContext(), token);
+    await handler.shutdown("test-done");
+    chmodSync(fenceDir, 0o700);
+    rmSync(fenceDir, { recursive: true, force: true });
+
+    // The first call was blocked at the authorize boundary, and the second
+    // hit the fail-closed fenceError path: neither marker may exist, and the
+    // delivery keeps custody instead of a false terminal ACK.
+    expect(existsSync(join(workDir, "marker-one.txt"))).toBe(false);
+    expect(existsSync(join(workDir, "marker-two.txt"))).toBe(false);
+    expect(token.completed).toEqual([]);
+    expect(token.retried).toContain("replay_fence_persist_failed");
+    expect(fenceStore.snapshot()).toEqual([]);
   }, 60_000);
 });

--- a/packages/client/src/__tests__/kimi-sdk-authorize-hook.test.ts
+++ b/packages/client/src/__tests__/kimi-sdk-authorize-hook.test.ts
@@ -1,0 +1,276 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * End-to-end regression through the REAL patched `@botiverse/kimi-code-sdk`
+ * bundle: a live harness + core session + the actual RPC/event bridge, driven
+ * by a local mock OpenAI-compatible provider (no external network, no
+ * credentials). It proves the replay-fence host hook is invoked at the SDK's
+ * awaited authorize boundary and that a hook failure blocks the unsafe tool
+ * BEFORE its effect executes — the guarantee the (async, error-swallowing)
+ * live-event listener path cannot provide.
+ */
+
+type ToolCallSpec = { id: string; name: string; arguments: string };
+
+class MockOpenAIProvider {
+  private server: Server | null = null;
+  port = 0;
+  requests: Array<{ stream: boolean; toolNames: string[] }> = [];
+  private step = 0;
+
+  constructor(private readonly toolCall: ToolCallSpec) {}
+
+  async start(): Promise<void> {
+    const server = createServer((req, res) => void this.handle(req, res));
+    this.server = server;
+    await new Promise<void>((resolvePromise) => {
+      server.listen(0, "127.0.0.1", resolvePromise);
+    });
+    const address = server.address();
+    if (typeof address !== "object" || address === null) throw new Error("mock provider has no address");
+    this.port = address.port;
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    if (!server) return;
+    await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+    this.server = null;
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (req.method !== "POST" || !req.url?.includes("chat/completions")) {
+      res.writeHead(404).end("{}");
+      return;
+    }
+    const body = await this.readBody(req);
+    const parsed = JSON.parse(body) as { stream?: boolean; tools?: Array<{ function?: { name?: string } }> };
+    this.requests.push({
+      stream: parsed.stream === true,
+      toolNames: (parsed.tools ?? []).map((tool) => tool.function?.name ?? ""),
+    });
+    this.step += 1;
+    const withToolCall = this.step === 1;
+    if (parsed.stream === true) {
+      this.respondSse(res, withToolCall);
+    } else {
+      this.respondJson(res, withToolCall);
+    }
+  }
+
+  private respondJson(res: ServerResponse, withToolCall: boolean): void {
+    const message = withToolCall
+      ? {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: this.toolCall.id,
+              type: "function",
+              function: { name: this.toolCall.name, arguments: this.toolCall.arguments },
+            },
+          ],
+        }
+      : { role: "assistant", content: "turn done" };
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        id: "chatcmpl-mock",
+        object: "chat.completion",
+        created: 0,
+        model: "mock-model",
+        choices: [{ index: 0, message, finish_reason: withToolCall ? "tool_calls" : "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+    );
+  }
+
+  private respondSse(res: ServerResponse, withToolCall: boolean): void {
+    res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+    const chunk = (delta: Record<string, unknown>, finish: string | null) =>
+      `data: ${JSON.stringify({
+        id: "chatcmpl-mock",
+        object: "chat.completion.chunk",
+        created: 0,
+        model: "mock-model",
+        choices: [{ index: 0, delta, finish_reason: finish }],
+      })}\n\n`;
+    if (withToolCall) {
+      res.write(chunk({ role: "assistant", content: "" }, null));
+      res.write(
+        chunk(
+          {
+            tool_calls: [
+              {
+                index: 0,
+                id: this.toolCall.id,
+                type: "function",
+                function: { name: this.toolCall.name, arguments: "" },
+              },
+            ],
+          },
+          null,
+        ),
+      );
+      res.write(chunk({ tool_calls: [{ index: 0, function: { arguments: this.toolCall.arguments } }] }, null));
+      res.write(chunk({}, "tool_calls"));
+    } else {
+      res.write(chunk({ role: "assistant", content: "turn done" }, null));
+      res.write(chunk({}, "stop"));
+    }
+    res.write("data: [DONE]\n\n");
+    res.end();
+  }
+
+  private readBody(req: IncomingMessage): Promise<string> {
+    return new Promise((resolvePromise, rejectPromise) => {
+      let body = "";
+      req.on("data", (chunk: Buffer) => {
+        body += chunk.toString("utf8");
+      });
+      req.on("end", () => resolvePromise(body));
+      req.on("error", rejectPromise);
+    });
+  }
+}
+
+type SdkHarness = {
+  createSession(options: Record<string, unknown>): Promise<{
+    id: string;
+    prompt(input: string): Promise<void>;
+    onEvent(listener: (event: { type: string }) => void): () => void;
+    close(): Promise<void>;
+  }>;
+  close(): Promise<void>;
+};
+
+type SdkTestSession = Awaited<ReturnType<SdkHarness["createSession"]>>;
+
+async function runTurnToEnd(session: SdkTestSession, events: string[], prompt: string): Promise<void> {
+  let resolveEnded: () => void = () => {};
+  const ended = new Promise<void>((resolvePromise) => {
+    resolveEnded = resolvePromise;
+  });
+  const unsubscribe = session.onEvent((event) => {
+    events.push(event.type);
+    if (event.type === "turn.ended") resolveEnded();
+  });
+  try {
+    await session.prompt(prompt);
+    await Promise.race([
+      ended,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("turn never ended")), 30_000)),
+    ]);
+  } finally {
+    unsubscribe();
+  }
+}
+
+let homeDir: string;
+let workDir: string;
+let provider: MockOpenAIProvider;
+let harness: SdkHarness | null = null;
+
+const MARKER_NAME = "authorize-hook-effect-marker.txt";
+
+beforeEach(async () => {
+  homeDir = mkdtempSync(join(tmpdir(), "kimi-sdk-hook-home-"));
+  workDir = mkdtempSync(join(tmpdir(), "kimi-sdk-hook-work-"));
+  provider = new MockOpenAIProvider({
+    id: "call_bash_marker",
+    name: "Bash",
+    arguments: JSON.stringify({ command: `touch ${MARKER_NAME}` }),
+  });
+  await provider.start();
+  writeFileSync(
+    join(homeDir, "config.toml"),
+    [
+      'default_provider = "mock"',
+      'default_model = "mock-model"',
+      "telemetry = false",
+      "",
+      "[providers.mock]",
+      'type = "openai"',
+      `base_url = "http://127.0.0.1:${provider.port}/v1"`,
+      'api_key = "mock-key"',
+      "",
+      '[models."mock-model"]',
+      'provider = "mock"',
+      'model = "mock-model"',
+      "max_context_size = 131072",
+      'capabilities = ["tool_use"]',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+});
+
+afterEach(async () => {
+  delete (globalThis as { __firstTreeBeforeToolCall?: unknown }).__firstTreeBeforeToolCall;
+  if (harness) {
+    await harness.close().catch(() => {});
+    harness = null;
+  }
+  await provider.stop();
+  rmSync(homeDir, { recursive: true, force: true });
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+async function createHarness(): Promise<SdkHarness> {
+  const require = createRequire(import.meta.url);
+  const sdk = (await import(
+    require.resolve("@botiverse/kimi-code-sdk", {
+      paths: [join(process.cwd(), "src", "__tests__")],
+    })
+  )) as { createKimiHarness(options: Record<string, unknown>): SdkHarness };
+  return sdk.createKimiHarness({
+    identity: { userAgentProduct: "first-tree-test", version: "0.0.0" },
+    uiMode: "first-tree",
+    homeDir,
+  });
+}
+
+describe("patched SDK authorize boundary (real bundle + mock provider)", () => {
+  it("invokes the host hook with session/agent identity and blocks the unsafe effect when it throws", async () => {
+    const hookCalls: Array<{ sessionId?: string; agentId?: string; toolName: string }> = [];
+    (globalThis as { __firstTreeBeforeToolCall?: unknown }).__firstTreeBeforeToolCall = (info: {
+      sessionId?: string;
+      agentId?: string;
+      toolName: string;
+    }) => {
+      hookCalls.push(info);
+      if (info.toolName === "Bash") throw new Error("durable fence failed");
+    };
+
+    harness = await createHarness();
+    const session = await harness.createSession({ workDir, permission: "yolo" });
+    const events: string[] = [];
+    await runTurnToEnd(session, events, "run the bash tool, then finish");
+    await session.close();
+
+    expect(hookCalls.length).toBeGreaterThan(0);
+    expect(hookCalls[0]).toMatchObject({ sessionId: session.id, agentId: "main", toolName: "Bash" });
+    // The decisive assertion: the hook failure blocked the call at the
+    // authorize boundary, so the Bash effect never executed.
+    expect(existsSync(join(workDir, MARKER_NAME))).toBe(false);
+    // The turn continued past the blocked tool and ended on the main agent.
+    expect(events).toContain("tool.call.started");
+    expect(events).toContain("turn.ended");
+  }, 60_000);
+
+  it("lets the effect run when the host hook allows the call", async () => {
+    (globalThis as { __firstTreeBeforeToolCall?: unknown }).__firstTreeBeforeToolCall = () => {};
+
+    harness = await createHarness();
+    const session = await harness.createSession({ workDir, permission: "yolo" });
+    await runTurnToEnd(session, [], "run the bash tool, then finish");
+    await session.close();
+
+    expect(existsSync(join(workDir, MARKER_NAME))).toBe(true);
+  }, 60_000);
+});

--- a/packages/client/src/__tests__/replay-fence.test.ts
+++ b/packages/client/src/__tests__/replay-fence.test.ts
@@ -1,0 +1,144 @@
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type ReplayFenceEntry, ReplayFenceError, ReplayFenceStore } from "../runtime/replay-fence.js";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "replay-fence-test-"));
+});
+
+afterEach(() => {
+  chmodSync(root, 0o700);
+  rmSync(root, { recursive: true, force: true });
+});
+
+function entry(overrides: Partial<ReplayFenceEntry> = {}): ReplayFenceEntry {
+  return {
+    chatId: "chat-1",
+    messageId: "msg-1",
+    provider: "kimi-code",
+    toolName: "Write",
+    toolUseId: "agent-0:tool-1",
+    fencedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("ReplayFenceStore", () => {
+  it("persists a fence crash-safely and reloads it in a fresh process view", () => {
+    const path = join(root, "fence.json");
+    const store = new ReplayFenceStore(path);
+    store.load();
+    store.fence(entry());
+
+    const reloaded = new ReplayFenceStore(path);
+    reloaded.load();
+    expect(reloaded.isFenced("chat-1", "msg-1")).toBe(true);
+    expect(reloaded.isFenced("chat-1", "msg-2")).toBe(false);
+    expect(reloaded.snapshot()[0]).toMatchObject({
+      chatId: "chat-1",
+      messageId: "msg-1",
+      provider: "kimi-code",
+      toolName: "Write",
+      toolUseId: "agent-0:tool-1",
+    });
+  });
+
+  it("clears a fence durably after settlement", () => {
+    const path = join(root, "fence.json");
+    const store = new ReplayFenceStore(path);
+    store.load();
+    store.fence(entry());
+    store.clear("chat-1", "msg-1");
+
+    const reloaded = new ReplayFenceStore(path);
+    reloaded.load();
+    expect(reloaded.isFenced("chat-1", "msg-1")).toBe(false);
+  });
+
+  it("keeps independent (chat, message) fences isolated", () => {
+    const path = join(root, "fence.json");
+    const store = new ReplayFenceStore(path);
+    store.load();
+    store.fence(entry());
+    store.fence(entry({ chatId: "chat-2" }));
+    store.fence(entry({ messageId: "msg-2" }));
+    store.clear("chat-1", "msg-1");
+
+    expect(store.isFenced("chat-1", "msg-1")).toBe(false);
+    expect(store.isFenced("chat-2", "msg-1")).toBe(true);
+    expect(store.isFenced("chat-1", "msg-2")).toBe(true);
+  });
+
+  it("treats a missing file as an empty store", () => {
+    const store = new ReplayFenceStore(join(root, "absent.json"));
+    store.load();
+    expect(store.isFenced("chat-1", "msg-1")).toBe(false);
+  });
+
+  it("fails closed on a corrupted store file", () => {
+    const path = join(root, "fence.json");
+    writeFileSync(path, "{ not json", "utf-8");
+    const store = new ReplayFenceStore(path);
+    expect(() => store.load()).toThrow(ReplayFenceError);
+  });
+
+  it("fails closed on an unsupported store version", () => {
+    const path = join(root, "fence.json");
+    writeFileSync(path, JSON.stringify({ version: 99, entries: {} }), "utf-8");
+    const store = new ReplayFenceStore(path);
+    expect(() => store.load()).toThrow(/unsupported version/);
+  });
+
+  it("fails closed on a malformed entry whose key does not match its identity", () => {
+    const path = join(root, "fence.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        entries: { "chat-1 msg-1": { ...entry(), messageId: "msg-other" } },
+      }),
+      "utf-8",
+    );
+    const store = new ReplayFenceStore(path);
+    expect(() => store.load()).toThrow(/malformed entry/);
+  });
+
+  it("throws on persist failure and does not keep the in-memory fence", () => {
+    const blocked = join(root, "blocked");
+    mkdirSync(blocked);
+    chmodSync(blocked, 0o500);
+    const path = join(blocked, "fence.json");
+    const store = new ReplayFenceStore(path);
+    store.load();
+
+    expect(() => store.fence(entry())).toThrow(ReplayFenceError);
+    expect(store.isFenced("chat-1", "msg-1")).toBe(false);
+    chmodSync(blocked, 0o700);
+  });
+
+  it("restores the in-memory fence when a clear fails to persist", () => {
+    const path = join(root, "fence.json");
+    const store = new ReplayFenceStore(path);
+    store.load();
+    store.fence(entry());
+    chmodSync(root, 0o500);
+
+    expect(() => store.clear("chat-1", "msg-1")).toThrow(ReplayFenceError);
+    expect(store.isFenced("chat-1", "msg-1")).toBe(true);
+    chmodSync(root, 0o700);
+  });
+
+  it("does not rewrite the file when fencing an already-fenced delivery", () => {
+    const path = join(root, "fence.json");
+    const store = new ReplayFenceStore(path);
+    store.load();
+    store.fence(entry());
+    const before = readFileSync(path, "utf-8");
+    store.fence(entry({ toolName: "Bash" }));
+    expect(readFileSync(path, "utf-8")).toBe(before);
+  });
+});

--- a/packages/client/src/__tests__/replay-fence.test.ts
+++ b/packages/client/src/__tests__/replay-fence.test.ts
@@ -79,6 +79,53 @@ describe("ReplayFenceStore", () => {
     expect(store.isFenced("chat-1", "msg-1")).toBe(false);
   });
 
+  it("fails closed on non-ENOENT read failures (directory at store path)", () => {
+    const path = join(root, "fence-dir");
+    mkdirSync(path);
+    const store = new ReplayFenceStore(path);
+    expect(() => store.load()).toThrow(ReplayFenceError);
+    expect(() => store.load()).toThrow(/unreadable/);
+  });
+
+  it("fails closed on non-ENOENT read failures (permission denied)", () => {
+    const path = join(root, "fence.json");
+    writeFileSync(path, JSON.stringify({ version: 1, entries: {} }), "utf-8");
+    chmodSync(path, 0o000);
+    const store = new ReplayFenceStore(path);
+    expect(() => store.load()).toThrow(/unreadable/);
+    chmodSync(path, 0o600);
+  });
+
+  it("keeps id pairs with concatenation-colliding shapes distinct", () => {
+    const path = join(root, "fence.json");
+    const store = new ReplayFenceStore(path);
+    store.load();
+    store.fence(entry({ chatId: "a1", messageId: "b" }));
+
+    expect(store.isFenced("a1", "b")).toBe(true);
+    expect(store.isFenced("a", "1b")).toBe(false);
+    expect(store.hasFenceForChat("a")).toBe(false);
+    expect(store.hasFenceForChat("a1")).toBe(true);
+
+    store.fence(entry({ chatId: "a", messageId: "1b" }));
+    store.clear("a1", "b");
+    expect(store.isFenced("a1", "b")).toBe(false);
+    expect(store.isFenced("a", "1b")).toBe(true);
+    expect(store.hasFenceForChat("a")).toBe(true);
+  });
+
+  it("reports chat-level fence state for the FIFO hold", () => {
+    const path = join(root, "fence.json");
+    const store = new ReplayFenceStore(path);
+    store.load();
+    expect(store.hasFenceForChat("chat-1")).toBe(false);
+    store.fence(entry());
+    expect(store.hasFenceForChat("chat-1")).toBe(true);
+    expect(store.hasFenceForChat("chat-2")).toBe(false);
+    store.clear("chat-1", "msg-1");
+    expect(store.hasFenceForChat("chat-1")).toBe(false);
+  });
+
   it("fails closed on a corrupted store file", () => {
     const path = join(root, "fence.json");
     writeFileSync(path, "{ not json", "utf-8");
@@ -91,6 +138,20 @@ describe("ReplayFenceStore", () => {
     writeFileSync(path, JSON.stringify({ version: 99, entries: {} }), "utf-8");
     const store = new ReplayFenceStore(path);
     expect(() => store.load()).toThrow(/unsupported version/);
+  });
+
+  it("fails closed on a malformed entry whose fields fail validation", () => {
+    const path = join(root, "fence.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        entries: { "6:chat-1msg-1": { ...entry(), provider: 42 } },
+      }),
+      "utf-8",
+    );
+    const store = new ReplayFenceStore(path);
+    expect(() => store.load()).toThrow(/malformed entry/);
   });
 
   it("fails closed on a malformed entry whose key does not match its identity", () => {

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -205,6 +205,7 @@ function createSessionManager(opts: {
   log?: pino.Logger;
   agentConfigCache?: AgentConfigCache;
   recoverChat?: (chatId: string) => Promise<void>;
+  recoverChatWithCount?: (chatId: string) => Promise<number>;
   recoverRuntimeSessionProof?: (reasonCode: string) => Promise<void>;
   onSessionEvent?: (chatId: string, event: SessionEvent) => void;
   onSessionRuntimeChange?: (chatId: string, state: RuntimeState) => void;
@@ -246,6 +247,7 @@ function createSessionManager(opts: {
     replayFencePath: opts.replayFencePath,
     ackEntry: opts.ackEntry ?? mockAckEntry(),
     recoverChat: opts.recoverChat,
+    recoverChatWithCount: opts.recoverChatWithCount,
     recoverRuntimeSessionProof: opts.recoverRuntimeSessionProof,
     agentConfigCache: opts.agentConfigCache,
     onSessionEvent: opts.onSessionEvent,
@@ -3160,6 +3162,105 @@ describe("SessionManager replay fence reconcile", () => {
       // The chat is unblocked: the next delivery routes into the provider.
       await sm.dispatch(mockEntry({ id: 32, chatId: "chat-rec", messageId: "msg-32" }));
       expect(handler.inject).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("SessionManager replay fence startup reconciliation", () => {
+  function seedFenceStore(path: string, chatId: string, messageId: string): void {
+    const store = new ReplayFenceStore(path);
+    store.load();
+    store.fence({
+      chatId,
+      messageId,
+      provider: "kimi-code",
+      toolName: "Bash",
+      toolUseId: "agent-0:tool_1",
+      fencedAt: new Date().toISOString(),
+    });
+  }
+
+  it("clears a stale fence when the server confirms zero unacked entries after a crash, then admits the chat", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      // Pre-crash state: unsafe effect fenced, then the ACK committed
+      // server-side but the process died before the local clear.
+      seedFenceStore(fencePath, "chat-crash", "msg-1");
+      const recoverChatWithCount = vi.fn<(chatId: string) => Promise<number>>().mockResolvedValue(0);
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      // A fresh manager (post-crash) loads the fence file.
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+
+      await sm.reconcileReplayFencesWithServer();
+
+      expect(recoverChatWithCount).toHaveBeenCalledWith("chat-crash");
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-crash")).toBe(false);
+
+      await sm.dispatch(mockEntry({ id: 41, chatId: "chat-crash", messageId: "msg-2" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the fence and the chat hold when the server still resets unacked entries", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFenceStore(fencePath, "chat-debt", "msg-1");
+      const recoverChatWithCount = vi.fn<(chatId: string) => Promise<number>>().mockResolvedValue(1);
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+
+      await sm.reconcileReplayFencesWithServer();
+
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-debt")).toBe(true);
+
+      await sm.dispatch(mockEntry({ id: 42, chatId: "chat-debt", messageId: "msg-1" }));
+      expect(handler.start).not.toHaveBeenCalled();
+      expect(handler.resume).not.toHaveBeenCalled();
+      expect(ackEntry).not.toHaveBeenCalled();
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps fences fail-closed when the readback fails", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFenceStore(fencePath, "chat-fail", "msg-1");
+      const recoverChatWithCount = vi
+        .fn<(chatId: string) => Promise<number>>()
+        .mockRejectedValue(new Error("socket not bound"));
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+
+      await sm.reconcileReplayFencesWithServer();
+
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-fail")).toBe(true);
+
+      await sm.dispatch(mockEntry({ id: 43, chatId: "chat-fail", messageId: "msg-9" }));
+      expect(handler.start).not.toHaveBeenCalled();
+      expect(ackEntry).not.toHaveBeenCalled();
 
       await sm.shutdown();
     } finally {

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3311,17 +3311,131 @@ describe("SessionManager replay fence startup reconciliation", () => {
       expect(reloaded.hasFenceForChat("chat-tail")).toBe(false);
       expect(handler.start).not.toHaveBeenCalled();
 
-      // The server's redelivery re-admits the withheld entries — and a
-      // duplicated redelivery frame cannot start a second provider turn.
-      await sm.dispatch(mockEntry({ id: 45, chatId: "chat-tail", messageId: "msg-1" }));
-      await sm.dispatch(mockEntry({ id: 45, chatId: "chat-tail", messageId: "msg-1" }));
+      // Only the still-unacked tail is redelivered by the server. The
+      // settled head's ledger entry was dropped on clear, and the withheld
+      // tail re-admits — a duplicated redelivery frame cannot start a
+      // second provider turn.
+      await sm.dispatch(mockEntry({ id: 46, chatId: "chat-tail", messageId: "msg-2" }));
       await sm.dispatch(mockEntry({ id: 46, chatId: "chat-tail", messageId: "msg-2" }));
       expect(handler.start).toHaveBeenCalledTimes(1);
-      expect(handler.inject).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(handler.start).mock.calls[0]?.[0]).toMatchObject({ id: "msg-2" });
+      expect(handler.inject).not.toHaveBeenCalled();
 
       await sm.shutdown();
     } finally {
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("probes exactly once per fenced chat at startup and ignores ids outside the request", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFenceStore(fencePath, "chat-subset", "msg-1");
+      seedFenceStore(fencePath, "chat-subset", "msg-2");
+      const probeFencedSettlement = makeProbe(["msg-1", "msg-not-requested"]);
+      const handler = createMockHandler();
+      const sm = createSessionManager({ handler, replayFencePath: fencePath, probeFencedSettlement });
+
+      await sm.reconcileReplayFencesWithServer();
+
+      // One probe only — no immediate second probe from arming the loop.
+      expect(probeFencedSettlement).toHaveBeenCalledTimes(1);
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      // msg-1 proved settled; msg-not-requested must not clear msg-2.
+      expect(reloaded.isFenced("chat-subset", "msg-1")).toBe(false);
+      expect(reloaded.isFenced("chat-subset", "msg-2")).toBe(true);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("converges a committed-ACK clear failure through the retry loop and recovers the tail", async () => {
+    vi.useFakeTimers();
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+      const probeFencedSettlement = makeProbe([]);
+      const ackEntry = mockAckEntry();
+      let capturedCtx: SessionContext | undefined;
+      let capturedFence: ReplayFenceStore | undefined;
+      const handler = createMockHandler({
+        start: vi.fn().mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
+          capturedCtx = ctx;
+          return "session-id-mock";
+        }),
+      });
+      const sm = createSessionManager({
+        replayFencePath: fencePath,
+        recoverChat,
+        probeFencedSettlement,
+        ackEntry,
+        handlerFactory: (config) => {
+          capturedFence = config.replayFence as ReplayFenceStore;
+          return handler;
+        },
+      });
+
+      // msg-1 runs as an unsafe fenced delivery; the tail msg-2 arrives
+      // while the fence is up and is withheld even though a session is live.
+      await sm.dispatch(mockEntry({ id: 61, chatId: "chat-acktail", messageId: "msg-1" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      capturedFence?.fence({
+        chatId: "chat-acktail",
+        messageId: "msg-1",
+        provider: "kimi-code",
+        toolName: "Write",
+        toolUseId: "write-1",
+        fencedAt: new Date().toISOString(),
+      });
+      await sm.dispatch(mockEntry({ id: 62, chatId: "chat-acktail", messageId: "msg-2" }));
+      expect(handler.inject).not.toHaveBeenCalled();
+
+      // The committed ACK lands while the store is unwritable: the clear
+      // fails but the key is already proven settled — the loop retries
+      // locally without probing.
+      chmodSync(root, 0o500);
+      const disposition = await capturedCtx?.finishTurn(
+        {
+          inboxEntryId: 61,
+          id: "msg-1",
+          chatId: "chat-acktail",
+          senderId: "s",
+          format: "text",
+          content: "",
+          metadata: {},
+        },
+        { status: "success", terminal: true },
+      );
+      expect(disposition).toBe("settled");
+      let reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-acktail")).toBe(true);
+
+      chmodSync(root, 0o700);
+      probeFencedSettlement.mockClear();
+      await vi.advanceTimersByTimeAsync(31_000);
+      reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-acktail")).toBe(false);
+      // The retry redid only the local clear — no re-probe — then fired
+      // exactly one recovery for the withheld tail.
+      expect(probeFencedSettlement).not.toHaveBeenCalled();
+      expect(recoverChat).toHaveBeenCalledWith("chat-acktail");
+
+      // The tail's redelivery re-admits and injects into the live session.
+      await sm.dispatch(mockEntry({ id: 62, chatId: "chat-acktail", messageId: "msg-2" }));
+      expect(handler.inject).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      chmodSync(root, 0o700);
+      rmSync(root, { recursive: true, force: true });
+      vi.useRealTimers();
     }
   });
 
@@ -3339,6 +3453,7 @@ describe("SessionManager replay fence startup reconciliation", () => {
       // Clear fails on I/O during the first gate-triggered probe round.
       chmodSync(root, 0o500);
       await sm.dispatch(mockEntry({ id: 47, chatId: "chat-timer", messageId: "msg-1" }));
+      await sm.dispatch(mockEntry({ id: 48, chatId: "chat-timer", messageId: "msg-2" }));
       await vi.waitFor(() => expect(probeFencedSettlement).toHaveBeenCalledTimes(1));
       let reloaded = new ReplayFenceStore(fencePath);
       reloaded.load();
@@ -3347,7 +3462,7 @@ describe("SessionManager replay fence startup reconciliation", () => {
 
       // Repair the store, then ONLY advance the timer: the loop redoes the
       // local clear of the already-proven fence (no new probe) and fires
-      // the single redrive recovery.
+      // the single redrive recovery for the withheld tail.
       chmodSync(root, 0o700);
       probeFencedSettlement.mockClear();
       await vi.advanceTimersByTimeAsync(31_000);
@@ -3357,9 +3472,11 @@ describe("SessionManager replay fence startup reconciliation", () => {
       expect(probeFencedSettlement).not.toHaveBeenCalled();
       expect(recoverChat).toHaveBeenCalledTimes(1);
 
-      // The redelivery now routes into the provider.
-      await sm.dispatch(mockEntry({ id: 47, chatId: "chat-timer", messageId: "msg-1" }));
+      // Only the tail routes into the provider; the settled head is gone
+      // from the ledger and is never re-driven.
+      await sm.dispatch(mockEntry({ id: 48, chatId: "chat-timer", messageId: "msg-2" }));
       expect(handler.start).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(handler.start).mock.calls[0]?.[0]).toMatchObject({ id: "msg-2" });
 
       await sm.shutdown();
     } finally {

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -23,6 +23,7 @@ import type {
   SessionMessage,
   TurnOutcome,
 } from "../runtime/handler.js";
+import { InboxDeliveryCoordinator } from "../runtime/inbox-delivery-coordinator.js";
 import type { SubprocessProbe } from "../runtime/process-tree-probe.js";
 import { ReplayFenceStore } from "../runtime/replay-fence.js";
 import { SessionManager } from "../runtime/session-manager.js";
@@ -3625,9 +3626,13 @@ describe("SessionManager replay fence convergence matrix", () => {
       expect(reloaded.hasFenceForChat("chat-postretry")).toBe(false);
 
       // While the recovery is failing, a NEW message must not overtake the
-      // withheld tail — it is held too, without another recovery firing.
+      // withheld tail — and a DUPLICATE of the withheld entry must not
+      // bypass the debt either (local withholding is not recovery success).
       await sm.dispatch(mockEntry({ id: 77, chatId: "chat-postretry", messageId: "msg-3" }));
+      await sm.dispatch(mockEntry({ id: 76, chatId: "chat-postretry", messageId: "msg-2" }));
+      await sm.dispatch(mockEntry({ id: 76, chatId: "chat-postretry", messageId: "msg-2" }));
       expect(handler.start).not.toHaveBeenCalled();
+      expect(handler.inject).not.toHaveBeenCalled();
       expect(recoverChat).toHaveBeenCalledTimes(1);
 
       // The timer retries: the second recovery succeeds exactly once, and
@@ -3699,5 +3704,44 @@ describe("SessionManager replay fence convergence matrix", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("InboxDeliveryCoordinator fence-settled tombstones at high water", () => {
+  it("suppresses first and last stale frames beyond 1000 settled entries while real redelivery still flows", () => {
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry: async () => {},
+      onWorkChanged: () => {},
+      log: silentLogger(),
+    });
+
+    // 1100 fenced-withheld entries become probe-settled — well past the old
+    // 1000-entry FIFO dedup horizon and above the supported per-chat cap.
+    const ids: string[] = [];
+    for (let i = 0; i < 1100; i += 1) {
+      const messageId = `settled-${i}`;
+      ids.push(messageId);
+      const entry = mockEntry({ id: 1000 + i, chatId: "chat-cap", messageId });
+      expect(coordinator.receive(entry).kind).toBe("deliver");
+      coordinator.markReplayFenceWithheld("chat-cap", [messageId]);
+    }
+    const tail = mockEntry({ id: 3001, chatId: "chat-cap", messageId: "tail-live" });
+    expect(coordinator.receive(tail).kind).toBe("deliver");
+    coordinator.markReplayFenceWithheld("chat-cap", ["tail-live"]);
+
+    coordinator.settleReplayFencedEntries("chat-cap", ids);
+
+    // First and last settled heads' stale frames are both tombstoned.
+    expect(coordinator.receive(mockEntry({ id: 1000, chatId: "chat-cap", messageId: "settled-0" })).kind).toBe(
+      "duplicate-in-flight",
+    );
+    expect(coordinator.receive(mockEntry({ id: 2099, chatId: "chat-cap", messageId: "settled-1099" })).kind).toBe(
+      "duplicate-in-flight",
+    );
+
+    // The genuinely unacked tail still re-admits and routes.
+    expect(coordinator.receive(mockEntry({ id: 3001, chatId: "chat-cap", messageId: "tail-live" })).kind).toBe(
+      "deliver",
+    );
   });
 });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3678,19 +3678,19 @@ describe("SessionManager replay fence convergence matrix", () => {
 
       await sm.reconcileReplayFencesWithServer();
 
-      // The failing middle chunk stops the pass: chunks 1 proves and
-      // clears, chunks 2-3 stay fenced (and the timer loop retries them).
+      // All-or-nothing per round: the failing middle chunk discards the
+      // whole round — even the first chunk's proofs must NOT clear.
       expect(probeCalls.map((chunk) => chunk.length)).toEqual([50, 50]);
       const reloaded = new ReplayFenceStore(fencePath);
       reloaded.load();
-      expect(reloaded.isFenced("chat-chunks", "msg-1")).toBe(false);
-      expect(reloaded.isFenced("chat-chunks", "msg-50")).toBe(false);
+      expect(reloaded.isFenced("chat-chunks", "msg-1")).toBe(true);
+      expect(reloaded.isFenced("chat-chunks", "msg-50")).toBe(true);
       expect(reloaded.isFenced("chat-chunks", "msg-51")).toBe(true);
       expect(reloaded.isFenced("chat-chunks", "msg-101")).toBe(true);
 
-      // The retry loop re-probes the remainder — a later success settles it.
+      // A later round with every chunk succeeding merges proof and clears.
       await sm.reconcileReplayFencesWithServer();
-      expect(probeCalls.map((chunk) => chunk.length)).toEqual([50, 50, 50, 1]);
+      expect(probeCalls.slice(2).map((chunk) => chunk.length)).toEqual([50, 50, 1]);
       const after = new ReplayFenceStore(fencePath);
       after.load();
       expect(after.hasFenceForChat("chat-chunks")).toBe(false);

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -7,6 +7,7 @@ import {
   encodeProviderRetryEventMessage,
   parseProviderRetryEventMessage,
   RUNTIME_NOTICE_METADATA_KEY,
+  type RuntimeState,
   type SessionEvent,
 } from "@first-tree/shared";
 import type pino from "pino";
@@ -206,6 +207,7 @@ function createSessionManager(opts: {
   recoverChat?: (chatId: string) => Promise<void>;
   recoverRuntimeSessionProof?: (reasonCode: string) => Promise<void>;
   onSessionEvent?: (chatId: string, event: SessionEvent) => void;
+  onSessionRuntimeChange?: (chatId: string, state: RuntimeState) => void;
   confirmSessionEvent?: (chatId: string, event: SessionEvent) => Promise<void>;
   subprocessProbe?: SubprocessProbe;
   registryPath?: string;
@@ -247,6 +249,7 @@ function createSessionManager(opts: {
     recoverRuntimeSessionProof: opts.recoverRuntimeSessionProof,
     agentConfigCache: opts.agentConfigCache,
     onSessionEvent: opts.onSessionEvent,
+    onSessionRuntimeChange: opts.onSessionRuntimeChange,
     confirmSessionEvent: opts.confirmSessionEvent,
   });
 }
@@ -2831,14 +2834,20 @@ describe("SessionManager replay fence gate", () => {
     return mkdtempSync(join(tmpdir(), "sm-replay-fence-"));
   }
 
-  it("withholds a replay-fenced redelivery: no provider start, no ACK, debt retained", async () => {
+  it("withholds the fenced head and the chat's whole tail; other chats proceed", async () => {
     const root = makeTmp();
     try {
       const fencePath = join(root, "fence.json");
       seedFence(fencePath, "chat-1", "msg-1");
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
-      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath });
+      const runtimeStates: Array<{ chatId: string; state: RuntimeState }> = [];
+      const sm = createSessionManager({
+        handler,
+        ackEntry,
+        replayFencePath: fencePath,
+        onSessionRuntimeChange: (chatId, state) => runtimeStates.push({ chatId, state }),
+      });
 
       // The crashed delivery is redelivered after restart: it must NOT be
       // re-entered into the provider and must NOT be ACKed.
@@ -2848,8 +2857,17 @@ describe("SessionManager replay fence gate", () => {
       expect(handler.inject).not.toHaveBeenCalled();
       expect(ackEntry).not.toHaveBeenCalled();
 
-      // A different, unfenced delivery for the same chat runs normally.
+      // The same chat's later tail must also hold: inbox ACK is
+      // prefix-based, so letting msg-2 run would execute it out of order
+      // before the fenced head resolves.
       await sm.dispatch(mockEntry({ id: 2, chatId: "chat-1", messageId: "msg-2" }));
+      expect(handler.start).not.toHaveBeenCalled();
+      expect(handler.inject).not.toHaveBeenCalled();
+      expect(ackEntry).not.toHaveBeenCalled();
+      expect(runtimeStates).toContainEqual({ chatId: "chat-1", state: "error" });
+
+      // An unfenced chat is unaffected.
+      await sm.dispatch(mockEntry({ id: 3, chatId: "chat-2", messageId: "msg-9" }));
       expect(handler.start).toHaveBeenCalledTimes(1);
 
       await sm.shutdown();
@@ -2961,5 +2979,105 @@ describe("SessionManager replay fence gate", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("SessionManager completion disposition", () => {
+  function turnMessage(entryId: number, chatId: string, messageId: string): SessionMessage {
+    return {
+      inboxEntryId: entryId,
+      id: messageId,
+      chatId,
+      senderId: "sender-1",
+      format: "text",
+      content: "",
+      metadata: {},
+    };
+  }
+
+  it("returns retry when the server rejects the ACK, keeping delivery custody", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockRejectedValue(new Error("ack boom"));
+    let capturedCtx: SessionContext | undefined;
+    const handler = createMockHandler({
+      async start(_msg, ctx) {
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+    });
+    const sm = createSessionManager({ handler, ackEntry, recoverChat: async () => {} });
+
+    await sm.dispatch(mockEntry({ id: 7, chatId: "chat-ack", messageId: "msg-7" }));
+    const disposition = await capturedCtx?.finishTurn(turnMessage(7, "chat-ack", "msg-7"), {
+      status: "success",
+      terminal: true,
+    });
+
+    expect(disposition).toBe("retry");
+    expect(ackEntry).toHaveBeenCalledWith(7);
+
+    await sm.shutdown();
+  });
+
+  it("returns retry on a non-terminal prefix gap and holds custody pending recovery", async () => {
+    const ackEntry = mockAckEntry();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    const handler = createMockHandler({
+      async start(_msg, ctx) {
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+    });
+    const sm = createSessionManager({ handler, ackEntry, recoverChat });
+
+    await sm.dispatch(mockEntry({ id: 11, chatId: "chat-gap", messageId: "msg-11" }));
+    await sm.dispatch(mockEntry({ id: 12, chatId: "chat-gap", messageId: "msg-12" }));
+    expect(handler.inject).toHaveBeenCalledTimes(1);
+
+    // Finishing the tail while the head is still open must not report a
+    // durable settlement: the ACK-through cannot cross the non-terminal
+    // prefix, so custody is retained and reported as retry.
+    const gap = await capturedCtx?.finishTurn(turnMessage(12, "chat-gap", "msg-12"), {
+      status: "success",
+      terminal: true,
+    });
+    expect(gap).toBe("retry");
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(recoverChat).toHaveBeenCalledWith("chat-gap");
+
+    // The prefix gap already moved the chat into recovery debt: further
+    // completions stay deferred (retry, no ACK) until recovery redelivers,
+    // so a late head completion cannot sneak an ACK past the debt either.
+    const deferred = await capturedCtx?.finishTurn(turnMessage(11, "chat-gap", "msg-11"), {
+      status: "success",
+      terminal: true,
+    });
+    expect(deferred).toBe("retry");
+    expect(ackEntry).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("returns settled once the ACK commits the whole terminal prefix", async () => {
+    const ackEntry = mockAckEntry();
+    let capturedCtx: SessionContext | undefined;
+    const handler = createMockHandler({
+      async start(_msg, ctx) {
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+    });
+    const sm = createSessionManager({ handler, ackEntry });
+
+    await sm.dispatch(mockEntry({ id: 21, chatId: "chat-settled", messageId: "msg-21" }));
+    const disposition = await capturedCtx?.finishTurn(turnMessage(21, "chat-settled", "msg-21"), {
+      status: "success",
+      terminal: true,
+    });
+
+    expect(disposition).toBe("settled");
+    expect(ackEntry).toHaveBeenCalledWith(21);
+
+    await sm.shutdown();
   });
 });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3081,3 +3081,89 @@ describe("SessionManager completion disposition", () => {
     await sm.shutdown();
   });
 });
+
+describe("SessionManager replay fence reconcile", () => {
+  it("clears the chat fence when recovery redelivery commits the ACK, then admits later deliveries", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-reconcile-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      // ACK rejects once (transient), then succeeds on the redelivery retry.
+      const ackEntry = vi
+        .fn<(entryId: number) => Promise<void>>()
+        .mockRejectedValueOnce(new Error("ack boom"))
+        .mockResolvedValue(undefined);
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+      let capturedCtx: SessionContext | undefined;
+      let capturedFence: ReplayFenceStore | undefined;
+      const handler = createMockHandler({
+        start: vi.fn().mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
+          capturedCtx = ctx;
+          return "session-id-mock";
+        }),
+      });
+      const sm = createSessionManager({
+        handler,
+        ackEntry,
+        recoverChat,
+        replayFencePath: fencePath,
+        handlerFactory: (config) => {
+          capturedFence = config.replayFence as ReplayFenceStore;
+          return handler;
+        },
+      });
+
+      await sm.dispatch(mockEntry({ id: 31, chatId: "chat-rec", messageId: "msg-31" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+
+      // The handler fenced the delivery when its unsafe tool started, using
+      // the same store object the manager reconciles against.
+      capturedFence?.fence({
+        chatId: "chat-rec",
+        messageId: "msg-31",
+        provider: "kimi-code",
+        toolName: "Write",
+        toolUseId: "write-1",
+        fencedAt: new Date().toISOString(),
+      });
+
+      // The completion's ACK fails: disposition keeps custody, fence stays.
+      const disposition = await capturedCtx?.finishTurn(
+        {
+          inboxEntryId: 31,
+          id: "msg-31",
+          chatId: "chat-rec",
+          senderId: "s",
+          format: "text",
+          content: "",
+          metadata: {},
+        },
+        { status: "success", terminal: true },
+      );
+      expect(disposition).toBe("retry");
+      const retained = new ReplayFenceStore(fencePath);
+      retained.load();
+      expect(retained.hasFenceForChat("chat-rec")).toBe(true);
+
+      // Recovery redelivers the terminal entry; the retried ACK commits and
+      // the reconcile path clears the fence without any handler involvement.
+      // The first re-dispatch lets the in-flight recovery finish; the second
+      // is the redelivery frame that retries the ACK.
+      await sm.dispatch(mockEntry({ id: 31, chatId: "chat-rec", messageId: "msg-31" }));
+      await sm.dispatch(mockEntry({ id: 31, chatId: "chat-rec", messageId: "msg-31" }));
+      await vi.waitFor(() => {
+        const reloaded = new ReplayFenceStore(fencePath);
+        reloaded.load();
+        expect(reloaded.hasFenceForChat("chat-rec")).toBe(false);
+      });
+      expect(ackEntry).toHaveBeenCalledTimes(2);
+
+      // The chat is unblocked: the next delivery routes into the provider.
+      await sm.dispatch(mockEntry({ id: 32, chatId: "chat-rec", messageId: "msg-32" }));
+      expect(handler.inject).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3524,3 +3524,180 @@ describe("SessionManager replay fence startup reconciliation", () => {
     }
   });
 });
+
+describe("SessionManager replay fence convergence matrix", () => {
+  function seedFence(path: string, chatId: string, messageId: string): void {
+    const store = new ReplayFenceStore(path);
+    store.load();
+    store.fence({
+      chatId,
+      messageId,
+      provider: "kimi-code",
+      toolName: "Bash",
+      toolUseId: "agent-0:tool_1",
+      fencedAt: new Date().toISOString(),
+    });
+  }
+
+  it("never fires a post-fence recovery for an ordinary never-fenced turn", async () => {
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const ackEntry = mockAckEntry();
+    let capturedCtx: SessionContext | undefined;
+    const handler = createMockHandler({
+      start: vi.fn().mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
+        capturedCtx = ctx;
+        return "session-id-mock";
+      }),
+    });
+    const sm = createSessionManager({ handler, ackEntry, recoverChat });
+
+    await sm.dispatch(mockEntry({ id: 71, chatId: "chat-normal", messageId: "msg-1" }));
+    await sm.dispatch(mockEntry({ id: 72, chatId: "chat-normal", messageId: "msg-2" }));
+    const disposition = await capturedCtx?.finishTurn(
+      {
+        inboxEntryId: 71,
+        id: "msg-1",
+        chatId: "chat-normal",
+        senderId: "s",
+        format: "text",
+        content: "",
+        metadata: {},
+      },
+      { status: "success", terminal: true },
+    );
+
+    expect(disposition).toBe("settled");
+    expect(recoverChat).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("suppresses a stale frame for a probe-settled delivery instead of reprocessing it", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-tombstone-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFence(fencePath, "chat-tomb", "msg-1");
+      const probeFencedSettlement = vi.fn(async (_chatId: string, _ids: readonly string[]) => ["msg-1"]);
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+      const handler = createMockHandler();
+      const sm = createSessionManager({ handler, replayFencePath: fencePath, probeFencedSettlement, recoverChat });
+
+      await sm.dispatch(mockEntry({ id: 73, chatId: "chat-tomb", messageId: "msg-1" }));
+      await sm.dispatch(mockEntry({ id: 74, chatId: "chat-tomb", messageId: "msg-2" }));
+      await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+
+      // The tail redelivers and starts the provider...
+      await sm.dispatch(mockEntry({ id: 74, chatId: "chat-tomb", messageId: "msg-2" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(handler.start).mock.calls[0]?.[0]).toMatchObject({ id: "msg-2" });
+
+      // ...but a stray duplicate of the settled head is tombstoned: no
+      // re-route, no new provider entry, no ACK-prefix disturbance.
+      await sm.dispatch(mockEntry({ id: 73, chatId: "chat-tomb", messageId: "msg-1" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(handler.start).mock.calls[0]?.[0]).toMatchObject({ id: "msg-2" });
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("holds later admissions while a failed post-fence recovery retries, then converges once", async () => {
+    vi.useFakeTimers();
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-postretry-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFence(fencePath, "chat-postretry", "msg-1");
+      const recoverChat = vi
+        .fn<(chatId: string) => Promise<void>>()
+        .mockRejectedValueOnce(new Error("socket flap"))
+        .mockResolvedValue(undefined);
+      const probeFencedSettlement = vi.fn(async (_chatId: string, _ids: readonly string[]) => ["msg-1"]);
+      const handler = createMockHandler();
+      const sm = createSessionManager({ handler, replayFencePath: fencePath, probeFencedSettlement, recoverChat });
+
+      await sm.dispatch(mockEntry({ id: 75, chatId: "chat-postretry", messageId: "msg-1" }));
+      await sm.dispatch(mockEntry({ id: 76, chatId: "chat-postretry", messageId: "msg-2" }));
+      await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-postretry")).toBe(false);
+
+      // While the recovery is failing, a NEW message must not overtake the
+      // withheld tail — it is held too, without another recovery firing.
+      await sm.dispatch(mockEntry({ id: 77, chatId: "chat-postretry", messageId: "msg-3" }));
+      expect(handler.start).not.toHaveBeenCalled();
+      expect(recoverChat).toHaveBeenCalledTimes(1);
+
+      // The timer retries: the second recovery succeeds exactly once, and
+      // the redelivered tail routes.
+      await vi.advanceTimersByTimeAsync(31_000);
+      expect(recoverChat).toHaveBeenCalledTimes(2);
+      await sm.dispatch(mockEntry({ id: 76, chatId: "chat-postretry", messageId: "msg-2" }));
+      await sm.dispatch(mockEntry({ id: 77, chatId: "chat-postretry", messageId: "msg-3" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      expect(handler.inject).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      vi.useRealTimers();
+    }
+  });
+
+  it("chunks fence probes at the wire limit and keeps unproven chunks fenced", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-chunks-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      const store = new ReplayFenceStore(fencePath);
+      store.load();
+      const ids = Array.from({ length: 101 }, (_, i) => `msg-${i + 1}`);
+      for (const id of ids) {
+        store.fence({
+          chatId: "chat-chunks",
+          messageId: id,
+          provider: "kimi-code",
+          toolName: "Write",
+          toolUseId: "w1",
+          fencedAt: new Date().toISOString(),
+        });
+      }
+      const probeCalls: string[][] = [];
+      const probeFencedSettlement = vi.fn(async (_chatId: string, chunk: readonly string[]) => {
+        probeCalls.push([...chunk]);
+        // The middle chunk fails: only the first chunk's ids may clear.
+        if (probeCalls.length === 2) throw new Error("probe flap");
+        return [...chunk];
+      });
+      const sm = createSessionManager({
+        handler: createMockHandler(),
+        replayFencePath: fencePath,
+        probeFencedSettlement,
+      });
+
+      await sm.reconcileReplayFencesWithServer();
+
+      // The failing middle chunk stops the pass: chunks 1 proves and
+      // clears, chunks 2-3 stay fenced (and the timer loop retries them).
+      expect(probeCalls.map((chunk) => chunk.length)).toEqual([50, 50]);
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.isFenced("chat-chunks", "msg-1")).toBe(false);
+      expect(reloaded.isFenced("chat-chunks", "msg-50")).toBe(false);
+      expect(reloaded.isFenced("chat-chunks", "msg-51")).toBe(true);
+      expect(reloaded.isFenced("chat-chunks", "msg-101")).toBe(true);
+
+      // The retry loop re-probes the remainder — a later success settles it.
+      await sm.reconcileReplayFencesWithServer();
+      expect(probeCalls.map((chunk) => chunk.length)).toEqual([50, 50, 50, 1]);
+      const after = new ReplayFenceStore(fencePath);
+      after.load();
+      expect(after.hasFenceForChat("chat-chunks")).toBe(false);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3329,82 +3329,113 @@ describe("SessionManager replay fence startup reconciliation", () => {
     }
   });
 
-  it("converges a stale fence through gate-triggered reconciliation retries without a restart", async () => {
+  it("clears a settled stale head even with a newer unacked tail, then admits the buffered tail", async () => {
     const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
     try {
       const fencePath = join(root, "fence.json");
-      seedFenceStore(fencePath, "chat-converge", "msg-1");
+      seedFenceStore(fencePath, "chat-tail", "msg-1");
+      // Server truth: msg-1 settled; only the newer tail msg-2 is unacked.
       const recoverChatWithCount = vi
-        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
-        .mockResolvedValueOnce({ resetCount: 0, unackedOutstanding: 1 })
-        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 0 });
+        .fn<
+          (chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number; unackedMessageIds?: string[] }>
+        >()
+        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 1, unackedMessageIds: ["msg-2"] });
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
       const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
 
-      // First withheld dispatch triggers a reconciliation that still sees
-      // backlog — the fence stays.
-      await sm.dispatch(mockEntry({ id: 45, chatId: "chat-converge", messageId: "msg-1" }));
-      await vi.waitFor(() => expect(recoverChatWithCount).toHaveBeenCalledTimes(1));
-      let reloaded = new ReplayFenceStore(fencePath);
+      // Both the fenced head and the tail are withheld and buffered.
+      await sm.dispatch(mockEntry({ id: 45, chatId: "chat-tail", messageId: "msg-1" }));
+      await sm.dispatch(mockEntry({ id: 46, chatId: "chat-tail", messageId: "msg-2" }));
+
+      // The gate's first reconciliation proves msg-1 settled (it is NOT in
+      // the unacked list), clears it, and re-drives the buffered deliveries
+      // — no further dispatch or timer advance needed.
+      await vi.waitFor(() => expect(handler.start).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(handler.inject).toHaveBeenCalledTimes(1));
+      const reloaded = new ReplayFenceStore(fencePath);
       reloaded.load();
-      expect(reloaded.hasFenceForChat("chat-converge")).toBe(true);
-      expect(handler.start).not.toHaveBeenCalled();
-
-      // After the spacing interval the next withheld dispatch retries; the
-      // server now reports authoritative zero, so the fence clears.
-      vi.setSystemTime(Date.now() + 31_000);
-      await sm.dispatch(mockEntry({ id: 46, chatId: "chat-converge", messageId: "msg-2" }));
-      await vi.waitFor(() => {
-        reloaded = new ReplayFenceStore(fencePath);
-        reloaded.load();
-        expect(reloaded.hasFenceForChat("chat-converge")).toBe(false);
-      });
-
-      // The chat is admitted again.
-      await sm.dispatch(mockEntry({ id: 47, chatId: "chat-converge", messageId: "msg-3" }));
-      expect(handler.start).toHaveBeenCalledTimes(1);
+      expect(reloaded.hasFenceForChat("chat-tail")).toBe(false);
 
       await sm.shutdown();
     } finally {
-      vi.setSystemTime(new Date());
       rmSync(root, { recursive: true, force: true });
     }
   });
 
-  it("retries a failed stale-fence clear on the next reconciliation and admits the chat", async () => {
+  it("retries a failed local clear on the retry timer without any new dispatch or manual reconcile", async () => {
+    vi.useFakeTimers();
     const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
     try {
       const fencePath = join(root, "fence.json");
-      seedFenceStore(fencePath, "chat-retry", "msg-1");
+      seedFenceStore(fencePath, "chat-timer", "msg-1");
       const recoverChatWithCount = vi
-        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
-        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 0 });
+        .fn<
+          (chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number; unackedMessageIds?: string[] }>
+        >()
+        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 0, unackedMessageIds: [] });
       const handler = createMockHandler();
       const sm = createSessionManager({ handler, replayFencePath: fencePath, recoverChatWithCount });
 
-      // First clear fails on I/O — the fence stays but must not be
-      // permanently stuck.
+      // Clear fails on I/O during the first gate-triggered reconciliation.
       chmodSync(root, 0o500);
-      await sm.reconcileReplayFencesWithServer();
+      await sm.dispatch(mockEntry({ id: 47, chatId: "chat-timer", messageId: "msg-1" }));
+      await vi.waitFor(() => expect(recoverChatWithCount).toHaveBeenCalledTimes(1));
       let reloaded = new ReplayFenceStore(fencePath);
       reloaded.load();
-      expect(reloaded.hasFenceForChat("chat-retry")).toBe(true);
+      expect(reloaded.hasFenceForChat("chat-timer")).toBe(true);
+      expect(handler.start).not.toHaveBeenCalled();
 
-      // After the store is repaired the next reconciliation clears it.
+      // Repair the store, then ONLY advance the timer: the loop must redo
+      // the local clear of the already-proven-settled fence and re-drive
+      // the buffered delivery — no readback, no new dispatch.
       chmodSync(root, 0o700);
-      await sm.reconcileReplayFencesWithServer();
+      recoverChatWithCount.mockClear();
+      await vi.advanceTimersByTimeAsync(31_000);
       reloaded = new ReplayFenceStore(fencePath);
       reloaded.load();
-      expect(reloaded.hasFenceForChat("chat-retry")).toBe(false);
-
-      await sm.dispatch(mockEntry({ id: 48, chatId: "chat-retry", messageId: "msg-2" }));
+      expect(reloaded.hasFenceForChat("chat-timer")).toBe(false);
+      expect(recoverChatWithCount).not.toHaveBeenCalled();
       expect(handler.start).toHaveBeenCalledTimes(1);
 
       await sm.shutdown();
     } finally {
       chmodSync(root, 0o700);
       rmSync(root, { recursive: true, force: true });
+      vi.useRealTimers();
+    }
+  });
+
+  it("never clears on the retry timer without authoritative settlement truth", async () => {
+    vi.useFakeTimers();
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFenceStore(fencePath, "chat-never", "msg-1");
+      const recoverChatWithCount = vi
+        .fn<
+          (chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number; unackedMessageIds?: string[] }>
+        >()
+        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 2, unackedMessageIds: ["msg-1", "msg-2"] });
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+
+      await sm.dispatch(mockEntry({ id: 49, chatId: "chat-never", messageId: "msg-1" }));
+      await vi.advanceTimersByTimeAsync(95_000);
+
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-never")).toBe(true);
+      expect(handler.start).not.toHaveBeenCalled();
+      expect(ackEntry).not.toHaveBeenCalled();
+      // The loop kept re-reading server truth on its own schedule.
+      expect(recoverChatWithCount.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      vi.useRealTimers();
     }
   });
 });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -205,7 +205,7 @@ function createSessionManager(opts: {
   log?: pino.Logger;
   agentConfigCache?: AgentConfigCache;
   recoverChat?: (chatId: string) => Promise<void>;
-  recoverChatWithCount?: (chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>;
+  probeFencedSettlement?: (chatId: string, messageIds: readonly string[]) => Promise<readonly string[]>;
   recoverRuntimeSessionProof?: (reasonCode: string) => Promise<void>;
   onSessionEvent?: (chatId: string, event: SessionEvent) => void;
   onSessionRuntimeChange?: (chatId: string, state: RuntimeState) => void;
@@ -247,7 +247,7 @@ function createSessionManager(opts: {
     replayFencePath: opts.replayFencePath,
     ackEntry: opts.ackEntry ?? mockAckEntry(),
     recoverChat: opts.recoverChat,
-    recoverChatWithCount: opts.recoverChatWithCount,
+    probeFencedSettlement: opts.probeFencedSettlement,
     recoverRuntimeSessionProof: opts.recoverRuntimeSessionProof,
     agentConfigCache: opts.agentConfigCache,
     onSessionEvent: opts.onSessionEvent,
@@ -3184,24 +3184,26 @@ describe("SessionManager replay fence startup reconciliation", () => {
     });
   }
 
-  it("clears a stale fence when the server confirms zero unacked entries after a crash, then admits the chat", async () => {
+  function makeProbe(settled: readonly string[]) {
+    return vi.fn(async (_chatId: string, _messageIds: readonly string[]) => [...settled]);
+  }
+
+  it("clears a stale fence when the probe proves the fenced delivery settled, then admits the chat", async () => {
     const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
     try {
       const fencePath = join(root, "fence.json");
       // Pre-crash state: unsafe effect fenced, then the ACK committed
       // server-side but the process died before the local clear.
       seedFenceStore(fencePath, "chat-crash", "msg-1");
-      const recoverChatWithCount = vi
-        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
-        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 0 });
+      const probeFencedSettlement = makeProbe(["msg-1"]);
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
       // A fresh manager (post-crash) loads the fence file.
-      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, probeFencedSettlement });
 
       await sm.reconcileReplayFencesWithServer();
 
-      expect(recoverChatWithCount).toHaveBeenCalledWith("chat-crash");
+      expect(probeFencedSettlement).toHaveBeenCalledWith("chat-crash", ["msg-1"]);
       const reloaded = new ReplayFenceStore(fencePath);
       reloaded.load();
       expect(reloaded.hasFenceForChat("chat-crash")).toBe(false);
@@ -3215,17 +3217,15 @@ describe("SessionManager replay fence startup reconciliation", () => {
     }
   });
 
-  it("keeps the fence and the chat hold when the server still resets unacked entries", async () => {
+  it("keeps the fence and the chat hold when the probe leaves the fenced delivery unsettled", async () => {
     const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
     try {
       const fencePath = join(root, "fence.json");
       seedFenceStore(fencePath, "chat-debt", "msg-1");
-      const recoverChatWithCount = vi
-        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
-        .mockResolvedValue({ resetCount: 1, unackedOutstanding: 1 });
+      const probeFencedSettlement = makeProbe([]);
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
-      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, probeFencedSettlement });
 
       await sm.reconcileReplayFencesWithServer();
 
@@ -3244,17 +3244,17 @@ describe("SessionManager replay fence startup reconciliation", () => {
     }
   });
 
-  it("keeps fences fail-closed when the readback fails", async () => {
+  it("keeps fences fail-closed when the probe fails or is absent", async () => {
     const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
     try {
       const fencePath = join(root, "fence.json");
       seedFenceStore(fencePath, "chat-fail", "msg-1");
-      const recoverChatWithCount = vi
-        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
+      const probeFencedSettlement = vi
+        .fn<(chatId: string, messageIds: readonly string[]) => Promise<readonly string[]>>()
         .mockRejectedValue(new Error("socket not bound"));
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
-      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, probeFencedSettlement });
 
       await sm.reconcileReplayFencesWithServer();
 
@@ -3272,90 +3272,52 @@ describe("SessionManager replay fence startup reconciliation", () => {
     }
   });
 
-  it("does NOT clear when delivered resetCount is 0 but unacked backlog is still pending", async () => {
-    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
-    try {
-      const fencePath = join(root, "fence.json");
-      seedFenceStore(fencePath, "chat-pending", "msg-1");
-      // Bind reset moved the unacked row to pending BEFORE the recovery ran:
-      // the delivered resetCount is 0, but the authoritative outstanding is
-      // not. Clearing here would let the pending backlog replay the effect.
-      const recoverChatWithCount = vi
-        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
-        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 1 });
-      const handler = createMockHandler();
-      const ackEntry = mockAckEntry();
-      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
-
-      await sm.reconcileReplayFencesWithServer();
-
-      const reloaded = new ReplayFenceStore(fencePath);
-      reloaded.load();
-      expect(reloaded.hasFenceForChat("chat-pending")).toBe(true);
-
-      // The later backlog delivery must not enter the provider either.
-      await sm.dispatch(mockEntry({ id: 44, chatId: "chat-pending", messageId: "msg-1" }));
-      expect(handler.start).not.toHaveBeenCalled();
-      expect(handler.resume).not.toHaveBeenCalled();
-      expect(ackEntry).not.toHaveBeenCalled();
-
-      await sm.shutdown();
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("keeps fences when an older server omits the authoritative outstanding field", async () => {
-    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
-    try {
-      const fencePath = join(root, "fence.json");
-      seedFenceStore(fencePath, "chat-old", "msg-1");
-      const recoverChatWithCount = vi
-        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
-        .mockResolvedValue({ resetCount: 0 });
-      const handler = createMockHandler();
-      const ackEntry = mockAckEntry();
-      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
-
-      await sm.reconcileReplayFencesWithServer();
-
-      const reloaded = new ReplayFenceStore(fencePath);
-      reloaded.load();
-      expect(reloaded.hasFenceForChat("chat-old")).toBe(true);
-
-      await sm.shutdown();
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("clears a settled stale head even with a newer unacked tail, then admits the buffered tail", async () => {
+  it("clears a settled stale head, then one recovery redelivers the withheld tail into the provider exactly once", async () => {
     const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
     try {
       const fencePath = join(root, "fence.json");
       seedFenceStore(fencePath, "chat-tail", "msg-1");
-      // Server truth: msg-1 settled; only the newer tail msg-2 is unacked.
-      const recoverChatWithCount = vi
-        .fn<
-          (chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number; unackedMessageIds?: string[] }>
-        >()
-        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 1, unackedMessageIds: ["msg-2"] });
+      // Hold the probe so both deliveries are verifiably withheld+marked
+      // before the settlement proof lands.
+      let resolveProbe: (settled: readonly string[]) => void = () => {};
+      const probeResult = new Promise<readonly string[]>((resolvePromise) => {
+        resolveProbe = resolvePromise;
+      });
+      const probeFencedSettlement = vi.fn(async (_chatId: string, _messageIds: readonly string[]) => probeResult);
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
-      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+      const sm = createSessionManager({
+        handler,
+        ackEntry,
+        replayFencePath: fencePath,
+        probeFencedSettlement,
+        recoverChat,
+      });
 
-      // Both the fenced head and the tail are withheld and buffered.
+      // Both the fenced head and the tail are withheld and marked in the ledger.
       await sm.dispatch(mockEntry({ id: 45, chatId: "chat-tail", messageId: "msg-1" }));
       await sm.dispatch(mockEntry({ id: 46, chatId: "chat-tail", messageId: "msg-2" }));
+      await vi.waitFor(() => expect(probeFencedSettlement).toHaveBeenCalledTimes(1));
+      expect(handler.start).not.toHaveBeenCalled();
 
-      // The gate's first reconciliation proves msg-1 settled (it is NOT in
-      // the unacked list), clears it, and re-drives the buffered deliveries
-      // — no further dispatch or timer advance needed.
-      await vi.waitFor(() => expect(handler.start).toHaveBeenCalledTimes(1));
-      await vi.waitFor(() => expect(handler.inject).toHaveBeenCalledTimes(1));
+      // The probe proves msg-1 settled, clears it, and fires exactly one
+      // destructive recovery for the withheld backlog.
+      resolveProbe(["msg-1"]);
+      await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+      expect(recoverChat).toHaveBeenCalledWith("chat-tail");
       const reloaded = new ReplayFenceStore(fencePath);
       reloaded.load();
       expect(reloaded.hasFenceForChat("chat-tail")).toBe(false);
+      expect(handler.start).not.toHaveBeenCalled();
+
+      // The server's redelivery re-admits the withheld entries — and a
+      // duplicated redelivery frame cannot start a second provider turn.
+      await sm.dispatch(mockEntry({ id: 45, chatId: "chat-tail", messageId: "msg-1" }));
+      await sm.dispatch(mockEntry({ id: 45, chatId: "chat-tail", messageId: "msg-1" }));
+      await sm.dispatch(mockEntry({ id: 46, chatId: "chat-tail", messageId: "msg-2" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      expect(handler.inject).toHaveBeenCalledTimes(1);
 
       await sm.shutdown();
     } finally {
@@ -3363,39 +3325,40 @@ describe("SessionManager replay fence startup reconciliation", () => {
     }
   });
 
-  it("retries a failed local clear on the retry timer without any new dispatch or manual reconcile", async () => {
+  it("retries a failed local clear on the retry timer without any new dispatch or probe", async () => {
     vi.useFakeTimers();
     const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
     try {
       const fencePath = join(root, "fence.json");
       seedFenceStore(fencePath, "chat-timer", "msg-1");
-      const recoverChatWithCount = vi
-        .fn<
-          (chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number; unackedMessageIds?: string[] }>
-        >()
-        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 0, unackedMessageIds: [] });
+      const probeFencedSettlement = makeProbe(["msg-1"]);
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
       const handler = createMockHandler();
-      const sm = createSessionManager({ handler, replayFencePath: fencePath, recoverChatWithCount });
+      const sm = createSessionManager({ handler, replayFencePath: fencePath, probeFencedSettlement, recoverChat });
 
-      // Clear fails on I/O during the first gate-triggered reconciliation.
+      // Clear fails on I/O during the first gate-triggered probe round.
       chmodSync(root, 0o500);
       await sm.dispatch(mockEntry({ id: 47, chatId: "chat-timer", messageId: "msg-1" }));
-      await vi.waitFor(() => expect(recoverChatWithCount).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(probeFencedSettlement).toHaveBeenCalledTimes(1));
       let reloaded = new ReplayFenceStore(fencePath);
       reloaded.load();
       expect(reloaded.hasFenceForChat("chat-timer")).toBe(true);
       expect(handler.start).not.toHaveBeenCalled();
 
-      // Repair the store, then ONLY advance the timer: the loop must redo
-      // the local clear of the already-proven-settled fence and re-drive
-      // the buffered delivery — no readback, no new dispatch.
+      // Repair the store, then ONLY advance the timer: the loop redoes the
+      // local clear of the already-proven fence (no new probe) and fires
+      // the single redrive recovery.
       chmodSync(root, 0o700);
-      recoverChatWithCount.mockClear();
+      probeFencedSettlement.mockClear();
       await vi.advanceTimersByTimeAsync(31_000);
       reloaded = new ReplayFenceStore(fencePath);
       reloaded.load();
       expect(reloaded.hasFenceForChat("chat-timer")).toBe(false);
-      expect(recoverChatWithCount).not.toHaveBeenCalled();
+      expect(probeFencedSettlement).not.toHaveBeenCalled();
+      expect(recoverChat).toHaveBeenCalledTimes(1);
+
+      // The redelivery now routes into the provider.
+      await sm.dispatch(mockEntry({ id: 47, chatId: "chat-timer", messageId: "msg-1" }));
       expect(handler.start).toHaveBeenCalledTimes(1);
 
       await sm.shutdown();
@@ -3406,20 +3369,23 @@ describe("SessionManager replay fence startup reconciliation", () => {
     }
   });
 
-  it("never clears on the retry timer without authoritative settlement truth", async () => {
+  it("never clears on the retry timer without settlement proof, and never fires a destructive recover", async () => {
     vi.useFakeTimers();
     const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
     try {
       const fencePath = join(root, "fence.json");
       seedFenceStore(fencePath, "chat-never", "msg-1");
-      const recoverChatWithCount = vi
-        .fn<
-          (chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number; unackedMessageIds?: string[] }>
-        >()
-        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 2, unackedMessageIds: ["msg-1", "msg-2"] });
+      const probeFencedSettlement = makeProbe([]);
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
-      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+      const sm = createSessionManager({
+        handler,
+        ackEntry,
+        replayFencePath: fencePath,
+        probeFencedSettlement,
+        recoverChat,
+      });
 
       await sm.dispatch(mockEntry({ id: 49, chatId: "chat-never", messageId: "msg-1" }));
       await vi.advanceTimersByTimeAsync(95_000);
@@ -3429,8 +3395,10 @@ describe("SessionManager replay fence startup reconciliation", () => {
       expect(reloaded.hasFenceForChat("chat-never")).toBe(true);
       expect(handler.start).not.toHaveBeenCalled();
       expect(ackEntry).not.toHaveBeenCalled();
-      // The loop kept re-reading server truth on its own schedule.
-      expect(recoverChatWithCount.mock.calls.length).toBeGreaterThanOrEqual(3);
+      // The loop keeps re-probing on its own schedule — read-only, so no
+      // destructive reset/no-progress circuit can trip.
+      expect(probeFencedSettlement.mock.calls.length).toBeGreaterThanOrEqual(3);
+      expect(recoverChat).not.toHaveBeenCalled();
 
       await sm.shutdown();
     } finally {

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -205,7 +205,7 @@ function createSessionManager(opts: {
   log?: pino.Logger;
   agentConfigCache?: AgentConfigCache;
   recoverChat?: (chatId: string) => Promise<void>;
-  recoverChatWithCount?: (chatId: string) => Promise<number>;
+  recoverChatWithCount?: (chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>;
   recoverRuntimeSessionProof?: (reasonCode: string) => Promise<void>;
   onSessionEvent?: (chatId: string, event: SessionEvent) => void;
   onSessionRuntimeChange?: (chatId: string, state: RuntimeState) => void;
@@ -3191,7 +3191,9 @@ describe("SessionManager replay fence startup reconciliation", () => {
       // Pre-crash state: unsafe effect fenced, then the ACK committed
       // server-side but the process died before the local clear.
       seedFenceStore(fencePath, "chat-crash", "msg-1");
-      const recoverChatWithCount = vi.fn<(chatId: string) => Promise<number>>().mockResolvedValue(0);
+      const recoverChatWithCount = vi
+        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
+        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 0 });
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
       // A fresh manager (post-crash) loads the fence file.
@@ -3218,7 +3220,9 @@ describe("SessionManager replay fence startup reconciliation", () => {
     try {
       const fencePath = join(root, "fence.json");
       seedFenceStore(fencePath, "chat-debt", "msg-1");
-      const recoverChatWithCount = vi.fn<(chatId: string) => Promise<number>>().mockResolvedValue(1);
+      const recoverChatWithCount = vi
+        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
+        .mockResolvedValue({ resetCount: 1, unackedOutstanding: 1 });
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
       const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
@@ -3246,7 +3250,7 @@ describe("SessionManager replay fence startup reconciliation", () => {
       const fencePath = join(root, "fence.json");
       seedFenceStore(fencePath, "chat-fail", "msg-1");
       const recoverChatWithCount = vi
-        .fn<(chatId: string) => Promise<number>>()
+        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
         .mockRejectedValue(new Error("socket not bound"));
       const handler = createMockHandler();
       const ackEntry = mockAckEntry();
@@ -3264,6 +3268,142 @@ describe("SessionManager replay fence startup reconciliation", () => {
 
       await sm.shutdown();
     } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT clear when delivered resetCount is 0 but unacked backlog is still pending", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFenceStore(fencePath, "chat-pending", "msg-1");
+      // Bind reset moved the unacked row to pending BEFORE the recovery ran:
+      // the delivered resetCount is 0, but the authoritative outstanding is
+      // not. Clearing here would let the pending backlog replay the effect.
+      const recoverChatWithCount = vi
+        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
+        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 1 });
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+
+      await sm.reconcileReplayFencesWithServer();
+
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-pending")).toBe(true);
+
+      // The later backlog delivery must not enter the provider either.
+      await sm.dispatch(mockEntry({ id: 44, chatId: "chat-pending", messageId: "msg-1" }));
+      expect(handler.start).not.toHaveBeenCalled();
+      expect(handler.resume).not.toHaveBeenCalled();
+      expect(ackEntry).not.toHaveBeenCalled();
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps fences when an older server omits the authoritative outstanding field", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFenceStore(fencePath, "chat-old", "msg-1");
+      const recoverChatWithCount = vi
+        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
+        .mockResolvedValue({ resetCount: 0 });
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+
+      await sm.reconcileReplayFencesWithServer();
+
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-old")).toBe(true);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("converges a stale fence through gate-triggered reconciliation retries without a restart", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFenceStore(fencePath, "chat-converge", "msg-1");
+      const recoverChatWithCount = vi
+        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
+        .mockResolvedValueOnce({ resetCount: 0, unackedOutstanding: 1 })
+        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 0 });
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath, recoverChatWithCount });
+
+      // First withheld dispatch triggers a reconciliation that still sees
+      // backlog — the fence stays.
+      await sm.dispatch(mockEntry({ id: 45, chatId: "chat-converge", messageId: "msg-1" }));
+      await vi.waitFor(() => expect(recoverChatWithCount).toHaveBeenCalledTimes(1));
+      let reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-converge")).toBe(true);
+      expect(handler.start).not.toHaveBeenCalled();
+
+      // After the spacing interval the next withheld dispatch retries; the
+      // server now reports authoritative zero, so the fence clears.
+      vi.setSystemTime(Date.now() + 31_000);
+      await sm.dispatch(mockEntry({ id: 46, chatId: "chat-converge", messageId: "msg-2" }));
+      await vi.waitFor(() => {
+        reloaded = new ReplayFenceStore(fencePath);
+        reloaded.load();
+        expect(reloaded.hasFenceForChat("chat-converge")).toBe(false);
+      });
+
+      // The chat is admitted again.
+      await sm.dispatch(mockEntry({ id: 47, chatId: "chat-converge", messageId: "msg-3" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      vi.setSystemTime(new Date());
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retries a failed stale-fence clear on the next reconciliation and admits the chat", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-fence-startup-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFenceStore(fencePath, "chat-retry", "msg-1");
+      const recoverChatWithCount = vi
+        .fn<(chatId: string) => Promise<{ resetCount: number; unackedOutstanding?: number }>>()
+        .mockResolvedValue({ resetCount: 0, unackedOutstanding: 0 });
+      const handler = createMockHandler();
+      const sm = createSessionManager({ handler, replayFencePath: fencePath, recoverChatWithCount });
+
+      // First clear fails on I/O — the fence stays but must not be
+      // permanently stuck.
+      chmodSync(root, 0o500);
+      await sm.reconcileReplayFencesWithServer();
+      let reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-retry")).toBe(true);
+
+      // After the store is repaired the next reconciliation clears it.
+      chmodSync(root, 0o700);
+      await sm.reconcileReplayFencesWithServer();
+      reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-retry")).toBe(false);
+
+      await sm.dispatch(mockEntry({ id: 48, chatId: "chat-retry", messageId: "msg-2" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      chmodSync(root, 0o700);
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3822,3 +3822,76 @@ describe("SessionManager pre-ledger settlement race", () => {
     }
   });
 });
+
+describe("SessionManager confirmed-ACK fence settlement suppression", () => {
+  it("suppresses a stale duplicate after a fenced delivery ACKs, even across suspend", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-ack-tombstone-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+      const ackEntry = mockAckEntry();
+      let capturedCtx: SessionContext | undefined;
+      let capturedFence: ReplayFenceStore | undefined;
+      const handler = createMockHandler({
+        start: vi.fn().mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
+          capturedCtx = ctx;
+          return "session-id-mock";
+        }),
+      });
+      const sm = createSessionManager({
+        ackEntry,
+        recoverChat,
+        replayFencePath: fencePath,
+        handlerFactory: (config) => {
+          capturedFence = config.replayFence as ReplayFenceStore;
+          return handler;
+        },
+      });
+
+      // A fenced unsafe delivery runs and ACKs successfully.
+      await sm.dispatch(mockEntry({ id: 81, chatId: "chat-acktomb", messageId: "msg-1" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      capturedFence?.fence({
+        chatId: "chat-acktomb",
+        messageId: "msg-1",
+        provider: "kimi-code",
+        toolName: "Write",
+        toolUseId: "write-1",
+        fencedAt: new Date().toISOString(),
+      });
+      const disposition = await capturedCtx?.finishTurn(
+        {
+          inboxEntryId: 81,
+          id: "msg-1",
+          chatId: "chat-acktomb",
+          senderId: "s",
+          format: "text",
+          content: "",
+          metadata: {},
+        },
+        { status: "success", terminal: true },
+      );
+      expect(disposition).toBe("settled");
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-acktomb")).toBe(false);
+
+      // The session goes away; a stale duplicate of the settled delivery
+      // must be suppressed at receive() — no resume, no start, no effect,
+      // no new ACK.
+      await sm.handleCommand("chat-acktomb", "session:suspend");
+      await sm.dispatch(mockEntry({ id: 81, chatId: "chat-acktomb", messageId: "msg-1" }));
+      expect(handler.resume).not.toHaveBeenCalled();
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      expect(ackEntry).toHaveBeenCalledTimes(1);
+
+      // A genuine newer unacked delivery still flows normally.
+      await sm.dispatch(mockEntry({ id: 82, chatId: "chat-acktomb", messageId: "msg-2" }));
+      expect(handler.resume).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -23,6 +23,7 @@ import type {
   TurnOutcome,
 } from "../runtime/handler.js";
 import type { SubprocessProbe } from "../runtime/process-tree-probe.js";
+import { ReplayFenceStore } from "../runtime/replay-fence.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import { type FirstTreeHubSDK, SdkError } from "../sdk.js";
 import { recordingLogger, silentLogger } from "./_logger-helpers.js";
@@ -208,6 +209,7 @@ function createSessionManager(opts: {
   confirmSessionEvent?: (chatId: string, event: SessionEvent) => Promise<void>;
   subprocessProbe?: SubprocessProbe;
   registryPath?: string;
+  replayFencePath?: string;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
@@ -239,6 +241,7 @@ function createSessionManager(opts: {
     sdk,
     log: opts.log ?? silentLogger(),
     registryPath: opts.registryPath,
+    replayFencePath: opts.replayFencePath,
     ackEntry: opts.ackEntry ?? mockAckEntry(),
     recoverChat: opts.recoverChat,
     recoverRuntimeSessionProof: opts.recoverRuntimeSessionProof,
@@ -2807,5 +2810,156 @@ describe("SessionManager subprocess-aware suspend/eviction", () => {
     expect(handlers[1]?.suspend).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
+  });
+});
+
+describe("SessionManager replay fence gate", () => {
+  function seedFence(path: string, chatId: string, messageId: string): void {
+    const store = new ReplayFenceStore(path);
+    store.load();
+    store.fence({
+      chatId,
+      messageId,
+      provider: "kimi-code",
+      toolName: "Bash",
+      toolUseId: "agent-0:tool_1",
+      fencedAt: new Date().toISOString(),
+    });
+  }
+
+  function makeTmp(): string {
+    return mkdtempSync(join(tmpdir(), "sm-replay-fence-"));
+  }
+
+  it("withholds a replay-fenced redelivery: no provider start, no ACK, debt retained", async () => {
+    const root = makeTmp();
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFence(fencePath, "chat-1", "msg-1");
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      const sm = createSessionManager({ handler, ackEntry, replayFencePath: fencePath });
+
+      // The crashed delivery is redelivered after restart: it must NOT be
+      // re-entered into the provider and must NOT be ACKed.
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1", messageId: "msg-1" }));
+      expect(handler.start).not.toHaveBeenCalled();
+      expect(handler.resume).not.toHaveBeenCalled();
+      expect(handler.inject).not.toHaveBeenCalled();
+      expect(ackEntry).not.toHaveBeenCalled();
+
+      // A different, unfenced delivery for the same chat runs normally.
+      await sm.dispatch(mockEntry({ id: 2, chatId: "chat-1", messageId: "msg-2" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("withholds a fenced redelivery even with a persisted provider session mapping", async () => {
+    const root = makeTmp();
+    try {
+      const fencePath = join(root, "fence.json");
+      const registryPath = join(root, "registry.json");
+      seedFence(fencePath, "chat-1", "msg-1");
+      writeFileSync(
+        registryPath,
+        JSON.stringify({
+          version: 1,
+          entries: {
+            "chat-1": {
+              claudeSessionId: "kimi-session-persisted",
+              lastActivity: new Date().toISOString(),
+              status: "suspended",
+            },
+          },
+        }),
+        "utf-8",
+      );
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      const sm = createSessionManager({ handler, ackEntry, registryPath, replayFencePath: fencePath });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1", messageId: "msg-1" }));
+
+      expect(handler.resume).not.toHaveBeenCalled();
+      expect(handler.start).not.toHaveBeenCalled();
+      expect(ackEntry).not.toHaveBeenCalled();
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("admits the same delivery once its fence was cleared by a settled completion", async () => {
+    const root = makeTmp();
+    try {
+      const fencePath = join(root, "fence.json");
+      seedFence(fencePath, "chat-1", "msg-1");
+      const cleared = new ReplayFenceStore(fencePath);
+      cleared.load();
+      cleared.clear("chat-1", "msg-1");
+      const handler = createMockHandler();
+      const sm = createSessionManager({ handler, replayFencePath: fencePath });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1", messageId: "msg-1" }));
+
+      expect(handler.start).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the fence store is corrupted", async () => {
+    const root = makeTmp();
+    try {
+      const fencePath = join(root, "fence.json");
+      writeFileSync(fencePath, "{ corrupted", "utf-8");
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      const log = recordingLogger();
+      const sm = createSessionManager({ handler, ackEntry, log: log.logger, replayFencePath: fencePath });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1", messageId: "msg-1" }));
+
+      expect(handler.start).not.toHaveBeenCalled();
+      expect(handler.resume).not.toHaveBeenCalled();
+      expect(ackEntry).not.toHaveBeenCalled();
+      expect(log.records.some((record) => typeof record.level === "number" && record.level >= 50)).toBe(true);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("hands the replay fence store to handlers through handlerConfig", async () => {
+    const root = makeTmp();
+    try {
+      const fencePath = join(root, "fence.json");
+      let captured: HandlerConfig | undefined;
+      const handler = createMockHandler();
+      const sm = createSessionManager({
+        replayFencePath: fencePath,
+        handlerFactory: (config) => {
+          captured = config;
+          return handler;
+        },
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1", messageId: "msg-1" }));
+
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      expect(captured?.replayFence).toBeInstanceOf(ReplayFenceStore);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3745,3 +3745,80 @@ describe("InboxDeliveryCoordinator fence-settled tombstones at high water", () =
     );
   });
 });
+
+describe("SessionManager pre-ledger settlement race", () => {
+  it("suppresses a frame parked before receive() while its fence is cleared by the probe", async () => {
+    const root = mkdtempSync(join(tmpdir(), "sm-pre-ledger-"));
+    try {
+      const fencePath = join(root, "fence.json");
+      const probeFencedSettlement = vi.fn(async (_chatId: string, _ids: readonly string[]) => ["msg-1"]);
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+      const handler = createMockHandler();
+      const ackEntry = mockAckEntry();
+      let capturedFence: ReplayFenceStore | undefined;
+      const sm = createSessionManager({
+        handler,
+        ackEntry,
+        replayFencePath: fencePath,
+        probeFencedSettlement,
+        recoverChat,
+        handlerFactory: (config) => {
+          capturedFence = config.replayFence as ReplayFenceStore;
+          return handler;
+        },
+      });
+
+      // A live session exists so its `suspending` promise can park dispatch.
+      await sm.dispatch(mockEntry({ id: 60, chatId: "chat-race", messageId: "msg-0" }));
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      // msg-1 was fenced mid-turn (the replay-risk delivery).
+      capturedFence?.fence({
+        chatId: "chat-race",
+        messageId: "msg-1",
+        provider: "kimi-code",
+        toolName: "Write",
+        toolUseId: "w1",
+        fencedAt: new Date().toISOString(),
+      });
+      let releaseSuspension: () => void = () => {};
+      const suspending = new Promise<void>((resolvePromise) => {
+        releaseSuspension = resolvePromise;
+      });
+      const internals = sm as unknown as {
+        sessions: Map<string, { suspending: Promise<void> | null }>;
+      };
+      const entry = internals.sessions.get("chat-race");
+      if (!entry) throw new Error("session entry missing");
+      entry.suspending = suspending;
+
+      // The frame arrives but dispatch is parked BEFORE receive() — the
+      // entry is not in the coordinator ledger yet.
+      const parked = sm.dispatch(mockEntry({ id: 61, chatId: "chat-race", messageId: "msg-1" }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The probe proves msg-1 settled while it is still pre-ledger, and
+      // the fence clears.
+      await sm.reconcileReplayFencesWithServer();
+      const reloaded = new ReplayFenceStore(fencePath);
+      reloaded.load();
+      expect(reloaded.hasFenceForChat("chat-race")).toBe(false);
+
+      // Release the suspension: the stale frame must be tombstoned at
+      // receive() — no route, no inject, no ACK, no second provider entry.
+      releaseSuspension();
+      await parked;
+      expect(handler.start).toHaveBeenCalledTimes(1);
+      expect(handler.inject).not.toHaveBeenCalled();
+      expect(ackEntry).not.toHaveBeenCalled();
+
+      // A genuinely unacked later message still flows through the now
+      // unfenced chat.
+      await sm.dispatch(mockEntry({ id: 62, chatId: "chat-race", messageId: "msg-2" }));
+      expect(handler.inject).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -68,8 +68,8 @@ type PendingInboxRecover = {
   ref: string;
   firstSentAt: number;
   timer: ReturnType<typeof setTimeout> | null;
-  promise: Promise<void>;
-  resolve: () => void;
+  promise: Promise<number>;
+  resolve: (resetCount: number) => void;
   reject: (err: Error) => void;
 };
 
@@ -629,9 +629,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * Ask the server to reset delivered-but-unacked entries for one chat and
    * redeliver them on this socket. Unlike ACKs, recovery is bounded: callers
    * must get an accepted/rejected/timeout outcome instead of waiting forever
-   * behind a per-chat recovery gate.
+   * behind a per-chat recovery gate. Resolves with the server's reset count —
+   * how many entries were still unacked — which is the only client-visible
+   * server ACK truth for crash-safe reconciliation (e.g. replay fences).
    */
-  sendInboxRecover(agentId: string, chatId: string): Promise<void> {
+  sendInboxRecover(agentId: string, chatId: string): Promise<number> {
     if (
       !this.ws ||
       this.ws.readyState !== WebSocket.OPEN ||
@@ -647,11 +649,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       ref: `recover_${randomUUID().slice(0, 12)}`,
       firstSentAt: Date.now(),
       timer: null,
-      promise: Promise.resolve(),
+      promise: Promise.resolve(0),
       resolve: () => {},
       reject: () => {},
     };
-    pending.promise = new Promise<void>((resolve, reject) => {
+    pending.promise = new Promise<number>((resolve, reject) => {
       pending.resolve = resolve;
       pending.reject = reject;
     });
@@ -851,7 +853,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       },
       "inbox:recover accepted",
     );
-    pending.resolve();
+    pending.resolve(resetCount);
   }
 
   private rejectPendingInboxRecover(pending: PendingInboxRecover, reason: string): void {

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -14,6 +14,8 @@ import {
   inboxAckAcceptedFrameSchema,
   inboxAckRejectedFrameSchema,
   inboxDeliverFrameSchema,
+  inboxFenceProbeAcceptedFrameSchema,
+  inboxFenceProbeRejectedFrameSchema,
   inboxRecoverAcceptedFrameSchema,
   inboxRecoverRejectedFrameSchema,
   PROVIDER_MODELS_LIST_TYPE,
@@ -73,18 +75,33 @@ type PendingInboxRecover = {
   reject: (err: Error) => void;
 };
 
+type PendingInboxFenceProbe = {
+  agentId: string;
+  chatId: string;
+  ref: string;
+  firstSentAt: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  promise: Promise<InboxFenceProbeResult>;
+  resolve: (result: InboxFenceProbeResult) => void;
+  reject: (err: Error) => void;
+};
+
+/** Result of a fence settlement probe: the probed ids proven settled server-side. */
+export type InboxFenceProbeResult = {
+  settledMessageIds: string[];
+};
+
 /**
  * Result of an accepted inbox recovery. `resetCount` only covers rows the
  * reset moved out of `delivered`; `unackedOutstanding` is the server's
  * authoritative pending+delivered backlog for the chat scope, and
- * `unackedMessageIds` its message-level form. Only `unackedOutstanding === 0`
+Only `unackedOutstanding === 0`
  * or an explicit id list may prove settlement; older servers omit them, and
  * absence must be treated as unknown, never as zero/empty.
  */
 export type InboxRecoverResult = {
   resetCount: number;
   unackedOutstanding?: number;
-  unackedMessageIds?: string[];
 };
 
 type PendingSessionEvent = {
@@ -535,6 +552,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   private readonly bindRetryRecords = new Map<string, BindRetryRecord>();
   private readonly pendingInboxAcks = new Map<number, PendingInboxAck>();
   private readonly pendingInboxRecovers = new Map<string, PendingInboxRecover>();
+  private readonly pendingInboxFenceProbes = new Map<string, PendingInboxFenceProbe>();
   private readonly pendingSessionEvents = new Map<string, PendingSessionEvent>();
   private readonly socketBoundAgentIds = new Set<string>();
 
@@ -688,6 +706,106 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       this.forceReconnectAfterInboxRecoverTimeout(pending);
     }, INBOX_RECOVER_CONFIRM_TIMEOUT_MS);
     return pending.promise;
+  }
+
+  /**
+   * Read-only settlement probe for concrete fenced deliveries. Resolves
+   * with the probed message ids the server proves settled (no unsettled
+   * notify row), computed inside the server's serialized recovery
+   * boundary. Bounded confirmation like recovery, but never destructive:
+   * no reset, no redelivery, and timeout only rejects.
+   */
+  sendInboxFenceProbe(agentId: string, chatId: string, messageIds: string[]): Promise<InboxFenceProbeResult> {
+    if (
+      !this.ws ||
+      this.ws.readyState !== WebSocket.OPEN ||
+      !this.registered ||
+      !this.socketBoundAgentIds.has(agentId)
+    ) {
+      return Promise.reject(new Error("inbox:fence-probe unavailable; socket not bound"));
+    }
+
+    const pending: PendingInboxFenceProbe = {
+      agentId,
+      chatId,
+      ref: `fenceprobe_${randomUUID().slice(0, 12)}`,
+      firstSentAt: Date.now(),
+      timer: null,
+      promise: Promise.resolve({ settledMessageIds: [] }),
+      resolve: () => {},
+      reject: () => {},
+    };
+    pending.promise = new Promise<InboxFenceProbeResult>((resolve, reject) => {
+      pending.resolve = resolve;
+      pending.reject = reject;
+    });
+    this.pendingInboxFenceProbes.set(pending.ref, pending);
+    this.ws.send(JSON.stringify({ type: "inbox:fence-probe", ref: pending.ref, agentId, chatId, messageIds }));
+    this.wsLogger.debug(
+      { agentId, chatId, ref: pending.ref, probeCount: messageIds.length, recoverEvent: "inbox_fence_probe_sent" },
+      "inbox:fence-probe sent",
+    );
+    pending.timer = setTimeout(() => {
+      if (!this.pendingInboxFenceProbes.has(pending.ref)) return;
+      this.pendingInboxFenceProbes.delete(pending.ref);
+      pending.reject(new Error("inbox:fence-probe confirmation timed out"));
+    }, INBOX_RECOVER_CONFIRM_TIMEOUT_MS);
+    return pending.promise;
+  }
+
+  private resolvePendingInboxFenceProbe(pending: PendingInboxFenceProbe, settledMessageIds: string[]): void {
+    this.clearPendingInboxFenceProbeTimer(pending);
+    this.pendingInboxFenceProbes.delete(pending.ref);
+    this.wsLogger.debug(
+      {
+        agentId: pending.agentId,
+        chatId: pending.chatId,
+        ref: pending.ref,
+        settledCount: settledMessageIds.length,
+        latencyMs: Date.now() - pending.firstSentAt,
+        recoverEvent: "inbox_fence_probe_accepted",
+      },
+      "inbox:fence-probe accepted",
+    );
+    pending.resolve({ settledMessageIds });
+  }
+
+  private rejectPendingInboxFenceProbe(pending: PendingInboxFenceProbe, reason: string): void {
+    this.clearPendingInboxFenceProbeTimer(pending);
+    this.pendingInboxFenceProbes.delete(pending.ref);
+    this.wsLogger.warn(
+      {
+        agentId: pending.agentId,
+        chatId: pending.chatId,
+        ref: pending.ref,
+        reason,
+        latencyMs: Date.now() - pending.firstSentAt,
+        recoverEvent: "inbox_fence_probe_rejected",
+      },
+      "inbox:fence-probe rejected",
+    );
+    pending.reject(new Error(`inbox:fence-probe rejected (${reason})`));
+  }
+
+  private clearPendingInboxFenceProbeTimer(pending: PendingInboxFenceProbe): void {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+      pending.timer = null;
+    }
+  }
+
+  private rejectAllPendingInboxFenceProbes(reason: string): void {
+    for (const pending of this.pendingInboxFenceProbes.values()) {
+      this.clearPendingInboxFenceProbeTimer(pending);
+      pending.reject(new Error(reason));
+    }
+    this.pendingInboxFenceProbes.clear();
+  }
+
+  private rejectPendingInboxFenceProbesForAgent(agentId: string, reason: string): void {
+    for (const pending of [...this.pendingInboxFenceProbes.values()]) {
+      if (pending.agentId === agentId) this.rejectPendingInboxFenceProbe(pending, reason);
+    }
   }
 
   private canSendClientFrame(): boolean {
@@ -857,7 +975,6 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     pending: PendingInboxRecover,
     resetCount: number,
     unackedOutstanding?: number,
-    unackedMessageIds?: string[],
   ): void {
     this.clearPendingInboxRecoverTimer(pending);
     this.pendingInboxRecovers.delete(pending.ref);
@@ -868,13 +985,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         ref: pending.ref,
         resetCount,
         unackedOutstanding,
-        unackedCount: unackedMessageIds?.length,
         latencyMs: Date.now() - pending.firstSentAt,
         recoverEvent: "inbox_recover_accepted",
       },
       "inbox:recover accepted",
     );
-    pending.resolve({ resetCount, unackedOutstanding, unackedMessageIds });
+    pending.resolve({ resetCount, unackedOutstanding });
   }
 
   private rejectPendingInboxRecover(pending: PendingInboxRecover, reason: string): void {
@@ -1033,6 +1149,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.socketBoundAgentIds.delete(agentId);
     this.rejectPendingInboxAcksForAgent(agentId, "agent_unbound");
     this.rejectPendingInboxRecoversForAgent(agentId, "agent_unbound");
+    this.rejectPendingInboxFenceProbesForAgent(agentId, "agent_unbound");
     this.rejectPendingSessionEventsForAgent(agentId, "agent_unbound");
     if (!shouldNotifyServer || !this.ws) return;
     this.ws.send(JSON.stringify({ type: "agent:unbind", agentId }));
@@ -1129,6 +1246,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.rejectAllPendingBinds("Client disconnected");
     this.rejectAllPendingInboxAcks("Client disconnected");
     this.rejectAllPendingInboxRecovers("Client disconnected");
+    this.rejectAllPendingInboxFenceProbes("Client disconnected");
     this.rejectAllPendingSessionEvents("Client disconnected");
     if (this.ws) {
       this.ws.removeAllListeners();
@@ -1294,6 +1412,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         this.socketBoundAgentIds.clear();
         this.rejectAllPendingBinds("WebSocket closed");
         this.rejectAllPendingInboxRecovers("WebSocket closed");
+        this.rejectAllPendingInboxFenceProbes("WebSocket closed");
         this.rejectAllPendingSessionEvents("WebSocket closed");
 
         if (!settled) {
@@ -1571,6 +1690,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       this.socketBoundAgentIds.delete(agentId);
       this.rejectPendingInboxAcksForAgent(agentId, "agent_unbound");
       this.rejectPendingInboxRecoversForAgent(agentId, "agent_unbound");
+      this.rejectPendingInboxFenceProbesForAgent(agentId, "agent_unbound");
       this.rejectPendingSessionEventsForAgent(agentId, "agent_unbound");
       this.emit("agent:unbound", agentId);
       return;
@@ -1761,12 +1881,43 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         );
         return;
       }
-      this.resolvePendingInboxRecover(
-        pending,
-        parsed.data.resetCount,
-        parsed.data.unackedOutstanding,
-        parsed.data.unackedMessageIds,
-      );
+      this.resolvePendingInboxRecover(pending, parsed.data.resetCount, parsed.data.unackedOutstanding);
+      return;
+    }
+
+    if (type === "inbox:fence-probe:accepted") {
+      const parsed = inboxFenceProbeAcceptedFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        this.wsLogger.warn(
+          { issues: parsed.error.issues.map((i) => i.message) },
+          "ignoring malformed inbox:fence-probe:accepted frame",
+        );
+        return;
+      }
+      const pending = this.pendingInboxFenceProbes.get(parsed.data.ref);
+      if (!pending || pending.agentId !== parsed.data.agentId || pending.chatId !== parsed.data.chatId) {
+        this.wsLogger.debug(
+          { agentId: parsed.data.agentId, chatId: parsed.data.chatId, ref: parsed.data.ref },
+          "inbox:fence-probe:accepted matched no pending probe",
+        );
+        return;
+      }
+      this.resolvePendingInboxFenceProbe(pending, parsed.data.settledMessageIds);
+      return;
+    }
+
+    if (type === "inbox:fence-probe:rejected") {
+      const parsed = inboxFenceProbeRejectedFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        this.wsLogger.warn(
+          { issues: parsed.error.issues.map((i) => i.message) },
+          "ignoring malformed inbox:fence-probe:rejected frame",
+        );
+        return;
+      }
+      const pending = this.pendingInboxFenceProbes.get(parsed.data.ref);
+      if (!pending) return;
+      this.rejectPendingInboxFenceProbe(pending, parsed.data.reason);
       return;
     }
 

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -68,9 +68,21 @@ type PendingInboxRecover = {
   ref: string;
   firstSentAt: number;
   timer: ReturnType<typeof setTimeout> | null;
-  promise: Promise<number>;
-  resolve: (resetCount: number) => void;
+  promise: Promise<InboxRecoverResult>;
+  resolve: (result: InboxRecoverResult) => void;
   reject: (err: Error) => void;
+};
+
+/**
+ * Result of an accepted inbox recovery. `resetCount` only covers rows the
+ * reset moved out of `delivered`; `unackedOutstanding` is the server's
+ * authoritative pending+delivered backlog for the chat scope, and is the
+ * only value that may prove settlement when it is zero. Older servers omit
+ * it — absence must be treated as unknown, never as zero.
+ */
+export type InboxRecoverResult = {
+  resetCount: number;
+  unackedOutstanding?: number;
 };
 
 type PendingSessionEvent = {
@@ -629,11 +641,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * Ask the server to reset delivered-but-unacked entries for one chat and
    * redeliver them on this socket. Unlike ACKs, recovery is bounded: callers
    * must get an accepted/rejected/timeout outcome instead of waiting forever
-   * behind a per-chat recovery gate. Resolves with the server's reset count —
-   * how many entries were still unacked — which is the only client-visible
-   * server ACK truth for crash-safe reconciliation (e.g. replay fences).
+   * behind a per-chat recovery gate. Resolves with the server's reset count
+   * plus (on new servers) the authoritative unacked outstanding count —
+   * the only client-visible server ACK truth for crash-safe reconciliation.
    */
-  sendInboxRecover(agentId: string, chatId: string): Promise<number> {
+  sendInboxRecover(agentId: string, chatId: string): Promise<InboxRecoverResult> {
     if (
       !this.ws ||
       this.ws.readyState !== WebSocket.OPEN ||
@@ -649,11 +661,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       ref: `recover_${randomUUID().slice(0, 12)}`,
       firstSentAt: Date.now(),
       timer: null,
-      promise: Promise.resolve(0),
+      promise: Promise.resolve({ resetCount: 0 }),
       resolve: () => {},
       reject: () => {},
     };
-    pending.promise = new Promise<number>((resolve, reject) => {
+    pending.promise = new Promise<InboxRecoverResult>((resolve, reject) => {
       pending.resolve = resolve;
       pending.reject = reject;
     });
@@ -839,7 +851,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     }
   }
 
-  private resolvePendingInboxRecover(pending: PendingInboxRecover, resetCount: number): void {
+  private resolvePendingInboxRecover(
+    pending: PendingInboxRecover,
+    resetCount: number,
+    unackedOutstanding?: number,
+  ): void {
     this.clearPendingInboxRecoverTimer(pending);
     this.pendingInboxRecovers.delete(pending.ref);
     this.wsLogger.debug(
@@ -848,12 +864,13 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         chatId: pending.chatId,
         ref: pending.ref,
         resetCount,
+        unackedOutstanding,
         latencyMs: Date.now() - pending.firstSentAt,
         recoverEvent: "inbox_recover_accepted",
       },
       "inbox:recover accepted",
     );
-    pending.resolve(resetCount);
+    pending.resolve({ resetCount, unackedOutstanding });
   }
 
   private rejectPendingInboxRecover(pending: PendingInboxRecover, reason: string): void {
@@ -1740,7 +1757,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         );
         return;
       }
-      this.resolvePendingInboxRecover(pending, parsed.data.resetCount);
+      this.resolvePendingInboxRecover(pending, parsed.data.resetCount, parsed.data.unackedOutstanding);
       return;
     }
 

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -76,13 +76,15 @@ type PendingInboxRecover = {
 /**
  * Result of an accepted inbox recovery. `resetCount` only covers rows the
  * reset moved out of `delivered`; `unackedOutstanding` is the server's
- * authoritative pending+delivered backlog for the chat scope, and is the
- * only value that may prove settlement when it is zero. Older servers omit
- * it — absence must be treated as unknown, never as zero.
+ * authoritative pending+delivered backlog for the chat scope, and
+ * `unackedMessageIds` its message-level form. Only `unackedOutstanding === 0`
+ * or an explicit id list may prove settlement; older servers omit them, and
+ * absence must be treated as unknown, never as zero/empty.
  */
 export type InboxRecoverResult = {
   resetCount: number;
   unackedOutstanding?: number;
+  unackedMessageIds?: string[];
 };
 
 type PendingSessionEvent = {
@@ -855,6 +857,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     pending: PendingInboxRecover,
     resetCount: number,
     unackedOutstanding?: number,
+    unackedMessageIds?: string[],
   ): void {
     this.clearPendingInboxRecoverTimer(pending);
     this.pendingInboxRecovers.delete(pending.ref);
@@ -865,12 +868,13 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         ref: pending.ref,
         resetCount,
         unackedOutstanding,
+        unackedCount: unackedMessageIds?.length,
         latencyMs: Date.now() - pending.firstSentAt,
         recoverEvent: "inbox_recover_accepted",
       },
       "inbox:recover accepted",
     );
-    pending.resolve({ resetCount, unackedOutstanding });
+    pending.resolve({ resetCount, unackedOutstanding, unackedMessageIds });
   }
 
   private rejectPendingInboxRecover(pending: PendingInboxRecover, reason: string): void {
@@ -1757,7 +1761,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         );
         return;
       }
-      this.resolvePendingInboxRecover(pending, parsed.data.resetCount, parsed.data.unackedOutstanding);
+      this.resolvePendingInboxRecover(
+        pending,
+        parsed.data.resetCount,
+        parsed.data.unackedOutstanding,
+        parsed.data.unackedMessageIds,
+      );
       return;
     }
 

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -49,6 +49,7 @@ import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { type ReconciledTeamSkill, reconcileManagedSkillsForConfig } from "../runtime/managed-skills.js";
 import { ProviderAttempt, type ProviderAttemptSettlement } from "../runtime/provider-attempt.js";
 import { maxProviderTurnRetryAttempts } from "../runtime/provider-retry-policy.js";
+import type { ReplayFenceWriter } from "../runtime/replay-fence.js";
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../runtime/source-repos.js";
 import { teamSkillBundleResolverFromSdk } from "../runtime/team-skill-bundle-resolver.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
@@ -119,8 +120,16 @@ type TurnObservation = {
   assistantText: string;
   ended: Extract<KimiEvent, { type: "turn.ended" }> | null;
   error: Error | null;
+  /**
+   * Set when the first unsafe tool effect could not be fenced durably. The
+   * turn must then settle as a terminal consumed error: continuing without a
+   * persisted fence would leave a crash-window where redelivery replays the
+   * effect.
+   */
+  fenceError: Error | null;
   thinkingEmitted: boolean;
   unsafeToolEffectStarted: boolean;
+  unsafeFenced: boolean;
 };
 
 type PreparedSession = {
@@ -215,6 +224,58 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
   const harnessFactory = (config.kimiHarnessFactory as KimiHarnessFactory | undefined) ?? createKimiHarness;
   const kaosFactory = (config.kimiKaosFactory as KimiKaosFactory | undefined) ?? (() => LocalKaos.create());
   const maxRetries = maxProviderTurnRetryAttempts();
+  const replayFence = (config.replayFence as ReplayFenceWriter | undefined) ?? null;
+
+  /**
+   * Durably fence every message of the current delivery the moment the first
+   * non-read-only tool call starts, so a crash after this point can never
+   * re-enter the provider for the same delivery. Returns the failure when the
+   * safety fact could not be persisted (or no store was wired) — callers must
+   * fail closed, never continue unfenced.
+   */
+  function fenceUnsafeDelivery(
+    chatId: string,
+    messages: readonly SessionMessage[],
+    toolName: string,
+    toolUseId: string,
+  ): Error | null {
+    if (!replayFence) return new Error("replay fence store is not configured");
+    for (const msg of messages) {
+      try {
+        replayFence.fence({
+          chatId,
+          messageId: msg.id,
+          provider: runtimeProvider,
+          toolName,
+          toolUseId,
+          fencedAt: new Date().toISOString(),
+        });
+      } catch (error) {
+        return error instanceof Error ? error : new Error(String(error));
+      }
+    }
+    return null;
+  }
+
+  /** Clear fences once their delivery's terminal settlement is confirmed. */
+  function clearFencedDelivery(
+    sessionCtx: SessionContext,
+    messages: readonly SessionMessage[],
+    completion: unknown,
+  ): void {
+    if (!replayFence || completion === "retry") return;
+    for (const msg of messages) {
+      try {
+        replayFence.clear(sessionCtx.chatId, msg.id);
+      } catch (error) {
+        // The delivery is ACKed, so no redelivery can re-enter it; a stale
+        // fence is benign but must be visible.
+        sessionCtx.log(
+          `kimi replay fence clear failed for ${msg.id}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
 
   let cwd: string | null = null;
   let ctx: SessionContext | null = null;
@@ -356,6 +417,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     attempt: ProviderAttempt,
     observation: TurnObservation,
     resolveEnded: () => void,
+    messages: readonly SessionMessage[],
   ): void {
     sessionCtx.recordProviderActivity();
     const isMainAgent = event.agentId === KIMI_MAIN_AGENT_ID;
@@ -385,7 +447,13 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
           refs: cwd ? nativeToolRefs(event.name, event.args, cwd) : [],
         };
         activeTools.set(toolUseId, tool);
-        if (!kimiToolIsReadOnly(event.name, event.args)) observation.unsafeToolEffectStarted = true;
+        if (!kimiToolIsReadOnly(event.name, event.args)) {
+          observation.unsafeToolEffectStarted = true;
+          if (!observation.unsafeFenced) {
+            observation.unsafeFenced = true;
+            observation.fenceError = fenceUnsafeDelivery(sessionCtx.chatId, messages, event.name, toolUseId);
+          }
+        }
         attempt.setReplaySafety(observation.unsafeToolEffectStarted ? "unsafe" : "pre_visible");
         emitToolCall(sessionCtx, toolUseId, tool, "pending");
         break;
@@ -421,13 +489,16 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     prompt: string,
     sessionCtx: SessionContext,
     attempt: ProviderAttempt,
+    messages: readonly SessionMessage[],
   ): Promise<TurnObservation> {
     const observation: TurnObservation = {
       assistantText: "",
       ended: null,
       error: null,
+      fenceError: null,
       thinkingEmitted: false,
       unsafeToolEffectStarted: false,
+      unsafeFenced: false,
     };
     let resolveEnded = (): void => {};
     const endedPromise = new Promise<void>((resolvePromise) => {
@@ -435,7 +506,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     });
     const unsubscribe = activeSession.onEvent((event) => {
       try {
-        processKimiEvent(event, sessionCtx, attempt, observation, resolveEnded);
+        processKimiEvent(event, sessionCtx, attempt, observation, resolveEnded, messages);
       } catch (error) {
         sessionCtx.log(`kimi event translation failed: ${error instanceof Error ? error.message : String(error)}`);
       }
@@ -521,13 +592,28 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       let observation: TurnObservation | null = null;
       let thrown: Error | null = null;
       try {
-        observation = await observeOneAttempt(activeSession, prompt, sessionCtx, attempt);
+        observation = await observeOneAttempt(activeSession, prompt, sessionCtx, attempt, messages);
       } catch (error) {
         thrown = error instanceof Error ? error : new Error(String(error));
       }
 
       if (!sessionActive) {
         token.retry(messages, "kimi_turn_cancelled");
+        return false;
+      }
+
+      if (observation?.fenceError) {
+        // Fail closed: the unsafe tool effect could not be fenced durably,
+        // so consume the delivery as a terminal error instead of leaving an
+        // unfenced crash window where redelivery would replay the effect.
+        const fenceMessage = `replay fence persistence failed: ${observation.fenceError.message}`;
+        sessionCtx.emitEvent({ kind: "error", payload: { source: "runtime", message: fenceMessage } });
+        sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+        await token.complete(messages, {
+          status: "error",
+          completion: "consumed",
+          reason: "replay_fence_persist_failed",
+        });
         return false;
       }
 
@@ -547,11 +633,17 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
             payload: { source: "runtime", message: `forward failed: ${message}` },
           });
           sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
-          await token.complete(messages, { status: "error", completion: "consumed", reason: "forward_failed" });
+          const forwardCompletion = await token.complete(messages, {
+            status: "error",
+            completion: "consumed",
+            reason: "forward_failed",
+          });
+          clearFencedDelivery(sessionCtx, messages, forwardCompletion);
           return false;
         }
         sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
-        await token.complete(messages, { status: "success" });
+        const completion = await token.complete(messages, { status: "success" });
+        clearFencedDelivery(sessionCtx, messages, completion);
         return true;
       }
 
@@ -591,11 +683,12 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       await emitUsage(sessionCtx, activeSession, usageBaseline);
       sessionCtx.emitEvent({ kind: "error", payload: { source: "sdk", message: formatted.slice(0, 2000) } });
       sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
-      await token.complete(messages, {
+      const failureCompletion = await token.complete(messages, {
         status: "error",
         completion: "consumed",
         reason: settlement.decision.reasonCode,
       });
+      clearFencedDelivery(sessionCtx, messages, failureCompletion);
       return false;
     }
 

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -163,28 +163,34 @@ function kimiEventError(event: { code: string; message: string; retryable?: bool
 }
 
 /**
- * Marker the patched SDK's event dispatch rethrows instead of swallowing
- * (`safeEmitLive`), so a failed replay-fence write aborts `prepareToolCall`
- * BEFORE the tool task starts. Without the marker the SDK's live-event path
- * catches listener errors and the unsafe effect would still execute.
+ * Host pre-effect hook the patched SDK invokes at its awaited
+ * `authorizeToolExecution` boundary — before any runnable tool task is
+ * created. Registered globally because the SDK bundle and this handler share
+ * one process, while the SDK's public RPC bridge cannot carry function
+ * values. The SDK converts a hook throw into a blocked tool call, so a
+ * failed replay-fence write provably stops the unsafe effect (the SDK's
+ * live-event path cannot deliver this guarantee: listener errors are
+ * swallowed and the event bridge is async).
  */
-const REPLAY_FENCE_BLOCK_FLAG = "__firstTreeReplayFenceBlock";
+type HostBeforeToolCallInfo = {
+  sessionId?: string;
+  agentId?: string;
+  toolName: string;
+  toolCallId: string;
+  args: unknown;
+};
 
-function replayFenceBlockError(cause: Error): Error {
-  const error = new Error(`replay fence persistence failed: ${cause.message}`) as Error & {
-    __firstTreeReplayFenceBlock?: boolean;
+const beforeToolCallHooks = new Map<string, (info: HostBeforeToolCallInfo) => void>();
+
+function ensureGlobalBeforeToolCallHook(): void {
+  const globalScope = globalThis as {
+    __firstTreeBeforeToolCall?: (info: HostBeforeToolCallInfo) => Promise<void> | void;
   };
-  error.name = "KimiReplayFenceError";
-  error[REPLAY_FENCE_BLOCK_FLAG] = true;
-  return error;
-}
-
-function isReplayFenceBlockError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as { __firstTreeReplayFenceBlock?: boolean })[REPLAY_FENCE_BLOCK_FLAG] === true
-  );
+  if (globalScope.__firstTreeBeforeToolCall) return;
+  globalScope.__firstTreeBeforeToolCall = (info) => {
+    const hook = typeof info.sessionId === "string" ? beforeToolCallHooks.get(info.sessionId) : undefined;
+    hook?.(info);
+  };
 }
 
 export function formatKimiCodeError(error: Error): string {
@@ -442,7 +448,6 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     attempt: ProviderAttempt,
     observation: TurnObservation,
     resolveEnded: () => void,
-    messages: readonly SessionMessage[],
   ): void {
     sessionCtx.recordProviderActivity();
     const isMainAgent = event.agentId === KIMI_MAIN_AGENT_ID;
@@ -472,19 +477,13 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
           refs: cwd ? nativeToolRefs(event.name, event.args, cwd) : [],
         };
         activeTools.set(toolUseId, tool);
-        if (!kimiToolIsReadOnly(event.name, event.args)) {
+        // The durable fence itself is written earlier, at the SDK's awaited
+        // authorize boundary (see the hook registered in observeOneAttempt),
+        // which also marks replay safety for calls it allows through. A call
+        // the hook just blocked (fenceError set) produced no effect, so it
+        // must not mark the turn unsafe.
+        if (!kimiToolIsReadOnly(event.name, event.args) && !observation.fenceError) {
           observation.unsafeToolEffectStarted = true;
-          if (!observation.unsafeFenced) {
-            observation.unsafeFenced = true;
-            const fenceFailure = fenceUnsafeDelivery(sessionCtx.chatId, messages, event.name, toolUseId);
-            if (fenceFailure) {
-              observation.fenceError = fenceFailure;
-              // Throw the marked error so the SDK aborts this tool call
-              // before the effect executes; the catch below only records
-              // the observation for settlement.
-              throw replayFenceBlockError(fenceFailure);
-            }
-          }
         }
         attempt.setReplaySafety(observation.unsafeToolEffectStarted ? "unsafe" : "pre_visible");
         emitToolCall(sessionCtx, toolUseId, tool, "pending");
@@ -538,20 +537,48 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     });
     const unsubscribe = activeSession.onEvent((event) => {
       try {
-        processKimiEvent(event, sessionCtx, attempt, observation, resolveEnded, messages);
+        processKimiEvent(event, sessionCtx, attempt, observation, resolveEnded);
       } catch (error) {
-        // Replay-fence blocks must propagate back into the SDK's tool
-        // dispatch so the unsafe effect never starts; every other listener
-        // error stays a local translation failure.
-        if (isReplayFenceBlockError(error)) throw error;
         sessionCtx.log(`kimi event translation failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     });
+    // Durably fence the delivery at the SDK's awaited authorize boundary —
+    // the only point where a persistence failure can still prevent the
+    // unsafe effect. The patched SDK converts a hook throw into a blocked
+    // tool call before the runnable task exists.
+    ensureGlobalBeforeToolCallHook();
+    beforeToolCallHooks.set(activeSession.id, beforeToolCallHook);
+    function beforeToolCallHook(info: HostBeforeToolCallInfo): void {
+      if (kimiToolIsReadOnly(info.toolName, info.args)) return;
+      if (observation.unsafeFenced) {
+        // A previous unsafe call was already fenced and allowed through.
+        observation.unsafeToolEffectStarted = true;
+        attempt.setReplaySafety("unsafe");
+        return;
+      }
+      observation.unsafeFenced = true;
+      const agentId = typeof info.agentId === "string" && info.agentId.length > 0 ? info.agentId : KIMI_MAIN_AGENT_ID;
+      const toolUseId = agentId === KIMI_MAIN_AGENT_ID ? info.toolCallId : `${agentId}:${info.toolCallId}`;
+      const fenceFailure = fenceUnsafeDelivery(sessionCtx.chatId, messages, info.toolName, toolUseId);
+      if (fenceFailure) {
+        // The throw makes the SDK block this call, so no unsafe effect has
+        // happened: deliberately do NOT mark replay safety unsafe here —
+        // settlement may safely retain custody for redelivery.
+        observation.fenceError = fenceFailure;
+        throw new Error(`replay fence persistence failed: ${fenceFailure.message}`);
+      }
+      // Fence persisted — the delivery is protected even if this effect
+      // executes and the process dies afterwards.
+      observation.unsafeToolEffectStarted = true;
+      attempt.setReplaySafety("unsafe");
+    }
     try {
       await activeSession.prompt(prompt);
       if (!observation.ended) await endedPromise;
       return observation;
     } finally {
+      if (beforeToolCallHooks.get(activeSession.id) === beforeToolCallHook)
+        beforeToolCallHooks.delete(activeSession.id);
       unsubscribe();
     }
   }
@@ -638,13 +665,13 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         return false;
       }
 
-      const fenceFailure = observation?.fenceError ?? (thrown && isReplayFenceBlockError(thrown) ? thrown : null);
+      const fenceFailure = observation?.fenceError ?? null;
       if (fenceFailure) {
-        // Fail closed: the unsafe tool call was aborted before its effect
-        // executed (the marked throw propagates through the SDK's tool
-        // dispatch), so custody here is purely about durability. Route the
-        // failure through the provider-attempt pipeline so a terminal
-        // settlement emits the durable provider-failure notice boundary
+        // Fail closed: the unsafe tool call was blocked at the SDK's awaited
+        // authorize boundary before its effect executed, so custody here is
+        // purely about durability. Route the failure through the
+        // provider-attempt pipeline so a terminal settlement emits the
+        // durable provider-failure notice boundary
         // before any consumed ACK.
         attempt.recordSignal({ kind: "local_error", error: fenceFailure });
         const fenceSettlement = attempt.settle({ attempt: attemptNumber });

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -162,6 +162,31 @@ function kimiEventError(event: { code: string; message: string; retryable?: bool
   return error;
 }
 
+/**
+ * Marker the patched SDK's event dispatch rethrows instead of swallowing
+ * (`safeEmitLive`), so a failed replay-fence write aborts `prepareToolCall`
+ * BEFORE the tool task starts. Without the marker the SDK's live-event path
+ * catches listener errors and the unsafe effect would still execute.
+ */
+const REPLAY_FENCE_BLOCK_FLAG = "__firstTreeReplayFenceBlock";
+
+function replayFenceBlockError(cause: Error): Error {
+  const error = new Error(`replay fence persistence failed: ${cause.message}`) as Error & {
+    __firstTreeReplayFenceBlock?: boolean;
+  };
+  error.name = "KimiReplayFenceError";
+  error[REPLAY_FENCE_BLOCK_FLAG] = true;
+  return error;
+}
+
+function isReplayFenceBlockError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { __firstTreeReplayFenceBlock?: boolean })[REPLAY_FENCE_BLOCK_FLAG] === true
+  );
+}
+
 export function formatKimiCodeError(error: Error): string {
   const record = error as Error & { code?: string };
   const combined = `${record.code ?? ""} ${error.message}`.trim();
@@ -451,7 +476,14 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
           observation.unsafeToolEffectStarted = true;
           if (!observation.unsafeFenced) {
             observation.unsafeFenced = true;
-            observation.fenceError = fenceUnsafeDelivery(sessionCtx.chatId, messages, event.name, toolUseId);
+            const fenceFailure = fenceUnsafeDelivery(sessionCtx.chatId, messages, event.name, toolUseId);
+            if (fenceFailure) {
+              observation.fenceError = fenceFailure;
+              // Throw the marked error so the SDK aborts this tool call
+              // before the effect executes; the catch below only records
+              // the observation for settlement.
+              throw replayFenceBlockError(fenceFailure);
+            }
           }
         }
         attempt.setReplaySafety(observation.unsafeToolEffectStarted ? "unsafe" : "pre_visible");
@@ -508,6 +540,10 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       try {
         processKimiEvent(event, sessionCtx, attempt, observation, resolveEnded, messages);
       } catch (error) {
+        // Replay-fence blocks must propagate back into the SDK's tool
+        // dispatch so the unsafe effect never starts; every other listener
+        // error stays a local translation failure.
+        if (isReplayFenceBlockError(error)) throw error;
         sessionCtx.log(`kimi event translation failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     });
@@ -602,18 +638,33 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         return false;
       }
 
-      if (observation?.fenceError) {
-        // Fail closed: the unsafe tool effect could not be fenced durably,
-        // so consume the delivery as a terminal error instead of leaving an
-        // unfenced crash window where redelivery would replay the effect.
-        const fenceMessage = `replay fence persistence failed: ${observation.fenceError.message}`;
-        sessionCtx.emitEvent({ kind: "error", payload: { source: "runtime", message: fenceMessage } });
-        sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
-        await token.complete(messages, {
-          status: "error",
-          completion: "consumed",
-          reason: "replay_fence_persist_failed",
-        });
+      const fenceFailure = observation?.fenceError ?? (thrown && isReplayFenceBlockError(thrown) ? thrown : null);
+      if (fenceFailure) {
+        // Fail closed: the unsafe tool call was aborted before its effect
+        // executed (the marked throw propagates through the SDK's tool
+        // dispatch), so custody here is purely about durability. Route the
+        // failure through the provider-attempt pipeline so a terminal
+        // settlement emits the durable provider-failure notice boundary
+        // before any consumed ACK.
+        attempt.recordSignal({ kind: "local_error", error: fenceFailure });
+        const fenceSettlement = attempt.settle({ attempt: attemptNumber });
+        if (fenceSettlement && fenceSettlement.decision.action !== "retry") {
+          emitSettlement(sessionCtx, fenceSettlement);
+          const formatted = formatKimiCodeError(fenceFailure);
+          await emitUsage(sessionCtx, activeSession, usageBaseline);
+          sessionCtx.emitEvent({ kind: "error", payload: { source: "sdk", message: formatted.slice(0, 2000) } });
+          sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+          const completion = await token.complete(messages, {
+            status: "error",
+            completion: "consumed",
+            reason: "replay_fence_persist_failed",
+          });
+          clearFencedDelivery(sessionCtx, messages, completion);
+          return false;
+        }
+        // Retryable/unclassified: retain custody. No effect was executed,
+        // so redelivery is safe once the fence store is healthy again.
+        token.retry(messages, "replay_fence_persist_failed");
         return false;
       }
 

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -70,8 +70,23 @@ type KimiManagedMcpSessionOptions = {
   readonly mcpServers?: Readonly<Record<string, KimiManagedMcpServer>>;
 };
 
-type KimiCreateSessionOptions = CreateSessionOptions & KimiManagedMcpSessionOptions;
-type KimiResumeSessionInput = ResumeSessionInput & KimiManagedMcpSessionOptions;
+// The pinned SDK applies `drainAgentTasksOnStop` on the create path only; a
+// pnpm patch (`patches/@botiverse__kimi-code-sdk@*.patch`) threads the same
+// flag through resume. Its declaration file predates the additive resume
+// field, so First Tree expresses it through a local intersection type.
+type KimiDrainSessionOption = { drainAgentTasksOnStop?: boolean };
+type KimiCreateSessionOptions = CreateSessionOptions & KimiManagedMcpSessionOptions & KimiDrainSessionOption;
+type KimiResumeSessionInput = ResumeSessionInput & KimiManagedMcpSessionOptions & KimiDrainSessionOption;
+
+// Hold the provider turn open until background subagents (`kind === "agent"`)
+// settle and the main agent has consumed their completions, so First Tree only
+// ACKs a delivery after the whole background workload is done.
+const KIMI_DRAIN_AGENT_TASKS_ON_STOP = true;
+
+// Only the main agent drives the logical parent turn: its text is chat output
+// and only its `turn.ended` may settle a delivery. Subagent events share the
+// same event stream while the drain flag keeps the turn open.
+const KIMI_MAIN_AGENT_ID = "main";
 
 export function mapKimiMcpServers(payload: AgentRuntimeConfigPayload): Record<string, KimiManagedMcpServer> {
   const servers: Record<string, KimiManagedMcpServer> = {};
@@ -343,43 +358,55 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     resolveEnded: () => void,
   ): void {
     sessionCtx.recordProviderActivity();
+    const isMainAgent = event.agentId === KIMI_MAIN_AGENT_ID;
     switch (event.type) {
       case "turn.started":
-        if (!observation.unsafeToolEffectStarted) attempt.setReplaySafety("pre_visible");
+        if (isMainAgent && !observation.unsafeToolEffectStarted) attempt.setReplaySafety("pre_visible");
         break;
       case "assistant.delta":
-        observation.assistantText += event.delta;
+        if (isMainAgent) observation.assistantText += event.delta;
         break;
       case "thinking.delta":
-        if (!observation.thinkingEmitted) {
+        if (isMainAgent && !observation.thinkingEmitted) {
           observation.thinkingEmitted = true;
           sessionCtx.emitEvent({ kind: "thinking", payload: {} });
         }
         break;
       case "tool.call.started": {
+        // Tool effects are real side effects regardless of which agent ran
+        // them, so keep every agent's calls observable. Namespace subagent ids
+        // so parallel child calls cannot collide with each other or the main
+        // agent's raw ids.
+        const toolUseId = isMainAgent ? event.toolCallId : `${event.agentId}:${event.toolCallId}`;
         const tool: ActiveTool = {
           name: event.name,
           args: event.args,
           startedAt: Date.now(),
           refs: cwd ? nativeToolRefs(event.name, event.args, cwd) : [],
         };
-        activeTools.set(event.toolCallId, tool);
+        activeTools.set(toolUseId, tool);
         if (!kimiToolIsReadOnly(event.name, event.args)) observation.unsafeToolEffectStarted = true;
         attempt.setReplaySafety(observation.unsafeToolEffectStarted ? "unsafe" : "pre_visible");
-        emitToolCall(sessionCtx, event.toolCallId, tool, "pending");
+        emitToolCall(sessionCtx, toolUseId, tool, "pending");
         break;
       }
       case "tool.result": {
-        const tool = activeTools.get(event.toolCallId);
+        const toolUseId = isMainAgent ? event.toolCallId : `${event.agentId}:${event.toolCallId}`;
+        const tool = activeTools.get(toolUseId);
         if (!tool) break;
-        emitToolCall(sessionCtx, event.toolCallId, tool, event.isError ? "error" : "ok", event.output);
-        activeTools.delete(event.toolCallId);
+        emitToolCall(sessionCtx, toolUseId, tool, event.isError ? "error" : "ok", event.output);
+        activeTools.delete(toolUseId);
         break;
       }
       case "error":
-        observation.error = kimiEventError(event);
+        if (isMainAgent) {
+          observation.error = kimiEventError(event);
+        } else {
+          sessionCtx.log(`kimi subagent ${event.agentId} error: ${event.message}`);
+        }
         break;
       case "turn.ended":
+        if (!isMainAgent) break;
         observation.ended = event;
         if (event.error) observation.error = kimiEventError(event.error);
         resolveEnded();
@@ -772,6 +799,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         kaos: prepared.kaos,
         additionalDirs: prepared.additionalDirs,
         roleAdditional: prepared.roleAdditional,
+        drainAgentTasksOnStop: KIMI_DRAIN_AGENT_TASKS_ON_STOP,
         ...(prepared.payload.model ? { model: prepared.payload.model } : {}),
         ...(prepared.payload.mcpServers.length > 0 ? { mcpServers } : {}),
       };
@@ -806,6 +834,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         kaos: prepared.kaos,
         additionalDirs: prepared.additionalDirs,
         roleAdditional: prepared.roleAdditional,
+        drainAgentTasksOnStop: KIMI_DRAIN_AGENT_TASKS_ON_STOP,
         ...(prepared.payload.mcpServers.length > 0 ? { mcpServers } : {}),
       };
       const kimiHome = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -271,6 +271,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     toolUseId: string,
   ): Error | null {
     if (!replayFence) return new Error("replay fence store is not configured");
+    const fencedMessageIds: string[] = [];
     for (const msg of messages) {
       try {
         replayFence.fence({
@@ -281,7 +282,19 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
           toolUseId,
           fencedAt: new Date().toISOString(),
         });
+        fencedMessageIds.push(msg.id);
       } catch (error) {
+        // Roll back the entries written by THIS call: the tool call is
+        // blocked, so no effect exists to protect, and a partial fence would
+        // wrongly mark the delivery as authorized (or strand the chat in
+        // permanent recovery debt once custody is retained).
+        for (const messageId of fencedMessageIds) {
+          try {
+            replayFence.clear(chatId, messageId);
+          } catch {
+            // A fence that cannot even be removed stays — conservative.
+          }
+        }
         return error instanceof Error ? error : new Error(String(error));
       }
     }
@@ -550,13 +563,19 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     beforeToolCallHooks.set(activeSession.id, beforeToolCallHook);
     function beforeToolCallHook(info: HostBeforeToolCallInfo): void {
       if (kimiToolIsReadOnly(info.toolName, info.args)) return;
+      if (observation.fenceError) {
+        // Fail-closed: a previous fence write failed in this attempt, so no
+        // later unsafe call may execute either — the SDK turns each throw
+        // into a blocked result and continues, and without this guard the
+        // next call would run unfenced.
+        throw new Error(`replay fence persistence failed: ${observation.fenceError.message}`);
+      }
       if (observation.unsafeFenced) {
         // A previous unsafe call was already fenced and allowed through.
         observation.unsafeToolEffectStarted = true;
         attempt.setReplaySafety("unsafe");
         return;
       }
-      observation.unsafeFenced = true;
       const agentId = typeof info.agentId === "string" && info.agentId.length > 0 ? info.agentId : KIMI_MAIN_AGENT_ID;
       const toolUseId = agentId === KIMI_MAIN_AGENT_ID ? info.toolCallId : `${agentId}:${info.toolCallId}`;
       const fenceFailure = fenceUnsafeDelivery(sessionCtx.chatId, messages, info.toolName, toolUseId);
@@ -567,8 +586,10 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         observation.fenceError = fenceFailure;
         throw new Error(`replay fence persistence failed: ${fenceFailure.message}`);
       }
-      // Fence persisted — the delivery is protected even if this effect
-      // executes and the process dies afterwards.
+      // Only now is the delivery durably authorized: every message of the
+      // delivery is fenced, so this effect may execute and later unsafe
+      // calls in the attempt may take the fenced fast path.
+      observation.unsafeFenced = true;
       observation.unsafeToolEffectStarted = true;
       attempt.setReplaySafety("unsafe");
     }

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -229,6 +229,13 @@ export class AgentSlot {
         // reconcile. Reconnects with an existing SessionManager are handled
         // here.
         if (!this.sessionManager) return;
+        // Replay-fence reconciliation on every (re)bind: an ACK committed
+        // while this client was offline can leave a stale fence the startup
+        // pass never revisits. Outstanding truth counts pending+delivered,
+        // so running it before the bind drain is safe.
+        void this.sessionManager.reconcileReplayFencesWithServer?.().catch((err) => {
+          this.logger.warn({ err }, "replay fence rebind reconciliation failed; keeping fences (fail-closed)");
+        });
         void this.refreshActiveRuntimeChatIds("bind").finally(() => {
           this.fullStateSync();
           this.scheduleActiveRuntimeChatIdsRefresh();

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -308,6 +308,7 @@ export class AgentSlot {
       this.throwIfRuntimeSessionTokenMutationFailed();
 
       const registryPath = join(defaultDataDir(), "sessions", `${this.config.name}.json`);
+      const replayFencePath = join(defaultDataDir(), "sessions", `${this.config.name}.replay-fence.json`);
 
       const ackEntry = (entryId: number) => this.clientConnection.sendInboxAck(entryId, agent.agentId);
       const recoverChat = (chatId: string) => this.clientConnection.sendInboxRecover(agent.agentId, chatId);
@@ -350,6 +351,7 @@ export class AgentSlot {
         sdk,
         log: this.logger,
         registryPath,
+        replayFencePath,
         agentConfigCache: this.agentConfigCache,
         runtimeSessionTokenFile: this.runtimeSessionTokenFile,
         ackEntry,

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -365,7 +365,10 @@ export class AgentSlot {
         runtimeSessionTokenFile: this.runtimeSessionTokenFile,
         ackEntry,
         recoverChat,
-        recoverChatWithCount: (chatId) => this.clientConnection.sendInboxRecover(agent.agentId, chatId),
+        probeFencedSettlement: async (chatId, messageIds) => {
+          const result = await this.clientConnection.sendInboxFenceProbe(agent.agentId, chatId, [...messageIds]);
+          return result.settledMessageIds;
+        },
         recoverRuntimeSessionProof: (reasonCode) => this.recoverRuntimeSessionProof(reasonCode),
         onStateChange: (chatId, state) => this.reportSessionState(chatId, state),
         onRuntimeStateChange: (state) => this.reportRuntimeState(state),

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -311,7 +311,9 @@ export class AgentSlot {
       const replayFencePath = join(defaultDataDir(), "sessions", `${this.config.name}.replay-fence.json`);
 
       const ackEntry = (entryId: number) => this.clientConnection.sendInboxAck(entryId, agent.agentId);
-      const recoverChat = (chatId: string) => this.clientConnection.sendInboxRecover(agent.agentId, chatId);
+      const recoverChat = async (chatId: string) => {
+        await this.clientConnection.sendInboxRecover(agent.agentId, chatId);
+      };
       const runtimeProvider = runtimeProviderSchema.safeParse(runtimeType);
 
       // Defer idle-suspend while a provider has a live background subprocess
@@ -356,6 +358,7 @@ export class AgentSlot {
         runtimeSessionTokenFile: this.runtimeSessionTokenFile,
         ackEntry,
         recoverChat,
+        recoverChatWithCount: (chatId) => this.clientConnection.sendInboxRecover(agent.agentId, chatId),
         recoverRuntimeSessionProof: (reasonCode) => this.recoverRuntimeSessionProof(reasonCode),
         onStateChange: (chatId, state) => this.reportSessionState(chatId, state),
         onRuntimeStateChange: (state) => this.reportRuntimeState(state),
@@ -400,6 +403,14 @@ export class AgentSlot {
           });
         }
       }
+
+      // Crash-safe replay-fence reconciliation: a fence whose delivery was
+      // ACKed just before a crash would otherwise stall its chat forever.
+      // Server ACK truth (inbox recovery reset count) decides; failures keep
+      // fences fail-closed. Optional-call: slot tests stub a partial manager.
+      await this.sessionManager.reconcileReplayFencesWithServer?.().catch((err) => {
+        this.logger.warn({ err }, "replay fence startup reconciliation failed; keeping fences (fail-closed)");
+      });
 
       await this.refreshActiveRuntimeChatIds("startup");
       // Initial-startup fullStateSync. The `on("agent:bound", onBound)`

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -284,10 +284,15 @@ export class InboxDeliveryCoordinator {
    * keeping them would let a stray duplicate frame re-admit an
    * already-settled unsafe delivery into the provider.
    */
-  settleReplayFencedEntries(chatId: string, messageIds: readonly string[]): void {
-    // Register the settlement fact for EVERY proven id first — independent
-    // of whether a ledger entry exists yet (a frame may still be parked
-    // before receive()).
+  /**
+   * Register the settlement fact for proven-settled deliveries. This is
+   * THE shared suppression boundary for every server-proven settlement of
+   * a fenced delivery — probe or confirmed ACK — and must run BEFORE the
+   * local fence is cleared, so a later stale frame is suppressed at
+   * receive() instead of resuming the provider. Independent of ledger
+   * membership (a frame may still be parked before receive()).
+   */
+  markFenceSettled(chatId: string, messageIds: readonly string[]): void {
     let markers = this.fenceSettledMessages.get(chatId);
     if (!markers) {
       markers = new Set();
@@ -302,6 +307,10 @@ export class InboxDeliveryCoordinator {
         "fence-settled marker set exceeds the defensive bound; refusing to evict safety markers",
       );
     }
+  }
+
+  settleReplayFencedEntries(chatId: string, messageIds: readonly string[]): void {
+    this.markFenceSettled(chatId, messageIds);
     const ledger = this.ledgers.get(chatId);
     if (!ledger) return;
     const ids = new Set(messageIds);

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -68,6 +68,13 @@ type InboxDeliveryCoordinatorConfig = {
   ackEntry: (entryId: number) => Promise<void>;
   recoverChat?: (chatId: string) => Promise<void>;
   onWorkChanged: (chatId: string) => void;
+  /**
+   * Called after concrete ledger entries are durably committed through a
+   * confirmed ACK — including the recovery/redelivery retry path, which is
+   * the only settlement route left when the original completion could not
+   * ACK. Consumers reconcile per-delivery safety facts (replay fences) here.
+   */
+  onDeliveriesCommitted?: (chatId: string, messageIds: readonly string[]) => void;
   log: pino.Logger;
 };
 
@@ -555,6 +562,12 @@ export class InboxDeliveryCoordinator {
       this.deduplicator.drop(tracked.dedupKey);
       this.recentlySettled.isDuplicate(
         this.settledKey({ chatId, entryId: tracked.entryId, messageId: tracked.messageId }),
+      );
+    }
+    if (committed.length > 0) {
+      this.config.onDeliveriesCommitted?.(
+        chatId,
+        committed.map((tracked) => tracked.messageId),
       );
     }
     if (current.entries.length === 0 && current.recoveryDebt === "required") {

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -15,9 +15,7 @@ export type DeliveryWork = {
 };
 
 export type DeliveryDecision =
-  // `readmitted` marks a previously fence-withheld entry re-admitted for a
-  // fresh route-gate evaluation, so recovery-debt FIFO gates let it pass.
-  | { kind: "deliver"; work: DeliveryWork; readmitted?: boolean }
+  | { kind: "deliver"; work: DeliveryWork }
   | { kind: "duplicate-in-flight" }
   | { kind: "recovering" };
 
@@ -34,6 +32,11 @@ export type WorkSnapshot = {
 };
 
 type DeliveryPhase = "open" | "owned" | "terminal";
+
+/** Tombstone retention for fence-probe-settled deliveries (stale frames are short-lived socket duplicates). */
+const FENCE_SETTLED_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000;
+/** Per-chat tombstone cap — safely above the supported max-in-flight high water (1024). */
+const FENCE_SETTLED_TOMBSTONE_MAX_PER_CHAT = 4096;
 type RecoveryDebt = "none" | "required" | "running";
 
 type TrackedDelivery = {
@@ -96,8 +99,15 @@ export class InboxDeliveryCoordinator {
    * recentlySettled: committed entries deliberately allow one post-commit
    * reprocess (ack-lost recovery), while a probe-settled unsafe delivery
    * must never re-enter the provider from a stray frame.
+   *
+   * Safety-critical capacity: keyed PER CHAT so unrelated chats cannot
+   * evict each other, and capped per chat well above the supported
+   * max-in-flight high water (1024) — a shared FIFO dedup below that mark
+   * would silently drop the oldest tombstone exactly when it is needed.
+   * Entries expire after one day; stale frames for an ACKed row are only
+   * ever socket duplicates shortly after settlement.
    */
-  private readonly fenceSettledKeys = new Deduplicator(1000);
+  private readonly fenceSettledTombstones = new Map<string, Map<string, number>>();
   private readonly ledgers = new Map<string, ChatInboxLedger>();
   private readonly recoveringChats = new Map<string, Promise<void>>();
 
@@ -122,7 +132,7 @@ export class InboxDeliveryCoordinator {
         // the flag is consumed here).
         activeByEntryId.replayFencedWithheld = undefined;
         this.emitWorkChanged(chatId);
-        return { kind: "deliver", work: { chatId, entryId: entry.id, messageId }, readmitted: true };
+        return { kind: "deliver", work: { chatId, entryId: entry.id, messageId } };
       }
       this.config.log.debug(
         { chatId, messageId, entryId: entry.id, phase: activeByEntryId.phase },
@@ -138,7 +148,7 @@ export class InboxDeliveryCoordinator {
 
     // Tombstone: this exact delivery was proven settled by a fence probe —
     // suppress stray duplicate frames instead of reprocessing.
-    if (this.fenceSettledKeys.has(this.settledKey({ chatId, entryId: entry.id, messageId }))) {
+    if (this.hasFenceSettledTombstone(chatId, entry.id, messageId)) {
       this.config.log.debug({ chatId, messageId, entryId: entry.id }, "suppressing frame for already-settled delivery");
       return { kind: "duplicate-in-flight" };
     }
@@ -278,9 +288,7 @@ export class InboxDeliveryCoordinator {
     const ids = new Set(messageIds);
     for (const tracked of ledger.entries) {
       if (ids.has(tracked.messageId)) {
-        this.fenceSettledKeys.isDuplicate(
-          this.settledKey({ chatId, entryId: tracked.entryId, messageId: tracked.messageId }),
-        );
+        this.addFenceSettledTombstone(chatId, tracked.entryId, tracked.messageId);
       }
     }
     ledger.entries = ledger.entries.filter((tracked) => !ids.has(tracked.messageId));
@@ -769,6 +777,42 @@ export class InboxDeliveryCoordinator {
 
   private dedupKey(chatId: string, messageId: string): string {
     return `${chatId}:${messageId}`;
+  }
+
+  private addFenceSettledTombstone(chatId: string, entryId: number, messageId: string): void {
+    let tombstones = this.fenceSettledTombstones.get(chatId);
+    if (!tombstones) {
+      tombstones = new Map();
+      this.fenceSettledTombstones.set(chatId, tombstones);
+    }
+    this.pruneFenceSettledTombstones(tombstones);
+    tombstones.set(this.settledKey({ chatId, entryId, messageId }), Date.now() + FENCE_SETTLED_TOMBSTONE_TTL_MS);
+  }
+
+  private hasFenceSettledTombstone(chatId: string, entryId: number, messageId: string): boolean {
+    const tombstones = this.fenceSettledTombstones.get(chatId);
+    if (!tombstones) return false;
+    const key = this.settledKey({ chatId, entryId, messageId });
+    const expiresAt = tombstones.get(key);
+    if (expiresAt === undefined) return false;
+    if (expiresAt <= Date.now()) {
+      tombstones.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  /** Drop expired entries, then bound the per-chat size beyond the supported high water. */
+  private pruneFenceSettledTombstones(tombstones: Map<string, number>): void {
+    const now = Date.now();
+    for (const [key, expiresAt] of tombstones) {
+      if (expiresAt <= now) tombstones.delete(key);
+    }
+    while (tombstones.size >= FENCE_SETTLED_TOMBSTONE_MAX_PER_CHAT) {
+      const oldest = tombstones.keys().next().value;
+      if (oldest === undefined) break;
+      tombstones.delete(oldest);
+    }
   }
 
   private settledKey(work: DeliveryWork): string {

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -1,7 +1,12 @@
 import type { InboxEntryWithMessage } from "@first-tree/shared";
 import type { pino } from "../observability/logger.js";
 import { Deduplicator } from "./deduplicator.js";
-import type { SessionMessage, TerminalRejectionEvidence, TurnOutcome } from "./handler.js";
+import type {
+  DeliveryCompletionDisposition,
+  SessionMessage,
+  TerminalRejectionEvidence,
+  TurnOutcome,
+} from "./handler.js";
 
 export type DeliveryWork = {
   chatId: string;
@@ -56,7 +61,7 @@ type ChatInboxLedger = {
   // keep classifying that burst as recovery while any redelivered work is unsettled.
   recoveryWindowOpen: boolean;
   admissionQueue: Promise<void> | null;
-  ackQueue: Promise<void> | null;
+  ackQueue: Promise<unknown> | null;
 };
 
 type InboxDeliveryCoordinatorConfig = {
@@ -246,14 +251,20 @@ export class InboxDeliveryCoordinator {
     chatId: string,
     messages: SessionMessage | readonly SessionMessage[],
     outcome: TurnOutcome,
-  ): Promise<void> {
+  ): Promise<DeliveryCompletionDisposition> {
     const throughEntryId = this.lastMessageEntryId(chatId, messages);
     if (throughEntryId === undefined) {
       this.config.log.warn({ chatId }, "turn completion ignored because no inboxEntryId was provided");
-      return;
+      return "retry";
     }
     this.markTerminal(chatId, messages, outcome);
-    await this.ackThrough(chatId, throughEntryId, "finish_turn", { requireTerminalPrefix: true });
+    // The completion is only "settled" once the concrete entries have left
+    // the ledger through a confirmed ACK. ACK rejection, recovery debt, and
+    // non-terminal prefix gaps all retain server custody and must surface as
+    // "retry" so callers (e.g. replay-fence cleanup) do not treat the
+    // delivery as durably finished.
+    const committed = await this.ackThrough(chatId, throughEntryId, "finish_turn", { requireTerminalPrefix: true });
+    return committed ? "settled" : "retry";
   }
 
   async terminalRejected(
@@ -451,11 +462,11 @@ export class InboxDeliveryCoordinator {
     throughEntryId: number,
     reason: string,
     opts: { requireTerminalPrefix?: boolean; requestRecoveryOnAckFailure?: boolean } = {},
-  ): Promise<void> {
+  ): Promise<boolean> {
     const ledger = this.ledgers.get(chatId);
-    if (!ledger) return;
-    const prev = ledger.ackQueue ?? Promise.resolve();
-    const next = prev.catch(() => undefined).then(() => this.ackThroughNow(chatId, throughEntryId, reason, opts));
+    if (!ledger) return false;
+    const prev: Promise<unknown> = ledger.ackQueue ?? Promise.resolve(false);
+    const next = prev.catch(() => false).then(() => this.ackThroughNow(chatId, throughEntryId, reason, opts));
     const queueMarker = next.then(
       () => {},
       () => {},
@@ -463,7 +474,7 @@ export class InboxDeliveryCoordinator {
     ledger.ackQueue = queueMarker;
     this.emitWorkChanged(chatId);
     try {
-      await next;
+      return await next;
     } finally {
       if (ledger.ackQueue === queueMarker) {
         ledger.ackQueue = null;
@@ -478,20 +489,20 @@ export class InboxDeliveryCoordinator {
     throughEntryId: number,
     reason: string,
     opts: { requireTerminalPrefix?: boolean; requestRecoveryOnAckFailure?: boolean },
-  ): Promise<void> {
+  ): Promise<boolean> {
     const ledger = this.ledgers.get(chatId);
-    if (!ledger || ledger.entries.length === 0) return;
+    if (!ledger || ledger.entries.length === 0) return false;
     if (ledger.recoveryDebt !== "none") {
       this.config.log.debug(
         { chatId, throughEntryId, reason },
         "ACK-through deferred because chat recovery is required",
       );
-      return;
+      return false;
     }
     const index = ledger.entries.findIndex((tracked) => tracked.entryId === throughEntryId);
     if (index < 0) {
       this.config.log.warn({ chatId, throughEntryId, reason }, "attempt completion ignored for untracked inbox entry");
-      return;
+      return false;
     }
 
     const ackPrefix = ledger.entries.slice(0, index + 1);
@@ -506,7 +517,7 @@ export class InboxDeliveryCoordinator {
         "ACK-through blocked because delivery prefix has non-terminal entries",
       );
       await this.markRecoveryDebt(chatId, `${reason}:non_terminal_prefix_gap`);
-      return;
+      return false;
     }
     let changed = false;
     for (const tracked of ackPrefix) {
@@ -533,11 +544,11 @@ export class InboxDeliveryCoordinator {
       void this.markRecoveryDebt(chatId, `${reason}:ack_failed`, {
         requestNow: opts.requestRecoveryOnAckFailure ?? true,
       });
-      return;
+      return false;
     }
 
     const current = this.ledgers.get(chatId);
-    if (!current) return;
+    if (!current) return false;
     const committed = current.entries.filter((tracked) => tracked.entryId <= throughEntryId);
     current.entries = current.entries.filter((tracked) => tracked.entryId > throughEntryId);
     for (const tracked of committed) {
@@ -551,6 +562,7 @@ export class InboxDeliveryCoordinator {
     }
     this.cleanupLedger(chatId);
     this.emitWorkChanged(chatId);
+    return true;
   }
 
   private async markRecoveryDebt(chatId: string, reason: string, opts: { requestNow?: boolean } = {}): Promise<void> {

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -51,6 +51,13 @@ type TrackedDelivery = {
     reason: string;
     startedAt: number;
   };
+  /**
+   * Set when the replay-fence gate withheld this delivery before any route
+   * ownership or processing started. A later redelivery of such an entry
+   * must be re-admitted (not swallowed as duplicate-in-flight) once the
+   * fence is gone — the server row is the only durable copy.
+   */
+  replayFencedWithheld?: boolean;
 };
 
 type ChatInboxLedger = {
@@ -100,6 +107,14 @@ export class InboxDeliveryCoordinator {
 
     const activeByEntryId = ledger.entries.find((tracked) => tracked.entryId === entry.id);
     if (activeByEntryId) {
+      if (activeByEntryId.replayFencedWithheld) {
+        // Previously withheld by the replay-fence gate before any custody:
+        // re-admit so the route gate can re-evaluate (exactly-once, since
+        // the flag is consumed here).
+        activeByEntryId.replayFencedWithheld = undefined;
+        this.emitWorkChanged(chatId);
+        return { kind: "deliver", work: { chatId, entryId: entry.id, messageId } };
+      }
       this.config.log.debug(
         { chatId, messageId, entryId: entry.id, phase: activeByEntryId.phase },
         "redelivery observed for active ledger entry",
@@ -216,6 +231,23 @@ export class InboxDeliveryCoordinator {
     };
     void next.then(cleanup, cleanup);
     return next;
+  }
+
+  /**
+   * Mark ledger entries withheld by the replay-fence gate (no custody
+   * taken). Their next redelivery is re-admitted instead of swallowed as
+   * duplicate-in-flight — the only path that lets server redelivery drive a
+   * withheld delivery once its fence clears.
+   */
+  markReplayFenceWithheld(chatId: string, messageIds: readonly string[]): void {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger) return;
+    const ids = new Set(messageIds);
+    for (const tracked of ledger.entries) {
+      if (ids.has(tracked.messageId) && tracked.phase === "open" && tracked.processingStartedAt === undefined) {
+        tracked.replayFencedWithheld = true;
+      }
+    }
   }
 
   markOwned(work: DeliveryWork): DeliveryRouteOwnership {

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -250,6 +250,21 @@ export class InboxDeliveryCoordinator {
     }
   }
 
+  /**
+   * Drop ledger entries the server proved durably settled (fence probe).
+   * The client never observed their ACK, but the server is authoritative:
+   * keeping them would let a stray duplicate frame re-admit an
+   * already-settled unsafe delivery into the provider.
+   */
+  settleReplayFencedEntries(chatId: string, messageIds: readonly string[]): void {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger) return;
+    const ids = new Set(messageIds);
+    ledger.entries = ledger.entries.filter((tracked) => !ids.has(tracked.messageId));
+    this.cleanupLedger(chatId);
+    this.emitWorkChanged(chatId);
+  }
+
   markOwned(work: DeliveryWork): DeliveryRouteOwnership {
     const tracked = this.findEntry(work.chatId, work.entryId);
     if (!tracked) {

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -15,7 +15,9 @@ export type DeliveryWork = {
 };
 
 export type DeliveryDecision =
-  | { kind: "deliver"; work: DeliveryWork }
+  // `readmitted` marks a previously fence-withheld entry re-admitted for a
+  // fresh route-gate evaluation, so recovery-debt FIFO gates let it pass.
+  | { kind: "deliver"; work: DeliveryWork; readmitted?: boolean }
   | { kind: "duplicate-in-flight" }
   | { kind: "recovering" };
 
@@ -89,6 +91,13 @@ export class InboxDeliveryCoordinator {
   private readonly config: InboxDeliveryCoordinatorConfig;
   private readonly deduplicator = new Deduplicator(1000);
   private readonly recentlySettled = new Deduplicator(1000);
+  /**
+   * Tombstones for fence-probe-settled deliveries. Distinct from
+   * recentlySettled: committed entries deliberately allow one post-commit
+   * reprocess (ack-lost recovery), while a probe-settled unsafe delivery
+   * must never re-enter the provider from a stray frame.
+   */
+  private readonly fenceSettledKeys = new Deduplicator(1000);
   private readonly ledgers = new Map<string, ChatInboxLedger>();
   private readonly recoveringChats = new Map<string, Promise<void>>();
 
@@ -113,7 +122,7 @@ export class InboxDeliveryCoordinator {
         // the flag is consumed here).
         activeByEntryId.replayFencedWithheld = undefined;
         this.emitWorkChanged(chatId);
-        return { kind: "deliver", work: { chatId, entryId: entry.id, messageId } };
+        return { kind: "deliver", work: { chatId, entryId: entry.id, messageId }, readmitted: true };
       }
       this.config.log.debug(
         { chatId, messageId, entryId: entry.id, phase: activeByEntryId.phase },
@@ -124,6 +133,13 @@ export class InboxDeliveryCoordinator {
           requireTerminalPrefix: true,
         });
       }
+      return { kind: "duplicate-in-flight" };
+    }
+
+    // Tombstone: this exact delivery was proven settled by a fence probe —
+    // suppress stray duplicate frames instead of reprocessing.
+    if (this.fenceSettledKeys.has(this.settledKey({ chatId, entryId: entry.id, messageId }))) {
+      this.config.log.debug({ chatId, messageId, entryId: entry.id }, "suppressing frame for already-settled delivery");
       return { kind: "duplicate-in-flight" };
     }
 
@@ -260,6 +276,13 @@ export class InboxDeliveryCoordinator {
     const ledger = this.ledgers.get(chatId);
     if (!ledger) return;
     const ids = new Set(messageIds);
+    for (const tracked of ledger.entries) {
+      if (ids.has(tracked.messageId)) {
+        this.fenceSettledKeys.isDuplicate(
+          this.settledKey({ chatId, entryId: tracked.entryId, messageId: tracked.messageId }),
+        );
+      }
+    }
     ledger.entries = ledger.entries.filter((tracked) => !ids.has(tracked.messageId));
     this.cleanupLedger(chatId);
     this.emitWorkChanged(chatId);

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -33,10 +33,12 @@ export type WorkSnapshot = {
 
 type DeliveryPhase = "open" | "owned" | "terminal";
 
-/** Tombstone retention for fence-probe-settled deliveries (stale frames are short-lived socket duplicates). */
-const FENCE_SETTLED_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000;
-/** Per-chat tombstone cap — safely above the supported max-in-flight high water (1024). */
-const FENCE_SETTLED_TOMBSTONE_MAX_PER_CHAT = 4096;
+/**
+ * Defensive per-chat bound for fence-settled markers. Practically
+ * unreachable — markers only exist for unsafe-interrupted deliveries —
+ * and eviction would be a safety hole, so overflow only logs loudly.
+ */
+const FENCE_SETTLED_MARKER_WARN_PER_CHAT = 16384;
 type RecoveryDebt = "none" | "required" | "running";
 
 type TrackedDelivery = {
@@ -95,19 +97,19 @@ export class InboxDeliveryCoordinator {
   private readonly deduplicator = new Deduplicator(1000);
   private readonly recentlySettled = new Deduplicator(1000);
   /**
-   * Tombstones for fence-probe-settled deliveries. Distinct from
+   * Settlement markers for fence-probe-settled deliveries, keyed by
+   * (chatId, messageId) — the delivery's ackable identity. Registered
+   * UNCONDITIONALLY at settlement proof, independent of ledger membership:
+   * a frame parked before receive() (e.g. behind a suspending session)
+   * must be just as suppressed as a tracked one. Distinct from
    * recentlySettled: committed entries deliberately allow one post-commit
    * reprocess (ack-lost recovery), while a probe-settled unsafe delivery
    * must never re-enter the provider from a stray frame.
    *
-   * Safety-critical capacity: keyed PER CHAT so unrelated chats cannot
-   * evict each other, and capped per chat well above the supported
-   * max-in-flight high water (1024) — a shared FIFO dedup below that mark
-   * would silently drop the oldest tombstone exactly when it is needed.
-   * Entries expire after one day; stale frames for an ACKed row are only
-   * ever socket duplicates shortly after settlement.
+   * No wall-clock expiry: a clock jump must never authorize an unsafe
+   * re-entry. Fences are exceptional, so the set stays tiny in practice.
    */
-  private readonly fenceSettledTombstones = new Map<string, Map<string, number>>();
+  private readonly fenceSettledMessages = new Map<string, Set<string>>();
   private readonly ledgers = new Map<string, ChatInboxLedger>();
   private readonly recoveringChats = new Map<string, Promise<void>>();
 
@@ -146,9 +148,9 @@ export class InboxDeliveryCoordinator {
       return { kind: "duplicate-in-flight" };
     }
 
-    // Tombstone: this exact delivery was proven settled by a fence probe —
-    // suppress stray duplicate frames instead of reprocessing.
-    if (this.hasFenceSettledTombstone(chatId, entry.id, messageId)) {
+    // Settlement marker: this delivery was proven settled by a fence probe —
+    // suppress stray frames instead of reprocessing them into the provider.
+    if (this.fenceSettledMessages.get(chatId)?.has(messageId)) {
       this.config.log.debug({ chatId, messageId, entryId: entry.id }, "suppressing frame for already-settled delivery");
       return { kind: "duplicate-in-flight" };
     }
@@ -283,14 +285,26 @@ export class InboxDeliveryCoordinator {
    * already-settled unsafe delivery into the provider.
    */
   settleReplayFencedEntries(chatId: string, messageIds: readonly string[]): void {
+    // Register the settlement fact for EVERY proven id first — independent
+    // of whether a ledger entry exists yet (a frame may still be parked
+    // before receive()).
+    let markers = this.fenceSettledMessages.get(chatId);
+    if (!markers) {
+      markers = new Set();
+      this.fenceSettledMessages.set(chatId, markers);
+    }
+    for (const messageId of messageIds) {
+      markers.add(messageId);
+    }
+    if (markers.size > FENCE_SETTLED_MARKER_WARN_PER_CHAT) {
+      this.config.log.error(
+        { chatId, count: markers.size },
+        "fence-settled marker set exceeds the defensive bound; refusing to evict safety markers",
+      );
+    }
     const ledger = this.ledgers.get(chatId);
     if (!ledger) return;
     const ids = new Set(messageIds);
-    for (const tracked of ledger.entries) {
-      if (ids.has(tracked.messageId)) {
-        this.addFenceSettledTombstone(chatId, tracked.entryId, tracked.messageId);
-      }
-    }
     ledger.entries = ledger.entries.filter((tracked) => !ids.has(tracked.messageId));
     this.cleanupLedger(chatId);
     this.emitWorkChanged(chatId);
@@ -777,42 +791,6 @@ export class InboxDeliveryCoordinator {
 
   private dedupKey(chatId: string, messageId: string): string {
     return `${chatId}:${messageId}`;
-  }
-
-  private addFenceSettledTombstone(chatId: string, entryId: number, messageId: string): void {
-    let tombstones = this.fenceSettledTombstones.get(chatId);
-    if (!tombstones) {
-      tombstones = new Map();
-      this.fenceSettledTombstones.set(chatId, tombstones);
-    }
-    this.pruneFenceSettledTombstones(tombstones);
-    tombstones.set(this.settledKey({ chatId, entryId, messageId }), Date.now() + FENCE_SETTLED_TOMBSTONE_TTL_MS);
-  }
-
-  private hasFenceSettledTombstone(chatId: string, entryId: number, messageId: string): boolean {
-    const tombstones = this.fenceSettledTombstones.get(chatId);
-    if (!tombstones) return false;
-    const key = this.settledKey({ chatId, entryId, messageId });
-    const expiresAt = tombstones.get(key);
-    if (expiresAt === undefined) return false;
-    if (expiresAt <= Date.now()) {
-      tombstones.delete(key);
-      return false;
-    }
-    return true;
-  }
-
-  /** Drop expired entries, then bound the per-chat size beyond the supported high water. */
-  private pruneFenceSettledTombstones(tombstones: Map<string, number>): void {
-    const now = Date.now();
-    for (const [key, expiresAt] of tombstones) {
-      if (expiresAt <= now) tombstones.delete(key);
-    }
-    while (tombstones.size >= FENCE_SETTLED_TOMBSTONE_MAX_PER_CHAT) {
-      const oldest = tombstones.keys().next().value;
-      if (oldest === undefined) break;
-      tombstones.delete(oldest);
-    }
   }
 
   private settledKey(work: DeliveryWork): string {

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -18,6 +18,8 @@ export type {
 export { getHandlerFactory, hasHandler, registerHandler } from "./handler.js";
 export { InputController } from "./input-controller.js";
 export { registerShutdownHook, runShutdown } from "./lifecycle.js";
+export type { ReplayFenceEntry, ReplayFenceWriter } from "./replay-fence.js";
+export { ReplayFenceError, ReplayFenceStore } from "./replay-fence.js";
 export type { AgentRuntimeOptions } from "./runtime.js";
 export { AgentRuntime } from "./runtime.js";
 export { SessionManager } from "./session-manager.js";

--- a/packages/client/src/runtime/replay-fence.ts
+++ b/packages/client/src/runtime/replay-fence.ts
@@ -36,7 +36,28 @@ export class ReplayFenceError extends Error {
 }
 
 function keyOf(chatId: string, messageId: string): string {
-  return `${chatId}${messageId}`;
+  // Length-prefixed pair encoding: unambiguous for any id contents, unlike
+  // raw concatenation where ("a1", "b") and ("a", "1b") collide.
+  return `${chatId.length}:${chatId}${messageId}`;
+}
+
+function isValidEntry(entry: unknown): entry is ReplayFenceEntry {
+  if (typeof entry !== "object" || entry === null) return false;
+  const candidate = entry as Record<string, unknown>;
+  return (
+    typeof candidate.chatId === "string" &&
+    typeof candidate.messageId === "string" &&
+    typeof candidate.provider === "string" &&
+    typeof candidate.toolName === "string" &&
+    typeof candidate.toolUseId === "string" &&
+    typeof candidate.fencedAt === "string"
+  );
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+    ? error.code
+    : undefined;
 }
 
 /**
@@ -64,15 +85,23 @@ export class ReplayFenceStore {
     this.filePath = filePath;
   }
 
-  /** Load persisted fences. Missing file means an empty store. */
+  /** Load persisted fences. Only a missing file (ENOENT) means an empty store. */
   load(): void {
     let raw: string;
     try {
       raw = readFileSync(this.filePath, "utf-8");
-    } catch {
-      // File does not exist yet — empty store, no fences.
-      this.loaded = true;
-      return;
+    } catch (error) {
+      if (readErrorCode(error) === "ENOENT") {
+        // First start — no fences persisted yet.
+        this.loaded = true;
+        return;
+      }
+      // EACCES / EISDIR / I/O errors: the persisted safety facts exist (or
+      // their state is unknown) but cannot be read. Fail closed — callers
+      // must treat the store as unavailable, never as empty.
+      throw new ReplayFenceError(
+        `replay fence store is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
 
     let data: ReplayFenceData;
@@ -92,13 +121,7 @@ export class ReplayFenceStore {
 
     const loaded = new Map<string, ReplayFenceEntry>();
     for (const [key, entry] of Object.entries(data.entries)) {
-      if (
-        typeof entry !== "object" ||
-        entry === null ||
-        typeof entry.chatId !== "string" ||
-        typeof entry.messageId !== "string" ||
-        keyOf(entry.chatId, entry.messageId) !== key
-      ) {
+      if (!isValidEntry(entry) || keyOf(entry.chatId, entry.messageId) !== key) {
         throw new ReplayFenceError(`replay fence store has malformed entry: ${key}`);
       }
       loaded.set(key, entry);
@@ -109,6 +132,14 @@ export class ReplayFenceStore {
 
   isFenced(chatId: string, messageId: string): boolean {
     return this.entries.has(keyOf(chatId, messageId));
+  }
+
+  /** True when the chat has any unresolved fence — its whole FIFO tail must hold. */
+  hasFenceForChat(chatId: string): boolean {
+    for (const entry of this.entries.values()) {
+      if (entry.chatId === chatId) return true;
+    }
+    return false;
   }
 
   fence(entry: ReplayFenceEntry): void {
@@ -161,6 +192,22 @@ export class ReplayFenceStore {
         closeSync(fd);
       }
       renameSync(tmpPath, this.filePath);
+      // Durability scope: the write+fsync+rename sequence survives a process
+      // SIGKILL. The best-effort parent-directory fsync below extends that to
+      // host crashes on filesystems that require it; its failure is logged
+      // into the error rather than silently dropped, but a directory that
+      // cannot be fsynced does not undo the rename.
+      try {
+        const dirFd = openSync(dirname(this.filePath), constants.O_RDONLY);
+        try {
+          fsyncSync(dirFd);
+        } finally {
+          closeSync(dirFd);
+        }
+      } catch {
+        // Directory fsync unsupported (e.g. some virtual filesystems) — the
+        // file-level fsync above still guarantees process-crash durability.
+      }
     } catch (error) {
       throw new ReplayFenceError(
         `failed to persist replay fence: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/client/src/runtime/replay-fence.ts
+++ b/packages/client/src/runtime/replay-fence.ts
@@ -1,0 +1,170 @@
+import { closeSync, constants, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const FENCE_VERSION = 1;
+
+/** One durable replay-fence record, bound to a concrete chat + inbox message. */
+export type ReplayFenceEntry = {
+  readonly chatId: string;
+  readonly messageId: string;
+  readonly provider: string;
+  /** First observed non-read-only tool effect that made replay unsafe. */
+  readonly toolName: string;
+  readonly toolUseId: string;
+  /** ISO 8601 time the fence was persisted. */
+  readonly fencedAt: string;
+};
+
+type ReplayFenceData = {
+  version: number;
+  entries: Record<string, ReplayFenceEntry>;
+};
+
+/** Narrow surface handlers need; the full store also exposes load/isFenced. */
+export type ReplayFenceWriter = {
+  /** Persist a fence; throws ReplayFenceError when the durable write fails. */
+  fence(entry: ReplayFenceEntry): void;
+  /** Drop a fence after its delivery settled; throws ReplayFenceError on write failure. */
+  clear(chatId: string, messageId: string): void;
+};
+
+export class ReplayFenceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReplayFenceError";
+  }
+}
+
+function keyOf(chatId: string, messageId: string): string {
+  return `${chatId}${messageId}`;
+}
+
+/**
+ * ReplayFenceStore — durable record of provider-entered deliveries that have
+ * already produced a non-read-only tool effect. Unlike SessionRegistry, these
+ * facts are safety-critical: every mutation is written synchronously
+ * (write-then-fsync-then-rename) and failures THROW instead of being logged
+ * and swallowed. A store that cannot be trusted must fail closed — callers
+ * treat load/persist errors as "do not re-enter the provider", never as
+ * "safe to replay".
+ *
+ * Lifecycle: a handler fences (chatId, messageId) as soon as it observes an
+ * unsafe tool call start, and clears the fence only after the delivery's
+ * terminal settlement is confirmed. A crash in between leaves the fence on
+ * disk, and the next process's dispatch gate refuses to start/resume a
+ * provider turn for that concrete message, keeping it as unacknowledged
+ * recovery debt instead of replaying the effect.
+ */
+export class ReplayFenceStore {
+  private readonly filePath: string;
+  private entries = new Map<string, ReplayFenceEntry>();
+  private loaded = false;
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  /** Load persisted fences. Missing file means an empty store. */
+  load(): void {
+    let raw: string;
+    try {
+      raw = readFileSync(this.filePath, "utf-8");
+    } catch {
+      // File does not exist yet — empty store, no fences.
+      this.loaded = true;
+      return;
+    }
+
+    let data: ReplayFenceData;
+    try {
+      data = JSON.parse(raw) as ReplayFenceData;
+    } catch (error) {
+      throw new ReplayFenceError(
+        `replay fence store is corrupted: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (typeof data !== "object" || data === null || data.version !== FENCE_VERSION) {
+      throw new ReplayFenceError(`replay fence store has unsupported version: ${String(data?.version)}`);
+    }
+    if (typeof data.entries !== "object" || data.entries === null || Array.isArray(data.entries)) {
+      throw new ReplayFenceError("replay fence store has malformed entries");
+    }
+
+    const loaded = new Map<string, ReplayFenceEntry>();
+    for (const [key, entry] of Object.entries(data.entries)) {
+      if (
+        typeof entry !== "object" ||
+        entry === null ||
+        typeof entry.chatId !== "string" ||
+        typeof entry.messageId !== "string" ||
+        keyOf(entry.chatId, entry.messageId) !== key
+      ) {
+        throw new ReplayFenceError(`replay fence store has malformed entry: ${key}`);
+      }
+      loaded.set(key, entry);
+    }
+    this.entries = loaded;
+    this.loaded = true;
+  }
+
+  isFenced(chatId: string, messageId: string): boolean {
+    return this.entries.has(keyOf(chatId, messageId));
+  }
+
+  fence(entry: ReplayFenceEntry): void {
+    const key = keyOf(entry.chatId, entry.messageId);
+    if (this.entries.has(key)) return;
+    this.entries.set(key, entry);
+    try {
+      this.persist();
+    } catch (error) {
+      this.entries.delete(key);
+      throw error;
+    }
+  }
+
+  clear(chatId: string, messageId: string): void {
+    const key = keyOf(chatId, messageId);
+    const existing = this.entries.get(key);
+    if (!existing) return;
+    this.entries.delete(key);
+    try {
+      this.persist();
+    } catch (error) {
+      this.entries.set(key, existing);
+      throw error;
+    }
+  }
+
+  /** Test/debug surface: current in-memory fence records. */
+  snapshot(): readonly ReplayFenceEntry[] {
+    return [...this.entries.values()];
+  }
+
+  get isLoaded(): boolean {
+    return this.loaded;
+  }
+
+  private persist(): void {
+    const data: ReplayFenceData = { version: FENCE_VERSION, entries: {} };
+    for (const [key, entry] of this.entries) {
+      data.entries[key] = entry;
+    }
+    const tmpPath = `${this.filePath}.tmp`;
+    try {
+      mkdirSync(dirname(this.filePath), { recursive: true });
+      writeFileSync(tmpPath, JSON.stringify(data, null, 2), "utf-8");
+      const fd = openSync(tmpPath, constants.O_RDONLY);
+      try {
+        fsyncSync(fd);
+      } finally {
+        closeSync(fd);
+      }
+      renameSync(tmpPath, this.filePath);
+    } catch (error) {
+      throw new ReplayFenceError(
+        `failed to persist replay fence: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -540,6 +540,7 @@ export class SessionManager {
       ackEntry: config.ackEntry,
       recoverChat: config.recoverChat,
       onWorkChanged: (chatId) => this.projectSessionRuntime(chatId),
+      onDeliveriesCommitted: (chatId, messageIds) => this.reconcileReplayFences(chatId, messageIds),
       log: config.log,
     });
     this.registry = config.registryPath ? new SessionRegistry(config.registryPath) : null;
@@ -1102,6 +1103,27 @@ export class SessionManager {
     if (this.replayFenceUnavailable) return true;
     if (!this.replayFence) return false;
     return this.replayFence.hasFenceForChat(chatId);
+  }
+
+  /**
+   * Clear replay fences for deliveries whose ACK committed — including the
+   * recovery/redelivery retry path, which never passes through the handler's
+   * own completion cleanup. A clear that fails to persist leaves the chat
+   * fenced; make that loudly operator-visible instead of a silent stall.
+   */
+  private reconcileReplayFences(chatId: string, messageIds: readonly string[]): void {
+    if (!this.replayFence) return;
+    for (const messageId of messageIds) {
+      try {
+        this.replayFence.clear(chatId, messageId);
+      } catch (err) {
+        this.config.log.error(
+          { err, chatId, messageId },
+          "replay fence could not be cleared after confirmed ACK; chat stays fenced until the store is repaired",
+        );
+        this.config.onSessionRuntimeChange?.(chatId, "error");
+      }
+    }
   }
 
   private createHandler(): AgentHandler {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -63,6 +63,7 @@ import {
   type ProviderFailureClassification,
 } from "./provider-retry-policy.js";
 import { redactErrorPreview } from "./redact-error-preview.js";
+import { ReplayFenceStore } from "./replay-fence.js";
 import { createResultSink, type Trigger } from "./result-sink.js";
 import {
   isRuntimeSessionProofFailure,
@@ -342,6 +343,15 @@ type SessionManagerConfig = {
   sdk: FirstTreeHubSDK;
   log: pino.Logger;
   registryPath?: string;
+  /**
+   * Durable replay-fence store path. When set, the manager loads safety
+   * facts about provider-entered deliveries that already produced unsafe
+   * tool effects, refuses to start/resume a provider turn for a fenced
+   * (chatId, messageId) redelivery (leaving it as unacknowledged recovery
+   * debt), and hands the store to handlers via `handlerConfig.replayFence`.
+   * A store that fails to load fails closed: every dispatch is withheld.
+   */
+  replayFencePath?: string;
   /** Step 4: optional config cache for refresh-before-dispatch on configVersion bump. */
   agentConfigCache?: AgentConfigCache;
   /** Stable file path updated on every runtime-session rebind for long-lived child CLI calls. */
@@ -493,6 +503,13 @@ export class SessionManager {
    */
   private readonly currentTrigger = new Map<string, Trigger>();
   private readonly registry: SessionRegistry | null;
+  private readonly replayFence: ReplayFenceStore | null;
+  /**
+   * Set when the replay-fence store could not be loaded. Fail-closed: every
+   * dispatch is withheld as recovery debt until an operator repairs the
+   * store, because we can no longer tell safe redeliveries from unsafe ones.
+   */
+  private replayFenceUnavailable: string | null = null;
   private readonly pendingQueue: PendingMessage[] = [];
   /** Chats whose terminate command has closed admission but is still draining cleanup. */
   private readonly terminatingChats = new Set<string>();
@@ -526,6 +543,20 @@ export class SessionManager {
       log: config.log,
     });
     this.registry = config.registryPath ? new SessionRegistry(config.registryPath) : null;
+    if (config.replayFencePath) {
+      this.replayFence = new ReplayFenceStore(config.replayFencePath);
+      try {
+        this.replayFence.load();
+      } catch (err) {
+        this.replayFenceUnavailable = err instanceof Error ? err.message : String(err);
+        this.config.log.error(
+          { err, path: config.replayFencePath },
+          "replay fence store failed to load; withholding all provider dispatch fail-closed",
+        );
+      }
+    } else {
+      this.replayFence = null;
+    }
     this.idleTimer = setInterval(() => this.evictIdle(), 10_000);
     // Independent of `evictIdle` (which early-continues on freshly-active
     // sessions): re-affirm working / error sessions so the
@@ -1067,10 +1098,18 @@ export class SessionManager {
     entry.deferredMessages = [];
   }
 
+  private isReplayFenced(chatId: string, message: SessionMessage): boolean {
+    if (this.replayFenceUnavailable) return true;
+    if (!this.replayFence) return false;
+    return this.replayFence.isFenced(chatId, message.id);
+  }
+
   private createHandler(): AgentHandler {
-    const handlerCfg = this.config.agentConfigCache
-      ? { ...this.config.handlerConfig, agentConfigCache: this.config.agentConfigCache }
-      : this.config.handlerConfig;
+    const handlerCfg = {
+      ...this.config.handlerConfig,
+      ...(this.config.agentConfigCache ? { agentConfigCache: this.config.agentConfigCache } : {}),
+      ...(this.replayFence ? { replayFence: this.replayFence } : {}),
+    };
     return this.config.handlerFactory(handlerCfg);
   }
 
@@ -1612,6 +1651,17 @@ export class SessionManager {
     }
     if (this.terminatingChats.has(chatId)) {
       this.config.log.info({ chatId, messageId: message.id }, "delivery held while session termination is pending");
+      return;
+    }
+    if (this.isReplayFenced(chatId, message)) {
+      // A previous provider turn for this concrete delivery already produced
+      // a non-read-only tool effect before an interruption. Re-entering the
+      // provider would replay that effect, so the delivery stays
+      // unacknowledged recovery debt until an operator resolves it.
+      this.config.log.error(
+        { chatId, messageId: message.id },
+        "withholding provider re-entry for replay-fenced delivery; unsafe tool effect fenced before interruption",
+      );
       return;
     }
     const existing = this.sessions.get(chatId);

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1171,8 +1171,9 @@ export class SessionManager {
     ];
     if (fencedMessageIds.length === 0) return;
     // Probe in wire-sized chunks: oversized frames are rejected outright
-    // and would fail-closed forever. A failed chunk keeps its (and every
-    // later chunk's) ids fenced; earlier chunks still contribute proof.
+    // and would fail-closed forever. Settlement proof is merged ONLY when
+    // every chunk succeeds — a rejected/timed-out chunk discards the whole
+    // round and keeps every fence (fail-closed).
     const settled = new Set<string>();
     for (let offset = 0; offset < fencedMessageIds.length; offset += INBOX_FENCE_PROBE_MAX_IDS) {
       const chunk = fencedMessageIds.slice(offset, offset + INBOX_FENCE_PROBE_MAX_IDS);
@@ -1182,9 +1183,9 @@ export class SessionManager {
       } catch (err) {
         this.config.log.warn(
           { err, chatId, chunkOffset: offset },
-          "replay fence settlement probe failed; keeping unproven fences (fail-closed)",
+          "replay fence settlement probe failed; discarding this round and keeping every fence (fail-closed)",
         );
-        break;
+        return;
       }
       // Only ids from THIS chunk may prove settlement; anything else is a
       // protocol violation and must not clear anything.

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -368,6 +368,13 @@ type SessionManagerConfig = {
    */
   recoverChat?: (chatId: string) => Promise<void>;
   /**
+   * Optional count-returning variant of recoverChat used for crash-safe
+   * replay-fence reconciliation: resolves with the server's reset count
+   * (entries still unacked), the only client-visible server ACK truth.
+   * Without it the reconciliation conservatively keeps every fence.
+   */
+  recoverChatWithCount?: (chatId: string) => Promise<number>;
+  /**
    * Re-bind the owning agent after a bind-scoped HTTP proof failure. The
    * callback is agent-wide and must coalesce concurrent chat failures.
    */
@@ -1097,6 +1104,52 @@ export class SessionManager {
   private clearRetryState(entry: SessionEntry): void {
     this.clearRetryAttemptState(entry);
     entry.deferredMessages = [];
+  }
+
+  /**
+   * Crash-safe fence reconciliation driven by server ACK truth. After a
+   * crash the local fence file can lag the server: an entry ACKed just
+   * before the crash leaves a stale chat-wide fence with no automatic
+   * cleanup. Inbox recovery resets every delivered-but-unacked entry for a
+   * chat and reports how many it reset — zero means every fenced delivery
+   * in that chat is durably ACKed server-side, so those fences are stale
+   * and cleared. A nonzero count keeps the fences; the reset entries are
+   * redelivered and held by the route gate as recovery debt. Idempotent and
+   * replayable: safe to run on every startup/bind.
+   */
+  async reconcileReplayFencesWithServer(): Promise<void> {
+    if (!this.replayFence || this.replayFenceUnavailable || !this.config.recoverChatWithCount) return;
+    const recoverWithCount = this.config.recoverChatWithCount;
+    const chatIds = [...new Set(this.replayFence.snapshot().map((entry) => entry.chatId))];
+    for (const chatId of chatIds) {
+      let resetCount: number;
+      try {
+        resetCount = await recoverWithCount(chatId);
+      } catch (err) {
+        this.config.log.warn(
+          { err, chatId },
+          "replay fence reconciliation readback failed; keeping fences (fail-closed)",
+        );
+        continue;
+      }
+      if (resetCount > 0) continue;
+      for (const entry of this.replayFence.snapshot()) {
+        if (entry.chatId !== chatId) continue;
+        try {
+          this.replayFence.clear(entry.chatId, entry.messageId);
+          this.config.log.info(
+            { chatId, messageId: entry.messageId },
+            "cleared stale replay fence: delivery confirmed ACKed server-side",
+          );
+        } catch (err) {
+          this.config.log.error(
+            { err, chatId, messageId: entry.messageId },
+            "stale replay fence could not be cleared; chat stays fenced until the store is repaired",
+          );
+          this.config.onSessionRuntimeChange?.(chatId, "error");
+        }
+      }
+    }
   }
 
   private isChatReplayFenced(chatId: string): boolean {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -722,21 +722,16 @@ export class SessionManager {
         // turn, but same-chat later messages must still be able to append once
         // this entry has reached handler membership.
         const deliveryKind: SlotDeliveryKind = isRecoveryRedelivery ? "recovery" : "fresh";
-        routePromise = this.routeMessage(chatId, message, deliveryKind, decision.readmitted === true).catch(
-          async (err) => {
-            if (this.inboxDelivery.hasEntry(work)) {
-              const proofReason = this.runtimeSessionProofReasonForError(err);
-              if (
-                proofReason &&
-                (await this.holdDeliveryForRuntimeSessionProofRecovery(chatId, message, proofReason))
-              ) {
-                return;
-              }
-              this.retryDeliveryTurn(chatId, message, "route_message_failed");
+        routePromise = this.routeMessage(chatId, message, deliveryKind).catch(async (err) => {
+          if (this.inboxDelivery.hasEntry(work)) {
+            const proofReason = this.runtimeSessionProofReasonForError(err);
+            if (proofReason && (await this.holdDeliveryForRuntimeSessionProofRecovery(chatId, message, proofReason))) {
+              return;
             }
-            throw err;
-          },
-        );
+            this.retryDeliveryTurn(chatId, message, "route_message_failed");
+          }
+          throw err;
+        });
       });
     } catch (err) {
       if (this.inboxDelivery.hasEntry(work)) {
@@ -1932,7 +1927,6 @@ export class SessionManager {
     chatId: string,
     message: SessionMessage,
     deliveryKind: SlotDeliveryKind = "fresh",
-    readmitted = false,
   ): Promise<void> {
     if (this.shuttingDown) {
       this.retryDeliveryTurn(chatId, message, "manager_shutdown");
@@ -1960,10 +1954,12 @@ export class SessionManager {
       this.ensureReplayFenceReconcileLoop(chatId);
       return;
     }
-    if (this.postFenceRecoveryDebt.has(chatId) && !readmitted) {
-      // A post-fence-clear recovery is in flight or being retried: hold new
-      // admissions so the still-unacked tail keeps FIFO order until the
-      // server redelivery (which re-admits these withheld entries) lands.
+    if (this.postFenceRecoveryDebt.has(chatId)) {
+      // A post-fence-clear recovery is in flight or being retried: hold
+      // EVERY admission until one recovery is durably accepted. A
+      // re-admitted duplicate only proves local withholding, never recovery
+      // success, so it must not bypass the debt either — it is simply
+      // re-marked and redelivered by the eventual accepted recovery.
       this.config.log.info(
         { chatId, messageId: message.id },
         "holding delivery while post-fence-clear recovery is pending",

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -22,6 +22,7 @@ import {
   runtimeProviderSchema,
   SOURCE_REPOS_DIRNAME,
 } from "@first-tree/shared";
+import type { InboxRecoverResult } from "../client-connection.js";
 import type { pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { AgentConfigCache } from "./agent-config-cache.js";
@@ -369,11 +370,12 @@ type SessionManagerConfig = {
   recoverChat?: (chatId: string) => Promise<void>;
   /**
    * Optional count-returning variant of recoverChat used for crash-safe
-   * replay-fence reconciliation: resolves with the server's reset count
-   * (entries still unacked), the only client-visible server ACK truth.
-   * Without it the reconciliation conservatively keeps every fence.
+   * replay-fence reconciliation: resolves with the server's reset count and
+   * (on new servers) the authoritative unacked outstanding for the chat
+   * scope — the only client-visible server ACK truth. Without it the
+   * reconciliation conservatively keeps every fence.
    */
-  recoverChatWithCount?: (chatId: string) => Promise<number>;
+  recoverChatWithCount?: (chatId: string) => Promise<InboxRecoverResult>;
   /**
    * Re-bind the owning agent after a bind-scoped HTTP proof failure. The
    * callback is agent-wide and must coalesce concurrent chat failures.
@@ -419,6 +421,14 @@ type SessionManagerConfig = {
  */
 /** Maximum number of evicted session mappings to retain for resume recovery. */
 const MAX_EVICTED_MAPPINGS = 500;
+
+/**
+ * Minimum spacing between gate-triggered replay-fence reconciliations for
+ * one chat. Withheld dispatches retry the server-truth readback so a
+ * transient readback/clear failure converges without a process restart,
+ * without turning every redelivery burst into an inbox-recovery storm.
+ */
+const REPLAY_FENCE_RECONCILE_INTERVAL_MS = 30_000;
 const MAX_EAGER_IMAGE_FETCHES_PER_DELIVERY = MAX_MESSAGE_ATTACHMENT_REFS;
 
 /**
@@ -1107,49 +1117,84 @@ export class SessionManager {
   }
 
   /**
-   * Crash-safe fence reconciliation driven by server ACK truth. After a
-   * crash the local fence file can lag the server: an entry ACKed just
-   * before the crash leaves a stale chat-wide fence with no automatic
-   * cleanup. Inbox recovery resets every delivered-but-unacked entry for a
-   * chat and reports how many it reset — zero means every fenced delivery
-   * in that chat is durably ACKed server-side, so those fences are stale
-   * and cleared. A nonzero count keeps the fences; the reset entries are
-   * redelivered and held by the route gate as recovery debt. Idempotent and
-   * replayable: safe to run on every startup/bind.
+   * Crash-safe fence reconciliation driven by authoritative server ACK
+   * truth. After a crash the local fence file can lag the server: an entry
+   * ACKed just before the crash leaves a stale chat-wide fence with no
+   * automatic cleanup. The server's recovery reply carries
+   * `unackedOutstanding` — the pending+delivered backlog for the chat
+   * scope, counted inside the same serialized boundary — and only `0`
+   * proves every fenced delivery settled, so those fences are stale and
+   * cleared. Any other outcome (backlog present, field absent on an older
+   * server, readback failure) keeps the fences fail-closed. Idempotent and
+   * replayable: runs on startup/bind and is retried on withheld dispatches.
    */
   async reconcileReplayFencesWithServer(): Promise<void> {
-    if (!this.replayFence || this.replayFenceUnavailable || !this.config.recoverChatWithCount) return;
-    const recoverWithCount = this.config.recoverChatWithCount;
+    if (!this.replayFence || this.replayFenceUnavailable) return;
     const chatIds = [...new Set(this.replayFence.snapshot().map((entry) => entry.chatId))];
     for (const chatId of chatIds) {
-      let resetCount: number;
+      await this.reconcileReplayFenceForChat(chatId);
+    }
+  }
+
+  /** In-flight guard so gate-triggered reconciliations coalesce per chat. */
+  private readonly replayFenceReconciliations = new Map<string, Promise<void>>();
+  /** Per-chat spacing for gate-triggered reconciliation retries. */
+  private readonly replayFenceReconcileAt = new Map<string, number>();
+
+  private async reconcileReplayFenceForChat(chatId: string): Promise<void> {
+    if (!this.replayFence || this.replayFenceUnavailable || !this.config.recoverChatWithCount) return;
+    const recoverWithCount = this.config.recoverChatWithCount;
+    let result: InboxRecoverResult;
+    try {
+      result = await recoverWithCount(chatId);
+    } catch (err) {
+      this.config.log.warn(
+        { err, chatId },
+        "replay fence reconciliation readback failed; keeping fences (fail-closed)",
+      );
+      return;
+    }
+    if (result.unackedOutstanding !== 0) {
+      // Backlog present, or an older server omitted the authoritative
+      // field: either way this is NOT proof of settlement — keep fences.
+      return;
+    }
+    for (const entry of this.replayFence.snapshot()) {
+      if (entry.chatId !== chatId) continue;
       try {
-        resetCount = await recoverWithCount(chatId);
-      } catch (err) {
-        this.config.log.warn(
-          { err, chatId },
-          "replay fence reconciliation readback failed; keeping fences (fail-closed)",
+        this.replayFence.clear(entry.chatId, entry.messageId);
+        this.config.log.info(
+          { chatId, messageId: entry.messageId },
+          "cleared stale replay fence: delivery confirmed settled server-side",
         );
-        continue;
-      }
-      if (resetCount > 0) continue;
-      for (const entry of this.replayFence.snapshot()) {
-        if (entry.chatId !== chatId) continue;
-        try {
-          this.replayFence.clear(entry.chatId, entry.messageId);
-          this.config.log.info(
-            { chatId, messageId: entry.messageId },
-            "cleared stale replay fence: delivery confirmed ACKed server-side",
-          );
-        } catch (err) {
-          this.config.log.error(
-            { err, chatId, messageId: entry.messageId },
-            "stale replay fence could not be cleared; chat stays fenced until the store is repaired",
-          );
-          this.config.onSessionRuntimeChange?.(chatId, "error");
-        }
+      } catch (err) {
+        this.config.log.error(
+          { err, chatId, messageId: entry.messageId },
+          "stale replay fence could not be cleared; chat stays fenced until a later reconciliation succeeds",
+        );
+        this.config.onSessionRuntimeChange?.(chatId, "error");
       }
     }
+  }
+
+  /**
+   * Gate-triggered retry: a withheld chat gets a bounded re-reconciliation
+   * so a transient readback/clear failure converges without a restart.
+   */
+  private scheduleReplayFenceReconcile(chatId: string): void {
+    if (!this.config.recoverChatWithCount) return;
+    const now = Date.now();
+    const nextAt = this.replayFenceReconcileAt.get(chatId) ?? 0;
+    if (now < nextAt || this.replayFenceReconciliations.has(chatId)) return;
+    this.replayFenceReconcileAt.set(chatId, now + REPLAY_FENCE_RECONCILE_INTERVAL_MS);
+    const pending = this.reconcileReplayFenceForChat(chatId)
+      .catch((err) => {
+        this.config.log.warn({ err, chatId }, "replay fence reconciliation attempt failed");
+      })
+      .finally(() => {
+        if (this.replayFenceReconciliations.get(chatId) === pending) this.replayFenceReconciliations.delete(chatId);
+      });
+    this.replayFenceReconciliations.set(chatId, pending);
   }
 
   private isChatReplayFenced(chatId: string): boolean {
@@ -1743,6 +1788,7 @@ export class SessionManager {
         "withholding provider re-entry for replay-fenced chat; unsafe tool effect fenced before interruption",
       );
       this.config.onSessionRuntimeChange?.(chatId, "error");
+      this.scheduleReplayFenceReconcile(chatId);
       return;
     }
     const existing = this.sessions.get(chatId);

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -22,7 +22,6 @@ import {
   runtimeProviderSchema,
   SOURCE_REPOS_DIRNAME,
 } from "@first-tree/shared";
-import type { InboxRecoverResult } from "../client-connection.js";
 import type { pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { AgentConfigCache } from "./agent-config-cache.js";
@@ -369,13 +368,12 @@ type SessionManagerConfig = {
    */
   recoverChat?: (chatId: string) => Promise<void>;
   /**
-   * Optional count-returning variant of recoverChat used for crash-safe
-   * replay-fence reconciliation: resolves with the server's reset count and
-   * (on new servers) the authoritative unacked outstanding for the chat
-   * scope — the only client-visible server ACK truth. Without it the
-   * reconciliation conservatively keeps every fence.
+   * Read-only settlement probe for concrete fenced deliveries: resolves
+   * with the probed message ids the server proves settled (no unsettled
+   * notify row), computed inside the server's serialized recovery
+   * boundary. Without it the reconciliation keeps every fence.
    */
-  recoverChatWithCount?: (chatId: string) => Promise<InboxRecoverResult>;
+  probeFencedSettlement?: (chatId: string, messageIds: readonly string[]) => Promise<readonly string[]>;
   /**
    * Re-bind the owning agent after a bind-scoped HTTP proof failure. The
    * callback is agent-wide and must coalesce concurrent chat failures.
@@ -430,8 +428,6 @@ const MAX_EVICTED_MAPPINGS = 500;
  */
 const REPLAY_FENCE_RECONCILE_INTERVAL_MS = 30_000;
 
-/** In-memory cap for gate-withheld messages awaiting a fence clear. */
-const MAX_WITHHELD_REPLAY_FENCED_MESSAGES = 50;
 const MAX_EAGER_IMAGE_FETCHES_PER_DELIVERY = MAX_MESSAGE_ATTACHMENT_REFS;
 
 /**
@@ -1124,16 +1120,15 @@ export class SessionManager {
   }
 
   /**
-   * Crash-safe fence reconciliation driven by authoritative server
+   * Crash-safe fence reconciliation driven by per-delivery server
    * settlement truth. After a crash the local fence file can lag the
    * server: an entry ACKed just before the crash leaves a stale chat-wide
-   * fence with no automatic cleanup. The server's recovery reply carries
-   * the pending+delivered backlog for the chat scope — as a count
-   * (`unackedOutstanding`, proving settlement only at exactly 0) and, on
-   * new servers, per-message (`unackedMessageIds`), so an already-settled
-   * fenced head can clear even while a newer unacked tail exists. Anything
-   * less than authoritative truth keeps the fences fail-closed. Idempotent
-   * and replayable: runs on startup/rebind and on the per-chat retry loop.
+   * fence with no automatic cleanup. A read-only probe proves, inside the
+   * server's serialized recovery boundary, exactly which fenced message
+   * ids are settled; only those fences clear. Anything less (older server,
+   * missing probe, readback failure) keeps the fences fail-closed.
+   * Idempotent and replayable: runs on startup/rebind and on the per-chat
+   * retry loop.
    */
   async reconcileReplayFencesWithServer(): Promise<void> {
     if (!this.replayFence || this.replayFenceUnavailable) return;
@@ -1150,41 +1145,32 @@ export class SessionManager {
    * the retry loop only needs to redo the LOCAL clear, not the readback.
    */
   private readonly provenSettledFences = new Map<string, Set<string>>();
-  /** Messages withheld by the fence gate, re-driven once the fence clears. */
-  private readonly withheldReplayFencedMessages = new Map<string, SessionMessage[]>();
   /** Per-chat retry timers for the reconciliation/clear loop. */
   private readonly replayFenceRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   private async reconcileReplayFenceForChat(chatId: string): Promise<void> {
-    if (!this.replayFence || this.replayFenceUnavailable || !this.config.recoverChatWithCount) return;
-    const recoverWithCount = this.config.recoverChatWithCount;
-    let result: InboxRecoverResult;
+    if (!this.replayFence || this.replayFenceUnavailable || !this.config.probeFencedSettlement) return;
+    const probe = this.config.probeFencedSettlement;
+    const fencedMessageIds = [
+      ...new Set(
+        this.replayFence
+          .snapshot()
+          .filter((entry) => entry.chatId === chatId)
+          .map((entry) => entry.messageId),
+      ),
+    ];
+    if (fencedMessageIds.length === 0) return;
+    let settledIds: readonly string[];
     try {
-      result = await recoverWithCount(chatId);
+      settledIds = await probe(chatId, fencedMessageIds);
     } catch (err) {
-      this.config.log.warn(
-        { err, chatId },
-        "replay fence reconciliation readback failed; keeping fences (fail-closed)",
-      );
+      this.config.log.warn({ err, chatId }, "replay fence settlement probe failed; keeping fences (fail-closed)");
       return;
     }
+    const settled = new Set(settledIds);
     const proven = this.provenSettledFences.get(chatId) ?? new Set<string>();
-    if (result.unackedMessageIds !== undefined) {
-      // Message-level truth: a fenced delivery is settled iff the server's
-      // unacked list does not contain it — a newer unacked tail cannot
-      // block the stale head's cleanup.
-      const unacked = new Set(result.unackedMessageIds);
-      for (const entry of this.replayFence.snapshot()) {
-        if (entry.chatId === chatId && !unacked.has(entry.messageId)) proven.add(entry.messageId);
-      }
-    } else if (result.unackedOutstanding === 0) {
-      for (const entry of this.replayFence.snapshot()) {
-        if (entry.chatId === chatId) proven.add(entry.messageId);
-      }
-    } else {
-      // Backlog present without per-message detail, or an older server
-      // omitted the fields: NOT proof of settlement — keep fences.
-      return;
+    for (const messageId of fencedMessageIds) {
+      if (settled.has(messageId)) proven.add(messageId);
     }
     if (proven.size > 0) {
       this.provenSettledFences.set(chatId, proven);
@@ -1218,27 +1204,20 @@ export class SessionManager {
       }
     }
     if (proven.size === 0) this.provenSettledFences.delete(chatId);
-    if (!this.replayFence.hasFenceForChat(chatId)) {
-      this.stopReplayFenceReconcileLoop(chatId);
-      await this.drainWithheldReplayFencedMessages(chatId);
-    }
-  }
-
-  /** Re-drive deliveries the gate withheld while the fence was up. */
-  private async drainWithheldReplayFencedMessages(chatId: string): Promise<void> {
-    const withheld = this.withheldReplayFencedMessages.get(chatId);
-    if (!withheld || withheld.length === 0) return;
-    this.withheldReplayFencedMessages.delete(chatId);
-    for (const message of withheld) {
-      this.config.log.info(
-        { chatId, messageId: message.id },
-        "re-driving replay-fence-withheld delivery after fence clear",
-      );
+    if (this.replayFence.hasFenceForChat(chatId)) return;
+    this.stopReplayFenceReconcileLoop(chatId);
+    // Single destructive recovery to re-drive whatever the gate withheld:
+    // the server resets and redelivers the rows, and the coordinator
+    // re-admits fence-withheld ledger entries instead of deduplicating
+    // them. This is the ONLY redrive path — exactly-once by construction.
+    if (this.config.recoverChat && this.inboxDelivery.hasUnsettledWork(chatId)) {
       try {
-        await this.routeMessage(chatId, message, "fresh");
+        await this.config.recoverChat(chatId);
       } catch (err) {
-        this.config.log.warn({ err, chatId, messageId: message.id }, "withheld delivery re-drive failed");
-        this.retryDeliveryTurn(chatId, message, "replay_fence_redrive_failed");
+        this.config.log.warn(
+          { err, chatId },
+          "post-fence-clear recovery failed; withheld deliveries stay recovery debt",
+        );
       }
     }
     this.projectSessionRuntime(chatId);
@@ -1874,24 +1853,15 @@ export class SessionManager {
       // provider for the fenced head would replay that effect, and inbox ACK
       // is prefix-based, so the chat's entire FIFO tail must hold behind it:
       // every delivery stays unacknowledged recovery debt until an operator
-      // resolves the fenced head. The message is buffered in memory so a
-      // later fence clear can re-drive it in-process; the server row stays
-      // delivered/unacked as the durable copy.
+      // resolves the fenced head. The ledger entry is marked fence-withheld
+      // (no custody taken) so a later post-clear server redelivery is
+      // re-admitted instead of deduplicated.
       this.config.log.error(
         { chatId, messageId: message.id },
         "withholding provider re-entry for replay-fenced chat; unsafe tool effect fenced before interruption",
       );
       this.config.onSessionRuntimeChange?.(chatId, "error");
-      const withheld = this.withheldReplayFencedMessages.get(chatId) ?? [];
-      if (withheld.length < MAX_WITHHELD_REPLAY_FENCED_MESSAGES) {
-        withheld.push(message);
-        this.withheldReplayFencedMessages.set(chatId, withheld);
-      } else {
-        this.config.log.error(
-          { chatId, messageId: message.id },
-          "replay-fence withheld buffer full; delivery relies on server redelivery",
-        );
-      }
+      this.inboxDelivery.markReplayFenceWithheld(chatId, [message.id]);
       this.ensureReplayFenceReconcileLoop(chatId);
       return;
     }

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -429,6 +429,9 @@ const MAX_EVICTED_MAPPINGS = 500;
  * without turning every redelivery burst into an inbox-recovery storm.
  */
 const REPLAY_FENCE_RECONCILE_INTERVAL_MS = 30_000;
+
+/** In-memory cap for gate-withheld messages awaiting a fence clear. */
+const MAX_WITHHELD_REPLAY_FENCED_MESSAGES = 50;
 const MAX_EAGER_IMAGE_FETCHES_PER_DELIVERY = MAX_MESSAGE_ATTACHMENT_REFS;
 
 /**
@@ -965,6 +968,10 @@ export class SessionManager {
         session.retryTimer = null;
       }
     }
+    for (const timer of this.replayFenceRetryTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.replayFenceRetryTimers.clear();
 
     const shutdowns = [...this.sessions.values()].map((session) => {
       this.invalidateRouteTransition(session, reason ?? "manager_shutdown");
@@ -1117,29 +1124,36 @@ export class SessionManager {
   }
 
   /**
-   * Crash-safe fence reconciliation driven by authoritative server ACK
-   * truth. After a crash the local fence file can lag the server: an entry
-   * ACKed just before the crash leaves a stale chat-wide fence with no
-   * automatic cleanup. The server's recovery reply carries
-   * `unackedOutstanding` — the pending+delivered backlog for the chat
-   * scope, counted inside the same serialized boundary — and only `0`
-   * proves every fenced delivery settled, so those fences are stale and
-   * cleared. Any other outcome (backlog present, field absent on an older
-   * server, readback failure) keeps the fences fail-closed. Idempotent and
-   * replayable: runs on startup/bind and is retried on withheld dispatches.
+   * Crash-safe fence reconciliation driven by authoritative server
+   * settlement truth. After a crash the local fence file can lag the
+   * server: an entry ACKed just before the crash leaves a stale chat-wide
+   * fence with no automatic cleanup. The server's recovery reply carries
+   * the pending+delivered backlog for the chat scope — as a count
+   * (`unackedOutstanding`, proving settlement only at exactly 0) and, on
+   * new servers, per-message (`unackedMessageIds`), so an already-settled
+   * fenced head can clear even while a newer unacked tail exists. Anything
+   * less than authoritative truth keeps the fences fail-closed. Idempotent
+   * and replayable: runs on startup/rebind and on the per-chat retry loop.
    */
   async reconcileReplayFencesWithServer(): Promise<void> {
     if (!this.replayFence || this.replayFenceUnavailable) return;
     const chatIds = [...new Set(this.replayFence.snapshot().map((entry) => entry.chatId))];
     for (const chatId of chatIds) {
       await this.reconcileReplayFenceForChat(chatId);
+      this.ensureReplayFenceReconcileLoop(chatId);
     }
   }
 
-  /** In-flight guard so gate-triggered reconciliations coalesce per chat. */
-  private readonly replayFenceReconciliations = new Map<string, Promise<void>>();
-  /** Per-chat spacing for gate-triggered reconciliation retries. */
-  private readonly replayFenceReconcileAt = new Map<string, number>();
+  /**
+   * Fence keys the server has authoritatively proven settled. Once a key
+   * lands here its settlement fact cannot be revoked by later tail traffic;
+   * the retry loop only needs to redo the LOCAL clear, not the readback.
+   */
+  private readonly provenSettledFences = new Map<string, Set<string>>();
+  /** Messages withheld by the fence gate, re-driven once the fence clears. */
+  private readonly withheldReplayFencedMessages = new Map<string, SessionMessage[]>();
+  /** Per-chat retry timers for the reconciliation/clear loop. */
+  private readonly replayFenceRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   private async reconcileReplayFenceForChat(chatId: string): Promise<void> {
     if (!this.replayFence || this.replayFenceUnavailable || !this.config.recoverChatWithCount) return;
@@ -1154,47 +1168,125 @@ export class SessionManager {
       );
       return;
     }
-    if (result.unackedOutstanding !== 0) {
-      // Backlog present, or an older server omitted the authoritative
-      // field: either way this is NOT proof of settlement — keep fences.
+    const proven = this.provenSettledFences.get(chatId) ?? new Set<string>();
+    if (result.unackedMessageIds !== undefined) {
+      // Message-level truth: a fenced delivery is settled iff the server's
+      // unacked list does not contain it — a newer unacked tail cannot
+      // block the stale head's cleanup.
+      const unacked = new Set(result.unackedMessageIds);
+      for (const entry of this.replayFence.snapshot()) {
+        if (entry.chatId === chatId && !unacked.has(entry.messageId)) proven.add(entry.messageId);
+      }
+    } else if (result.unackedOutstanding === 0) {
+      for (const entry of this.replayFence.snapshot()) {
+        if (entry.chatId === chatId) proven.add(entry.messageId);
+      }
+    } else {
+      // Backlog present without per-message detail, or an older server
+      // omitted the fields: NOT proof of settlement — keep fences.
       return;
     }
-    for (const entry of this.replayFence.snapshot()) {
-      if (entry.chatId !== chatId) continue;
-      try {
-        this.replayFence.clear(entry.chatId, entry.messageId);
-        this.config.log.info(
-          { chatId, messageId: entry.messageId },
-          "cleared stale replay fence: delivery confirmed settled server-side",
-        );
-      } catch (err) {
-        this.config.log.error(
-          { err, chatId, messageId: entry.messageId },
-          "stale replay fence could not be cleared; chat stays fenced until a later reconciliation succeeds",
-        );
-        this.config.onSessionRuntimeChange?.(chatId, "error");
-      }
+    if (proven.size > 0) {
+      this.provenSettledFences.set(chatId, proven);
+      await this.clearProvenSettledFences(chatId);
     }
   }
 
   /**
-   * Gate-triggered retry: a withheld chat gets a bounded re-reconciliation
-   * so a transient readback/clear failure converges without a restart.
+   * Clear every server-proven-settled fence for the chat, retrying local
+   * I/O failures through the loop. When the last fence goes, withheld
+   * deliveries re-enter routing and the chat's runtime projection recovers.
    */
-  private scheduleReplayFenceReconcile(chatId: string): void {
-    if (!this.config.recoverChatWithCount) return;
-    const now = Date.now();
-    const nextAt = this.replayFenceReconcileAt.get(chatId) ?? 0;
-    if (now < nextAt || this.replayFenceReconciliations.has(chatId)) return;
-    this.replayFenceReconcileAt.set(chatId, now + REPLAY_FENCE_RECONCILE_INTERVAL_MS);
-    const pending = this.reconcileReplayFenceForChat(chatId)
-      .catch((err) => {
-        this.config.log.warn({ err, chatId }, "replay fence reconciliation attempt failed");
-      })
-      .finally(() => {
-        if (this.replayFenceReconciliations.get(chatId) === pending) this.replayFenceReconciliations.delete(chatId);
-      });
-    this.replayFenceReconciliations.set(chatId, pending);
+  private async clearProvenSettledFences(chatId: string): Promise<void> {
+    if (!this.replayFence) return;
+    const proven = this.provenSettledFences.get(chatId);
+    if (!proven) return;
+    for (const messageId of [...proven]) {
+      try {
+        this.replayFence.clear(chatId, messageId);
+        proven.delete(messageId);
+        this.config.log.info(
+          { chatId, messageId },
+          "cleared stale replay fence: delivery confirmed settled server-side",
+        );
+      } catch (err) {
+        this.config.log.error(
+          { err, chatId, messageId },
+          "stale replay fence could not be cleared; the retry loop will redo the local clear",
+        );
+        this.config.onSessionRuntimeChange?.(chatId, "error");
+      }
+    }
+    if (proven.size === 0) this.provenSettledFences.delete(chatId);
+    if (!this.replayFence.hasFenceForChat(chatId)) {
+      this.stopReplayFenceReconcileLoop(chatId);
+      await this.drainWithheldReplayFencedMessages(chatId);
+    }
+  }
+
+  /** Re-drive deliveries the gate withheld while the fence was up. */
+  private async drainWithheldReplayFencedMessages(chatId: string): Promise<void> {
+    const withheld = this.withheldReplayFencedMessages.get(chatId);
+    if (!withheld || withheld.length === 0) return;
+    this.withheldReplayFencedMessages.delete(chatId);
+    for (const message of withheld) {
+      this.config.log.info(
+        { chatId, messageId: message.id },
+        "re-driving replay-fence-withheld delivery after fence clear",
+      );
+      try {
+        await this.routeMessage(chatId, message, "fresh");
+      } catch (err) {
+        this.config.log.warn({ err, chatId, messageId: message.id }, "withheld delivery re-drive failed");
+        this.retryDeliveryTurn(chatId, message, "replay_fence_redrive_failed");
+      }
+    }
+    this.projectSessionRuntime(chatId);
+  }
+
+  /**
+   * Start (or keep) the per-chat retry loop. The timer fires on its own —
+   * no dependence on another dispatch — and alternates between retrying
+   * local clears of server-proven fences and re-reading server truth.
+   */
+  private ensureReplayFenceReconcileLoop(chatId: string): void {
+    if (this.shuttingDown) return;
+    if (this.replayFenceRetryTimers.has(chatId)) return;
+    void this.reconcileReplayFenceForChat(chatId).catch((err) => {
+      this.config.log.warn({ err, chatId }, "replay fence reconciliation attempt failed");
+    });
+    this.armReplayFenceRetryTimer(chatId);
+  }
+
+  private armReplayFenceRetryTimer(chatId: string): void {
+    const timer = setTimeout(() => {
+      this.replayFenceRetryTimers.delete(chatId);
+      void this.runReplayFenceReconcileLoop(chatId);
+    }, REPLAY_FENCE_RECONCILE_INTERVAL_MS);
+    this.replayFenceRetryTimers.set(chatId, timer);
+  }
+
+  private async runReplayFenceReconcileLoop(chatId: string): Promise<void> {
+    if (this.shuttingDown || !this.replayFence) return;
+    try {
+      if ((this.provenSettledFences.get(chatId)?.size ?? 0) > 0) {
+        await this.clearProvenSettledFences(chatId);
+      } else {
+        await this.reconcileReplayFenceForChat(chatId);
+      }
+    } catch (err) {
+      this.config.log.warn({ err, chatId }, "replay fence reconciliation loop iteration failed");
+    }
+    if (!this.shuttingDown && this.replayFence.hasFenceForChat(chatId)) {
+      this.armReplayFenceRetryTimer(chatId);
+    }
+  }
+
+  private stopReplayFenceReconcileLoop(chatId: string): void {
+    const timer = this.replayFenceRetryTimers.get(chatId);
+    if (timer) clearTimeout(timer);
+    this.replayFenceRetryTimers.delete(chatId);
+    this.provenSettledFences.delete(chatId);
   }
 
   private isChatReplayFenced(chatId: string): boolean {
@@ -1782,13 +1874,25 @@ export class SessionManager {
       // provider for the fenced head would replay that effect, and inbox ACK
       // is prefix-based, so the chat's entire FIFO tail must hold behind it:
       // every delivery stays unacknowledged recovery debt until an operator
-      // resolves the fenced head.
+      // resolves the fenced head. The message is buffered in memory so a
+      // later fence clear can re-drive it in-process; the server row stays
+      // delivered/unacked as the durable copy.
       this.config.log.error(
         { chatId, messageId: message.id },
         "withholding provider re-entry for replay-fenced chat; unsafe tool effect fenced before interruption",
       );
       this.config.onSessionRuntimeChange?.(chatId, "error");
-      this.scheduleReplayFenceReconcile(chatId);
+      const withheld = this.withheldReplayFencedMessages.get(chatId) ?? [];
+      if (withheld.length < MAX_WITHHELD_REPLAY_FENCED_MESSAGES) {
+        withheld.push(message);
+        this.withheldReplayFencedMessages.set(chatId, withheld);
+      } else {
+        this.config.log.error(
+          { chatId, messageId: message.id },
+          "replay-fence withheld buffer full; delivery relies on server redelivery",
+        );
+      }
+      this.ensureReplayFenceReconcileLoop(chatId);
       return;
     }
     const existing = this.sessions.get(chatId);

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1355,9 +1355,17 @@ export class SessionManager {
    */
   private reconcileReplayFences(chatId: string, messageIds: readonly string[]): void {
     if (!this.replayFence) return;
+    const replayFence = this.replayFence;
     // Converge only on a real fence transition: an ordinary never-fenced
     // turn must never fire a post-fence recovery.
     let transitioned = false;
+    const fencedMessageIds = messageIds.filter((messageId) => replayFence.isFenced(chatId, messageId));
+    if (fencedMessageIds.length > 0) {
+      // Invariant: authoritative settlement marker BEFORE any local fence
+      // clear. The ACK is already server-confirmed, so the marker must
+      // survive even if the clear below fails on I/O.
+      this.inboxDelivery.markFenceSettled(chatId, fencedMessageIds);
+    }
     for (const messageId of messageIds) {
       if (!this.replayFence.isFenced(chatId, messageId)) continue;
       transitioned = true;

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1098,10 +1098,10 @@ export class SessionManager {
     entry.deferredMessages = [];
   }
 
-  private isReplayFenced(chatId: string, message: SessionMessage): boolean {
+  private isChatReplayFenced(chatId: string): boolean {
     if (this.replayFenceUnavailable) return true;
     if (!this.replayFence) return false;
-    return this.replayFence.isFenced(chatId, message.id);
+    return this.replayFence.hasFenceForChat(chatId);
   }
 
   private createHandler(): AgentHandler {
@@ -1516,9 +1516,12 @@ export class SessionManager {
       }
     }
     if (deliveryLeaseValid && !deliveryLeaseValid()) return "retry";
-    await this.inboxDelivery.finishTurn(chatId, messages, outcome);
+    // The coordinator reports "settled" only once the concrete entries left
+    // the ledger through a confirmed ACK; recovery debt, prefix gaps, and
+    // ACK rejections keep custody and surface as "retry".
+    const disposition = await this.inboxDelivery.finishTurn(chatId, messages, outcome);
     this.projectSessionRuntime(chatId);
-    return "settled";
+    return disposition;
   }
 
   private createDeliveryToken(chatId: string, routeLeaseValid: (() => boolean) | null = null): DeliveryToken {
@@ -1653,15 +1656,18 @@ export class SessionManager {
       this.config.log.info({ chatId, messageId: message.id }, "delivery held while session termination is pending");
       return;
     }
-    if (this.isReplayFenced(chatId, message)) {
-      // A previous provider turn for this concrete delivery already produced
-      // a non-read-only tool effect before an interruption. Re-entering the
-      // provider would replay that effect, so the delivery stays
-      // unacknowledged recovery debt until an operator resolves it.
+    if (this.isChatReplayFenced(chatId)) {
+      // A previous provider turn in this chat produced a non-read-only tool
+      // effect before an interruption and never settled. Re-entering the
+      // provider for the fenced head would replay that effect, and inbox ACK
+      // is prefix-based, so the chat's entire FIFO tail must hold behind it:
+      // every delivery stays unacknowledged recovery debt until an operator
+      // resolves the fenced head.
       this.config.log.error(
         { chatId, messageId: message.id },
-        "withholding provider re-entry for replay-fenced delivery; unsafe tool effect fenced before interruption",
+        "withholding provider re-entry for replay-fenced chat; unsafe tool effect fenced before interruption",
       );
+      this.config.onSessionRuntimeChange?.(chatId, "error");
       return;
     }
     const existing = this.sessions.get(chatId);

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1135,7 +1135,7 @@ export class SessionManager {
     const chatIds = [...new Set(this.replayFence.snapshot().map((entry) => entry.chatId))];
     for (const chatId of chatIds) {
       await this.reconcileReplayFenceForChat(chatId);
-      this.ensureReplayFenceReconcileLoop(chatId);
+      this.ensureReplayFenceReconcileLoop(chatId, { immediate: false });
     }
   }
 
@@ -1167,7 +1167,16 @@ export class SessionManager {
       this.config.log.warn({ err, chatId }, "replay fence settlement probe failed; keeping fences (fail-closed)");
       return;
     }
-    const settled = new Set(settledIds);
+    // Only ids from THIS request may prove settlement; anything else is a
+    // protocol violation and must not clear anything.
+    const requested = new Set(fencedMessageIds);
+    const settled = new Set([...settledIds].filter((id) => requested.has(id)));
+    if (settled.size !== settledIds.length) {
+      this.config.log.warn(
+        { chatId, settled: settledIds, requested: fencedMessageIds },
+        "fence probe returned ids outside the request; ignoring them",
+      );
+    }
     const proven = this.provenSettledFences.get(chatId) ?? new Set<string>();
     for (const messageId of fencedMessageIds) {
       if (settled.has(messageId)) proven.add(messageId);
@@ -1187,10 +1196,12 @@ export class SessionManager {
     if (!this.replayFence) return;
     const proven = this.provenSettledFences.get(chatId);
     if (!proven) return;
+    const clearedMessageIds: string[] = [];
     for (const messageId of [...proven]) {
       try {
         this.replayFence.clear(chatId, messageId);
         proven.delete(messageId);
+        clearedMessageIds.push(messageId);
         this.config.log.info(
           { chatId, messageId },
           "cleared stale replay fence: delivery confirmed settled server-side",
@@ -1204,12 +1215,21 @@ export class SessionManager {
       }
     }
     if (proven.size === 0) this.provenSettledFences.delete(chatId);
+    if (clearedMessageIds.length > 0) this.inboxDelivery.settleReplayFencedEntries(chatId, clearedMessageIds);
     if (this.replayFence.hasFenceForChat(chatId)) return;
+    await this.onChatFencesCleared(chatId);
+  }
+
+  /**
+   * The single convergence point for "the last replay fence of a chat is
+   * gone" — reached from the probe loop, the committed-ACK callback, and
+   * local clear retries. Stops the retry loop and fires ONE destructive
+   * recovery so the server resets and redelivers only the still-unacked
+   * tail; the coordinator re-admits fence-withheld entries instead of
+   * deduplicating them. Already-settled heads are never re-driven.
+   */
+  private async onChatFencesCleared(chatId: string): Promise<void> {
     this.stopReplayFenceReconcileLoop(chatId);
-    // Single destructive recovery to re-drive whatever the gate withheld:
-    // the server resets and redelivers the rows, and the coordinator
-    // re-admits fence-withheld ledger entries instead of deduplicating
-    // them. This is the ONLY redrive path — exactly-once by construction.
     if (this.config.recoverChat && this.inboxDelivery.hasUnsettledWork(chatId)) {
       try {
         await this.config.recoverChat(chatId);
@@ -1228,12 +1248,14 @@ export class SessionManager {
    * no dependence on another dispatch — and alternates between retrying
    * local clears of server-proven fences and re-reading server truth.
    */
-  private ensureReplayFenceReconcileLoop(chatId: string): void {
+  private ensureReplayFenceReconcileLoop(chatId: string, opts: { immediate?: boolean } = {}): void {
     if (this.shuttingDown) return;
     if (this.replayFenceRetryTimers.has(chatId)) return;
-    void this.reconcileReplayFenceForChat(chatId).catch((err) => {
-      this.config.log.warn({ err, chatId }, "replay fence reconciliation attempt failed");
-    });
+    if (opts.immediate !== false) {
+      void this.reconcileReplayFenceForChat(chatId).catch((err) => {
+        this.config.log.warn({ err, chatId }, "replay fence reconciliation attempt failed");
+      });
+    }
     this.armReplayFenceRetryTimer(chatId);
   }
 
@@ -1286,12 +1308,23 @@ export class SessionManager {
       try {
         this.replayFence.clear(chatId, messageId);
       } catch (err) {
+        // The ACK is already confirmed server-side, so this key is proven
+        // settled; the retry loop redoes only the local clear.
+        const proven = this.provenSettledFences.get(chatId) ?? new Set<string>();
+        proven.add(messageId);
+        this.provenSettledFences.set(chatId, proven);
+        this.ensureReplayFenceReconcileLoop(chatId, { immediate: false });
         this.config.log.error(
           { err, chatId, messageId },
-          "replay fence could not be cleared after confirmed ACK; chat stays fenced until the store is repaired",
+          "replay fence could not be cleared after confirmed ACK; the retry loop will redo the local clear",
         );
         this.config.onSessionRuntimeChange?.(chatId, "error");
       }
+    }
+    if (!this.replayFence.hasFenceForChat(chatId)) {
+      void this.onChatFencesCleared(chatId).catch((err) => {
+        this.config.log.warn({ err, chatId }, "post-fence-clear convergence failed");
+      });
     }
   }
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -14,6 +14,7 @@ import {
   attachmentRefsFromMetadata,
   deriveRepoLocalPath,
   encodeProviderRetryEventMessage,
+  INBOX_FENCE_PROBE_MAX_IDS,
   imageAttachmentRefsFromMetadata,
   isImageBatchRefContent,
   isImageRefContent,
@@ -721,16 +722,21 @@ export class SessionManager {
         // turn, but same-chat later messages must still be able to append once
         // this entry has reached handler membership.
         const deliveryKind: SlotDeliveryKind = isRecoveryRedelivery ? "recovery" : "fresh";
-        routePromise = this.routeMessage(chatId, message, deliveryKind).catch(async (err) => {
-          if (this.inboxDelivery.hasEntry(work)) {
-            const proofReason = this.runtimeSessionProofReasonForError(err);
-            if (proofReason && (await this.holdDeliveryForRuntimeSessionProofRecovery(chatId, message, proofReason))) {
-              return;
+        routePromise = this.routeMessage(chatId, message, deliveryKind, decision.readmitted === true).catch(
+          async (err) => {
+            if (this.inboxDelivery.hasEntry(work)) {
+              const proofReason = this.runtimeSessionProofReasonForError(err);
+              if (
+                proofReason &&
+                (await this.holdDeliveryForRuntimeSessionProofRecovery(chatId, message, proofReason))
+              ) {
+                return;
+              }
+              this.retryDeliveryTurn(chatId, message, "route_message_failed");
             }
-            this.retryDeliveryTurn(chatId, message, "route_message_failed");
-          }
-          throw err;
-        });
+            throw err;
+          },
+        );
       });
     } catch (err) {
       if (this.inboxDelivery.hasEntry(work)) {
@@ -968,6 +974,10 @@ export class SessionManager {
       clearTimeout(timer);
     }
     this.replayFenceRetryTimers.clear();
+    for (const timer of this.postFenceRecoveryTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.postFenceRecoveryTimers.clear();
 
     const shutdowns = [...this.sessions.values()].map((session) => {
       this.invalidateRouteTransition(session, reason ?? "manager_shutdown");
@@ -1160,22 +1170,31 @@ export class SessionManager {
       ),
     ];
     if (fencedMessageIds.length === 0) return;
-    let settledIds: readonly string[];
-    try {
-      settledIds = await probe(chatId, fencedMessageIds);
-    } catch (err) {
-      this.config.log.warn({ err, chatId }, "replay fence settlement probe failed; keeping fences (fail-closed)");
-      return;
-    }
-    // Only ids from THIS request may prove settlement; anything else is a
-    // protocol violation and must not clear anything.
-    const requested = new Set(fencedMessageIds);
-    const settled = new Set([...settledIds].filter((id) => requested.has(id)));
-    if (settled.size !== settledIds.length) {
-      this.config.log.warn(
-        { chatId, settled: settledIds, requested: fencedMessageIds },
-        "fence probe returned ids outside the request; ignoring them",
-      );
+    // Probe in wire-sized chunks: oversized frames are rejected outright
+    // and would fail-closed forever. A failed chunk keeps its (and every
+    // later chunk's) ids fenced; earlier chunks still contribute proof.
+    const settled = new Set<string>();
+    for (let offset = 0; offset < fencedMessageIds.length; offset += INBOX_FENCE_PROBE_MAX_IDS) {
+      const chunk = fencedMessageIds.slice(offset, offset + INBOX_FENCE_PROBE_MAX_IDS);
+      let settledIds: readonly string[];
+      try {
+        settledIds = await probe(chatId, chunk);
+      } catch (err) {
+        this.config.log.warn(
+          { err, chatId, chunkOffset: offset },
+          "replay fence settlement probe failed; keeping unproven fences (fail-closed)",
+        );
+        break;
+      }
+      // Only ids from THIS chunk may prove settlement; anything else is a
+      // protocol violation and must not clear anything.
+      const requested = new Set(chunk);
+      for (const id of settledIds) {
+        if (requested.has(id)) settled.add(id);
+        else {
+          this.config.log.warn({ chatId, id }, "fence probe returned an id outside the request chunk; ignoring it");
+        }
+      }
     }
     const proven = this.provenSettledFences.get(chatId) ?? new Set<string>();
     for (const messageId of fencedMessageIds) {
@@ -1231,16 +1250,52 @@ export class SessionManager {
   private async onChatFencesCleared(chatId: string): Promise<void> {
     this.stopReplayFenceReconcileLoop(chatId);
     if (this.config.recoverChat && this.inboxDelivery.hasUnsettledWork(chatId)) {
-      try {
-        await this.config.recoverChat(chatId);
-      } catch (err) {
-        this.config.log.warn(
-          { err, chatId },
-          "post-fence-clear recovery failed; withheld deliveries stay recovery debt",
-        );
-      }
+      this.beginPostFenceRecovery(chatId);
+      return;
     }
     this.projectSessionRuntime(chatId);
+  }
+
+  /** Chats whose post-fence-clear recovery has not yet succeeded. */
+  private readonly postFenceRecoveryDebt = new Set<string>();
+  private readonly postFenceRecoveryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly postFenceRecoveryInFlight = new Map<string, Promise<void>>();
+
+  /**
+   * Fire the ONE successful destructive recovery that redelivers the
+   * withheld tail after a fence clear, coalescing concurrent convergences
+   * and retrying failures on a timer (failures hold new admissions via the
+   * post-fence debt gate; retries are not duplicate successes).
+   */
+  private beginPostFenceRecovery(chatId: string): void {
+    if (this.shuttingDown || !this.config.recoverChat) return;
+    if (this.postFenceRecoveryInFlight.has(chatId) || this.postFenceRecoveryTimers.has(chatId)) return;
+    this.postFenceRecoveryDebt.add(chatId);
+    const recoverChat = this.config.recoverChat;
+    const inFlight = (async () => {
+      try {
+        await recoverChat(chatId);
+        this.postFenceRecoveryDebt.delete(chatId);
+        this.config.log.info({ chatId }, "post-fence-clear recovery accepted; redelivery may proceed");
+      } catch (err) {
+        this.config.log.warn({ err, chatId }, "post-fence-clear recovery failed; retrying on a timer");
+        this.armPostFenceRecoveryTimer(chatId);
+      } finally {
+        this.postFenceRecoveryInFlight.delete(chatId);
+        this.projectSessionRuntime(chatId);
+      }
+    })();
+    this.postFenceRecoveryInFlight.set(chatId, inFlight);
+    void inFlight.catch(() => {});
+  }
+
+  private armPostFenceRecoveryTimer(chatId: string): void {
+    if (this.shuttingDown) return;
+    const timer = setTimeout(() => {
+      this.postFenceRecoveryTimers.delete(chatId);
+      this.beginPostFenceRecovery(chatId);
+    }, REPLAY_FENCE_RECONCILE_INTERVAL_MS);
+    this.postFenceRecoveryTimers.set(chatId, timer);
   }
 
   /**
@@ -1304,7 +1359,12 @@ export class SessionManager {
    */
   private reconcileReplayFences(chatId: string, messageIds: readonly string[]): void {
     if (!this.replayFence) return;
+    // Converge only on a real fence transition: an ordinary never-fenced
+    // turn must never fire a post-fence recovery.
+    let transitioned = false;
     for (const messageId of messageIds) {
+      if (!this.replayFence.isFenced(chatId, messageId)) continue;
+      transitioned = true;
       try {
         this.replayFence.clear(chatId, messageId);
       } catch (err) {
@@ -1321,7 +1381,7 @@ export class SessionManager {
         this.config.onSessionRuntimeChange?.(chatId, "error");
       }
     }
-    if (!this.replayFence.hasFenceForChat(chatId)) {
+    if (transitioned && !this.replayFence.hasFenceForChat(chatId)) {
       void this.onChatFencesCleared(chatId).catch((err) => {
         this.config.log.warn({ err, chatId }, "post-fence-clear convergence failed");
       });
@@ -1871,6 +1931,7 @@ export class SessionManager {
     chatId: string,
     message: SessionMessage,
     deliveryKind: SlotDeliveryKind = "fresh",
+    readmitted = false,
   ): Promise<void> {
     if (this.shuttingDown) {
       this.retryDeliveryTurn(chatId, message, "manager_shutdown");
@@ -1896,6 +1957,17 @@ export class SessionManager {
       this.config.onSessionRuntimeChange?.(chatId, "error");
       this.inboxDelivery.markReplayFenceWithheld(chatId, [message.id]);
       this.ensureReplayFenceReconcileLoop(chatId);
+      return;
+    }
+    if (this.postFenceRecoveryDebt.has(chatId) && !readmitted) {
+      // A post-fence-clear recovery is in flight or being retried: hold new
+      // admissions so the still-unacked tail keeps FIFO order until the
+      // server redelivery (which re-admits these withheld entries) lands.
+      this.config.log.info(
+        { chatId, messageId: message.id },
+        "holding delivery while post-fence-clear recovery is pending",
+      );
+      this.inboxDelivery.markReplayFenceWithheld(chatId, [message.id]);
       return;
     }
     const existing = this.sessions.get(chatId);

--- a/packages/qa/cases/runtime/kimi-code-provider.md
+++ b/packages/qa/cases/runtime/kimi-code-provider.md
@@ -53,6 +53,13 @@ classification, or Context Tree Kimi-tool derivation changes.
   unsupported diagnostic is emitted. Verify the stdio/http/SSE projection shapes without retaining secret headers.
   An empty managed list must omit the caller field so operator-global and project Kimi configuration keep their normal
   behavior.
+- Background subagents: instruct Kimi to launch two background subagents (`Agent` with `run_in_background`) whose work
+  runs longer than a deliberately short client idle threshold (for example 5 seconds). Verify both SDK `createSession`
+  and `resumeSession` carry `drainAgentTasksOnStop`, the session keeps reporting activity instead of idle-suspending,
+  subagent text never appears as the agent's own assistant output, subagent tool effects stay observable with
+  collision-safe tool-call ids while main-agent ids stay raw, and exactly one successful turn-end plus delivery
+  completion lands only after the main agent has consumed both subagent completions. Repeat the scenario once across a
+  suspend/resume boundary.
 - Failure and replay: prove a transient connection/rate error retries only before visible/unsafe output. After `Write`,
   `Edit`, or an unproven `Bash`, a failure must stop as unsafe replay rather than repeat the side effect; a later
   read-only tool must not downgrade that unsafe state.
@@ -70,7 +77,8 @@ Context Tree rows, and verified auth/failure boundaries.
 
 `FAIL` means a reproducible product violation such as device OAuth launched by First Tree, credentials exposed, model
 silently changed, missing standing role contract on resume, unsafe side effects replayed, terminal failure ACKed without
-the durable notice, configured caller MCP absent after create/resume, or absent Context Tree evidence.
+the durable notice, a delivery settled before the main agent consumed its background subagents (or child text leaking
+into assistant output), configured caller MCP absent after create/resume, or absent Context Tree evidence.
 
 `BLOCKED` means the Kimi account, credential, provider entitlement/network, or isolated run-cell topology prevented a
 live branch. Mocked SDK unit tests do not turn a blocked live branch into PASS. `INCONCLUSIVE` means the turn ran but

--- a/packages/server/src/__tests__/inbox-bind-recovery.test.ts
+++ b/packages/server/src/__tests__/inbox-bind-recovery.test.ts
@@ -533,3 +533,51 @@ describe("listSettledMessageIdsForScope (per-delivery settlement truth)", () => 
     ).toEqual([msg1, msg2]);
   });
 });
+
+describe("listSettledMessageIdsForScope under an oversized unrelated backlog", () => {
+  const getApp = useTestApp();
+
+  it("proves a settled fenced head even with 501 unacked tail rows in the same chat", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `big-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `big-a2-${uid}` });
+
+    const chatRes = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [a2.agent.uuid],
+    });
+    const chatId = chatRes.json().id;
+    const headId = (
+      await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+        format: "text",
+        content: "settled fenced head",
+        receiverNames: [a2.agent.name],
+      })
+    ).json().id;
+
+    // 501 unrelated unacked tail rows — far beyond any response cap.
+    for (let i = 0; i < 501; i += 1) {
+      await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+        format: "text",
+        content: `tail ${i}`,
+        receiverNames: [a2.agent.name],
+      });
+    }
+
+    // The head is ACKed; the tail stays pending/delivered.
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "acked", ackedAt: new Date() })
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.messageId, headId)));
+
+    expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(501);
+    expect(
+      await inboxService.listSettledMessageIdsForScope(app.db, {
+        inboxId: a2.agent.inboxId,
+        chatId,
+        messageIds: [headId],
+      }),
+    ).toEqual([headId]);
+  });
+});

--- a/packages/server/src/__tests__/inbox-bind-recovery.test.ts
+++ b/packages/server/src/__tests__/inbox-bind-recovery.test.ts
@@ -410,3 +410,51 @@ describe("inbox same-socket chat recovery", () => {
     await expect(inboxService.assertInboxOwner("inbox-a", "inbox-a")).resolves.toBeUndefined();
   });
 });
+
+describe("countUnackedForScope (authoritative unacked backlog)", () => {
+  const getApp = useTestApp();
+
+  it("counts pending AND delivered rows, so a bind-reset unacked row still blocks a settlement claim", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `count-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `count-a2-${uid}` });
+
+    const chatRes = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [a2.agent.uuid],
+    });
+    const chatId = chatRes.json().id;
+    const msgRes = await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+      format: "text",
+      content: "count pending vs delivered",
+      receiverNames: [a2.agent.name],
+    });
+    const messageId = msgRes.json().id;
+
+    // Fresh row: pending → outstanding is 1 while the delivered reset count
+    // a recovery would report is 0. This is the bind-reset race shape: a
+    // resetCount of 0 must never be read as "settled".
+    expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(1);
+
+    // Claim (delivered) → still outstanding 1.
+    const claimed = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
+    expect(claimed).toHaveLength(1);
+    expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(1);
+
+    // Bind-style reset back to pending → a second recover would reset 0
+    // delivered rows, yet the outstanding truth stays 1.
+    const recovered = await inboxService.recoverUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId });
+    expect(recovered.resetEntryIds).toHaveLength(1);
+    const secondRecover = await inboxService.recoverUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId });
+    expect(secondRecover.resetEntryIds).toHaveLength(0);
+    expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(1);
+
+    // Only a real ACK settles the scope.
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "acked", ackedAt: new Date() })
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.chatId, chatId)));
+    expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/inbox-bind-recovery.test.ts
+++ b/packages/server/src/__tests__/inbox-bind-recovery.test.ts
@@ -458,3 +458,59 @@ describe("countUnackedForScope (authoritative unacked backlog)", () => {
     expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(0);
   });
 });
+
+describe("listUnackedMessageIdsForScope (message-level settlement truth)", () => {
+  const getApp = useTestApp();
+
+  it("distinguishes a settled head from an unacked tail in the same chat", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `list-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `list-a2-${uid}` });
+
+    const chatRes = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [a2.agent.uuid],
+    });
+    const chatId = chatRes.json().id;
+    const msg1 = (
+      await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+        format: "text",
+        content: "settled head",
+        receiverNames: [a2.agent.name],
+      })
+    ).json().id;
+    const msg2 = (
+      await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+        format: "text",
+        content: "unacked tail",
+        receiverNames: [a2.agent.name],
+      })
+    ).json().id;
+
+    // Both unacked initially.
+    expect(await inboxService.listUnackedMessageIdsForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toEqual([
+      msg1,
+      msg2,
+    ]);
+
+    // ACK the head only: the tail stays, the head disappears from the
+    // unacked list — a stale fence for the head can clear while the tail
+    // is genuinely outstanding.
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "acked", ackedAt: new Date() })
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.messageId, msg1)));
+    expect(await inboxService.listUnackedMessageIdsForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toEqual([
+      msg2,
+    ]);
+    expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(1);
+
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "acked", ackedAt: new Date() })
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.messageId, msg2)));
+    expect(await inboxService.listUnackedMessageIdsForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toEqual([]);
+    expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/inbox-bind-recovery.test.ts
+++ b/packages/server/src/__tests__/inbox-bind-recovery.test.ts
@@ -459,14 +459,14 @@ describe("countUnackedForScope (authoritative unacked backlog)", () => {
   });
 });
 
-describe("listUnackedMessageIdsForScope (message-level settlement truth)", () => {
+describe("listSettledMessageIdsForScope (per-delivery settlement truth)", () => {
   const getApp = useTestApp();
 
-  it("distinguishes a settled head from an unacked tail in the same chat", async () => {
+  it("proves a settled head without being diluted by an unacked tail in the same chat", async () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
-    const a1 = await createTestAgent(app, { name: `list-a1-${uid}` });
-    const a2 = await createTestAgent(app, { name: `list-a2-${uid}` });
+    const a1 = await createTestAgent(app, { name: `probe-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `probe-a2-${uid}` });
 
     const chatRes = await a1.request("POST", "/api/v1/agent/chats", {
       type: "group",
@@ -488,29 +488,48 @@ describe("listUnackedMessageIdsForScope (message-level settlement truth)", () =>
       })
     ).json().id;
 
-    // Both unacked initially.
-    expect(await inboxService.listUnackedMessageIdsForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toEqual([
-      msg1,
-      msg2,
-    ]);
+    // Both unsettled initially.
+    expect(
+      await inboxService.listSettledMessageIdsForScope(app.db, {
+        inboxId: a2.agent.inboxId,
+        chatId,
+        messageIds: [msg1, msg2],
+      }),
+    ).toEqual([]);
 
-    // ACK the head only: the tail stays, the head disappears from the
-    // unacked list — a stale fence for the head can clear while the tail
-    // is genuinely outstanding.
+    // ACK the head only: it is proven settled even though the tail is
+    // still outstanding — the exact fenced-head + newer-tail scenario.
     await app.db
       .update(inboxEntries)
       .set({ status: "acked", ackedAt: new Date() })
       .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.messageId, msg1)));
-    expect(await inboxService.listUnackedMessageIdsForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toEqual([
-      msg2,
-    ]);
-    expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(1);
+    expect(
+      await inboxService.listSettledMessageIdsForScope(app.db, {
+        inboxId: a2.agent.inboxId,
+        chatId,
+        messageIds: [msg1, msg2],
+      }),
+    ).toEqual([msg1]);
+
+    // Unknown ids are not proven; a fully settled scope proves everything.
+    expect(
+      await inboxService.listSettledMessageIdsForScope(app.db, {
+        inboxId: a2.agent.inboxId,
+        chatId,
+        messageIds: [msg1, "msg-unknown"],
+      }),
+    ).toEqual([msg1]);
 
     await app.db
       .update(inboxEntries)
       .set({ status: "acked", ackedAt: new Date() })
       .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.messageId, msg2)));
-    expect(await inboxService.listUnackedMessageIdsForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toEqual([]);
-    expect(await inboxService.countUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId })).toBe(0);
+    expect(
+      await inboxService.listSettledMessageIdsForScope(app.db, {
+        inboxId: a2.agent.inboxId,
+        chatId,
+        messageIds: [msg1, msg2],
+      }),
+    ).toEqual([msg1, msg2]);
   });
 });

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -355,6 +355,7 @@ describe("Agent client WS branch fakes", () => {
     vi.spyOn(inboxService, "claimBacklogForPushForChat").mockResolvedValue([]);
     vi.spyOn(inboxService, "recoverUnackedForScope").mockResolvedValue({ resetEntryIds: [] });
     vi.spyOn(inboxService, "countUnackedForScope").mockResolvedValue(0);
+    vi.spyOn(inboxService, "listUnackedMessageIdsForScope").mockResolvedValue([]);
     vi.spyOn(inboxService, "ackEntryByIdForBoundAgents").mockResolvedValue({
       ok: true,
       throughEntry: inboxDbRow(),
@@ -617,6 +618,7 @@ describe("Agent client WS branch fakes", () => {
       chatId: "chat_1",
       resetCount: 0,
       unackedOutstanding: 0,
+      unackedMessageIds: [],
     });
   });
 
@@ -624,6 +626,7 @@ describe("Agent client WS branch fakes", () => {
     mockSuccessfulBindServices();
     const recoverSpy = vi.spyOn(inboxService, "recoverUnackedForScope").mockResolvedValue({ resetEntryIds: [101] });
     vi.spyOn(inboxService, "countUnackedForScope").mockResolvedValue(1);
+    vi.spyOn(inboxService, "listUnackedMessageIdsForScope").mockResolvedValue(["msg-no-progress"]);
     const { handler } = routeHarness(
       queuedDb([
         [{ id: "user_1", status: "active" }],
@@ -648,6 +651,7 @@ describe("Agent client WS branch fakes", () => {
         chatId: "chat_no_progress",
         resetCount: 1,
         unackedOutstanding: 1,
+        unackedMessageIds: ["msg-no-progress"],
       });
     }
 
@@ -710,6 +714,7 @@ describe("Agent client WS branch fakes", () => {
       chatId: "chat_no_progress",
       resetCount: 1,
       unackedOutstanding: 1,
+      unackedMessageIds: ["msg-no-progress"],
     });
     expect(recoverSpy).toHaveBeenCalledTimes(4);
   });

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -354,6 +354,7 @@ describe("Agent client WS branch fakes", () => {
     vi.spyOn(inboxService, "claimBacklogForPushFair").mockResolvedValue([]);
     vi.spyOn(inboxService, "claimBacklogForPushForChat").mockResolvedValue([]);
     vi.spyOn(inboxService, "recoverUnackedForScope").mockResolvedValue({ resetEntryIds: [] });
+    vi.spyOn(inboxService, "countUnackedForScope").mockResolvedValue(0);
     vi.spyOn(inboxService, "ackEntryByIdForBoundAgents").mockResolvedValue({
       ok: true,
       throughEntry: inboxDbRow(),
@@ -615,12 +616,14 @@ describe("Agent client WS branch fakes", () => {
       agentId: "agent_1",
       chatId: "chat_1",
       resetCount: 0,
+      unackedOutstanding: 0,
     });
   });
 
   it("opens a same-socket recovery circuit after repeated identical debt without progress", async () => {
     mockSuccessfulBindServices();
     const recoverSpy = vi.spyOn(inboxService, "recoverUnackedForScope").mockResolvedValue({ resetEntryIds: [101] });
+    vi.spyOn(inboxService, "countUnackedForScope").mockResolvedValue(1);
     const { handler } = routeHarness(
       queuedDb([
         [{ id: "user_1", status: "active" }],
@@ -644,6 +647,7 @@ describe("Agent client WS branch fakes", () => {
         agentId: "agent_1",
         chatId: "chat_no_progress",
         resetCount: 1,
+        unackedOutstanding: 1,
       });
     }
 
@@ -705,6 +709,7 @@ describe("Agent client WS branch fakes", () => {
       agentId: "agent_1",
       chatId: "chat_no_progress",
       resetCount: 1,
+      unackedOutstanding: 1,
     });
     expect(recoverSpy).toHaveBeenCalledTimes(4);
   });

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -355,7 +355,6 @@ describe("Agent client WS branch fakes", () => {
     vi.spyOn(inboxService, "claimBacklogForPushForChat").mockResolvedValue([]);
     vi.spyOn(inboxService, "recoverUnackedForScope").mockResolvedValue({ resetEntryIds: [] });
     vi.spyOn(inboxService, "countUnackedForScope").mockResolvedValue(0);
-    vi.spyOn(inboxService, "listUnackedMessageIdsForScope").mockResolvedValue([]);
     vi.spyOn(inboxService, "ackEntryByIdForBoundAgents").mockResolvedValue({
       ok: true,
       throughEntry: inboxDbRow(),
@@ -618,7 +617,55 @@ describe("Agent client WS branch fakes", () => {
       chatId: "chat_1",
       resetCount: 0,
       unackedOutstanding: 0,
-      unackedMessageIds: [],
+    });
+  });
+
+  it("answers fence probes with per-delivery settlement truth and rejects unbound agents", async () => {
+    mockSuccessfulBindServices();
+    const settledSpy = vi.spyOn(inboxService, "listSettledMessageIdsForScope").mockResolvedValue(["msg-settled"]);
+    const { handler } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        ...Array.from({ length: 12 }, () => [activeAgentRow()]),
+      ]),
+    );
+    const socket = new FakeSocket();
+    await bindAgent(socket, handler);
+
+    await emitMessage(socket, {
+      type: "inbox:fence-probe",
+      ref: "probe-1",
+      agentId: "agent_1",
+      chatId: "chat_1",
+      messageIds: ["msg-settled", "msg-pending"],
+    });
+    expect(socket.sent).toContainEqual({
+      type: "inbox:fence-probe:accepted",
+      ref: "probe-1",
+      agentId: "agent_1",
+      chatId: "chat_1",
+      settledMessageIds: ["msg-settled"],
+    });
+    expect(settledSpy).toHaveBeenCalledWith(expect.anything(), {
+      inboxId: expect.any(String),
+      chatId: "chat_1",
+      messageIds: ["msg-settled", "msg-pending"],
+    });
+
+    await emitMessage(socket, {
+      type: "inbox:fence-probe",
+      ref: "probe-2",
+      agentId: "agent_unknown",
+      chatId: "chat_1",
+      messageIds: ["msg-1"],
+    });
+    expect(socket.sent).toContainEqual({
+      type: "inbox:fence-probe:rejected",
+      ref: "probe-2",
+      agentId: "agent_unknown",
+      chatId: "chat_1",
+      reason: "agent_not_bound",
     });
   });
 
@@ -626,7 +673,6 @@ describe("Agent client WS branch fakes", () => {
     mockSuccessfulBindServices();
     const recoverSpy = vi.spyOn(inboxService, "recoverUnackedForScope").mockResolvedValue({ resetEntryIds: [101] });
     vi.spyOn(inboxService, "countUnackedForScope").mockResolvedValue(1);
-    vi.spyOn(inboxService, "listUnackedMessageIdsForScope").mockResolvedValue(["msg-no-progress"]);
     const { handler } = routeHarness(
       queuedDb([
         [{ id: "user_1", status: "active" }],
@@ -651,7 +697,6 @@ describe("Agent client WS branch fakes", () => {
         chatId: "chat_no_progress",
         resetCount: 1,
         unackedOutstanding: 1,
-        unackedMessageIds: ["msg-no-progress"],
       });
     }
 
@@ -714,7 +759,6 @@ describe("Agent client WS branch fakes", () => {
       chatId: "chat_no_progress",
       resetCount: 1,
       unackedOutstanding: 1,
-      unackedMessageIds: ["msg-no-progress"],
     });
     expect(recoverSpy).toHaveBeenCalledTimes(4);
   });

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -11,6 +11,7 @@ import {
   type InboxEntryWithMessage,
   inboxAckFrameSchema,
   inboxDeliverFrameSchema,
+  inboxFenceProbeFrameSchema,
   inboxRecoverFrameSchema,
   PROVIDER_MODELS_LIST_TYPE,
   PROVIDER_MODELS_RESULT_TYPE,
@@ -1859,14 +1860,8 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   }
                   // Counted inside the same serialized chain as the reset:
                   // unacked rows may already be `pending` (bind reset), so
-                  // only pending+delivered = 0 proves the chat settled. The
-                  // message-level list lets the client settle individual
-                  // fenced deliveries even when a newer unacked tail exists.
+                  // only pending+delivered = 0 proves the chat settled.
                   const unackedOutstanding = await inboxService.countUnackedForScope(app.db, {
-                    inboxId: info.inboxId,
-                    chatId,
-                  });
-                  const unackedMessageIds = await inboxService.listUnackedMessageIdsForScope(app.db, {
                     inboxId: info.inboxId,
                     chatId,
                   });
@@ -1878,7 +1873,6 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                       chatId,
                       resetCount: recovered.resetEntryIds.length,
                       unackedOutstanding,
-                      ...(unackedMessageIds !== null ? { unackedMessageIds } : {}),
                     }),
                   );
                   await drainBacklogForAgent(agentId, info.inboxId, { source: "recover", chatId });
@@ -1887,6 +1881,69 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   socket.send(
                     JSON.stringify({
                       type: "inbox:recover:rejected",
+                      ref,
+                      agentId,
+                      chatId,
+                      reason: "recover_failed",
+                    }),
+                  );
+                }
+              });
+            } else if (type === "inbox:fence-probe") {
+              const payloadResult = inboxFenceProbeFrameSchema.safeParse(msg);
+              if (!payloadResult.success) {
+                app.log.warn(
+                  {
+                    clientId,
+                    issues: payloadResult.error.issues.map((i) => ({
+                      path: i.path.join("."),
+                      code: i.code,
+                      message: i.message,
+                    })),
+                  },
+                  "malformed inbox:fence-probe frame — replying error",
+                );
+                socket.send(JSON.stringify({ type: "error", message: "Malformed inbox:fence-probe frame" }));
+                return;
+              }
+              const { agentId, chatId, ref, messageIds } = payloadResult.data;
+              // Read-only settlement probe, but serialized through the same
+              // boundary as recovery so the answer is consistent with any
+              // concurrent reset/drain.
+              await chainInboxDelivery("__socket", async () => {
+                const info = boundAgents.get(agentId);
+                if (!info || !(await ensureAgentStillRoutedHere(agentId))) {
+                  socket.send(
+                    JSON.stringify({
+                      type: "inbox:fence-probe:rejected",
+                      ref,
+                      agentId,
+                      chatId,
+                      reason: "agent_not_bound",
+                    }),
+                  );
+                  return;
+                }
+                try {
+                  const settledMessageIds = await inboxService.listSettledMessageIdsForScope(app.db, {
+                    inboxId: info.inboxId,
+                    chatId,
+                    messageIds,
+                  });
+                  socket.send(
+                    JSON.stringify({
+                      type: "inbox:fence-probe:accepted",
+                      ref,
+                      agentId,
+                      chatId,
+                      settledMessageIds,
+                    }),
+                  );
+                } catch (err) {
+                  app.log.error({ err, agentId, chatId }, "inbox:fence-probe handling failed");
+                  socket.send(
+                    JSON.stringify({
+                      type: "inbox:fence-probe:rejected",
                       ref,
                       agentId,
                       chatId,

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -1859,8 +1859,14 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   }
                   // Counted inside the same serialized chain as the reset:
                   // unacked rows may already be `pending` (bind reset), so
-                  // only pending+delivered = 0 proves the chat settled.
+                  // only pending+delivered = 0 proves the chat settled. The
+                  // message-level list lets the client settle individual
+                  // fenced deliveries even when a newer unacked tail exists.
                   const unackedOutstanding = await inboxService.countUnackedForScope(app.db, {
+                    inboxId: info.inboxId,
+                    chatId,
+                  });
+                  const unackedMessageIds = await inboxService.listUnackedMessageIdsForScope(app.db, {
                     inboxId: info.inboxId,
                     chatId,
                   });
@@ -1872,6 +1878,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                       chatId,
                       resetCount: recovered.resetEntryIds.length,
                       unackedOutstanding,
+                      ...(unackedMessageIds !== null ? { unackedMessageIds } : {}),
                     }),
                   );
                   await drainBacklogForAgent(agentId, info.inboxId, { source: "recover", chatId });

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -1857,6 +1857,13 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   } else {
                     inboxRecoverProgress.delete(progressKey);
                   }
+                  // Counted inside the same serialized chain as the reset:
+                  // unacked rows may already be `pending` (bind reset), so
+                  // only pending+delivered = 0 proves the chat settled.
+                  const unackedOutstanding = await inboxService.countUnackedForScope(app.db, {
+                    inboxId: info.inboxId,
+                    chatId,
+                  });
                   socket.send(
                     JSON.stringify({
                       type: "inbox:recover:accepted",
@@ -1864,6 +1871,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                       agentId,
                       chatId,
                       resetCount: recovered.resetEntryIds.length,
+                      unackedOutstanding,
                     }),
                   );
                   await drainBacklogForAgent(agentId, info.inboxId, { source: "recover", chatId });

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -701,34 +701,40 @@ export async function countUnackedForScope(db: Database, opts: { inboxId: string
   return rows[0]?.count ?? 0;
 }
 
-/** Cap for the message-level unacked list; larger backlogs omit the field so consumers stay conservative. */
-export const UNACKED_MESSAGE_IDS_LIMIT = 500;
+/** Cap for one fence-probe request; the client chunks larger fence sets. */
+export const FENCE_PROBE_MAX_IDS = 50;
 
 /**
- * Message-level companion to {@link countUnackedForScope}: the concrete
- * unacked message ids for one chat scope. Settlement truth is per delivery —
- * a newer unacked tail must not make an already-settled fenced head look
- * unsettled. Returns null when the backlog exceeds UNACKED_MESSAGE_IDS_LIMIT
- * (callers must treat that as unknown, never as empty).
+ * Per-delivery settlement truth for the replay-fence probe: of the probed
+ * message ids, which are durably settled — the delivery's notify row EXISTS
+ * in the chat scope and is no longer unsettled (pending/delivered). An id
+ * with no row at all is UNKNOWN, not settled, and must never clear a fence.
+ * Settlement is per concrete inbox delivery — unrelated backlog size must
+ * never dilute the answer. Must be called inside the same serialized
+ * recovery boundary as resets.
  */
-export async function listUnackedMessageIdsForScope(
+export async function listSettledMessageIdsForScope(
   db: Database,
-  opts: { inboxId: string; chatId: string },
-): Promise<string[] | null> {
+  opts: { inboxId: string; chatId: string; messageIds: string[] },
+): Promise<string[]> {
+  const uniqueIds = [...new Set(opts.messageIds)];
+  if (uniqueIds.length === 0) return [];
   const rows = await db
-    .select({ messageId: inboxEntries.messageId })
+    .select({ messageId: inboxEntries.messageId, status: inboxEntries.status })
     .from(inboxEntries)
     .where(
       and(
         eq(inboxEntries.inboxId, opts.inboxId),
         eq(inboxEntries.chatId, opts.chatId),
-        inArray(inboxEntries.status, ["pending", "delivered"]),
+        inArray(inboxEntries.messageId, uniqueIds),
         eq(inboxEntries.notify, true),
       ),
-    )
-    .limit(UNACKED_MESSAGE_IDS_LIMIT + 1);
-  if (rows.length > UNACKED_MESSAGE_IDS_LIMIT) return null;
-  return rows.map((row) => row.messageId);
+    );
+  const known = new Set(rows.map((row) => row.messageId));
+  const unacked = new Set(
+    rows.filter((row) => row.status === "pending" || row.status === "delivered").map((row) => row.messageId),
+  );
+  return uniqueIds.filter((id) => known.has(id) && !unacked.has(id));
 }
 
 /**

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -1,4 +1,5 @@
 import {
+  INBOX_FENCE_PROBE_MAX_IDS,
   type InboxEntryWithMessage,
   inboxEntryStatusSchema,
   messageSourceSchema,
@@ -701,8 +702,8 @@ export async function countUnackedForScope(db: Database, opts: { inboxId: string
   return rows[0]?.count ?? 0;
 }
 
-/** Cap for one fence-probe request; the client chunks larger fence sets. */
-export const FENCE_PROBE_MAX_IDS = 50;
+/** Cap for one fence-probe request — the shared wire constant; the client chunks larger fence sets. */
+export const FENCE_PROBE_MAX_IDS = INBOX_FENCE_PROBE_MAX_IDS;
 
 /**
  * Per-delivery settlement truth for the replay-fence probe: of the probed

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -701,6 +701,36 @@ export async function countUnackedForScope(db: Database, opts: { inboxId: string
   return rows[0]?.count ?? 0;
 }
 
+/** Cap for the message-level unacked list; larger backlogs omit the field so consumers stay conservative. */
+export const UNACKED_MESSAGE_IDS_LIMIT = 500;
+
+/**
+ * Message-level companion to {@link countUnackedForScope}: the concrete
+ * unacked message ids for one chat scope. Settlement truth is per delivery —
+ * a newer unacked tail must not make an already-settled fenced head look
+ * unsettled. Returns null when the backlog exceeds UNACKED_MESSAGE_IDS_LIMIT
+ * (callers must treat that as unknown, never as empty).
+ */
+export async function listUnackedMessageIdsForScope(
+  db: Database,
+  opts: { inboxId: string; chatId: string },
+): Promise<string[] | null> {
+  const rows = await db
+    .select({ messageId: inboxEntries.messageId })
+    .from(inboxEntries)
+    .where(
+      and(
+        eq(inboxEntries.inboxId, opts.inboxId),
+        eq(inboxEntries.chatId, opts.chatId),
+        inArray(inboxEntries.status, ["pending", "delivered"]),
+        eq(inboxEntries.notify, true),
+      ),
+    )
+    .limit(UNACKED_MESSAGE_IDS_LIMIT + 1);
+  if (rows.length > UNACKED_MESSAGE_IDS_LIMIT) return null;
+  return rows.map((row) => row.messageId);
+}
+
 /**
  * Reset delivered-but-unacked notify rows for a single inbox, optionally
  * narrowed to one chat, and return the concrete ids that were reset. The id

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -680,6 +680,28 @@ export type RecoverUnackedForScopeResult = {
 };
 
 /**
+ * Authoritative unacked backlog for one inbox scope: rows in EITHER
+ * `pending` or `delivered` (both unsettled per the wire contract; only
+ * `acked` is settlement). `recoverUnackedForScope`'s reset count alone can
+ * never prove settlement, because unacked rows may already be `pending`
+ * (e.g. after a bind reset). Callers must compute this inside the same
+ * serialized recovery boundary as the reset itself.
+ */
+export async function countUnackedForScope(db: Database, opts: { inboxId: string; chatId?: string }): Promise<number> {
+  const conditions = [
+    eq(inboxEntries.inboxId, opts.inboxId),
+    inArray(inboxEntries.status, ["pending", "delivered"]),
+    eq(inboxEntries.notify, true),
+  ];
+  if (opts.chatId !== undefined) conditions.push(eq(inboxEntries.chatId, opts.chatId));
+  const rows = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(inboxEntries)
+    .where(and(...conditions));
+  return rows[0]?.count ?? 0;
+}
+
+/**
  * Reset delivered-but-unacked notify rows for a single inbox, optionally
  * narrowed to one chat, and return the concrete ids that were reset. The id
  * list lets the WS layer remove only those entries from same-socket in-flight

--- a/packages/shared/src/__tests__/inbox-frames-schema.test.ts
+++ b/packages/shared/src/__tests__/inbox-frames-schema.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  INBOX_FENCE_PROBE_MAX_IDS,
   inboxAckAcceptedFrameSchema,
   inboxAckFrameSchema,
   inboxAckRejectedFrameSchema,
   inboxDeliverFrameSchema,
+  inboxFenceProbeAcceptedFrameSchema,
+  inboxFenceProbeFrameSchema,
+  inboxFenceProbeRejectedFrameSchema,
   inboxRecoverAcceptedFrameSchema,
   inboxRecoverFrameSchema,
   inboxRecoverRejectedFrameSchema,
@@ -253,5 +257,57 @@ describe("inboxRecoverRejectedFrameSchema", () => {
       reason: "agent_not_bound",
     });
     expect(res.success).toBe(true);
+  });
+});
+
+describe("inbox:fence-probe frames", () => {
+  it("accepts a well-formed probe and answer", () => {
+    expect(
+      inboxFenceProbeFrameSchema.safeParse({
+        type: "inbox:fence-probe",
+        ref: "r1",
+        agentId: "a1",
+        chatId: "c1",
+        messageIds: ["m1", "m2"],
+      }).success,
+    ).toBe(true);
+    expect(
+      inboxFenceProbeAcceptedFrameSchema.safeParse({
+        type: "inbox:fence-probe:accepted",
+        ref: "r1",
+        agentId: "a1",
+        chatId: "c1",
+        settledMessageIds: ["m1"],
+      }).success,
+    ).toBe(true);
+    expect(
+      inboxFenceProbeRejectedFrameSchema.safeParse({
+        type: "inbox:fence-probe:rejected",
+        ref: "r1",
+        agentId: "a1",
+        reason: "agent_not_bound",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects empty and oversized id lists", () => {
+    expect(
+      inboxFenceProbeFrameSchema.safeParse({
+        type: "inbox:fence-probe",
+        ref: "r1",
+        agentId: "a1",
+        chatId: "c1",
+        messageIds: [],
+      }).success,
+    ).toBe(false);
+    expect(
+      inboxFenceProbeFrameSchema.safeParse({
+        type: "inbox:fence-probe",
+        ref: "r1",
+        agentId: "a1",
+        chatId: "c1",
+        messageIds: Array.from({ length: INBOX_FENCE_PROBE_MAX_IDS + 1 }, (_, i) => `m${i}`),
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -801,6 +801,9 @@ export type {
   InboxAckRejectedFrame,
   InboxAckRejectedReason,
   InboxDeliverFrame,
+  InboxFenceProbeAcceptedFrame,
+  InboxFenceProbeFrame,
+  InboxFenceProbeRejectedFrame,
   InboxRecoverAcceptedFrame,
   InboxRecoverFrame,
   InboxRecoverRejectedFrame,
@@ -808,12 +811,16 @@ export type {
 } from "./schemas/inbox-frames.js";
 // -- WebSocket inbox data-plane frames --
 export {
+  INBOX_FENCE_PROBE_MAX_IDS,
   inboxAckAcceptedDispositionSchema,
   inboxAckAcceptedFrameSchema,
   inboxAckFrameSchema,
   inboxAckRejectedFrameSchema,
   inboxAckRejectedReasonSchema,
   inboxDeliverFrameSchema,
+  inboxFenceProbeAcceptedFrameSchema,
+  inboxFenceProbeFrameSchema,
+  inboxFenceProbeRejectedFrameSchema,
   inboxRecoverAcceptedFrameSchema,
   inboxRecoverFrameSchema,
   inboxRecoverRejectedFrameSchema,

--- a/packages/shared/src/schemas/inbox-frames.ts
+++ b/packages/shared/src/schemas/inbox-frames.ts
@@ -92,15 +92,45 @@ export const inboxRecoverAcceptedFrameSchema = z.object({
    * consumers must treat its absence as "unknown", never as zero.
    */
   unackedOutstanding: z.number().int().nonnegative().optional(),
-  /**
-   * Message-level settlement truth: the concrete unacked message ids for
-   * the chat scope. Settlement is per delivery, so a newer unacked tail
-   * must not keep an already-settled fenced head fenced. Omitted when the
-   * backlog exceeds the server's list cap or on older servers; consumers
-   * must treat absence as unknown, never as empty.
-   */
-  unackedMessageIds: z.array(z.string().min(1)).max(500).optional(),
 });
+
+/**
+ * client → server: read-only settlement probe for concrete fenced
+ * deliveries. The server answers, inside the same serialized recovery
+ * boundary, which of the probed message ids have no unsettled
+ * (pending/delivered) notify row in the chat scope — the only truth that
+ * may clear a replay fence. Bounded per request; unrelated backlog size
+ * must never dilute the answer.
+ */
+export const INBOX_FENCE_PROBE_MAX_IDS = 50;
+
+export const inboxFenceProbeFrameSchema = z.object({
+  type: z.literal("inbox:fence-probe"),
+  ref: z.string().min(1),
+  agentId: z.string().min(1),
+  chatId: z.string().min(1),
+  messageIds: z.array(z.string().min(1)).min(1).max(INBOX_FENCE_PROBE_MAX_IDS),
+});
+export type InboxFenceProbeFrame = z.infer<typeof inboxFenceProbeFrameSchema>;
+
+export const inboxFenceProbeAcceptedFrameSchema = z.object({
+  type: z.literal("inbox:fence-probe:accepted"),
+  ref: z.string().min(1),
+  agentId: z.string().min(1),
+  chatId: z.string().min(1),
+  /** Probed ids proven settled (no unsettled notify row for that delivery). */
+  settledMessageIds: z.array(z.string().min(1)),
+});
+export type InboxFenceProbeAcceptedFrame = z.infer<typeof inboxFenceProbeAcceptedFrameSchema>;
+
+export const inboxFenceProbeRejectedFrameSchema = z.object({
+  type: z.literal("inbox:fence-probe:rejected"),
+  ref: z.string().min(1),
+  agentId: z.string().min(1),
+  chatId: z.string().min(1).optional(),
+  reason: inboxRecoverRejectedReasonSchema,
+});
+export type InboxFenceProbeRejectedFrame = z.infer<typeof inboxFenceProbeRejectedFrameSchema>;
 export type InboxRecoverAcceptedFrame = z.infer<typeof inboxRecoverAcceptedFrameSchema>;
 
 export const inboxRecoverRejectedFrameSchema = z.object({

--- a/packages/shared/src/schemas/inbox-frames.ts
+++ b/packages/shared/src/schemas/inbox-frames.ts
@@ -92,6 +92,14 @@ export const inboxRecoverAcceptedFrameSchema = z.object({
    * consumers must treat its absence as "unknown", never as zero.
    */
   unackedOutstanding: z.number().int().nonnegative().optional(),
+  /**
+   * Message-level settlement truth: the concrete unacked message ids for
+   * the chat scope. Settlement is per delivery, so a newer unacked tail
+   * must not keep an already-settled fenced head fenced. Omitted when the
+   * backlog exceeds the server's list cap or on older servers; consumers
+   * must treat absence as unknown, never as empty.
+   */
+  unackedMessageIds: z.array(z.string().min(1)).max(500).optional(),
 });
 export type InboxRecoverAcceptedFrame = z.infer<typeof inboxRecoverAcceptedFrameSchema>;
 

--- a/packages/shared/src/schemas/inbox-frames.ts
+++ b/packages/shared/src/schemas/inbox-frames.ts
@@ -81,7 +81,17 @@ export const inboxRecoverAcceptedFrameSchema = z.object({
   ref: z.string().min(1),
   agentId: z.string().min(1),
   chatId: z.string().min(1),
+  /** Rows the recovery reset from delivered back to pending. */
   resetCount: z.number().int().nonnegative(),
+  /**
+   * Authoritative unacked backlog for the chat scope: rows in EITHER
+   * `pending` or `delivered`, counted inside the same serialized recovery
+   * boundary. Only `0` proves every delivery in the chat settled — a plain
+   * `resetCount` of 0 cannot, since unacked rows may already be `pending`
+   * (e.g. after a bind reset). Optional so older servers stay compatible;
+   * consumers must treat its absence as "unknown", never as zero.
+   */
+  unackedOutstanding: z.number().int().nonnegative().optional(),
 });
 export type InboxRecoverAcceptedFrame = z.infer<typeof inboxRecoverAcceptedFrameSchema>;
 

--- a/patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch
+++ b/patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch
@@ -1,22 +1,25 @@
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 2d300d14b5e5375b0c4a90cc578341b62983f07b..0800efda1a4390c2261ba7b4f695e56500519fe9 100644
+index 2d300d14b5e5375b0c4a90cc578341b62983f07b..84926bb10d7761499a9670da0bdeae10158e789d 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -74311,7 +74311,12 @@ function safeEmitLive(emit, event) {
- 	let maybePromise;
- 	try {
- 		maybePromise = emit(event);
--	} catch {
-+	} catch (error) {
-+		// Botiverse mirror: host lifecycle fences (e.g. First Tree's replay
-+		// fence) mark errors that must abort the in-flight tool dispatch
-+		// instead of being swallowed, so a failed durable write can never let
-+		// an unsafe tool effect proceed.
-+		if (error && typeof error === "object" && error.__firstTreeReplayFenceBlock === true) throw error;
- 		return;
- 	}
- 	if (maybePromise !== void 0 && maybePromise !== null && typeof maybePromise.then === "function" && typeof maybePromise.catch === "function") maybePromise.catch(() => {});
-@@ -133036,6 +133041,7 @@ var Session$1 = class {
+@@ -100625,6 +100625,16 @@ var TurnFlow = class {
+ 							if (cached !== null) return { syntheticResult: cached };
+ 						},
+ 						authorizeToolExecution: async (ctx) => {
++							const hostBeforeToolCall = globalThis.__firstTreeBeforeToolCall;
++							if (typeof hostBeforeToolCall === "function") {
++								await hostBeforeToolCall({
++									sessionId: this.agent.sessionId,
++									agentId: this.agent.agentId ?? (this.agent.homedir ? basename$1(this.agent.homedir) : this.agent.type),
++									toolName: ctx.toolCall.name,
++									toolCallId: ctx.toolCall.id,
++									args: ctx.args
++								});
++							}
+ 							return this.agent.permission.beforeToolCall(ctx);
+ 						},
+ 						finalizeToolResult: async (ctx) => {
+@@ -133036,6 +133046,7 @@ var Session$1 = class {
  		this.agents.clear();
  		const { warning } = agents["main"] === void 0 ? { warning: void 0 } : await this.resumeAgent("main");
  		const main = this.getReadyAgent("main");
@@ -24,7 +27,16 @@ index 2d300d14b5e5375b0c4a90cc578341b62983f07b..0800efda1a4390c2261ba7b4f695e565
  		const profile = DEFAULT_AGENT_PROFILES["agent"];
  		if (main !== void 0 && profile !== void 0 && main.config.systemPrompt === "") await this.bootstrapAgentProfile(main, profile);
  		await this.triggerSessionStart("resume");
-@@ -153788,7 +153794,8 @@ var KimiCore = class {
+@@ -133487,6 +133498,8 @@ var Session$1 = class {
+ 			roleAdditional: this.roleAdditional,
+ 			systemPromptContextProvider: () => prepareSystemPromptContext(this.systemContextKaos(agent.kaos.getcwd()), this.options.kimiHomeDir, { additionalDirs: agent.getAdditionalDirs() })
+ 		});
++		agent.sessionId = this.options.id;
++		agent.agentId = id;
+ 		return agent;
+ 	}
+ 	permissionOptions(parentAgentId, input) {
+@@ -153788,7 +153801,8 @@ var KimiCore = class {
  			pluginCommands,
  			appVersion: this.appVersion,
  			additionalDirs,

--- a/patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch
+++ b/patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch
@@ -1,8 +1,22 @@
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 2d300d14b5e5375b0c4a90cc578341b62983f07b..f327220c02a1cdcacd9ef4edf8abca9aeb458ca1 100644
+index 2d300d14b5e5375b0c4a90cc578341b62983f07b..0800efda1a4390c2261ba7b4f695e56500519fe9 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -133036,6 +133036,7 @@ var Session$1 = class {
+@@ -74311,7 +74311,12 @@ function safeEmitLive(emit, event) {
+ 	let maybePromise;
+ 	try {
+ 		maybePromise = emit(event);
+-	} catch {
++	} catch (error) {
++		// Botiverse mirror: host lifecycle fences (e.g. First Tree's replay
++		// fence) mark errors that must abort the in-flight tool dispatch
++		// instead of being swallowed, so a failed durable write can never let
++		// an unsafe tool effect proceed.
++		if (error && typeof error === "object" && error.__firstTreeReplayFenceBlock === true) throw error;
+ 		return;
+ 	}
+ 	if (maybePromise !== void 0 && maybePromise !== null && typeof maybePromise.then === "function" && typeof maybePromise.catch === "function") maybePromise.catch(() => {});
+@@ -133036,6 +133041,7 @@ var Session$1 = class {
  		this.agents.clear();
  		const { warning } = agents["main"] === void 0 ? { warning: void 0 } : await this.resumeAgent("main");
  		const main = this.getReadyAgent("main");
@@ -10,7 +24,7 @@ index 2d300d14b5e5375b0c4a90cc578341b62983f07b..f327220c02a1cdcacd9ef4edf8abca9a
  		const profile = DEFAULT_AGENT_PROFILES["agent"];
  		if (main !== void 0 && profile !== void 0 && main.config.systemPrompt === "") await this.bootstrapAgentProfile(main, profile);
  		await this.triggerSessionStart("resume");
-@@ -153788,7 +153789,8 @@ var KimiCore = class {
+@@ -153788,7 +153794,8 @@ var KimiCore = class {
  			pluginCommands,
  			appVersion: this.appVersion,
  			additionalDirs,

--- a/patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch
+++ b/patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch
@@ -1,0 +1,22 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 2d300d14b5e5375b0c4a90cc578341b62983f07b..f327220c02a1cdcacd9ef4edf8abca9aeb458ca1 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -133036,6 +133036,7 @@ var Session$1 = class {
+ 		this.agents.clear();
+ 		const { warning } = agents["main"] === void 0 ? { warning: void 0 } : await this.resumeAgent("main");
+ 		const main = this.getReadyAgent("main");
++		if (main !== void 0 && this.options.drainAgentTasksOnStop) main.printDrainAgentTasksOnStop = true;
+ 		const profile = DEFAULT_AGENT_PROFILES["agent"];
+ 		if (main !== void 0 && profile !== void 0 && main.config.systemPrompt === "") await this.bootstrapAgentProfile(main, profile);
+ 		await this.triggerSessionStart("resume");
+@@ -153788,7 +153789,8 @@ var KimiCore = class {
+ 			pluginCommands,
+ 			appVersion: this.appVersion,
+ 			additionalDirs,
+-			roleAdditional: input.roleAdditional
++			roleAdditional: input.roleAdditional,
++			drainAgentTasksOnStop: input.drainAgentTasksOnStop
+ 		});
+ 		let warning;
+ 		try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@botiverse/kimi-code-sdk@0.26.0-botiverse.2':
+    hash: ab8351a223dcf9d292d0ad17805ab911904378a30b3cfd16240ce56f7b051f47
+    path: patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch
+
 importers:
 
   .:
@@ -28,7 +33,7 @@ importers:
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@botiverse/kimi-code-sdk':
         specifier: 0.26.0-botiverse.2
-        version: 0.26.0-botiverse.2
+        version: 0.26.0-botiverse.2(patch_hash=ab8351a223dcf9d292d0ad17805ab911904378a30b3cfd16240ce56f7b051f47)
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.2(@types/node@22.19.15)
@@ -110,7 +115,7 @@ importers:
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@botiverse/kimi-code-sdk':
         specifier: 0.26.0-botiverse.2
-        version: 0.26.0-botiverse.2
+        version: 0.26.0-botiverse.2(patch_hash=ab8351a223dcf9d292d0ad17805ab911904378a30b3cfd16240ce56f7b051f47)
       '@openai/codex-sdk':
         specifier: ^0.144.1
         version: 0.144.1
@@ -5886,7 +5891,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.8':
     optional: true
 
-  '@botiverse/kimi-code-sdk@0.26.0-botiverse.2':
+  '@botiverse/kimi-code-sdk@0.26.0-botiverse.2(patch_hash=ab8351a223dcf9d292d0ad17805ab911904378a30b3cfd16240ce56f7b051f47)':
     dependencies:
       '@antfu/utils': 9.3.0
       smol-toml: 1.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@botiverse/kimi-code-sdk@0.26.0-botiverse.2':
-    hash: ab8351a223dcf9d292d0ad17805ab911904378a30b3cfd16240ce56f7b051f47
+    hash: 4b5c46a481537c404d4ab1f9cb7e66aec677be764dddba5e7af97be462916ed8
     path: patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch
 
 importers:
@@ -36,7 +36,7 @@ importers:
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@botiverse/kimi-code-sdk':
         specifier: 0.26.0-botiverse.2
-        version: 0.26.0-botiverse.2(patch_hash=ab8351a223dcf9d292d0ad17805ab911904378a30b3cfd16240ce56f7b051f47)
+        version: 0.26.0-botiverse.2(patch_hash=4b5c46a481537c404d4ab1f9cb7e66aec677be764dddba5e7af97be462916ed8)
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.2(@types/node@22.19.15)
@@ -124,7 +124,7 @@ importers:
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@botiverse/kimi-code-sdk':
         specifier: 0.26.0-botiverse.2
-        version: 0.26.0-botiverse.2(patch_hash=ab8351a223dcf9d292d0ad17805ab911904378a30b3cfd16240ce56f7b051f47)
+        version: 0.26.0-botiverse.2(patch_hash=4b5c46a481537c404d4ab1f9cb7e66aec677be764dddba5e7af97be462916ed8)
       '@openai/codex-sdk':
         specifier: ^0.144.1
         version: 0.144.1
@@ -5900,7 +5900,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.8':
     optional: true
 
-  '@botiverse/kimi-code-sdk@0.26.0-botiverse.2(patch_hash=ab8351a223dcf9d292d0ad17805ab911904378a30b3cfd16240ce56f7b051f47)':
+  '@botiverse/kimi-code-sdk@0.26.0-botiverse.2(patch_hash=4b5c46a481537c404d4ab1f9cb7e66aec677be764dddba5e7af97be462916ed8)':
     dependencies:
       '@antfu/utils': 9.3.0
       smol-toml: 1.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@botiverse/kimi-code-sdk@0.26.0-botiverse.2':
-    hash: 4b5c46a481537c404d4ab1f9cb7e66aec677be764dddba5e7af97be462916ed8
+    hash: d1b4ebdff0d387514d10b9b1bc2ee8b5eb9ba86cd1ae42d2030bc5c57b73d20a
     path: patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch
 
 importers:
@@ -36,7 +36,7 @@ importers:
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@botiverse/kimi-code-sdk':
         specifier: 0.26.0-botiverse.2
-        version: 0.26.0-botiverse.2(patch_hash=4b5c46a481537c404d4ab1f9cb7e66aec677be764dddba5e7af97be462916ed8)
+        version: 0.26.0-botiverse.2(patch_hash=d1b4ebdff0d387514d10b9b1bc2ee8b5eb9ba86cd1ae42d2030bc5c57b73d20a)
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.2(@types/node@22.19.15)
@@ -124,7 +124,7 @@ importers:
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@botiverse/kimi-code-sdk':
         specifier: 0.26.0-botiverse.2
-        version: 0.26.0-botiverse.2(patch_hash=4b5c46a481537c404d4ab1f9cb7e66aec677be764dddba5e7af97be462916ed8)
+        version: 0.26.0-botiverse.2(patch_hash=d1b4ebdff0d387514d10b9b1bc2ee8b5eb9ba86cd1ae42d2030bc5c57b73d20a)
       '@openai/codex-sdk':
         specifier: ^0.144.1
         version: 0.144.1
@@ -5900,7 +5900,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.8':
     optional: true
 
-  '@botiverse/kimi-code-sdk@0.26.0-botiverse.2(patch_hash=4b5c46a481537c404d4ab1f9cb7e66aec677be764dddba5e7af97be462916ed8)':
+  '@botiverse/kimi-code-sdk@0.26.0-botiverse.2(patch_hash=d1b4ebdff0d387514d10b9b1bc2ee8b5eb9ba86cd1ae42d2030bc5c57b73d20a)':
     dependencies:
       '@antfu/utils': 9.3.0
       smol-toml: 1.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
 
   apps/cli:
     dependencies:
+      '@antfu/utils':
+        specifier: ^9.3.0
+        version: 9.3.0
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.187
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
@@ -61,12 +64,18 @@ importers:
       semver:
         specifier: ^7.6.3
         version: 7.7.4
+      smol-toml:
+        specifier: ^1.6.1
+        version: 1.7.0
       ws:
         specifier: ^8.20.0
         version: 8.20.0
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
+      yazl:
+        specifier: ^3.3.1
+        version: 3.3.1
       zod:
         specifier: ^4.0.0
         version: 4.3.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
-  - "apps/cli"
-  - "packages/*"
+  - apps/cli
+  - packages/*
+
+patchedDependencies:
+  '@botiverse/kimi-code-sdk@0.26.0-botiverse.2': patches/@botiverse__kimi-code-sdk@0.26.0-botiverse.2.patch

--- a/scripts/portable/build-portable.mjs
+++ b/scripts/portable/build-portable.mjs
@@ -449,12 +449,38 @@ export function readWorkspacePackageManager(rootPackage = readJson(join(REPO_ROO
   return value;
 }
 
+// The workspace pins dependency patches in pnpm-workspace.yaml (for example
+// the Kimi SDK resume-drain patch). The synthetic portable app is a single
+// package without that workspace file, so its generated lockfile would
+// silently resolve the unpatched registry artifact. Extract the block with a
+// narrow indentation parse (this script must stay dependency-free) and inject
+// it into the app's own package.json so both portable install steps apply the
+// same patches.
+export function readWorkspacePatchedDependencies(workspaceYamlPath = join(REPO_ROOT, "pnpm-workspace.yaml")) {
+  const text = readFileSync(workspaceYamlPath, "utf8");
+  const patched = {};
+  let inBlock = false;
+  for (const line of text.split("\n")) {
+    if (!inBlock) {
+      if (/^patchedDependencies:\s*$/.test(line)) inBlock = true;
+      continue;
+    }
+    if (line.trim() === "" || line.trimStart().startsWith("#")) continue;
+    if (!/^[ \t]+\S/.test(line)) break;
+    const match = line.match(/^\s+(?:'([^']+)'|"([^"]+)"|([^":]+)):\s*(?:'([^']+)'|"([^"]+)"|(\S+))\s*$/);
+    if (!match) fail(`unparseable patchedDependencies entry in ${workspaceYamlPath}: ${line}`);
+    patched[match[1] ?? match[2] ?? match[3]] = match[4] ?? match[5] ?? match[6];
+  }
+  return patched;
+}
+
 export function packageJsonForApp({
   channelConfig,
   version,
   dependencies,
   sourcePackage = readJson(join(CLI_ROOT, "package.json")),
   packageManager = null,
+  patchedDependencies = {},
 }) {
   return {
     name: channelConfig.packageName,
@@ -470,6 +496,7 @@ export function packageJsonForApp({
       [channelConfig.aliasName]: "./cli/index.mjs",
     },
     dependencies,
+    ...(Object.keys(patchedDependencies).length > 0 ? { pnpm: { patchedDependencies } } : {}),
   };
 }
 
@@ -653,14 +680,21 @@ async function prepareAppTemplate({ channel, channelConfig, version }) {
   cpSync(join(CLI_ROOT, "README.md"), join(appDir, "README.md"));
   cpSync(join(CLI_ROOT, "LICENSE"), join(appDir, "LICENSE"));
   copyPruneScripts(appDir);
+  const patchedDependencies = readWorkspacePatchedDependencies();
+  if (Object.keys(patchedDependencies).length > 0) {
+    cpSync(join(REPO_ROOT, "patches"), join(appDir, "patches"), { recursive: true });
+  }
   writeJson(
     join(appDir, "package.json"),
-    packageJsonForApp({ channelConfig, version, dependencies, sourcePackage, packageManager }),
+    packageJsonForApp({ channelConfig, version, dependencies, sourcePackage, packageManager, patchedDependencies }),
   );
   cpSync(join(REPO_ROOT, "pnpm-lock.yaml"), join(appDir, "pnpm-lock.yaml"));
 
   run("pnpm", PORTABLE_LOCKFILE_INSTALL_ARGS, { cwd: appDir });
   run("pnpm", PORTABLE_NODE_MODULES_INSTALL_ARGS, { cwd: appDir });
+  // The patches only matter while pnpm materializes node_modules; the
+  // shipped app must not carry them.
+  rmSync(join(appDir, "patches"), { recursive: true, force: true });
   for (const script of [
     "scripts/prune-codex-runtime-binary.mjs",
     "scripts/prune-claude-runtime-binary.mjs",

--- a/scripts/release-pack-smoke.mjs
+++ b/scripts/release-pack-smoke.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Release-pack smoke: prove the public npm packaging boundary works for the
+ * built CLI under the trusted-publishing npm client the workflow pins.
+ *
+ *   1. `npm pack` the built apps/cli package through REAL pack semantics
+ *      (prepack copies skills, postpack cleans up — no --ignore-scripts).
+ *   2. Install the tarball into an empty consumer with plain npm.
+ *   3. Run the public CLI (`--version`).
+ *   4. Resolve the bundled `@botiverse/kimi-code-sdk` from the consumer and
+ *      assert the patched sites this PR ships: create-time drain flag, resume
+ *      option threading, resume main-agent flag application, and the awaited
+ *      replay-fence authorization hook.
+ *
+ * No registry publish, no credentials, no network beyond npm itself.
+ * Everything happens in a disposable temp directory removed on exit.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const CLI_ROOT = join(REPO_ROOT, "apps", "cli");
+
+function fail(message) {
+  console.error(`release-pack-smoke: FAIL: ${message}`);
+  process.exit(1);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    encoding: "utf8",
+    stdio: options.stdio ?? "pipe",
+  });
+  if (result.error) fail(`${command} failed to start: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    fail(`${command} ${args.join(" ")} exited ${result.status}\n${detail}`);
+  }
+  return result;
+}
+
+if (!existsSync(join(CLI_ROOT, "dist", "cli", "index.mjs")) || !existsSync(join(CLI_ROOT, "dist", "index.mjs"))) {
+  fail("apps/cli/dist is missing — run `pnpm build` first");
+}
+
+const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-"));
+try {
+  const consumerDir = join(work, "consumer");
+  run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
+  const tarballs = readdirSync(CLI_ROOT)
+    .filter((name) => /^first-tree-dev-.*\.tgz$/.test(name))
+    .map((name) => join(CLI_ROOT, name));
+  if (tarballs.length !== 1) fail(`expected exactly one first-tree-dev tarball in apps/cli, got ${tarballs.length}`);
+  const tarball = tarballs[0];
+  const tarballName = tarballs[0].split("/").pop();
+  try {
+    run("npm", ["install", "--prefix", consumerDir, tarball]);
+    const binName = "first-tree-dev";
+    const binPath = join(consumerDir, "node_modules", ".bin", binName);
+    if (!existsSync(binPath)) fail(`consumer is missing ${binPath}`);
+    const version = run(binPath, ["--version"]);
+    const versionText = version.stdout.trim();
+    if (!/^\d+\.\d+\.\d+/.test(versionText)) fail(`unexpected --version output: ${versionText}`);
+
+    const sdkEntry = join(
+      consumerDir,
+      "node_modules",
+      "first-tree-dev",
+      "node_modules",
+      "@botiverse",
+      "kimi-code-sdk",
+      "dist",
+      "index.mjs",
+    );
+    if (!existsSync(sdkEntry)) {
+      fail(`consumer did not resolve the bundled Kimi SDK at ${sdkEntry} — bundleDependencies is not shipping`);
+    }
+    const source = readFileSync(sdkEntry, "utf8");
+    const requiredSites = [
+      ["create drain flag", "if (this.options.drainAgentTasksOnStop) agent.printDrainAgentTasksOnStop = true"],
+      ["resume option threading", "drainAgentTasksOnStop: input.drainAgentTasksOnStop"],
+      ["resume main-agent flag", "this.options.drainAgentTasksOnStop) main.printDrainAgentTasksOnStop = true"],
+      ["awaited replay-fence authorization hook", "__firstTreeBeforeToolCall"],
+    ];
+    for (const [label, needle] of requiredSites) {
+      if (!source.includes(needle)) fail(`bundled Kimi SDK is missing the ${label} site`);
+    }
+
+    run(process.execPath, [
+      "-e",
+      `import(${JSON.stringify(`file://${sdkEntry}`)}).then(() => process.exit(0), (error) => { console.error(error); process.exit(1); })`,
+    ]);
+
+    console.log(
+      `release-pack-smoke: PASS — packed ${tarballName}, consumer CLI ${versionText}, bundled patched Kimi SDK verified`,
+    );
+  } finally {
+    // Real pack semantics write the tarball into the package dir; never
+    // leave it in the repo.
+    rmSync(tarball, { force: true });
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- keep Kimi deliveries in processing custody while top-level background `Agent` tasks are still running, on both new and resumed SDK sessions
- separate main-agent chat/turn lifecycle from subagent streams while retaining every agent's real tool effects with collision-safe child tool IDs
- carry the pinned SDK resume fix through workspace installs, production Docker builds, npm CLI packages, and portable artifacts

## Root cause

Mention delivery and agent wake-up were healthy. The Kimi main turn could finish immediately after launching `Agent(run_in_background)`, so First Tree completed and ACKed the delivery while an in-process child still owned unfinished work. The pinned SDK already had an internal drain-on-stop path for newly created sessions, but First Tree did not enable it and the SDK did not thread the option through resume.

The handler also consumed one shared SDK event stream without checking `agentId`, allowing child assistant/turn events to be treated as parent output or completion.

## Implementation

- apply a narrow pnpm patch to `@botiverse/kimi-code-sdk@0.26.0-botiverse.2` so resumed sessions mirror create-session drain behavior
- request drain-on-stop for both handler create and resume paths
- let only `agentId === "main"` drive parent assistant/thinking/error/turn completion
- retain tool events from all agents; preserve main tool IDs and prefix child IDs with their agent ID
- bundle the patched SDK in npm CLI artifacts and propagate workspace patched dependencies into portable builds
- make the Docker dependency stage copy patch inputs before frozen install
- extend deterministic handler, packaging, portable, and live QA coverage

## Verification

Deterministic gates:

- frozen install, root build, check, and typecheck pass
- Kimi handler: 24/24
- client: 1875/1875, 3 skipped
- affected CLI/portable release tests: 43/43
- production target and base images build and serve `/healthz`
- clean npm consumer runs the CLI and imports the nested bundled `_patch_hash=ab8351...` SDK with both resume behavior sites
- staging portable artifact runs with the same patched SDK and no raw patch sources

Independent real-provider QA reached full `QA READY` and passed the change's create and resume custody paths:

- both turns launched two background Agents and remained delivered/unacked beyond a 5-second idle threshold
- create settled once after 111 seconds; resume settled once after 98 seconds with the same persisted provider session ID
- each path emitted exactly one successful parent `turn_end` followed by ACK, with retry count 0
- child assistant output did not leak; child tool IDs were agent-prefixed and main IDs remained raw
- daemon lifecycle reported processing work instead of idle suspension

Formal QA status is `BLOCKED`, not `PASS`, solely because a third adjacent unsafe-write interruption attempt hit the Kimi billing-cycle limit with HTTP 403 before any tool event. No target defect was found, and the required create/resume behavior plus release artifacts passed with real product-boundary evidence.

## Known release observations

- the real publish path uses `npm publish`; local artifact verification therefore uses `npm pack` (pnpm's isolated linker rejects `bundleDependencies`)
- the clean npm consumer emitted path-normalization warnings while npm traversed the pnpm-linked bundled dependency; the installed SDK tree matched the workspace digest and all required chunks, assets, licenses, and runtime imports were verified

## Context Tree

No Context Tree update is needed. This change enforces the existing Kimi direct-SDK lifecycle, deferred-ACK, replay-safety, and recoverable-delivery constraints; it does not establish a new durable decision.
