### PR TITLE
fix(cli): explain BYO login recovery

### DIFF
--- a/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
+++ b/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
@@ -720,6 +720,11 @@ describe("client switch transaction recovery", () => {
         targetServerUrl: "https://new.example",
       }),
     ).rejects.toMatchObject({ code: "ACCOUNT_SWITCH_REQUIRES_CONFIRMATION" });
+    expect(outputMocks.fail).toHaveBeenLastCalledWith(
+      "ACCOUNT_SWITCH_REQUIRES_CONFIRMATION",
+      expect.stringMatching(/consumed.*approve.*fresh setup prompt.*--force-switch/iu),
+      1,
+    );
 
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     promptMocks.confirm.mockResolvedValueOnce(false);

--- a/apps/cli/src/__tests__/login-command.test.ts
+++ b/apps/cli/src/__tests__/login-command.test.ts
@@ -459,6 +459,18 @@ describe("login command", { timeout: 60_000 }, () => {
     });
   });
 
+  it("tells the coding agent to request a fresh setup prompt for an expired or used code", async () => {
+    process.env.FIRST_TREE_SERVER_URL = "http://first-tree.test";
+    cliFetchMock.mockResolvedValueOnce(response(401, { error: "Invalid or expired connect token" }));
+
+    await expect(runLogin(["login", "short_code-1234567890", "--no-start"])).rejects.toThrow("process.exit");
+
+    const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("expired or has already been used");
+    expect(output).toContain("fresh setup prompt from First Tree Settings");
+    expect(output).toContain("never reuse this code");
+  });
+
   it("rejects a connect URL instead of accepting it as a short code", async () => {
     const token = "http://first-tree.test/connect/short_code-123";
     await expect(runLogin(["login", token, "--no-start"])).rejects.toThrow("process.exit");
@@ -505,6 +517,9 @@ describe("login command", { timeout: 60_000 }, () => {
     expect(installClientServiceMock).not.toHaveBeenCalled();
     const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("ACCOUNT_SWITCH_REQUIRES_CONFIRMATION");
+    expect(output).toContain("has now been consumed");
+    expect(output).toContain("Ask the user to approve switching this computer first");
+    expect(output).toContain("fresh setup prompt");
     expect(output).toContain("--force-switch");
   });
 

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -62,7 +62,11 @@ async function exchangeToken(url: string, token: string): Promise<{ accessToken:
   });
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as { error?: string };
-    fail("AUTH_ERROR", body.error ?? `Token exchange failed (HTTP ${res.status})`, 1);
+    const message =
+      body.error === "Invalid or expired connect token"
+        ? "This connect code is expired or has already been used. Ask the user for a fresh setup prompt from First Tree Settings; never reuse this code."
+        : (body.error ?? `Token exchange failed (HTTP ${res.status})`);
+    fail("AUTH_ERROR", message, 1);
   }
   return (await res.json()) as { accessToken: string; refreshToken: string };
 }

--- a/apps/cli/src/core/client-switch.ts
+++ b/apps/cli/src/core/client-switch.ts
@@ -357,7 +357,7 @@ export async function confirmLocalClientSwitch(opts: {
   if (process.stdin.isTTY !== true) {
     fail(
       "ACCOUNT_SWITCH_REQUIRES_CONFIRMATION",
-      "This connect code belongs to a different First Tree user. Re-run with `--force-switch` in non-interactive mode to confirm account switching. Safety checks still run and cannot be skipped.",
+      "This connect code belongs to a different First Tree user and has now been consumed. Ask the user to approve switching this computer first. If they approve, ask for a fresh setup prompt and run its login command with `--force-switch`; never reuse this code. Safety checks still run and cannot be skipped.",
       1,
     );
   }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -87,13 +87,22 @@ codes are exchanged against this CLI channel's default server URL
 (`first-tree` → production, `first-tree-staging` → staging, `first-tree-dev` →
 local dev), with `FIRST_TREE_SERVER_URL` as an explicit override for custom
 deployments. Connect URLs are not accepted; only legacy JWT tokens with an
-`iss` claim remain accepted during rollout.
+`iss` claim remain accepted during rollout. Short connect codes are single-use:
+an expired or already-used code requires a fresh setup prompt/code from First
+Tree Settings and must never be retried.
+
 If this machine already has credentials for another user, `login` asks for
 explicit confirmation and switches the active local client after stopping and
-draining the old runtime. In non-TTY automation, `--force-switch` is the only
-confirmation flag; it does not skip supervisor, drain, filesystem, or journal
-safety checks. If credentials are missing, `login` preserves `client.yaml` and
-local agent state so the same user can reconnect after a normal `logout`.
+draining the old runtime. The CLI exchanges the short code before it can compare
+the target account with the active local owner. In non-TTY automation, a
+different-user result therefore consumes that code and stops before switching:
+the coding agent must ask the user to approve the switch, request a fresh
+Settings setup prompt/code after approval, and run that fresh prompt's login
+command with `--force-switch`. The consumed code must not be reused.
+`--force-switch` is only the non-interactive confirmation flag; it does not skip
+supervisor, drain, filesystem, or journal safety checks. If credentials are
+missing, `login` preserves `client.yaml` and local agent state so the same user
+can reconnect after a normal `logout`.
 
 | Flag | Effect |
 |---|---|


### PR DESCRIPTION
## Summary

- explain that expired or already-used connect codes require a fresh setup prompt
- explain that cross-account detection consumes the code before non-interactive approval
- direct the agent to obtain user approval, request a fresh prompt, and append `--force-switch`
- keep all existing account-switch safety gates intact

## Why

The CLI envelope needs to own complete recovery guidance so the Web setup prompt can relay errors instead of duplicating stateful login instructions.

## Paired Context Tree update

- Draft Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/883
- The Tree PR remains draft until this source PR merges, then it will be reconciled against the merged implementation before being marked ready.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm --filter first-tree-dev test` (complete 24-batch CLI suite)
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/login-command.test.ts src/__tests__/client-switch-transaction-extra.test.ts`
- isolated reruns of unrelated full-suite timeout cases passed

