### PR TITLE
feat(cli): return exact Context apply commands

### DIFF
--- a/apps/cli/src/__tests__/context-enable-command.test.ts
+++ b/apps/cli/src/__tests__/context-enable-command.test.ts
@@ -128,7 +128,7 @@ describe("context enable v3 command", () => {
                 kind: scope,
                 applyCommand: expect.stringMatching(
                   new RegExp(
-                    `^'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope '${scope}' --plan-id '${planIdPattern}' --yes$`,
+                    `^'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --project-root '/work/repo' --scope '${scope}' --plan-id '${planIdPattern}' --yes$`,
                     "u",
                   ),
                 ),
@@ -157,6 +157,8 @@ describe("context enable v3 command", () => {
         plan: expect.objectContaining({
           choices: expect.arrayContaining([
             expect.objectContaining({ kind: "directory", available: false, applyCommand: null }),
+            expect.objectContaining({ kind: "global", applyCommand: expect.stringContaining(" --pathless ") }),
+            expect.objectContaining({ kind: "session", applyCommand: expect.stringContaining(" --pathless ") }),
           ]),
         }),
       }),
@@ -167,7 +169,7 @@ describe("context enable v3 command", () => {
     await runContextEnable({ ...context({ plan: true }), options: { json: false, debug: false, quiet: false } });
     const statusRows = output.status.mock.calls.map(([label, value]) => `${label}: ${value}`).join("\n");
     expect(statusRows).toContain(
-      `Apply command: 'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope 'global'`,
+      `Apply command: 'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --project-root '/work/repo' --scope 'global'`,
     );
     expect(statusRows).toContain("Next: Choose one scope, then run its exact apply command unchanged.");
   });
@@ -188,6 +190,38 @@ describe("context enable v3 command", () => {
         }),
       }),
     );
+  });
+
+  it("applies an exact generated command with its canonical project root after cwd changes", async () => {
+    await runContextEnable(context({ plan: true, projectRoot: "/requested/../work/repo" }));
+    const command = readApplyCommand("global");
+    expect(command).toContain(" --project-root '/work/repo' ");
+
+    output.result.mockClear();
+    await runContextEnable(context(parseGeneratedApplyCommand(command)));
+
+    expect(mocks.enableOperation).toHaveBeenCalledTimes(1);
+    expect(output.result.mock.calls[0]?.[0]).toMatchObject({ setup: { complete: true } });
+  });
+
+  it("applies an exact generated pathless command without reclassifying the shell cwd", async () => {
+    mocks.inspectLocation.mockReturnValue({
+      project: { kind: "pathless" },
+      directory: null,
+      directoryAvailable: false,
+      temporaryDirectory: false,
+      warning: "This provider session did not expose a usable directory.",
+    });
+    await runContextEnable(context({ plan: true, projectRoot: undefined, pathless: true }));
+    const command = readApplyCommand("session");
+    expect(command).toContain(" --pathless ");
+    expect(command).not.toContain("--project-root");
+
+    output.result.mockClear();
+    await runContextEnable(context(parseGeneratedApplyCommand(command)));
+
+    expect(mocks.issueSession).toHaveBeenCalledTimes(1);
+    expect(output.result.mock.calls[0]?.[0]).toMatchObject({ setup: { complete: true } });
   });
 
   it("rejects a concurrent grant add/remove before persistent mutation", async () => {
@@ -364,6 +398,28 @@ async function createPlanId(): Promise<string> {
   output.result.mockClear();
   await runContextEnable(context({ plan: true }));
   return (output.result.mock.calls[0]?.[0] as { plan: { planId: string } }).plan.planId;
+}
+
+function readApplyCommand(kind: "global" | "directory" | "session"): string {
+  const result = output.result.mock.calls.at(-1)?.[0] as {
+    plan: { choices: Array<{ kind: string; applyCommand: string | null }> };
+  };
+  const command = result.plan.choices.find((choice) => choice.kind === kind)?.applyCommand;
+  if (!command) throw new Error(`Missing ${kind} apply command`);
+  return command;
+}
+
+function parseGeneratedApplyCommand(command: string): Record<string, unknown> {
+  const value = (flag: string): string | undefined => new RegExp(`${flag} '([^']+)'`, "u").exec(command)?.[1];
+  return {
+    provider: value("--provider"),
+    team: value("--team"),
+    projectRoot: value("--project-root"),
+    pathless: command.includes(" --pathless "),
+    scope: value("--scope"),
+    planId: value("--plan-id"),
+    yes: command.endsWith(" --yes"),
+  };
 }
 
 function context(options: Record<string, unknown>): CommandContext {

--- a/apps/cli/src/__tests__/context-enable-command.test.ts
+++ b/apps/cli/src/__tests__/context-enable-command.test.ts
@@ -26,9 +26,11 @@ const mocks = vi.hoisted(() => ({
   readConfig: vi.fn(),
   resolveRelease: vi.fn(),
   validateActivation: vi.fn(),
+  channelConfig: { channel: "dev", binName: "first-tree-dev" },
 }));
 
 vi.mock("../core/output.js", () => ({ print: output }));
+vi.mock("../core/channel.js", () => ({ channelConfig: mocks.channelConfig }));
 vi.mock("../core/context-integration/account-state-guard.js", () => ({
   readActiveContextAccountClientId: mocks.readAccount,
   withAccountStateMutationLockAsync: (action: () => Promise<unknown>) => action(),
@@ -76,6 +78,8 @@ const project = { kind: "path" as const, root: "/work/repo" };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.channelConfig.channel = "dev";
+  mocks.channelConfig.binName = "first-tree-dev";
   mocks.readAccount.mockReturnValue("client-1");
   mocks.inspectLocation.mockReturnValue({
     project,
@@ -111,12 +115,73 @@ beforeEach(() => {
 describe("context enable v3 command", () => {
   it("keeps plan read-only and fixes the grant-store fingerprint", async () => {
     await runContextEnable(context({ plan: true }));
-    const result = output.result.mock.calls[0]?.[0] as { plan: { planId: string; grantStoreFingerprint: string } };
+    const result = output.result.mock.calls[0]?.[0] as {
+      plan: {
+        planId: string;
+        grantStoreFingerprint: string;
+        choices: Array<{ kind: string; applyCommand: string | null }>;
+      };
+    };
     expect(result.plan.grantStoreFingerprint).toBe("a".repeat(64));
     expect(result.plan.planId).toContain(`.${"a".repeat(64)}.`);
+    expect(result.plan.choices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "global",
+          applyCommand: `'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope 'global' --plan-id '${result.plan.planId}' --yes`,
+        }),
+        expect.objectContaining({
+          kind: "directory",
+          applyCommand: `'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope 'directory' --plan-id '${result.plan.planId}' --yes`,
+        }),
+        expect.objectContaining({
+          kind: "session",
+          applyCommand: `'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope 'session' --plan-id '${result.plan.planId}' --yes`,
+        }),
+      ]),
+    );
     expect(mocks.enableOperation).not.toHaveBeenCalled();
     expect(mocks.issueSession).not.toHaveBeenCalled();
     expect(mocks.assertFingerprint).not.toHaveBeenCalled();
+  });
+
+  it("omits an apply command for an unavailable directory choice", async () => {
+    mocks.inspectLocation.mockReturnValue({
+      project: { kind: "pathless" },
+      directory: null,
+      directoryAvailable: false,
+      temporaryDirectory: false,
+      warning: null,
+    });
+    await runContextEnable(context({ plan: true, projectRoot: undefined, pathless: true }));
+    const result = output.result.mock.calls[0]?.[0] as {
+      plan: { choices: Array<{ kind: string; available: boolean; applyCommand: string | null }> };
+    };
+    expect(result.plan.choices.find((choice) => choice.kind === "directory")).toMatchObject({
+      available: false,
+      applyCommand: null,
+    });
+  });
+
+  it("renders exact apply commands in the human-readable plan", async () => {
+    await runContextEnable({ ...context({ plan: true }), options: { json: false, debug: false, quiet: false } });
+    const statusRows = output.status.mock.calls.map(([label, value]) => `${label}: ${value}`).join("\n");
+    expect(statusRows).toContain(
+      `Apply command: 'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope 'global'`,
+    );
+    expect(statusRows).toContain("Next: Choose one scope, then run its exact apply command unchanged.");
+  });
+
+  it("pins non-dev apply commands to the portable executable without quoting away tilde expansion", async () => {
+    mocks.channelConfig.channel = "staging";
+    mocks.channelConfig.binName = "first-tree-staging";
+    await runContextEnable(context({ plan: true }));
+    const result = output.result.mock.calls[0]?.[0] as {
+      plan: { choices: Array<{ kind: string; applyCommand: string | null }> };
+    };
+    expect(result.plan.choices.find((choice) => choice.kind === "global")?.applyCommand).toMatch(
+      /^~\/\.local\/bin\/first-tree-staging --json context enable/u,
+    );
   });
 
   it("rejects a concurrent grant add/remove before persistent mutation", async () => {

--- a/apps/cli/src/__tests__/context-enable-command.test.ts
+++ b/apps/cli/src/__tests__/context-enable-command.test.ts
@@ -115,30 +115,28 @@ beforeEach(() => {
 describe("context enable v3 command", () => {
   it("keeps plan read-only and fixes the grant-store fingerprint", async () => {
     await runContextEnable(context({ plan: true }));
-    const result = output.result.mock.calls[0]?.[0] as {
-      plan: {
-        planId: string;
-        grantStoreFingerprint: string;
-        choices: Array<{ kind: string; applyCommand: string | null }>;
-      };
-    };
-    expect(result.plan.grantStoreFingerprint).toBe("a".repeat(64));
-    expect(result.plan.planId).toContain(`.${"a".repeat(64)}.`);
-    expect(result.plan.choices).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: "global",
-          applyCommand: `'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope 'global' --plan-id '${result.plan.planId}' --yes`,
+    const planIdPattern = `v1\\.[0-9a-f]{64}\\.${"a".repeat(64)}\\.[0-9a-f]{64}\\.[0-9a-f]{64}`;
+    expect(output.result).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "choice_required",
+        plan: expect.objectContaining({
+          grantStoreFingerprint: "a".repeat(64),
+          planId: expect.stringMatching(new RegExp(planIdPattern, "u")),
+          choices: expect.arrayContaining(
+            ["global", "directory", "session"].map((scope) =>
+              expect.objectContaining({
+                kind: scope,
+                applyCommand: expect.stringMatching(
+                  new RegExp(
+                    `^'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope '${scope}' --plan-id '${planIdPattern}' --yes$`,
+                    "u",
+                  ),
+                ),
+              }),
+            ),
+          ),
         }),
-        expect.objectContaining({
-          kind: "directory",
-          applyCommand: `'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope 'directory' --plan-id '${result.plan.planId}' --yes`,
-        }),
-        expect.objectContaining({
-          kind: "session",
-          applyCommand: `'first-tree-dev' --json context enable --provider 'codex' --team 'org-a' --scope 'session' --plan-id '${result.plan.planId}' --yes`,
-        }),
-      ]),
+      }),
     );
     expect(mocks.enableOperation).not.toHaveBeenCalled();
     expect(mocks.issueSession).not.toHaveBeenCalled();
@@ -154,13 +152,15 @@ describe("context enable v3 command", () => {
       warning: null,
     });
     await runContextEnable(context({ plan: true, projectRoot: undefined, pathless: true }));
-    const result = output.result.mock.calls[0]?.[0] as {
-      plan: { choices: Array<{ kind: string; available: boolean; applyCommand: string | null }> };
-    };
-    expect(result.plan.choices.find((choice) => choice.kind === "directory")).toMatchObject({
-      available: false,
-      applyCommand: null,
-    });
+    expect(output.result).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: expect.objectContaining({
+          choices: expect.arrayContaining([
+            expect.objectContaining({ kind: "directory", available: false, applyCommand: null }),
+          ]),
+        }),
+      }),
+    );
   });
 
   it("renders exact apply commands in the human-readable plan", async () => {
@@ -176,11 +176,17 @@ describe("context enable v3 command", () => {
     mocks.channelConfig.channel = "staging";
     mocks.channelConfig.binName = "first-tree-staging";
     await runContextEnable(context({ plan: true }));
-    const result = output.result.mock.calls[0]?.[0] as {
-      plan: { choices: Array<{ kind: string; applyCommand: string | null }> };
-    };
-    expect(result.plan.choices.find((choice) => choice.kind === "global")?.applyCommand).toMatch(
-      /^~\/\.local\/bin\/first-tree-staging --json context enable/u,
+    expect(output.result).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: expect.objectContaining({
+          choices: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "global",
+              applyCommand: expect.stringMatching(/^~\/\.local\/bin\/first-tree-staging --json context enable/u),
+            }),
+          ]),
+        }),
+      }),
     );
   });
 

--- a/apps/cli/src/__tests__/context-enable-command.test.ts
+++ b/apps/cli/src/__tests__/context-enable-command.test.ts
@@ -401,11 +401,13 @@ async function createPlanId(): Promise<string> {
 }
 
 function readApplyCommand(kind: "global" | "directory" | "session"): string {
-  const result = output.result.mock.calls.at(-1)?.[0] as {
-    plan: { choices: Array<{ kind: string; applyCommand: string | null }> };
-  };
-  const command = result.plan.choices.find((choice) => choice.kind === kind)?.applyCommand;
-  if (!command) throw new Error(`Missing ${kind} apply command`);
+  const result: unknown = output.result.mock.calls.at(-1)?.[0];
+  if (!isRecord(result) || !isRecord(result.plan) || !Array.isArray(result.plan.choices)) {
+    throw new Error("Missing setup plan result");
+  }
+  const choice = result.plan.choices.find((candidate: unknown) => isRecord(candidate) && candidate.kind === kind);
+  const command = isRecord(choice) ? choice.applyCommand : null;
+  if (typeof command !== "string") throw new Error(`Missing ${kind} apply command`);
   return command;
 }
 
@@ -420,6 +422,10 @@ function parseGeneratedApplyCommand(command: string): Record<string, unknown> {
     planId: value("--plan-id"),
     yes: command.endsWith(" --yes"),
   };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function context(options: Record<string, unknown>): CommandContext {

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -1,13 +1,7 @@
 import { createHash } from "node:crypto";
-import {
-  type ContextActivationScope,
-  type ContextIntegrationGrant,
-  type ContextIntegrationProvider,
-  portableCliExecutable,
-} from "@first-tree/shared";
+import type { ContextActivationScope, ContextIntegrationGrant, ContextIntegrationProvider } from "@first-tree/shared";
 import { confirm } from "@inquirer/prompts";
 import type { Command } from "commander";
-import { channelConfig } from "../../core/channel.js";
 import {
   readActiveContextAccountClientId,
   withAccountStateMutationLockAsync,
@@ -27,8 +21,8 @@ import { planContextIntegrationInstall } from "../../core/context-integration/in
 import { enableContextIntegrationOperation } from "../../core/context-integration/operation.js";
 import { providerPluginRoot, resolveContextIntegrationRelease } from "../../core/context-integration/release.js";
 import { inspectContextIntegrationRuntime } from "../../core/context-integration/runtime-health.js";
+import { buildContextSetupChoices, type ContextSetupChoice } from "../../core/context-integration/setup-plan.js";
 import { print } from "../../core/output.js";
-import { quotePosixShellArg } from "../../core/posix-shell.js";
 import { createMemberSdk } from "../_shared/member.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
 import { createContextIntegrationDriver, parseContextProvider } from "./shared.js";
@@ -53,14 +47,7 @@ type SetupPlan = {
   provider: ContextIntegrationProvider;
   team: { organizationId: string; displayName: string; role: string };
   location: ReturnType<typeof inspectContextSetupLocation>;
-  choices: Array<{
-    kind: "global" | "directory" | "session";
-    label: string;
-    available: boolean;
-    recommended: boolean;
-    description: string;
-    applyCommand: string | null;
-  }>;
+  choices: ContextSetupChoice[];
   [setupPlanAccountClientId]: string;
 };
 
@@ -223,58 +210,6 @@ async function buildSetupPlan(
     }),
     [setupPlanAccountClientId]: accountClientId,
   };
-}
-
-export function buildContextSetupChoices(
-  location: ReturnType<typeof inspectContextSetupLocation>,
-  plan: { provider: ContextIntegrationProvider; teamId: string; planId: string },
-): SetupPlan["choices"] {
-  return [
-    {
-      kind: "global",
-      label: "All sessions",
-      available: true,
-      recommended: !location.temporaryDirectory,
-      description: "Make this Team eligible in every session for this provider.",
-      applyCommand: renderApplyCommand(plan, "global"),
-    },
-    {
-      kind: "directory",
-      label: location.directory ? `This directory: ${location.directory}` : "This directory",
-      available: location.directoryAvailable,
-      recommended: location.directoryAvailable && !location.temporaryDirectory,
-      description: location.directoryAvailable
-        ? "Make this Team eligible in this directory and its descendants."
-        : "Unavailable because the provider did not expose a stable directory.",
-      applyCommand: location.directoryAvailable ? renderApplyCommand(plan, "directory") : null,
-    },
-    {
-      kind: "session",
-      label: "This session only",
-      available: true,
-      recommended: location.temporaryDirectory,
-      description: "Use verified Read/Write Skills now without installing a Plugin, Hook, or persistent grant.",
-      applyCommand: renderApplyCommand(plan, "session"),
-    },
-  ];
-}
-
-function renderApplyCommand(
-  plan: { provider: ContextIntegrationProvider; teamId: string; planId: string },
-  scope: "global" | "directory" | "session",
-): string {
-  const executable =
-    channelConfig.channel === "dev"
-      ? quotePosixShellArg(channelConfig.binName)
-      : portableCliExecutable(channelConfig.binName);
-  return [
-    `${executable} --json context enable`,
-    `--provider ${quotePosixShellArg(plan.provider)}`,
-    `--team ${quotePosixShellArg(plan.teamId)}`,
-    `--scope ${quotePosixShellArg(scope)}`,
-    `--plan-id ${quotePosixShellArg(plan.planId)}`,
-    "--yes",
-  ].join(" ");
 }
 
 function parseActivationScope(scope: string, plan: SetupPlan): ContextActivationScope {

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -1,7 +1,13 @@
 import { createHash } from "node:crypto";
-import type { ContextActivationScope, ContextIntegrationGrant, ContextIntegrationProvider } from "@first-tree/shared";
+import {
+  type ContextActivationScope,
+  type ContextIntegrationGrant,
+  type ContextIntegrationProvider,
+  portableCliExecutable,
+} from "@first-tree/shared";
 import { confirm } from "@inquirer/prompts";
 import type { Command } from "commander";
+import { channelConfig } from "../../core/channel.js";
 import {
   readActiveContextAccountClientId,
   withAccountStateMutationLockAsync,
@@ -22,6 +28,7 @@ import { enableContextIntegrationOperation } from "../../core/context-integratio
 import { providerPluginRoot, resolveContextIntegrationRelease } from "../../core/context-integration/release.js";
 import { inspectContextIntegrationRuntime } from "../../core/context-integration/runtime-health.js";
 import { print } from "../../core/output.js";
+import { quotePosixShellArg } from "../../core/posix-shell.js";
 import { createMemberSdk } from "../_shared/member.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
 import { createContextIntegrationDriver, parseContextProvider } from "./shared.js";
@@ -52,6 +59,7 @@ type SetupPlan = {
     available: boolean;
     recommended: boolean;
     description: string;
+    applyCommand: string | null;
   }>;
   [setupPlanAccountClientId]: string;
 };
@@ -200,20 +208,26 @@ async function buildSetupPlan(
       ? contextGrantStoreFingerprintAfterGrant(grantStore, directoryGrant)
       : null,
   };
+  const planId = renderSetupPlanToken(token);
   return {
     schemaVersion: 1,
-    planId: renderSetupPlanToken(token),
+    planId,
     grantStoreFingerprint: grantStore.fingerprint,
     provider,
     team: activation.team,
     location,
-    choices: buildContextSetupChoices(location),
+    choices: buildContextSetupChoices(location, {
+      provider,
+      teamId: activation.team.organizationId,
+      planId,
+    }),
     [setupPlanAccountClientId]: accountClientId,
   };
 }
 
 export function buildContextSetupChoices(
   location: ReturnType<typeof inspectContextSetupLocation>,
+  plan: { provider: ContextIntegrationProvider; teamId: string; planId: string },
 ): SetupPlan["choices"] {
   return [
     {
@@ -222,6 +236,7 @@ export function buildContextSetupChoices(
       available: true,
       recommended: !location.temporaryDirectory,
       description: "Make this Team eligible in every session for this provider.",
+      applyCommand: renderApplyCommand(plan, "global"),
     },
     {
       kind: "directory",
@@ -231,6 +246,7 @@ export function buildContextSetupChoices(
       description: location.directoryAvailable
         ? "Make this Team eligible in this directory and its descendants."
         : "Unavailable because the provider did not expose a stable directory.",
+      applyCommand: location.directoryAvailable ? renderApplyCommand(plan, "directory") : null,
     },
     {
       kind: "session",
@@ -238,8 +254,27 @@ export function buildContextSetupChoices(
       available: true,
       recommended: location.temporaryDirectory,
       description: "Use verified Read/Write Skills now without installing a Plugin, Hook, or persistent grant.",
+      applyCommand: renderApplyCommand(plan, "session"),
     },
   ];
+}
+
+function renderApplyCommand(
+  plan: { provider: ContextIntegrationProvider; teamId: string; planId: string },
+  scope: "global" | "directory" | "session",
+): string {
+  const executable =
+    channelConfig.channel === "dev"
+      ? quotePosixShellArg(channelConfig.binName)
+      : portableCliExecutable(channelConfig.binName);
+  return [
+    `${executable} --json context enable`,
+    `--provider ${quotePosixShellArg(plan.provider)}`,
+    `--team ${quotePosixShellArg(plan.teamId)}`,
+    `--scope ${quotePosixShellArg(scope)}`,
+    `--plan-id ${quotePosixShellArg(plan.planId)}`,
+    "--yes",
+  ].join(" ");
 }
 
 function parseActivationScope(scope: string, plan: SetupPlan): ContextActivationScope {
@@ -439,8 +474,9 @@ function renderPlan(plan: SetupPlan, json: boolean): void {
   if (plan.location.warning) print.status("Warning", plan.location.warning);
   for (const choice of plan.choices) {
     print.status(choice.label, choice.available ? choice.description : `Unavailable — ${choice.description}`);
+    if (choice.applyCommand) print.status("Apply command", choice.applyCommand);
   }
-  print.status("Next", "Choose one scope, then rerun with --scope <scope> --plan-id <planId> --yes.");
+  print.status("Next", "Choose one scope, then run its exact apply command unchanged.");
 }
 
 function renderScope(scope: ContextActivationScope): string {

--- a/apps/cli/src/core/context-integration/setup-plan.ts
+++ b/apps/cli/src/core/context-integration/setup-plan.ts
@@ -1,0 +1,68 @@
+import { type ContextIntegrationProvider, portableCliExecutable } from "@first-tree/shared";
+import { channelConfig } from "../channel.js";
+import { quotePosixShellArg } from "../posix-shell.js";
+import type { ContextSetupLocation } from "./client-preflight.js";
+
+export type ContextSetupChoice = {
+  kind: "global" | "directory" | "session";
+  label: string;
+  available: boolean;
+  recommended: boolean;
+  description: string;
+  applyCommand: string | null;
+};
+
+type ContextSetupCommandIdentity = {
+  provider: ContextIntegrationProvider;
+  teamId: string;
+  planId: string;
+};
+
+export function buildContextSetupChoices(
+  location: ContextSetupLocation,
+  command: ContextSetupCommandIdentity,
+): ContextSetupChoice[] {
+  return [
+    {
+      kind: "global",
+      label: "All sessions",
+      available: true,
+      recommended: !location.temporaryDirectory,
+      description: "Make this Team eligible in every session for this provider.",
+      applyCommand: renderApplyCommand(command, "global"),
+    },
+    {
+      kind: "directory",
+      label: location.directory ? `This directory: ${location.directory}` : "This directory",
+      available: location.directoryAvailable,
+      recommended: location.directoryAvailable && !location.temporaryDirectory,
+      description: location.directoryAvailable
+        ? "Make this Team eligible in this directory and its descendants."
+        : "Unavailable because the provider did not expose a stable directory.",
+      applyCommand: location.directoryAvailable ? renderApplyCommand(command, "directory") : null,
+    },
+    {
+      kind: "session",
+      label: "This session only",
+      available: true,
+      recommended: location.temporaryDirectory,
+      description: "Use verified Read/Write Skills now without installing a Plugin, Hook, or persistent grant.",
+      applyCommand: renderApplyCommand(command, "session"),
+    },
+  ];
+}
+
+function renderApplyCommand(command: ContextSetupCommandIdentity, scope: ContextSetupChoice["kind"]): string {
+  const executable =
+    channelConfig.channel === "dev"
+      ? quotePosixShellArg(channelConfig.binName)
+      : portableCliExecutable(channelConfig.binName);
+  return [
+    `${executable} --json context enable`,
+    `--provider ${quotePosixShellArg(command.provider)}`,
+    `--team ${quotePosixShellArg(command.teamId)}`,
+    `--scope ${quotePosixShellArg(scope)}`,
+    `--plan-id ${quotePosixShellArg(command.planId)}`,
+    "--yes",
+  ].join(" ");
+}

--- a/apps/cli/src/core/context-integration/setup-plan.ts
+++ b/apps/cli/src/core/context-integration/setup-plan.ts
@@ -1,4 +1,8 @@
-import { type ContextIntegrationProvider, portableCliExecutable } from "@first-tree/shared";
+import {
+  type ContextIntegrationProject,
+  type ContextIntegrationProvider,
+  portableCliExecutable,
+} from "@first-tree/shared";
 import { channelConfig } from "../channel.js";
 import { quotePosixShellArg } from "../posix-shell.js";
 import type { ContextSetupLocation } from "./client-preflight.js";
@@ -29,7 +33,7 @@ export function buildContextSetupChoices(
       available: true,
       recommended: !location.temporaryDirectory,
       description: "Make this Team eligible in every session for this provider.",
-      applyCommand: renderApplyCommand(command, "global"),
+      applyCommand: renderApplyCommand(command, location.project, "global"),
     },
     {
       kind: "directory",
@@ -39,7 +43,7 @@ export function buildContextSetupChoices(
       description: location.directoryAvailable
         ? "Make this Team eligible in this directory and its descendants."
         : "Unavailable because the provider did not expose a stable directory.",
-      applyCommand: location.directoryAvailable ? renderApplyCommand(command, "directory") : null,
+      applyCommand: location.directoryAvailable ? renderApplyCommand(command, location.project, "directory") : null,
     },
     {
       kind: "session",
@@ -47,20 +51,26 @@ export function buildContextSetupChoices(
       available: true,
       recommended: location.temporaryDirectory,
       description: "Use verified Read/Write Skills now without installing a Plugin, Hook, or persistent grant.",
-      applyCommand: renderApplyCommand(command, "session"),
+      applyCommand: renderApplyCommand(command, location.project, "session"),
     },
   ];
 }
 
-function renderApplyCommand(command: ContextSetupCommandIdentity, scope: ContextSetupChoice["kind"]): string {
+function renderApplyCommand(
+  command: ContextSetupCommandIdentity,
+  project: ContextIntegrationProject,
+  scope: ContextSetupChoice["kind"],
+): string {
   const executable =
     channelConfig.channel === "dev"
       ? quotePosixShellArg(channelConfig.binName)
       : portableCliExecutable(channelConfig.binName);
+  const projectSelector = project.kind === "path" ? `--project-root ${quotePosixShellArg(project.root)}` : "--pathless";
   return [
     `${executable} --json context enable`,
     `--provider ${quotePosixShellArg(command.provider)}`,
     `--team ${quotePosixShellArg(command.teamId)}`,
+    projectSelector,
     `--scope ${quotePosixShellArg(scope)}`,
     `--plan-id ${quotePosixShellArg(command.planId)}`,
     "--yes",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1223,10 +1223,11 @@ choices:
 - `session`: use it only now, without a Plugin, Hook or persistent grant.
 
 Every available choice includes an authoritative `applyCommand` that is ready
-to execute unchanged. It pins the channel's portable CLI, provider, Team,
-canonical `--project-root` or `--pathless` identity, selected scope, exact
-`planId`, and non-interactive consent flag. An unavailable directory choice has
-`applyCommand: null`; human-readable output omits a command for that choice.
+to execute unchanged. It pins the channel-appropriate executable (the portable
+CLI path outside development), provider, Team, canonical `--project-root` or
+`--pathless` identity, selected scope, exact `planId`, and non-interactive
+consent flag. An unavailable directory choice has `applyCommand: null`;
+human-readable output omits a command for that choice.
 
 The current agent displays the choices and waits for a new user reply, then
 runs only the selected choice's exact command. Apply must use the unchanged

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1222,11 +1222,18 @@ choices:
 - `directory`: make it eligible under the displayed canonical directory;
 - `session`: use it only now, without a Plugin, Hook or persistent grant.
 
-The current agent displays those choices and waits for a new user reply. Apply
-must use the unchanged `planId`; identity drift forces a new plan. Global and
-directory install/update the shared Plugin and add one schema-v3 grant.
-Session-only verifies the release bundle, writes no grant, and returns only
-Read/Write Skills plus a signed opaque candidate receipt.
+Every available choice includes an authoritative `applyCommand` that is ready
+to execute unchanged. It pins the channel's portable CLI, provider, Team,
+canonical `--project-root` or `--pathless` identity, selected scope, exact
+`planId`, and non-interactive consent flag. An unavailable directory choice has
+`applyCommand: null`; human-readable output omits a command for that choice.
+
+The current agent displays the choices and waits for a new user reply, then
+runs only the selected choice's exact command. Apply must use the unchanged
+`planId`; identity drift forces a new plan. Global and directory install/update
+the shared Plugin and add one schema-v3 grant. Session-only verifies the
+release bundle, writes no grant, and returns only Read/Write Skills plus a
+signed opaque candidate receipt.
 
 Successful apply returns `currentSessionHandoff` schema v2. It contains
 immutable provider/project identity, `consumerKind: byo`, activation scope,


### PR DESCRIPTION
## Summary

- add a complete CLI-authored `applyCommand` to every available Context setup choice
- keep unavailable directory choices explicit with `applyCommand: null`
- render the exact command in human-readable plans as well as JSON
- pin non-development commands to the portable CLI path used by bootstrap

## Why

The setup agent should execute an authoritative command from the plan envelope instead of reconstructing `--scope`, `--plan-id`, and consent flags itself.

## Paired Context Tree update

- Draft Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/882
- The Tree PR remains draft until this source PR merges, then it will be reconciled against the merged implementation before being marked ready.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm --filter first-tree-dev test` (complete 24-batch CLI suite)
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/context-enable-command.test.ts`
- isolated reruns of unrelated full-suite timeout cases passed
