### PR TITLE
fix(cli): preserve portable install identity

### DIFF
--- a/apps/cli/src/__tests__/context-bundle-manifest.test.ts
+++ b/apps/cli/src/__tests__/context-bundle-manifest.test.ts
@@ -4,7 +4,7 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, 
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { contextIntegrationReleaseManifestSchema } from "@first-tree/shared";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   contextIntegrationMarketplaceSourcePath,
   installContextIntegration,
@@ -24,11 +24,26 @@ import { COMMAND_VERSION } from "../core/version.js";
 
 const roots: string[] = [];
 const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
+const originalInstallMode = process.env.FIRST_TREE_INSTALL_MODE;
+const originalPortableRoot = process.env.FIRST_TREE_PORTABLE_ROOT;
+const originalPortableBinDir = process.env.FIRST_TREE_PORTABLE_BIN_DIR;
+
+beforeEach(() => {
+  delete process.env.FIRST_TREE_INSTALL_MODE;
+  delete process.env.FIRST_TREE_PORTABLE_ROOT;
+  delete process.env.FIRST_TREE_PORTABLE_BIN_DIR;
+});
 
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   if (originalFirstTreeHome === undefined) delete process.env.FIRST_TREE_HOME;
   else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
+  if (originalInstallMode === undefined) delete process.env.FIRST_TREE_INSTALL_MODE;
+  else process.env.FIRST_TREE_INSTALL_MODE = originalInstallMode;
+  if (originalPortableRoot === undefined) delete process.env.FIRST_TREE_PORTABLE_ROOT;
+  else process.env.FIRST_TREE_PORTABLE_ROOT = originalPortableRoot;
+  if (originalPortableBinDir === undefined) delete process.env.FIRST_TREE_PORTABLE_BIN_DIR;
+  else process.env.FIRST_TREE_PORTABLE_BIN_DIR = originalPortableBinDir;
 });
 
 describe("context integration bundle", () => {

--- a/apps/cli/src/__tests__/core-attention-update-extra.test.ts
+++ b/apps/cli/src/__tests__/core-attention-update-extra.test.ts
@@ -89,7 +89,14 @@ beforeEach(() => {
   bootstrapMocks.ensureFreshAccessToken.mockResolvedValue("token");
   bootstrapMocks.resolveServerUrl.mockReturnValue("https://hub.example");
   childRegistryMocks.classify.mockReturnValue({ kind: "permanent", reasonCode: "classified" });
-  spawnSyncMock.mockReturnValue({ status: 0, stdout: "0.6.0\n", stderr: "" });
+  spawnSyncMock.mockImplementation((_command: string, args: string[]) =>
+    args.includes("prefix")
+      ? { status: 0, stdout: "/usr/local\n", stderr: "" }
+      : { status: 0, stdout: "0.6.0\n", stderr: "" },
+  );
+  vi.stubEnv("FIRST_TREE_INSTALL_MODE", "");
+  vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", "");
+  vi.stubEnv("FIRST_TREE_PORTABLE_BIN_DIR", "");
 });
 
 describe("core update helpers", () => {

--- a/apps/cli/src/__tests__/portable-install-context.test.ts
+++ b/apps/cli/src/__tests__/portable-install-context.test.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { channelConfig } from "../core/channel.js";
+import { portableShimContents, resolvePortableInstallContext } from "../core/portable-install-context.js";
+
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "ft-portable-context-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+describe("portable install context", () => {
+  it("ignores a real stale global-first PATH and preserves the stable custom shim", () => {
+    const home = tempRoot();
+    const prefix = join(home, "portable");
+    const root = join(prefix, "current");
+    const binDir = join(home, "custom-bin");
+    const legacyBinDir = join(home, "legacy-global-bin");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(legacyBinDir, { recursive: true });
+    writeFileSync(join(binDir, channelConfig.binName), portableShimContents(root, binDir), { mode: 0o755 });
+    writeFileSync(join(legacyBinDir, channelConfig.binName), "#!/bin/sh\necho stale-global\n", { mode: 0o755 });
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("PATH", `${legacyBinDir}${delimiter}${binDir}`);
+    vi.stubEnv("FIRST_TREE_INSTALL_MODE", "portable");
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", root);
+    vi.stubEnv("FIRST_TREE_PORTABLE_BIN_DIR", binDir);
+
+    expect(resolvePortableInstallContext()).toEqual({
+      root,
+      prefix,
+      binDir,
+      cliPath: join(binDir, channelConfig.binName),
+      nodeBinDir: join(root, "node", "bin"),
+    });
+  });
+
+  it("refuses incomplete or ambiguous portable identity instead of scanning PATH", () => {
+    const home = tempRoot();
+    const prefix = join(home, "portable");
+    const root = join(prefix, "current");
+    const customBin = join(home, "old-custom-bin");
+    mkdirSync(customBin, { recursive: true });
+    writeFileSync(
+      join(customBin, channelConfig.binName),
+      `#!/bin/sh\nroot="${root}"\nexport FIRST_TREE_INSTALL_MODE=portable\nexport FIRST_TREE_PORTABLE_ROOT="$root"\nexec "$root/node/bin/node" "$root/app/cli/index.mjs" "$@"\n`,
+      { mode: 0o755 },
+    );
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("PATH", customBin);
+    vi.stubEnv("FIRST_TREE_INSTALL_MODE", "portable");
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", root);
+    vi.stubEnv("FIRST_TREE_PORTABLE_BIN_DIR", "");
+
+    expect(() => resolvePortableInstallContext()).toThrow("Rerun the");
+
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", "relative/current");
+    expect(() => resolvePortableInstallContext()).toThrow("must be absolute");
+
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", "");
+    expect(() => resolvePortableInstallContext()).toThrow("missing FIRST_TREE_PORTABLE_ROOT");
+  });
+});

--- a/apps/cli/src/__tests__/render-unit-channel.test.ts
+++ b/apps/cli/src/__tests__/render-unit-channel.test.ts
@@ -38,6 +38,10 @@ const FAKE_BIN_INVOCATION = { kind: "bin", program: "/usr/local/bin/first-tree-d
 // name is what macOS shows in the background-items list.
 const FAKE_WRAPPER_PATH = join(defaultHome(), "service", channelConfig.displayName);
 
+function nonPortablePath(basePaths: readonly string[]): string {
+  return [...new Set([dirname(process.execPath), ...basePaths])].join(":");
+}
+
 function extractPlistPathValue(plist: string): string {
   const match = /<key>PATH<\/key>\s*<string>([^<]+)<\/string>/.exec(plist);
   if (!match?.[1]) {
@@ -57,7 +61,7 @@ function withExecPath(execPath: string, callback: () => void): void {
 }
 
 describe("renderSystemdUnit — channel identity baked into unit text", () => {
-  const unit = renderSystemdUnit(FAKE_BIN_INVOCATION);
+  const unit = renderSystemdUnit(FAKE_BIN_INVOCATION, "user", nonPortablePath(["/usr/local/bin", "/usr/bin", "/bin"]));
 
   it("uses the channel's syslog identifier (bare name, no .service)", () => {
     expect(unit).toMatch(new RegExp(`SyslogIdentifier=${channelConfig.launchdLabel}\\b`));
@@ -90,7 +94,10 @@ describe("renderSystemdUnit — channel identity baked into unit text", () => {
 });
 
 describe("renderPlist — channel identity baked into plist text", () => {
-  const plist = renderPlist(FAKE_WRAPPER_PATH);
+  const plist = renderPlist(
+    FAKE_WRAPPER_PATH,
+    nonPortablePath(["/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin"]),
+  );
 
   it("uses the channel's launchd label", () => {
     // Label tag — exact match in the <key>Label</key><string>…</string> pair.
@@ -135,7 +142,9 @@ describe("renderPlist — channel identity baked into plist text", () => {
 
   it("does not duplicate launchd fallback paths that match the current Node binary directory", () => {
     withExecPath("/usr/local/bin/node", () => {
-      const pathEntries = extractPlistPathValue(renderPlist(FAKE_WRAPPER_PATH)).split(":");
+      const pathEntries = extractPlistPathValue(
+        renderPlist(FAKE_WRAPPER_PATH, nonPortablePath(["/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin"])),
+      ).split(":");
       expect(pathEntries[0]).toBe("/usr/local/bin");
       expect(pathEntries.filter((entry) => entry === "/usr/local/bin")).toHaveLength(1);
     });

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { channelConfig } from "../core/channel.js";
+import { portableShimContents } from "../core/portable-install-context.js";
 import {
   getClientServiceStatus,
   installClientService,
@@ -71,6 +72,10 @@ const originalSystemdSystemDir = process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR;
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 const originalXdgRuntimeDir = process.env.XDG_RUNTIME_DIR;
 const originalDbusSessionBusAddress = process.env.DBUS_SESSION_BUS_ADDRESS;
+const originalPath = process.env.PATH;
+const originalInstallMode = process.env.FIRST_TREE_INSTALL_MODE;
+const originalPortableRoot = process.env.FIRST_TREE_PORTABLE_ROOT;
+const originalPortableBinDir = process.env.FIRST_TREE_PORTABLE_BIN_DIR;
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", { configurable: true, value: platform });
@@ -140,6 +145,9 @@ beforeEach(() => {
   process.env.FIRST_TREE_HOME = join(home, "ft-home");
   process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR = join(home, "systemd-system");
   process.env.XDG_CONFIG_HOME = join(home, "xdg");
+  delete process.env.FIRST_TREE_INSTALL_MODE;
+  delete process.env.FIRST_TREE_PORTABLE_ROOT;
+  delete process.env.FIRST_TREE_PORTABLE_BIN_DIR;
   process.argv = ["node", "/repo/dist/cli/index.mjs"];
   setExecPath("/opt/node/bin/node");
   process.cwd = () => "/repo";
@@ -163,6 +171,14 @@ afterEach(() => {
   else process.env.XDG_RUNTIME_DIR = originalXdgRuntimeDir;
   if (originalDbusSessionBusAddress === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
   else process.env.DBUS_SESSION_BUS_ADDRESS = originalDbusSessionBusAddress;
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
+  if (originalInstallMode === undefined) delete process.env.FIRST_TREE_INSTALL_MODE;
+  else process.env.FIRST_TREE_INSTALL_MODE = originalInstallMode;
+  if (originalPortableRoot === undefined) delete process.env.FIRST_TREE_PORTABLE_ROOT;
+  else process.env.FIRST_TREE_PORTABLE_ROOT = originalPortableRoot;
+  if (originalPortableBinDir === undefined) delete process.env.FIRST_TREE_PORTABLE_BIN_DIR;
+  else process.env.FIRST_TREE_PORTABLE_BIN_DIR = originalPortableBinDir;
   process.argv = [...originalArgv];
   setExecPath(originalExecPath);
   process.cwd = originalCwd;
@@ -200,6 +216,33 @@ describe("service install helpers", () => {
     execFileSyncMock.mockReturnValueOnce(`${extensionlessShim}\r\n${cmdShim}\r\n`);
 
     expect(resolveCliInvocation()).toEqual({ kind: "bin", program: realpathSync(cmdShim) });
+  });
+
+  it("keeps portable service identity stable when a legacy global binary is first on PATH", () => {
+    setPlatform("linux");
+    const prefix = join(home, "portable");
+    const root = join(prefix, "current");
+    const binDir = join(home, "custom-bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, channelConfig.binName), portableShimContents(root, binDir), { mode: 0o755 });
+    process.env.FIRST_TREE_INSTALL_MODE = "portable";
+    process.env.FIRST_TREE_PORTABLE_ROOT = root;
+    process.env.FIRST_TREE_PORTABLE_BIN_DIR = binDir;
+    process.env.PATH = `/usr/local/bin:${binDir}`;
+    execFileSyncMock.mockReturnValue(`/usr/local/bin/${channelConfig.binName}\n`);
+
+    const invocation = resolveCliInvocation();
+    expect(invocation).toEqual({ kind: "bin", program: join(binDir, channelConfig.binName) });
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+
+    const unit = renderSystemdUnit(invocation);
+    expect(unit).toContain(`ExecStart=${join(binDir, channelConfig.binName)} daemon start --no-interactive`);
+    expect(unit).toContain(`Environment=PATH=${binDir}:${root}/node/bin:/usr/local/bin:/usr/bin:/bin`);
+    expect(unit).not.toContain("/versions/");
+
+    const plist = renderPlist("/tmp/First Tree");
+    expect(plist).toContain(`${binDir}:${root}/node/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin`);
+    expect(plist).not.toContain("/versions/");
   });
 
   it("renders service templates with escaped values and quoted shell arguments", () => {

--- a/apps/cli/src/__tests__/update-global-extra.test.ts
+++ b/apps/cli/src/__tests__/update-global-extra.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
@@ -77,12 +80,79 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  spawnSyncMock.mockImplementation((_command: string, args: string[]) =>
+    args.includes("prefix")
+      ? { status: 0, stdout: "/usr/local\n", stderr: "" }
+      : { status: 0, stdout: "null", stderr: "" },
+  );
   existsSyncMock.mockReturnValue(false);
   classifyMock.mockReturnValue({ kind: "permanent", reasonCode: "classified" });
   resolveServerUrlMock.mockReturnValue("https://hub.example///");
 });
 
 describe("global update helpers", () => {
+  it("refuses npm-global writes inside a validated portable version tree", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ft-npm-portable-prefix-"));
+    try {
+      const versionDir = join(root, "versions", "1.2.3");
+      const nodePrefix = join(versionDir, "node");
+      mkdirSync(nodePrefix, { recursive: true });
+      writeFileSync(
+        join(versionDir, "INSTALL.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          channel: "prod",
+          version: "1.2.3",
+          gitSha: "abc123",
+          nodeVersion: "v24.0.0",
+          packageName: "first-tree",
+          binName: "first-tree",
+          aliasName: "ft",
+          generatedAt: new Date().toISOString(),
+          platform: process.platform === "darwin" ? "darwin-x64" : "linux-x64",
+          installMode: "portable",
+          appEntry: "app/cli/index.mjs",
+        }),
+      );
+      spawnSyncMock.mockImplementation((_command: string, args: string[]) =>
+        args.includes("prefix")
+          ? { status: 0, stdout: `${nodePrefix}\n`, stderr: "" }
+          : { status: 0, stdout: "null", stderr: "" },
+      );
+      const output = vi.fn();
+      const { installGlobalSpec } = await import("../core/update.js");
+
+      await expect(installGlobalSpec("latest", { output })).resolves.toMatchObject({
+        ok: false,
+        mode: "global",
+        retryable: false,
+        reasonCode: "npm_prefix_inside_portable_install",
+        reason: expect.stringContaining("immutable portable version 1.2.3"),
+      });
+      expect(registrySpawnMock).not.toHaveBeenCalled();
+      expect(output).toHaveBeenCalledWith(expect.stringContaining("absolute channel shim"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the npm global prefix cannot be verified", async () => {
+    spawnSyncMock.mockImplementation((_command: string, args: string[]) =>
+      args.includes("prefix")
+        ? { status: 1, stdout: "", stderr: "prefix denied" }
+        : { status: 0, stdout: "null", stderr: "" },
+    );
+    const { installGlobalSpec } = await import("../core/update.js");
+
+    await expect(installGlobalSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      retryable: false,
+      reasonCode: "npm_prefix_probe_failed",
+      reason: expect.stringContaining("prefix denied"),
+    });
+    expect(registrySpawnMock).not.toHaveBeenCalled();
+  });
+
   it("rejects npm targets whose engine metadata excludes the current Node", async () => {
     spawnSyncMock.mockReturnValueOnce({
       status: 0,
@@ -166,7 +236,11 @@ describe("global update helpers", () => {
   });
 
   it("classifies npm child errors and timeout exits", async () => {
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: "null", stderr: "" });
+    spawnSyncMock.mockImplementation((_command: string, args: string[]) =>
+      args.includes("prefix")
+        ? { status: 0, stdout: "/usr/local\n", stderr: "" }
+        : { status: 0, stdout: "null", stderr: "" },
+    );
     classifyMock.mockReturnValueOnce({ kind: "transient", reasonCode: "spawn_failed" });
     const errored = new FakeChild();
     registrySpawnMock.mockReturnValueOnce({ child: errored });
@@ -193,7 +267,11 @@ describe("global update helpers", () => {
   });
 
   it("stringifies non-Error npm child failures", async () => {
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: "null", stderr: "" });
+    spawnSyncMock.mockImplementation((_command: string, args: string[]) =>
+      args.includes("prefix")
+        ? { status: 0, stdout: "/usr/local\n", stderr: "" }
+        : { status: 0, stdout: "null", stderr: "" },
+    );
     classifyMock.mockReturnValueOnce({ kind: "transient", reasonCode: "string_failure" });
     const child = new FakeChild();
     registrySpawnMock.mockReturnValueOnce({ child });

--- a/apps/cli/src/__tests__/update-glue.test.ts
+++ b/apps/cli/src/__tests__/update-glue.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { channelConfig } from "../core/channel.js";
 
 const updateMocks = vi.hoisted(() => ({
   detectInstallMode: vi.fn(),
@@ -15,6 +14,9 @@ const updateStateMocks = vi.hoisted(() => ({
 }));
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
+const resolveCliInvocationMock = vi.hoisted(() =>
+  vi.fn(() => ({ kind: "bin" as const, program: "/opt/first-tree/bin/first-tree-dev" })),
+);
 const printLineMock = vi.hoisted(() => vi.fn());
 const exitMock = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
   throw Object.assign(new Error(`process.exit ${code}`), { exitCode: code });
@@ -26,6 +28,7 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("../core/update.js", () => updateMocks);
 vi.mock("../core/update-state.js", () => updateStateMocks);
+vi.mock("../core/supervisor/index.js", () => ({ resolveCliInvocation: resolveCliInvocationMock }));
 vi.mock("../core/output.js", () => ({
   print: { line: printLineMock },
 }));
@@ -43,6 +46,8 @@ describe("update glue", () => {
     updateStateMocks.isLoopGuarded.mockReset();
     updateStateMocks.recordUpdateAttempt.mockReset();
     spawnSyncMock.mockReset();
+    resolveCliInvocationMock.mockReset();
+    resolveCliInvocationMock.mockReturnValue({ kind: "bin", program: "/opt/first-tree/bin/first-tree-dev" });
     printLineMock.mockClear();
     exitMock.mockClear();
 
@@ -219,7 +224,7 @@ describe("update glue", () => {
       createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
     ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
     expect(spawnSyncMock).toHaveBeenCalledWith(
-      channelConfig.binName,
+      "/opt/first-tree/bin/first-tree-dev",
       ["daemon", "refresh-unit"],
       expect.objectContaining({ timeout: 45_000 }),
     );
@@ -230,7 +235,9 @@ describe("update glue", () => {
     await expect(
       createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
     ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
-    expect(output()).toContain("warning: 'daemon refresh-unit' exited with status 7");
+    expect(output()).toContain(
+      "warning: '/opt/first-tree/bin/first-tree-dev daemon refresh-unit' exited with status 7",
+    );
 
     printLineMock.mockClear();
     spawnSyncMock.mockReturnValueOnce({ status: undefined, signal: undefined });
@@ -246,7 +253,8 @@ describe("update glue", () => {
     await expect(
       createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
     ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
-    expect(output()).toContain("warning: could not spawn 'daemon refresh-unit': spawn denied");
+    expect(output()).toContain("warning: could not resolve or spawn the installed CLI");
+    expect(output()).toContain("spawn denied");
 
     printLineMock.mockClear();
     spawnSyncMock.mockImplementationOnce(() => {
@@ -255,7 +263,7 @@ describe("update glue", () => {
     await expect(
       createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
     ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
-    expect(output()).toContain("warning: could not spawn 'daemon refresh-unit': spawn string denied");
+    expect(output()).toContain("spawn string denied");
   });
 
   it("routes managed update output through the injected logger and captures refresh-unit output", async () => {
@@ -283,14 +291,19 @@ describe("update glue", () => {
 
     expect(printLineMock).not.toHaveBeenCalled();
     expect(spawnSyncMock).toHaveBeenCalledWith(
-      channelConfig.binName,
+      "/opt/first-tree/bin/first-tree-dev",
       ["daemon", "refresh-unit"],
       expect.objectContaining({ encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }),
     );
     expect(logs).toEqual(
       expect.arrayContaining([
         ["info", "npm stderr line"],
-        ["warn", expect.stringContaining("warning: 'daemon refresh-unit' exited with status 7")],
+        [
+          "warn",
+          expect.stringContaining(
+            "warning: '/opt/first-tree/bin/first-tree-dev daemon refresh-unit' exited with status 7",
+          ),
+        ],
         ["warn", expect.stringContaining("Output: stderr line | stdout line")],
       ]),
     );

--- a/apps/cli/src/__tests__/update-portable-install.test.ts
+++ b/apps/cli/src/__tests__/update-portable-install.test.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, join } from "node:path";
+import { basename, delimiter, dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const childRegistryMocks = vi.hoisted(() => ({
@@ -167,7 +167,29 @@ async function makePortableFixture(
   return { root, latestPath, manifestPath, tarball, platform };
 }
 
-async function seedOldInstall(prefix: string, options: { nodeVersion?: string } = {}): Promise<void> {
+function stableShimContents(root: string, binDir: string): string {
+  return `#!/bin/sh
+set -eu
+root='${root}'
+bin_dir='${binDir}'
+export FIRST_TREE_INSTALL_MODE=portable
+export FIRST_TREE_PORTABLE_ROOT="$root"
+export FIRST_TREE_PORTABLE_BIN_DIR="$bin_dir"
+exec "$root/node/bin/node" "$root/app/cli/index.mjs" "$@"
+`;
+}
+
+function configurePortableIdentity(prefix: string, binDir = join(dirname(prefix), ".local", "bin")): void {
+  const root = join(prefix, "current");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(binDir, "first-tree"), stableShimContents(root, binDir), { mode: 0o755 });
+  writeFileSync(join(binDir, "ft"), stableShimContents(root, binDir), { mode: 0o755 });
+  vi.stubEnv("FIRST_TREE_INSTALL_MODE", "portable");
+  vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", root);
+  vi.stubEnv("FIRST_TREE_PORTABLE_BIN_DIR", binDir);
+}
+
+async function seedOldInstall(prefix: string, options: { nodeVersion?: string; binDir?: string } = {}): Promise<void> {
   const nodeVersion = options.nodeVersion ?? "v24.0.0";
   await mkdir(join(prefix, "versions", "old"), { recursive: true });
   await writeFile(join(prefix, "versions", "old", "VERSION"), "old\n");
@@ -189,6 +211,8 @@ async function seedOldInstall(prefix: string, options: { nodeVersion?: string } 
     }),
   );
   await symlink(join(prefix, "versions", "old"), join(prefix, "current"));
+  const binDir = options.binDir ?? join(dirname(prefix), ".local", "bin");
+  configurePortableIdentity(prefix, binDir);
 }
 
 async function importProdUpdateModule(
@@ -229,6 +253,9 @@ beforeEach(() => {
   // Keep every test inside a disposable shim directory and exclude operator
   // installs from the inherited PATH so a test can never rewrite them.
   vi.stubEnv("PATH", isolatedPortablePath(binDir));
+  vi.stubEnv("FIRST_TREE_INSTALL_MODE", "");
+  vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", "");
+  vi.stubEnv("FIRST_TREE_PORTABLE_BIN_DIR", "");
 });
 
 afterEach(() => {
@@ -425,13 +452,18 @@ describe("installPortableSpec", () => {
     const home = tempDir("ft-portable-home-");
     const prefix = join(home, "prefix");
     const binDir = join(home, "bin");
-    mkdirSync(binDir, { recursive: true });
-    writeFileSync(join(binDir, "first-tree"), "#!/bin/sh\nexit 0\n");
-    await seedOldInstall(prefix);
+    const legacyBinDir = join(home, "legacy-global-bin");
+    const legacyBin = join(legacyBinDir, "first-tree");
+    await seedOldInstall(prefix, { binDir });
+    mkdirSync(legacyBinDir, { recursive: true });
+    writeFileSync(legacyBin, "#!/bin/sh\necho stale-global\n", { mode: 0o755 });
+    const oldSentinel = join(prefix, "versions", "old", "node", "lib", "node_modules", "first-tree", "sentinel");
+    mkdirSync(dirname(oldSentinel), { recursive: true });
+    writeFileSync(oldSentinel, "immutable-old-version\n");
     vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
     vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
     vi.stubEnv("HOME", home);
-    vi.stubEnv("PATH", `${binDir}${delimiter}${process.env.PATH ?? ""}`);
+    vi.stubEnv("PATH", `${legacyBinDir}${delimiter}${binDir}${delimiter}${process.env.PATH ?? ""}`);
 
     const { installPortableSpec } = await importProdUpdateModule();
     await expect(installPortableSpec("latest")).resolves.toEqual({
@@ -444,7 +476,10 @@ describe("installPortableSpec", () => {
     const shim = readFileSync(join(binDir, "first-tree"), "utf8");
     expect(shim).toContain("FIRST_TREE_INSTALL_MODE=portable");
     expect(shim).toContain(`FIRST_TREE_PORTABLE_ROOT="$root"`);
-    expect(readFileSync(join(binDir, "ft"), "utf8")).toContain('root="');
+    expect(shim).toContain(`FIRST_TREE_PORTABLE_BIN_DIR="$bin_dir"`);
+    expect(readFileSync(join(binDir, "ft"), "utf8")).toContain("root='");
+    expect(readFileSync(legacyBin, "utf8")).toBe("#!/bin/sh\necho stale-global\n");
+    expect(readFileSync(oldSentinel, "utf8")).toBe("immutable-old-version\n");
   });
 
   it("downloads portable payloads over HTTP and writes fallback shims when PATH has no existing shim", async () => {
@@ -495,7 +530,7 @@ describe("installPortableSpec", () => {
     await expect(installPortableSpec("latest")).resolves.toMatchObject({
       ok: false,
       mode: "portable",
-      reason: expect.stringContaining("Cannot derive portable install prefix"),
+      reason: expect.stringContaining("must name the stable current symlink"),
     });
 
     const httpFixture = await makePortableFixture({ version: "1.2.4" });
@@ -612,6 +647,71 @@ describe("installPortableSpec", () => {
     expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("old\n");
   });
 
+  it("keeps current on the old version when preparing a stable shim fails", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        writeFile: async (
+          path: Parameters<typeof actual.writeFile>[0],
+          data: Parameters<typeof actual.writeFile>[1],
+          options?: Parameters<typeof actual.writeFile>[2],
+        ) => {
+          if (basename(String(path)).startsWith("ft.")) throw new Error("alias shim write denied");
+          return actual.writeFile(path, data, options);
+        },
+      };
+    });
+    const fixture = await makePortableFixture({ version: "3.0.0" });
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    const result = await installPortableSpec("latest");
+
+    expect(result).toMatchObject({ ok: false, mode: "portable", reason: "alias shim write denied" });
+    expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("old\n");
+    expect(readFileSync(join(home, ".local", "bin", "first-tree"), "utf8")).toContain(
+      `FIRST_TREE_PORTABLE_ROOT="$root"`,
+    );
+  });
+
+  it("keeps a committed update successful when temporary cleanup fails", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makePortableFixture({ version: "3.1.0" });
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    const cleanupPrefix = join(prefix, ".tmp", "update-");
+    let cleanupAttempts = 0;
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        rm: async (path: Parameters<typeof actual.rm>[0], options?: Parameters<typeof actual.rm>[1]) => {
+          if (String(path).startsWith(cleanupPrefix) && options?.recursive) {
+            cleanupAttempts += 1;
+            throw new Error("temporary cleanup denied");
+          }
+          return actual.rm(path, options);
+        },
+      };
+    });
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    const result = await installPortableSpec("latest");
+
+    expect(result).toEqual({ ok: true, mode: "portable", installedVersion: "3.1.0" });
+    expect(cleanupAttempts).toBe(1);
+    expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("3.1.0\n");
+  });
+
   it("rejects channel, package, bin, alias, version-channel, and asset name mismatches", async () => {
     const platform = currentPlatform();
     if (platform === null) return;
@@ -672,10 +772,11 @@ describe("installPortableSpec", () => {
 
     const rootFixture = await makePortableFixture({ version: "1.2.4" });
     vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${rootFixture.root}`);
+    vi.stubEnv("FIRST_TREE_INSTALL_MODE", "portable");
     vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", "   ");
     await expect(installPortableSpec("latest")).resolves.toMatchObject({
       ok: false,
-      reason: "FIRST_TREE_PORTABLE_ROOT is required for portable self-update.",
+      reason: expect.stringContaining("missing FIRST_TREE_PORTABLE_ROOT"),
     });
 
     vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${rootFixture.root}`);
@@ -771,7 +872,7 @@ describe("installPortableSpec", () => {
     const secondHome = tempDir("ft-portable-home-");
     const secondPrefix = join(secondHome, "prefix");
     mkdirSync(join(secondPrefix, "current"), { recursive: true });
-    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(secondPrefix, "current"));
+    configurePortableIdentity(secondPrefix);
     vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${badCurrent.root}`);
     const currentFailure = await installPortableSpec("latest");
     expect(currentFailure.ok).toBe(false);

--- a/apps/cli/src/core/portable-install-context.ts
+++ b/apps/cli/src/core/portable-install-context.ts
@@ -1,0 +1,132 @@
+import { accessSync, constants, existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { channelConfig } from "./channel.js";
+
+export type PortableInstallContext = {
+  /** Stable `<prefix>/current` symlink. Never realpath this value. */
+  root: string;
+  prefix: string;
+  /** Authoritative directory containing the channel shims. */
+  binDir: string;
+  /** Stable outer channel shim used by services and managed refresh. */
+  cliPath: string;
+  /** Stable bundled-Node directory used in supervisor PATH. */
+  nodeBinDir: string;
+};
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+/** Render the stable outer shim contract shared by installer and self-update. */
+export function portableShimContents(root: string, binDir: string): string {
+  return `#!/bin/sh
+set -eu
+root=${shellSingleQuote(root)}
+bin_dir=${shellSingleQuote(binDir)}
+export FIRST_TREE_INSTALL_MODE=portable
+export FIRST_TREE_PORTABLE_ROOT="$root"
+export FIRST_TREE_PORTABLE_BIN_DIR="$bin_dir"
+exec "$root/node/bin/node" "$root/app/cli/index.mjs" "$@"
+`;
+}
+
+function portableRepairError(detail: string): Error {
+  return new Error(
+    `${detail} Rerun the ${channelConfig.channel} portable installer to repair the stable shim and service unit.`,
+  );
+}
+
+function assertExecutable(path: string): void {
+  if (!existsSync(path)) throw portableRepairError(`Portable CLI shim does not exist: ${path}.`);
+  try {
+    accessSync(path, constants.R_OK | constants.X_OK);
+  } catch {
+    throw portableRepairError(`Portable CLI shim is not readable and executable: ${path}.`);
+  }
+}
+
+function isLegacyDefaultShimForRoot(path: string, root: string): boolean {
+  let body: string;
+  try {
+    body = readFileSync(path, "utf8");
+  } catch {
+    return false;
+  }
+  const escapedRoot = root.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return (
+    body.includes(`root="${escapedRoot}"`) &&
+    body.includes("export FIRST_TREE_INSTALL_MODE=portable") &&
+    body.includes('export FIRST_TREE_PORTABLE_ROOT="$root"') &&
+    body.includes('exec "$root/node/bin/node" "$root/app/cli/index.mjs" "$@"')
+  );
+}
+
+function assertShimIdentity(path: string, root: string, binDir: string, allowLegacyDefault: boolean): void {
+  assertExecutable(path);
+  let body: string;
+  try {
+    body = readFileSync(path, "utf8");
+  } catch {
+    throw portableRepairError(`Cannot read portable CLI shim: ${path}.`);
+  }
+  if (body === portableShimContents(root, binDir)) return;
+  if (allowLegacyDefault && isLegacyDefaultShimForRoot(path, root)) return;
+  throw portableRepairError(
+    `Portable CLI shim ${path} does not identify the same portable root and channel as ${root}.`,
+  );
+}
+
+/**
+ * Resolve authoritative portable installation identity without consulting PATH.
+ *
+ * Old shims did not export a bin directory. For those, only the documented
+ * default `~/.local/bin` is accepted, and only when its channel shim can be
+ * verified against the same stable `current` root. Custom legacy installs are
+ * deliberately ambiguous and must be repaired by rerunning the installer.
+ */
+export function resolvePortableInstallContext(): PortableInstallContext | null {
+  const mode = process.env.FIRST_TREE_INSTALL_MODE?.trim();
+  const rootSignal = process.env.FIRST_TREE_PORTABLE_ROOT?.trim();
+  if (mode !== "portable" && !rootSignal) return null;
+
+  if (!rootSignal) {
+    throw portableRepairError("FIRST_TREE_INSTALL_MODE=portable is missing FIRST_TREE_PORTABLE_ROOT.");
+  }
+  if (!isAbsolute(rootSignal)) {
+    throw portableRepairError(`FIRST_TREE_PORTABLE_ROOT must be absolute, got ${JSON.stringify(rootSignal)}.`);
+  }
+  const root = resolve(rootSignal);
+  if (basename(root) !== "current") {
+    throw portableRepairError(`FIRST_TREE_PORTABLE_ROOT must name the stable current symlink, got ${root}.`);
+  }
+  const prefix = dirname(root);
+  if (prefix === root) {
+    throw portableRepairError(`Cannot derive a portable install prefix from ${root}.`);
+  }
+
+  const binSignal = process.env.FIRST_TREE_PORTABLE_BIN_DIR?.trim();
+  const defaultBinDir = join(homedir(), ".local", "bin");
+  const binDir = binSignal || defaultBinDir;
+  if (!isAbsolute(binDir)) {
+    throw portableRepairError(`FIRST_TREE_PORTABLE_BIN_DIR must be absolute, got ${JSON.stringify(binDir)}.`);
+  }
+  const normalizedBinDir = resolve(binDir);
+  const cliPath = join(normalizedBinDir, channelConfig.binName);
+  assertShimIdentity(cliPath, root, normalizedBinDir, !binSignal && normalizedBinDir === resolve(defaultBinDir));
+
+  return {
+    root,
+    prefix,
+    binDir: normalizedBinDir,
+    cliPath,
+    nodeBinDir: join(root, "node", "bin"),
+  };
+}
+
+export function hasPortableInstallSignal(): boolean {
+  return (
+    process.env.FIRST_TREE_INSTALL_MODE?.trim() === "portable" || Boolean(process.env.FIRST_TREE_PORTABLE_ROOT?.trim())
+  );
+}

--- a/apps/cli/src/core/supervisor/launchd.ts
+++ b/apps/cli/src/core/supervisor/launchd.ts
@@ -13,7 +13,7 @@ import {
   logDir,
   migrateBakedProxyEnv,
   readFileOrFlagDrift,
-  resolveCliInvocation,
+  resolveCliInstall,
   runCapture,
   runCaptureOut,
   type ShellResult,
@@ -54,7 +54,7 @@ function launchdWrapperPath(): string {
  * itself `exec`s the resolved CLI invocation with the daemon args (see
  * `renderLaunchdWrapper`), so nothing else needs to be on the command line.
  */
-export function renderPlist(wrapperPath: string): string {
+export function renderPlist(wrapperPath: string, servicePath: string = launchdPathEnv()): string {
   const programArgs: string[] = [wrapperPath];
 
   const argsXml = programArgs.map((a) => `    <string>${escapeXml(a)}</string>`).join("\n");
@@ -78,7 +78,7 @@ export function renderPlist(wrapperPath: string): string {
   // launchd does not inherit the operator's interactive shell PATH. Put the
   // current Node directory first so npm-installed CLI shims and self-update
   // run under the same Node toolchain that installed/refreshed the service.
-  const pathEnvXml = escapeXml(launchdPathEnv());
+  const pathEnvXml = escapeXml(servicePath);
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
@@ -194,7 +194,7 @@ function waitForLabelEvicted(target: string, label: string, timeoutMs: number): 
 }
 
 function writeLaunchdServiceFiles(): { plistPath: string; wrapperPath: string } {
-  const invocation = resolveCliInvocation();
+  const install = resolveCliInstall();
   ensureLogDir();
 
   const plistPath = launchdPlistPath();
@@ -207,10 +207,10 @@ function writeLaunchdServiceFiles(): { plistPath: string; wrapperPath: string } 
 
   const wrapperPath = launchdWrapperPath();
   mkdirSync(dirname(wrapperPath), { recursive: true, mode: 0o700 });
-  writeFileSync(wrapperPath, renderLaunchdWrapper(invocation), { mode: 0o755 });
+  writeFileSync(wrapperPath, renderLaunchdWrapper(install.invocation), { mode: 0o755 });
 
   mkdirSync(dirname(plistPath), { recursive: true });
-  writeFileSync(plistPath, renderPlist(wrapperPath), { mode: 0o644 });
+  writeFileSync(plistPath, renderPlist(wrapperPath, launchdPathEnv(install.portable)), { mode: 0o644 });
 
   return { plistPath, wrapperPath };
 }
@@ -312,15 +312,18 @@ function uninstallLaunchd(): ServiceInfo {
 }
 
 function launchdUnitDriftDetected(): boolean {
-  const invocation = resolveCliInvocation();
+  const install = resolveCliInstall();
   const wrapperPath = launchdWrapperPath();
   // Two files back the launchd service: the plist (points at the stable
   // wrapper path) and the wrapper (embeds the resolved Node/CLI invocation).
   // The plist rarely changes now, so the wrapper is what catches a Node
   // upgrade or install-path move — check both or auto-update would skip a
   // reinstall and keep launching a stale binary.
-  const wrapperDrift = readFileOrFlagDrift(wrapperPath, renderLaunchdWrapper(invocation));
-  const plistDrift = readFileOrFlagDrift(launchdPlistPath(), renderPlist(wrapperPath));
+  const wrapperDrift = readFileOrFlagDrift(wrapperPath, renderLaunchdWrapper(install.invocation));
+  const plistDrift = readFileOrFlagDrift(
+    launchdPlistPath(),
+    renderPlist(wrapperPath, launchdPathEnv(install.portable)),
+  );
   return wrapperDrift || plistDrift;
 }
 

--- a/apps/cli/src/core/supervisor/shared.ts
+++ b/apps/cli/src/core/supervisor/shared.ts
@@ -5,6 +5,7 @@ import { defaultHome } from "@first-tree/shared/config";
 import { channelConfig } from "../channel.js";
 import { daemonEnvPath } from "../daemon-env.js";
 import { print } from "../output.js";
+import { type PortableInstallContext, resolvePortableInstallContext } from "../portable-install-context.js";
 import type { ResolvedBinary } from "./types.js";
 
 export type ShellResult = { ok: true } | { ok: false; stderr: string; code: number | null };
@@ -67,9 +68,11 @@ export function logDir(): string {
   return join(defaultHome(), "logs");
 }
 
-function servicePathEnv(basePaths: readonly string[]): string {
+function servicePathEnv(basePaths: readonly string[], portable?: PortableInstallContext | null): string {
   const seen = new Set<string>();
-  const paths = [dirname(process.execPath), ...basePaths].filter((value) => {
+  const identity = portable === undefined ? resolvePortableInstallContext() : portable;
+  const installPaths = identity ? [identity.binDir, identity.nodeBinDir] : [dirname(process.execPath)];
+  const paths = [...installPaths, ...basePaths].filter((value) => {
     if (seen.has(value)) return false;
     seen.add(value);
     return true;
@@ -77,12 +80,12 @@ function servicePathEnv(basePaths: readonly string[]): string {
   return paths.join(":");
 }
 
-export function systemdPathEnv(): string {
-  return servicePathEnv(SYSTEMD_BASE_PATH);
+export function systemdPathEnv(portable?: PortableInstallContext | null): string {
+  return servicePathEnv(SYSTEMD_BASE_PATH, portable);
 }
 
-export function launchdPathEnv(): string {
-  return servicePathEnv(LAUNCHD_BASE_PATH);
+export function launchdPathEnv(portable?: PortableInstallContext | null): string {
+  return servicePathEnv(LAUNCHD_BASE_PATH, portable);
 }
 
 // Proxy env keys scanned during the one-time upgrade migration below. Both
@@ -230,15 +233,25 @@ function normalizeWindowsCliBin(bin: string): string {
  *      symlink or absolute path), so this guarantees the service launches
  *      the same binary the operator invoked.
  */
-export function resolveCliInvocation(): ResolvedBinary {
+export type ResolvedCliInstall = {
+  invocation: ResolvedBinary;
+  portable: PortableInstallContext | null;
+};
+
+export function resolveCliInstall(): ResolvedCliInstall {
+  const portable = resolvePortableInstallContext();
+  if (portable) {
+    return { invocation: { kind: "bin", program: portable.cliPath }, portable };
+  }
+
   const bin = whichBin(channelConfig.binName);
   if (bin && isAbsolute(bin)) {
     const serviceBin = normalizeWindowsCliBin(bin);
     try {
       // Resolve symlinks so launchd records a stable path.
-      return { kind: "bin", program: realpathSync(serviceBin) };
+      return { invocation: { kind: "bin", program: realpathSync(serviceBin) }, portable: null };
     } catch {
-      return { kind: "bin", program: serviceBin };
+      return { invocation: { kind: "bin", program: serviceBin }, portable: null };
     }
   }
 
@@ -247,7 +260,11 @@ export function resolveCliInvocation(): ResolvedBinary {
     throw new Error("Cannot resolve CLI entry point (process.argv[1] is empty).");
   }
   const scriptAbs = isAbsolute(script) ? script : join(process.cwd(), script);
-  return { kind: "node", program: process.execPath, args: [scriptAbs] };
+  return { invocation: { kind: "node", program: process.execPath, args: [scriptAbs] }, portable: null };
+}
+
+export function resolveCliInvocation(): ResolvedBinary {
+  return resolveCliInstall().invocation;
 }
 
 export function ensureLogDir(): void {

--- a/apps/cli/src/core/supervisor/systemd.ts
+++ b/apps/cli/src/core/supervisor/systemd.ts
@@ -12,7 +12,7 @@ import {
   logDir,
   migrateBakedProxyEnv,
   readFileOrFlagDrift,
-  resolveCliInvocation,
+  resolveCliInstall,
   runCapture,
   runCaptureOut,
   shellQuote,
@@ -83,7 +83,11 @@ function blockingLegacyRootUserUnitPath(scope: SystemdScope = systemdScope()): s
   return existsSync(legacyUnitPath) ? legacyUnitPath : null;
 }
 
-export function renderSystemdUnit(invocation: ResolvedBinary, scope: SystemdScope = "user"): string {
+export function renderSystemdUnit(
+  invocation: ResolvedBinary,
+  scope: SystemdScope = "user",
+  servicePath: string = systemdPathEnv(),
+): string {
   const execStart: string =
     invocation.kind === "bin"
       ? `${shellQuote(invocation.program)} daemon start --no-interactive`
@@ -99,7 +103,7 @@ export function renderSystemdUnit(invocation: ResolvedBinary, scope: SystemdScop
   // `systemd --user` does not inherit the operator's interactive shell PATH.
   // Put this CLI's Node directory first so npm/nvm-installed shebangs and
   // self-update use the same Node toolchain when supervised.
-  const pathEnv = `Environment=PATH=${shellQuote(systemdPathEnv())}\n`;
+  const pathEnv = `Environment=PATH=${shellQuote(servicePath)}\n`;
   const wantedBy = scope === "system" ? "multi-user.target" : "default.target";
 
   // Restart policy split:
@@ -257,7 +261,7 @@ function assertNoLegacyRootUserUnitDuringRefresh(): void {
 }
 
 function writeAndEnableSystemd(scope: SystemdScope): ServiceInfo {
-  const invocation = resolveCliInvocation();
+  const install = resolveCliInstall();
   ensureLogDir();
   const unitPath = systemdUnitPath(scope);
   // Upgrade buffer: lift any proxy env a prior version baked into the unit into
@@ -267,7 +271,9 @@ function writeAndEnableSystemd(scope: SystemdScope): ServiceInfo {
     migrateBakedProxyEnv(extractProxyFromSystemd(readFileSync(unitPath, "utf-8")));
   }
   mkdirSync(dirname(unitPath), { recursive: true });
-  writeFileSync(unitPath, renderSystemdUnit(invocation, scope), { mode: 0o644 });
+  writeFileSync(unitPath, renderSystemdUnit(install.invocation, scope, systemdPathEnv(install.portable)), {
+    mode: 0o644,
+  });
 
   const reloadRes = runCapture("systemctl", systemctlArgs(scope, ["daemon-reload"]), 5_000);
   if (!reloadRes.ok) {
@@ -360,8 +366,8 @@ function uninstallSystemd(): ServiceInfo {
 function systemdUnitDriftDetected(): boolean {
   const scope = systemdScope();
   if (blockingLegacyRootUserUnitPath(scope)) return true;
-  const invocation = resolveCliInvocation();
-  const expected = renderSystemdUnit(invocation, scope);
+  const install = resolveCliInstall();
+  const expected = renderSystemdUnit(install.invocation, scope, systemdPathEnv(install.portable));
   return readFileOrFlagDrift(systemdUnitPath(scope), expected);
 }
 

--- a/apps/cli/src/core/update-glue.ts
+++ b/apps/cli/src/core/update-glue.ts
@@ -5,6 +5,7 @@ import * as semver from "semver";
 import { channelConfig } from "./channel.js";
 import { getChannelInstallCommand } from "./install-guidance.js";
 import { print } from "./output.js";
+import { resolveCliInvocation } from "./supervisor/index.js";
 import {
   detectInstallMode,
   fetchServerCommandVersion,
@@ -276,9 +277,9 @@ export function createExecuteUpdate({
 }
 
 /**
- * Spawn the newly-installed channel binary (now on PATH at
- * `/usr/local/bin/<binName>` or the equivalent global location) to
- * rewrite the service unit using its OWN templates.
+ * Resolve and spawn the newly-installed CLI through its installed identity to
+ * rewrite the service unit using its OWN templates. Portable installs use the
+ * explicit stable outer shim; npm installs retain their installed-bin lookup.
  *
  * Why a subprocess: this whole function runs inside the OLD daemon process,
  * which has the OLD `installClientService()` code loaded in memory.
@@ -296,15 +297,12 @@ export function createExecuteUpdate({
  * `bootstrap`, both of which routinely take 10-30s under load.
  */
 function refreshServiceUnit(log: (level: "info" | "warn", message: string) => void): void {
-  // Spawn the channel's own bin name (prod → `first-tree`, staging →
-  // `first-tree-staging`, dev → `first-tree-dev`). Crossing channels here
-  // would either ENOENT (the other bin isn't installed) or, worse,
-  // silently rewrite the wrong service unit with the wrong channel's
-  // templates.
-  const bin = channelConfig.binName;
-  const recovery = `\`${bin} logout && ${bin} login <code>\``;
   try {
-    const res = spawnSync(bin, ["daemon", "refresh-unit"], {
+    const invocation = resolveCliInvocation();
+    const args = [...(invocation.kind === "node" ? invocation.args : []), "daemon", "refresh-unit"];
+    const invocationLabel = [invocation.program, ...(invocation.kind === "node" ? invocation.args : [])].join(" ");
+    const recovery = `\`${invocationLabel} daemon ensure-service\``;
+    const res = spawnSync(invocation.program, args, {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 45_000,
@@ -319,7 +317,7 @@ function refreshServiceUnit(log: (level: "info" | "warn", message: string) => vo
       const outputSuffix = output ? ` Output: ${output}` : "";
       log(
         "warn",
-        `warning: 'daemon refresh-unit' exited with status ${res.status ?? "unknown"} ` +
+        `warning: '${invocationLabel} daemon refresh-unit' exited with status ${res.status ?? "unknown"} ` +
           `(signal=${res.signal ?? "none"}). If the supervisor restart fails after exit ${SELF_RESTART_EXIT_CODE}, ` +
           `recover with ${recovery}.${outputSuffix}`,
       );
@@ -328,7 +326,8 @@ function refreshServiceUnit(log: (level: "info" | "warn", message: string) => vo
     const msg = err instanceof Error ? err.message : String(err);
     log(
       "warn",
-      `warning: could not spawn 'daemon refresh-unit': ${msg}. If the supervisor restart fails, recover with ${recovery}.`,
+      `warning: could not resolve or spawn the installed CLI for 'daemon refresh-unit': ${msg}. ` +
+        `If the supervisor restart fails, rerun the ${channelConfig.channel} portable installer or invoke the installed channel shim by absolute path.`,
     );
   }
 }

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -2,8 +2,7 @@ import { type ChildProcess, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { chmod, lstat, mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { classify, ERROR_KINDS, getChildProcessRegistry } from "@first-tree/client";
 import {
@@ -24,6 +23,12 @@ import { channelConfig } from "./channel.js";
 import { cliFetch } from "./cli-fetch.js";
 import { resolveNpmInvocation } from "./npm-invocation.js";
 import { print } from "./output.js";
+import {
+  hasPortableInstallSignal,
+  type PortableInstallContext,
+  portableShimContents,
+  resolvePortableInstallContext,
+} from "./portable-install-context.js";
 
 /** Hard ceiling on a single `npm install -g` invocation (5 min). */
 const NPM_INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
@@ -66,7 +71,7 @@ export function detectInstallMode(
   argv1: string = process.argv[1] ?? "",
   packageName: string | null = PACKAGE_NAME,
 ): InstallMode {
-  if (process.env.FIRST_TREE_INSTALL_MODE === "portable" || process.env.FIRST_TREE_PORTABLE_ROOT) return "portable";
+  if (hasPortableInstallSignal()) return "portable";
   // dev channel is not published to npm — there is no `node_modules/<pkg>`
   // tree to detect a "global" install against. Treat dev binaries as
   // running from source so the update path declines self-update with the
@@ -262,6 +267,101 @@ function checkNpmTargetNodeEngine(spec: string): Extract<ExecuteUpdateResult, { 
   };
 }
 
+function npmPrefixFailure(reason: string, reasonCode: string): Extract<ExecuteUpdateResult, { ok: false }> {
+  return {
+    ok: false,
+    mode: "global",
+    reason,
+    retryable: false,
+    reasonCode,
+  };
+}
+
+function portableNodeVersionDir(prefix: string): string | null {
+  let cursor = resolve(prefix);
+  for (let depth = 0; depth < 8; depth++) {
+    const versionDir = dirname(cursor);
+    if (basename(cursor) === "node" && basename(dirname(versionDir)) === "versions") return versionDir;
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+  return null;
+}
+
+/** Refuse npm-global writes when this npm resolves inside a portable version tree. */
+function guardNpmGlobalPrefix(): Extract<ExecuteUpdateResult, { ok: false }> | null {
+  const npm = resolveNpmInvocation(["prefix", "--global"]);
+  const probe = spawnSync(npm.command, npm.args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: NPM_METADATA_TIMEOUT_MS,
+    shell: npm.shell,
+  });
+  if (probe.error || probe.status !== 0) {
+    const detail = probe.error?.message ?? probe.stderr?.trim() ?? `exit ${probe.status ?? "unknown"}`;
+    return npmPrefixFailure(
+      `Refusing npm-global update because the npm global prefix could not be verified (${detail}).`,
+      "npm_prefix_probe_failed",
+    );
+  }
+
+  const prefix = probe.stdout?.trim();
+  if (!prefix || !isAbsolute(prefix)) {
+    return npmPrefixFailure(
+      `Refusing npm-global update because npm returned an invalid global prefix: ${JSON.stringify(prefix ?? "")}.`,
+      "npm_prefix_probe_failed",
+    );
+  }
+
+  let canonicalPrefix: string;
+  try {
+    canonicalPrefix = realpathSync(prefix);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return npmPrefixFailure(
+      `Refusing npm-global update because npm prefix ${prefix} could not be resolved (${detail}).`,
+      "npm_prefix_probe_failed",
+    );
+  }
+
+  const versionDir = portableNodeVersionDir(canonicalPrefix);
+  if (versionDir === null) return null;
+
+  let parsed: ReturnType<typeof portableInstallMetadataSchema.safeParse>;
+  try {
+    parsed = portableInstallMetadataSchema.safeParse(
+      JSON.parse(readFileSync(join(versionDir, "INSTALL.json"), "utf8")),
+    );
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return npmPrefixFailure(
+      `Refusing npm-global update because ${canonicalPrefix} is inside a portable-shaped versions tree whose provenance cannot be verified (${detail}).`,
+      "npm_prefix_provenance_unknown",
+    );
+  }
+  if (!parsed.success) {
+    return npmPrefixFailure(
+      `Refusing npm-global update because ${canonicalPrefix} is inside a portable-shaped versions tree with invalid INSTALL.json metadata.`,
+      "npm_prefix_provenance_unknown",
+    );
+  }
+
+  const mismatch = validatePortableMetadata(parsed.data);
+  if (parsed.data.installMode !== "portable" || mismatch) {
+    return npmPrefixFailure(
+      `Refusing npm-global update because ${canonicalPrefix} is inside a portable-shaped versions tree with conflicting installation metadata${mismatch ? ` (${mismatch})` : ""}.`,
+      "npm_prefix_provenance_unknown",
+    );
+  }
+
+  return npmPrefixFailure(
+    `Refusing npm-global update because npm prefix ${canonicalPrefix} is inside the immutable portable version ${parsed.data.version}. ` +
+      `Rerun the current channel portable installer and then invoke its absolute channel shim to repair the service; ${portableMigrationHint()}.`,
+    "npm_prefix_inside_portable_install",
+  );
+}
+
 function failPortable(reason: string, retryable = false, reasonCode?: string): ExecuteUpdateResult {
   const base = { ok: false as const, mode: "portable" as const, reason, retryable };
   return reasonCode ? { ...base, reasonCode } : base;
@@ -276,19 +376,6 @@ function portableDownloadBaseUrl(): string | null {
   if (override && override.trim().length > 0) return normalizeBaseUrl(override.trim());
   const configured = channelConfig.portable.downloadBaseUrl;
   return configured ? normalizeBaseUrl(configured) : null;
-}
-
-function currentPortableRoot(): string | null {
-  const root = process.env.FIRST_TREE_PORTABLE_ROOT;
-  if (!root || root.trim().length === 0) return null;
-  return resolve(root);
-}
-
-function portableInstallPrefix(root: string): string | null {
-  if (basename(root) !== "current") return null;
-  const base = dirname(root);
-  if (base === root) return null;
-  return base;
 }
 
 function detectPortablePlatform(): PortablePlatform | null {
@@ -455,41 +542,19 @@ async function switchPortableCurrent(prefix: string, versionDir: string): Promis
   }
 }
 
-function portableShimContents(root: string): string {
-  return `#!/bin/sh
-set -eu
-root="${root.replace(/"/g, '\\"')}"
-export FIRST_TREE_INSTALL_MODE=portable
-export FIRST_TREE_PORTABLE_ROOT="$root"
-exec "$root/node/bin/node" "$root/app/cli/index.mjs" "$@"
-`;
-}
-
-async function writePortableShim(path: string, root: string): Promise<void> {
+async function writePortableShim(path: string, root: string, binDir: string): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.${process.pid}.tmp`;
-  await writeFile(tmp, portableShimContents(root), { mode: 0o755 });
+  await writeFile(tmp, portableShimContents(root, binDir), { mode: 0o755 });
   await chmod(tmp, 0o755);
   await rename(tmp, path);
 }
 
-function pathEntries(): string[] {
-  return (process.env.PATH ?? "").split(process.platform === "win32" ? ";" : ":").filter((entry) => entry.length > 0);
-}
-
-function firstExistingShimDir(binNames: string[]): string | null {
-  for (const dir of pathEntries()) {
-    for (const bin of binNames) {
-      if (existsSync(join(dir, bin))) return dir;
-    }
-  }
-  return null;
-}
-
-async function rewritePortableShims(root: string): Promise<void> {
+async function rewritePortableShims(context: PortableInstallContext): Promise<void> {
   const binNames = [channelConfig.binName, channelConfig.aliasName];
-  const shimDir = firstExistingShimDir(binNames) ?? join(homedir(), ".local", "bin");
-  await Promise.all(binNames.map((name) => writePortableShim(join(shimDir, name), root)));
+  await Promise.all(
+    binNames.map((name) => writePortableShim(join(context.binDir, name), context.root, context.binDir)),
+  );
 }
 
 function portableInstallFailure(err: unknown, reasonCode = "portable_update_failed"): ExecuteUpdateResult {
@@ -510,11 +575,11 @@ async function installPortableMeta(
   const assetMismatch = validatePortableAsset(asset);
   if (assetMismatch) return failPortable(`Refusing to install portable update: ${assetMismatch}`);
 
-  const currentRoot = currentPortableRoot();
-  if (currentRoot === null) return failPortable("FIRST_TREE_PORTABLE_ROOT is required for portable self-update.");
-  const prefix = portableInstallPrefix(currentRoot);
-  if (prefix === null)
-    return failPortable(`Cannot derive portable install prefix from FIRST_TREE_PORTABLE_ROOT=${currentRoot}`);
+  const installContext = resolvePortableInstallContext();
+  if (installContext === null) {
+    return failPortable("Portable self-update requires an explicit portable installation identity.");
+  }
+  const { prefix } = installContext;
 
   await mkdir(join(prefix, ".tmp"), { recursive: true });
   const tempRoot = await mkdtemp(join(prefix, ".tmp", "update-"));
@@ -542,13 +607,23 @@ async function installPortableMeta(
       await rename(extractDir, finalVersionDir);
     }
 
+    // Prepare both stable shims while `current` still points at the old,
+    // known-good version. A shim-write failure therefore cannot partially
+    // commit the new runtime. Switching `current` is the final commit point.
+    await rewritePortableShims(installContext);
     await switchPortableCurrent(prefix, finalVersionDir);
-    await rewritePortableShims(join(prefix, "current"));
     return { ok: true, mode: "portable", installedVersion: meta.version };
   } catch (err) {
     return portableInstallFailure(err);
   } finally {
-    await rm(tempRoot, { recursive: true, force: true });
+    // `current` is the commit point. Cleanup must never turn an already
+    // committed update into a reported failure, because callers would then
+    // retry against a runtime that has in fact changed underneath them.
+    try {
+      await rm(tempRoot, { recursive: true, force: true });
+    } catch {
+      // best-effort; the next update uses a distinct mkdtemp directory
+    }
   }
 }
 
@@ -576,7 +651,7 @@ export async function installPortableSpec(spec: string): Promise<ExecuteUpdateRe
   try {
     const raw = await fetchPortableJson(metadataUrl);
     const parsed = spec === "latest" ? portableLatestSchema.parse(raw) : portableManifestSchema.parse(raw);
-    return installPortableMeta(parsed, platform);
+    return await installPortableMeta(parsed, platform);
   } catch (err) {
     return portableInstallFailure(err);
   }
@@ -655,6 +730,11 @@ export async function installGlobalSpec(
   if (engineMismatch) {
     writeInstallOutput(options, `  [update] ${engineMismatch.reason}\n`);
     return engineMismatch;
+  }
+  const prefixFailure = guardNpmGlobalPrefix();
+  if (prefixFailure) {
+    writeInstallOutput(options, `  [update] ${prefixFailure.reason}\n`);
+    return prefixFailure;
   }
   return new Promise((resolvePromise) => {
     const npm = resolveNpmInvocation(["install", "-g", `${PACKAGE_NAME}@${spec}`]);

--- a/apps/cli/tests/portable-builder.test.ts
+++ b/apps/cli/tests/portable-builder.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  cpSync,
   existsSync,
   mkdtempSync,
   readdirSync,
@@ -12,9 +13,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   artifactDownloadUrl,
@@ -51,6 +53,7 @@ import {
 } from "../../../scripts/portable/build-portable.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const TSX_IMPORT = pathToFileURL(createRequire(import.meta.url).resolve("tsx")).href;
 
 let tmpDirs: string[] = [];
 
@@ -68,6 +71,30 @@ function currentPlatform(): string | null {
 
 function sha256(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function treeManifest(root: string): string {
+  const entries: string[] = [];
+  const walk = (directory: string, relativeRoot: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const absolute = join(directory, entry.name);
+      const relative = join(relativeRoot, entry.name).split("\\").join("/");
+      if (entry.isDirectory()) {
+        entries.push(`d ${relative}`);
+        walk(absolute, relative);
+      } else if (entry.isSymbolicLink()) {
+        entries.push(`l ${relative} ${readlinkSync(absolute)}`);
+      } else {
+        entries.push(`f ${relative} ${sha256(absolute)}`);
+      }
+    }
+  };
+  walk(root, "");
+  return entries.join("\n");
 }
 
 function commandPath(command: string): string {
@@ -587,26 +614,85 @@ exec node "$basedir/../${target}" "$@"
 });
 
 describe("portable installer", () => {
-  async function writeFixtureVersion(root: string, version: string, platform: string): Promise<void> {
+  async function writeFixtureVersion(
+    root: string,
+    version: string,
+    platform: string,
+    options: { failRuntimeSmoke?: boolean; integrationRuntime?: boolean } = {},
+  ): Promise<void> {
     const channelDir = join(root, "prod");
     const versionDir = join(channelDir, version);
     const payload = join(root, `payload-${version}`);
     await mkdir(join(payload, "node", "bin"), { recursive: true });
     await mkdir(join(payload, "app", "cli"), { recursive: true });
     await mkdir(join(payload, "bin"), { recursive: true });
-    await writeFile(
-      join(payload, "node", "bin", "node"),
-      `#!/bin/sh
+    const nodeScript = options.integrationRuntime
+      ? `#!/bin/sh
+exec ${shellSingleQuote(process.execPath)} --import ${shellSingleQuote(TSX_IMPORT)} "$@"
+`
+      : `#!/bin/sh
 if [ -n "\${FT_TEST_NODE_ARGS_LOG:-}" ]; then
   printf '%s\\n' "$*" >>"$FT_TEST_NODE_ARGS_LOG"
 fi
-if [ "$2" = "--version" ]; then echo ${version}; exit 0; fi
-if [ "$1" = "--version" ]; then echo ${version}; exit 0; fi
+if [ "$2" = "--version" ]; then ${options.failRuntimeSmoke ? "exit 51" : `echo ${version}; exit 0;`} fi
+if [ "$1" = "--version" ]; then ${options.failRuntimeSmoke ? "exit 51" : `echo ${version}; exit 0;`} fi
 echo node-stub "$@"
-`,
-      { mode: 0o755 },
+`;
+    await writeFile(join(payload, "node", "bin", "node"), nodeScript, { mode: 0o755 });
+    if (options.integrationRuntime) {
+      const runtimeRoot = join(payload, "test-runtime");
+      cpSync(join(REPO_ROOT, "apps", "cli", "src"), join(runtimeRoot, "src"), { recursive: true });
+      writeFileSync(join(runtimeRoot, "package.json"), JSON.stringify({ type: "module" }));
+      const buildInfoPath = join(runtimeRoot, "src", "build-info.ts");
+      const buildInfo = readFileSync(buildInfoPath, "utf8").replace('= "dev";', '= "prod";');
+      writeFileSync(buildInfoPath, buildInfo);
+      await symlink(join(REPO_ROOT, "apps", "cli", "node_modules"), join(runtimeRoot, "node_modules"));
+    }
+    const integrationApp = `
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+const { resolveCliInstall, systemdPathEnv } = await import(
+  new URL("../../test-runtime/src/core/supervisor/shared.ts", import.meta.url)
+);
+const { renderSystemdUnit } = await import(
+  new URL("../../test-runtime/src/core/supervisor/systemd.ts", import.meta.url)
+);
+const { createExecuteUpdate } = await import(
+  new URL("../../test-runtime/src/core/update-glue.ts", import.meta.url)
+);
+
+const version = ${JSON.stringify(version)};
+const args = process.argv.slice(2);
+
+function refreshService(kind) {
+  const install = resolveCliInstall();
+  const unit = renderSystemdUnit(install.invocation, "user", systemdPathEnv(install.portable));
+  writeFileSync(process.env.FT_INTEGRATION_UNIT, unit);
+  appendFileSync(process.env.FT_INTEGRATION_LOG, [kind, version, install.invocation.program].join(" ") + "\\n");
+}
+
+if (args[0] === "--version") {
+  console.log(version);
+} else if (args[0] === "login") {
+  refreshService("login");
+} else if (args[0] === "daemon" && (args[1] === "ensure-service" || args[1] === "refresh-unit")) {
+  refreshService(args[1]);
+} else if (args[0] === "managed-update") {
+  const execute = createExecuteUpdate({
+    managed: true,
+    log: (_level, message) => appendFileSync(process.env.FT_INTEGRATION_LOG, "update " + message + "\\n"),
+  });
+  await execute({ currentVersion: version, targetVersion: args[1] });
+  throw new Error("managed update returned without the restart exit");
+} else if (args[0] === "tree-version") {
+  console.log(readFileSync(new URL("../../VERSION", import.meta.url), "utf8").trim());
+} else {
+  throw new Error("unsupported integration fixture command: " + args.join(" "));
+}
+`;
+    await writeFile(
+      join(payload, "app", "cli", "index.mjs"),
+      options.integrationRuntime ? integrationApp : "// fixture\n",
     );
-    await writeFile(join(payload, "app", "cli", "index.mjs"), "// fixture\n");
     await writeFile(join(payload, "app", "package.json"), JSON.stringify({ name: "first-tree", version }));
     await writeFile(join(payload, "VERSION"), `${version}\n`);
     await writeFile(
@@ -697,6 +783,7 @@ echo node-stub "$@"
     const shim = readFileSync(join(binDir, "first-tree"), "utf8");
     expect(shim).toContain("FIRST_TREE_INSTALL_MODE=portable");
     expect(shim).toContain("FIRST_TREE_PORTABLE_ROOT");
+    expect(shim).toContain("FIRST_TREE_PORTABLE_BIN_DIR");
   });
 
   it("prints shell refresh guidance for the profile it updates", async () => {
@@ -841,6 +928,84 @@ echo node-stub "$@"
     expect(nodeArgs).toContain("app/cli/index.mjs daemon ensure-service");
   });
 
+  it("keeps one portable identity across installer, service render, managed update, and real shim refresh", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = tempDir("first-tree-portable-integration-");
+    await writeFixtureVersion(fixture, "1.0.0", platform, { integrationRuntime: true });
+
+    const home = tempDir("first-tree-integration-home-");
+    const rawPrefix = `${join(home, "portable-parent", "..", "portable-root")}/`;
+    const rawBinDir = `${join(home, "bin-parent", "..", "custom-bin")}/`;
+    const prefix = resolve(rawPrefix);
+    const binDir = resolve(rawBinDir);
+    const shim = join(binDir, "first-tree");
+    const unitPath = join(home, "rendered.service");
+    const integrationLog = join(home, "integration.log");
+    const legacyMarker = join(home, "legacy-invoked");
+    const legacyBinDir = join(home, "legacy-global-bin");
+    const npmRoot = join(home, "npm-root");
+    await mkdir(legacyBinDir, { recursive: true });
+    await mkdir(npmRoot, { recursive: true });
+    await writeFile(join(legacyBinDir, "first-tree"), '#!/bin/sh\nprintf invoked >"$FT_LEGACY_MARKER"\nexit 99\n', {
+      mode: 0o755,
+    });
+    await writeFile(
+      join(legacyBinDir, "npm"),
+      '#!/bin/sh\nif [ "$1" = "root" ] && [ "$2" = "-g" ]; then echo "$FT_TEST_NPM_ROOT"; exit 0; fi\nexit 1\n',
+      { mode: 0o755 },
+    );
+
+    const env = {
+      ...process.env,
+      HOME: home,
+      FIRST_TREE_HOME: join(home, "state"),
+      FIRST_TREE_CHANNEL: "prod",
+      FIRST_TREE_PORTABLE_CHANNEL: "prod",
+      FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL: `file://${fixture}`,
+      FIRST_TREE_SERVICE_MODE: "",
+      FT_INTEGRATION_UNIT: unitPath,
+      FT_INTEGRATION_LOG: integrationLog,
+      FT_LEGACY_MARKER: legacyMarker,
+      FT_TEST_NPM_ROOT: npmRoot,
+      PATH: `${legacyBinDir}:${process.env.PATH ?? ""}`,
+    };
+    const installer = join(REPO_ROOT, "scripts", "portable", "install.sh");
+    const install = spawnSync("sh", [installer, "--prefix", rawPrefix, "--bin-dir", rawBinDir, "--no-path-edit"], {
+      cwd: REPO_ROOT,
+      env,
+      encoding: "utf8",
+    });
+    expect(install.status, install.stderr || install.stdout).toBe(0);
+    expect(realpathSync(join(prefix, "current"))).toBe(join(prefix, "versions", "1.0.0"));
+
+    const login = spawnSync(shim, ["login", "test-code"], { cwd: REPO_ROOT, env, encoding: "utf8" });
+    expect(login.status, login.stderr || login.stdout).toBe(0);
+    const unitBefore = readFileSync(unitPath, "utf8");
+    expect(unitBefore).toContain(shim);
+    expect(unitBefore).toContain(join(prefix, "current", "node", "bin"));
+    expect(unitBefore).not.toContain("/versions/");
+    const oldTree = treeManifest(join(prefix, "versions", "1.0.0"));
+
+    await writeFixtureVersion(fixture, "2.0.0", platform, { integrationRuntime: true });
+    const update = spawnSync(shim, ["managed-update", "2.0.0"], { cwd: REPO_ROOT, env, encoding: "utf8" });
+    expect(update.status, update.stderr || update.stdout).toBe(75);
+
+    expect(treeManifest(join(prefix, "versions", "1.0.0"))).toBe(oldTree);
+    expect(existsSync(legacyMarker)).toBe(false);
+    const unitAfter = readFileSync(unitPath, "utf8");
+    expect(unitAfter).toContain(shim);
+    expect(unitAfter).toContain(join(prefix, "current", "node", "bin"));
+    expect(unitAfter).not.toContain("/versions/");
+    const log = readFileSync(integrationLog, "utf8");
+    expect(log).toContain(`login 1.0.0 ${shim}`);
+    expect(log).toContain(`refresh-unit 2.0.0 ${shim}`);
+
+    const version = spawnSync(shim, ["--version"], { cwd: REPO_ROOT, env, encoding: "utf8" });
+    expect(version.status, version.stderr).toBe(0);
+    expect(version.stdout.trim()).toBe("2.0.0");
+  }, 45_000);
+
   it("replaces the current symlink itself when upgrading with the shell installer", async () => {
     const platform = currentPlatform();
     if (platform === null) return;
@@ -888,6 +1053,41 @@ echo node-stub "$@"
     expect(secondInstall.status, secondInstall.stderr || secondInstall.stdout).toBe(0);
     expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("1.2.4\n");
     expect(readdirSync(join(prefix, "versions", "1.2.3")).filter((entry) => entry.startsWith(".current."))).toEqual([]);
+  });
+
+  it("keeps the old current when the candidate runtime smoke check fails", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makeFixture(platform);
+    const home = tempDir("first-tree-home-");
+    const prefix = join(home, "prefix");
+    const binDir = join(home, "bin");
+    const installArgs = [
+      join(REPO_ROOT, "scripts", "portable", "install.sh"),
+      "--prefix",
+      prefix,
+      "--bin-dir",
+      binDir,
+      "--no-path-edit",
+    ];
+    const env = {
+      ...process.env,
+      HOME: home,
+      FIRST_TREE_PORTABLE_CHANNEL: "prod",
+      FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL: `file://${fixture}`,
+    };
+
+    const firstInstall = spawnSync("sh", installArgs, { cwd: REPO_ROOT, env, encoding: "utf8" });
+    expect(firstInstall.status, firstInstall.stderr || firstInstall.stdout).toBe(0);
+    const oldShim = readFileSync(join(binDir, "first-tree"), "utf8");
+
+    await writeFixtureVersion(fixture, "1.2.4", platform, { failRuntimeSmoke: true });
+    const failedUpgrade = spawnSync("sh", installArgs, { cwd: REPO_ROOT, env, encoding: "utf8" });
+
+    expect(failedUpgrade.status).not.toBe(0);
+    expect(failedUpgrade.stderr).toContain("pre-commit runtime smoke check");
+    expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("1.2.3\n");
+    expect(readFileSync(join(binDir, "first-tree"), "utf8")).toBe(oldShim);
   });
 
   it("leaves the previous current symlink intact when atomic current replacement fails", async () => {

--- a/packages/qa/cases/cross-surface/portable-legacy-global-migration.md
+++ b/packages/qa/cases/cross-surface/portable-legacy-global-migration.md
@@ -1,0 +1,62 @@
+---
+id: portable-legacy-global-migration
+description: Validate migration from a legacy npm-global CLI to the portable installer without losing portable service or update identity.
+areas: [cross-surface]
+surfaces: [cli, runtime, systemd, launchd, distribution]
+---
+
+# Portable migration from a legacy global install
+
+## Goal
+
+Confirm that portable bootstrap, service installation, and one managed update remain bound to the explicit stable
+portable shim when a stale npm-global binary for the same channel appears first on the operator's inherited `PATH`.
+The portable version tree is immutable throughout the handoff.
+
+## Preconditions
+
+- Use a disposable Linux systemd-user cell and, when available, a disposable macOS launchd cell. Do not run this case
+  against an operator's real First Tree home or service definitions.
+- Install an older channel-correct npm-global CLI in a legacy prefix and place its bin directory first on the parent
+  process `PATH`.
+- Prepare the candidate channel portable installer, two consecutive portable artifacts, a temporary portable prefix,
+  and a custom shim directory that is not already on `PATH`.
+- Capture service definitions, executable resolution, version-tree hashes, CLI/daemon versions, update logs, and npm
+  prefix probes without retaining credentials or connect codes.
+
+## Operate and observe
+
+1. Run the candidate portable installer with the temporary prefix and custom shim directory, then invoke login through
+   the absolute portable channel shim. Verify the service entrypoint is that stable shim, not the legacy global binary.
+2. Inspect the generated supervisor environment. Its `PATH` starts with the authoritative shim directory and
+   `<prefix>/current/node/bin`; it contains no concrete `versions/<version>/node/bin` entry and does not depend on a
+   login-shell profile.
+3. Trigger one managed update to the second artifact. Verify the update prepares both shims before atomically switching
+   `current`, invokes `daemon refresh-unit` through the absolute stable shim, and restarts into the advertised version.
+4. Compare the first version directory before and after the update. Its file list and content hashes are unchanged,
+   including any bundled Node npm prefix. The legacy global prefix is also unchanged.
+5. Force a shim preparation failure in a fresh disposable install and verify `current` still targets the previous
+   version. Then rerun the installer and verify it converges by repairing the shims and service definition.
+6. Start a legacy/global process whose npm global prefix points inside a validated portable `versions/<version>/node`
+   tree. Verify the update refuses before `npm install -g`, reports a non-retryable portable-repair error, and changes
+   no files.
+
+## Expected result
+
+`PASS` requires both initial service installation and managed refresh to use the explicit stable portable identity,
+matching CLI/daemon versions after restart, stable supervisor paths, and byte-for-byte preservation of every old
+portable version directory.
+
+`FAIL` means ambient `PATH` selects the legacy CLI, a service definition contains a concrete portable version path,
+`npm install -g` writes under a portable version, refresh uses a bare channel command, a reported pre-commit failure
+switches `current`, or the final CLI and daemon versions differ.
+
+`BLOCKED` means disposable supervisor access, candidate artifacts, or the managed-update trigger cannot be prepared.
+`INCONCLUSIVE` means only mocked command arguments or source inspection are available without real executable
+resolution, filesystem hashes, and supervisor definitions.
+
+## Evidence
+
+Retain the target ref, installer/update commands with exit codes, sanitized inherited and rendered PATH values,
+resolved service entrypoint, before/after version-tree manifests and hashes, npm prefix probe, managed-refresh log, and
+CLI/daemon version output. Keep all run artifacts outside the source repository.

--- a/scripts/portable/build-portable.mjs
+++ b/scripts/portable/build-portable.mjs
@@ -781,8 +781,10 @@ function writeArtifactShim(path, appEntry) {
     `#!/bin/sh
 set -eu
 root=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+bin_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 export FIRST_TREE_INSTALL_MODE=portable
 export FIRST_TREE_PORTABLE_ROOT="$root"
+export FIRST_TREE_PORTABLE_BIN_DIR="$bin_dir"
 exec "$root/node/bin/node" "$root/${appEntry}" "$@"
 `,
     { mode: 0o755 },

--- a/scripts/portable/install.sh
+++ b/scripts/portable/install.sh
@@ -84,6 +84,15 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+case "$PREFIX" in
+  /*) ;;
+  *) die "--prefix must be an absolute path" ;;
+esac
+case "$BIN_DIR" in
+  /*) ;;
+  *) die "--bin-dir must be an absolute path" ;;
+esac
+
 command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
@@ -128,13 +137,13 @@ extract_tarball() {
 json_string() {
   file="$1"
   key="$2"
-  sed -n "s/.*\"$key\": \"\\([^\"]*\\)\".*/\\1/p" "$file" | sed -n '1p'
+  sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$file" | sed -n '1p'
 }
 
 json_number() {
   file="$1"
   key="$2"
-  sed -n "s/.*\"$key\": \\([0-9][0-9]*\\).*/\\1/p" "$file" | sed -n '1p'
+  sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\\([0-9][0-9]*\\).*/\\1/p" "$file" | sed -n '1p'
 }
 
 asset_block() {
@@ -163,16 +172,27 @@ detect_platform() {
   printf '%s-%s' "$portable_os" "$portable_arch"
 }
 
+shell_single_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\"'\"'/g"
+  printf "'"
+}
+
 write_shim() {
   path="$1"
   current_root="$2"
+  bin_dir="$3"
   tmp="${path}.$$"
+  root_literal="$(shell_single_quote "$current_root")"
+  bin_literal="$(shell_single_quote "$bin_dir")"
   cat >"$tmp" <<EOF
 #!/bin/sh
 set -eu
-root="$current_root"
+root=$root_literal
+bin_dir=$bin_literal
 export FIRST_TREE_INSTALL_MODE=portable
 export FIRST_TREE_PORTABLE_ROOT="\$root"
+export FIRST_TREE_PORTABLE_BIN_DIR="\$bin_dir"
 exec "\$root/node/bin/node" "\$root/app/cli/index.mjs" "\$@"
 EOF
   chmod 755 "$tmp"
@@ -376,6 +396,11 @@ ASSET_SIZE="$(json_number "$ASSET_FILE" size)"
 
 clean_npm_temp_residue "$PACKAGE_NAME"
 mkdir -p "$PREFIX/versions" "$PREFIX/.tmp" "$BIN_DIR"
+# Store one lexical absolute-path contract in shims and metadata consumers.
+# `pwd -L` removes trailing slashes and dot segments without resolving a
+# caller-selected symlink prefix, matching Node's path.resolve semantics.
+PREFIX="$(CDPATH= cd -L "$PREFIX" && pwd -L)"
+BIN_DIR="$(CDPATH= cd -L "$BIN_DIR" && pwd -L)"
 TARBALL="$WORK_DIR/payload.tar.gz"
 log "Downloading First Tree ${VERSION} for ${PLATFORM}"
 download_to "$ASSET_URL" "$TARBALL"
@@ -392,7 +417,29 @@ extract_tarball "$TARBALL" "$TEMP_VERSION_DIR"
 
 if [ -e "$FINAL_VERSION_DIR" ]; then
   rm -rf "$TEMP_VERSION_DIR"
+  VALIDATION_DIR="$FINAL_VERSION_DIR"
 else
+  VALIDATION_DIR="$TEMP_VERSION_DIR"
+fi
+
+INSTALL_FILE="$VALIDATION_DIR/INSTALL.json"
+[ -f "$INSTALL_FILE" ] || die "portable payload missing INSTALL.json"
+INSTALL_VERSION="$(json_string "$INSTALL_FILE" version)"
+INSTALL_PACKAGE="$(json_string "$INSTALL_FILE" packageName)"
+INSTALL_BIN="$(json_string "$INSTALL_FILE" binName)"
+INSTALL_ALIAS="$(json_string "$INSTALL_FILE" aliasName)"
+INSTALL_PLATFORM="$(json_string "$INSTALL_FILE" platform)"
+INSTALL_MODE="$(json_string "$INSTALL_FILE" installMode)"
+INSTALL_ENTRY="$(json_string "$INSTALL_FILE" appEntry)"
+[ "$INSTALL_VERSION" = "$VERSION" ] || die "INSTALL.json version does not match downloaded metadata"
+[ "$INSTALL_PACKAGE" = "$PACKAGE_NAME" ] || die "INSTALL.json packageName does not match downloaded metadata"
+[ "$INSTALL_BIN" = "$BIN_NAME" ] || die "INSTALL.json binName does not match downloaded metadata"
+[ "$INSTALL_ALIAS" = "$ALIAS_NAME" ] || die "INSTALL.json aliasName does not match downloaded metadata"
+[ "$INSTALL_PLATFORM" = "$PLATFORM" ] || die "INSTALL.json platform does not match the current platform"
+[ "$INSTALL_MODE" = "portable" ] || die "INSTALL.json does not describe a portable install"
+[ "$INSTALL_ENTRY" = "app/cli/index.mjs" ] || die "INSTALL.json appEntry is unsupported"
+
+if [ "$VALIDATION_DIR" = "$TEMP_VERSION_DIR" ]; then
   mv "$TEMP_VERSION_DIR" "$FINAL_VERSION_DIR"
 fi
 
@@ -401,16 +448,25 @@ if [ -e "$CURRENT_LINK" ] && [ ! -L "$CURRENT_LINK" ]; then
   die "$CURRENT_LINK exists and is not a symlink"
 fi
 NEW_LINK="$PREFIX/.current.$$"
+
+# Exercise the candidate runtime directly before changing stable shims or
+# `current`. Once `current` moves, every remaining operation is best-effort or
+# non-failing so installer success/failure always reflects the active version.
+if ! "$FINAL_VERSION_DIR/node/bin/node" "$FINAL_VERSION_DIR/app/cli/index.mjs" --version >/dev/null; then
+  die "portable payload failed the pre-commit runtime smoke check"
+fi
+
+# Prepare both stable shims while current still names the old version. The
+# current symlink is the final commit point, so a shim write failure never
+# reports failure after activating the new runtime.
+write_shim "$BIN_DIR/$BIN_NAME" "$CURRENT_LINK" "$BIN_DIR"
+write_shim "$BIN_DIR/$ALIAS_NAME" "$CURRENT_LINK" "$BIN_DIR"
 rm -f "$NEW_LINK"
 ln -s "$FINAL_VERSION_DIR" "$NEW_LINK"
 atomic_replace_current_link "$NEW_LINK" "$CURRENT_LINK"
 
-write_shim "$BIN_DIR/$BIN_NAME" "$CURRENT_LINK"
-write_shim "$BIN_DIR/$ALIAS_NAME" "$CURRENT_LINK"
-
 PATH="$BIN_DIR:${PATH:-}"
 export PATH
-"$BIN_DIR/$BIN_NAME" --version >/dev/null
 maybe_edit_path "$BIN_NAME"
 ensure_daemon_service "$BIN_NAME"
 


### PR DESCRIPTION
## Summary

- make the portable install identity authoritative across service installation, drift detection, and managed refresh
- propagate the portable shim directory explicitly and render stable supervisor entrypoints/PATH values
- make portable updates prepare shims before the atomic `current` switch and block npm-global writes into portable version trees
- add filesystem-backed migration, rollback, prefix-guard, and supervisor regression coverage plus a reusable cross-surface QA case

## Migration behavior

New portable shims export `FIRST_TREE_PORTABLE_BIN_DIR` together with the existing install mode and stable `current` root. Existing default-location shims are accepted only when they can be verified against the same portable root and channel; ambiguous custom legacy shims fail with guidance to rerun the installer. Rerunning the installer rewrites both stable shims and refreshes the service through the absolute portable entrypoint.

Portable systemd and launchd definitions now use the explicit stable shim and `<prefix>/current/node/bin`. They no longer infer the First Tree executable from an inherited shell `PATH` or pin a concrete version directory.

## Risk and safety

- Portable identity is fail-closed: incomplete or inconsistent metadata never falls back to npm-global resolution.
- Both installer paths validate artifact identity and prepare stable shims before atomically switching `current`.
- npm-mode updates probe the global prefix with the same npm runtime and refuse any portable-shaped prefix whose provenance is valid or cannot be safely established.
- True npm-global installations keep their existing service resolution and update behavior.
- The deterministic subprocess coverage renders the real service templates and executes the real portable update/refresh chain, but a live systemd/launchd migration QA run has not yet been performed.

## Validation

- focused CLI regression suite: 9 files, 173 tests passed (`maxWorkers=2`), including the full stale-global/portable migration subprocess chain
- `pnpm check`
- `pnpm typecheck`
- `pnpm test` was run with `TURBO_CONCURRENCY=2`, `VITEST_MAX_FORKS=1`, and `umask 0022`: an earlier complete run passed 12/12 tasks; the final run passed the changed CLI task but hit two unrelated timing flakes in `@first-tree/skill-evals` `first-tree-qa/grader.test.ts`, which passed 8/8 immediately when rerun in isolation
- `sh -n scripts/portable/install.sh`
- `git diff --check`

Fixes #2145
