### PR TITLE
fix: pin BYO handoff to portable CLI

### DIFF
--- a/packages/qa/cases/cross-surface/external-context-current-session-handoff.md
+++ b/packages/qa/cases/cross-surface/external-context-current-session-handoff.md
@@ -25,12 +25,17 @@ Plugin UI discovery as proof of current-session adoption.
   committed artifacts and redact login codes, Team ids, and private Tree data.
 - Begin Claude Code and Codex attached sessions with no First Tree Plugin.
   Also prepare Codex already-trusted and pathless variants.
+- Put an older same-channel global npm CLI earlier on `PATH` than
+  `~/.local/bin`, while allowing the Web bootstrap to install the current
+  portable CLI. Record both versions before setup.
 
 ## Operate
 
 1. Copy the provider-neutral setup prompt from Web and paste it into the
    already-running Claude Code conversation. Let the agent run bootstrap and
    the server-authored JSON enable command with its host-confirmed selector.
+   Confirm the enable command uses the same `~/.local/bin` portable executable
+   as bootstrap rather than the older global CLI resolved from `PATH`.
 2. Without restarting or running `/reload-plugins`, ask a task that triggers
    `first-tree-read`. Confirm the same agent reads the exact `skillPath`,
    uses the handoff's immutable provider/project receipt for the first Read,
@@ -60,7 +65,9 @@ Plugin UI discovery as proof of current-session adoption.
 ## Observe
 
 - The Server command places global `--json` before `context enable`, includes
-  the exact provider and Team, and includes `--yes`; Web adds no flags.
+  the exact provider and Team, and includes `--yes`; Web adds no flags. On
+  non-dev channels, the command uses bootstrap's `~/.local/bin` portable
+  executable even when an older same-channel global CLI shadows it on `PATH`.
 - Claude Code completes setup in one agent turn. Codex without consent returns
   `setup.complete: false` and `currentSessionHandoff: null`, asks only for
   `/hooks` consent plus return to the original conversation, and re-runs enable

--- a/packages/server/src/__tests__/context-enablement-handoff.test.ts
+++ b/packages/server/src/__tests__/context-enablement-handoff.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it } from "vitest";
+import { contextEnablementExecutable } from "../api/orgs/context-enablement.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 describe("Context enablement handoff", () => {
   const getApp = useTestApp({ channel: "staging" });
+
+  it("uses the channel bin for dev and the shared portable executable for published channels", () => {
+    expect(contextEnablementExecutable({ channel: "dev", binName: "first-tree-dev" })).toBe("'first-tree-dev'");
+    expect(contextEnablementExecutable({ channel: "staging", binName: "first-tree-staging" })).toBe(
+      "~/.local/bin/first-tree-staging",
+    );
+    expect(contextEnablementExecutable({ channel: "prod", binName: "first-tree" })).toBe("~/.local/bin/first-tree");
+  });
 
   it("authors an exact Team, provider, and channel command for active members", async () => {
     const app = getApp();
@@ -21,7 +30,7 @@ describe("Context enablement handoff", () => {
       role: "admin",
     });
     expect(response.json().command).toBe(
-      `'first-tree-staging' --json context enable --provider 'codex' --team '${admin.organizationId}' --yes`,
+      `~/.local/bin/first-tree-staging --json context enable --provider 'codex' --team '${admin.organizationId}' --yes`,
     );
     expect(response.json().workingDirectoryInstruction).toContain("CLI centrally classifies");
     expect(response.json().workingDirectoryInstruction).not.toContain("shell cwd");
@@ -45,7 +54,7 @@ describe("Context enablement handoff", () => {
       intent: "onboarding",
     });
     expect(response.json().command).toBe(
-      `'first-tree-staging' --json context enable --provider 'claude-code' --team '${admin.organizationId}' --yes`,
+      `~/.local/bin/first-tree-staging --json context enable --provider 'claude-code' --team '${admin.organizationId}' --yes`,
     );
     expect(response.json().workingDirectoryInstruction).toContain("host-confirmed Claude Code selector");
     expect(response.json().workingDirectoryInstruction).toContain("--pathless");

--- a/packages/server/src/api/orgs/context-enablement.ts
+++ b/packages/server/src/api/orgs/context-enablement.ts
@@ -1,5 +1,9 @@
-import { contextEnablementHandoffQuerySchema, contextEnablementHandoffSchema } from "@first-tree/shared";
-import { getServerCliBinding } from "@first-tree/shared/channel";
+import {
+  contextEnablementHandoffQuerySchema,
+  contextEnablementHandoffSchema,
+  portableCliExecutable,
+} from "@first-tree/shared";
+import { type ChannelConfig, getServerCliBinding } from "@first-tree/shared/channel";
 import type { FastifyInstance } from "fastify";
 import { requireOrgMembership } from "../../scope/require-org.js";
 import { getOrganization } from "../../services/organization.js";
@@ -12,7 +16,7 @@ export async function orgContextEnablementRoutes(app: FastifyInstance): Promise<
     const scope = await requireOrgMembership(request, app.db);
     const query = contextEnablementHandoffQuerySchema.parse(request.query);
     const organization = await getOrganization(app.db, scope.organizationId);
-    const executable = shellQuote(getServerCliBinding().binName);
+    const executable = contextEnablementExecutable(getServerCliBinding());
     return contextEnablementHandoffSchema.parse({
       protocolVersion: 1,
       organizationId: scope.organizationId,
@@ -39,4 +43,11 @@ export async function orgContextEnablementRoutes(app: FastifyInstance): Promise<
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}
+
+export function contextEnablementExecutable(binding: Pick<ChannelConfig, "binName" | "channel">): string {
+  // The non-dev bootstrap installs and logs in through this exact portable
+  // path. Keep enable on the same binary so an older global npm install that
+  // appears earlier on PATH cannot satisfy a newer Web handoff contract.
+  return binding.channel === "dev" ? shellQuote(binding.binName) : portableCliExecutable(binding.binName);
 }

--- a/packages/shared/src/__tests__/connect-bootstrap.test.ts
+++ b/packages/shared/src/__tests__/connect-bootstrap.test.ts
@@ -4,9 +4,15 @@ import {
   buildPortableBootstrapCommand,
   CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
   materializeConnectBootstrapCommand,
+  portableCliExecutable,
 } from "../connect-bootstrap.js";
 
 describe("connect bootstrap commands", () => {
+  it("resolves channel binaries under the portable install directory", () => {
+    expect(portableCliExecutable("first-tree-staging")).toBe("~/.local/bin/first-tree-staging");
+    expect(portableCliExecutable("first-tree")).toBe("~/.local/bin/first-tree");
+  });
+
   it("builds the default hosted portable bootstrap", () => {
     expect(
       buildPortableBootstrapCommand({

--- a/packages/shared/src/connect-bootstrap.ts
+++ b/packages/shared/src/connect-bootstrap.ts
@@ -44,6 +44,10 @@ export function buildLoginCommand(options: {
   return `${prefix}${options.executable} login ${shellArg(options.tokenArg)}`;
 }
 
+export function portableCliExecutable(binName: string): string {
+  return `~/.local/bin/${binName}`;
+}
+
 export function buildPortableBootstrapCommand(options: {
   installerUrl: string;
   portableDownloadBaseUrl: string;
@@ -61,7 +65,7 @@ export function buildPortableBootstrapCommand(options: {
     ? `FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL=${shellQuote(options.portableDownloadBaseUrl)} `
     : "";
   const loginCommand = buildLoginCommand({
-    executable: `~/.local/bin/${options.binName}`,
+    executable: portableCliExecutable(options.binName),
     tokenArg: options.token,
     serverUrl: options.serverUrl,
     defaultServerUrl: options.defaultServerUrl,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,7 @@ export {
   CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
   type ConnectBootstrapCommandTemplate,
   materializeConnectBootstrapCommand,
+  portableCliExecutable,
 } from "./connect-bootstrap.js";
 // -- Document review (docloop) anchor building / locating --
 export {


### PR DESCRIPTION
## Summary

- make the Server-authored BYO enable handoff invoke the same portable CLI executable installed by bootstrap
- centralize the portable executable under one Shared helper used by both bootstrap and handoff
- preserve the bare channel binary for dev while pinning staging and production to `~/.local/bin`
- cover dev/staging/prod resolution and extend the cross-surface QA case for stale global CLI PATH shadowing

## Reproduction

The staging bootstrap installed and started `~/.local/bin/first-tree-staging@0.5.19-staging.1035.1`, while the Server-authored handoff emitted bare `first-tree-staging`. A shell-cached/global `/usr/local/bin/first-tree-staging@0.5.18-staging.1004.1` therefore handled `context enable`, returned the old Complete contract without `currentSessionHandoff`, and the new Web prompt correctly failed closed.

## Validation

- `pnpm --filter @first-tree/shared exec vitest run src/__tests__/connect-bootstrap.test.ts --maxWorkers=2` (6/6)
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-enablement-handoff.test.ts --maxWorkers=2` (3/3)
- Shared and Server package typechecks
- `pnpm check` (passes with existing repository warnings/info)
- `git diff --check`

## QA and release risk

The real Codex surface reproduced the pre-fix PATH-shadowing failure. The fixed Server handoff has deterministic coverage, but the complete Claude Code/Codex real-provider qualification case remains pending and must still be run before release qualification.
