### PR TITLE
fix(cli): materialize bundled Kimi SDK paths for npm registry pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,11 +223,16 @@ jobs:
       # trusted-publishing client is pinned to the exact version QA qualifies
       # (a floated range already broke this boundary upstream). Smoke the real
       # pack → empty-consumer install → public CLI → patched SDK chain on
-      # every CLI-affecting PR.
+      # every CLI-affecting PR. The turbo context-integration cache selftest
+      # wraps that same runSmoke() path after proving a cache hit restores
+      # context-integration/** — keep it as a shell step (not Vitest), because
+      # the forced rebuild + pack chain exceeds the worker IPC heartbeat that
+      # previously failed jobs with `Timeout calling "onTaskUpdate"` even when
+      # every assertion passed.
       - name: Pin trusted-publishing npm client
         run: npm install -g npm@11.5.1
-      - name: Release pack smoke (bundled Kimi SDK)
-        run: node scripts/release-pack-smoke.mjs
+      - name: Release pack smoke (bundled Kimi SDK + turbo context-integration cache)
+        run: node scripts/release-pack-smoke.mjs selftest-turbo-context-integration-cache
       # Keep the CLI behind Turbo so an unchanged first-tree-dev#test task can
       # use cache while its package script releases heap between batches.
       - run: pnpm exec turbo run test --filter=first-tree-dev --concurrency=1

--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -15,4 +15,3 @@
 # Written by `materialize-bundled-deps.mjs prepare` during prepack so postpack
 # can restore pnpm symlinks. Never commit a stranded pack-time workspace mutation.
 /.bundled-deps-materialize.json
-

--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -11,3 +11,8 @@
 # stops at the first hit). If the dev CLI starts behaving as if a recent
 # `skills/` edit didn't take, run `rm -rf apps/cli/skills` and re-test.
 /skills/
+
+# Written by `materialize-bundled-deps.mjs prepare` during prepack so postpack
+# can restore pnpm symlinks. Never commit a stranded pack-time workspace mutation.
+/.bundled-deps-materialize.json
+

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -44,8 +44,8 @@
     "typecheck": "tsc --noEmit",
     "test": "node scripts/run-vitest-batches.mjs",
     "coverage": "pnpm run build && vitest run --coverage --passWithNoTests",
-    "prepack": "rm -rf skills && cp -R ../../skills .",
-    "postpack": "rm -rf skills context-integration",
+    "prepack": "rm -rf skills && cp -R ../../skills . && node scripts/materialize-bundled-deps.mjs prepare",
+    "postpack": "node scripts/materialize-bundled-deps.mjs restore && rm -rf skills context-integration",
     "postinstall": "node scripts/prune-codex-runtime-binary.mjs && node scripts/prune-claude-runtime-binary.mjs && node scripts/prune-claude-sdk-deps.mjs"
   },
   "license": "Apache-2.0",

--- a/apps/cli/scripts/materialize-bundled-deps.mjs
+++ b/apps/cli/scripts/materialize-bundled-deps.mjs
@@ -16,10 +16,12 @@
  *   prepack  → node scripts/materialize-bundled-deps.mjs prepare
  *   postpack → node scripts/materialize-bundled-deps.mjs restore
  *
- * Restore puts the original symlink targets back so the pnpm workspace stays
- * consistent after a local pack. The restore manifest lives beside this package
- * and is removed on restore.
+ * Recovery: each original symlink target is persisted to the restore manifest
+ * *before* that link is unlinked, via an atomic rename. A mid-prepare failure
+ * (or a later `prepare` that finds a stranded manifest) restores every recorded
+ * target so the pnpm workspace cannot be left with unrecoverable real copies.
  */
+import { spawnSync } from "node:child_process";
 import {
   cpSync,
   existsSync,
@@ -28,6 +30,7 @@ import {
   readFileSync,
   readlinkSync,
   realpathSync,
+  renameSync,
   rmSync,
   symlinkSync,
   unlinkSync,
@@ -40,6 +43,7 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = dirname(SCRIPT_DIR);
 const NODE_MODULES = join(PACKAGE_ROOT, "node_modules");
 const MANIFEST_PATH = join(PACKAGE_ROOT, ".bundled-deps-materialize.json");
+const THIS_SCRIPT = fileURLToPath(import.meta.url);
 
 function fail(message) {
   console.error(`materialize-bundled-deps: ${message}`);
@@ -87,7 +91,42 @@ function listBundleClosure(rootPkg) {
   return ordered;
 }
 
-function prepare() {
+/** Persist the recovery manifest via write-temp + rename so a crash cannot leave
+ * a half-written JSON that omits already-unlinked targets. */
+function persistManifest(entries) {
+  const tmpPath = `${MANIFEST_PATH}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, `${JSON.stringify({ version: 1, entries }, null, 2)}\n`);
+  renameSync(tmpPath, MANIFEST_PATH);
+}
+
+function parseFailAfter(argv) {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--fail-after") {
+      const value = Number.parseInt(argv[i + 1] ?? "", 10);
+      if (!Number.isFinite(value) || value < 1) fail("--fail-after requires a positive integer");
+      return value;
+    }
+    if (arg.startsWith("--fail-after=")) {
+      const value = Number.parseInt(arg.slice("--fail-after=".length), 10);
+      if (!Number.isFinite(value) || value < 1) fail("--fail-after requires a positive integer");
+      return value;
+    }
+  }
+  const fromEnv = process.env.MATERIALIZE_BUNDLED_DEPS_FAIL_AFTER;
+  if (fromEnv !== undefined && fromEnv !== "") {
+    const value = Number.parseInt(fromEnv, 10);
+    if (!Number.isFinite(value) || value < 1) {
+      fail("MATERIALIZE_BUNDLED_DEPS_FAIL_AFTER requires a positive integer");
+    }
+    return value;
+  }
+  return null;
+}
+
+function prepare(options = {}) {
+  const failAfter = options.failAfter ?? null;
+
   if (existsSync(MANIFEST_PATH)) {
     // A previous prepare without restore (interrupted pack). Restore first so we
     // never nest a real copy on top of another real copy.
@@ -98,36 +137,69 @@ function prepare() {
   const names = listBundleClosure(rootPkg);
   if (names.length === 0) return;
 
+  /** @type {{ name: string, path: string, linkTarget: string }[]} */
   const entries = [];
-  for (const name of names) {
-    const dir = packageDir(name);
-    if (!existsSync(join(dir, "package.json")) && !lstatSyncSafe(dir)?.isSymbolicLink()) {
-      fail(`bundle closure package missing from node_modules: ${name}`);
+  let mutated = 0;
+
+  try {
+    for (const name of names) {
+      const dir = packageDir(name);
+      if (!existsSync(join(dir, "package.json")) && !lstatSyncSafe(dir)?.isSymbolicLink()) {
+        throw new Error(`bundle closure package missing from node_modules: ${name}`);
+      }
+      const stat = lstatSyncSafe(dir);
+      if (!stat) throw new Error(`cannot stat ${name}`);
+      if (!stat.isSymbolicLink()) {
+        // After a successful restore-at-start, every closure entry must still be
+        // a symlink. A real directory here means a prior run lost its recovery
+        // record — fail closed rather than skip and strand the workspace.
+        throw new Error(
+          `expected symlink for ${name} but found a real path; refusing to materialize without a recoverable link target`,
+        );
+      }
+
+      const linkTarget = readlinkSync(dir);
+      const resolvedSource = realpathSync(dir);
+      const entry = {
+        name,
+        path: relative(PACKAGE_ROOT, dir),
+        linkTarget,
+      };
+
+      // Record the original target BEFORE unlinking so any later failure in this
+      // loop (or process death after the rename) can restore via the manifest.
+      entries.push(entry);
+      persistManifest(entries);
+
+      // Unlink the symlink itself — never rmSync a directory symlink without
+      // care: Node may treat the target as the path and raise EISDIR.
+      unlinkSync(dir);
+      mutated += 1;
+
+      if (failAfter !== null && mutated >= failAfter) {
+        throw new Error(`injected mid-prepare failure after ${mutated} unlink(s)`);
+      }
+
+      mkdirSync(dirname(dir), { recursive: true });
+      // Copy package files only. The package directory under .pnpm has no nested
+      // node_modules of its own; its deps live as sibling symlinks that we
+      // materialize separately via the closure walk.
+      cpSync(resolvedSource, dir, { recursive: true, dereference: true });
     }
-    const stat = lstatSyncSafe(dir);
-    if (!stat) fail(`cannot stat ${name}`);
-    if (!stat.isSymbolicLink()) {
-      // Already a real directory (e.g. re-entrant prepare). Leave it alone.
-      continue;
+  } catch (error) {
+    // Best-effort rollback of every entry already recorded in the manifest.
+    try {
+      restore({ allowMissing: true });
+    } catch (restoreError) {
+      console.error(
+        `materialize-bundled-deps: restore after prepare failure also failed: ${
+          restoreError instanceof Error ? restoreError.message : restoreError
+        }`,
+      );
     }
-    const linkTarget = readlinkSync(dir);
-    const resolvedSource = realpathSync(dir);
-    // Unlink the symlink itself — never rmSync a directory symlink without
-    // care: Node may treat the target as the path and raise EISDIR.
-    unlinkSync(dir);
-    mkdirSync(dirname(dir), { recursive: true });
-    // Copy package files only. The package directory under .pnpm has no nested
-    // node_modules of its own; its deps live as sibling symlinks that we
-    // materialize separately via the closure walk.
-    cpSync(resolvedSource, dir, { recursive: true, dereference: true });
-    entries.push({
-      name,
-      path: relative(PACKAGE_ROOT, dir),
-      linkTarget,
-    });
+    fail(error instanceof Error ? error.message : String(error));
   }
 
-  writeFileSync(MANIFEST_PATH, `${JSON.stringify({ version: 1, entries }, null, 2)}\n`);
   if (entries.length > 0) {
     console.log(`materialize-bundled-deps: prepared ${entries.length} pack input(s) as real directories`);
   }
@@ -152,7 +224,64 @@ function restore(options = {}) {
   }
 }
 
-const action = process.argv[2] ?? "prepare";
-if (action === "prepare") prepare();
+/**
+ * Regression: capture symlink targets, force a mid-prepare failure, prove every
+ * original symlink (and the absence of a stranded manifest) is restored.
+ */
+function selftestRecovery() {
+  const rootPkg = readPackageJson(PACKAGE_ROOT);
+  const names = listBundleClosure(rootPkg);
+  if (names.length < 2) {
+    fail("selftest-recovery needs at least two bundle-closure packages to inject a mid-prepare failure");
+  }
+
+  // Start from a clean symlink workspace.
+  if (existsSync(MANIFEST_PATH)) restore({ allowMissing: true });
+
+  /** @type {Map<string, string>} */
+  const before = new Map();
+  for (const name of names) {
+    const dir = packageDir(name);
+    const stat = lstatSyncSafe(dir);
+    if (!stat?.isSymbolicLink()) {
+      fail(`selftest-recovery precondition failed: ${name} is not a symlink`);
+    }
+    before.set(name, readlinkSync(dir));
+  }
+
+  // Run prepare in a child so process.exit from fail() does not kill this harness.
+  const child = spawnSync(process.execPath, [THIS_SCRIPT, "prepare", "--fail-after=1"], {
+    cwd: PACKAGE_ROOT,
+    encoding: "utf8",
+  });
+  if (child.status === 0) {
+    fail("selftest-recovery expected prepare --fail-after=1 to exit non-zero");
+  }
+
+  if (existsSync(MANIFEST_PATH)) {
+    fail("selftest-recovery left a stranded restore manifest");
+  }
+
+  for (const name of names) {
+    const dir = packageDir(name);
+    const stat = lstatSyncSafe(dir);
+    if (!stat?.isSymbolicLink()) {
+      fail(`selftest-recovery did not restore symlink for ${name}`);
+    }
+    const target = readlinkSync(dir);
+    if (target !== before.get(name)) {
+      fail(`selftest-recovery restored wrong target for ${name}: ${target} (want ${before.get(name)})`);
+    }
+  }
+
+  console.log(
+    `materialize-bundled-deps: selftest-recovery PASS (${names.length} symlinks restored after mid-prepare failure)`,
+  );
+}
+
+const argv = process.argv.slice(2);
+const action = argv[0] ?? "prepare";
+if (action === "prepare") prepare({ failAfter: parseFailAfter(argv.slice(1)) });
 else if (action === "restore") restore();
-else fail(`unknown action '${action}' (expected prepare|restore)`);
+else if (action === "selftest-recovery") selftestRecovery();
+else fail(`unknown action '${action}' (expected prepare|restore|selftest-recovery)`);

--- a/apps/cli/scripts/materialize-bundled-deps.mjs
+++ b/apps/cli/scripts/materialize-bundled-deps.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Materialize `bundleDependencies` (and the bundled packages' direct deps that
+ * resolve from this package's node_modules) as real directories before `npm pack`
+ * / `npm publish`.
+ *
+ * Why: the workspace is installed with pnpm, so `node_modules/<pkg>` entries are
+ * symlinks into `node_modules/.pnpm/...`. npm 11.5.1's pack path follows those
+ * links and writes tar entry names like `package/../../node_modules/.pnpm/...`.
+ * The npm registry rejects that layout with E415 ("invalid path"). Replacing
+ * the pack-time inputs with in-package real copies keeps every tar entry under
+ * `package/` with no `..` traversal, while preserving `bundleDependencies` and
+ * the patched Kimi SDK payload.
+ *
+ * Lifecycle:
+ *   prepack  → node scripts/materialize-bundled-deps.mjs prepare
+ *   postpack → node scripts/materialize-bundled-deps.mjs restore
+ *
+ * Restore puts the original symlink targets back so the pnpm workspace stays
+ * consistent after a local pack. The restore manifest lives beside this package
+ * and is removed on restore.
+ */
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = dirname(SCRIPT_DIR);
+const NODE_MODULES = join(PACKAGE_ROOT, "node_modules");
+const MANIFEST_PATH = join(PACKAGE_ROOT, ".bundled-deps-materialize.json");
+
+function fail(message) {
+  console.error(`materialize-bundled-deps: ${message}`);
+  process.exit(1);
+}
+
+function readPackageJson(dir) {
+  return JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+}
+
+function packageDir(name) {
+  return join(NODE_MODULES, ...name.split("/"));
+}
+
+function lstatSyncSafe(path) {
+  try {
+    return lstatSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function listBundleClosure(rootPkg) {
+  const bundled = rootPkg.bundleDependencies ?? rootPkg.bundledDependencies ?? [];
+  if (!Array.isArray(bundled) || bundled.length === 0) return [];
+
+  const ordered = [];
+  const seen = new Set();
+
+  const visit = (name) => {
+    if (seen.has(name)) return;
+    seen.add(name);
+    ordered.push(name);
+    const dir = packageDir(name);
+    if (!existsSync(join(dir, "package.json"))) return;
+    const pkg = readPackageJson(dir);
+    for (const dep of Object.keys(pkg.dependencies ?? {})) {
+      // Only materialize deps that already resolve beside this package. Transitive
+      // store-only packages are not pack inputs unless npm can see them here.
+      if (existsSync(join(packageDir(dep), "package.json"))) visit(dep);
+    }
+  };
+
+  for (const name of bundled) visit(name);
+  return ordered;
+}
+
+function prepare() {
+  if (existsSync(MANIFEST_PATH)) {
+    // A previous prepare without restore (interrupted pack). Restore first so we
+    // never nest a real copy on top of another real copy.
+    restore({ allowMissing: true });
+  }
+
+  const rootPkg = readPackageJson(PACKAGE_ROOT);
+  const names = listBundleClosure(rootPkg);
+  if (names.length === 0) return;
+
+  const entries = [];
+  for (const name of names) {
+    const dir = packageDir(name);
+    if (!existsSync(join(dir, "package.json")) && !lstatSyncSafe(dir)?.isSymbolicLink()) {
+      fail(`bundle closure package missing from node_modules: ${name}`);
+    }
+    const stat = lstatSyncSafe(dir);
+    if (!stat) fail(`cannot stat ${name}`);
+    if (!stat.isSymbolicLink()) {
+      // Already a real directory (e.g. re-entrant prepare). Leave it alone.
+      continue;
+    }
+    const linkTarget = readlinkSync(dir);
+    const resolvedSource = realpathSync(dir);
+    // Unlink the symlink itself — never rmSync a directory symlink without
+    // care: Node may treat the target as the path and raise EISDIR.
+    unlinkSync(dir);
+    mkdirSync(dirname(dir), { recursive: true });
+    // Copy package files only. The package directory under .pnpm has no nested
+    // node_modules of its own; its deps live as sibling symlinks that we
+    // materialize separately via the closure walk.
+    cpSync(resolvedSource, dir, { recursive: true, dereference: true });
+    entries.push({
+      name,
+      path: relative(PACKAGE_ROOT, dir),
+      linkTarget,
+    });
+  }
+
+  writeFileSync(MANIFEST_PATH, `${JSON.stringify({ version: 1, entries }, null, 2)}\n`);
+  if (entries.length > 0) {
+    console.log(`materialize-bundled-deps: prepared ${entries.length} pack input(s) as real directories`);
+  }
+}
+
+function restore(options = {}) {
+  if (!existsSync(MANIFEST_PATH)) {
+    if (options.allowMissing === true) return;
+    return;
+  }
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const entries = Array.isArray(manifest.entries) ? manifest.entries : [];
+  for (const entry of entries) {
+    const dir = join(PACKAGE_ROOT, entry.path);
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dirname(dir), { recursive: true });
+    symlinkSync(entry.linkTarget, dir);
+  }
+  rmSync(MANIFEST_PATH, { force: true });
+  if (entries.length > 0) {
+    console.log(`materialize-bundled-deps: restored ${entries.length} symlink(s)`);
+  }
+}
+
+const action = process.argv[2] ?? "prepare";
+if (action === "prepare") prepare();
+else if (action === "restore") restore();
+else fail(`unknown action '${action}' (expected prepare|restore)`);

--- a/apps/cli/scripts/materialize-bundled-deps.mjs
+++ b/apps/cli/scripts/materialize-bundled-deps.mjs
@@ -16,10 +16,14 @@
  *   prepack  → node scripts/materialize-bundled-deps.mjs prepare
  *   postpack → node scripts/materialize-bundled-deps.mjs restore
  *
- * Recovery: each original symlink target is persisted to the restore manifest
- * *before* that link is unlinked, via an atomic rename. A mid-prepare failure
- * (or a later `prepare` that finds a stranded manifest) restores every recorded
- * target so the pnpm workspace cannot be left with unrecoverable real copies.
+ * Recovery (failure-atomic):
+ *   1. Preflight the full bundle closure and require every entry to still be a
+ *      symlink (collect every original link target).
+ *   2. Persist the COMPLETE restore journal with write-temp + rename BEFORE the
+ *      first unlink/cpSync.
+ *   3. Mutate. Any failure (or a later prepare that finds a stranded journal)
+ *      runs idempotent restore, which can repair a mix of still-linked and
+ *      already-materialized entries.
  */
 import { spawnSync } from "node:child_process";
 import {
@@ -91,8 +95,7 @@ function listBundleClosure(rootPkg) {
   return ordered;
 }
 
-/** Persist the recovery manifest via write-temp + rename so a crash cannot leave
- * a half-written JSON that omits already-unlinked targets. */
+/** Persist the recovery journal via write-temp + rename. */
 function persistManifest(entries) {
   const tmpPath = `${MANIFEST_PATH}.${process.pid}.tmp`;
   writeFileSync(tmpPath, `${JSON.stringify({ version: 1, entries }, null, 2)}\n`);
@@ -124,12 +127,42 @@ function parseFailAfter(argv) {
   return null;
 }
 
+/**
+ * Read every closure entry that must be materialized. Fail closed unless each
+ * path is still a recoverable symlink.
+ * @returns {{ name: string, path: string, linkTarget: string, resolvedSource: string }[]}
+ */
+function preflightEntries(names) {
+  /** @type {{ name: string, path: string, linkTarget: string, resolvedSource: string }[]} */
+  const entries = [];
+  for (const name of names) {
+    const dir = packageDir(name);
+    if (!existsSync(join(dir, "package.json")) && !lstatSyncSafe(dir)?.isSymbolicLink()) {
+      throw new Error(`bundle closure package missing from node_modules: ${name}`);
+    }
+    const stat = lstatSyncSafe(dir);
+    if (!stat) throw new Error(`cannot stat ${name}`);
+    if (!stat.isSymbolicLink()) {
+      throw new Error(
+        `expected symlink for ${name} but found a real path; refusing to materialize without a recoverable link target`,
+      );
+    }
+    entries.push({
+      name,
+      path: relative(PACKAGE_ROOT, dir),
+      linkTarget: readlinkSync(dir),
+      resolvedSource: realpathSync(dir),
+    });
+  }
+  return entries;
+}
+
 function prepare(options = {}) {
   const failAfter = options.failAfter ?? null;
 
   if (existsSync(MANIFEST_PATH)) {
-    // A previous prepare without restore (interrupted pack). Restore first so we
-    // never nest a real copy on top of another real copy.
+    // A previous prepare without restore (interrupted pack / crashed mutation).
+    // Restore first so we never nest a real copy on top of another real copy.
     restore({ allowMissing: true });
   }
 
@@ -137,40 +170,22 @@ function prepare(options = {}) {
   const names = listBundleClosure(rootPkg);
   if (names.length === 0) return;
 
-  /** @type {{ name: string, path: string, linkTarget: string }[]} */
-  const entries = [];
-  let mutated = 0;
-
+  /** @type {{ name: string, path: string, linkTarget: string, resolvedSource: string }[]} */
+  let entries;
   try {
-    for (const name of names) {
-      const dir = packageDir(name);
-      if (!existsSync(join(dir, "package.json")) && !lstatSyncSafe(dir)?.isSymbolicLink()) {
-        throw new Error(`bundle closure package missing from node_modules: ${name}`);
-      }
-      const stat = lstatSyncSafe(dir);
-      if (!stat) throw new Error(`cannot stat ${name}`);
-      if (!stat.isSymbolicLink()) {
-        // After a successful restore-at-start, every closure entry must still be
-        // a symlink. A real directory here means a prior run lost its recovery
-        // record — fail closed rather than skip and strand the workspace.
-        throw new Error(
-          `expected symlink for ${name} but found a real path; refusing to materialize without a recoverable link target`,
-        );
-      }
+    entries = preflightEntries(names);
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
 
-      const linkTarget = readlinkSync(dir);
-      const resolvedSource = realpathSync(dir);
-      const entry = {
-        name,
-        path: relative(PACKAGE_ROOT, dir),
-        linkTarget,
-      };
+  // Persist the COMPLETE journal before the first destructive mutation.
+  const journal = entries.map(({ name, path, linkTarget }) => ({ name, path, linkTarget }));
+  persistManifest(journal);
 
-      // Record the original target BEFORE unlinking so any later failure in this
-      // loop (or process death after the rename) can restore via the manifest.
-      entries.push(entry);
-      persistManifest(entries);
-
+  let mutated = 0;
+  try {
+    for (const entry of entries) {
+      const dir = join(PACKAGE_ROOT, entry.path);
       // Unlink the symlink itself — never rmSync a directory symlink without
       // care: Node may treat the target as the path and raise EISDIR.
       unlinkSync(dir);
@@ -184,10 +199,10 @@ function prepare(options = {}) {
       // Copy package files only. The package directory under .pnpm has no nested
       // node_modules of its own; its deps live as sibling symlinks that we
       // materialize separately via the closure walk.
-      cpSync(resolvedSource, dir, { recursive: true, dereference: true });
+      cpSync(entry.resolvedSource, dir, { recursive: true, dereference: true });
     }
   } catch (error) {
-    // Best-effort rollback of every entry already recorded in the manifest.
+    // Best-effort rollback from the full journal (covers partial materialize).
     try {
       restore({ allowMissing: true });
     } catch (restoreError) {
@@ -205,6 +220,11 @@ function prepare(options = {}) {
   }
 }
 
+/**
+ * Idempotent restore from the journal. Each entry may still be a symlink (not
+ * yet mutated) or a real directory (already copied); both become the recorded
+ * original symlink target.
+ */
 function restore(options = {}) {
   if (!existsSync(MANIFEST_PATH)) {
     if (options.allowMissing === true) return;
@@ -213,20 +233,25 @@ function restore(options = {}) {
   const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
   const entries = Array.isArray(manifest.entries) ? manifest.entries : [];
   for (const entry of entries) {
+    if (typeof entry?.path !== "string" || typeof entry?.linkTarget !== "string") {
+      throw new Error("restore journal entry missing path/linkTarget");
+    }
     const dir = join(PACKAGE_ROOT, entry.path);
     rmSync(dir, { recursive: true, force: true });
     mkdirSync(dirname(dir), { recursive: true });
     symlinkSync(entry.linkTarget, dir);
   }
   rmSync(MANIFEST_PATH, { force: true });
+  rmSync(`${MANIFEST_PATH}.${process.pid}.tmp`, { force: true });
   if (entries.length > 0) {
     console.log(`materialize-bundled-deps: restored ${entries.length} symlink(s)`);
   }
 }
 
 /**
- * Regression: capture symlink targets, force a mid-prepare failure, prove every
- * original symlink (and the absence of a stranded manifest) is restored.
+ * Regression: capture symlink targets, force a mid-prepare failure after at
+ * least one replacement, prove every original symlink is restored with no
+ * stranded journal/real-copy, then prove a clean prepare+restore still works.
  */
 function selftestRecovery() {
   const rootPkg = readPackageJson(PACKAGE_ROOT);
@@ -235,7 +260,6 @@ function selftestRecovery() {
     fail("selftest-recovery needs at least two bundle-closure packages to inject a mid-prepare failure");
   }
 
-  // Start from a clean symlink workspace.
   if (existsSync(MANIFEST_PATH)) restore({ allowMissing: true });
 
   /** @type {Map<string, string>} */
@@ -249,7 +273,9 @@ function selftestRecovery() {
     before.set(name, readlinkSync(dir));
   }
 
-  // Run prepare in a child so process.exit from fail() does not kill this harness.
+  // Confirm the journal is fully written before the injected failure: the child
+  // fails after the first unlink, so recovery must use the preflight journal
+  // that already listed every closure entry.
   const child = spawnSync(process.execPath, [THIS_SCRIPT, "prepare", "--fail-after=1"], {
     cwd: PACKAGE_ROOT,
     encoding: "utf8",
@@ -274,8 +300,46 @@ function selftestRecovery() {
     }
   }
 
+  // Clean prepare + restore must still succeed after the failure path.
+  const prepareOk = spawnSync(process.execPath, [THIS_SCRIPT, "prepare"], {
+    cwd: PACKAGE_ROOT,
+    encoding: "utf8",
+  });
+  if (prepareOk.status !== 0) {
+    fail(`selftest-recovery follow-up prepare failed:\n${prepareOk.stderr || prepareOk.stdout}`);
+  }
+  if (!existsSync(MANIFEST_PATH)) {
+    fail("selftest-recovery follow-up prepare did not leave a restore manifest");
+  }
+  for (const name of names) {
+    const dir = packageDir(name);
+    if (lstatSyncSafe(dir)?.isSymbolicLink()) {
+      fail(`selftest-recovery follow-up prepare left ${name} as a symlink`);
+    }
+  }
+  const restoreOk = spawnSync(process.execPath, [THIS_SCRIPT, "restore"], {
+    cwd: PACKAGE_ROOT,
+    encoding: "utf8",
+  });
+  if (restoreOk.status !== 0) {
+    fail(`selftest-recovery follow-up restore failed:\n${restoreOk.stderr || restoreOk.stdout}`);
+  }
+  if (existsSync(MANIFEST_PATH)) {
+    fail("selftest-recovery follow-up restore left a stranded manifest");
+  }
+  for (const name of names) {
+    const dir = packageDir(name);
+    const stat = lstatSyncSafe(dir);
+    if (!stat?.isSymbolicLink()) {
+      fail(`selftest-recovery follow-up restore did not restore symlink for ${name}`);
+    }
+    if (readlinkSync(dir) !== before.get(name)) {
+      fail(`selftest-recovery follow-up restore wrong target for ${name}`);
+    }
+  }
+
   console.log(
-    `materialize-bundled-deps: selftest-recovery PASS (${names.length} symlinks restored after mid-prepare failure)`,
+    `materialize-bundled-deps: selftest-recovery PASS (${names.length} symlinks restored after mid-prepare failure; clean prepare/restore ok)`,
   );
 }
 

--- a/apps/cli/scripts/materialize-bundled-deps.mjs
+++ b/apps/cli/scripts/materialize-bundled-deps.mjs
@@ -189,17 +189,22 @@ function prepare(options = {}) {
       // Unlink the symlink itself — never rmSync a directory symlink without
       // care: Node may treat the target as the path and raise EISDIR.
       unlinkSync(dir);
-      mutated += 1;
-
-      if (failAfter !== null && mutated >= failAfter) {
-        throw new Error(`injected mid-prepare failure after ${mutated} unlink(s)`);
-      }
-
       mkdirSync(dirname(dir), { recursive: true });
       // Copy package files only. The package directory under .pnpm has no nested
       // node_modules of its own; its deps live as sibling symlinks that we
       // materialize separately via the closure walk.
       cpSync(entry.resolvedSource, dir, { recursive: true, dereference: true });
+      mutated += 1;
+
+      // Inject only AFTER a successful real-directory replacement so restore is
+      // proven against a partially-materialized workspace (not merely an unlink).
+      if (failAfter !== null && mutated >= failAfter) {
+        const afterCopy = lstatSyncSafe(dir);
+        if (!afterCopy || afterCopy.isSymbolicLink()) {
+          throw new Error("injected failure precondition failed: expected a real directory after cpSync");
+        }
+        throw new Error(`injected mid-prepare failure after ${mutated} successful materialization(s)`);
+      }
     }
   } catch (error) {
     // Best-effort rollback from the full journal (covers partial materialize).
@@ -273,15 +278,19 @@ function selftestRecovery() {
     before.set(name, readlinkSync(dir));
   }
 
-  // Confirm the journal is fully written before the injected failure: the child
-  // fails after the first unlink, so recovery must use the preflight journal
-  // that already listed every closure entry.
+  // Child fails after the first successful cpSync (real directory present) and
+  // before the next entry, so restore must delete that copy and recreate every
+  // original symlink from the preflight journal.
   const child = spawnSync(process.execPath, [THIS_SCRIPT, "prepare", "--fail-after=1"], {
     cwd: PACKAGE_ROOT,
     encoding: "utf8",
   });
   if (child.status === 0) {
     fail("selftest-recovery expected prepare --fail-after=1 to exit non-zero");
+  }
+  const childOut = `${child.stdout}\n${child.stderr}`;
+  if (!childOut.includes("successful materialization")) {
+    fail(`selftest-recovery expected failure after a successful copy, got:\n${childOut}`);
   }
 
   if (existsSync(MANIFEST_PATH)) {

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -143,8 +143,27 @@ describe("trusted-publishing npm toolchain contract", () => {
   it("runs a real release-pack smoke under the pinned client on CLI-affecting PRs", () => {
     const ci = readText(CI_WORKFLOW);
     expect(ci).toContain("npm install -g npm@11.5.1");
-    expect(ci).toContain("node scripts/release-pack-smoke.mjs");
+    // Heavy turbo cache + real pack smoke stays a shell step outside Vitest
+    // (same class of failure as building dist inside beforeAll).
+    expect(ci).toContain("node scripts/release-pack-smoke.mjs selftest-turbo-context-integration-cache");
+    expect(ci).toContain("Release pack smoke (bundled Kimi SDK + turbo context-integration cache)");
+    // Do not also run the default smoke in the same job — the selftest already
+    // ends in runSmoke() (pack → consumer → bundled SDK).
+    expect(ci).not.toMatch(/^\s*run:\s*node scripts\/release-pack-smoke\.mjs\s*$/m);
     expect(existsSync(join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"))).toBe(true);
+
+    const smoke = readText(join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"));
+    // Prove the CI-selected selftest does not bypass the real release smoke.
+    const cacheFnStart = smoke.indexOf("function selftestTurboContextIntegrationCache()");
+    const mainFnStart = smoke.indexOf("\nfunction main()");
+    expect(cacheFnStart).toBeGreaterThanOrEqual(0);
+    expect(mainFnStart).toBeGreaterThan(cacheFnStart);
+    const cacheSelftest = smoke.slice(cacheFnStart, mainFnStart);
+    expect(cacheSelftest).toContain("runSmoke()");
+    expect(cacheSelftest).toContain('turbo.json build.outputs must include "context-integration/**"');
+    // This file must not spawn the heavy selftest inside Vitest workers.
+    const thisFile = readText(join(HERE, "package-metadata.test.ts"));
+    expect(thisFile).not.toMatch(/spawnSync\([\s\S]{0,400}selftest-turbo-context-integration-cache/);
   });
 
   it("materializes bundled deps around pack so pnpm symlink targets cannot escape the tarball", () => {
@@ -227,24 +246,6 @@ describe("trusted-publishing npm toolchain contract", () => {
     }
     expect(result.stdout).toContain("selftest-preserve-preexisting PASS");
   });
-
-  it("restores context-integration from a turbo cache hit after the directory is deleted", () => {
-    const result = spawnSync(
-      process.execPath,
-      [join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"), "selftest-turbo-context-integration-cache"],
-      {
-        cwd: REPO_ROOT,
-        encoding: "utf8",
-        env: process.env,
-      },
-    );
-    if (result.status !== 0) {
-      throw new Error(
-        `release-pack-smoke selftest-turbo-context-integration-cache failed:\n${result.stderr || result.stdout}`,
-      );
-    }
-    expect(result.stdout).toContain("selftest-turbo-context-integration-cache PASS");
-  }, 180_000);
 });
 
 describe("npm tarball registry-safety helper", () => {

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -163,6 +163,9 @@ describe("trusted-publishing npm toolchain contract", () => {
     expect(postpack.indexOf("materialize-bundled-deps.mjs restore")).toBeLessThan(postpack.indexOf("rm -rf skills"));
     const smoke = readText(join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"));
     expect(smoke).toContain("assertNpmTarballRegistrySafe");
+    // Pack into a run-owned destination so the deterministic name/version
+    // filename cannot overwrite a pre-existing apps/cli artifact.
+    expect(smoke).toContain("--pack-destination");
     // Helpers must throw so finally/cleanup always runs; only the outermost
     // main() may set process.exitCode.
     const failFn = smoke.match(/function fail\([^)]*\) \{[^}]*\}/)?.[0] ?? "";
@@ -197,7 +200,7 @@ describe("trusted-publishing npm toolchain contract", () => {
     expect(result.stdout).toContain("selftest-cleanup PASS");
   });
 
-  it("preserves pre-existing first-tree-dev tarballs across smoke success and failure cleanup", () => {
+  it("preserves a same-name pre-existing first-tree-dev tarball across smoke success and failure cleanup", () => {
     const result = spawnSync(
       process.execPath,
       [join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"), "selftest-preserve-preexisting"],

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -161,7 +161,13 @@ describe("trusted-publishing npm toolchain contract", () => {
     // workspace symlink graph recoverable by a subsequent prepare/restore.
     const postpack = pkg.scripts?.postpack ?? "";
     expect(postpack.indexOf("materialize-bundled-deps.mjs restore")).toBeLessThan(postpack.indexOf("rm -rf skills"));
-    expect(readText(join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"))).toContain("assertNpmTarballRegistrySafe");
+    const smoke = readText(join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"));
+    expect(smoke).toContain("assertNpmTarballRegistrySafe");
+    // Helpers must throw so finally/cleanup always runs; only the outermost
+    // main() may set process.exitCode.
+    const failFn = smoke.match(/function fail\([^)]*\) \{[^}]*\}/)?.[0] ?? "";
+    expect(failFn).toContain("throw new SmokeFailure");
+    expect(failFn).not.toContain("process.exit");
   });
 
   it("restores every original symlink after a mid-prepare failure", () => {
@@ -175,10 +181,25 @@ describe("trusted-publishing npm toolchain contract", () => {
     }
     expect(result.stdout).toContain("selftest-recovery PASS");
   });
+
+  it("cleans tarballs, temp consumers, and symlinks after a release-pack smoke failure", () => {
+    const result = spawnSync(
+      process.execPath,
+      [join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"), "selftest-cleanup"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+      },
+    );
+    if (result.status !== 0) {
+      throw new Error(`release-pack-smoke selftest-cleanup failed:\n${result.stderr || result.stdout}`);
+    }
+    expect(result.stdout).toContain("selftest-cleanup PASS");
+  });
 });
 
 describe("npm tarball registry-safety helper", () => {
-  it("accepts canonical package-root paths and rejects traversal and rootless layouts", () => {
+  it("accepts canonical package-root paths and rejects traversal, rootless, and escaping layouts", () => {
     const result = spawnSync(process.execPath, [join(REPO_ROOT, "scripts", "npm-tarball-safety.mjs")], {
       encoding: "utf8",
     });

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -166,11 +166,24 @@ describe("trusted-publishing npm toolchain contract", () => {
     // Pack into a run-owned destination so the deterministic name/version
     // filename cannot overwrite a pre-existing apps/cli artifact.
     expect(smoke).toContain("--pack-destination");
+    // Incomplete Turbo cache restores (dist-only) must not PASS smoke.
+    expect(smoke).toContain("assertSourceContextIntegrationPresent");
+    expect(smoke).toContain("assertConsumerContextIntegration");
+    expect(smoke).toContain("package/context-integration/release-manifest.json");
     // Helpers must throw so finally/cleanup always runs; only the outermost
     // main() may set process.exitCode.
     const failFn = smoke.match(/function fail\([^)]*\) \{[^}]*\}/)?.[0] ?? "";
     expect(failFn).toContain("throw new SmokeFailure");
     expect(failFn).not.toContain("process.exit");
+  });
+
+  it("declares context-integration as a turbo build output so cache hits restore the release payload", () => {
+    const turbo = readJson(join(CLI_ROOT, "turbo.json")) as {
+      tasks?: { build?: { outputs?: string[] } };
+    };
+    const outputs = turbo.tasks?.build?.outputs ?? [];
+    expect(outputs).toContain("dist/**");
+    expect(outputs).toContain("context-integration/**");
   });
 
   it("restores every original symlink after a mid-prepare failure", () => {
@@ -214,6 +227,24 @@ describe("trusted-publishing npm toolchain contract", () => {
     }
     expect(result.stdout).toContain("selftest-preserve-preexisting PASS");
   });
+
+  it("restores context-integration from a turbo cache hit after the directory is deleted", () => {
+    const result = spawnSync(
+      process.execPath,
+      [join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"), "selftest-turbo-context-integration-cache"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: process.env,
+      },
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `release-pack-smoke selftest-turbo-context-integration-cache failed:\n${result.stderr || result.stdout}`,
+      );
+    }
+    expect(result.stdout).toContain("selftest-turbo-context-integration-cache PASS");
+  }, 180_000);
 });
 
 describe("npm tarball registry-safety helper", () => {

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -144,5 +145,34 @@ describe("trusted-publishing npm toolchain contract", () => {
     expect(ci).toContain("npm install -g npm@11.5.1");
     expect(ci).toContain("node scripts/release-pack-smoke.mjs");
     expect(existsSync(join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"))).toBe(true);
+  });
+
+  it("materializes bundled deps around pack so pnpm symlink targets cannot escape the tarball", () => {
+    const pkg = readJson(join(CLI_ROOT, "package.json")) as {
+      scripts?: Record<string, string>;
+    };
+    const materialize = join(CLI_ROOT, "scripts", "materialize-bundled-deps.mjs");
+    const safety = join(REPO_ROOT, "scripts", "npm-tarball-safety.mjs");
+    expect(existsSync(materialize)).toBe(true);
+    expect(existsSync(safety)).toBe(true);
+    expect(pkg.scripts?.prepack ?? "").toContain("materialize-bundled-deps.mjs prepare");
+    expect(pkg.scripts?.postpack ?? "").toContain("materialize-bundled-deps.mjs restore");
+    // Restore must run before skill cleanup so a failed restore still leaves the
+    // workspace symlink graph recoverable by a subsequent prepare/restore.
+    const postpack = pkg.scripts?.postpack ?? "";
+    expect(postpack.indexOf("materialize-bundled-deps.mjs restore")).toBeLessThan(postpack.indexOf("rm -rf skills"));
+    expect(readText(join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"))).toContain("assertNpmTarballRegistrySafe");
+  });
+});
+
+describe("npm tarball registry-safety helper", () => {
+  it("accepts canonical package-root paths and rejects pnpm traversal layouts", () => {
+    const result = spawnSync(process.execPath, [join(REPO_ROOT, "scripts", "npm-tarball-safety.mjs")], {
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      throw new Error(`npm-tarball-safety selftest failed:\n${result.stderr || result.stdout}`);
+    }
+    expect(result.stdout).toContain("selftest PASS");
   });
 });

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -163,10 +163,22 @@ describe("trusted-publishing npm toolchain contract", () => {
     expect(postpack.indexOf("materialize-bundled-deps.mjs restore")).toBeLessThan(postpack.indexOf("rm -rf skills"));
     expect(readText(join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"))).toContain("assertNpmTarballRegistrySafe");
   });
+
+  it("restores every original symlink after a mid-prepare failure", () => {
+    const materialize = join(CLI_ROOT, "scripts", "materialize-bundled-deps.mjs");
+    const result = spawnSync(process.execPath, [materialize, "selftest-recovery"], {
+      cwd: CLI_ROOT,
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      throw new Error(`materialize selftest-recovery failed:\n${result.stderr || result.stdout}`);
+    }
+    expect(result.stdout).toContain("selftest-recovery PASS");
+  });
 });
 
 describe("npm tarball registry-safety helper", () => {
-  it("accepts canonical package-root paths and rejects pnpm traversal layouts", () => {
+  it("accepts canonical package-root paths and rejects traversal and rootless layouts", () => {
     const result = spawnSync(process.execPath, [join(REPO_ROOT, "scripts", "npm-tarball-safety.mjs")], {
       encoding: "utf8",
     });

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -196,6 +196,21 @@ describe("trusted-publishing npm toolchain contract", () => {
     }
     expect(result.stdout).toContain("selftest-cleanup PASS");
   });
+
+  it("preserves pre-existing first-tree-dev tarballs across smoke success and failure cleanup", () => {
+    const result = spawnSync(
+      process.execPath,
+      [join(REPO_ROOT, "scripts", "release-pack-smoke.mjs"), "selftest-preserve-preexisting"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+      },
+    );
+    if (result.status !== 0) {
+      throw new Error(`release-pack-smoke selftest-preserve-preexisting failed:\n${result.stderr || result.stdout}`);
+    }
+    expect(result.stdout).toContain("selftest-preserve-preexisting PASS");
+  });
 });
 
 describe("npm tarball registry-safety helper", () => {

--- a/apps/cli/turbo.json
+++ b/apps/cli/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"],
+      "outputs": ["dist/**", "context-integration/**"],
       "inputs": ["$TURBO_DEFAULT$", "../../skills/**"]
     },
     "test": {

--- a/scripts/npm-tarball-safety.mjs
+++ b/scripts/npm-tarball-safety.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Registry-safe npm tarball checks shared by release-pack smoke and unit tests.
+ *
+ * The npm registry rejects pack payloads whose entry names escape `package/`
+ * (E415 Unsupported Media Type / "invalid path"). pnpm symlink layouts produce
+ * exactly those names when `bundleDependencies` are packed without materializing
+ * real in-package copies first.
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as pathJoin, resolve as pathResolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { gunzipSync, gzipSync } from "node:zlib";
+
+/**
+ * @typedef {{ name: string, typeFlag: string, linkname?: string }} TarEntry
+ */
+
+/**
+ * List entries from a `.tgz` (gzip+ustar) using only Node builtins.
+ * @param {string} tarballPath
+ * @returns {TarEntry[]}
+ */
+export function listNpmTarballEntries(tarballPath) {
+  const buf = gunzipSync(readFileSync(tarballPath));
+  /** @type {TarEntry[]} */
+  const entries = [];
+  let offset = 0;
+  while (offset + 512 <= buf.length) {
+    const header = buf.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+
+    const name = readTarString(header, 0, 100);
+    const size = Number.parseInt(readTarString(header, 124, 12) || "0", 8);
+    if (!Number.isFinite(size) || size < 0) {
+      throw new Error(`invalid tar size field at offset ${offset}`);
+    }
+    const typeFlag = String.fromCharCode(header[156] || 0) || "0";
+    const linkname = readTarString(header, 157, 100);
+    const magic = readTarString(header, 257, 6);
+    const prefix = magic.startsWith("ustar") ? readTarString(header, 345, 155) : "";
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    entries.push({
+      name: fullName,
+      typeFlag,
+      ...(linkname ? { linkname } : {}),
+    });
+
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+/**
+ * @param {Uint8Array} header
+ * @param {number} start
+ * @param {number} length
+ */
+function readTarString(header, start, length) {
+  return Buffer.from(header.subarray(start, start + length))
+    .toString("utf8")
+    .replace(/\0.*$/s, "")
+    .trim();
+}
+
+/**
+ * Return human-readable violations for registry-unsafe entry names / link targets.
+ * @param {TarEntry[]} entries
+ * @returns {string[]}
+ */
+export function findUnsafeNpmTarballEntries(entries) {
+  /** @type {string[]} */
+  const violations = [];
+  for (const entry of entries) {
+    const rel = entry.name.startsWith("package/") ? entry.name.slice("package/".length) : entry.name;
+    const parts = rel.split("/");
+    if (parts.includes("..")) {
+      violations.push(`traversal path: ${entry.name}`);
+      continue;
+    }
+    if (rel.startsWith("/") || entry.name.startsWith("/")) {
+      violations.push(`absolute path: ${entry.name}`);
+      continue;
+    }
+    if (entry.typeFlag === "2" || entry.typeFlag === "1") {
+      const target = entry.linkname ?? "";
+      const targetParts = target.split("/");
+      if (target.startsWith("/") || targetParts.includes("..") || target.includes("node_modules/.pnpm/")) {
+        violations.push(`escaping ${entry.typeFlag === "2" ? "symlink" : "hardlink"}: ${entry.name} -> ${target}`);
+      }
+    }
+  }
+  return violations;
+}
+
+/**
+ * @param {string} tarballPath
+ */
+export function assertNpmTarballRegistrySafe(tarballPath) {
+  const entries = listNpmTarballEntries(tarballPath);
+  if (entries.length === 0) {
+    throw new Error(`tarball has no entries: ${tarballPath}`);
+  }
+  const violations = findUnsafeNpmTarballEntries(entries);
+  if (violations.length > 0) {
+    const preview = violations.slice(0, 8).join("\n");
+    const more = violations.length > 8 ? `\n... and ${violations.length - 8} more` : "";
+    throw new Error(`npm tarball is not registry-safe (${violations.length} violation(s)):\n${preview}${more}`);
+  }
+  return { entryCount: entries.length };
+}
+
+/**
+ * Build a tiny `.tgz` for unit tests (ustar + gzip). Not a general-purpose packer.
+ * @param {string} outPath
+ * @param {{ name: string, content?: string, typeFlag?: string, linkname?: string }[]} files
+ */
+export function writeSyntheticNpmTarball(outPath, files) {
+  /** @type {Buffer[]} */
+  const chunks = [];
+  for (const file of files) {
+    const content = Buffer.from(file.content ?? "", "utf8");
+    const typeFlag = file.typeFlag ?? (file.linkname ? "2" : "0");
+    chunks.push(buildUstarHeader(file.name, content.length, typeFlag, file.linkname ?? ""));
+    if (typeFlag === "0" || typeFlag === "\0") {
+      chunks.push(content);
+      const pad = (512 - (content.length % 512)) % 512;
+      if (pad > 0) chunks.push(Buffer.alloc(pad));
+    }
+  }
+  chunks.push(Buffer.alloc(1024));
+  writeFileSync(outPath, gzipSync(Buffer.concat(chunks)));
+}
+
+/**
+ * @param {string} name
+ * @param {number} size
+ * @param {string} typeFlag
+ * @param {string} linkname
+ */
+function buildUstarHeader(name, size, typeFlag, linkname) {
+  const header = Buffer.alloc(512);
+  writeTarField(header, 0, 100, name);
+  writeTarField(header, 100, 8, "0000644");
+  writeTarField(header, 108, 8, "0000000");
+  writeTarField(header, 116, 8, "0000000");
+  writeTarField(header, 124, 12, size.toString(8).padStart(11, "0"));
+  writeTarField(
+    header,
+    136,
+    12,
+    Math.floor(Date.now() / 1000)
+      .toString(8)
+      .padStart(11, "0"),
+  );
+  header[156] = typeFlag.charCodeAt(0);
+  writeTarField(header, 157, 100, linkname);
+  writeTarField(header, 257, 6, "ustar");
+  writeTarField(header, 263, 2, "00");
+  // checksum: sum of header bytes with checksum field as spaces
+  writeTarField(header, 148, 8, "        ");
+  let sum = 0;
+  for (const byte of header) sum += byte;
+  writeTarField(header, 148, 8, `${sum.toString(8).padStart(6, "0")}\0 `);
+  return header;
+}
+
+/**
+ * @param {Buffer} header
+ * @param {number} start
+ * @param {number} length
+ * @param {string} value
+ */
+function writeTarField(header, start, length, value) {
+  const buf = Buffer.alloc(length);
+  Buffer.from(value, "utf8").copy(buf);
+  buf.copy(header, start);
+}
+
+function runSelftest() {
+  const dir = mkdtempSync(pathJoin(tmpdir(), "npm-tarball-safety-selftest-"));
+  try {
+    const safePath = pathJoin(dir, "safe.tgz");
+    writeSyntheticNpmTarball(safePath, [
+      { name: "package/package.json", content: '{"name":"demo"}' },
+      {
+        name: "package/node_modules/@botiverse/kimi-code-sdk/package.json",
+        content: '{"name":"@botiverse/kimi-code-sdk"}',
+      },
+    ]);
+    assertNpmTarballRegistrySafe(safePath);
+
+    const badPath = pathJoin(dir, "bad.tgz");
+    // Mirrors the registry-rejected layout from staging publish run 30703432848.
+    writeSyntheticNpmTarball(badPath, [
+      {
+        name: "package/../../node_modules/.pnpm/@botiverse+kimi-code-sdk@0.26.0/node_modules/@antfu/utils/LICENSE",
+        content: "license",
+      },
+    ]);
+    const violations = findUnsafeNpmTarballEntries(listNpmTarballEntries(badPath));
+    if (!violations.some((line) => line.includes("traversal path"))) {
+      throw new Error("expected traversal violation for synthetic pnpm layout");
+    }
+    let rejected = false;
+    try {
+      assertNpmTarballRegistrySafe(badPath);
+    } catch {
+      rejected = true;
+    }
+    if (!rejected) throw new Error("expected registry-safe assertion to reject traversal tarball");
+    console.log("npm-tarball-safety: selftest PASS");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(pathResolve(process.argv[1])).href) {
+  runSelftest();
+}

--- a/scripts/npm-tarball-safety.mjs
+++ b/scripts/npm-tarball-safety.mjs
@@ -6,6 +6,12 @@
  * (E415 Unsupported Media Type / "invalid path"). pnpm symlink layouts produce
  * exactly those names when `bundleDependencies` are packed without materializing
  * real in-package copies first.
+ *
+ * Invariant: every member name must be a POSIX-canonical path under `package/`
+ * (or the bare `package` directory entry). Dot segments, empty segments,
+ * backslashes, absolute paths, and link targets that resolve outside `package/`
+ * are rejected. GNU/PAX long-name / extended headers are fail-closed because
+ * this parser does not interpret them — silently skipping would under-enumerate.
  */
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -17,8 +23,12 @@ import { gunzipSync, gzipSync } from "node:zlib";
  * @typedef {{ name: string, typeFlag: string, linkname?: string }} TarEntry
  */
 
+/** GNU long-name / PAX extended headers this parser does not interpret. */
+const UNSUPPORTED_TYPE_FLAGS = new Set(["L", "K", "x", "g", "X"]);
+
 /**
  * List entries from a `.tgz` (gzip+ustar) using only Node builtins.
+ * Fail closed on GNU/PAX long-name / extended headers.
  * @param {string} tarballPath
  * @returns {TarEntry[]}
  */
@@ -37,9 +47,16 @@ export function listNpmTarballEntries(tarballPath) {
       throw new Error(`invalid tar size field at offset ${offset}`);
     }
     const typeFlag = String.fromCharCode(header[156] || 0) || "0";
+    if (UNSUPPORTED_TYPE_FLAGS.has(typeFlag)) {
+      throw new Error(
+        `unsupported tar typeflag '${typeFlag}' at offset ${offset} (GNU/PAX long-name or extended header); fail closed rather than under-enumerate`,
+      );
+    }
     const linkname = readTarString(header, 157, 100);
     const magic = readTarString(header, 257, 6);
     const prefix = magic.startsWith("ustar") ? readTarString(header, 345, 155) : "";
+    // Preserve backslashes in the joined name so the safety classifier can reject
+    // non-POSIX separators explicitly (rather than silently normalizing them).
     const fullName = prefix ? `${prefix}/${name}` : name;
     entries.push({
       name: fullName,
@@ -65,6 +82,55 @@ function readTarString(header, start, length) {
 }
 
 /**
+ * Return null when `name` is not a POSIX-canonical path under `package/`.
+ * @param {string} name
+ * @returns {string | null} relative path under package/ ("" for the package dir itself)
+ */
+export function packageRelativeCanonicalPath(name) {
+  if (name.includes("\0") || name.includes("\\")) return null;
+  if (name.startsWith("/")) return null;
+  if (name === "package") return "";
+  if (!name.startsWith("package/")) return null;
+  const rel = name.slice("package/".length);
+  if (rel === "") return "";
+  const parts = rel.split("/");
+  for (const part of parts) {
+    if (part === "" || part === "." || part === "..") return null;
+  }
+  return rel;
+}
+
+/**
+ * Resolve a tar link target relative to the entry's directory and prove the
+ * result stays under `package/`. Returns the canonical package-relative path
+ * or null when the link escapes / is non-canonical.
+ * @param {string} entryName
+ * @param {string} linkTarget
+ */
+export function resolveTarLinkWithinPackage(entryName, linkTarget) {
+  if (!linkTarget || linkTarget.includes("\0") || linkTarget.includes("\\")) return null;
+  if (linkTarget.startsWith("/")) return null;
+
+  const entryRel = packageRelativeCanonicalPath(entryName);
+  if (entryRel === null) return null;
+
+  const entryDirParts = entryName === "package" ? ["package"] : entryName.split("/").slice(0, -1);
+  const stack = [...entryDirParts];
+  for (const part of linkTarget.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (stack.length <= 1) return null; // would leave package/
+      stack.pop();
+      continue;
+    }
+    stack.push(part);
+  }
+  if (stack[0] !== "package") return null;
+  const resolved = stack.join("/");
+  return packageRelativeCanonicalPath(resolved) === null ? null : resolved;
+}
+
+/**
  * Return human-readable violations for registry-unsafe entry names / link targets.
  * @param {TarEntry[]} entries
  * @returns {string[]}
@@ -73,27 +139,21 @@ export function findUnsafeNpmTarballEntries(entries) {
   /** @type {string[]} */
   const violations = [];
   for (const entry of entries) {
-    // npm pack payloads must place every member under the canonical `package/`
-    // root (or the bare `package` directory entry). Rootless names like
-    // `outside.txt` are registry-unsafe even without `..` traversal.
-    if (entry.name !== "package" && !entry.name.startsWith("package/")) {
-      violations.push(`missing package/ root: ${entry.name}`);
-      continue;
-    }
-    const rel = entry.name === "package" ? "" : entry.name.slice("package/".length);
-    const parts = rel === "" ? [] : rel.split("/");
-    if (parts.includes("..")) {
-      violations.push(`traversal path: ${entry.name}`);
-      continue;
-    }
-    if (rel.startsWith("/") || entry.name.startsWith("/")) {
-      violations.push(`absolute path: ${entry.name}`);
+    const rel = packageRelativeCanonicalPath(entry.name);
+    if (rel === null) {
+      if (entry.name.includes("\\") || entry.name.includes("\0")) {
+        violations.push(`non-posix path separator: ${entry.name}`);
+      } else if (!entry.name.startsWith("package/") && entry.name !== "package") {
+        violations.push(`missing package/ root: ${entry.name}`);
+      } else {
+        violations.push(`non-canonical package path: ${entry.name}`);
+      }
       continue;
     }
     if (entry.typeFlag === "2" || entry.typeFlag === "1") {
       const target = entry.linkname ?? "";
-      const targetParts = target.split("/");
-      if (target.startsWith("/") || targetParts.includes("..") || target.includes("node_modules/.pnpm/")) {
+      const resolved = resolveTarLinkWithinPackage(entry.name, target);
+      if (resolved === null) {
         violations.push(`escaping ${entry.typeFlag === "2" ? "symlink" : "hardlink"}: ${entry.name} -> ${target}`);
       }
     }
@@ -165,7 +225,6 @@ function buildUstarHeader(name, size, typeFlag, linkname) {
   writeTarField(header, 157, 100, linkname);
   writeTarField(header, 257, 6, "ustar");
   writeTarField(header, 263, 2, "00");
-  // checksum: sum of header bytes with checksum field as spaces
   writeTarField(header, 148, 8, "        ");
   let sum = 0;
   for (const byte of header) sum += byte;
@@ -185,6 +244,29 @@ function writeTarField(header, start, length, value) {
   buf.copy(header, start);
 }
 
+function expectReject(label, files, needle) {
+  const dir = mkdtempSync(pathJoin(tmpdir(), "npm-tarball-safety-case-"));
+  try {
+    const path = pathJoin(dir, "case.tgz");
+    writeSyntheticNpmTarball(path, files);
+    const violations = findUnsafeNpmTarballEntries(listNpmTarballEntries(path));
+    if (!violations.some((line) => line.includes(needle))) {
+      throw new Error(
+        `${label}: expected violation containing ${JSON.stringify(needle)}, got ${JSON.stringify(violations)}`,
+      );
+    }
+    let rejected = false;
+    try {
+      assertNpmTarballRegistrySafe(path);
+    } catch {
+      rejected = true;
+    }
+    if (!rejected) throw new Error(`${label}: expected assertNpmTarballRegistrySafe to throw`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 function runSelftest() {
   const dir = mkdtempSync(pathJoin(tmpdir(), "npm-tarball-safety-selftest-"));
   try {
@@ -195,44 +277,72 @@ function runSelftest() {
         name: "package/node_modules/@botiverse/kimi-code-sdk/package.json",
         content: '{"name":"@botiverse/kimi-code-sdk"}',
       },
+      {
+        name: "package/node_modules/@botiverse/kimi-code-sdk/dist/index.mjs",
+        content: "export {}",
+        typeFlag: "2",
+        linkname: "./other.mjs",
+      },
+    ]);
+    // Re-write safe tarball without the relative link that stays in-package —
+    // keep a plain safe set for the happy path.
+    writeSyntheticNpmTarball(safePath, [
+      { name: "package/package.json", content: '{"name":"demo"}' },
+      {
+        name: "package/node_modules/@botiverse/kimi-code-sdk/package.json",
+        content: '{"name":"@botiverse/kimi-code-sdk"}',
+      },
     ]);
     assertNpmTarballRegistrySafe(safePath);
 
-    const badPath = pathJoin(dir, "bad.tgz");
-    // Mirrors the registry-rejected layout from staging publish run 30703432848.
-    writeSyntheticNpmTarball(badPath, [
-      {
-        name: "package/../../node_modules/.pnpm/@botiverse+kimi-code-sdk@0.26.0/node_modules/@antfu/utils/LICENSE",
-        content: "license",
-      },
-    ]);
-    const violations = findUnsafeNpmTarballEntries(listNpmTarballEntries(badPath));
-    if (!violations.some((line) => line.includes("traversal path"))) {
-      throw new Error("expected traversal violation for synthetic pnpm layout");
-    }
-    let rejected = false;
-    try {
-      assertNpmTarballRegistrySafe(badPath);
-    } catch {
-      rejected = true;
-    }
-    if (!rejected) throw new Error("expected registry-safe assertion to reject traversal tarball");
+    expectReject(
+      "pnpm traversal",
+      [
+        {
+          name: "package/../../node_modules/.pnpm/@botiverse+kimi-code-sdk@0.26.0/node_modules/@antfu/utils/LICENSE",
+          content: "license",
+        },
+      ],
+      "non-canonical package path",
+    );
+    expectReject("rootless entry", [{ name: "outside.txt", content: "x" }], "missing package/ root");
+    expectReject("dot segment", [{ name: "package/./inside.txt", content: "x" }], "non-canonical package path");
+    expectReject(
+      "backslash traversal",
+      [{ name: "package\\..\\outside.txt", content: "x" }],
+      "non-posix path separator",
+    );
+    expectReject("empty segment", [{ name: "package//inside.txt", content: "x" }], "non-canonical package path");
+    expectReject(
+      "escaping symlink",
+      [
+        {
+          name: "package/node_modules/demo/link",
+          typeFlag: "2",
+          linkname: "../../../outside",
+        },
+      ],
+      "escaping symlink",
+    );
 
-    const rootlessPath = pathJoin(dir, "rootless.tgz");
-    writeSyntheticNpmTarball(rootlessPath, [{ name: "outside.txt", content: "x" }]);
-    const rootlessViolations = findUnsafeNpmTarballEntries(listNpmTarballEntries(rootlessPath));
-    if (!rootlessViolations.some((line) => line.includes("missing package/ root"))) {
-      throw new Error("expected missing package/ root violation for rootless entry");
-    }
-    let rootlessRejected = false;
+    // In-package relative symlink must be accepted.
+    const okLink = pathJoin(dir, "ok-link.tgz");
+    writeSyntheticNpmTarball(okLink, [
+      { name: "package/a/file.txt", content: "a" },
+      { name: "package/a/link", typeFlag: "2", linkname: "./file.txt" },
+    ]);
+    assertNpmTarballRegistrySafe(okLink);
+
+    // GNU long-name typeflag must fail closed at parse time.
+    const gnuPath = pathJoin(dir, "gnu.tgz");
+    writeSyntheticNpmTarball(gnuPath, [{ name: "package/ignored", content: "", typeFlag: "L" }]);
+    let gnuFailed = false;
     try {
-      assertNpmTarballRegistrySafe(rootlessPath);
-    } catch {
-      rootlessRejected = true;
+      listNpmTarballEntries(gnuPath);
+    } catch (error) {
+      gnuFailed = error instanceof Error && error.message.includes("unsupported tar typeflag");
     }
-    if (!rootlessRejected) {
-      throw new Error("expected registry-safe assertion to reject rootless entry");
-    }
+    if (!gnuFailed) throw new Error("expected GNU long-name typeflag to fail closed");
 
     console.log("npm-tarball-safety: selftest PASS");
   } finally {

--- a/scripts/npm-tarball-safety.mjs
+++ b/scripts/npm-tarball-safety.mjs
@@ -150,11 +150,20 @@ export function findUnsafeNpmTarballEntries(entries) {
       }
       continue;
     }
-    if (entry.typeFlag === "2" || entry.typeFlag === "1") {
+    if (entry.typeFlag === "2") {
+      // Symlink targets are resolved relative to the link entry's directory.
       const target = entry.linkname ?? "";
       const resolved = resolveTarLinkWithinPackage(entry.name, target);
       if (resolved === null) {
-        violations.push(`escaping ${entry.typeFlag === "2" ? "symlink" : "hardlink"}: ${entry.name} -> ${target}`);
+        violations.push(`escaping symlink: ${entry.name} -> ${target}`);
+      }
+    } else if (entry.typeFlag === "1") {
+      // Hardlink targets are archive-root paths, not directory-relative. Require
+      // the linkname itself to be a canonical package/... member path so a
+      // nested entry cannot smuggle `../outside` through relative resolution.
+      const target = entry.linkname ?? "";
+      if (packageRelativeCanonicalPath(target) === null) {
+        violations.push(`escaping hardlink: ${entry.name} -> ${target}`);
       }
     }
   }
@@ -324,6 +333,19 @@ function runSelftest() {
       ],
       "escaping symlink",
     );
+    // Hardlink targets are archive-root paths: `../outside` must NOT be accepted
+    // via directory-relative resolution from a nested entry.
+    expectReject(
+      "escaping hardlink",
+      [
+        {
+          name: "package/node_modules/demo/hard",
+          typeFlag: "1",
+          linkname: "../outside",
+        },
+      ],
+      "escaping hardlink",
+    );
 
     // In-package relative symlink must be accepted.
     const okLink = pathJoin(dir, "ok-link.tgz");
@@ -332,6 +354,14 @@ function runSelftest() {
       { name: "package/a/link", typeFlag: "2", linkname: "./file.txt" },
     ]);
     assertNpmTarballRegistrySafe(okLink);
+
+    // Canonical hardlink target under package/ must be accepted.
+    const okHard = pathJoin(dir, "ok-hard.tgz");
+    writeSyntheticNpmTarball(okHard, [
+      { name: "package/a/file.txt", content: "a" },
+      { name: "package/a/hard", typeFlag: "1", linkname: "package/a/file.txt" },
+    ]);
+    assertNpmTarballRegistrySafe(okHard);
 
     // GNU long-name typeflag must fail closed at parse time.
     const gnuPath = pathJoin(dir, "gnu.tgz");

--- a/scripts/npm-tarball-safety.mjs
+++ b/scripts/npm-tarball-safety.mjs
@@ -73,8 +73,15 @@ export function findUnsafeNpmTarballEntries(entries) {
   /** @type {string[]} */
   const violations = [];
   for (const entry of entries) {
-    const rel = entry.name.startsWith("package/") ? entry.name.slice("package/".length) : entry.name;
-    const parts = rel.split("/");
+    // npm pack payloads must place every member under the canonical `package/`
+    // root (or the bare `package` directory entry). Rootless names like
+    // `outside.txt` are registry-unsafe even without `..` traversal.
+    if (entry.name !== "package" && !entry.name.startsWith("package/")) {
+      violations.push(`missing package/ root: ${entry.name}`);
+      continue;
+    }
+    const rel = entry.name === "package" ? "" : entry.name.slice("package/".length);
+    const parts = rel === "" ? [] : rel.split("/");
     if (parts.includes("..")) {
       violations.push(`traversal path: ${entry.name}`);
       continue;
@@ -210,6 +217,23 @@ function runSelftest() {
       rejected = true;
     }
     if (!rejected) throw new Error("expected registry-safe assertion to reject traversal tarball");
+
+    const rootlessPath = pathJoin(dir, "rootless.tgz");
+    writeSyntheticNpmTarball(rootlessPath, [{ name: "outside.txt", content: "x" }]);
+    const rootlessViolations = findUnsafeNpmTarballEntries(listNpmTarballEntries(rootlessPath));
+    if (!rootlessViolations.some((line) => line.includes("missing package/ root"))) {
+      throw new Error("expected missing package/ root violation for rootless entry");
+    }
+    let rootlessRejected = false;
+    try {
+      assertNpmTarballRegistrySafe(rootlessPath);
+    } catch {
+      rootlessRejected = true;
+    }
+    if (!rootlessRejected) {
+      throw new Error("expected registry-safe assertion to reject rootless entry");
+    }
+
     console.log("npm-tarball-safety: selftest PASS");
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/scripts/release-pack-smoke.mjs
+++ b/scripts/release-pack-smoke.mjs
@@ -4,23 +4,28 @@
  * built CLI under the trusted-publishing npm client the workflow pins.
  *
  *   1. `npm pack` the built apps/cli package through REAL pack semantics
- *      (prepack copies skills, postpack cleans up — no --ignore-scripts).
- *   2. Install the tarball into an empty consumer with plain npm.
- *   3. Run the public CLI (`--version`).
- *   4. Resolve the bundled `@botiverse/kimi-code-sdk` from the consumer and
- *      assert the patched sites this PR ships: create-time drain flag, resume
- *      option threading, resume main-agent flag application, and the awaited
- *      replay-fence authorization hook.
+ *      (prepack copies skills + materializes bundled deps, postpack restores —
+ *      no --ignore-scripts).
+ *   2. Enumerate every tarball entry and reject traversal / absolute /
+ *      escaping-link paths (the npm registry E415 class).
+ *   3. Install the tarball into an empty consumer with plain npm.
+ *   4. Run the public CLI (`--version`).
+ *   5. Resolve the bundled `@botiverse/kimi-code-sdk` from the consumer and
+ *      assert the patched sites this release ships: create-time drain flag,
+ *      resume option threading, resume main-agent flag application, and the
+ *      awaited replay-fence authorization hook.
  *
  * No registry publish, no credentials, no network beyond npm itself.
  * Everything happens in a disposable temp directory removed on exit.
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertNpmTarballRegistrySafe } from "./npm-tarball-safety.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
@@ -61,6 +66,13 @@ try {
   const tarball = tarballs[0];
   const tarballName = tarballs[0].split("/").pop();
   try {
+    let safety;
+    try {
+      safety = assertNpmTarballRegistrySafe(tarball);
+    } catch (error) {
+      fail(error instanceof Error ? error.message : String(error));
+    }
+
     run("npm", ["install", "--prefix", consumerDir, tarball]);
     const binName = "first-tree-dev";
     const binPath = join(consumerDir, "node_modules", ".bin", binName);
@@ -98,8 +110,10 @@ try {
       `import(${JSON.stringify(`file://${sdkEntry}`)}).then(() => process.exit(0), (error) => { console.error(error); process.exit(1); })`,
     ]);
 
+    const sha256 = createHash("sha256").update(readFileSync(tarball)).digest("hex");
+    const bytes = statSync(tarball).size;
     console.log(
-      `release-pack-smoke: PASS — packed ${tarballName}, consumer CLI ${versionText}, bundled patched Kimi SDK verified`,
+      `release-pack-smoke: PASS — packed ${tarballName} (${bytes} B, sha256=${sha256}, ${safety.entryCount} entries), consumer CLI ${versionText}, registry-safe paths, bundled patched Kimi SDK verified`,
     );
   } finally {
     // Real pack semantics write the tarball into the package dir; never
@@ -108,4 +122,12 @@ try {
   }
 } finally {
   rmSync(work, { recursive: true, force: true });
+  // Belt-and-suspenders: pack lifecycle should restore, but never leave the
+  // materialize manifest or a stranded real copy if postpack was interrupted.
+  const manifest = join(CLI_ROOT, ".bundled-deps-materialize.json");
+  if (existsSync(manifest)) {
+    run(process.execPath, [join(CLI_ROOT, "scripts", "materialize-bundled-deps.mjs"), "restore"], {
+      cwd: CLI_ROOT,
+    });
+  }
 }

--- a/scripts/release-pack-smoke.mjs
+++ b/scripts/release-pack-smoke.mjs
@@ -5,7 +5,8 @@
  *
  *   1. `npm pack` the built apps/cli package through REAL pack semantics
  *      (prepack copies skills + materializes bundled deps, postpack restores —
- *      no --ignore-scripts).
+ *      no --ignore-scripts), writing the tarball into a run-owned temp
+ *      directory via `--pack-destination` so apps/cli is never overwritten.
  *   2. Enumerate every tarball entry and reject traversal / absolute /
  *      escaping-link / non-canonical package paths (the npm registry E415 class).
  *   3. Install the tarball into an empty consumer with plain npm.
@@ -15,10 +16,12 @@
  *      resume option threading, resume main-agent flag application, and the
  *      awaited replay-fence authorization hook.
  *
- * Failures throw; the outermost handler always cleans *this run's* tarballs,
- * temp consumers, and any stranded materialize journal before exiting non-zero.
- * Pre-existing `first-tree-dev-*.tgz` files in apps/cli are snapshotted and
- * preserved. Helpers never call `process.exit`.
+ * Failures throw; the outermost handler always cleans *this run's* pack
+ * destination, temp consumers, and any stranded materialize journal before
+ * exiting non-zero. Pre-existing `first-tree-dev-*.tgz` files in apps/cli —
+ * including ones that share npm pack's deterministic current name/version —
+ * are snapshotted by path+digest and never overwritten or deleted. Helpers
+ * never call `process.exit`.
  *
  * No registry publish, no credentials, no network beyond npm itself.
  */
@@ -28,6 +31,7 @@ import { createHash } from "node:crypto";
 import {
   existsSync,
   lstatSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
@@ -37,7 +41,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertNpmTarballRegistrySafe } from "./npm-tarball-safety.mjs";
 
@@ -74,6 +78,10 @@ function run(command, args, options = {}) {
   return result;
 }
 
+function sha256File(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
 function listCliTarballs() {
   return readdirSync(CLI_ROOT)
     .filter((name) => /^first-tree-dev-.*\.tgz$/.test(name))
@@ -81,43 +89,61 @@ function listCliTarballs() {
     .sort();
 }
 
-/**
- * Track which tarballs this invocation may delete. Pre-existing developer
- * artifacts are snapshotted at process start and never removed.
- * @type {{ preexisting: Set<string>, owned: Set<string> }}
- */
-const tarballOwnership = {
-  preexisting: new Set(),
-  owned: new Set(),
-};
-
-function snapshotPreexistingTarballs() {
-  tarballOwnership.preexisting = new Set(listCliTarballs());
-  tarballOwnership.owned = new Set();
+function expectedPackFilename() {
+  const pkg = JSON.parse(readFileSync(join(CLI_ROOT, "package.json"), "utf8"));
+  const name = String(pkg.name ?? "")
+    .replace(/^@/, "")
+    .replace(/\//g, "-");
+  return `${name}-${pkg.version}.tgz`;
 }
 
-/** Record tarballs created since the preexisting snapshot as owned by this run. */
-function adoptNewTarballs() {
+/**
+ * Path → sha256 digest for every pre-existing apps/cli tarball. Digests catch
+ * same-name overwrites that path-only ownership cannot see.
+ * @type {Map<string, string>}
+ */
+const preexistingTarballDigests = new Map();
+
+/** @type {string | undefined} Active run-owned work directory (pack + consumer). */
+let activeWorkDir;
+
+function snapshotPreexistingTarballs() {
+  preexistingTarballDigests.clear();
   for (const tarball of listCliTarballs()) {
-    if (!tarballOwnership.preexisting.has(tarball)) {
-      tarballOwnership.owned.add(tarball);
-    }
+    preexistingTarballDigests.set(tarball, sha256File(tarball));
   }
 }
 
 /**
- * Remove only work-owned pack artifacts (new tarballs + optional temp dir +
- * stranded materialize journal). Never deletes preexisting tarballs.
+ * Pack into a run-owned destination so npm's deterministic filename cannot
+ * overwrite a developer artifact already present under apps/cli.
+ * @param {string} packDestination
+ * @returns {string} absolute path of the packed tarball
+ */
+function packCliInto(packDestination) {
+  // npm pack does not create pack-destination; missing dirs surface as ENOENT
+  // while writing the deterministic tarball name.
+  mkdirSync(packDestination, { recursive: true });
+  run("npm", ["pack", "--json", "--pack-destination", packDestination], { cwd: CLI_ROOT });
+  const expectedName = expectedPackFilename();
+  const tarball = join(packDestination, expectedName);
+  if (!existsSync(tarball)) {
+    const found = readdirSync(packDestination).filter((name) => name.endsWith(".tgz"));
+    fail(`expected packed tarball at ${tarball}, found: ${found.join(", ") || "(none)"}`);
+  }
+  return tarball;
+}
+
+/**
+ * Remove only run-owned temp work (pack destination + consumer) and any
+ * stranded materialize journal. Never deletes or rewrites apps/cli tarballs.
  * @param {string | undefined} workDir
  */
 function cleanupPackArtifacts(workDir) {
-  adoptNewTarballs();
-  for (const tarball of tarballOwnership.owned) {
-    rmSync(tarball, { force: true });
-  }
-  tarballOwnership.owned.clear();
-  if (workDir) {
-    rmSync(workDir, { recursive: true, force: true });
+  const target = workDir ?? activeWorkDir;
+  activeWorkDir = undefined;
+  if (target) {
+    rmSync(target, { recursive: true, force: true });
   }
   if (existsSync(MANIFEST_PATH)) {
     const restore = spawnSync(process.execPath, [MATERIALIZE_SCRIPT, "restore"], {
@@ -138,13 +164,17 @@ function cleanupPackArtifacts(workDir) {
 function assertCleanWorkspace(symlinkSnapshot) {
   const current = new Set(listCliTarballs());
   for (const tarball of current) {
-    if (!tarballOwnership.preexisting.has(tarball)) {
-      fail(`cleanup left work-owned tarball residue: ${tarball}`);
+    if (!preexistingTarballDigests.has(tarball)) {
+      fail(`cleanup left work-owned tarball residue under apps/cli: ${tarball}`);
     }
   }
-  for (const tarball of tarballOwnership.preexisting) {
+  for (const [tarball, digest] of preexistingTarballDigests) {
     if (!existsSync(tarball)) {
       fail(`cleanup deleted pre-existing tarball it does not own: ${tarball}`);
+    }
+    const now = sha256File(tarball);
+    if (now !== digest) {
+      fail(`pre-existing tarball was overwritten or altered: ${tarball} (was ${digest}, now ${now})`);
     }
   }
   if (existsSync(MANIFEST_PATH)) {
@@ -204,15 +234,12 @@ function runSmoke() {
 
   const symlinkSnapshot = captureBundledSymlinks();
   const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-"));
+  activeWorkDir = work;
   try {
+    const packDir = join(work, "pack");
     const consumerDir = join(work, "consumer");
-    run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
-    adoptNewTarballs();
-    if (tarballOwnership.owned.size !== 1) {
-      fail(`expected exactly one new first-tree-dev tarball, got ${tarballOwnership.owned.size}`);
-    }
-    const tarball = [...tarballOwnership.owned][0];
-    const tarballName = tarball.split("/").pop();
+    const tarball = packCliInto(packDir);
+    const tarballName = basename(tarball);
 
     const safety = assertNpmTarballRegistrySafe(tarball);
 
@@ -253,7 +280,7 @@ function runSmoke() {
       `import(${JSON.stringify(`file://${sdkEntry}`)}).then(() => process.exit(0), (error) => { console.error(error); process.exit(1); })`,
     ]);
 
-    const sha256 = createHash("sha256").update(readFileSync(tarball)).digest("hex");
+    const sha256 = sha256File(tarball);
     const bytes = statSync(tarball).size;
     console.log(
       `release-pack-smoke: PASS — packed ${tarballName} (${bytes} B, sha256=${sha256}, ${safety.entryCount} entries), consumer CLI ${versionText}, registry-safe paths, bundled patched Kimi SDK verified`,
@@ -265,9 +292,9 @@ function runSmoke() {
 }
 
 /**
- * Deterministic negative cleanup regression: pack succeeds, then an injected
- * post-pack failure must still remove *this run's* tgz/temp/manifest and
- * restore symlinks — without deleting pre-existing tarballs.
+ * Deterministic negative cleanup regression: pack succeeds into a run-owned
+ * destination, then an injected post-pack failure must still remove that
+ * work tree and restore symlinks — without touching apps/cli tarballs.
  */
 function selftestCleanup() {
   if (!existsSync(join(CLI_ROOT, "dist", "cli", "index.mjs"))) {
@@ -275,14 +302,13 @@ function selftestCleanup() {
   }
   const symlinkSnapshot = captureBundledSymlinks();
   const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-neg-"));
+  activeWorkDir = work;
   let failedAsExpected = false;
+  let packedPath;
   try {
     try {
-      run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
-      adoptNewTarballs();
-      if (tarballOwnership.owned.size !== 1) {
-        fail(`expected one new tarball before injected failure, got ${tarballOwnership.owned.size}`);
-      }
+      packedPath = packCliInto(join(work, "pack"));
+      if (!existsSync(packedPath)) fail("selftest-cleanup: pack did not produce a tarball");
       fail("injected post-pack failure for cleanup regression");
     } catch (error) {
       if (!(error instanceof SmokeFailure) || !error.message.includes("injected post-pack failure")) {
@@ -297,21 +323,33 @@ function selftestCleanup() {
   if (!failedAsExpected) fail("selftest-cleanup did not take the injected failure path");
   assertCleanWorkspace(symlinkSnapshot);
   if (existsSync(work)) fail("selftest-cleanup left consumer work directory");
+  if (packedPath && existsSync(packedPath)) fail("selftest-cleanup left run-owned packed tarball");
   console.log("release-pack-smoke: selftest-cleanup PASS");
 }
 
 /**
- * Prove cleanup preserves developer-owned tarballs that pre-existed this run,
- * on both the success cleanup path and the top-level failure path.
+ * Prove pack destination isolation preserves a pre-existing artifact that
+ * already uses npm pack's deterministic current name/version filename —
+ * verified by content digest across success and failure cleanup.
  */
 function selftestPreservePreexistingTarball() {
-  const sentinel = join(CLI_ROOT, "first-tree-dev-0.0.0-sentinel-preexisting.tgz");
-  writeFileSync(sentinel, "preexisting-sentinel\n");
+  const deterministicName = expectedPackFilename();
+  const collisionPath = join(CLI_ROOT, deterministicName);
+  const sentinelBody = `preexisting-deterministic-sentinel:${deterministicName}\n`;
+  const createdBySelftest = !existsSync(collisionPath);
+  if (createdBySelftest) {
+    writeFileSync(collisionPath, sentinelBody);
+  }
+  const expectedDigest = sha256File(collisionPath);
+  const expectedBytes = createdBySelftest ? sentinelBody : readFileSync(collisionPath);
+
   try {
-    // Re-snapshot so the sentinel counts as preexisting for this selftest.
     snapshotPreexistingTarballs();
-    if (!tarballOwnership.preexisting.has(sentinel)) {
-      fail("selftest-preserve: sentinel was not recorded as preexisting");
+    if (!preexistingTarballDigests.has(collisionPath)) {
+      fail("selftest-preserve: deterministic preexisting tarball was not snapshotted");
+    }
+    if (preexistingTarballDigests.get(collisionPath) !== expectedDigest) {
+      fail("selftest-preserve: snapshot digest mismatch before pack");
     }
 
     if (!existsSync(join(CLI_ROOT, "dist", "cli", "index.mjs"))) {
@@ -319,41 +357,54 @@ function selftestPreservePreexistingTarball() {
     }
     const symlinkSnapshot = captureBundledSymlinks();
 
-    // Success-path cleanup: pack then clean; sentinel must survive.
+    // Success-path: pack into run-owned destination; collision path must keep
+    // the exact preexisting bytes (path-only ownership cannot catch overwrite).
     const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-preserve-"));
+    activeWorkDir = work;
     try {
-      run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
-      adoptNewTarballs();
-      if (tarballOwnership.owned.size < 1) fail("selftest-preserve: pack produced no owned tarball");
-      if (tarballOwnership.owned.has(sentinel)) {
-        fail("selftest-preserve: sentinel incorrectly marked owned");
+      const packed = packCliInto(join(work, "pack"));
+      if (basename(packed) !== deterministicName) {
+        fail(`selftest-preserve: packed name ${basename(packed)} !== ${deterministicName}`);
+      }
+      if (sha256File(packed) === expectedDigest && createdBySelftest) {
+        fail("selftest-preserve: packed artifact unexpectedly matched sentinel digest");
+      }
+      if (sha256File(collisionPath) !== expectedDigest) {
+        fail("selftest-preserve: pack overwrote the deterministic preexisting tarball");
       }
     } finally {
       cleanupPackArtifacts(work);
     }
     assertCleanWorkspace(symlinkSnapshot);
-    if (!existsSync(sentinel) || readFileSync(sentinel, "utf8") !== "preexisting-sentinel\n") {
-      fail("selftest-preserve: success cleanup deleted or altered the sentinel tarball");
+    if (!existsSync(collisionPath) || sha256File(collisionPath) !== expectedDigest) {
+      fail("selftest-preserve: success cleanup deleted or altered the deterministic preexisting tarball");
+    }
+    if (createdBySelftest && readFileSync(collisionPath, "utf8") !== sentinelBody) {
+      fail("selftest-preserve: sentinel body changed after success cleanup");
     }
 
-    // Failure-path cleanup via top-level catch (missing action / early fail):
-    // snapshot already includes sentinel; cleanup must not remove it.
+    // Failure-path cleanup via top-level catch must likewise leave digests alone.
     try {
       fail("injected top-level failure for preexisting preservation");
     } catch (error) {
       if (!(error instanceof SmokeFailure)) throw error;
       cleanupPackArtifacts(undefined);
     }
-    if (!existsSync(sentinel) || readFileSync(sentinel, "utf8") !== "preexisting-sentinel\n") {
-      fail("selftest-preserve: failure cleanup deleted or altered the sentinel tarball");
+    if (!existsSync(collisionPath) || sha256File(collisionPath) !== expectedDigest) {
+      fail("selftest-preserve: failure cleanup deleted or altered the deterministic preexisting tarball");
+    }
+    if (createdBySelftest && Buffer.compare(readFileSync(collisionPath), Buffer.from(expectedBytes)) !== 0) {
+      fail("selftest-preserve: sentinel bytes changed after failure cleanup");
     }
 
-    console.log("release-pack-smoke: selftest-preserve-preexisting PASS");
+    console.log(
+      `release-pack-smoke: selftest-preserve-preexisting PASS — preserved ${deterministicName} sha256=${expectedDigest}`,
+    );
   } finally {
-    rmSync(sentinel, { force: true });
-    // Drop the sentinel from the in-memory preexisting set for any later action
-    // in the same process (selftests are process-isolated via spawn in vitest).
-    tarballOwnership.preexisting.delete(sentinel);
+    if (createdBySelftest) {
+      rmSync(collisionPath, { force: true });
+    }
+    preexistingTarballDigests.delete(collisionPath);
   }
 }
 

--- a/scripts/release-pack-smoke.mjs
+++ b/scripts/release-pack-smoke.mjs
@@ -328,20 +328,68 @@ function selftestCleanup() {
 }
 
 /**
+ * Assert the deterministic apps/cli collision path still holds the exact
+ * preexisting bytes/digest, then that run-owned residue is gone and bundled
+ * symlinks match the pre-smoke snapshot.
+ * @param {string} collisionPath
+ * @param {string} expectedDigest
+ * @param {Buffer} expectedBytes
+ * @param {Map<string, string>} symlinkSnapshot
+ * @param {string} phase
+ * @param {string | undefined} workDir
+ * @param {string | undefined} packedPath
+ */
+function assertPreservedCollision(
+  collisionPath,
+  expectedDigest,
+  expectedBytes,
+  symlinkSnapshot,
+  phase,
+  workDir,
+  packedPath,
+) {
+  if (!existsSync(collisionPath)) {
+    fail(`selftest-preserve [${phase}]: deterministic preexisting tarball missing`);
+  }
+  const digest = sha256File(collisionPath);
+  if (digest !== expectedDigest) {
+    fail(`selftest-preserve [${phase}]: digest changed (was ${expectedDigest}, now ${digest})`);
+  }
+  if (Buffer.compare(readFileSync(collisionPath), expectedBytes) !== 0) {
+    fail(`selftest-preserve [${phase}]: preexisting bytes changed`);
+  }
+  assertCleanWorkspace(symlinkSnapshot);
+  if (workDir && existsSync(workDir)) {
+    fail(`selftest-preserve [${phase}]: left run-owned work directory`);
+  }
+  if (packedPath && existsSync(packedPath)) {
+    fail(`selftest-preserve [${phase}]: left run-owned packed tarball`);
+  }
+  if (existsSync(MANIFEST_PATH)) {
+    fail(`selftest-preserve [${phase}]: left stranded materialize manifest`);
+  }
+}
+
+/**
  * Prove pack destination isolation preserves a pre-existing artifact that
- * already uses npm pack's deterministic current name/version filename —
- * verified by content digest across success and failure cleanup.
+ * already uses npm pack's deterministic current name/version filename
+ * (e.g. first-tree-dev-0.5.18.tgz) — verified by exact bytes + sha256 across
+ * success cleanup, post-pack failure cleanup, and invalid/early failure cleanup.
  */
 function selftestPreservePreexistingTarball() {
   const deterministicName = expectedPackFilename();
   const collisionPath = join(CLI_ROOT, deterministicName);
-  const sentinelBody = `preexisting-deterministic-sentinel:${deterministicName}\n`;
+  // Fixed 31-byte sentinel matching the real collision shape reviewers reproduce.
+  const sentinelBody = Buffer.from("preexisting-sentinel-31-bytes!\n", "utf8");
+  if (sentinelBody.length !== 31) {
+    fail(`selftest-preserve: sentinel must be 31 bytes, got ${sentinelBody.length}`);
+  }
   const createdBySelftest = !existsSync(collisionPath);
   if (createdBySelftest) {
     writeFileSync(collisionPath, sentinelBody);
   }
+  const expectedBytes = readFileSync(collisionPath);
   const expectedDigest = sha256File(collisionPath);
-  const expectedBytes = createdBySelftest ? sentinelBody : readFileSync(collisionPath);
 
   try {
     snapshotPreexistingTarballs();
@@ -357,48 +405,79 @@ function selftestPreservePreexistingTarball() {
     }
     const symlinkSnapshot = captureBundledSymlinks();
 
-    // Success-path: pack into run-owned destination; collision path must keep
-    // the exact preexisting bytes (path-only ownership cannot catch overwrite).
-    const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-preserve-"));
-    activeWorkDir = work;
-    try {
-      const packed = packCliInto(join(work, "pack"));
-      if (basename(packed) !== deterministicName) {
-        fail(`selftest-preserve: packed name ${basename(packed)} !== ${deterministicName}`);
+    // 1) Success-path: pack into run-owned destination; collision path untouched.
+    {
+      const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-preserve-ok-"));
+      activeWorkDir = work;
+      let packed;
+      try {
+        packed = packCliInto(join(work, "pack"));
+        if (basename(packed) !== deterministicName) {
+          fail(`selftest-preserve: packed name ${basename(packed)} !== ${deterministicName}`);
+        }
+        if (sha256File(packed) === expectedDigest) {
+          fail("selftest-preserve: packed artifact unexpectedly matched preexisting digest");
+        }
+        if (sha256File(collisionPath) !== expectedDigest) {
+          fail("selftest-preserve: pack overwrote the deterministic preexisting tarball");
+        }
+      } finally {
+        cleanupPackArtifacts(work);
       }
-      if (sha256File(packed) === expectedDigest && createdBySelftest) {
-        fail("selftest-preserve: packed artifact unexpectedly matched sentinel digest");
-      }
-      if (sha256File(collisionPath) !== expectedDigest) {
-        fail("selftest-preserve: pack overwrote the deterministic preexisting tarball");
-      }
-    } finally {
-      cleanupPackArtifacts(work);
-    }
-    assertCleanWorkspace(symlinkSnapshot);
-    if (!existsSync(collisionPath) || sha256File(collisionPath) !== expectedDigest) {
-      fail("selftest-preserve: success cleanup deleted or altered the deterministic preexisting tarball");
-    }
-    if (createdBySelftest && readFileSync(collisionPath, "utf8") !== sentinelBody) {
-      fail("selftest-preserve: sentinel body changed after success cleanup");
+      assertPreservedCollision(collisionPath, expectedDigest, expectedBytes, symlinkSnapshot, "success", work, packed);
     }
 
-    // Failure-path cleanup via top-level catch must likewise leave digests alone.
+    // 2) Post-pack failure: pack succeeds into temp, then injected failure cleanup
+    // must remove run-owned outputs without touching the collision path.
+    {
+      const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-preserve-post-"));
+      activeWorkDir = work;
+      let packed;
+      let failedAsExpected = false;
+      try {
+        try {
+          packed = packCliInto(join(work, "pack"));
+          fail("injected post-pack failure for preexisting preservation");
+        } catch (error) {
+          if (!(error instanceof SmokeFailure) || !error.message.includes("injected post-pack failure")) {
+            throw error;
+          }
+          failedAsExpected = true;
+        }
+      } finally {
+        cleanupPackArtifacts(work);
+      }
+      if (!failedAsExpected) fail("selftest-preserve: post-pack failure path not taken");
+      assertPreservedCollision(
+        collisionPath,
+        expectedDigest,
+        expectedBytes,
+        symlinkSnapshot,
+        "post-pack-failure",
+        work,
+        packed,
+      );
+    }
     try {
-      fail("injected top-level failure for preexisting preservation");
+      fail("injected early failure for preexisting preservation");
     } catch (error) {
-      if (!(error instanceof SmokeFailure)) throw error;
+      if (!(error instanceof SmokeFailure) || !error.message.includes("injected early failure")) {
+        throw error;
+      }
       cleanupPackArtifacts(undefined);
     }
-    if (!existsSync(collisionPath) || sha256File(collisionPath) !== expectedDigest) {
-      fail("selftest-preserve: failure cleanup deleted or altered the deterministic preexisting tarball");
-    }
-    if (createdBySelftest && Buffer.compare(readFileSync(collisionPath), Buffer.from(expectedBytes)) !== 0) {
-      fail("selftest-preserve: sentinel bytes changed after failure cleanup");
-    }
+    assertPreservedCollision(
+      collisionPath,
+      expectedDigest,
+      expectedBytes,
+      symlinkSnapshot,
+      "early-failure",
+      undefined,
+      undefined,
+    );
 
     console.log(
-      `release-pack-smoke: selftest-preserve-preexisting PASS — preserved ${deterministicName} sha256=${expectedDigest}`,
+      `release-pack-smoke: selftest-preserve-preexisting PASS — preserved ${deterministicName} sha256=${expectedDigest} across success/post-pack/early failure`,
     );
   } finally {
     if (createdBySelftest) {

--- a/scripts/release-pack-smoke.mjs
+++ b/scripts/release-pack-smoke.mjs
@@ -15,16 +15,27 @@
  *      resume option threading, resume main-agent flag application, and the
  *      awaited replay-fence authorization hook.
  *
- * Failures throw; the outermost handler always cleans tarballs, temp consumers,
- * and any stranded materialize journal before exiting non-zero. Helpers never
- * call `process.exit`.
+ * Failures throw; the outermost handler always cleans *this run's* tarballs,
+ * temp consumers, and any stranded materialize journal before exiting non-zero.
+ * Pre-existing `first-tree-dev-*.tgz` files in apps/cli are snapshotted and
+ * preserved. Helpers never call `process.exit`.
  *
  * No registry publish, no credentials, no network beyond npm itself.
  */
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, lstatSync, mkdtempSync, readdirSync, readFileSync, readlinkSync, rmSync, statSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -66,13 +77,45 @@ function run(command, args, options = {}) {
 function listCliTarballs() {
   return readdirSync(CLI_ROOT)
     .filter((name) => /^first-tree-dev-.*\.tgz$/.test(name))
-    .map((name) => join(CLI_ROOT, name));
+    .map((name) => join(CLI_ROOT, name))
+    .sort();
 }
 
-function cleanupPackArtifacts(workDir) {
+/**
+ * Track which tarballs this invocation may delete. Pre-existing developer
+ * artifacts are snapshotted at process start and never removed.
+ * @type {{ preexisting: Set<string>, owned: Set<string> }}
+ */
+const tarballOwnership = {
+  preexisting: new Set(),
+  owned: new Set(),
+};
+
+function snapshotPreexistingTarballs() {
+  tarballOwnership.preexisting = new Set(listCliTarballs());
+  tarballOwnership.owned = new Set();
+}
+
+/** Record tarballs created since the preexisting snapshot as owned by this run. */
+function adoptNewTarballs() {
   for (const tarball of listCliTarballs()) {
+    if (!tarballOwnership.preexisting.has(tarball)) {
+      tarballOwnership.owned.add(tarball);
+    }
+  }
+}
+
+/**
+ * Remove only work-owned pack artifacts (new tarballs + optional temp dir +
+ * stranded materialize journal). Never deletes preexisting tarballs.
+ * @param {string | undefined} workDir
+ */
+function cleanupPackArtifacts(workDir) {
+  adoptNewTarballs();
+  for (const tarball of tarballOwnership.owned) {
     rmSync(tarball, { force: true });
   }
+  tarballOwnership.owned.clear();
   if (workDir) {
     rmSync(workDir, { recursive: true, force: true });
   }
@@ -89,9 +132,20 @@ function cleanupPackArtifacts(workDir) {
   }
 }
 
+/**
+ * @param {Map<string, string>} symlinkSnapshot
+ */
 function assertCleanWorkspace(symlinkSnapshot) {
-  if (listCliTarballs().length !== 0) {
-    fail(`cleanup left tarball residue: ${listCliTarballs().join(", ")}`);
+  const current = new Set(listCliTarballs());
+  for (const tarball of current) {
+    if (!tarballOwnership.preexisting.has(tarball)) {
+      fail(`cleanup left work-owned tarball residue: ${tarball}`);
+    }
+  }
+  for (const tarball of tarballOwnership.preexisting) {
+    if (!existsSync(tarball)) {
+      fail(`cleanup deleted pre-existing tarball it does not own: ${tarball}`);
+    }
   }
   if (existsSync(MANIFEST_PATH)) {
     fail("cleanup left stranded materialize manifest");
@@ -153,11 +207,11 @@ function runSmoke() {
   try {
     const consumerDir = join(work, "consumer");
     run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
-    const tarballs = listCliTarballs();
-    if (tarballs.length !== 1) {
-      fail(`expected exactly one first-tree-dev tarball in apps/cli, got ${tarballs.length}`);
+    adoptNewTarballs();
+    if (tarballOwnership.owned.size !== 1) {
+      fail(`expected exactly one new first-tree-dev tarball, got ${tarballOwnership.owned.size}`);
     }
-    const tarball = tarballs[0];
+    const tarball = [...tarballOwnership.owned][0];
     const tarballName = tarball.split("/").pop();
 
     const safety = assertNpmTarballRegistrySafe(tarball);
@@ -212,8 +266,8 @@ function runSmoke() {
 
 /**
  * Deterministic negative cleanup regression: pack succeeds, then an injected
- * post-pack failure must still remove tgz/temp/manifest and restore symlinks
- * before the process exits non-zero.
+ * post-pack failure must still remove *this run's* tgz/temp/manifest and
+ * restore symlinks — without deleting pre-existing tarballs.
  */
 function selftestCleanup() {
   if (!existsSync(join(CLI_ROOT, "dist", "cli", "index.mjs"))) {
@@ -225,8 +279,10 @@ function selftestCleanup() {
   try {
     try {
       run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
-      const tarballs = listCliTarballs();
-      if (tarballs.length !== 1) fail(`expected one tarball before injected failure, got ${tarballs.length}`);
+      adoptNewTarballs();
+      if (tarballOwnership.owned.size !== 1) {
+        fail(`expected one new tarball before injected failure, got ${tarballOwnership.owned.size}`);
+      }
       fail("injected post-pack failure for cleanup regression");
     } catch (error) {
       if (!(error instanceof SmokeFailure) || !error.message.includes("injected post-pack failure")) {
@@ -244,12 +300,72 @@ function selftestCleanup() {
   console.log("release-pack-smoke: selftest-cleanup PASS");
 }
 
+/**
+ * Prove cleanup preserves developer-owned tarballs that pre-existed this run,
+ * on both the success cleanup path and the top-level failure path.
+ */
+function selftestPreservePreexistingTarball() {
+  const sentinel = join(CLI_ROOT, "first-tree-dev-0.0.0-sentinel-preexisting.tgz");
+  writeFileSync(sentinel, "preexisting-sentinel\n");
+  try {
+    // Re-snapshot so the sentinel counts as preexisting for this selftest.
+    snapshotPreexistingTarballs();
+    if (!tarballOwnership.preexisting.has(sentinel)) {
+      fail("selftest-preserve: sentinel was not recorded as preexisting");
+    }
+
+    if (!existsSync(join(CLI_ROOT, "dist", "cli", "index.mjs"))) {
+      fail("apps/cli/dist is missing — run `pnpm build` before selftest-preserve-preexisting");
+    }
+    const symlinkSnapshot = captureBundledSymlinks();
+
+    // Success-path cleanup: pack then clean; sentinel must survive.
+    const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-preserve-"));
+    try {
+      run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
+      adoptNewTarballs();
+      if (tarballOwnership.owned.size < 1) fail("selftest-preserve: pack produced no owned tarball");
+      if (tarballOwnership.owned.has(sentinel)) {
+        fail("selftest-preserve: sentinel incorrectly marked owned");
+      }
+    } finally {
+      cleanupPackArtifacts(work);
+    }
+    assertCleanWorkspace(symlinkSnapshot);
+    if (!existsSync(sentinel) || readFileSync(sentinel, "utf8") !== "preexisting-sentinel\n") {
+      fail("selftest-preserve: success cleanup deleted or altered the sentinel tarball");
+    }
+
+    // Failure-path cleanup via top-level catch (missing action / early fail):
+    // snapshot already includes sentinel; cleanup must not remove it.
+    try {
+      fail("injected top-level failure for preexisting preservation");
+    } catch (error) {
+      if (!(error instanceof SmokeFailure)) throw error;
+      cleanupPackArtifacts(undefined);
+    }
+    if (!existsSync(sentinel) || readFileSync(sentinel, "utf8") !== "preexisting-sentinel\n") {
+      fail("selftest-preserve: failure cleanup deleted or altered the sentinel tarball");
+    }
+
+    console.log("release-pack-smoke: selftest-preserve-preexisting PASS");
+  } finally {
+    rmSync(sentinel, { force: true });
+    // Drop the sentinel from the in-memory preexisting set for any later action
+    // in the same process (selftests are process-isolated via spawn in vitest).
+    tarballOwnership.preexisting.delete(sentinel);
+  }
+}
+
 function main() {
+  snapshotPreexistingTarballs();
   const action = process.argv[2];
   try {
     if (action === "selftest-cleanup") selftestCleanup();
+    else if (action === "selftest-preserve-preexisting") selftestPreservePreexistingTarball();
     else if (action === undefined) runSmoke();
-    else fail(`unknown action '${action}' (expected default smoke or selftest-cleanup)`);
+    else
+      fail(`unknown action '${action}' (expected default smoke, selftest-cleanup, or selftest-preserve-preexisting)`);
   } catch (error) {
     try {
       cleanupPackArtifacts(undefined);

--- a/scripts/release-pack-smoke.mjs
+++ b/scripts/release-pack-smoke.mjs
@@ -11,7 +11,10 @@
  *      escaping-link / non-canonical package paths (the npm registry E415 class).
  *   3. Install the tarball into an empty consumer with plain npm.
  *   4. Run the public CLI (`--version`).
- *   5. Resolve the bundled `@botiverse/kimi-code-sdk` from the consumer and
+ *   5. Fail-closed if the built `context-integration` release payload is
+ *      missing from the pack source or from the empty-consumer install
+ *      (guards Turbo cache hits that restore only `dist/**`).
+ *   6. Resolve the bundled `@botiverse/kimi-code-sdk` from the consumer and
  *      assert the patched sites this release ships: create-time drain flag,
  *      resume option threading, resume main-agent flag application, and the
  *      awaited replay-fence authorization hook.
@@ -43,13 +46,16 @@ import {
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { assertNpmTarballRegistrySafe } from "./npm-tarball-safety.mjs";
+import { assertNpmTarballRegistrySafe, listNpmTarballEntries } from "./npm-tarball-safety.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const CLI_ROOT = join(REPO_ROOT, "apps", "cli");
 const MATERIALIZE_SCRIPT = join(CLI_ROOT, "scripts", "materialize-bundled-deps.mjs");
 const MANIFEST_PATH = join(CLI_ROOT, ".bundled-deps-materialize.json");
+const CONTEXT_INTEGRATION_ROOT = join(CLI_ROOT, "context-integration");
+const CONTEXT_INTEGRATION_MANIFEST = join(CONTEXT_INTEGRATION_ROOT, "release-manifest.json");
+const PACKAGED_CONTEXT_MANIFEST_ENTRY = "package/context-integration/release-manifest.json";
 
 class SmokeFailure extends Error {
   /** @param {string} message */
@@ -197,6 +203,80 @@ function assertCleanWorkspace(symlinkSnapshot) {
   }
 }
 
+/**
+ * Fail closed before pack when the release payload Turbo must restore is gone
+ * (postpack deletes it; a dist-only cache hit must not silently pack without it).
+ * @returns {{ version: string, bundleDigest: string, providers: string[] }}
+ */
+function assertSourceContextIntegrationPresent() {
+  if (!existsSync(CONTEXT_INTEGRATION_MANIFEST)) {
+    fail(
+      "apps/cli/context-integration/release-manifest.json is missing — run a full `pnpm build` that restores context-integration/** (Turbo build outputs must include it)",
+    );
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(CONTEXT_INTEGRATION_MANIFEST, "utf8"));
+  } catch (error) {
+    fail(
+      `apps/cli/context-integration/release-manifest.json is not valid JSON: ${
+        error instanceof Error ? error.message : error
+      }`,
+    );
+  }
+  if (!manifest || typeof manifest !== "object" || typeof manifest.bundleDigest !== "string") {
+    fail("apps/cli/context-integration/release-manifest.json is missing bundleDigest");
+  }
+  const providers = Object.keys(manifest.providers ?? {});
+  if (providers.length < 1) {
+    fail("apps/cli/context-integration/release-manifest.json declares no providers");
+  }
+  for (const provider of providers) {
+    const providerRoot = join(CONTEXT_INTEGRATION_ROOT, provider);
+    if (!existsSync(providerRoot)) {
+      fail(`apps/cli/context-integration missing provider payload directory: ${provider}`);
+    }
+  }
+  return {
+    version: String(manifest.version ?? ""),
+    bundleDigest: manifest.bundleDigest,
+    providers,
+  };
+}
+
+/**
+ * @param {string} consumerDir
+ * @param {{ bundleDigest: string, providers: string[] }} source
+ */
+function assertConsumerContextIntegration(consumerDir, source) {
+  const packagedRoot = join(consumerDir, "node_modules", "first-tree-dev", "context-integration");
+  const packagedManifestPath = join(packagedRoot, "release-manifest.json");
+  if (!existsSync(packagedManifestPath)) {
+    fail(`consumer is missing packaged context-integration/release-manifest.json at ${packagedManifestPath}`);
+  }
+  const packaged = JSON.parse(readFileSync(packagedManifestPath, "utf8"));
+  if (packaged.bundleDigest !== source.bundleDigest) {
+    fail(
+      `consumer context-integration bundleDigest mismatch: source=${source.bundleDigest} packaged=${packaged.bundleDigest}`,
+    );
+  }
+  for (const provider of source.providers) {
+    if (!existsSync(join(packagedRoot, provider))) {
+      fail(`consumer context-integration missing provider payload: ${provider}`);
+    }
+  }
+}
+
+/**
+ * @param {string} tarballPath
+ */
+function assertTarballContainsContextIntegration(tarballPath) {
+  const entries = listNpmTarballEntries(tarballPath);
+  if (!entries.some((entry) => entry.name === PACKAGED_CONTEXT_MANIFEST_ENTRY)) {
+    fail(`tarball is missing ${PACKAGED_CONTEXT_MANIFEST_ENTRY}`);
+  }
+}
+
 function captureBundledSymlinks() {
   /** @type {Map<string, string>} */
   const snapshot = new Map();
@@ -231,6 +311,7 @@ function runSmoke() {
   if (!existsSync(join(CLI_ROOT, "dist", "cli", "index.mjs")) || !existsSync(join(CLI_ROOT, "dist", "index.mjs"))) {
     fail("apps/cli/dist is missing — run `pnpm build` first");
   }
+  const contextIntegration = assertSourceContextIntegrationPresent();
 
   const symlinkSnapshot = captureBundledSymlinks();
   const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-"));
@@ -242,6 +323,7 @@ function runSmoke() {
     const tarballName = basename(tarball);
 
     const safety = assertNpmTarballRegistrySafe(tarball);
+    assertTarballContainsContextIntegration(tarball);
 
     run("npm", ["install", "--prefix", consumerDir, tarball]);
     const binName = "first-tree-dev";
@@ -250,6 +332,8 @@ function runSmoke() {
     const version = run(binPath, ["--version"]);
     const versionText = version.stdout.trim();
     if (!/^\d+\.\d+\.\d+/.test(versionText)) fail(`unexpected --version output: ${versionText}`);
+
+    assertConsumerContextIntegration(consumerDir, contextIntegration);
 
     const sdkEntry = join(
       consumerDir,
@@ -283,7 +367,7 @@ function runSmoke() {
     const sha256 = sha256File(tarball);
     const bytes = statSync(tarball).size;
     console.log(
-      `release-pack-smoke: PASS — packed ${tarballName} (${bytes} B, sha256=${sha256}, ${safety.entryCount} entries), consumer CLI ${versionText}, registry-safe paths, bundled patched Kimi SDK verified`,
+      `release-pack-smoke: PASS — packed ${tarballName} (${bytes} B, sha256=${sha256}, ${safety.entryCount} entries), consumer CLI ${versionText}, registry-safe paths, context-integration ${contextIntegration.bundleDigest}, bundled patched Kimi SDK verified`,
     );
   } finally {
     cleanupPackArtifacts(work);
@@ -487,15 +571,74 @@ function selftestPreservePreexistingTarball() {
   }
 }
 
+/**
+ * Neuter regression: populate a private Turbo cache from a full CLI build,
+ * delete context-integration (as postpack does), then prove a cache-hit build
+ * restores the release payload so pack smoke stays complete (not the 817-entry
+ * dist-only false green).
+ */
+function selftestTurboContextIntegrationCache() {
+  const turboJson = JSON.parse(readFileSync(join(CLI_ROOT, "turbo.json"), "utf8"));
+  const outputs = turboJson?.tasks?.build?.outputs;
+  if (!Array.isArray(outputs) || !outputs.includes("context-integration/**")) {
+    fail('apps/cli/turbo.json build.outputs must include "context-integration/**"');
+  }
+  if (!outputs.includes("dist/**")) {
+    fail('apps/cli/turbo.json build.outputs must include "dist/**"');
+  }
+
+  const cacheDir = mkdtempSync(join(tmpdir(), "first-tree-turbo-ci-cache-"));
+  try {
+    // Force a real build into an isolated cache so outputs include the payload.
+    run("pnpm", ["exec", "turbo", "run", "build", "--filter=first-tree-dev", "--force", "--cache-dir", cacheDir], {
+      cwd: REPO_ROOT,
+    });
+    const seeded = assertSourceContextIntegrationPresent();
+    const seededDigest = seeded.bundleDigest;
+
+    rmSync(CONTEXT_INTEGRATION_ROOT, { recursive: true, force: true });
+    if (existsSync(CONTEXT_INTEGRATION_MANIFEST)) {
+      fail("selftest-turbo-cache: failed to delete context-integration before cache-hit build");
+    }
+
+    const hit = run("pnpm", ["exec", "turbo", "run", "build", "--filter=first-tree-dev", "--cache-dir", cacheDir], {
+      cwd: REPO_ROOT,
+    });
+    const hitLog = `${hit.stdout}\n${hit.stderr}`;
+    if (!/first-tree-dev:build:\s*cache (hit|HIT)/i.test(hitLog) && !/cache hit/i.test(hitLog)) {
+      // Turbo prints "cache hit, replaying logs" — accept either stream.
+      if (!/cache hit/i.test(hitLog)) {
+        fail(`selftest-turbo-cache: expected cache hit for first-tree-dev#build\n${hitLog}`);
+      }
+    }
+
+    const restored = assertSourceContextIntegrationPresent();
+    if (restored.bundleDigest !== seededDigest) {
+      fail(`selftest-turbo-cache: restored bundleDigest ${restored.bundleDigest} !== seeded ${seededDigest}`);
+    }
+
+    // Pack smoke must remain complete after a cache-hit restore (not 817 / dist-only).
+    runSmoke();
+    console.log(
+      `release-pack-smoke: selftest-turbo-context-integration-cache PASS — restored ${seededDigest} via turbo cache hit`,
+    );
+  } finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+}
+
 function main() {
   snapshotPreexistingTarballs();
   const action = process.argv[2];
   try {
     if (action === "selftest-cleanup") selftestCleanup();
     else if (action === "selftest-preserve-preexisting") selftestPreservePreexistingTarball();
+    else if (action === "selftest-turbo-context-integration-cache") selftestTurboContextIntegrationCache();
     else if (action === undefined) runSmoke();
     else
-      fail(`unknown action '${action}' (expected default smoke, selftest-cleanup, or selftest-preserve-preexisting)`);
+      fail(
+        `unknown action '${action}' (expected default smoke, selftest-cleanup, selftest-preserve-preexisting, or selftest-turbo-context-integration-cache)`,
+      );
   } catch (error) {
     try {
       cleanupPackArtifacts(undefined);

--- a/scripts/release-pack-smoke.mjs
+++ b/scripts/release-pack-smoke.mjs
@@ -7,7 +7,7 @@
  *      (prepack copies skills + materializes bundled deps, postpack restores —
  *      no --ignore-scripts).
  *   2. Enumerate every tarball entry and reject traversal / absolute /
- *      escaping-link paths (the npm registry E415 class).
+ *      escaping-link / non-canonical package paths (the npm registry E415 class).
  *   3. Install the tarball into an empty consumer with plain npm.
  *   4. Run the public CLI (`--version`).
  *   5. Resolve the bundled `@botiverse/kimi-code-sdk` from the consumer and
@@ -15,13 +15,16 @@
  *      resume option threading, resume main-agent flag application, and the
  *      awaited replay-fence authorization hook.
  *
+ * Failures throw; the outermost handler always cleans tarballs, temp consumers,
+ * and any stranded materialize journal before exiting non-zero. Helpers never
+ * call `process.exit`.
+ *
  * No registry publish, no credentials, no network beyond npm itself.
- * Everything happens in a disposable temp directory removed on exit.
  */
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { existsSync, lstatSync, mkdtempSync, readdirSync, readFileSync, readlinkSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -30,10 +33,19 @@ import { assertNpmTarballRegistrySafe } from "./npm-tarball-safety.mjs";
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const CLI_ROOT = join(REPO_ROOT, "apps", "cli");
+const MATERIALIZE_SCRIPT = join(CLI_ROOT, "scripts", "materialize-bundled-deps.mjs");
+const MANIFEST_PATH = join(CLI_ROOT, ".bundled-deps-materialize.json");
+
+class SmokeFailure extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = "SmokeFailure";
+  }
+}
 
 function fail(message) {
-  console.error(`release-pack-smoke: FAIL: ${message}`);
-  process.exit(1);
+  throw new SmokeFailure(message);
 }
 
 function run(command, args, options = {}) {
@@ -51,27 +63,104 @@ function run(command, args, options = {}) {
   return result;
 }
 
-if (!existsSync(join(CLI_ROOT, "dist", "cli", "index.mjs")) || !existsSync(join(CLI_ROOT, "dist", "index.mjs"))) {
-  fail("apps/cli/dist is missing — run `pnpm build` first");
-}
-
-const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-"));
-try {
-  const consumerDir = join(work, "consumer");
-  run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
-  const tarballs = readdirSync(CLI_ROOT)
+function listCliTarballs() {
+  return readdirSync(CLI_ROOT)
     .filter((name) => /^first-tree-dev-.*\.tgz$/.test(name))
     .map((name) => join(CLI_ROOT, name));
-  if (tarballs.length !== 1) fail(`expected exactly one first-tree-dev tarball in apps/cli, got ${tarballs.length}`);
-  const tarball = tarballs[0];
-  const tarballName = tarballs[0].split("/").pop();
-  try {
-    let safety;
-    try {
-      safety = assertNpmTarballRegistrySafe(tarball);
-    } catch (error) {
-      fail(error instanceof Error ? error.message : String(error));
+}
+
+function cleanupPackArtifacts(workDir) {
+  for (const tarball of listCliTarballs()) {
+    rmSync(tarball, { force: true });
+  }
+  if (workDir) {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+  if (existsSync(MANIFEST_PATH)) {
+    const restore = spawnSync(process.execPath, [MATERIALIZE_SCRIPT, "restore"], {
+      cwd: CLI_ROOT,
+      encoding: "utf8",
+    });
+    if (restore.status !== 0) {
+      console.error(
+        `release-pack-smoke: WARNING: materialize restore during cleanup failed:\n${restore.stderr || restore.stdout}`,
+      );
     }
+  }
+}
+
+function assertCleanWorkspace(symlinkSnapshot) {
+  if (listCliTarballs().length !== 0) {
+    fail(`cleanup left tarball residue: ${listCliTarballs().join(", ")}`);
+  }
+  if (existsSync(MANIFEST_PATH)) {
+    fail("cleanup left stranded materialize manifest");
+  }
+  for (const [name, target] of symlinkSnapshot) {
+    const dir = join(CLI_ROOT, "node_modules", ...name.split("/"));
+    let stat;
+    try {
+      stat = lstatSync(dir);
+    } catch {
+      fail(`cleanup missing package path for ${name}`);
+    }
+    if (!stat.isSymbolicLink()) {
+      fail(`cleanup left real copy instead of symlink for ${name}`);
+    }
+    if (readlinkSync(dir) !== target) {
+      fail(`cleanup restored wrong symlink target for ${name}`);
+    }
+  }
+}
+
+function captureBundledSymlinks() {
+  /** @type {Map<string, string>} */
+  const snapshot = new Map();
+  const pkg = JSON.parse(readFileSync(join(CLI_ROOT, "package.json"), "utf8"));
+  const bundled = pkg.bundleDependencies ?? [];
+  const names = new Set(bundled);
+  for (const name of bundled) {
+    const dir = join(CLI_ROOT, "node_modules", ...name.split("/"));
+    try {
+      const depPkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+      for (const dep of Object.keys(depPkg.dependencies ?? {})) {
+        if (existsSync(join(CLI_ROOT, "node_modules", ...dep.split("/"), "package.json"))) {
+          names.add(dep);
+        }
+      }
+    } catch {
+      // ignore — prepare/preflight owns hard failures
+    }
+  }
+  for (const name of names) {
+    const dir = join(CLI_ROOT, "node_modules", ...name.split("/"));
+    const stat = lstatSync(dir);
+    if (!stat.isSymbolicLink()) {
+      fail(`precondition: ${name} must be a pnpm symlink before smoke`);
+    }
+    snapshot.set(name, readlinkSync(dir));
+  }
+  return snapshot;
+}
+
+function runSmoke() {
+  if (!existsSync(join(CLI_ROOT, "dist", "cli", "index.mjs")) || !existsSync(join(CLI_ROOT, "dist", "index.mjs"))) {
+    fail("apps/cli/dist is missing — run `pnpm build` first");
+  }
+
+  const symlinkSnapshot = captureBundledSymlinks();
+  const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-"));
+  try {
+    const consumerDir = join(work, "consumer");
+    run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
+    const tarballs = listCliTarballs();
+    if (tarballs.length !== 1) {
+      fail(`expected exactly one first-tree-dev tarball in apps/cli, got ${tarballs.length}`);
+    }
+    const tarball = tarballs[0];
+    const tarballName = tarball.split("/").pop();
+
+    const safety = assertNpmTarballRegistrySafe(tarball);
 
     run("npm", ["install", "--prefix", consumerDir, tarball]);
     const binName = "first-tree-dev";
@@ -116,18 +205,64 @@ try {
       `release-pack-smoke: PASS — packed ${tarballName} (${bytes} B, sha256=${sha256}, ${safety.entryCount} entries), consumer CLI ${versionText}, registry-safe paths, bundled patched Kimi SDK verified`,
     );
   } finally {
-    // Real pack semantics write the tarball into the package dir; never
-    // leave it in the repo.
-    rmSync(tarball, { force: true });
-  }
-} finally {
-  rmSync(work, { recursive: true, force: true });
-  // Belt-and-suspenders: pack lifecycle should restore, but never leave the
-  // materialize manifest or a stranded real copy if postpack was interrupted.
-  const manifest = join(CLI_ROOT, ".bundled-deps-materialize.json");
-  if (existsSync(manifest)) {
-    run(process.execPath, [join(CLI_ROOT, "scripts", "materialize-bundled-deps.mjs"), "restore"], {
-      cwd: CLI_ROOT,
-    });
+    cleanupPackArtifacts(work);
+    assertCleanWorkspace(symlinkSnapshot);
   }
 }
+
+/**
+ * Deterministic negative cleanup regression: pack succeeds, then an injected
+ * post-pack failure must still remove tgz/temp/manifest and restore symlinks
+ * before the process exits non-zero.
+ */
+function selftestCleanup() {
+  if (!existsSync(join(CLI_ROOT, "dist", "cli", "index.mjs"))) {
+    fail("apps/cli/dist is missing — run `pnpm build` before selftest-cleanup");
+  }
+  const symlinkSnapshot = captureBundledSymlinks();
+  const work = mkdtempSync(join(tmpdir(), "first-tree-release-pack-smoke-neg-"));
+  let failedAsExpected = false;
+  try {
+    try {
+      run("npm", ["pack", "--json"], { cwd: CLI_ROOT });
+      const tarballs = listCliTarballs();
+      if (tarballs.length !== 1) fail(`expected one tarball before injected failure, got ${tarballs.length}`);
+      fail("injected post-pack failure for cleanup regression");
+    } catch (error) {
+      if (!(error instanceof SmokeFailure) || !error.message.includes("injected post-pack failure")) {
+        throw error;
+      }
+      failedAsExpected = true;
+    }
+  } finally {
+    cleanupPackArtifacts(work);
+  }
+
+  if (!failedAsExpected) fail("selftest-cleanup did not take the injected failure path");
+  assertCleanWorkspace(symlinkSnapshot);
+  if (existsSync(work)) fail("selftest-cleanup left consumer work directory");
+  console.log("release-pack-smoke: selftest-cleanup PASS");
+}
+
+function main() {
+  const action = process.argv[2];
+  try {
+    if (action === "selftest-cleanup") selftestCleanup();
+    else if (action === undefined) runSmoke();
+    else fail(`unknown action '${action}' (expected default smoke or selftest-cleanup)`);
+  } catch (error) {
+    try {
+      cleanupPackArtifacts(undefined);
+    } catch (cleanupError) {
+      console.error(
+        `release-pack-smoke: cleanup after failure also failed: ${
+          cleanupError instanceof Error ? cleanupError.message : cleanupError
+        }`,
+      );
+    }
+    console.error(`release-pack-smoke: FAIL: ${error instanceof Error ? error.message : error}`);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Staging npm publish on `main@2df85072…` failed with registry **E415** because `npm pack`/`publish` under pnpm followed `bundleDependencies` symlinks into `package/../../node_modules/.pnpm/...` traversal paths.
- Prepack now materializes the bundled `@botiverse/kimi-code-sdk` closure as real in-package directories (and postpack restores the pnpm symlinks), keeping `bundleDependencies`, the pnpm patch, and exact npm `11.5.1` unchanged.
- Release-pack smoke enumerates every tarball entry and rejects traversal/absolute/escaping-link paths before empty-consumer install / CLI / patched SDK import checks; contract tests + a selftest cover the E415 layout.

## Test plan
- [x] Neuter control: pack without materialize → 761 traversal entries; safety helper rejects
- [x] `npm pack` after fix → 0 unsafe entries; canonical `package/node_modules/@botiverse/kimi-code-sdk/**` present
- [x] `node scripts/release-pack-smoke.mjs` PASS (tarball sha256 `51fa0eb92e777e3b61c807cf0689b344635076ea718ba0641e755c51c5bb04aa`, 3,771,903 B, 844 entries)
- [x] `package-metadata.test.ts` 11/11
- [x] `pnpm check` (16 warnings baseline) / `pnpm typecheck` / `pnpm build`
- [ ] CI Test CLI + release-pack smoke on Linux/Node 24/npm 11.5.1
- [ ] Formal QA / staging publish re-run after merge (not done in this PR)

## Notes
- Does **not** remove `bundleDependencies` or change Kimi runtime semantics.
- Shared alpha publish path untouched (no Kimi bundling).
- No merge / no live npm publish from this PR.


Made with [Cursor](https://cursor.com)