### PR TITLE
fix: keep working turn elapsed time monotonic

### DIFF
--- a/packages/server/src/__tests__/session-event.test.ts
+++ b/packages/server/src/__tests__/session-event.test.ts
@@ -318,12 +318,14 @@ describe("sessionEventService", () => {
       { chatId: c, agentId: viewer.humanAgentUuid, accessMode: "speaker" },
     ]);
 
+    const firstEventAtByAgent = new Map<string, string>();
     for (const target of [privateOne.agent.uuid, privateTwo.agent.uuid]) {
       for (let i = 1; i <= 3; i++) {
-        await sessionEventService.appendEvent(app.db, target, c, {
+        const event = await sessionEventService.appendEvent(app.db, target, c, {
           kind: "assistant_text",
           payload: { text: `${target}-event-${i}` },
         });
+        if (i === 1) firstEventAtByAgent.set(target, event.createdAt);
       }
     }
     // A forged/stale event for an agent that is not a chat speaker must never
@@ -343,7 +345,12 @@ describe("sessionEventService", () => {
     const speakerResponse = await requestAsViewer();
     expect(speakerResponse.statusCode).toBe(200);
     const speakerBody = speakerResponse.json<{
-      feeds: Array<{ agentId: string; items: Array<{ seq: number; payload: unknown }>; nextCursor: number | null }>;
+      feeds: Array<{
+        agentId: string;
+        items: Array<{ seq: number; payload: unknown }>;
+        nextCursor: number | null;
+        turnStartedAt: string | null;
+      }>;
     }>();
     expect(speakerBody.feeds.map((feed) => feed.agentId)).toEqual(
       [privateOne.agent.uuid, privateTwo.agent.uuid].sort(),
@@ -351,6 +358,7 @@ describe("sessionEventService", () => {
     for (const feed of speakerBody.feeds) {
       expect(feed.items.map((event) => event.seq)).toEqual([3, 2]);
       expect(feed.nextCursor).toBe(2);
+      expect(feed.turnStartedAt).toBe(firstEventAtByAgent.get(feed.agentId));
     }
     expect(speakerBody.feeds.some((feed) => feed.agentId === nonSpeaker.agent.uuid)).toBe(false);
 

--- a/packages/server/src/services/session-event.ts
+++ b/packages/server/src/services/session-event.ts
@@ -43,6 +43,8 @@ export type ChatSessionEventFeed = {
   agentId: string;
   items: SessionEventRow[];
   nextCursor: number | null;
+  /** Stable start of the active turn, independent of the capped event window. */
+  turnStartedAt: string | null;
 };
 
 const NUL_CHAR = "\u0000";
@@ -283,7 +285,7 @@ export async function listChatSpeakerEvents(
   const direction = options?.direction ?? "asc";
   const orderFragment = direction === "desc" ? sql`DESC` : sql`ASC`;
 
-  const ranked = db
+  const scoped = db
     .select({
       id: sessionEvents.id,
       agentId: sessionEvents.agentId,
@@ -292,10 +294,11 @@ export async function listChatSpeakerEvents(
       kind: sessionEvents.kind,
       payload: sessionEvents.payload,
       createdAt: sessionEvents.createdAt,
-      rank: sql<number>`row_number() over (
-        partition by ${sessionEvents.agentId}
-        order by ${sessionEvents.seq} ${orderFragment}
-      )`.as("event_rank"),
+      lastTurnEndSeq: sql<number>`coalesce(
+        max(${sessionEvents.seq}) filter (where ${sessionEvents.kind} = 'turn_end')
+          over (partition by ${sessionEvents.agentId}),
+        0
+      )`.as("last_turn_end_seq"),
     })
     .from(sessionEvents)
     .innerJoin(
@@ -312,6 +315,27 @@ export async function listChatSpeakerEvents(
         eq(agents.organizationId, chats.organizationId),
       ),
     )
+    .as("scoped_chat_session_events");
+
+  const ranked = db
+    .select({
+      id: scoped.id,
+      agentId: scoped.agentId,
+      chatId: scoped.chatId,
+      seq: scoped.seq,
+      kind: scoped.kind,
+      payload: scoped.payload,
+      createdAt: scoped.createdAt,
+      turnStartedAt: sql<Date | string | null>`min(${scoped.createdAt}) filter (
+        where ${scoped.seq} > ${scoped.lastTurnEndSeq}
+          and ${scoped.kind} in ('tool_call', 'thinking', 'assistant_text')
+      ) over (partition by ${scoped.agentId})`.as("turn_started_at"),
+      rank: sql<number>`row_number() over (
+        partition by ${scoped.agentId}
+        order by ${scoped.seq} ${orderFragment}
+      )`.as("event_rank"),
+    })
+    .from(scoped)
     .as("ranked_chat_session_events");
 
   const rows = await db
@@ -323,6 +347,7 @@ export async function listChatSpeakerEvents(
       kind: ranked.kind,
       payload: ranked.payload,
       createdAt: ranked.createdAt,
+      turnStartedAt: ranked.turnStartedAt,
     })
     .from(ranked)
     .where(lte(ranked.rank, limit + 1))
@@ -340,7 +365,19 @@ export async function listChatSpeakerEvents(
       const hasMore = feedRows.length > limit;
       const items = (hasMore ? feedRows.slice(0, limit) : feedRows).map(rowToEvent);
       const last = items[items.length - 1];
-      return { agentId, items, nextCursor: hasMore && last ? last.seq : null };
+      const turnStartedAt = feedRows[0]?.turnStartedAt ?? null;
+      const turnStartedAtIso =
+        turnStartedAt instanceof Date
+          ? turnStartedAt.toISOString()
+          : typeof turnStartedAt === "string"
+            ? new Date(turnStartedAt).toISOString()
+            : null;
+      return {
+        agentId,
+        items,
+        nextCursor: hasMore && last ? last.seq : null,
+        turnStartedAt: turnStartedAtIso,
+      };
     }),
   };
 }

--- a/packages/web/src/api/sessions.ts
+++ b/packages/web/src/api/sessions.ts
@@ -117,7 +117,13 @@ export type SessionEventsResponse = {
 };
 
 export type ChatSessionEventsResponse = {
-  feeds: Array<SessionEventsResponse & { agentId: string }>;
+  feeds: Array<
+    SessionEventsResponse & {
+      agentId: string;
+      /** Stable active-turn origin. Optional while older servers roll out. */
+      turnStartedAt?: string | null;
+    }
+  >;
 };
 
 export const chatSessionEventsQueryKey = (chatId: string) => ["chat-session-events", chatId] as const;

--- a/packages/web/src/components/chat/__tests__/working-turn-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/working-turn-dom.test.tsx
@@ -50,6 +50,7 @@ function buttonByLabel(container: ParentNode, label: string): HTMLButtonElement 
 }
 
 const props = {
+  startedAt: NOW,
   agentNameFn: (id: string) => (id === "agent-1" ? "Nova" : id),
   agentAvatarFn: (id: string) => `https://example.test/${id}.png`,
   agentColorTokenFn: () => "hue-2",
@@ -122,6 +123,29 @@ describe("WorkingTurn", () => {
 
     await click(buttonByLabel(container, "Expand working details"));
     expect(container.textContent).toContain("pnpm test");
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps elapsed time stable when the capped event window drops its oldest row", async () => {
+    const { WorkingTurn } = await import("../working-turn.js");
+    const startedAt = "2026-05-28T11:39:00.000Z";
+    const newerEvent = event({
+      id: "newer",
+      seq: 2,
+      kind: "assistant_text",
+      createdAt: "2026-05-28T11:40:00.000Z",
+    });
+    const firstWindow = [event({ id: "oldest", seq: 1, kind: "assistant_text", createdAt: startedAt }), newerEvent];
+    const { container, root } = await renderDom(
+      <WorkingTurn {...props} startedAt={startedAt} events={firstWindow} defaultOpen={false} />,
+    );
+    expect(container.textContent).toContain("working · 21m00s");
+
+    await act(async () => {
+      root.render(<WorkingTurn {...props} startedAt={startedAt} events={[newerEvent]} defaultOpen={false} />);
+    });
+    expect(container.textContent).toContain("working · 21m00s");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/components/chat/working-turn.tsx
+++ b/packages/web/src/components/chat/working-turn.tsx
@@ -34,6 +34,8 @@ type WorkingTurnProps = {
    * open/closed state.
    */
   events: SessionEventRow[];
+  /** Stable active-turn origin supplied independently of the capped event window. */
+  startedAt: string;
   /** Direct chats pass `true` (expand the process lane); group chats `false`. */
   defaultOpen: boolean;
   agentNameFn: (id: string) => string;
@@ -225,13 +227,20 @@ function useElapsedSeconds(startIso: string): number {
   return Math.max(0, Math.round((now - new Date(startIso).getTime()) / 1000));
 }
 
-export function WorkingTurn({ events, defaultOpen, agentNameFn, agentAvatarFn, agentColorTokenFn }: WorkingTurnProps) {
+export function WorkingTurn({
+  events,
+  startedAt,
+  defaultOpen,
+  agentNameFn,
+  agentAvatarFn,
+  agentColorTokenFn,
+}: WorkingTurnProps) {
   // `open` is local state so a manual toggle survives incoming events. It only
   // resets on remount, which the parent triggers when `turn_end` ends the turn.
   const [open, setOpen] = useState<boolean>(defaultOpen);
 
   const first = events[0];
-  const elapsedSec = useElapsedSeconds(first?.createdAt ?? new Date().toISOString());
+  const elapsedSec = useElapsedSeconds(startedAt);
   if (!first) return null;
 
   const agentId = first.agentId;

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1276,7 +1276,7 @@ function ImageBatchFromRef({
 type TimelineItem =
   | { kind: "message"; at: string; key: string; data: MessageWithDelivery }
   | { kind: "event"; at: string; key: string; data: SessionEventRow }
-  | { kind: "workgroup"; at: string; key: string; events: SessionEventRow[] };
+  | { kind: "workgroup"; at: string; key: string; events: SessionEventRow[]; startedAt: string };
 
 /**
  * Resolve the one participant whose tag must remain visible on request-action
@@ -1423,6 +1423,7 @@ const ChatTimeline = memo(function ChatTimeline({
                   <WorkingTurn
                     key={item.key}
                     events={item.events}
+                    startedAt={item.startedAt}
                     defaultOpen={defaultWorkgroupOpen}
                     agentNameFn={agentNameFn}
                     agentAvatarFn={agentAvatarFn}
@@ -2734,7 +2735,9 @@ export function ChatView({
     // independently fetched feeds by agent before finding turn boundaries.
     // Dedup by event id protects a temporarily duplicated participant/query.
     const rawEventsByAgent = new Map<string, Map<string, SessionEventRow>>();
+    const turnStartedAtByAgent = new Map<string, string>();
     for (const feed of eventFeedsData?.feeds ?? []) {
+      if (feed.turnStartedAt) turnStartedAtByAgent.set(feed.agentId, feed.turnStartedAt);
       for (const event of feed.items) {
         const existing = rawEventsByAgent.get(event.agentId);
         if (existing) existing.set(event.id, event);
@@ -2767,6 +2770,9 @@ export function ChatView({
           at: first.createdAt,
           key: `wg-${lastTurnEndSeq}-${eventAgentId}`,
           events: turnEvents,
+          // Older servers omit the stable anchor; preserve compatibility by
+          // falling back to the first event in the current response window.
+          startedAt: turnStartedAtByAgent.get(eventAgentId) ?? first.createdAt,
         });
       }
     }


### PR DESCRIPTION
## Summary

- compute a stable active-turn start timestamp across the full chat-speaker event scope before applying the capped event window
- return `turnStartedAt` with each chat session-event feed and use it as the WorkingTurn elapsed-time origin
- keep Web compatible with older Server deployments by falling back to the first visible event
- add regressions for a server event window that has already dropped the turn's first event and for a Web rerender that drops the oldest row

## Testing

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/session-event.test.ts`
- `pnpm --filter @first-tree/web exec vitest run src/components/chat/__tests__/working-turn-dom.test.tsx`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm check`
