### PR TITLE
fix(cli): skip BYO context hook in managed sessions

### DIFF
--- a/apps/cli/src/__tests__/context-activate-command.test.ts
+++ b/apps/cli/src/__tests__/context-activate-command.test.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommandContext } from "../commands/types.js";
 
 const mocks = vi.hoisted(() => ({
@@ -28,17 +28,56 @@ function context(options: Record<string, unknown>): CommandContext {
   };
 }
 
+const stalePluginHealth = {
+  healthy: false,
+  issues: ["The installed Context Plugin payload differs from this release."],
+  install: { adapterDigest: "sha256:old" },
+  release: { manifest: { providers: { codex: { adapterDigest: "sha256:new" } } } },
+};
+
 describe("context activate command", () => {
-  it("keeps stale Plugin sessions usable and makes repair explicit-user-only", async () => {
-    mocks.inspectRuntime.mockReturnValue({
-      healthy: false,
-      issues: ["The installed Context Plugin payload differs from this release."],
-      install: { adapterDigest: "sha256:old" },
-      release: { manifest: { providers: { codex: { adapterDigest: "sha256:new" } } } },
-    });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("FIRST_TREE_AGENT_ID", "");
+    vi.stubEnv("FIRST_TREE_CHAT_ID", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("skips the external Context hook inside a managed First Tree agent session", async () => {
+    vi.stubEnv("FIRST_TREE_AGENT_ID", "agent-1");
+    vi.stubEnv("FIRST_TREE_CHAT_ID", "chat-1");
 
     await runContextActivate(context({ provider: "codex", releaseDigest: "sha256:old" }));
 
+    expect(mocks.inspectRuntime).not.toHaveBeenCalled();
+    expect(mocks.hook).toHaveBeenCalledWith({ continue: true });
+  });
+
+  it.each([
+    ["agent", "agent-1", ""],
+    ["chat", "", "chat-1"],
+  ])("keeps external activation enabled when only the managed %s marker is present", async (_marker, agentId, chatId) => {
+    vi.stubEnv("FIRST_TREE_AGENT_ID", agentId);
+    vi.stubEnv("FIRST_TREE_CHAT_ID", chatId);
+    mocks.inspectRuntime.mockReturnValue(stalePluginHealth);
+
+    await runContextActivate(context({ provider: "codex", releaseDigest: "sha256:old" }));
+
+    expect(mocks.inspectRuntime).toHaveBeenCalledOnce();
+    expect(mocks.hook.mock.calls[0]?.[0]).toMatchObject({
+      hookSpecificOutput: { hookEventName: "SessionStart" },
+    });
+  });
+
+  it("keeps stale Plugin sessions usable and makes repair explicit-user-only", async () => {
+    mocks.inspectRuntime.mockReturnValue(stalePluginHealth);
+
+    await runContextActivate(context({ provider: "codex", releaseDigest: "sha256:old" }));
+
+    expect(mocks.inspectRuntime).toHaveBeenCalledOnce();
     expect(mocks.hook).toHaveBeenCalledOnce();
     const response = mocks.hook.mock.calls[0]?.[0];
     expect(response).toMatchObject({

--- a/apps/cli/src/commands/context/activate.ts
+++ b/apps/cli/src/commands/context/activate.ts
@@ -30,6 +30,10 @@ function configure(command: Command): void {
 
 export async function runContextActivate(context: CommandContext): Promise<void> {
   try {
+    if (isManagedFirstTreeAgentSession(process.env)) {
+      print.hook({ continue: true });
+      return;
+    }
     const options = context.command.opts<ActivateOptions>();
     const provider = parseContextProvider(options.provider ?? "");
     const health = inspectContextIntegrationRuntime(createContextIntegrationDriver(provider));
@@ -91,6 +95,11 @@ export async function runContextActivate(context: CommandContext): Promise<void>
       }. Ordinary provider work can continue.`,
     });
   }
+}
+
+/** Managed providers can still discover the user's BYO Plugin; never let its hook override the managed briefing. */
+function isManagedFirstTreeAgentSession(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(env.FIRST_TREE_AGENT_ID?.trim()) && Boolean(env.FIRST_TREE_CHAT_ID?.trim());
 }
 
 export const contextActivateCommand: SubcommandModule = {


### PR DESCRIPTION
## Summary

- detect First Tree-managed agent sessions before external Context Plugin health checks or activation
- return a silent `continue` response so the user-scoped BYO SessionStart hook cannot override the managed agent briefing
- preserve external BYO activation unless both managed runtime markers are present

## Why

Managed Codex and Claude Code processes can still discover a user's globally installed `first-tree-context` plugin. The plugin's SessionStart hook previously injected `consumerKind: byo` into an already managed First Tree agent session, causing managed Context Tree writes to incorrectly request the BYO-only second human confirmation.

## Validation

- `pnpm --filter first-tree-dev exec vitest run src/__tests__/context-activate-command.test.ts src/__tests__/context-activation.test.ts --maxWorkers=2` (8 tests passed)
- `pnpm --filter first-tree-dev typecheck`
- `pnpm exec biome check apps/cli/src/commands/context/activate.ts apps/cli/src/__tests__/context-activate-command.test.ts`
- `pnpm --filter first-tree-dev... build`
- built CLI smoke: managed environment returns only `{"continue":true}`; external environment still returns `additionalContext`
- `git diff --check`
