### PR TITLE
fix: clean up session operation queues

### DIFF
--- a/packages/server/src/__tests__/keyed-operation-queue.test.ts
+++ b/packages/server/src/__tests__/keyed-operation-queue.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { KeyedOperationQueue } from "../utils/keyed-operation-queue.js";
+
+describe("KeyedOperationQueue", () => {
+  it("serializes operations for the same key and removes the completed tail", async () => {
+    const queue = new KeyedOperationQueue();
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = queue.run("agent-1:chat-1", async () => {
+      order.push("first:start");
+      await firstBlocked;
+      order.push("first:end");
+    });
+    const second = queue.run("agent-1:chat-1", async () => {
+      order.push("second");
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+    expect(queue.size).toBe(1);
+
+    releaseFirst?.();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(["first:start", "first:end", "second"]);
+    expect(queue.size).toBe(0);
+  });
+
+  it("removes every completed key", async () => {
+    const queue = new KeyedOperationQueue();
+
+    await Promise.all(
+      Array.from({ length: 100 }, (_, index) => queue.run(`agent-1:fake-chat-${index}`, async () => {})),
+    );
+
+    expect(queue.size).toBe(0);
+  });
+
+  it("clears pending keys when their owner closes", async () => {
+    const queue = new KeyedOperationQueue();
+    let release: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const operation = queue.run("agent-1:chat-1", () => blocked);
+
+    expect(queue.size).toBe(1);
+    queue.clear();
+    expect(queue.size).toBe(0);
+
+    release?.();
+    await operation;
+    expect(queue.size).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/keyed-operation-queue.test.ts
+++ b/packages/server/src/__tests__/keyed-operation-queue.test.ts
@@ -39,21 +39,4 @@ describe("KeyedOperationQueue", () => {
 
     expect(queue.size).toBe(0);
   });
-
-  it("clears pending keys when their owner closes", async () => {
-    const queue = new KeyedOperationQueue();
-    let release: (() => void) | undefined;
-    const blocked = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const operation = queue.run("agent-1:chat-1", () => blocked);
-
-    expect(queue.size).toBe(1);
-    queue.clear();
-    expect(queue.size).toBe(0);
-
-    release?.();
-    await operation;
-    expect(queue.size).toBe(0);
-  });
 });

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -11,6 +11,7 @@ import * as inboxService from "../services/inbox.js";
 import * as notificationService from "../services/notification.js";
 import * as presenceService from "../services/presence.js";
 import * as runtimeLivenessService from "../services/runtime-liveness.js";
+import * as sessionEventService from "../services/session-event.js";
 
 type WsHandler = (socket: FakeSocket, request: { headers: Record<string, string | undefined>; ip: string }) => unknown;
 
@@ -34,7 +35,7 @@ class FakeSocket extends EventEmitter {
   }
 }
 
-function queryChain(rows: unknown[] = []): unknown {
+function queryChain(rows: unknown[] | Promise<unknown[]> = []): unknown {
   const promise = Promise.resolve(rows);
   const chain = new Proxy(
     function queryProxy(): unknown {
@@ -45,7 +46,10 @@ function queryChain(rows: unknown[] = []): unknown {
         if (prop === "then") return promise.then.bind(promise);
         if (prop === "catch") return promise.catch.bind(promise);
         if (prop === "finally") return promise.finally.bind(promise);
-        if (prop === Symbol.iterator) return rows[Symbol.iterator].bind(rows);
+        if (prop === Symbol.iterator) {
+          const iterableRows = Array.isArray(rows) ? rows : [];
+          return iterableRows[Symbol.iterator].bind(iterableRows);
+        }
         return vi.fn(() => chain);
       },
     },
@@ -53,7 +57,7 @@ function queryChain(rows: unknown[] = []): unknown {
   return chain;
 }
 
-function queuedDb(results: unknown[][]): unknown {
+function queuedDb(results: Array<unknown[] | Promise<unknown[]>>): unknown {
   return {
     select: vi.fn(() => queryChain(results.shift() ?? [])),
     update: vi.fn(() => queryChain(results.shift() ?? [])),
@@ -965,5 +969,60 @@ describe("Agent client WS branch fakes", () => {
       "idle",
       expect.objectContaining({ organizationId: "org_1" }),
     );
+  });
+
+  it("preserves a session FIFO when a routed message resumes after socket close", async () => {
+    mockSuccessfulBindServices();
+    let releaseState: (() => void) | undefined;
+    const stateBlocked = new Promise<void>((resolve) => {
+      releaseState = resolve;
+    });
+    let resumeRouteCheck: ((rows: unknown[]) => void) | undefined;
+    const routeCheckBlocked = new Promise<unknown[]>((resolve) => {
+      resumeRouteCheck = resolve;
+    });
+    const db = queuedDb([
+      [{ id: "user_1", status: "active" }],
+      [{ userId: "user_1", retiredAt: null }],
+      [activeAgentRow()],
+      [activeAgentRow()],
+      [activeAgentRow()],
+      routeCheckBlocked,
+    ]) as { select: ReturnType<typeof vi.fn> };
+    const { handler } = routeHarness(db);
+    const socket = new FakeSocket();
+    const order: string[] = [];
+    vi.mocked(activityService.upsertSessionState).mockImplementation(async () => {
+      order.push("state:start");
+      await stateBlocked;
+      order.push("state:end");
+    });
+    const appendEvent = vi.spyOn(sessionEventService, "appendLiveEvent").mockImplementation(async () => {
+      order.push("event");
+      return null;
+    });
+    await bindAgent(socket, handler);
+
+    await emitMessage(socket, { type: "session:state", agentId: "agent_1", chatId: "chat_1", state: "active" });
+    await waitUntil(() => order.includes("state:start"));
+
+    await emitMessage(socket, {
+      type: "session:event",
+      agentId: "agent_1",
+      chatId: "chat_1",
+      event: { kind: "error", payload: { source: "runtime", message: "test" } },
+    });
+    await waitUntil(() => db.select.mock.calls.length === 6);
+
+    socket.close(1000, "test close");
+    resumeRouteCheck?.([activeAgentRow()]);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(appendEvent).not.toHaveBeenCalled();
+    expect(order).toEqual(["state:start"]);
+
+    releaseState?.();
+    await waitUntil(() => appendEvent.mock.calls.length === 1);
+    expect(order).toEqual(["state:start", "state:end", "event"]);
   });
 });

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -2148,7 +2148,6 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         lastInboxRepairDrainAtByAgent.clear();
         inboxInFlightByAgent.clear();
         inboxInFlightOwnersByEntryId.clear();
-        sessionOpQueue.clear();
 
         if (clientId) {
           // Reconnect-race guard. A typical `systemctl restart` produces this

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -67,6 +67,7 @@ import {
   storeSessionCommandRpcResult,
 } from "../../services/session-command-rpc.js";
 import * as sessionEventService from "../../services/session-event.js";
+import { KeyedOperationQueue } from "../../utils/keyed-operation-queue.js";
 
 /**
  * Default per-agent in-flight fuse when `server.inbox.maxInFlightPerAgent` is
@@ -829,18 +830,10 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
       // FIFO per session so session:event persistence happens before any
       // subsequent eviction's clearEvents — without this, the message handler
       // is async and the next message can race the previous one's DB write.
-      const sessionOpQueues = new Map<string, Promise<void>>();
+      const sessionOpQueue = new KeyedOperationQueue();
       function chainSessionOp(agentId: string, chatId: string, op: () => Promise<void>): Promise<void> {
         const key = `${agentId}:${chatId}`;
-        const prev = sessionOpQueues.get(key) ?? Promise.resolve();
-        const next = prev.then(op, op);
-        sessionOpQueues.set(
-          key,
-          next.finally(() => {
-            if (sessionOpQueues.get(key) === next) sessionOpQueues.delete(key);
-          }),
-        );
-        return next;
+        return sessionOpQueue.run(key, op);
       }
 
       let authTimeout: NodeJS.Timeout | null = null;
@@ -2155,6 +2148,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         lastInboxRepairDrainAtByAgent.clear();
         inboxInFlightByAgent.clear();
         inboxInFlightOwnersByEntryId.clear();
+        sessionOpQueue.clear();
 
         if (clientId) {
           // Reconnect-race guard. A typical `systemctl restart` produces this

--- a/packages/server/src/utils/keyed-operation-queue.ts
+++ b/packages/server/src/utils/keyed-operation-queue.ts
@@ -21,8 +21,4 @@ export class KeyedOperationQueue {
     this.tails.set(key, queued);
     return next;
   }
-
-  clear(): void {
-    this.tails.clear();
-  }
 }

--- a/packages/server/src/utils/keyed-operation-queue.ts
+++ b/packages/server/src/utils/keyed-operation-queue.ts
@@ -1,0 +1,28 @@
+/**
+ * Serializes asynchronous operations per key while allowing different keys to
+ * progress independently.
+ */
+export class KeyedOperationQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  get size(): number {
+    return this.tails.size;
+  }
+
+  run(key: string, operation: () => Promise<void>): Promise<void> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    const next = previous.then(operation, operation);
+    let queued: Promise<void>;
+    queued = next.finally(() => {
+      if (this.tails.get(key) === queued) {
+        this.tails.delete(key);
+      }
+    });
+    this.tails.set(key, queued);
+    return next;
+  }
+
+  clear(): void {
+    this.tails.clear();
+  }
+}


### PR DESCRIPTION
## Summary

- replace the per-socket session tail map with a keyed operation queue that compares and removes the same wrapped promise
- retain live tails across WebSocket close so already-dispatched handlers cannot bypass per-session FIFO ordering
- add regression coverage for FIFO ordering, arbitrary chat-key cleanup, and the close/resume race

## Why

The previous map stored `next.finally(...)` but compared it with the unwrapped `next`. That comparison could never succeed, so every historical `(agentId, chatId)` key remained for the socket lifetime.

Completed keys now reclaim themselves during long-lived connections. In-flight tails are deliberately retained through close until they settle, preserving ordering for handlers that passed their route check before close; the queue is then collectible with its socket owner.

Closes #1722.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] 24 focused queue and WebSocket tests