### PR TITLE
fix(web): reuse template responsibility labels

### DIFF
--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -163,6 +163,9 @@ vi.mock("../pages/agent-detail.js", async () => {
   };
 });
 vi.mock("../pages/agent-detail/profile-tab.js", () => ({ ProfileTab: () => <div>profile tab</div> }));
+vi.mock("../pages/agent-detail/responsibilities-tab.js", () => ({
+  ResponsibilitiesTab: () => <div>responsibilities tab</div>,
+}));
 vi.mock("../pages/agent-detail/runtime-tab.js", () => ({ RuntimeTab: () => <div>runtime tab</div> }));
 vi.mock("../pages/agent-detail/prompt-tab.js", () => ({ PromptTab: () => <div>prompt tab</div> }));
 vi.mock("../pages/agent-detail/resources-tab.js", () => ({ ResourcesTab: () => <div>resources tab</div> }));
@@ -353,6 +356,9 @@ describe("App routes", () => {
     await resetRenderedApp();
 
     expect(await renderAppAt("/agents/agent-1/usage")).toContain("usage tab");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/agents/agent-1/responsibilities")).toContain("responsibilities tab");
     await resetRenderedApp();
 
     expect(await renderAppAt("/agents/agent-1/runtime")).toContain("runtime tab");

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -14,6 +14,7 @@ import { ProfileTab } from "./pages/agent-detail/profile-tab.js";
 import { PromptTab } from "./pages/agent-detail/prompt-tab.js";
 import { RepositoriesTab } from "./pages/agent-detail/repositories-tab.js";
 import { ResourcesTab } from "./pages/agent-detail/resources-tab.js";
+import { ResponsibilitiesTab } from "./pages/agent-detail/responsibilities-tab.js";
 import { RuntimeTab } from "./pages/agent-detail/runtime-tab.js";
 import { UsageTab } from "./pages/agent-detail/usage-tab.js";
 import { AgentDetailPage } from "./pages/agent-detail.js";
@@ -470,13 +471,14 @@ export function App() {
                   <Route path="agents/:uuid" element={<AgentDetailPage />}>
                     <Route index element={<Navigate to="profile" replace />} />
                     <Route path="profile" element={<ProfileTab />} />
-                    <Route path="usage" element={<UsageTab />} />
+                    <Route path="responsibilities" element={<ResponsibilitiesTab />} />
                     <Route path="runtime" element={<RuntimeTab />} />
                     <Route path="setup" element={<Navigate to="../runtime" replace />} />
                     <Route path="prompt" element={<PromptTab />} />
                     <Route path="tools" element={<Navigate to="../profile" replace />} />
                     <Route path="capabilities" element={<ResourcesTab />} />
                     <Route path="repositories" element={<RepositoriesTab />} />
+                    <Route path="usage" element={<UsageTab />} />
                     {/* Legacy deep links: the tab was renamed Resources → Capabilities. */}
                     <Route path="resources" element={<Navigate to="../capabilities" replace />} />
                   </Route>

--- a/packages/web/src/components/__tests__/new-agent-dialog-initial-template.test.tsx
+++ b/packages/web/src/components/__tests__/new-agent-dialog-initial-template.test.tsx
@@ -271,12 +271,12 @@ describe("NewAgentDialog initial Template", () => {
     );
     await renderHarness("pr-engineer");
     // Catalog still pending — nothing preselected yet, no crash.
-    expect(document.body.textContent).not.toContain("Tagline of PR Engineer");
+    expect(document.body.textContent).not.toContain("Purpose of PR Engineer");
 
     await act(async () => {
       resolveCatalog({ templates: [TEMPLATE_A, TEMPLATE_B] });
     });
-    await waitForText("Tagline of PR Engineer");
+    await waitForText("Purpose of PR Engineer");
 
     await fillNameAndSubmit("Build Bot");
     await waitForCondition(() => agentMocks.createAgent.mock.calls.length === 1, "create not called");
@@ -317,7 +317,7 @@ describe("NewAgentDialog initial Template", () => {
     await act(async () => {
       resolveCatalog({ templates: [TEMPLATE_A, TEMPLATE_B] });
     });
-    await waitForText("Tagline of PR Engineer");
+    await waitForText("Purpose of PR Engineer");
     expect(buttonByText("Create").disabled).toBe(false);
   });
 
@@ -345,7 +345,7 @@ describe("NewAgentDialog initial Template", () => {
     });
     await flush();
     await flush();
-    expect(document.body.textContent).not.toContain("Tagline of PR Engineer");
+    expect(document.body.textContent).not.toContain("Purpose of PR Engineer");
     expect(document.body.textContent).not.toContain("Resolving your template…");
   });
 
@@ -364,7 +364,7 @@ describe("NewAgentDialog initial Template", () => {
   it("never re-applies the intent after the user removes it", async () => {
     templateMocks.listAgentTemplates.mockResolvedValue({ templates: [TEMPLATE_A, TEMPLATE_B] });
     await renderHarness("pr-engineer");
-    await waitForText("Tagline of PR Engineer");
+    await waitForText("Purpose of PR Engineer");
 
     await click(buttonByText("Remove"));
     expect(document.body.textContent).toContain("Choose a template");
@@ -372,7 +372,7 @@ describe("NewAgentDialog initial Template", () => {
     await flush();
     await flush();
     expect(document.body.textContent).toContain("Choose a template");
-    expect(document.body.textContent).not.toContain("Tagline of PR Engineer");
+    expect(document.body.textContent).not.toContain("Purpose of PR Engineer");
   });
 
   it("degrades safely when the intent slug is no longer an active template", async () => {
@@ -390,7 +390,7 @@ describe("NewAgentDialog initial Template", () => {
   it("does not leak the previous intent into a later ordinary open", async () => {
     templateMocks.listAgentTemplates.mockResolvedValue({ templates: [TEMPLATE_A, TEMPLATE_B] });
     await renderHarness("pr-engineer");
-    await waitForText("Tagline of PR Engineer");
+    await waitForText("Purpose of PR Engineer");
 
     // Close, drop the intent prop, reopen — an ordinary open starts clean.
     await click(buttonByText("harness-close"));
@@ -403,14 +403,14 @@ describe("NewAgentDialog initial Template", () => {
     );
     await flush();
     expect(document.body.textContent).toContain("Choose a template");
-    expect(document.body.textContent).not.toContain("Tagline of PR Engineer");
+    expect(document.body.textContent).not.toContain("Purpose of PR Engineer");
   });
 
   it("never preselects from the previous open's catalog when the template retired between opens", async () => {
     // First open: the slug is active and preselected.
     templateMocks.listAgentTemplates.mockResolvedValueOnce({ templates: [TEMPLATE_A, TEMPLATE_B] });
     await renderHarness("pr-engineer");
-    await waitForText("Tagline of PR Engineer");
+    await waitForText("Purpose of PR Engineer");
 
     // Close, then reopen with the SAME intent slug — but the Template has
     // since retired, so the fresh catalog no longer carries it.
@@ -418,7 +418,7 @@ describe("NewAgentDialog initial Template", () => {
     await click(buttonByText("harness-close"));
     await click(buttonByText("harness-open"));
     await waitForText("no longer available");
-    expect(document.body.textContent).not.toContain("Tagline of PR Engineer");
+    expect(document.body.textContent).not.toContain("Purpose of PR Engineer");
 
     // Submission must not contain the stale id.
     await fillNameAndSubmit("Build Bot");
@@ -451,6 +451,6 @@ describe("NewAgentDialog initial Template", () => {
     await flush();
     // Still the second open's catalog: no PR Engineer preselect, notice kept.
     expect(document.body.textContent).toContain("no longer available");
-    expect(document.body.textContent).not.toContain("Tagline of PR Engineer");
+    expect(document.body.textContent).not.toContain("Purpose of PR Engineer");
   });
 });

--- a/packages/web/src/components/__tests__/new-agent-dialog-templates.test.tsx
+++ b/packages/web/src/components/__tests__/new-agent-dialog-templates.test.tsx
@@ -276,18 +276,25 @@ describe("NewAgentDialog template responsibilities", () => {
     await renderDialog();
     await fillNameAndOpenPicker("Build Bot");
     await waitForText("PR Engineer");
+    const pickerLabel = [...document.body.querySelectorAll('[data-slot="template-responsibility-label"]')].find((el) =>
+      el.textContent?.includes("PR Engineer"),
+    );
+    expect(pickerLabel?.textContent).toBe(
+      "PR EngineerActivePurpose of PR EngineerValue of PR EngineerTools of PR Engineer",
+    );
     await click(optionCardByText("PR Engineer"));
 
     // Draft intact: name, visibility, computer, runtime untouched by selection.
     const nameInput = document.body.querySelector<HTMLInputElement>("#new-agent-display-name");
     expect(nameInput?.value).toBe("Build Bot");
-    // The selected card shows the complete safe summary: purpose, audience,
-    // value, and capabilities.
-    expect(document.body.textContent).toContain("Tagline of PR Engineer");
-    expect(document.body.textContent).toContain("Purpose of PR Engineer");
-    expect(document.body.textContent).toContain("For Users of PR Engineer");
-    expect(document.body.textContent).toContain("Value of PR Engineer");
-    expect(document.body.textContent).toContain("Tools of PR Engineer");
+    // Picker and selection use the same compact responsibility label. The
+    // catalog-only tagline and audience are not repeated in this Team flow.
+    const selectedLabel = [...document.body.querySelectorAll('[data-slot="template-responsibility-label"]')].find(
+      (el) => el.textContent?.includes("PR Engineer"),
+    );
+    expect(selectedLabel?.textContent).toBe(pickerLabel?.textContent);
+    expect(document.body.textContent).not.toContain("Tagline of PR Engineer");
+    expect(document.body.textContent).not.toContain("Users of PR Engineer");
 
     await click(buttonByText("Create"));
     await waitForCondition(() => agentMocks.createAgent.mock.calls.length === 1, "create not called");

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -26,6 +26,7 @@ import {
 import { useCopyFeedback } from "../lib/use-copy-feedback.js";
 import { runVisibilityAwareInterval } from "../lib/visibility-interval.js";
 import { slugify } from "../utils/agent-naming.js";
+import { activeTemplateResponsibilityLabel, TemplateResponsibilityLabel } from "./template-responsibility-label.js";
 import { Button } from "./ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog.js";
 import { Input } from "./ui/input.js";
@@ -935,21 +936,11 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
                 </div>
               )}
               {selectedTemplates.map((template) => (
-                <div
-                  key={template.id}
-                  className="rounded-[var(--radius-panel)] border border-border px-3 py-2 space-y-1"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="text-body font-medium">{template.name}</div>
-                    <Button type="button" variant="ghost" size="sm" onClick={() => toggleTemplate(template)}>
-                      Remove
-                    </Button>
-                  </div>
-                  <div className="text-caption text-muted-foreground">{template.public.tagline}</div>
-                  <div className="text-caption text-muted-foreground">{template.public.purpose}</div>
-                  <div className="text-caption text-muted-foreground">For {template.public.targetUsers}</div>
-                  <div className="text-caption text-muted-foreground">{template.public.userValue}</div>
-                  <div className="text-caption text-muted-foreground">{template.public.toolsAndSkillsSummary}</div>
+                <div key={template.id} className="flex items-start justify-between gap-2">
+                  <TemplateResponsibilityLabel template={activeTemplateResponsibilityLabel(template)} />
+                  <Button type="button" variant="ghost" size="sm" onClick={() => toggleTemplate(template)}>
+                    Remove
+                  </Button>
                 </div>
               ))}
               {selectedTemplates.length > 0 &&
@@ -977,11 +968,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
                         setTemplatePickerOpen(false);
                       }}
                     >
-                      <div className="flex-1 min-w-0">
-                        <div className="text-body font-medium">{template.name}</div>
-                        <div className="text-caption text-muted-foreground">{template.public.tagline}</div>
-                        <div className="text-caption text-muted-foreground">{template.public.purpose}</div>
-                      </div>
+                      <TemplateResponsibilityLabel template={activeTemplateResponsibilityLabel(template)} />
                     </OptionCard>
                   ))}
                 </div>

--- a/packages/web/src/components/template-responsibility-label.tsx
+++ b/packages/web/src/components/template-responsibility-label.tsx
@@ -1,0 +1,63 @@
+import type {
+  AgentTemplateAdoptionSummary,
+  AgentTemplatePublicProfile,
+  AgentTemplatePublicTemplate,
+} from "@first-tree/shared";
+import type { ReactElement } from "react";
+import { DenseBadge } from "./ui/dense-badge.js";
+
+export type TemplateResponsibilityLabelData = {
+  name: string | null;
+  status: AgentTemplateAdoptionSummary["status"];
+  public: AgentTemplatePublicProfile | null;
+  replacement: { name: string } | null;
+};
+
+/**
+ * New Agent reads the active-only public catalog, while Agent Detail may also
+ * receive retired or missing adoption summaries. Normalize the catalog shape
+ * explicitly at this boundary so the presentational label stays shared without
+ * weakening either surface's lifecycle contract.
+ */
+export function activeTemplateResponsibilityLabel(
+  template: AgentTemplatePublicTemplate,
+): TemplateResponsibilityLabelData {
+  return {
+    name: template.name,
+    status: "active",
+    public: template.public,
+    replacement: null,
+  };
+}
+
+/**
+ * Compact, public-safe responsibility label shared by Agent Detail and agent
+ * creation surfaces. It deliberately omits the catalog tagline and audience:
+ * purpose, user value, and capability summary are the responsibility signal.
+ */
+export function TemplateResponsibilityLabel({ template }: { template: TemplateResponsibilityLabelData }): ReactElement {
+  return (
+    <div className="flex-1 min-w-0 space-y-0.5" data-slot="template-responsibility-label">
+      <div className="flex items-baseline gap-2 min-w-0">
+        <span className="text-body font-medium truncate">{template.name ?? "Unavailable template"}</span>
+        <TemplateStatusBadge status={template.status} />
+        {template.status === "retired" && template.replacement && (
+          <span className="text-caption text-muted-foreground truncate">Try {template.replacement.name}</span>
+        )}
+      </div>
+      {template.public && (
+        <div className="text-caption text-muted-foreground">
+          <div className="truncate">{template.public.purpose}</div>
+          <div className="truncate">{template.public.userValue}</div>
+          <div className="truncate">{template.public.toolsAndSkillsSummary}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TemplateStatusBadge({ status }: { status: AgentTemplateAdoptionSummary["status"] }) {
+  if (status === "active") return <DenseBadge>Active</DenseBadge>;
+  if (status === "retired") return <DenseBadge>Retired</DenseBadge>;
+  return <DenseBadge>Unavailable</DenseBadge>;
+}

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -982,6 +982,7 @@ describe("page SSR smoke coverage", () => {
     const { ProfileTab } = await import("../agent-detail/profile-tab.js");
     const { PromptTab } = await import("../agent-detail/prompt-tab.js");
     const { RepositoriesTab } = await import("../agent-detail/repositories-tab.js");
+    const { ResponsibilitiesTab } = await import("../agent-detail/responsibilities-tab.js");
     const { ResourcesTab } = await import("../agent-detail/resources-tab.js");
     const { RuntimeTab } = await import("../agent-detail/runtime-tab.js");
 
@@ -989,6 +990,7 @@ describe("page SSR smoke coverage", () => {
       <Routes>
         <Route path="/agents/:uuid" element={<AgentDetailPage />}>
           <Route path="profile" element={<ProfileTab />} />
+          <Route path="responsibilities" element={<ResponsibilitiesTab />} />
           <Route path="runtime" element={<RuntimeTab />} />
           <Route path="prompt" element={<PromptTab />} />
           <Route path="resources" element={<ResourcesTab />} />
@@ -1004,6 +1006,7 @@ describe("page SSR smoke coverage", () => {
     for (const [route, expected] of [
       // IA recut: runtime shows model/effort/execution/env; repos + context tree
       // moved to their own Repositories tab; Tools & skills lists only skills + MCP.
+      ["/agents/agent-1/responsibilities", "No template responsibilities are assigned to this agent."],
       ["/agents/agent-1/runtime", "Reasoning effort"],
       ["/agents/agent-1/repositories", "Team web"],
       ["/agents/agent-1/prompt", "Instructions"],
@@ -1014,6 +1017,7 @@ describe("page SSR smoke coverage", () => {
           <Routes>
             <Route path="/agents/:uuid" element={<AgentDetailPage />}>
               <Route path="profile" element={<ProfileTab />} />
+              <Route path="responsibilities" element={<ResponsibilitiesTab />} />
               <Route path="runtime" element={<RuntimeTab />} />
               <Route path="prompt" element={<PromptTab />} />
               <Route path="resources" element={<ResourcesTab />} />

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -39,7 +39,6 @@ import { AgentSwitcherStrip } from "./agent-detail/agent-switcher-strip.js";
 import { useAgentResources } from "./agent-detail/capability-section.js";
 import { ContextBar } from "./agent-detail/context-bar.js";
 import type { AgentDetailContext, RuntimeSwitchClaimView } from "./agent-detail/layout-context.js";
-import { ResponsibilitiesSection } from "./agent-detail/responsibilities-section.js";
 import { buildTabs, type TabDef } from "./agent-detail/tabs.js";
 import { useAgentConfigSave } from "./agent-detail/use-agent-config-save.js";
 import { useLegacyAnchorRedirect } from "./agent-detail/use-legacy-anchor-redirect.js";
@@ -115,12 +114,13 @@ function AgentDetailPageView() {
     refetchInterval: 30_000,
   });
 
-  // Shared agent-resources cache (skills / MCP / repos). Fetched here so the
-  // Tools & skills badge shows its effective count on first paint — the badge's
-  // whole point is "tell me there's something in here before I click". One light
-  // query in the same tier as agent-config / client-status; the Tools & skills
-  // and Environment tabs then read+write this same ["agent-resources", uuid]
-  // cache, so their useAgentResources calls become cache hits.
+  // Shared agent-resources cache (Templates / skills / MCP / repos). Fetched
+  // here so the Tools & skills badge shows its effective count on first paint —
+  // the badge's whole point is "tell me there's something in here before I
+  // click". One light query in the same tier as agent-config / client-status;
+  // Responsibilities, Tools & skills, and Repositories then read+write this same
+  // ["agent-resources", uuid] cache, so their useAgentResources calls become
+  // cache hits.
   const toolsResources = useAgentResources(uuid, { enabled: !!uuid && agentQuery.data?.type !== "human" });
 
   // Immediate-save controller for model / reasoning effort / env. Lives in the
@@ -521,27 +521,6 @@ function AgentDetailPageView() {
           runtimeState={agent.runtimeState}
           visible={contextBarVisible}
         />
-      )}
-
-      {!isHuman && toolsResources.data && (
-        <div
-          style={{
-            padding: "var(--sp-3_5) var(--sp-5) 0",
-            maxWidth: "var(--agent-detail-rail)",
-            marginLeft: "auto",
-            marginRight: "auto",
-            width: "100%",
-          }}
-        >
-          <ResponsibilitiesSection
-            agentUuid={agent.uuid}
-            agentStatus={agent.status}
-            canManage={canEditConfig}
-            templateIds={toolsResources.data.templateIds}
-            adoptedTemplates={toolsResources.data.adoptedTemplates}
-            version={toolsResources.data.version}
-          />
-        </div>
       )}
 
       <TabsNav tabs={tabs} agentUuid={uuid} currentTabKey={currentTabKey} badges={tabBadges} />

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -928,9 +928,18 @@ describe("agent detail pure helpers", () => {
     expect(canEditConfigFor(agent(), "member-self", "member")).toBe(true);
     expect(canEditConfigFor(agent({ type: "human", clientId: null }), "member-self", "admin")).toBe(false);
     expect(resolveTabPath(agent({ type: "human", clientId: null }), "member-self", "admin", "usage")).toBe("profile");
+    expect(resolveTabPath(agent({ type: "human", clientId: null }), "member-self", "admin", "responsibilities")).toBe(
+      "profile",
+    );
     expect(resolveTabPath(agent(), "member-other", "member", "usage")).toBe("usage");
+    expect(resolveTabPath(agent(), "member-other", "member", "responsibilities")).toBe("responsibilities");
     expect(resolveTabPath(agent(), "member-other", "member", "runtime")).toBe("profile");
-    expect(buildTabs(false, false).map((tab) => tab.path)).toEqual(["profile", "capabilities", "usage"]);
+    expect(buildTabs(false, false).map((tab) => tab.path)).toEqual([
+      "profile",
+      "responsibilities",
+      "capabilities",
+      "usage",
+    ]);
 
     expect(isBindableClient({ status: "connected" })).toBe(true);
     expect(isBindableClient({ status: "retired" })).toBe(false);

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HubClient } from "../../../api/activity.js";
 import { ApiError } from "../../../api/client.js";
 import { ToastProvider } from "../../../components/ui/toast.js";
+import { ResponsibilitiesTab } from "../responsibilities-tab.js";
 import { UsageTab } from "../usage-tab.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -179,7 +180,7 @@ function agentResources(overrides: Partial<AgentResourcesOutput> = {}): AgentRes
   return {
     version: overrides.version ?? 7,
     templateIds: overrides.templateIds ?? [],
-    adoptedTemplates: [],
+    adoptedTemplates: overrides.adoptedTemplates ?? [],
     effective: overrides.effective ?? {
       version: overrides.version ?? 7,
       repos: [],
@@ -200,6 +201,24 @@ function agentResources(overrides: Partial<AgentResourcesOutput> = {}): AgentRes
       },
     ],
     availableTeamResources: overrides.availableTeamResources ?? [],
+  };
+}
+
+function adoptedTemplate(): AgentResourcesOutput["adoptedTemplates"][number] {
+  return {
+    id: "0190f000-0000-7000-8000-000000000001",
+    slug: "pr-engineer",
+    name: "PR Engineer",
+    status: "active",
+    public: {
+      tagline: "Ship review-ready pull requests",
+      purpose: "Review and implement focused changes",
+      targetUsers: "Software teams",
+      userValue: "Move pull requests forward safely",
+      instructionsSummary: "Review, implement, and verify",
+      toolsAndSkillsSummary: "Code review and repository tools",
+    },
+    replacement: null,
   };
 }
 
@@ -306,6 +325,7 @@ async function renderDom(route: string, child: ReactElement): Promise<{ containe
             <Routes>
               <Route path="/agents/:uuid" element={<AgentDetailPage />}>
                 <Route path="profile" element={child} />
+                <Route path="responsibilities" element={<ResponsibilitiesTab />} />
                 <Route path="prompt" element={child} />
                 <Route path="resources" element={<div>Resources route</div>} />
                 <Route path="runtime" element={child} />
@@ -458,6 +478,73 @@ afterEach(() => {
 });
 
 describe("AgentDetailPage", () => {
+  it("keeps Responsibilities out of Profile and renders the same section in its own tab", async () => {
+    const { ProfileTab } = await import("../profile-tab.js");
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        templateIds: [adoptedTemplate().id],
+        adoptedTemplates: [adoptedTemplate()],
+      }),
+    );
+
+    const profile = await renderDom("/agents/agent-1/profile", <ProfileTab />);
+    await waitForText(profile.container, "Identity");
+    expect(profile.container.textContent).not.toContain("PR Engineer");
+    expect([...profile.container.querySelectorAll("h2")].map((heading) => heading.textContent?.trim())).not.toContain(
+      "Responsibilities",
+    );
+    const profileTabList = profile.container.querySelector('[role="tablist"]');
+    expect(profileTabList?.parentElement?.previousElementSibling?.getAttribute("aria-hidden")).toBe("true");
+    expect([...profile.container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toEqual([
+      "Profile",
+      "Responsibilities",
+      "Runtime",
+      "Instructions",
+      "Tools & skills",
+      "Repositories",
+      "Usage",
+    ]);
+    await act(async () => profile.root.unmount());
+
+    const responsibilities = await renderDom("/agents/agent-1/responsibilities", <ProfileTab />);
+    await waitForText(responsibilities.container, "PR Engineer");
+    expect(responsibilities.container.querySelectorAll('[data-slot="template-responsibility-label"]')).toHaveLength(1);
+    expect(responsibilities.container.textContent).toContain("Edit responsibilities");
+    await act(async () => responsibilities.root.unmount());
+  });
+
+  it("keeps Responsibilities visible and read-only for a non-editor", async () => {
+    authMock.value = { memberId: "member-other", role: "member", organizationId: "org-1" };
+    agentMocks.getAgent.mockResolvedValue(agent({ managerId: "member-owner" }));
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        templateIds: [adoptedTemplate().id],
+        adoptedTemplates: [adoptedTemplate()],
+      }),
+    );
+
+    const view = await renderDom("/agents/agent-1/responsibilities", <div>Profile route</div>);
+    await waitForText(view.container, "PR Engineer");
+    expect([...view.container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toEqual([
+      "Profile",
+      "Responsibilities",
+      "Tools & skills",
+      "Usage",
+    ]);
+    expect(view.container.textContent).not.toContain("Edit responsibilities");
+    await act(async () => view.root.unmount());
+  });
+
+  it("hides Responsibilities for a human and redirects its deep link to Profile", async () => {
+    agentMocks.getAgent.mockResolvedValue(agent({ type: "human", clientId: null }));
+
+    const view = await renderDom("/agents/agent-1/responsibilities", <div>Human Profile route</div>);
+    await waitForText(view.container, "Human Profile route");
+    expect(view.container.querySelector('[role="tablist"]')).toBeNull();
+    expect(view.container.textContent).not.toContain("Responsibilities");
+    await act(async () => view.root.unmount());
+  });
+
   it("renders prompt resource blocks and edits the custom prompt inline", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
     agentResourceMocks.getAgentResources.mockResolvedValue(
@@ -493,6 +580,7 @@ describe("AgentDetailPage", () => {
     expect(container.textContent).toContain("Chat");
     expect([...container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toEqual([
       "Profile",
+      "Responsibilities",
       "Runtime",
       "Instructions",
       "Tools & skills",

--- a/packages/web/src/pages/agent-detail/__tests__/responsibilities-section.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/responsibilities-section.test.tsx
@@ -215,6 +215,9 @@ describe("ResponsibilitiesSection", () => {
     expect(text).toContain("Retired");
     expect(text).toContain("Try Docs Writer");
     expect(text).toContain("Unavailable template");
+    const labels = document.body.querySelectorAll('[data-slot="template-responsibility-label"]');
+    expect(labels).toHaveLength(3);
+    expect(labels[0]?.textContent).toBe("PR EngineerActivepurposevaluetools");
   });
 
   it("hides the edit affordance for read-only members", async () => {
@@ -336,6 +339,9 @@ describe("ResponsibilitiesSection", () => {
     await renderSection({ templateIds: [TEMPLATE_A_ID], adoptedTemplates: [summary({ id: TEMPLATE_A_ID })] });
     await click(buttonByText("Edit responsibilities"));
     await waitForText("Docs Writer");
+    const editor = document.body.querySelector('[role="dialog"]');
+    expect(editor?.querySelector('[data-slot="template-responsibility-label"]')).toBeNull();
+    expect(editor?.textContent).toContain("Tagline of Docs Writer");
     await click(buttonByText("Add"));
     await click(buttonByText("Save"));
     await waitForCondition(() => templateMocks.updateAgentTemplates.mock.calls.length === 1, "save not called");

--- a/packages/web/src/pages/agent-detail/__tests__/tabs.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/tabs.test.ts
@@ -2,11 +2,20 @@ import { describe, expect, it } from "vitest";
 import { buildTabs, tabKeysFor } from "../tabs.js";
 
 describe("agent-detail tabs", () => {
-  it("gives an editor the engine-first 6-tab set with Repositories inserted before Usage", () => {
+  it("gives an editor the 7-tab set with Responsibilities after Profile", () => {
     const tabs = buildTabs(true, false);
-    expect(tabs.map((t) => t.key)).toEqual(["profile", "runtime", "prompt", "capabilities", "repositories", "usage"]);
+    expect(tabs.map((t) => t.key)).toEqual([
+      "profile",
+      "responsibilities",
+      "runtime",
+      "prompt",
+      "capabilities",
+      "repositories",
+      "usage",
+    ]);
     expect(tabs.map((t) => t.label)).toEqual([
       "Profile",
+      "Responsibilities",
       "Runtime",
       "Instructions",
       "Tools & skills",
@@ -22,10 +31,15 @@ describe("agent-detail tabs", () => {
     expect(runtime?.label).toBe("Runtime");
   });
 
-  it("keeps Repositories (and Runtime) editor-only for non-editor agents", () => {
-    // Non-editor, non-human: only Profile / Tools & skills / Usage — no runtime,
-    // no repositories (repos + context tree were never visible to non-editors).
-    expect(tabKeysFor(false, false).map((t) => t.key)).toEqual(["profile", "capabilities", "usage"]);
+  it("shows Responsibilities read-only while keeping Repositories and Runtime editor-only", () => {
+    // Non-editor, non-human: Responsibilities remains visible, while runtime
+    // and repositories keep their existing manager-only visibility.
+    expect(tabKeysFor(false, false).map((t) => t.key)).toEqual([
+      "profile",
+      "responsibilities",
+      "capabilities",
+      "usage",
+    ]);
   });
 
   it("gives a human agent only Profile", () => {

--- a/packages/web/src/pages/agent-detail/responsibilities-section.tsx
+++ b/packages/web/src/pages/agent-detail/responsibilities-section.tsx
@@ -24,8 +24,8 @@ import { Section } from "../../components/ui/section.js";
 import { agentResourcesMutationHandlers } from "./capability-section.js";
 
 /**
- * Responsibilities — the compact card between identity and the config tabs.
- * Shows the agent's adopted official Templates (0-3) with public-safe
+ * Responsibilities — the content of the dedicated Agent Detail tab. Shows
+ * the agent's adopted official Templates (0-3) with public-safe
  * summaries only. Managers of an ACTIVE agent edit via the full replace-set
  * PATCH; everyone else sees the same card read-only. Saved changes apply
  * before the agent's next action — there is no current/next version display

--- a/packages/web/src/pages/agent-detail/responsibilities-section.tsx
+++ b/packages/web/src/pages/agent-detail/responsibilities-section.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { trackEvent } from "../../analytics.js";
 import { listAgentTemplates, updateAgentTemplates } from "../../api/agent-templates.js";
 import { ApiError } from "../../api/client.js";
+import { TemplateResponsibilityLabel } from "../../components/template-responsibility-label.js";
 import { Button } from "../../components/ui/button.js";
 import { DenseBadge } from "../../components/ui/dense-badge.js";
 import {
@@ -74,22 +75,7 @@ export function ResponsibilitiesSection({
       ) : (
         <div className="space-y-3">
           {ordered.map((summary) => (
-            <div key={summary.id} className="space-y-0.5">
-              <div className="flex items-baseline gap-2 min-w-0">
-                <span className="text-body font-medium truncate">{summary.name ?? "Unavailable template"}</span>
-                <TemplateStatusBadge status={summary.status} />
-                {summary.status === "retired" && summary.replacement && (
-                  <span className="text-caption text-muted-foreground truncate">Try {summary.replacement.name}</span>
-                )}
-              </div>
-              {summary.public && (
-                <div className="text-caption text-muted-foreground">
-                  <div className="truncate">{summary.public.purpose}</div>
-                  <div className="truncate">{summary.public.userValue}</div>
-                  <div className="truncate">{summary.public.toolsAndSkillsSummary}</div>
-                </div>
-              )}
-            </div>
+            <TemplateResponsibilityLabel key={summary.id} template={summary} />
           ))}
         </div>
       )}

--- a/packages/web/src/pages/agent-detail/responsibilities-tab.tsx
+++ b/packages/web/src/pages/agent-detail/responsibilities-tab.tsx
@@ -1,0 +1,36 @@
+import { Navigate } from "react-router";
+import { useAgentResources } from "./capability-section.js";
+import { useAgentDetailContext } from "./layout-context.js";
+import { ResponsibilitiesSection } from "./responsibilities-section.js";
+
+export function ResponsibilitiesTab() {
+  const ctx = useAgentDetailContext();
+  const resources = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && !ctx.isHuman });
+
+  if (ctx.isHuman) return <Navigate to="../profile" replace />;
+  if (resources.isLoading) {
+    return (
+      <p className="text-body" style={{ color: "var(--fg-3)" }}>
+        Loading responsibilities…
+      </p>
+    );
+  }
+  if (resources.error || !resources.data) {
+    return (
+      <p className="text-body" style={{ color: "var(--state-error)" }}>
+        {resources.error instanceof Error ? resources.error.message : "Failed to load responsibilities"}
+      </p>
+    );
+  }
+
+  return (
+    <ResponsibilitiesSection
+      agentUuid={ctx.agent.uuid}
+      agentStatus={ctx.agent.status}
+      canManage={ctx.canEditConfig}
+      templateIds={resources.data.templateIds}
+      adoptedTemplates={resources.data.adoptedTemplates}
+      version={resources.data.version}
+    />
+  );
+}

--- a/packages/web/src/pages/agent-detail/tabs.ts
+++ b/packages/web/src/pages/agent-detail/tabs.ts
@@ -4,10 +4,11 @@ import { canManageAgentDetail } from "./access.js";
 export type TabDef = { key: string; label: string; path: string };
 
 // IA labels only. Routing `path` and the `key` (deep-link mapping) are kept
-// stable so existing URLs keep resolving; only the `runtime` label changed
-// (Environment → Runtime) and `repositories` was added.
+// stable so existing URLs keep resolving. Responsibilities has its own stable
+// deep link alongside the previously added Runtime and Repositories routes.
 const TAB_LABELS: Record<string, string> = {
   profile: "Profile",
+  responsibilities: "Responsibilities",
   runtime: "Runtime",
   prompt: "Instructions",
   capabilities: "Tools & skills",
@@ -23,11 +24,15 @@ const TAB_LABELS: Record<string, string> = {
  */
 export function tabKeysFor(canEditConfig: boolean, isHuman: boolean): { key: string; path: string }[] {
   const tabs: { key: string; path: string }[] = [{ key: "profile", path: "profile" }];
+  if (!isHuman) {
+    tabs.push({ key: "responsibilities", path: "responsibilities" });
+  }
   if (canEditConfig) {
-    // engine-first: Runtime (model/effort/computer/env) before Instructions, then
-    // the two resource tabs. Repositories is editor-only — repos + the read-only
-    // context tree lived on the old (editor-only) Environment tab, so non-editors
-    // never saw them and still don't.
+    // Responsibility comes directly after identity, followed by Runtime
+    // (model/effort/computer/env), Instructions, then the two resource tabs.
+    // Repositories is editor-only — repos + the read-only context tree lived on
+    // the old (editor-only) Environment tab, so non-editors never saw them and
+    // still don't.
     tabs.push(
       { key: "runtime", path: "runtime" },
       { key: "prompt", path: "prompt" },


### PR DESCRIPTION
## Summary

- Extract Agent Detail's existing Template responsibility label into a shared Web component.
- Reuse that label in New Agent selected and picker states, removing duplicate catalog tagline and target-audience rows while preserving selection and creation behavior.
- Keep the persistent Agent Detail header focused on identity and status; expose adopted Templates in a dedicated `Responsibilities` tab after `Profile`, preserving read-only visibility, lifecycle labels, and the compact editor.

## Validation

- [x] `pnpm check` (exit 0; repository-existing warnings only)
- [x] `pnpm typecheck` — 11/11 tasks
- [x] Full Web tests — 240 files / 2104 tests
- [x] Focused Agent Detail routing and responsibility suites — 6 files / 67 tests
- [x] Independent `focused-local` QA at `8cb88eb15ec6134ba850223a3f83317668a86fcd` — PASS
- [x] GitHub CI for the revised head — all required checks passed

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- New Agent selection, removal, max-three, initial intent, submit snapshot, lifecycle, and `409` behavior are unchanged
- non-human non-managers retain read-only Responsibilities access; human agents hide the tab and stale direct links return to Profile
- stable layout and routing assertions live in Web product tests; no QA case-library change is planned
- independent QA used run-owned PostgreSQL/Server/Web/isolated Chrome and covered wide/390px placement, active/retired/missing labels, compact editor, direct routes, role visibility, agent switching, New Agent creation smoke, keyboard paths, and candidate-scope axe scans with zero violations
- durable Agent Detail IA is synchronized separately in draft Context Tree PR [first-tree-context#884](https://github.com/agent-team-foundation/first-tree-context/pull/884), which remains draft until this source PR merges
