### PR TITLE
fix(client): migrate legacy managed skill modes

### DIFF
--- a/packages/client/src/__tests__/managed-skills.test.ts
+++ b/packages/client/src/__tests__/managed-skills.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
   chmodSync,
   cpSync,
@@ -1745,6 +1746,193 @@ describe("managed Skill reconciler", () => {
     expect(existsSync(join(workspace, ".claude", "skills", "first-tree-read"))).toBe(false);
     expect(readManagedStateResult(workspace)).toMatchObject({ kind: "current" });
   });
+
+  it.skipIf(process.platform === "win32")(
+    "reprojects a v1-owned Core target with legacy npm write modes before publication",
+    async () => {
+      const skillName = "first-tree-read";
+      const bundledRoot = join(bundledSkillsRoot, skillName);
+      const bundledExecutable = join(bundledRoot, "run.sh");
+      writeFileSync(bundledExecutable, "#!/bin/sh\necho legacy\n");
+      chmodSync(bundledExecutable, 0o755);
+
+      const legacyTarget = target(workspace, "codex", skillName);
+      mkdirSync(dirname(legacyTarget), { recursive: true });
+      cpSync(bundledRoot, legacyTarget, { recursive: true });
+      chmodSync(legacyTarget, 0o775);
+      chmodSync(join(legacyTarget, "references"), 0o775);
+      chmodSync(join(legacyTarget, "SKILL.md"), 0o664);
+      chmodSync(join(legacyTarget, "VERSION"), 0o664);
+      chmodSync(join(legacyTarget, "references", "guide.md"), 0o664);
+      chmodSync(join(legacyTarget, "run.sh"), 0o775);
+      writeLegacyState(workspace, [skillName]);
+
+      const result = await reconcileManagedSkills({
+        workspace,
+        provider: "codex",
+        teamSnapshot: authoritativeTeamSkillSnapshot(1, []),
+        bundledSkillsRoot,
+      });
+
+      expect(result.ok, JSON.stringify(result.failures)).toBe(true);
+      expect(result.installed).toContain(`core:${skillName}`);
+      expect(lstatSync(legacyTarget).mode & 0o777).toBe(0o700);
+      expect(lstatSync(join(legacyTarget, "references")).mode & 0o777).toBe(0o700);
+      expect(lstatSync(join(legacyTarget, "SKILL.md")).mode & 0o777).toBe(0o600);
+      expect(lstatSync(join(legacyTarget, "VERSION")).mode & 0o777).toBe(0o600);
+      expect(lstatSync(join(legacyTarget, "references", "guide.md")).mode & 0o777).toBe(0o600);
+      expect(lstatSync(join(legacyTarget, "run.sh")).mode & 0o777).toBe(0o700);
+      expect(lstatSync(join(legacyTarget, ".first-tree-managed.json")).mode & 0o777).toBe(0o600);
+      expect(JSON.parse(readFileSync(join(legacyTarget, ".first-tree-managed.json"), "utf-8"))).toMatchObject({
+        key: `core:${skillName}`,
+      });
+      const state = readManagedState(workspace);
+      expect(state).not.toBeNull();
+      expect(state?.skills).toContainEqual(
+        expect.objectContaining({
+          key: `core:${skillName}`,
+          target: `.agents/skills/${skillName}`,
+        }),
+      );
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves an unowned unsafe Core-name target and reports its full managed path",
+    async () => {
+      const skillName = "first-tree-write";
+      const userTarget = target(workspace, "codex", skillName);
+      mkdirSync(userTarget, { recursive: true });
+      writeFileSync(join(userTarget, "SKILL.md"), "unowned same-name user Skill\n");
+      chmodSync(userTarget, 0o775);
+      chmodSync(join(userTarget, "SKILL.md"), 0o664);
+      writeLegacyState(workspace, []);
+
+      let thrown: unknown;
+      try {
+        await reconcileManagedSkills({
+          workspace,
+          provider: "codex",
+          teamSnapshot: authoritativeTeamSkillSnapshot(1, []),
+          bundledSkillsRoot,
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(ManagedSkillsUnsafeDiscoveryError);
+      expect(thrown).toMatchObject({
+        cause: expect.objectContaining({
+          message: expect.stringContaining(`Managed Skill target .agents/skills/${skillName}`),
+        }),
+      });
+      expect(readFileSync(join(userTarget, "SKILL.md"), "utf-8")).toBe("unowned same-name user Skill\n");
+      expect(lstatSync(userTarget).mode & 0o777).toBe(0o775);
+      expect(lstatSync(join(userTarget, "SKILL.md")).mode & 0o777).toBe(0o664);
+      expect(existsSync(join(userTarget, ".first-tree-managed.json"))).toBe(false);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "reprojects an unsafe exact-bundle Core target without marker, ledger entry, or pair",
+    async () => {
+      const skillName = "first-tree-seed";
+      const bundledRoot = join(bundledSkillsRoot, skillName);
+      const legacyTarget = target(workspace, "codex", skillName);
+      mkdirSync(dirname(legacyTarget), { recursive: true });
+      cpSync(bundledRoot, legacyTarget, { recursive: true });
+      chmodSync(legacyTarget, 0o775);
+      chmodSync(join(legacyTarget, "references"), 0o775);
+      chmodSync(join(legacyTarget, "SKILL.md"), 0o664);
+      chmodSync(join(legacyTarget, "VERSION"), 0o664);
+      chmodSync(join(legacyTarget, "references", "guide.md"), 0o664);
+      writeLegacyState(workspace, []);
+
+      const result = await reconcileManagedSkills({
+        workspace,
+        provider: "codex",
+        teamSnapshot: authoritativeTeamSkillSnapshot(1, []),
+        bundledSkillsRoot,
+      });
+
+      expect(result.ok, JSON.stringify(result.failures)).toBe(true);
+      expect(result.installed).toContain(`core:${skillName}`);
+      expect(lstatSync(legacyTarget).mode & 0o777).toBe(0o700);
+      expect(lstatSync(join(legacyTarget, "references")).mode & 0o777).toBe(0o700);
+      expect(lstatSync(join(legacyTarget, "SKILL.md")).mode & 0o777).toBe(0o600);
+      expect(lstatSync(join(legacyTarget, "VERSION")).mode & 0o777).toBe(0o600);
+      expect(lstatSync(join(legacyTarget, "references", "guide.md")).mode & 0o777).toBe(0o600);
+      expect(JSON.parse(readFileSync(join(legacyTarget, ".first-tree-managed.json"), "utf-8"))).toMatchObject({
+        key: `core:${skillName}`,
+      });
+    },
+  );
+
+  it("rejects a symlink inside a v1-owned Core target without mutating it", async () => {
+    const skillName = "first-tree-read";
+    const legacyTarget = target(workspace, "codex", skillName);
+    mkdirSync(dirname(legacyTarget), { recursive: true });
+    cpSync(join(bundledSkillsRoot, skillName), legacyTarget, { recursive: true });
+    const linkedGuide = join(legacyTarget, "references", "guide.md");
+    rmSync(linkedGuide);
+    symlinkSync("../SKILL.md", linkedGuide);
+    writeLegacyState(workspace, [skillName]);
+
+    let thrown: unknown;
+    try {
+      await reconcileManagedSkills({
+        workspace,
+        provider: "codex",
+        teamSnapshot: authoritativeTeamSkillSnapshot(1, []),
+        bundledSkillsRoot,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ManagedSkillsUnsafeDiscoveryError);
+    expect(thrown).toMatchObject({
+      cause: expect.objectContaining({
+        message: expect.stringContaining(`Managed Skill target .agents/skills/${skillName}`),
+      }),
+    });
+    expect(lstatSync(linkedGuide).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(legacyTarget, ".first-tree-managed.json"))).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a special file inside a v1-owned Core target without mutating it",
+    async () => {
+      const skillName = "first-tree-read";
+      const legacyTarget = target(workspace, "codex", skillName);
+      mkdirSync(dirname(legacyTarget), { recursive: true });
+      cpSync(join(bundledSkillsRoot, skillName), legacyTarget, { recursive: true });
+      const fifo = join(legacyTarget, "references", "legacy.fifo");
+      execFileSync("mkfifo", [fifo]);
+      writeLegacyState(workspace, [skillName]);
+
+      let thrown: unknown;
+      try {
+        await reconcileManagedSkills({
+          workspace,
+          provider: "codex",
+          teamSnapshot: authoritativeTeamSkillSnapshot(1, []),
+          bundledSkillsRoot,
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(ManagedSkillsUnsafeDiscoveryError);
+      expect(thrown).toMatchObject({
+        cause: expect.objectContaining({
+          message: expect.stringContaining(`Managed Skill target .agents/skills/${skillName}`),
+        }),
+      });
+      expect(lstatSync(fifo).isFIFO()).toBe(true);
+      expect(existsSync(join(legacyTarget, ".first-tree-managed.json"))).toBe(false);
+    },
+  );
 
   it("does not follow a legacy managed-name symlink outside the workspace", async () => {
     const outside = join(sandbox, "outside-user-skill");

--- a/packages/client/src/runtime/managed-skills.ts
+++ b/packages/client/src/runtime/managed-skills.ts
@@ -617,15 +617,27 @@ async function digestLegacyTargetIfOwned(
 ): Promise<`sha256:${string}` | null> {
   const marker = await readOwnershipMarker(workspace, target);
   if (marker?.key === key) {
-    return digestManagedTarget(workspace, target, { followExpectedLegacySymlink: true });
+    return digestManagedTarget(workspace, target, {
+      followExpectedLegacySymlink: true,
+      modePolicy: "normalize-bundled",
+    });
   }
-  const targetDigest = await digestManagedTarget(workspace, target, { followExpectedLegacySymlink: true });
+  const targetDigest = await digestManagedTarget(workspace, target, {
+    followExpectedLegacySymlink: true,
+    modePolicy: "normalize-bundled",
+  });
   if (!targetDigest) return null;
   if (ownershipProven) return targetDigest;
   const bundledDigest = bundledPath
     ? await digestDirectoryIfPresent(bundledPath, undefined, "normalize-bundled")
     : null;
-  return bundledDigest === targetDigest ? targetDigest : null;
+  if (bundledDigest === targetDigest) return targetDigest;
+
+  // Normalized mode comparison is only an ownership probe. If no ownership
+  // evidence matches, retain the ordinary strict digest gate so an unsafe
+  // same-name target cannot remain in provider discovery unnoticed.
+  await digestManagedTarget(workspace, target, { followExpectedLegacySymlink: true });
+  return null;
 }
 
 async function adoptLegacyResourceSkills(
@@ -1867,13 +1879,15 @@ async function digestManagedTarget(
   options?: Readonly<{
     followExpectedLegacySymlink?: boolean;
     modePlatform?: NodeJS.Platform;
+    modePolicy?: SkillTreeModePolicy;
   }>,
 ): Promise<`sha256:${string}` | null> {
   assertManagedTarget(target);
   const path = resolveWorkspacePath(workspace, target, "target");
+  const modePolicy = options?.modePolicy ?? "enforce-safe";
   try {
     const targetStat = await lstat(path);
-    if (targetStat.isDirectory()) return await digestDirectory(path, options?.modePlatform);
+    if (targetStat.isDirectory()) return await digestDirectory(path, options?.modePlatform, modePolicy);
     if (targetStat.isSymbolicLink() && options?.followExpectedLegacySymlink) {
       const linked = resolve(dirname(path), await readlink(path));
       const [workspaceRealPath, linkedRealPath] = await Promise.all([realpath(workspace), realpath(linked)]);
@@ -1882,12 +1896,13 @@ async function digestManagedTarget(
       }
       const linkedStat = await stat(linkedRealPath);
       if (!linkedStat.isDirectory()) return null;
-      return await digestDirectory(linkedRealPath, options?.modePlatform);
+      return await digestDirectory(linkedRealPath, options?.modePlatform, modePolicy);
     }
     return null;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw error;
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Managed Skill target ${target} cannot be digested: ${reason}`, { cause: error });
   }
 }
 


### PR DESCRIPTION
## Summary

- allow legacy Core Skill ownership probes to normalize npm/umask-derived modes without weakening ordinary reconciliation or publication verification
- preserve fail-closed behavior for unsafe unmatched targets and keep symlink/special-file rejection intact
- include the workspace-relative managed target in digest failures for actionable diagnostics
- reproject proven legacy targets through the existing quarantine, staging, journal, and atomic install flow

## Background

Older clients could materialize bundled Core Skills as `0775` directories and `0664` files under `UMask=0002`. The v1-to-v2 migration attempted a strict digest before ownership adoption, so provider startup could remain in `managed_skills_unsafe_discovery` retry indefinitely.

The compatibility policy is intentionally limited to the legacy Core ownership probe. Marker, v1 ledger/pair, and exact normalized bundled-content evidence remain the accepted ownership signals. A human decision during review kept exact-content adoption automatic for legacy targets; strict verification still quarantines the adopted unsafe target before provider publication.

## Safety boundaries

- ordinary managed target digesting still defaults to `enforce-safe`
- final publication verification remains strict
- unmatched unsafe same-name targets are preserved and fail closed
- internal symlinks and special files remain rejected
- no recursive in-place permission repair was added

## Verification

- `umask 0022; pnpm --filter @first-tree/client exec vitest run src/__tests__/managed-skills.test.ts --maxWorkers=2 --minWorkers=1` (109 passed)
- `pnpm --filter @first-tree/client typecheck`
- `pnpm exec biome check packages/client/src/runtime/managed-skills.ts packages/client/src/__tests__/managed-skills.test.ts`
- `git diff --check`

## Review

Independent First Tree chat review completed with no blocking findings before commit. The reviewer-requested exact-bundle/no-ledger regression was added and included in the final verification above.
