### PR TITLE
refactor: isolate runtime auth provider drivers

### DIFF
--- a/apps/cli/src/__tests__/runtime-auth-login-defaults.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login-defaults.test.ts
@@ -1,97 +1,101 @@
 import type { CapabilityEntry } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-describe("runRuntimeAuthLogin default dependencies", () => {
+/**
+ * The daemon must reach the Client's frozen `RUNTIME_AUTH_DRIVERS` when no
+ * registry is injected. Mocking that export (rather than each provider's
+ * resolver / login / probe) is what keeps this file provider-neutral: the
+ * dispatcher is only allowed to know a typed key and the driver contract.
+ */
+describe("runRuntimeAuthLogin default driver registry", () => {
   afterEach(() => {
     vi.doUnmock("@first-tree/client");
-    vi.doUnmock("@first-tree/shared");
     vi.resetModules();
   });
 
-  it("uses the default Codex resolver, browser login, and probe", async () => {
-    const resolveCodexRuntimeBinary = vi.fn(async () => ({
-      ok: true as const,
-      binary: "/opt/codex",
-      runtimeSource: "bundled" as const,
-      runtimePath: null,
-      version: "1.0.0",
-    }));
-    const runCodexBrowserLogin = vi.fn(async (options: { onAuthUrl?: (url: string) => void }) => {
-      options.onAuthUrl?.("https://auth.example/codex");
-      return { ok: false as const, reason: "timeout" as const, error: "" };
-    });
-    const probeCodexCapability = vi.fn(async () => ({
-      state: "ok" as const,
-      available: true,
-      detectedAt: "2026-06-22T12:00:00.000Z",
-    }));
+  async function loadWithDefaultDrivers(drivers: Record<string, unknown>) {
     vi.doMock("@first-tree/client", () => ({
       BROWSER_LOGIN_TIMEOUT_MS: 120_000,
-      probeClaudeCodeCapability: vi.fn(),
-      probeClaudeCodeTuiCapability: vi.fn(),
-      probeCodexCapability,
-      resolveClaudeLoginInvocation: vi.fn(),
-      resolveCodexRuntimeBinary,
-      runClaudeBrowserLogin: vi.fn(),
-      runCodexBrowserLogin,
+      redactErrorPreview: (input: string, maxLen: number) => input.slice(0, maxLen),
+      RUNTIME_AUTH_DRIVERS: drivers,
     }));
-    vi.doMock("@first-tree/shared", () => ({
-      isRuntimeProviderEnabled: vi.fn(() => false),
-    }));
-    const { runRuntimeAuthLogin } = await import("../core/runtime-auth-login.js");
-    const calls: Array<{ provider: string; entry: CapabilityEntry }> = [];
+    return await import("../core/runtime-auth-login.js");
+  }
 
-    await runRuntimeAuthLogin(
-      { provider: "codex", ref: "default-codex" },
-      {
-        currentEntry: () => undefined,
-        setProviderEntry: async (provider, entry) => {
-          calls.push({ provider, entry });
-        },
-        log: vi.fn(),
+  it("resolves each auth provider through the default table when deps omit one", async () => {
+    const resolved: string[] = [];
+    const build = (provider: string, logLabel: string, artifactLabel: string) => ({
+      logLabel,
+      loginLabel: `${logLabel} login`,
+      artifactLabel,
+      resolveLogin: async () => {
+        resolved.push(provider);
+        return {
+          ok: true as const,
+          login: async ({ onAuthUrl }: { onAuthUrl: (url: string) => void }) => {
+            onAuthUrl(`https://auth.example/${provider}`);
+            return { ok: false as const, reason: "timeout" as const, error: "" };
+          },
+        };
       },
-    );
-
-    expect(resolveCodexRuntimeBinary).toHaveBeenCalled();
-    expect(runCodexBrowserLogin).toHaveBeenCalledWith({ binary: "/opt/codex", onAuthUrl: expect.any(Function) });
-    expect(probeCodexCapability).toHaveBeenCalled();
-    expect(calls.map((call) => call.provider)).toEqual(["codex", "codex", "codex"]);
-    expect(calls[1]?.entry.pendingAuth?.authUrl).toBe("https://auth.example/codex");
-    expect(calls.at(-1)?.entry.lastAuthError).toEqual({
-      reason: "timeout",
-      at: expect.any(String),
+      reprobe: async () => [
+        { provider, entry: { state: "ok", available: true, detectedAt: "2026-06-22T12:00:00.000Z" } },
+      ],
     });
+
+    const { runRuntimeAuthLogin } = await loadWithDefaultDrivers({
+      "claude-code": build("claude-code", "claude", "CLI"),
+      codex: build("codex", "codex", "binary"),
+      cursor: build("cursor", "cursor", "binary"),
+      grok: build("grok", "grok", "binary"),
+    });
+
+    const calls: Array<{ provider: string; entry: CapabilityEntry }> = [];
+    for (const provider of ["claude-code", "codex", "cursor", "grok"] as const) {
+      await runRuntimeAuthLogin(
+        { provider, ref: `default-${provider}` },
+        {
+          currentEntry: () => undefined,
+          setProviderEntry: async (p, entry) => {
+            calls.push({ provider: p, entry });
+          },
+          log: vi.fn(),
+        },
+      );
+    }
+
+    expect(resolved).toEqual(["claude-code", "codex", "cursor", "grok"]);
+    // Every provider walks pending → authUrl → re-probe with a terminal marker.
+    for (const provider of ["claude-code", "codex", "cursor", "grok"]) {
+      const forProvider = calls.filter((c) => c.provider === provider);
+      expect(forProvider, provider).toHaveLength(3);
+      expect(forProvider[1]?.entry.pendingAuth?.authUrl, provider).toBe(`https://auth.example/${provider}`);
+      expect(forProvider.at(-1)?.entry.lastAuthError, provider).toEqual({
+        reason: "timeout",
+        at: expect.any(String),
+      });
+    }
   });
 
-  it("logs Error objects from the default Codex browser login", async () => {
-    vi.doMock("@first-tree/client", () => ({
-      BROWSER_LOGIN_TIMEOUT_MS: 120_000,
-      probeClaudeCodeCapability: vi.fn(),
-      probeClaudeCodeTuiCapability: vi.fn(),
-      probeCodexCapability: vi.fn(async () => ({
-        state: "ok",
-        available: true,
-        detectedAt: "2026-06-22T12:00:00.000Z",
-      })),
-      resolveClaudeLoginInvocation: vi.fn(),
-      resolveCodexRuntimeBinary: vi.fn(async () => ({
-        ok: true,
-        binary: "/opt/codex",
-        runtimeSource: "bundled",
-        runtimePath: null,
-        version: "1.0.0",
-      })),
-      runClaudeBrowserLogin: vi.fn(),
-      runCodexBrowserLogin: vi.fn(async () => {
-        throw new Error("browser boom");
-      }),
-    }));
-    vi.doMock("@first-tree/shared", () => ({
-      isRuntimeProviderEnabled: vi.fn(() => false),
-    }));
-    const { runRuntimeAuthLogin } = await import("../core/runtime-auth-login.js");
-    const logs: string[] = [];
+  it("logs a thrown login from the default table without throwing", async () => {
+    const { runRuntimeAuthLogin } = await loadWithDefaultDrivers({
+      codex: {
+        logLabel: "codex",
+        loginLabel: "codex login",
+        artifactLabel: "binary",
+        resolveLogin: async () => ({
+          ok: true as const,
+          login: async () => {
+            throw new Error("browser boom");
+          },
+        }),
+        reprobe: async () => [
+          { provider: "codex", entry: { state: "ok", available: true, detectedAt: "2026-06-22T12:00:00.000Z" } },
+        ],
+      },
+    });
 
+    const logs: string[] = [];
     await runRuntimeAuthLogin(
       { provider: "codex", ref: "default-codex-error" },
       {
@@ -104,69 +108,5 @@ describe("runRuntimeAuthLogin default dependencies", () => {
     );
 
     expect(logs).toContain("runtime-auth: codex login threw: browser boom");
-  });
-
-  it("re-probes Claude Code and TUI through default dependencies when TUI is enabled", async () => {
-    const resolveClaudeLoginInvocation = vi.fn(() => ({
-      ok: true as const,
-      command: "/usr/local/bin/claude",
-      baseArgs: ["auth", "login"],
-    }));
-    const runClaudeBrowserLogin = vi.fn(async (options: { onAuthUrl?: (url: string) => void }) => {
-      options.onAuthUrl?.("https://auth.example/claude");
-      return { ok: true as const };
-    });
-    const probeClaudeCodeCapability = vi.fn(async () => ({
-      state: "ok" as const,
-      available: true,
-      detectedAt: "2026-06-22T12:00:00.000Z",
-    }));
-    const probeClaudeCodeTuiCapability = vi.fn(async () => ({
-      state: "ok" as const,
-      available: true,
-      detectedAt: "2026-06-22T12:00:01.000Z",
-    }));
-    vi.doMock("@first-tree/client", () => ({
-      BROWSER_LOGIN_TIMEOUT_MS: 120_000,
-      probeClaudeCodeCapability,
-      probeClaudeCodeTuiCapability,
-      probeCodexCapability: vi.fn(),
-      resolveClaudeLoginInvocation,
-      resolveCodexRuntimeBinary: vi.fn(),
-      runClaudeBrowserLogin,
-      runCodexBrowserLogin: vi.fn(),
-    }));
-    vi.doMock("@first-tree/shared", () => ({
-      isRuntimeProviderEnabled: vi.fn((provider: string) => provider === "claude-code-tui"),
-    }));
-    const { runRuntimeAuthLogin } = await import("../core/runtime-auth-login.js");
-    const calls: Array<{ provider: string; entry: CapabilityEntry }> = [];
-
-    await runRuntimeAuthLogin(
-      { provider: "claude-code", ref: "default-claude" },
-      {
-        currentEntry: () => undefined,
-        setProviderEntry: async (provider, entry) => {
-          calls.push({ provider, entry });
-        },
-        log: vi.fn(),
-      },
-    );
-
-    expect(resolveClaudeLoginInvocation).toHaveBeenCalled();
-    expect(runClaudeBrowserLogin).toHaveBeenCalledWith({
-      command: "/usr/local/bin/claude",
-      baseArgs: ["auth", "login"],
-      onAuthUrl: expect.any(Function),
-    });
-    expect(probeClaudeCodeCapability).toHaveBeenCalled();
-    expect(probeClaudeCodeTuiCapability).toHaveBeenCalled();
-    expect(calls.map((call) => call.provider)).toEqual([
-      "claude-code",
-      "claude-code",
-      "claude-code",
-      "claude-code-tui",
-    ]);
-    expect(calls[1]?.entry.pendingAuth?.authUrl).toBe("https://auth.example/claude");
   });
 });

--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -465,19 +465,30 @@ describe("runRuntimeAuthLogin — published failure text is redacted and bounded
 
   it("caps a thrown error and an unresolved-artifact error too", async () => {
     const thrown = harness(
-      fakeDriver({ provider: "codex", throwLogin: new Error(`token=${"a".repeat(2_000)}`) }).driver,
+      fakeDriver({
+        provider: "codex",
+        throwLogin: new Error(`spawn failed with token=abcdef1234567890\n${LONG_DIAGNOSTIC_TAIL}`),
+      }).driver,
       "codex",
     );
     await runRuntimeAuthLogin({ provider: "codex", ref: "cap-throw" }, thrown.deps);
     const thrownMessage = thrown.calls.at(-1)?.entry.lastAuthError?.message ?? "";
-    expect(thrownMessage.length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN);
+    expect(thrownMessage).not.toContain("abcdef1234567890");
     expect(thrownMessage).toContain("[REDACTED]");
+    expect(thrownMessage.length).toBe(RUNTIME_AUTH_ERROR_MAX_LEN);
+    expect(thrownMessage.endsWith("…")).toBe(true);
 
     const unresolved = harness(
-      fakeDriver({ provider: "codex", resolveError: `no codex at https://svc:pw_abcdef@registry.example/x` }).driver,
+      fakeDriver({
+        provider: "codex",
+        resolveError: `no codex at https://svc:pw_abcdef@registry.example/x\n${LONG_DIAGNOSTIC_TAIL}`,
+      }).driver,
       "codex",
     );
     await runRuntimeAuthLogin({ provider: "codex", ref: "cap-resolve" }, unresolved.deps);
-    expect(unresolved.calls.at(-1)?.entry.lastAuthError?.message).not.toContain("pw_abcdef");
+    const resolveMessage = unresolved.calls.at(-1)?.entry.lastAuthError?.message ?? "";
+    expect(resolveMessage).not.toContain("pw_abcdef");
+    expect(resolveMessage.length).toBe(RUNTIME_AUTH_ERROR_MAX_LEN);
+    expect(resolveMessage.endsWith("…")).toBe(true);
   });
 });

--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -34,6 +34,7 @@ type FakeDriverOptions = {
   loginLabel?: string;
   artifactLabel?: string;
   resolveError?: string;
+  throwResolve?: unknown;
   outcome?: LoginOutcome;
   fireAuthUrl?: string;
   throwLogin?: unknown;
@@ -50,6 +51,7 @@ function fakeDriver(opts: FakeDriverOptions) {
     loginLabel: opts.loginLabel ?? `${opts.provider} login`,
     artifactLabel: opts.artifactLabel ?? "binary",
     async resolveLogin() {
+      if (opts.throwResolve !== undefined) throw opts.throwResolve;
       if (opts.resolveError) return { ok: false, error: opts.resolveError };
       return {
         ok: true,
@@ -70,13 +72,21 @@ function fakeDriver(opts: FakeDriverOptions) {
   return { driver, loginCalls };
 }
 
-function harness(driver: RuntimeAuthDriver, provider: RuntimeAuthProvider, current?: CapabilityEntry) {
+function harness(
+  driver: RuntimeAuthDriver,
+  provider: RuntimeAuthProvider,
+  current?: CapabilityEntry,
+  /** Per-write latency, to expose ordering that a fast write would hide. */
+  writeDelayMs?: (entry: CapabilityEntry) => number,
+) {
   const calls: Recorded[] = [];
   const logs: string[] = [];
   const drivers = { [provider]: driver } as unknown as RuntimeAuthDriverTable;
   const deps: RuntimeAuthLoginDeps = {
     currentEntry: () => current,
     setProviderEntry: async (p, entry) => {
+      const delay = writeDelayMs?.(entry) ?? 0;
+      if (delay > 0) await new Promise((r) => setTimeout(r, delay));
       calls.push({ provider: p, entry });
     },
     log: (_symbol, msg) => {
@@ -175,6 +185,19 @@ describe("runRuntimeAuthLogin — browser OAuth lifecycle", () => {
     expect(withUrl?.entry.pendingAuth).toMatchObject({ method: "browser", authUrl: "https://auth.openai.com/x" });
   });
 
+  it("keeps the auth URL ahead of the terminal entry even when the write is slow", async () => {
+    // The URL arrives from the login's output stream, so its write is in flight
+    // when the login resolves. A slow write must not land after the terminal
+    // re-probe and resurrect a pending marker on a finished login.
+    const { driver } = fakeDriver({ provider: "codex", fireAuthUrl: "https://auth.openai.com/slow" });
+    const h = harness(driver, "codex", undefined, (entry) => (entry.pendingAuth?.authUrl ? 20 : 0));
+    await runRuntimeAuthLogin({ provider: "codex", ref: "order" }, h.deps);
+
+    expect(
+      h.calls.map((c) => (c.entry.pendingAuth?.authUrl ? "pending+url" : c.entry.pendingAuth ? "pending" : "terminal")),
+    ).toEqual(["pending", "pending+url", "terminal"]);
+  });
+
   it("preserves the prior entry's runtimeSource/version on the pending entry", async () => {
     const { driver } = fakeDriver({ provider: "codex" });
     const h = harness(driver, "codex", okEntry({ runtimeSource: "bundled" }));
@@ -197,6 +220,25 @@ describe("runRuntimeAuthLogin — browser OAuth lifecycle", () => {
     expect(h.calls).toHaveLength(1);
     expect(h.calls[0]?.entry.state).toBe("missing");
     expect(h.logs.some((l) => l.includes("codex binary unavailable"))).toBe(true);
+  });
+
+  it("contains a thrown resolver on the same path as a reported one", async () => {
+    const { driver, loginCalls } = fakeDriver({
+      provider: "codex",
+      throwResolve: new Error("PATH lookup exploded"),
+      probeResult: okEntry({ state: "missing", available: false }),
+    });
+    const h = harness(driver, "codex");
+    await runRuntimeAuthLogin({ provider: "codex", ref: "resolve-throw" }, h.deps);
+
+    expect(loginCalls).toHaveLength(0);
+    expect(h.calls).toHaveLength(1);
+    expect(h.calls[0]?.entry.state).toBe("missing");
+    expect(h.calls[0]?.entry.lastAuthError).toMatchObject({
+      reason: "spawn-error",
+      message: "PATH lookup exploded",
+    });
+    expect(h.logs.some((l) => l.includes("codex binary lookup threw: PATH lookup exploded"))).toBe(true);
   });
 
   it("uses the driver's artifact wording for a CLI-backed provider", async () => {

--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -384,6 +384,70 @@ describe("runRuntimeAuthLogin — published failure text is redacted and bounded
     expect(published).toBe("account not authorized");
   });
 
+  it("sanitizes a probe-reported error on the login target's row", async () => {
+    const { driver } = fakeDriver({
+      provider: "codex",
+      probeResult: okEntry({
+        state: "error",
+        available: false,
+        error: `detect failed for https://svc:hunter2pwd@registry.example/x token=${"b".repeat(2_000)}`,
+      }),
+    });
+    const h = harness(driver, "codex");
+    await runRuntimeAuthLogin({ provider: "codex", ref: "probe-error" }, h.deps);
+
+    const published = h.calls.at(-1)?.entry.error ?? "";
+    expect(published).not.toContain("hunter2pwd");
+    expect(published).toContain("[REDACTED]");
+    expect(published.length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN);
+  });
+
+  it("sanitizes a probe-reported error on a shared-credential extra row too", async () => {
+    const { driver } = fakeDriver({
+      provider: "claude-code",
+      logLabel: "claude",
+      artifactLabel: "CLI",
+      extraRows: [
+        {
+          provider: "claude-code-tui",
+          entry: okEntry({
+            state: "error",
+            available: false,
+            error: `tui detect failed: Authorization: Bearer sk-ant-abcdefghijklmnopqrstuvwx ${"x".repeat(2_000)}`,
+          }),
+        },
+      ],
+    });
+    const h = harness(driver, "claude-code");
+    await runRuntimeAuthLogin({ provider: "claude-code", ref: "tui-probe-error" }, h.deps);
+
+    const tuiRow = h.calls.filter((c) => c.provider === "claude-code-tui").at(-1)?.entry;
+    expect(tuiRow?.error).not.toContain("sk-ant-abcdefghijklmnopqrstuvwx");
+    expect(tuiRow?.error).toContain("[REDACTED]");
+    expect((tuiRow?.error ?? "").length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN);
+    // The extra row still carries no failure marker — that belongs to the target.
+    expect(tuiRow?.lastAuthError).toBeUndefined();
+  });
+
+  it("drops the previous attempt's error and failure marker from the pending entry", async () => {
+    const { driver } = fakeDriver({ provider: "codex" });
+    const stale = okEntry({
+      state: "error",
+      available: false,
+      error: "old detect failure for https://svc:hunter2pwd@registry.example/x",
+      lastAuthError: { reason: "timeout", message: "an earlier sign-in timed out", at: "2026-06-21T00:00:00.000Z" },
+    });
+    const h = harness(driver, "codex", stale);
+    await runRuntimeAuthLogin({ provider: "codex", ref: "stale" }, h.deps);
+
+    const pending = h.calls[0]?.entry;
+    expect(pending?.pendingAuth).toBeDefined();
+    // Starting a login clears the last verdict; nothing from it may ride along.
+    expect(pending?.error).toBeUndefined();
+    expect(pending?.lastAuthError).toBeUndefined();
+    expect(pending?.state).toBe("ok");
+  });
+
   it("caps a thrown error and an unresolved-artifact error too", async () => {
     const thrown = harness(
       fakeDriver({ provider: "codex", throwLogin: new Error(`token=${"a".repeat(2_000)}`) }).driver,

--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -337,6 +337,16 @@ describe("runRuntimeAuthLogin — shared-credential providers", () => {
   });
 });
 
+/**
+ * Ordinary diagnostic prose, long enough to blow the budget on its own and
+ * deliberately free of every shape the redaction helper matches — no
+ * credential-ish key, no `Bearer`, no `sk-` run, no scheme with userinfo. A
+ * secret that IS matched collapses into a short placeholder, so a test that
+ * only feeds a secret proves redaction and never reaches the cap; pairing the
+ * two on separate lines is what exercises both.
+ */
+const LONG_DIAGNOSTIC_TAIL = "the provider kept printing ordinary diagnostic prose ".repeat(40);
+
 describe("runRuntimeAuthLogin — published failure text is redacted and bounded (#1720)", () => {
   it("redacts credential shapes before they reach the capability snapshot", async () => {
     const { driver } = fakeDriver({
@@ -390,7 +400,7 @@ describe("runRuntimeAuthLogin — published failure text is redacted and bounded
       probeResult: okEntry({
         state: "error",
         available: false,
-        error: `detect failed for https://svc:hunter2pwd@registry.example/x token=${"b".repeat(2_000)}`,
+        error: `detect failed for https://svc:hunter2pwd@registry.example/x\n${LONG_DIAGNOSTIC_TAIL}`,
       }),
     });
     const h = harness(driver, "codex");
@@ -399,7 +409,9 @@ describe("runRuntimeAuthLogin — published failure text is redacted and bounded
     const published = h.calls.at(-1)?.entry.error ?? "";
     expect(published).not.toContain("hunter2pwd");
     expect(published).toContain("[REDACTED]");
-    expect(published.length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN);
+    // The tail survives redaction, so the cap is what ends the string.
+    expect(published.length).toBe(RUNTIME_AUTH_ERROR_MAX_LEN);
+    expect(published.endsWith("…")).toBe(true);
   });
 
   it("sanitizes a probe-reported error on a shared-credential extra row too", async () => {
@@ -413,7 +425,9 @@ describe("runRuntimeAuthLogin — published failure text is redacted and bounded
           entry: okEntry({
             state: "error",
             available: false,
-            error: `tui detect failed: Authorization: Bearer sk-ant-abcdefghijklmnopqrstuvwx ${"x".repeat(2_000)}`,
+            // The Authorization pattern eats to end-of-line, so the tail has to
+            // start on the next one to reach the cap.
+            error: `tui detect failed\nAuthorization: Bearer sk-ant-abcdefghijklmnopqrstuvwx\n${LONG_DIAGNOSTIC_TAIL}`,
           }),
         },
       ],
@@ -424,7 +438,8 @@ describe("runRuntimeAuthLogin — published failure text is redacted and bounded
     const tuiRow = h.calls.filter((c) => c.provider === "claude-code-tui").at(-1)?.entry;
     expect(tuiRow?.error).not.toContain("sk-ant-abcdefghijklmnopqrstuvwx");
     expect(tuiRow?.error).toContain("[REDACTED]");
-    expect((tuiRow?.error ?? "").length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN);
+    expect(tuiRow?.error?.length).toBe(RUNTIME_AUTH_ERROR_MAX_LEN);
+    expect(tuiRow?.error?.endsWith("…")).toBe(true);
     // The extra row still carries no failure marker — that belongs to the target.
     expect(tuiRow?.lastAuthError).toBeUndefined();
   });

--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -366,8 +366,22 @@ describe("runRuntimeAuthLogin — published failure text is redacted and bounded
     await runRuntimeAuthLogin({ provider: "codex", ref: "cap" }, h.deps);
 
     const published = h.calls.at(-1)?.entry.lastAuthError?.message ?? "";
-    // Truncation appends a single ellipsis marker past the budget.
-    expect(published.length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN + 1);
+    // The budget is the ceiling on the published string, ellipsis included —
+    // the redaction helper appends one when it truncates.
+    expect(published.length).toBe(RUNTIME_AUTH_ERROR_MAX_LEN);
+    expect(published.endsWith("…")).toBe(true);
+  });
+
+  it("leaves a message that fits the budget exactly as it is", async () => {
+    const { driver } = fakeDriver({
+      provider: "codex",
+      outcome: { ok: false, reason: "exit-nonzero", error: "account not authorized" },
+    });
+    const h = harness(driver, "codex");
+    await runRuntimeAuthLogin({ provider: "codex", ref: "short" }, h.deps);
+
+    const published = h.calls.at(-1)?.entry.lastAuthError?.message;
+    expect(published).toBe("account not authorized");
   });
 
   it("caps a thrown error and an unresolved-artifact error too", async () => {
@@ -377,7 +391,7 @@ describe("runRuntimeAuthLogin — published failure text is redacted and bounded
     );
     await runRuntimeAuthLogin({ provider: "codex", ref: "cap-throw" }, thrown.deps);
     const thrownMessage = thrown.calls.at(-1)?.entry.lastAuthError?.message ?? "";
-    expect(thrownMessage.length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN + 1);
+    expect(thrownMessage.length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN);
     expect(thrownMessage).toContain("[REDACTED]");
 
     const unresolved = harness(

--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -1,14 +1,23 @@
-import { BROWSER_LOGIN_TIMEOUT_MS, type CodexBrowserLoginOptions, type LoginOutcome } from "@first-tree/client";
-import type { CapabilityEntry } from "@first-tree/shared";
+import {
+  BROWSER_LOGIN_TIMEOUT_MS,
+  type LoginOutcome,
+  type RuntimeAuthDriver,
+  type RuntimeAuthDriverTable,
+  type RuntimeAuthProbeResult,
+} from "@first-tree/client";
+import type { CapabilityEntry, RuntimeAuthProvider } from "@first-tree/shared";
+import { runtimeAuthProviderSchema } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
-import { runRuntimeAuthLogin } from "../core/runtime-auth-login.js";
+import {
+  RUNTIME_AUTH_ERROR_MAX_LEN,
+  type RuntimeAuthLoginDeps,
+  runRuntimeAuthLogin,
+} from "../core/runtime-auth-login.js";
 
 const NOW = Date.parse("2026-06-22T12:00:00.000Z");
 
-// Detection is install-only: a re-probed installed provider is always `ok`
-// (no auth state). Both helpers build that install entry; `installedEntry` is
-// the marker-free re-probe result, and tests override `state`/`available` for
-// the binary-vanished (`missing`) case.
+// Detection is install-only: a re-probed installed provider is always `ok` (no
+// auth state). Tests override `state`/`available` for the binary-vanished case.
 const okEntry = (over: Partial<CapabilityEntry> = {}): CapabilityEntry => ({
   state: "ok",
   available: true,
@@ -17,57 +26,131 @@ const okEntry = (over: Partial<CapabilityEntry> = {}): CapabilityEntry => ({
   ...over,
 });
 
-const installedEntry = (over: Partial<CapabilityEntry> = {}): CapabilityEntry => okEntry(over);
-
 type Recorded = { provider: string; entry: CapabilityEntry };
 
-function harness(opts: {
-  resolveOk?: boolean;
+type FakeDriverOptions = {
+  provider: RuntimeAuthProvider;
+  logLabel?: string;
+  loginLabel?: string;
+  artifactLabel?: string;
+  resolveError?: string;
   outcome?: LoginOutcome;
   fireAuthUrl?: string;
-  probeResult?: CapabilityEntry;
-  current?: CapabilityEntry;
   throwLogin?: unknown;
   probeThrows?: unknown;
-}) {
+  probeResult?: CapabilityEntry;
+  /** Extra rows a shared-credential provider republishes alongside its own. */
+  extraRows?: readonly RuntimeAuthProbeResult[];
+};
+
+function fakeDriver(opts: FakeDriverOptions) {
+  const loginCalls: number[] = [];
+  const driver: RuntimeAuthDriver = {
+    logLabel: opts.logLabel ?? opts.provider,
+    loginLabel: opts.loginLabel ?? `${opts.provider} login`,
+    artifactLabel: opts.artifactLabel ?? "binary",
+    async resolveLogin() {
+      if (opts.resolveError) return { ok: false, error: opts.resolveError };
+      return {
+        ok: true,
+        login: async ({ onAuthUrl }) => {
+          loginCalls.push(1);
+          if (opts.fireAuthUrl) onAuthUrl(opts.fireAuthUrl);
+          if (opts.throwLogin !== undefined) throw opts.throwLogin;
+          await new Promise((r) => setTimeout(r, 0));
+          return opts.outcome ?? { ok: true };
+        },
+      };
+    },
+    async reprobe() {
+      if (opts.probeThrows !== undefined) throw opts.probeThrows;
+      return [{ provider: opts.provider, entry: opts.probeResult ?? okEntry() }, ...(opts.extraRows ?? [])];
+    },
+  };
+  return { driver, loginCalls };
+}
+
+function harness(driver: RuntimeAuthDriver, provider: RuntimeAuthProvider, current?: CapabilityEntry) {
   const calls: Recorded[] = [];
   const logs: string[] = [];
-  const deps = {
-    currentEntry: (): CapabilityEntry | undefined => opts.current,
-    setProviderEntry: async (provider: string, entry: CapabilityEntry): Promise<void> => {
-      calls.push({ provider, entry });
+  const drivers = { [provider]: driver } as unknown as RuntimeAuthDriverTable;
+  const deps: RuntimeAuthLoginDeps = {
+    currentEntry: () => current,
+    setProviderEntry: async (p, entry) => {
+      calls.push({ provider: p, entry });
     },
-    log: (_symbol: string, msg: string): void => {
+    log: (_symbol, msg) => {
       logs.push(msg);
     },
-    now: (): number => NOW,
-    resolveCodexBinary: async () =>
-      opts.resolveOk === false
-        ? ({ ok: false, error: "codex binary missing" } as const)
-        : ({
-            ok: true,
-            binary: "/bundled/codex",
-            runtimeSource: "bundled" as const,
-            runtimePath: null,
-            version: "0.130.0",
-          } as const),
-    runBrowserLogin: async (o: CodexBrowserLoginOptions): Promise<LoginOutcome> => {
-      if (opts.fireAuthUrl) o.onAuthUrl?.(opts.fireAuthUrl);
-      if (opts.throwLogin !== undefined) throw opts.throwLogin;
-      await new Promise((r) => setTimeout(r, 0));
-      return opts.outcome ?? ({ ok: true } as const);
-    },
-    probeCodex: async (): Promise<CapabilityEntry> => {
-      if (opts.probeThrows !== undefined) throw opts.probeThrows;
-      return opts.probeResult ?? installedEntry();
-    },
+    now: () => NOW,
+    drivers,
   };
   return { calls, logs, deps };
 }
 
-describe("runRuntimeAuthLogin — primary browser OAuth", () => {
+describe("runRuntimeAuthLogin — generic dispatch", () => {
+  it("dispatches by typed key into the supplied registry", async () => {
+    const seen: RuntimeAuthProvider[] = [];
+    const drivers = {} as Record<RuntimeAuthProvider, RuntimeAuthDriver>;
+    for (const provider of runtimeAuthProviderSchema.options) {
+      drivers[provider] = {
+        logLabel: provider,
+        loginLabel: `${provider} login`,
+        artifactLabel: "binary",
+        resolveLogin: async () => {
+          seen.push(provider);
+          return { ok: false, error: `${provider} not installed` };
+        },
+        reprobe: async () => [{ provider, entry: okEntry() }],
+      };
+    }
+
+    const calls: Recorded[] = [];
+    for (const provider of runtimeAuthProviderSchema.options) {
+      await runRuntimeAuthLogin(
+        { provider, ref: `dispatch-${provider}` },
+        {
+          currentEntry: () => undefined,
+          setProviderEntry: async (p, entry) => {
+            calls.push({ provider: p, entry });
+          },
+          log: vi.fn(),
+          now: () => NOW,
+          drivers,
+        },
+      );
+    }
+
+    expect(seen).toEqual([...runtimeAuthProviderSchema.options]);
+    expect(calls.map((c) => c.provider)).toEqual([...runtimeAuthProviderSchema.options]);
+  });
+
+  it("logs and stops when the registry has no driver for the provider", async () => {
+    const logs: string[] = [];
+    const calls: Recorded[] = [];
+    await runRuntimeAuthLogin(
+      { provider: "codex", ref: "r4" },
+      {
+        currentEntry: () => undefined,
+        setProviderEntry: async (provider, entry) => {
+          calls.push({ provider, entry });
+        },
+        log: (_s, msg) => {
+          logs.push(msg);
+        },
+        drivers: {} as RuntimeAuthDriverTable,
+      },
+    );
+
+    expect(calls).toHaveLength(0);
+    expect(logs.some((l) => l.includes("not supported yet"))).toBe(true);
+  });
+});
+
+describe("runRuntimeAuthLogin — browser OAuth lifecycle", () => {
   it("publishes a browser pending then the re-probed ok entry", async () => {
-    const h = harness({ outcome: { ok: true }, probeResult: okEntry() });
+    const { driver } = fakeDriver({ provider: "codex", outcome: { ok: true } });
+    const h = harness(driver, "codex");
     await runRuntimeAuthLogin({ provider: "codex", ref: "r1" }, h.deps);
 
     expect(h.calls).toHaveLength(2);
@@ -83,8 +166,9 @@ describe("runRuntimeAuthLogin — primary browser OAuth", () => {
     expect(h.calls[1]?.entry.pendingAuth).toBeUndefined();
   });
 
-  it("surfaces the browser auth URL into pendingAuth when the login emits it (no-auto-open recovery)", async () => {
-    const h = harness({ outcome: { ok: true }, probeResult: okEntry(), fireAuthUrl: "https://auth.openai.com/x" });
+  it("surfaces the browser auth URL into pendingAuth (no-auto-open recovery)", async () => {
+    const { driver } = fakeDriver({ provider: "codex", fireAuthUrl: "https://auth.openai.com/x" });
+    const h = harness(driver, "codex");
     await runRuntimeAuthLogin({ provider: "codex", ref: "u1" }, h.deps);
 
     const withUrl = h.calls.find((c) => c.entry.pendingAuth?.authUrl);
@@ -92,37 +176,51 @@ describe("runRuntimeAuthLogin — primary browser OAuth", () => {
   });
 
   it("preserves the prior entry's runtimeSource/version on the pending entry", async () => {
-    const h = harness({
-      outcome: { ok: true },
-      probeResult: okEntry(),
-      current: okEntry({ runtimeSource: "bundled" }),
-    });
+    const { driver } = fakeDriver({ provider: "codex" });
+    const h = harness(driver, "codex", okEntry({ runtimeSource: "bundled" }));
     await runRuntimeAuthLogin({ provider: "codex", ref: "r2" }, h.deps);
+
     expect(h.calls[0]?.entry.runtimeSource).toBe("bundled");
     expect(h.calls[0]?.entry.sdkVersion).toBe("0.130.0");
   });
 
-  it("on unresolved binary, reflects the real (missing) state and never logs in", async () => {
-    const h = harness({ resolveOk: false, probeResult: { ...installedEntry(), state: "missing", available: false } });
+  it("on an unresolved artifact, reflects the real state and never logs in", async () => {
+    const { driver, loginCalls } = fakeDriver({
+      provider: "codex",
+      resolveError: "codex binary missing",
+      probeResult: okEntry({ state: "missing", available: false }),
+    });
+    const h = harness(driver, "codex");
     await runRuntimeAuthLogin({ provider: "codex", ref: "r3" }, h.deps);
 
+    expect(loginCalls).toHaveLength(0);
     expect(h.calls).toHaveLength(1);
     expect(h.calls[0]?.entry.state).toBe("missing");
-    expect(h.logs.some((l) => l.includes("binary unavailable"))).toBe(true);
+    expect(h.logs.some((l) => l.includes("codex binary unavailable"))).toBe(true);
   });
 
-  it("ignores providers that are not yet supported", async () => {
-    const h = harness({});
-    await runRuntimeAuthLogin({ provider: "claude-code-tui", ref: "r4" }, h.deps);
-    expect(h.calls).toHaveLength(0);
-    expect(h.logs.some((l) => l.includes("not supported yet"))).toBe(true);
-  });
-
-  it("stamps lastAuthError on the re-probed entry when the login fails (so the web shows 'retry')", async () => {
-    const h = harness({
-      outcome: { ok: false, reason: "exit-nonzero", error: "account not authorized" },
-      probeResult: installedEntry(),
+  it("uses the driver's artifact wording for a CLI-backed provider", async () => {
+    const { driver } = fakeDriver({
+      provider: "claude-code",
+      logLabel: "claude",
+      loginLabel: "claude auth login",
+      artifactLabel: "CLI",
+      resolveError: "no claude CLI",
+      probeThrows: "probe crashed",
     });
+    const h = harness(driver, "claude-code");
+    await runRuntimeAuthLogin({ provider: "claude-code", ref: "c2" }, h.deps);
+
+    expect(h.logs.some((l) => l.includes("claude CLI unavailable: no claude CLI"))).toBe(true);
+    expect(h.logs.some((l) => l.includes("claude re-probe after unresolved CLI failed: probe crashed"))).toBe(true);
+  });
+
+  it("stamps lastAuthError on the re-probed entry when the login fails", async () => {
+    const { driver } = fakeDriver({
+      provider: "codex",
+      outcome: { ok: false, reason: "exit-nonzero", error: "account not authorized" },
+    });
+    const h = harness(driver, "codex");
     await runRuntimeAuthLogin({ provider: "codex", ref: "f1" }, h.deps);
 
     const last = h.calls.at(-1)?.entry;
@@ -135,23 +233,27 @@ describe("runRuntimeAuthLogin — primary browser OAuth", () => {
   });
 
   it("leaves no lastAuthError after a successful login", async () => {
-    const h = harness({ outcome: { ok: true }, probeResult: okEntry() });
+    const { driver } = fakeDriver({ provider: "codex", outcome: { ok: true } });
+    const h = harness(driver, "codex");
     await runRuntimeAuthLogin({ provider: "codex", ref: "f2" }, h.deps);
     expect(h.calls.at(-1)?.entry.lastAuthError).toBeUndefined();
   });
 
-  it("stamps lastAuthError even when the re-probe lands `missing` (failure is no longer state-gated)", async () => {
-    // Binary vanished mid-flight → re-probe lands `missing`. `attachAuthError`
-    // now stamps the failure whenever one is present, independent of state (the
-    // old "only when unauthenticated" gate is gone with install-only detection).
-    const h = harness({ resolveOk: false, probeResult: { ...installedEntry(), state: "missing", available: false } });
+  it("stamps lastAuthError even when the re-probe lands `missing`", async () => {
+    const { driver } = fakeDriver({
+      provider: "codex",
+      resolveError: "codex binary missing",
+      probeResult: okEntry({ state: "missing", available: false }),
+    });
+    const h = harness(driver, "codex");
     await runRuntimeAuthLogin({ provider: "codex", ref: "f3" }, h.deps);
+
     expect(h.calls.at(-1)?.entry.state).toBe("missing");
     expect(h.calls.at(-1)?.entry.lastAuthError).toMatchObject({ reason: "spawn-error" });
   });
 
-  it("logs thrown browser login errors and re-probe failures without throwing", async () => {
-    const loginThrows = harness({ throwLogin: "browser crashed", probeResult: installedEntry() });
+  it("logs thrown login errors and re-probe failures without throwing", async () => {
+    const loginThrows = harness(fakeDriver({ provider: "codex", throwLogin: "browser crashed" }).driver, "codex");
     await runRuntimeAuthLogin({ provider: "codex", ref: "throw-login" }, loginThrows.deps);
     expect(loginThrows.logs.some((l) => l.includes("codex login threw: browser crashed"))).toBe(true);
     expect(loginThrows.calls.at(-1)?.entry.lastAuthError).toMatchObject({
@@ -159,7 +261,10 @@ describe("runRuntimeAuthLogin — primary browser OAuth", () => {
       message: "browser crashed",
     });
 
-    const probeThrows = harness({ resolveOk: false, probeThrows: "probe crashed" });
+    const probeThrows = harness(
+      fakeDriver({ provider: "codex", resolveError: "codex binary missing", probeThrows: "probe crashed" }).driver,
+      "codex",
+    );
     await runRuntimeAuthLogin({ provider: "codex", ref: "throw-probe" }, probeThrows.deps);
     expect(
       probeThrows.logs.some((l) => l.includes("codex re-probe after unresolved binary failed: probe crashed")),
@@ -167,254 +272,77 @@ describe("runRuntimeAuthLogin — primary browser OAuth", () => {
   });
 });
 
-describe("runRuntimeAuthLogin — claude-code browser OAuth (cc/codex parity)", () => {
-  function claudeHarness(opts: {
-    resolveOk?: boolean;
-    outcome?: LoginOutcome;
-    fireAuthUrl?: string;
-    probeResult?: CapabilityEntry;
-    throwLogin?: unknown;
-    probeThrows?: unknown;
-  }) {
-    const calls: Recorded[] = [];
-    const logs: string[] = [];
-    // Spy so a test can assert the TUI probe is NOT spawned while claude-code-tui
-    // is disabled (it shares the Claude keychain, but "stop probing it" must hold
-    // on this login-reflection path too).
-    const probeClaudeTui = vi.fn(async (): Promise<CapabilityEntry> => opts.probeResult ?? installedEntry());
-    const deps = {
-      currentEntry: (): CapabilityEntry | undefined => undefined,
-      setProviderEntry: async (provider: string, entry: CapabilityEntry): Promise<void> => {
-        calls.push({ provider, entry });
-      },
-      log: (_s: string, msg: string): void => {
-        logs.push(msg);
-      },
-      now: (): number => NOW,
-      resolveClaudeLogin: () =>
-        opts.resolveOk === false
-          ? ({ ok: false, error: "no claude CLI" } as const)
-          : ({ ok: true, command: "/usr/local/bin/claude", baseArgs: [] as string[] } as const),
-      runClaudeBrowser: async (options: { onAuthUrl?: (url: string) => void }): Promise<LoginOutcome> => {
-        if (opts.fireAuthUrl) options.onAuthUrl?.(opts.fireAuthUrl);
-        if (opts.throwLogin !== undefined) throw opts.throwLogin;
-        return opts.outcome ?? ({ ok: true } as const);
-      },
-      probeClaude: async (): Promise<CapabilityEntry> => {
-        if (opts.probeThrows !== undefined) throw opts.probeThrows;
-        return opts.probeResult ?? installedEntry();
-      },
-      probeClaudeTui,
-    };
-    return { calls, logs, deps, probeClaudeTui };
-  }
-
-  // claude-code-tui is in DISABLED_RUNTIME_PROVIDERS, so a claude-code login
-  // reflects claude-code ONLY — the shared-keychain TUI re-probe is suppressed
-  // here exactly as it is in the capability aggregator (no `claude` / tmux spawn,
-  // no tui entry written). If TUI is ever re-enabled, the both-providers path
-  // (Promise.all) takes over again.
-  it("browser pending, then re-probes claude-code only while TUI is disabled (no TUI spawn)", async () => {
-    const h = claudeHarness({ outcome: { ok: true }, probeResult: okEntry() });
-    await runRuntimeAuthLogin({ provider: "claude-code", ref: "c1" }, h.deps);
-
-    // pending(claude-code) → ok(claude-code); no claude-code-tui write.
-    expect(h.calls).toHaveLength(2);
-    expect(h.calls.map((c) => c.provider)).toEqual(["claude-code", "claude-code"]);
-    expect(h.calls[0]?.entry.pendingAuth).toEqual({
-      method: "browser",
-      expiresAt: new Date(NOW + BROWSER_LOGIN_TIMEOUT_MS).toISOString(),
+describe("runRuntimeAuthLogin — shared-credential providers", () => {
+  it("republishes every row the driver returns, stamping only the login target", async () => {
+    const { driver } = fakeDriver({
+      provider: "claude-code",
+      logLabel: "claude",
+      loginLabel: "claude auth login",
+      artifactLabel: "CLI",
+      outcome: { ok: false, reason: "timeout", error: "claude auth login timed out" },
+      probeResult: okEntry({ sdkVersion: "sdk" }),
+      extraRows: [{ provider: "claude-code-tui", entry: okEntry({ sdkVersion: "tui" }) }],
     });
-    expect(h.calls[1]?.entry.state).toBe("ok");
-    expect(h.calls[1]?.entry.pendingAuth).toBeUndefined();
-    expect(h.calls.some((c) => c.provider === "claude-code-tui")).toBe(false);
-    expect(h.probeClaudeTui).not.toHaveBeenCalled();
-  });
-
-  it("surfaces the Claude browser auth URL into pendingAuth", async () => {
-    const h = claudeHarness({ outcome: { ok: true }, probeResult: okEntry(), fireAuthUrl: "https://claude.ai/login" });
-    await runRuntimeAuthLogin({ provider: "claude-code", ref: "c-url" }, h.deps);
-
-    const withUrl = h.calls.find((c) => c.entry.pendingAuth?.authUrl);
-    expect(withUrl?.entry.pendingAuth).toMatchObject({ method: "browser", authUrl: "https://claude.ai/login" });
-  });
-
-  it("on unresolved CLI, reflects claude-code real state and never logs in (TUI untouched)", async () => {
-    const h = claudeHarness({
-      resolveOk: false,
-      probeResult: { ...installedEntry(), state: "missing", available: false },
-    });
-    await runRuntimeAuthLogin({ provider: "claude-code", ref: "c2" }, h.deps);
-
-    expect(h.calls.map((c) => c.provider)).toEqual(["claude-code"]);
-    expect(h.calls.every((c) => c.entry.state === "missing")).toBe(true);
-    expect(h.probeClaudeTui).not.toHaveBeenCalled();
-    expect(h.logs.some((l) => l.includes("claude CLI unavailable"))).toBe(true);
-  });
-
-  it("on login failure, stamps lastAuthError on claude-code (TUI not re-probed while disabled)", async () => {
-    const h = claudeHarness({ outcome: { ok: false, reason: "timeout", error: "claude auth login timed out" } });
+    const h = harness(driver, "claude-code");
     await runRuntimeAuthLogin({ provider: "claude-code", ref: "c3" }, h.deps);
 
+    expect(h.calls.map((c) => c.provider)).toEqual(["claude-code", "claude-code", "claude-code-tui"]);
     const cc = h.calls.filter((c) => c.provider === "claude-code").at(-1)?.entry;
     expect(cc?.lastAuthError).toMatchObject({ reason: "timeout", message: "claude auth login timed out" });
-    expect(h.calls.some((c) => c.provider === "claude-code-tui")).toBe(false);
-    expect(h.probeClaudeTui).not.toHaveBeenCalled();
+    // The shared-keychain row reflects the re-probe only; the failure belongs to
+    // the row the operator actually tried to log in.
+    expect(h.calls.at(-1)?.entry.lastAuthError).toBeUndefined();
+  });
+});
+
+describe("runRuntimeAuthLogin — published failure text is redacted and bounded (#1720)", () => {
+  it("redacts credential shapes before they reach the capability snapshot", async () => {
+    const { driver } = fakeDriver({
+      provider: "codex",
+      outcome: {
+        ok: false,
+        reason: "exit-nonzero",
+        error:
+          "refresh failed for https://user:hunter2pwd@auth.example/cb (Authorization: Bearer sk-ant-abcdefghijklmnopqrstuvwx)",
+      },
+    });
+    const h = harness(driver, "codex");
+    await runRuntimeAuthLogin({ provider: "codex", ref: "redact" }, h.deps);
+
+    const published = h.calls.at(-1)?.entry.lastAuthError?.message ?? "";
+    expect(published).not.toContain("hunter2pwd");
+    expect(published).not.toContain("sk-ant-abcdefghijklmnopqrstuvwx");
+    expect(published).toContain("[REDACTED]");
   });
 
-  it("logs thrown Claude login errors and re-probe failures without throwing", async () => {
-    const loginThrows = claudeHarness({ throwLogin: "browser crashed" });
-    await runRuntimeAuthLogin({ provider: "claude-code", ref: "c4" }, loginThrows.deps);
-    expect(loginThrows.logs.some((l) => l.includes("claude auth login threw: browser crashed"))).toBe(true);
-    expect(loginThrows.calls.at(-1)?.entry.lastAuthError).toMatchObject({
-      reason: "spawn-error",
-      message: "browser crashed",
+  it("hard-caps an over-long provider failure at the capability error budget", async () => {
+    const { driver } = fakeDriver({
+      provider: "codex",
+      outcome: { ok: false, reason: "exit-nonzero", error: "boom ".repeat(1_000) },
     });
+    const h = harness(driver, "codex");
+    await runRuntimeAuthLogin({ provider: "codex", ref: "cap" }, h.deps);
 
-    const probeThrows = claudeHarness({ resolveOk: false, probeThrows: "probe crashed" });
-    await runRuntimeAuthLogin({ provider: "claude-code", ref: "c5" }, probeThrows.deps);
-    expect(probeThrows.logs.some((l) => l.includes("claude re-probe after unresolved CLI failed: probe crashed"))).toBe(
-      true,
+    const published = h.calls.at(-1)?.entry.lastAuthError?.message ?? "";
+    // Truncation appends a single ellipsis marker past the budget.
+    expect(published.length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN + 1);
+  });
+
+  it("caps a thrown error and an unresolved-artifact error too", async () => {
+    const thrown = harness(
+      fakeDriver({ provider: "codex", throwLogin: new Error(`token=${"a".repeat(2_000)}`) }).driver,
+      "codex",
     );
-  });
-});
+    await runRuntimeAuthLogin({ provider: "codex", ref: "cap-throw" }, thrown.deps);
+    const thrownMessage = thrown.calls.at(-1)?.entry.lastAuthError?.message ?? "";
+    expect(thrownMessage.length).toBeLessThanOrEqual(RUNTIME_AUTH_ERROR_MAX_LEN + 1);
+    expect(thrownMessage).toContain("[REDACTED]");
 
-describe("runRuntimeAuthLogin — cursor (external-only binary)", () => {
-  function cursorHarness(opts: {
-    resolveOk?: boolean;
-    outcome?: LoginOutcome;
-    fireAuthUrl?: string;
-    probeResult?: CapabilityEntry;
-  }) {
-    const calls: Recorded2[] = [];
-    const logs: string[] = [];
-    const loginCalls: string[] = [];
-    const deps = {
-      currentEntry: (): CapabilityEntry | undefined => undefined,
-      setProviderEntry: async (provider: string, entry: CapabilityEntry): Promise<void> => {
-        calls.push({ provider, entry });
-      },
-      log: (_symbol: string, msg: string): void => {
-        logs.push(msg);
-      },
-      now: (): number => NOW,
-      resolveCursorBinary: () =>
-        opts.resolveOk === false
-          ? ({ ok: false, error: "Cursor Agent CLI is missing on this machine.", transient: false } as const)
-          : ({ ok: true, binary: "/home/op/.local/bin/cursor-agent", version: "2026.07.09" } as const),
-      runCursorBrowser: async (o: { binary: string; onAuthUrl?: (url: string) => void }): Promise<LoginOutcome> => {
-        loginCalls.push(o.binary);
-        if (opts.fireAuthUrl) o.onAuthUrl?.(opts.fireAuthUrl);
-        await new Promise((r) => setTimeout(r, 0));
-        return opts.outcome ?? ({ ok: true } as const);
-      },
-      probeCursor: async (): Promise<CapabilityEntry> => opts.probeResult ?? installedEntry(),
-    };
-    return { calls, logs, loginCalls, deps };
-  }
-  type Recorded2 = { provider: string; entry: CapabilityEntry };
-
-  it("drives <resolved-binary> login and publishes pending → re-probed ok", async () => {
-    const h = cursorHarness({ outcome: { ok: true }, probeResult: okEntry() });
-    await runRuntimeAuthLogin({ provider: "cursor", ref: "rc1" }, h.deps);
-
-    expect(h.loginCalls).toEqual(["/home/op/.local/bin/cursor-agent"]);
-    expect(h.calls[0]?.provider).toBe("cursor");
-    expect(h.calls[0]?.entry.pendingAuth).toMatchObject({ method: "browser" });
-    expect(h.calls.at(-1)?.entry.state).toBe("ok");
-    expect(h.calls.at(-1)?.entry.lastAuthError).toBeUndefined();
-  });
-
-  it("on unresolved/unverified binary, reflects a spawn-error lastAuthError and never logs in", async () => {
-    const h = cursorHarness({
-      resolveOk: false,
-      probeResult: { ...installedEntry(), state: "missing", available: false },
-    });
-    await runRuntimeAuthLogin({ provider: "cursor", ref: "rc2" }, h.deps);
-
-    expect(h.loginCalls).toEqual([]);
-    expect(h.calls).toHaveLength(1);
-    expect(h.calls[0]?.entry.state).toBe("missing");
-    expect(h.calls[0]?.entry.lastAuthError).toMatchObject({ reason: "spawn-error" });
-    expect(h.logs.some((l) => l.includes("cursor binary unavailable"))).toBe(true);
-  });
-
-  it("stamps lastAuthError when the cursor login fails", async () => {
-    const h = cursorHarness({
-      outcome: { ok: false, reason: "exit-nonzero", error: "login failed" },
-      probeResult: installedEntry(),
-    });
-    await runRuntimeAuthLogin({ provider: "cursor", ref: "rc3" }, h.deps);
-    expect(h.calls.at(-1)?.entry.lastAuthError).toMatchObject({ reason: "exit-nonzero", message: "login failed" });
-  });
-});
-
-describe("runRuntimeAuthLogin — grok (external-only binary)", () => {
-  function grokHarness(opts: {
-    resolveOk?: boolean;
-    outcome?: LoginOutcome;
-    fireAuthUrl?: string;
-    probeResult?: CapabilityEntry;
-  }) {
-    const calls: Recorded2[] = [];
-    const logs: string[] = [];
-    const loginCalls: string[] = [];
-    const deps = {
-      currentEntry: (): CapabilityEntry | undefined => undefined,
-      setProviderEntry: async (provider: string, entry: CapabilityEntry): Promise<void> => {
-        calls.push({ provider, entry });
-      },
-      log: (_symbol: string, msg: string): void => {
-        logs.push(msg);
-      },
-      now: (): number => NOW,
-      resolveGrokBinary: () =>
-        opts.resolveOk === false
-          ? ({ ok: false, error: "Grok Build CLI is missing on this machine.", transient: false } as const)
-          : ({ ok: true, binary: "/home/op/.local/bin/grok", version: "2026.07.09" } as const),
-      runGrokBrowser: async (o: { binary: string; onAuthUrl?: (url: string) => void }): Promise<LoginOutcome> => {
-        loginCalls.push(o.binary);
-        if (opts.fireAuthUrl) o.onAuthUrl?.(opts.fireAuthUrl);
-        await new Promise((r) => setTimeout(r, 0));
-        return opts.outcome ?? ({ ok: true } as const);
-      },
-      probeGrok: async (): Promise<CapabilityEntry> => opts.probeResult ?? installedEntry(),
-    };
-    return { calls, logs, loginCalls, deps };
-  }
-  type Recorded2 = { provider: string; entry: CapabilityEntry };
-
-  it("drives <resolved-binary> login and publishes pending → re-probed ok", async () => {
-    const h = grokHarness({ outcome: { ok: true }, probeResult: okEntry() });
-    await runRuntimeAuthLogin({ provider: "grok", ref: "rg1" }, h.deps);
-
-    expect(h.loginCalls).toEqual(["/home/op/.local/bin/grok"]);
-    expect(h.calls[0]?.provider).toBe("grok");
-    expect(h.calls[0]?.entry.pendingAuth).toMatchObject({ method: "browser" });
-    expect(h.calls.at(-1)?.entry.state).toBe("ok");
-    expect(h.calls.at(-1)?.entry.lastAuthError).toBeUndefined();
-  });
-
-  it("on unresolved/unverified binary, reflects a spawn-error lastAuthError and never logs in", async () => {
-    const h = grokHarness({
-      resolveOk: false,
-      probeResult: { ...installedEntry(), state: "missing", available: false },
-    });
-    await runRuntimeAuthLogin({ provider: "grok", ref: "rg2" }, h.deps);
-
-    expect(h.loginCalls).toEqual([]);
-    expect(h.calls).toHaveLength(1);
-    expect(h.calls[0]?.entry.state).toBe("missing");
-    expect(h.calls[0]?.entry.lastAuthError).toMatchObject({ reason: "spawn-error" });
-    expect(h.logs.some((l) => l.includes("grok binary unavailable"))).toBe(true);
-  });
-
-  it("stamps lastAuthError when the grok login fails", async () => {
-    const h = grokHarness({
-      outcome: { ok: false, reason: "exit-nonzero", error: "login failed" },
-      probeResult: installedEntry(),
-    });
-    await runRuntimeAuthLogin({ provider: "grok", ref: "rg3" }, h.deps);
-    expect(h.calls.at(-1)?.entry.lastAuthError).toMatchObject({ reason: "exit-nonzero", message: "login failed" });
+    const unresolved = harness(
+      fakeDriver({ provider: "codex", resolveError: `no codex at https://svc:pw_abcdef@registry.example/x` }).driver,
+      "codex",
+    );
+    await runRuntimeAuthLogin({ provider: "codex", ref: "cap-resolve" }, unresolved.deps);
+    expect(unresolved.calls.at(-1)?.entry.lastAuthError?.message).not.toContain("pw_abcdef");
   });
 });

--- a/apps/cli/src/core/runtime-auth-login.ts
+++ b/apps/cli/src/core/runtime-auth-login.ts
@@ -58,6 +58,29 @@ function message(err: unknown): string {
 type AuthFailure = { reason: RuntimeAuthFailureReason; message?: string };
 
 /**
+ * Every free-text string this orchestrator publishes goes through here.
+ *
+ * `redactErrorPreview` treats its argument as the body budget and appends a
+ * single ellipsis when it truncates, so hand it one less than the ceiling to
+ * keep the result within {@link RUNTIME_AUTH_ERROR_MAX_LEN}.
+ */
+function boundedErrorText(raw: string): string {
+  return redactErrorPreview(raw, RUNTIME_AUTH_ERROR_MAX_LEN - 1);
+}
+
+/**
+ * A driver's re-probe reports detection failures in `error`, and that text
+ * comes from the same hosts, paths and subprocesses as a login failure — so it
+ * gets the same treatment before it reaches the snapshot. Sanitising here
+ * rather than in each driver keeps one publish boundary to audit, and covers
+ * the extra rows a shared-credential driver returns alongside its own.
+ */
+function sanitizeProbedEntry(entry: CapabilityEntry): CapabilityEntry {
+  if (!entry.error) return entry;
+  return { ...entry, error: boundedErrorText(entry.error) };
+}
+
+/**
  * Stamp a terminal `lastAuthError` onto a freshly re-probed entry so the web can
  * tell "sign-in failed — retry" from "never attempted".
  *
@@ -69,17 +92,14 @@ type AuthFailure = { reason: RuntimeAuthFailureReason; message?: string };
  * clears any prior failure). The in-chat "needs login" entry point reads these
  * markers, the same way the prior card-side Connect control did.
  *
- * This is the single boundary where provider, resolver, spawn and thrown text
- * becomes published state, so it is also where redaction and truncation happen:
- * a provider's stderr tail can carry a token or an authenticated URL, and it
- * must not reach the snapshot verbatim or unbounded.
+ * Provider, resolver, spawn and thrown text becomes published state here, so
+ * it passes through {@link boundedErrorText} first: a provider's stderr tail
+ * can carry a token or an authenticated URL, and it must not reach the snapshot
+ * verbatim or unbounded.
  */
 function attachAuthError(entry: CapabilityEntry, failure: AuthFailure | null, nowMs: number): CapabilityEntry {
   if (!failure) return entry;
-  // `redactErrorPreview` treats its argument as the body budget and appends a
-  // single ellipsis when it truncates, so hand it one less than the ceiling to
-  // keep the published string within RUNTIME_AUTH_ERROR_MAX_LEN.
-  const preview = failure.message ? redactErrorPreview(failure.message, RUNTIME_AUTH_ERROR_MAX_LEN - 1) : "";
+  const preview = failure.message ? boundedErrorText(failure.message) : "";
   return {
     ...entry,
     lastAuthError: {
@@ -102,13 +122,19 @@ function pendingEntry(base: CapabilityEntry | undefined, pending: PendingAuth, n
     available: true,
     detectedAt: new Date(nowMs).toISOString(),
   };
+  // Starting a login clears the previous attempt's verdict, so the stale
+  // `error` / `lastAuthError` of the snapshot we are layering onto are dropped
+  // rather than spread forward: keeping detection-failure text on an entry we
+  // are about to force to `ok` contradicts itself, and republishing it would
+  // slip old (possibly credential-bearing) text past the sanitising boundary.
+  const { error: _staleError, lastAuthError: _staleAuthError, ...carried } = baseEntry;
   // A login only starts after the provider binary resolved, so the provider IS
   // installed: force the install fields rather than inheriting a possibly-stale
   // non-`ok` base (which would yield a contradictory `missing` + pendingAuth
   // entry). `authenticated`/`authMethod` are deprecated wire-compat for older
   // servers (see the client-capabilities schema).
   return {
-    ...baseEntry,
+    ...carried,
     state: "ok",
     available: true,
     authenticated: true,
@@ -163,7 +189,8 @@ async function driveRuntimeAuthLogin(
   const reflect = async (label: string, failure: AuthFailure | null): Promise<void> => {
     try {
       for (const { provider, entry } of await driver.reprobe()) {
-        const published = provider === command.provider ? attachAuthError(entry, failure, now()) : entry;
+        const safe = sanitizeProbedEntry(entry);
+        const published = provider === command.provider ? attachAuthError(safe, failure, now()) : safe;
         await deps.setProviderEntry(provider, published);
       }
     } catch (err) {

--- a/apps/cli/src/core/runtime-auth-login.ts
+++ b/apps/cli/src/core/runtime-auth-login.ts
@@ -40,12 +40,13 @@ export type RuntimeAuthLoginDeps = {
 };
 
 /**
- * Budget for a login failure republished on a capability entry. Matched to the
- * probe's own error budget so a provider that streams a huge stack trace, or a
- * resolver that echoes a credential-bearing path, cannot grow the snapshot the
- * daemon PATCHes. The cap lives here rather than on the shared wire schema: a
- * `.max()` there would make a new server reject an older daemon's payload and
- * break the rolling-upgrade contract the capability map depends on.
+ * Hard ceiling on the length of a login failure republished on a capability
+ * entry, ellipsis included. Sized to the probe's own error budget so a provider
+ * that streams a huge stack trace, or a resolver that echoes a
+ * credential-bearing path, cannot grow the snapshot the daemon PATCHes. The cap
+ * lives here rather than on the shared wire schema: a `.max()` there would make
+ * a new server reject an older daemon's payload and break the rolling-upgrade
+ * contract the capability map depends on.
  */
 export const RUNTIME_AUTH_ERROR_MAX_LEN = 500;
 
@@ -75,7 +76,10 @@ type AuthFailure = { reason: RuntimeAuthFailureReason; message?: string };
  */
 function attachAuthError(entry: CapabilityEntry, failure: AuthFailure | null, nowMs: number): CapabilityEntry {
   if (!failure) return entry;
-  const preview = failure.message ? redactErrorPreview(failure.message, RUNTIME_AUTH_ERROR_MAX_LEN) : "";
+  // `redactErrorPreview` treats its argument as the body budget and appends a
+  // single ellipsis when it truncates, so hand it one less than the ceiling to
+  // keep the published string within RUNTIME_AUTH_ERROR_MAX_LEN.
+  const preview = failure.message ? redactErrorPreview(failure.message, RUNTIME_AUTH_ERROR_MAX_LEN - 1) : "";
   return {
     ...entry,
     lastAuthError: {

--- a/apps/cli/src/core/runtime-auth-login.ts
+++ b/apps/cli/src/core/runtime-auth-login.ts
@@ -5,6 +5,7 @@ import {
   type RuntimeAuthCommand,
   type RuntimeAuthDriver,
   type RuntimeAuthDriverTable,
+  type RuntimeAuthLoginResolution,
   redactErrorPreview,
 } from "@first-tree/client";
 import type { CapabilityEntry, PendingAuth, RuntimeAuthFailureReason } from "@first-tree/shared";
@@ -168,18 +169,42 @@ async function driveRuntimeAuthLogin(
 
   deps.log("•", `runtime-auth: starting ${loginLabel} (method=browser, ref ${command.ref})`);
 
-  const resolution = await driver.resolveLogin();
+  // A resolver reaches into PATH and the host filesystem, so it can throw as
+  // well as report a missing artifact. To an operator both mean the login never
+  // started, and neither may escape this orchestrator.
+  let resolution: RuntimeAuthLoginResolution;
+  try {
+    resolution = await driver.resolveLogin();
+  } catch (err) {
+    deps.log("⚠️", `runtime-auth: ${logLabel} ${artifactLabel} lookup threw: ${message(err)}`);
+    await reflect(`after ${artifactLabel} lookup threw`, { reason: "spawn-error", message: message(err) });
+    return;
+  }
   if (!resolution.ok) {
     deps.log("⚠️", `runtime-auth: ${logLabel} ${artifactLabel} unavailable: ${resolution.error}`);
     await reflect(`after unresolved ${artifactLabel}`, { reason: "spawn-error", message: resolution.error });
     return;
   }
 
-  const setPending = (authUrl?: string): Promise<void> =>
-    deps.setProviderEntry(
-      command.provider,
-      pendingEntry(deps.currentEntry(command.provider), browserPending(now(), authUrl), now()),
-    );
+  // `onAuthUrl` fires from the login's output stream, so its entry write races
+  // the terminal re-probe that follows the login. Chaining the pending writes
+  // and draining them before the terminal reflection keeps the operator's view
+  // moving forwards — pending, then pending + URL, then the outcome — instead
+  // of a late pending marker landing on top of an already finished login.
+  let pendingWrites: Promise<void> = Promise.resolve();
+  const setPending = (authUrl?: string): Promise<void> => {
+    pendingWrites = pendingWrites.then(async () => {
+      try {
+        await deps.setProviderEntry(
+          command.provider,
+          pendingEntry(deps.currentEntry(command.provider), browserPending(now(), authUrl), now()),
+        );
+      } catch (err) {
+        deps.log("⚠️", `runtime-auth: ${logLabel} pending update failed: ${message(err)}`);
+      }
+    });
+    return pendingWrites;
+  };
   await setPending();
   deps.log("•", `runtime-auth: ${logLabel} browser sign-in opened on this host`);
 
@@ -190,10 +215,12 @@ async function driveRuntimeAuthLogin(
     outcome = await resolution.login({ onAuthUrl: (url) => void setPending(url) });
   } catch (err) {
     deps.log("⚠️", `runtime-auth: ${loginLabel} threw: ${message(err)}`);
+    await pendingWrites;
     await reflect("after login threw", { reason: "spawn-error", message: message(err) });
     return;
   }
 
+  await pendingWrites;
   await reflect("after login", outcome.ok ? null : { reason: outcome.reason, message: outcome.error });
   logOutcome(logLabel, command.ref, outcome, deps);
 }

--- a/apps/cli/src/core/runtime-auth-login.ts
+++ b/apps/cli/src/core/runtime-auth-login.ts
@@ -1,31 +1,13 @@
 import {
   BROWSER_LOGIN_TIMEOUT_MS,
-  type ClaudeLoginInvocation,
-  type CodexBinaryResolution,
-  type CursorRuntimeBinaryResolution,
-  type GrokRuntimeBinaryResolution,
   type LoginOutcome,
-  probeClaudeCodeCapability,
-  probeClaudeCodeTuiCapability,
-  probeCodexCapability,
-  probeCursorCapability,
-  probeGrokCapability,
+  RUNTIME_AUTH_DRIVERS,
   type RuntimeAuthCommand,
-  resolveClaudeLoginInvocation,
-  resolveCodexRuntimeBinary,
-  resolveCursorRuntimeBinary,
-  resolveGrokRuntimeBinary,
-  runClaudeBrowserLogin,
-  runCodexBrowserLogin,
-  runCursorBrowserLogin,
-  runGrokBrowserLogin,
+  type RuntimeAuthDriver,
+  type RuntimeAuthDriverTable,
+  redactErrorPreview,
 } from "@first-tree/client";
-import {
-  type CapabilityEntry,
-  isRuntimeProviderEnabled,
-  type PendingAuth,
-  type RuntimeAuthFailureReason,
-} from "@first-tree/shared";
+import type { CapabilityEntry, PendingAuth, RuntimeAuthFailureReason } from "@first-tree/shared";
 
 /**
  * Daemon-side orchestrator for an in-product runtime-auth login.
@@ -37,9 +19,11 @@ import {
  * screen with no bespoke realtime channel, and the capability probe stays the
  * single source of truth. The OAuth token never transits First Tree.
  *
- * Browser OAuth across both providers:
- *   - codex: bare `codex login` → writes `~/.codex/auth.json`.
- *   - claude-code: `claude auth login` → writes keychain `Claude Code-credentials`.
+ * This module is provider-neutral on purpose: it owns the part of the flow that
+ * is identical for every browser-OAuth provider, and dispatches by typed key
+ * into the Client's `RUNTIME_AUTH_DRIVERS` composition root for the three steps
+ * that differ (resolve the artifact, spawn the login, re-probe the affected
+ * capability rows). Adding a provider must not add a branch here.
  */
 
 export type RuntimeAuthLoginDeps = {
@@ -49,22 +33,20 @@ export type RuntimeAuthLoginDeps = {
   setProviderEntry: (provider: string, entry: CapabilityEntry) => Promise<void>;
   /** Status logger (symbol + message). */
   log: (symbol: string, message: string) => void;
-  /** Seams for tests — production callers omit these. */
-  resolveCodexBinary?: () => Promise<CodexBinaryResolution>;
-  runBrowserLogin?: typeof runCodexBrowserLogin;
-  probeCodex?: () => Promise<CapabilityEntry>;
-  resolveClaudeLogin?: () => ClaudeLoginInvocation;
-  runClaudeBrowser?: typeof runClaudeBrowserLogin;
-  probeClaude?: () => Promise<CapabilityEntry>;
-  probeClaudeTui?: () => Promise<CapabilityEntry>;
-  resolveCursorBinary?: () => CursorRuntimeBinaryResolution;
-  runCursorBrowser?: typeof runCursorBrowserLogin;
-  probeCursor?: () => Promise<CapabilityEntry>;
-  resolveGrokBinary?: () => GrokRuntimeBinaryResolution;
-  runGrokBrowser?: typeof runGrokBrowserLogin;
-  probeGrok?: () => Promise<CapabilityEntry>;
+  /** Seam for tests — production callers omit this and get the frozen table. */
+  drivers?: RuntimeAuthDriverTable;
   now?: () => number;
 };
+
+/**
+ * Budget for a login failure republished on a capability entry. Matched to the
+ * probe's own error budget so a provider that streams a huge stack trace, or a
+ * resolver that echoes a credential-bearing path, cannot grow the snapshot the
+ * daemon PATCHes. The cap lives here rather than on the shared wire schema: a
+ * `.max()` there would make a new server reject an older daemon's payload and
+ * break the rolling-upgrade contract the capability map depends on.
+ */
+export const RUNTIME_AUTH_ERROR_MAX_LEN = 500;
 
 function message(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -84,14 +66,20 @@ type AuthFailure = { reason: RuntimeAuthFailureReason; message?: string };
  * (success passes `null`, which leaves the re-probed entry marker-free and thus
  * clears any prior failure). The in-chat "needs login" entry point reads these
  * markers, the same way the prior card-side Connect control did.
+ *
+ * This is the single boundary where provider, resolver, spawn and thrown text
+ * becomes published state, so it is also where redaction and truncation happen:
+ * a provider's stderr tail can carry a token or an authenticated URL, and it
+ * must not reach the snapshot verbatim or unbounded.
  */
 function attachAuthError(entry: CapabilityEntry, failure: AuthFailure | null, nowMs: number): CapabilityEntry {
   if (!failure) return entry;
+  const preview = failure.message ? redactErrorPreview(failure.message, RUNTIME_AUTH_ERROR_MAX_LEN) : "";
   return {
     ...entry,
     lastAuthError: {
       reason: failure.reason,
-      ...(failure.message ? { message: failure.message } : {}),
+      ...(preview ? { message: preview } : {}),
       at: new Date(nowMs).toISOString(),
     },
   };
@@ -138,230 +126,76 @@ function browserPending(nowMs: number, authUrl?: string): PendingAuth {
   };
 }
 
-/** Dispatch on provider. Never throws — failures are logged + reflected in caps. */
+/**
+ * Dispatch on the typed auth provider. Never throws — failures are logged and
+ * reflected in capabilities.
+ */
 export async function runRuntimeAuthLogin(command: RuntimeAuthCommand, deps: RuntimeAuthLoginDeps): Promise<void> {
-  if (command.provider === "codex") {
-    await runCodexRuntimeAuth(command, deps);
+  const driver: RuntimeAuthDriver | undefined = (deps.drivers ?? RUNTIME_AUTH_DRIVERS)[command.provider];
+  // Unreachable through the Zod-parsed reverse command, which only yields keys
+  // of the table. Kept because this orchestrator is exported and a table built
+  // elsewhere could still be short an entry.
+  if (!driver) {
+    deps.log("⚠️", `runtime-auth: provider "${command.provider}" is not supported yet (ref ${command.ref})`);
     return;
   }
-  if (command.provider === "claude-code") {
-    await runClaudeRuntimeAuth(command, deps);
-    return;
-  }
-  if (command.provider === "cursor") {
-    await runCursorRuntimeAuth(command, deps);
-    return;
-  }
-  if (command.provider === "grok") {
-    await runGrokRuntimeAuth(command, deps);
-    return;
-  }
-  deps.log("⚠️", `runtime-auth: provider "${command.provider}" is not supported yet (ref ${command.ref})`);
+  await driveRuntimeAuthLogin(command, driver, deps);
 }
 
-/** cursor: `<cursor-binary> login` (official browser OAuth on the host). */
-async function runCursorRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAuthLoginDeps): Promise<void> {
+async function driveRuntimeAuthLogin(
+  command: RuntimeAuthCommand,
+  driver: RuntimeAuthDriver,
+  deps: RuntimeAuthLoginDeps,
+): Promise<void> {
   const now = deps.now ?? Date.now;
-  const resolveBinary = deps.resolveCursorBinary ?? resolveCursorRuntimeBinary;
-  const probeCursor = deps.probeCursor ?? probeCursorCapability;
-  const runCursorBrowser = deps.runCursorBrowser ?? runCursorBrowserLogin;
-
-  const reflect = async (label: string, failure: AuthFailure | null): Promise<void> => {
-    try {
-      await deps.setProviderEntry("cursor", attachAuthError(await probeCursor(), failure, now()));
-    } catch (err) {
-      deps.log("⚠️", `runtime-auth: cursor re-probe ${label} failed: ${message(err)}`);
-    }
-  };
-
-  deps.log("•", `runtime-auth: starting cursor login (method=browser, ref ${command.ref})`);
-
-  // Login drives the SAME resolved binary the handler spawns (external-only),
-  // including its bounded `--version` smoke check — the first real use.
-  const resolved = resolveBinary();
-  if (!resolved.ok) {
-    deps.log("⚠️", `runtime-auth: cursor binary unavailable: ${resolved.error}`);
-    await reflect("after unresolved binary", { reason: "spawn-error", message: resolved.error });
-    return;
-  }
-
-  const setPending = (authUrl?: string): Promise<void> =>
-    deps.setProviderEntry("cursor", pendingEntry(deps.currentEntry("cursor"), browserPending(now(), authUrl), now()));
-  await setPending();
-  deps.log("•", "runtime-auth: cursor browser sign-in opened on this host");
-
-  let outcome: LoginOutcome;
-  try {
-    outcome = await runCursorBrowser({ binary: resolved.binary, onAuthUrl: (url) => void setPending(url) });
-  } catch (err) {
-    deps.log("⚠️", `runtime-auth: cursor login threw: ${message(err)}`);
-    await reflect("after login threw", { reason: "spawn-error", message: message(err) });
-    return;
-  }
-
-  await reflect("after login", outcome.ok ? null : { reason: outcome.reason, message: outcome.error });
-  logOutcome("cursor", command.ref, outcome, deps);
-}
-
-/** grok: `<grok-binary> login` (official browser OAuth on the host). */
-async function runGrokRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAuthLoginDeps): Promise<void> {
-  const now = deps.now ?? Date.now;
-  const resolveBinary = deps.resolveGrokBinary ?? resolveGrokRuntimeBinary;
-  const probeGrok = deps.probeGrok ?? probeGrokCapability;
-  const runGrokBrowser = deps.runGrokBrowser ?? runGrokBrowserLogin;
-
-  const reflect = async (label: string, failure: AuthFailure | null): Promise<void> => {
-    try {
-      await deps.setProviderEntry("grok", attachAuthError(await probeGrok(), failure, now()));
-    } catch (err) {
-      deps.log("⚠️", `runtime-auth: grok re-probe ${label} failed: ${message(err)}`);
-    }
-  };
-
-  deps.log("•", `runtime-auth: starting grok login (method=browser, ref ${command.ref})`);
-
-  // Login drives the SAME resolved binary the handler spawns (external-only),
-  // including its bounded `--version` smoke check — the first real use.
-  const resolved = resolveBinary();
-  if (!resolved.ok) {
-    deps.log("⚠️", `runtime-auth: grok binary unavailable: ${resolved.error}`);
-    await reflect("after unresolved binary", { reason: "spawn-error", message: resolved.error });
-    return;
-  }
-
-  const setPending = (authUrl?: string): Promise<void> =>
-    deps.setProviderEntry("grok", pendingEntry(deps.currentEntry("grok"), browserPending(now(), authUrl), now()));
-  await setPending();
-  deps.log("•", "runtime-auth: grok browser sign-in opened on this host");
-
-  let outcome: LoginOutcome;
-  try {
-    // `url` is annotated explicitly (unlike the cursor twin) because the
-    // `runGrokBrowserLogin` export has not landed in @first-tree/client yet,
-    // so there is no options type to infer from until it does.
-    outcome = await runGrokBrowser({ binary: resolved.binary, onAuthUrl: (url: string) => void setPending(url) });
-  } catch (err) {
-    deps.log("⚠️", `runtime-auth: grok login threw: ${message(err)}`);
-    await reflect("after login threw", { reason: "spawn-error", message: message(err) });
-    return;
-  }
-
-  await reflect("after login", outcome.ok ? null : { reason: outcome.reason, message: outcome.error });
-  logOutcome("grok", command.ref, outcome, deps);
-}
-
-async function runCodexRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAuthLoginDeps): Promise<void> {
-  const now = deps.now ?? Date.now;
-  const resolveBinary = deps.resolveCodexBinary ?? resolveCodexRuntimeBinary;
-  const probeCodex = deps.probeCodex ?? probeCodexCapability;
-  const runBrowserLogin = deps.runBrowserLogin ?? runCodexBrowserLogin;
+  const { logLabel, loginLabel, artifactLabel } = driver;
 
   // Re-probe the real state and, on a terminal failure, stamp `lastAuthError`
-  // onto the entry so the web shows "sign-in failed — retry" instead of silently
-  // resetting to a fresh Connect button.
+  // onto the login target's entry so the web shows "sign-in failed — retry"
+  // instead of silently resetting to a fresh Connect button. A driver may
+  // return more than one row when providers share a credential; only the
+  // target row carries the failure.
   const reflect = async (label: string, failure: AuthFailure | null): Promise<void> => {
     try {
-      await deps.setProviderEntry("codex", attachAuthError(await probeCodex(), failure, now()));
-    } catch (err) {
-      deps.log("⚠️", `runtime-auth: codex re-probe ${label} failed: ${message(err)}`);
-    }
-  };
-
-  deps.log("•", `runtime-auth: starting codex login (method=browser, ref ${command.ref})`);
-
-  const resolved = await resolveBinary();
-  if (!resolved.ok) {
-    deps.log("⚠️", `runtime-auth: codex binary unavailable: ${resolved.error}`);
-    await reflect("after unresolved binary", { reason: "spawn-error", message: resolved.error });
-    return;
-  }
-
-  const setPending = (authUrl?: string): Promise<void> =>
-    deps.setProviderEntry("codex", pendingEntry(deps.currentEntry("codex"), browserPending(now(), authUrl), now()));
-  await setPending();
-  deps.log("•", "runtime-auth: codex browser sign-in opened on this host");
-
-  let outcome: LoginOutcome;
-  try {
-    // Surface the sign-in URL into the pending marker once codex prints it, so
-    // the web can offer a fallback link when the host browser does not auto-open.
-    outcome = await runBrowserLogin({ binary: resolved.binary, onAuthUrl: (url) => void setPending(url) });
-  } catch (err) {
-    deps.log("⚠️", `runtime-auth: codex login threw: ${message(err)}`);
-    await reflect("after login threw", { reason: "spawn-error", message: message(err) });
-    return;
-  }
-
-  await reflect("after login", outcome.ok ? null : { reason: outcome.reason, message: outcome.error });
-  logOutcome("codex", command.ref, outcome, deps);
-}
-
-/** claude-code: `claude auth login` (browser OAuth → keychain). */
-async function runClaudeRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAuthLoginDeps): Promise<void> {
-  const now = deps.now ?? Date.now;
-  const resolveLogin = deps.resolveClaudeLogin ?? resolveClaudeLoginInvocation;
-  const runClaudeBrowser = deps.runClaudeBrowser ?? runClaudeBrowserLogin;
-  const probeClaude = deps.probeClaude ?? probeClaudeCodeCapability;
-  const probeClaudeTui = deps.probeClaudeTui ?? probeClaudeCodeTuiCapability;
-
-  // Claude auth is a single keychain credential shared by the SDK (claude-code)
-  // AND the TUI runtime (claude-code-tui). So a Claude login authenticates both;
-  // re-probe both here, otherwise the TUI row stays a stale "needs login" until
-  // the next background poll (the QA finding) and reads as a second, separate
-  // Claude login the user must do — it isn't.
-  // A failure stamps `lastAuthError` on the claude-code entry only (the login
-  // target); the shared-keychain tui entry just reflects the re-probed state.
-  // While claude-code-tui is disabled (DISABLED_RUNTIME_PROVIDERS), this path
-  // honours the same central switch as the capability aggregator: it must not
-  // spawn the TUI probe (`claude` / tmux) or write a tui entry — a claude-code
-  // login then reflects claude-code only.
-  const reflect = async (label: string, failure: AuthFailure | null): Promise<void> => {
-    try {
-      if (isRuntimeProviderEnabled("claude-code-tui")) {
-        const [cc, tui] = await Promise.all([probeClaude(), probeClaudeTui()]);
-        await deps.setProviderEntry("claude-code", attachAuthError(cc, failure, now()));
-        await deps.setProviderEntry("claude-code-tui", tui);
-      } else {
-        const cc = await probeClaude();
-        await deps.setProviderEntry("claude-code", attachAuthError(cc, failure, now()));
+      for (const { provider, entry } of await driver.reprobe()) {
+        const published = provider === command.provider ? attachAuthError(entry, failure, now()) : entry;
+        await deps.setProviderEntry(provider, published);
       }
     } catch (err) {
-      deps.log("⚠️", `runtime-auth: claude re-probe ${label} failed: ${message(err)}`);
+      deps.log("⚠️", `runtime-auth: ${logLabel} re-probe ${label} failed: ${message(err)}`);
     }
   };
 
-  deps.log("•", `runtime-auth: starting claude auth login (method=browser, ref ${command.ref})`);
+  deps.log("•", `runtime-auth: starting ${loginLabel} (method=browser, ref ${command.ref})`);
 
-  const invocation = resolveLogin();
-  if (!invocation.ok) {
-    deps.log("⚠️", `runtime-auth: claude CLI unavailable: ${invocation.error}`);
-    await reflect("after unresolved CLI", { reason: "spawn-error", message: invocation.error });
+  const resolution = await driver.resolveLogin();
+  if (!resolution.ok) {
+    deps.log("⚠️", `runtime-auth: ${logLabel} ${artifactLabel} unavailable: ${resolution.error}`);
+    await reflect(`after unresolved ${artifactLabel}`, { reason: "spawn-error", message: resolution.error });
     return;
   }
 
   const setPending = (authUrl?: string): Promise<void> =>
     deps.setProviderEntry(
-      "claude-code",
-      pendingEntry(deps.currentEntry("claude-code"), browserPending(now(), authUrl), now()),
+      command.provider,
+      pendingEntry(deps.currentEntry(command.provider), browserPending(now(), authUrl), now()),
     );
   await setPending();
-  deps.log("•", "runtime-auth: claude browser sign-in opened on this host");
+  deps.log("•", `runtime-auth: ${logLabel} browser sign-in opened on this host`);
 
   let outcome: LoginOutcome;
   try {
-    outcome = await runClaudeBrowser({
-      command: invocation.command,
-      baseArgs: invocation.baseArgs,
-      onAuthUrl: (url) => void setPending(url),
-    });
+    // Surface the sign-in URL into the pending marker once the login prints it,
+    // so the web can offer a fallback link when the host browser does not open.
+    outcome = await resolution.login({ onAuthUrl: (url) => void setPending(url) });
   } catch (err) {
-    deps.log("⚠️", `runtime-auth: claude auth login threw: ${message(err)}`);
+    deps.log("⚠️", `runtime-auth: ${loginLabel} threw: ${message(err)}`);
     await reflect("after login threw", { reason: "spawn-error", message: message(err) });
     return;
   }
 
   await reflect("after login", outcome.ok ? null : { reason: outcome.reason, message: outcome.error });
-  logOutcome("claude", command.ref, outcome, deps);
+  logOutcome(logLabel, command.ref, outcome, deps);
 }
 
 function logOutcome(provider: string, ref: string, outcome: LoginOutcome, deps: RuntimeAuthLoginDeps): void {

--- a/apps/cli/src/core/runtime-auth-login.ts
+++ b/apps/cli/src/core/runtime-auth-login.ts
@@ -58,7 +58,10 @@ function message(err: unknown): string {
 type AuthFailure = { reason: RuntimeAuthFailureReason; message?: string };
 
 /**
- * Every free-text string this orchestrator publishes goes through here.
+ * Every error/failure string this orchestrator republishes goes through here:
+ * `CapabilityEntry.error` and `lastAuthError.message`. Structured fields the
+ * daemon itself produces — `pendingAuth.authUrl`, the detected version, the
+ * runtime source — are not error text and deliberately do not pass through.
  *
  * `redactErrorPreview` treats its argument as the body budget and appends a
  * single ellipsis when it truncates, so hand it one less than the ceiling to

--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import type { ClientPausedReason, SessionEvent } from "@first-tree/shared";
+import { type ClientPausedReason, runtimeAuthProviderSchema, type SessionEvent } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BoundAgent } from "../client-connection.js";
 
@@ -730,6 +730,29 @@ describe("ClientConnection — additional branch coverage", () => {
     expect(commands).toContainEqual({ type: "session:resume", agentId: "agent-1", chatId: "chat-1" });
     expect(runtimeAuthStarts).toContainEqual({ provider: "codex", method: "browser", ref: "auth-ref" });
     expect(reconciles).toContainEqual({ agentId: "agent-1", staleChatIds: ["chat-1"] });
+
+    priv(connection).clearTimers();
+  });
+
+  it("emits a typed runtime-auth start for every legal target and for nothing else", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection);
+    await bindAgent(connection, socket);
+
+    const starts: Array<{ provider: string }> = [];
+    connection.on("runtime-auth:start", (command) => starts.push(command));
+
+    // The wire already narrows Connect to these four targets; the daemon now
+    // dispatches on that key, so an out-of-set target must never reach it.
+    // `claude-code-tui` shares Claude's credential and Kimi is a host login.
+    for (const provider of runtimeAuthProviderSchema.options) {
+      socket.emitMessage({ type: "runtime-auth:start", provider, method: "browser", ref: `ref-${provider}` });
+    }
+    for (const provider of ["claude-code-tui", "kimi", "opencode", "pi"]) {
+      socket.emitMessage({ type: "runtime-auth:start", provider, method: "browser", ref: `ref-${provider}` });
+    }
+
+    expect(starts.map((s) => s.provider)).toEqual([...runtimeAuthProviderSchema.options]);
 
     priv(connection).clearTimers();
   });

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -237,13 +237,15 @@ describe("runtime provider architecture guard", () => {
     // No full-output accumulation, and no full-buffer handoff to consumers.
     expect(source).not.toMatch(/\bbuffer\s*\+=/);
     expect(source).not.toMatch(/onOutput\?\.\([^)]*,/);
-    // `pendingAuth.authUrl` is a structured field that never passes through
-    // redactErrorPreview, so URL candidacy is the only gate that keeps a
-    // credential-bearing string (proxy URL, redirect echo, β€¦) out of the
-    // capability snapshot. It must share the same key set redactErrorPreview
-    // uses rather than maintain a second list that can drift, and it must
-    // reject a bad candidate outright rather than rewrite it.
-    expect(source).toContain("CREDENTIAL_KEY_PATTERN");
+    // `pendingAuth.authUrl` is a structured field that never itself passes
+    // through redactErrorPreview, so URL candidacy is the only gate that
+    // keeps a credential-bearing string (proxy URL, redirect echo, a vendor
+    // token under a neutral key, ...) out of the capability snapshot. It must
+    // delegate to that exact sanitizer rather than re-check a subset of its
+    // rules (a partial reimplementation would fall behind the moment that
+    // helper gains a new detection rule), and it must reject a bad candidate
+    // outright rather than rewrite it.
+    expect(source).toContain("redactErrorPreview");
     expect(source).toContain("hasCredentialShape");
   });
 

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
-import { RUNTIME_PROVIDER_IDS } from "@first-tree/shared";
+import { RUNTIME_PROVIDER_IDS, runtimeAuthProviderSchema } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -20,6 +20,7 @@ const THIRD_PARTY_SDK_IMPORTS = [
 
 /** Unique composition roots allowed to name concrete providers / import adapters. */
 const COMPOSITION_ALLOWLIST = new Set([
+  "providers/auth-drivers.ts",
   "providers/builtin-registry.ts",
   "providers/builtin-probes.ts",
   "providers/skill-roots.ts",
@@ -161,6 +162,49 @@ describe("runtime provider architecture guard", () => {
     expect(probes).not.toContain("builtinProbeProviderIds");
     expect(skills).toContain("Object.freeze");
     expect(skills).not.toContain("assertSkillRootsComplete");
+  });
+
+  it("keeps the runtime-auth driver projection in one frozen, schema-exhaustive composition root", () => {
+    const drivers = readFileSync(join(clientSrc, "providers/auth-drivers.ts"), "utf8");
+    expect(drivers).toContain("Object.freeze");
+    // The key set is a projection of the narrow server-accepted auth enum, not
+    // a second handwritten known-provider list.
+    expect(drivers).toContain("satisfies Record<RuntimeAuthProvider, RuntimeAuthDriver>");
+    for (const provider of runtimeAuthProviderSchema.options) {
+      expect(drivers, `auth-drivers must register ${provider}`).toContain(provider);
+    }
+    // The contract itself stays provider-neutral.
+    const contract = readFileSync(join(clientSrc, "providers/auth-driver.ts"), "utf8");
+    expect(containsAnyProviderLiteral(contract)).toBeNull();
+  });
+
+  it("keeps the daemon runtime-auth dispatcher free of provider literals, imports and branches", () => {
+    const rel = "apps/cli/src/core/runtime-auth-login.ts";
+    const source = readFileSync(join(repoRoot, rel), "utf8");
+
+    expect(source).toContain("RUNTIME_AUTH_DRIVERS");
+    const hit = containsAnyProviderLiteral(source);
+    expect(hit, `${rel} must not contain provider literal ${hit}`).toBeNull();
+    for (const provider of runtimeAuthProviderSchema.options) {
+      expect(source, `${rel} must not branch on ${provider}`).not.toMatch(
+        new RegExp(`(===|case)\\s*["']${provider}["']`),
+      );
+    }
+    // No provider-specific resolver / probe / browser-login imports remain.
+    expect(source).not.toMatch(/\b(resolve|probe|run)(Codex|Claude|Cursor|Grok)\w*/);
+    // Published failure text goes through the shared redaction boundary.
+    expect(source).toContain("redactErrorPreview");
+    expect(source).toContain("RUNTIME_AUTH_ERROR_MAX_LEN");
+  });
+
+  it("keeps provider login output bounded and incrementally scanned", () => {
+    const source = readFileSync(join(clientSrc, "runtime/runtime-login.ts"), "utf8");
+    expect(source).toContain("createAuthUrlScanner");
+    expect(source).toContain("AUTH_URL_TOKEN_MAX");
+    expect(source).toContain("LOGIN_STDERR_TAIL_MAX");
+    // No full-output accumulation, and no full-buffer handoff to consumers.
+    expect(source).not.toMatch(/\bbuffer\s*\+=/);
+    expect(source).not.toMatch(/onOutput\?\.\([^)]*,/);
   });
 
   it("keeps third-party provider SDKs out of shared and web packages", () => {

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -188,6 +188,20 @@ describe("runtime provider architecture guard", () => {
     // The contract itself stays provider-neutral.
     const contract = readFileSync(join(clientSrc, "providers/auth-driver.ts"), "utf8");
     expect(containsAnyProviderLiteral(contract)).toBeNull();
+    // Method-shorthand type syntax (`resolveLogin(): ...`) is NOT readonly, so
+    // the contract must declare its function members as readonly properties -
+    // the compile-time half of the immutability guarantee that Object.freeze
+    // on each production driver enforces at runtime.
+    expect(contract).toContain("readonly resolveLogin");
+    expect(contract).toContain("readonly reprobe");
+
+    // Every provider-owned factory must freeze what it hands back, so the
+    // guarantee holds regardless of how - or whether - it is composed into
+    // RUNTIME_AUTH_DRIVERS.
+    for (const file of ["claude-login.ts", "codex-login.ts", "cursor-login.ts", "grok-login.ts"]) {
+      const source = readFileSync(join(clientSrc, "runtime", file), "utf8");
+      expect(source, `${file} must freeze its returned driver`).toContain("Object.freeze");
+    }
   });
 
   it("keeps the daemon runtime-auth dispatcher free of provider literals, imports and branches", () => {
@@ -223,6 +237,14 @@ describe("runtime provider architecture guard", () => {
     // No full-output accumulation, and no full-buffer handoff to consumers.
     expect(source).not.toMatch(/\bbuffer\s*\+=/);
     expect(source).not.toMatch(/onOutput\?\.\([^)]*,/);
+    // `pendingAuth.authUrl` is a structured field that never passes through
+    // redactErrorPreview, so URL candidacy is the only gate that keeps a
+    // credential-bearing string (proxy URL, redirect echo, β€¦) out of the
+    // capability snapshot. It must share the same key set redactErrorPreview
+    // uses rather than maintain a second list that can drift, and it must
+    // reject a bad candidate outright rather than rewrite it.
+    expect(source).toContain("CREDENTIAL_KEY_PATTERN");
+    expect(source).toContain("hasCredentialShape");
   });
 
   it("keeps third-party provider SDKs out of shared and web packages", () => {

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -11,6 +11,18 @@ const repoRoot = join(clientSrc, "..", "..", "..");
 /** Quote tokens derived from the Zod ID set — auto-expands when a provider is added. */
 const PROVIDER_LITERAL_TOKENS: readonly string[] = RUNTIME_PROVIDER_IDS.flatMap((id) => [`"${id}"`, `'${id}'`]);
 
+/**
+ * The narrower in-product auth set, derived from its own schema so that
+ * extending `runtimeAuthProviderSchema` widens this guard in the same commit
+ * that widens the driver registry. The full-provider tokens above still apply
+ * to the daemon dispatcher; this set pins the enum the dispatcher keys on.
+ */
+const AUTH_PROVIDER_LITERAL_TOKENS: readonly string[] = runtimeAuthProviderSchema.options.flatMap((id) => [
+  `"${id}"`,
+  `'${id}'`,
+  `\`${id}\``,
+]);
+
 const THIRD_PARTY_SDK_IMPORTS = [
   "@anthropic-ai/claude-agent-sdk",
   "@openai/codex-sdk",
@@ -185,6 +197,12 @@ describe("runtime provider architecture guard", () => {
     expect(source).toContain("RUNTIME_AUTH_DRIVERS");
     const hit = containsAnyProviderLiteral(source);
     expect(hit, `${rel} must not contain provider literal ${hit}`).toBeNull();
+    // Same file, narrower lens: the auth enum the dispatcher keys on, derived
+    // from its own schema so a new in-product target cannot widen the registry
+    // without widening this guard.
+    for (const token of AUTH_PROVIDER_LITERAL_TOKENS) {
+      expect(source, `${rel} must not contain auth provider literal ${token}`).not.toContain(token);
+    }
     for (const provider of runtimeAuthProviderSchema.options) {
       expect(source, `${rel} must not branch on ${provider}`).not.toMatch(
         new RegExp(`(===|case)\\s*["']${provider}["']`),

--- a/packages/client/src/__tests__/runtime-auth-drivers.test.ts
+++ b/packages/client/src/__tests__/runtime-auth-drivers.test.ts
@@ -1,0 +1,211 @@
+import type { CapabilityEntry } from "@first-tree/shared";
+import { runtimeAuthProviderSchema } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeAuthDriver } from "../providers/auth-driver.js";
+import { RUNTIME_AUTH_DRIVERS } from "../providers/auth-drivers.js";
+import { createClaudeAuthDriver } from "../runtime/claude-login.js";
+import { createCodexAuthDriver } from "../runtime/codex-login.js";
+import { createCursorAuthDriver } from "../runtime/cursor-login.js";
+import { createGrokAuthDriver } from "../runtime/grok-login.js";
+import type { LoginOutcome } from "../runtime/runtime-login.js";
+
+const entry = (over: Partial<CapabilityEntry> = {}): CapabilityEntry => ({
+  state: "ok",
+  available: true,
+  detectedAt: "2026-06-22T12:00:00.000Z",
+  ...over,
+});
+
+describe("RUNTIME_AUTH_DRIVERS composition root", () => {
+  it("is frozen and exhaustive over the server-accepted auth provider set", () => {
+    expect(Object.isFrozen(RUNTIME_AUTH_DRIVERS)).toBe(true);
+    // The narrow runtime-auth enum, not the full runtime-provider enum: Kimi /
+    // OpenCode / Pi keep provider-owned host login and claude-code-tui shares
+    // Claude Code's credential, so none of them may become a Connect target.
+    expect(Object.keys(RUNTIME_AUTH_DRIVERS).sort()).toEqual([...runtimeAuthProviderSchema.options].sort());
+  });
+
+  it("exposes a complete driver for every auth provider", () => {
+    for (const provider of runtimeAuthProviderSchema.options) {
+      const driver: RuntimeAuthDriver = RUNTIME_AUTH_DRIVERS[provider];
+      expect(driver.logLabel, provider).toBeTruthy();
+      expect(driver.loginLabel, provider).toBeTruthy();
+      expect(driver.artifactLabel, provider).toBeTruthy();
+      expect(typeof driver.resolveLogin, provider).toBe("function");
+      expect(typeof driver.reprobe, provider).toBe("function");
+    }
+  });
+
+  it("registers the production-configured driver for each provider", () => {
+    const labels = (driver: RuntimeAuthDriver) => [driver.logLabel, driver.loginLabel, driver.artifactLabel];
+    expect(labels(RUNTIME_AUTH_DRIVERS["claude-code"])).toEqual(labels(createClaudeAuthDriver()));
+    expect(labels(RUNTIME_AUTH_DRIVERS.codex)).toEqual(labels(createCodexAuthDriver()));
+    expect(labels(RUNTIME_AUTH_DRIVERS.cursor)).toEqual(labels(createCursorAuthDriver()));
+    expect(labels(RUNTIME_AUTH_DRIVERS.grok)).toEqual(labels(createGrokAuthDriver()));
+  });
+
+  it("labels claude as a CLI gap and the external providers as binary gaps", () => {
+    // Claude may fall back to the SDK-bundled engine, so the operator-facing
+    // remediation differs from the external-only providers.
+    expect(RUNTIME_AUTH_DRIVERS["claude-code"].artifactLabel).toBe("CLI");
+    expect(RUNTIME_AUTH_DRIVERS["claude-code"].loginLabel).toBe("claude auth login");
+    for (const provider of ["codex", "cursor", "grok"] as const) {
+      expect(RUNTIME_AUTH_DRIVERS[provider].artifactLabel, provider).toBe("binary");
+      expect(RUNTIME_AUTH_DRIVERS[provider].loginLabel, provider).toBe(`${provider} login`);
+    }
+  });
+});
+
+describe("codex auth driver", () => {
+  it("drives the resolved binary and re-probes only codex", async () => {
+    const runBrowserLogin = vi.fn(async (): Promise<LoginOutcome> => ({ ok: true }));
+    const driver = createCodexAuthDriver({
+      resolveBinary: async () => ({
+        ok: true,
+        binary: "/bundled/codex",
+        runtimeSource: "bundled",
+        runtimePath: null,
+        version: "0.130.0",
+      }),
+      runBrowserLogin,
+      probe: async () => entry({ sdkVersion: "0.130.0" }),
+    });
+
+    const resolution = await driver.resolveLogin();
+    expect(resolution.ok).toBe(true);
+    if (!resolution.ok) return;
+
+    const onAuthUrl = vi.fn();
+    await expect(resolution.login({ onAuthUrl })).resolves.toEqual({ ok: true });
+    expect(runBrowserLogin).toHaveBeenCalledWith({ binary: "/bundled/codex", onAuthUrl });
+
+    await expect(driver.reprobe()).resolves.toEqual([{ provider: "codex", entry: entry({ sdkVersion: "0.130.0" }) }]);
+  });
+
+  it("reports an unresolved binary instead of spawning a login", async () => {
+    const runBrowserLogin = vi.fn();
+    const driver = createCodexAuthDriver({
+      resolveBinary: async () => ({ ok: false, error: "codex binary missing" }),
+      runBrowserLogin,
+      probe: async () => entry(),
+    });
+
+    await expect(driver.resolveLogin()).resolves.toEqual({ ok: false, error: "codex binary missing" });
+    expect(runBrowserLogin).not.toHaveBeenCalled();
+  });
+});
+
+describe("cursor and grok auth drivers", () => {
+  it("cursor drives the resolved binary and re-probes only cursor", async () => {
+    const runBrowserLogin = vi.fn(async (): Promise<LoginOutcome> => ({ ok: true }));
+    const driver = createCursorAuthDriver({
+      resolveBinary: () => ({ ok: true, binary: "/home/op/.local/bin/cursor-agent", version: "2026.07.09" }),
+      runBrowserLogin,
+      probe: async () => entry(),
+    });
+
+    const resolution = await driver.resolveLogin();
+    if (!resolution.ok) throw new Error("expected cursor to resolve");
+    const onAuthUrl = vi.fn();
+    await resolution.login({ onAuthUrl });
+
+    expect(runBrowserLogin).toHaveBeenCalledWith({ binary: "/home/op/.local/bin/cursor-agent", onAuthUrl });
+    await expect(driver.reprobe()).resolves.toEqual([{ provider: "cursor", entry: entry() }]);
+  });
+
+  it("grok drives the resolved binary and re-probes only grok", async () => {
+    const runBrowserLogin = vi.fn(async (): Promise<LoginOutcome> => ({ ok: true }));
+    const driver = createGrokAuthDriver({
+      resolveBinary: () => ({ ok: true, binary: "/home/op/.local/bin/grok", version: "2026.07.09" }),
+      runBrowserLogin,
+      probe: async () => entry(),
+    });
+
+    const resolution = await driver.resolveLogin();
+    if (!resolution.ok) throw new Error("expected grok to resolve");
+    const onAuthUrl = vi.fn();
+    await resolution.login({ onAuthUrl });
+
+    expect(runBrowserLogin).toHaveBeenCalledWith({ binary: "/home/op/.local/bin/grok", onAuthUrl });
+    await expect(driver.reprobe()).resolves.toEqual([{ provider: "grok", entry: entry() }]);
+  });
+
+  it("reports an unresolved binary for both external providers", async () => {
+    const cursor = createCursorAuthDriver({
+      resolveBinary: () => ({ ok: false, error: "Cursor Agent CLI is missing on this machine.", transient: false }),
+      runBrowserLogin: vi.fn(),
+      probe: async () => entry(),
+    });
+    const grok = createGrokAuthDriver({
+      resolveBinary: () => ({ ok: false, error: "Grok Build CLI is missing on this machine.", transient: false }),
+      runBrowserLogin: vi.fn(),
+      probe: async () => entry(),
+    });
+
+    await expect(cursor.resolveLogin()).resolves.toMatchObject({ ok: false });
+    await expect(grok.resolveLogin()).resolves.toMatchObject({ ok: false });
+  });
+});
+
+describe("claude auth driver (shared keychain credential)", () => {
+  function claudeDriver(opts: { tuiEnabled: boolean }) {
+    const probe = vi.fn(async () => entry({ sdkVersion: "sdk" }));
+    const probeTui = vi.fn(async () => entry({ sdkVersion: "tui" }));
+    const runBrowserLogin = vi.fn(async (): Promise<LoginOutcome> => ({ ok: true }));
+    const driver = createClaudeAuthDriver({
+      resolveLogin: () => ({ ok: true, command: "/usr/local/bin/claude", baseArgs: [] }),
+      runBrowserLogin,
+      probe,
+      probeTui,
+      isProviderEnabled: (provider) => (provider === "claude-code-tui" ? opts.tuiEnabled : true),
+    });
+    return { driver, probe, probeTui, runBrowserLogin };
+  }
+
+  it("refreshes claude-code only, without spawning the TUI probe, while the TUI is disabled", async () => {
+    const h = claudeDriver({ tuiEnabled: false });
+    await expect(h.driver.reprobe()).resolves.toEqual([
+      { provider: "claude-code", entry: entry({ sdkVersion: "sdk" }) },
+    ]);
+    expect(h.probeTui).not.toHaveBeenCalled();
+  });
+
+  it("refreshes both Claude rows in publish order when the TUI is enabled", async () => {
+    const h = claudeDriver({ tuiEnabled: true });
+    // One Claude login authenticates both runtimes, so the TUI row must not be
+    // left reading as a second, separate login the operator still has to do.
+    await expect(h.driver.reprobe()).resolves.toEqual([
+      { provider: "claude-code", entry: entry({ sdkVersion: "sdk" }) },
+      { provider: "claude-code-tui", entry: entry({ sdkVersion: "tui" }) },
+    ]);
+    expect(h.probe).toHaveBeenCalledTimes(1);
+    expect(h.probeTui).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the resolved invocation through to the browser login", async () => {
+    const h = claudeDriver({ tuiEnabled: false });
+    const resolution = await h.driver.resolveLogin();
+    if (!resolution.ok) throw new Error("expected claude to resolve");
+    const onAuthUrl = vi.fn();
+    await resolution.login({ onAuthUrl });
+    expect(h.runBrowserLogin).toHaveBeenCalledWith({
+      command: "/usr/local/bin/claude",
+      baseArgs: [],
+      onAuthUrl,
+    });
+  });
+
+  it("reports an unresolved CLI instead of spawning a login", async () => {
+    const runBrowserLogin = vi.fn();
+    const driver = createClaudeAuthDriver({
+      resolveLogin: () => ({ ok: false, error: "no claude CLI" }),
+      runBrowserLogin,
+      probe: async () => entry(),
+      probeTui: async () => entry(),
+      isProviderEnabled: () => false,
+    });
+
+    await expect(driver.resolveLogin()).resolves.toEqual({ ok: false, error: "no claude CLI" });
+    expect(runBrowserLogin).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/__tests__/runtime-auth-drivers.test.ts
+++ b/packages/client/src/__tests__/runtime-auth-drivers.test.ts
@@ -56,6 +56,28 @@ describe("RUNTIME_AUTH_DRIVERS composition root", () => {
   });
 });
 
+describe("every driver keeps a broken artifact lookup away from the login", () => {
+  // Resolvers touch PATH and the filesystem, so they can throw as well as
+  // report a gap. Neither outcome may reach a spawn; the dispatcher turns the
+  // throw into the same "login never started" reflection.
+  const boom = () => {
+    throw new Error("PATH lookup exploded");
+  };
+
+  type FakeLogin = () => Promise<LoginOutcome>;
+
+  it.each([
+    ["claude-code", (login: FakeLogin) => createClaudeAuthDriver({ resolveLogin: boom, runBrowserLogin: login })],
+    ["codex", (login: FakeLogin) => createCodexAuthDriver({ resolveBinary: boom, runBrowserLogin: login })],
+    ["cursor", (login: FakeLogin) => createCursorAuthDriver({ resolveBinary: boom, runBrowserLogin: login })],
+    ["grok", (login: FakeLogin) => createGrokAuthDriver({ resolveBinary: boom, runBrowserLogin: login })],
+  ] as const)("%s", async (_provider, build) => {
+    const login = vi.fn(async (): Promise<LoginOutcome> => ({ ok: true }));
+    await expect(build(login).resolveLogin()).rejects.toThrow("PATH lookup exploded");
+    expect(login).not.toHaveBeenCalled();
+  });
+});
+
 describe("codex auth driver", () => {
   it("drives the resolved binary and re-probes only codex", async () => {
     const runBrowserLogin = vi.fn(async (): Promise<LoginOutcome> => ({ ok: true }));

--- a/packages/client/src/__tests__/runtime-auth-drivers.test.ts
+++ b/packages/client/src/__tests__/runtime-auth-drivers.test.ts
@@ -25,6 +25,41 @@ describe("RUNTIME_AUTH_DRIVERS composition root", () => {
     expect(Object.keys(RUNTIME_AUTH_DRIVERS).sort()).toEqual([...runtimeAuthProviderSchema.options].sort());
   });
 
+  it("freezes every registered driver, not just the table that holds them", () => {
+    // Object.freeze on the table alone leaves each driver value mutable, so an
+    // importer could still repoint RUNTIME_AUTH_DRIVERS.codex.resolveLogin (or
+    // .reprobe) for the rest of the process without ever touching the table
+    // itself. Every value the table holds must be independently frozen too.
+    for (const provider of runtimeAuthProviderSchema.options) {
+      expect(Object.isFrozen(RUNTIME_AUTH_DRIVERS[provider]), provider).toBe(true);
+    }
+  });
+
+  it("rejects reassignment of a driver's methods, and the reassignment never takes effect", () => {
+    for (const provider of runtimeAuthProviderSchema.options) {
+      const driver = RUNTIME_AUTH_DRIVERS[provider];
+      const originalResolveLogin = driver.resolveLogin;
+      const originalReprobe = driver.reprobe;
+      const hijack = async () => ({ ok: false as const, error: "hijacked" });
+      // Assigning to a frozen property throws under the strict-mode ESM this
+      // module runs as; either way, the property must be unchanged afterwards.
+      try {
+        // @ts-expect-error intentional mutation attempt on a readonly contract member
+        driver.resolveLogin = hijack;
+      } catch {
+        // Expected in strict mode.
+      }
+      try {
+        // @ts-expect-error intentional mutation attempt on a readonly contract member
+        driver.reprobe = hijack;
+      } catch {
+        // Expected in strict mode.
+      }
+      expect(driver.resolveLogin, provider).toBe(originalResolveLogin);
+      expect(driver.reprobe, provider).toBe(originalReprobe);
+    }
+  });
+
   it("exposes a complete driver for every auth provider", () => {
     for (const provider of runtimeAuthProviderSchema.options) {
       const driver: RuntimeAuthDriver = RUNTIME_AUTH_DRIVERS[provider];
@@ -53,6 +88,20 @@ describe("RUNTIME_AUTH_DRIVERS composition root", () => {
       expect(RUNTIME_AUTH_DRIVERS[provider].artifactLabel, provider).toBe("binary");
       expect(RUNTIME_AUTH_DRIVERS[provider].loginLabel, provider).toBe(`${provider} login`);
     }
+  });
+});
+
+describe("every create*AuthDriver factory freezes its own return value", () => {
+  // The guarantee has to hold at construction, independent of composition: a
+  // caller that constructs a driver directly (a test, a future composition
+  // root) gets the same immutability as one read through RUNTIME_AUTH_DRIVERS.
+  it.each([
+    ["claude-code", () => createClaudeAuthDriver()],
+    ["codex", () => createCodexAuthDriver()],
+    ["cursor", () => createCursorAuthDriver()],
+    ["grok", () => createGrokAuthDriver()],
+  ] as const)("%s", (_provider, build) => {
+    expect(Object.isFrozen(build())).toBe(true);
   });
 });
 

--- a/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
+++ b/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
@@ -65,24 +65,27 @@ describe("auth URL scanner keeps retained state bounded", () => {
     expect(scanner.push("visit https://auth.openai.com/x\n")).toBe("https://auth.openai.com/x");
   });
 
-  it("stops growing and stops reporting once a URL is found", () => {
+  it("stops scanning, stops growing and stops reporting once a URL is found", () => {
     const scanner = createAuthUrlScanner();
     expect(scanner.push("visit https://auth.openai.com/x\n")).toBe("https://auth.openai.com/x");
+    const scannedAtHit = scanner.scannedChars();
     for (let i = 0; i < 1_000; i++) {
       expect(scanner.push(`https://auth.example/later-${i} and a very long unterminated tail`)).toBeNull();
       expect(scanner.retainedChars()).toBe(0);
     }
+    expect(scanner.scannedChars()).toBe(scannedAtHit);
   });
 
-  it("scans a large stream in linear time (no cumulative full-buffer rescans)", () => {
-    // Roughly 4 MB with no URL. Re-splitting the accumulated buffer per chunk
-    // would be quadratic here (tens of GB of scanning); an incremental parser
-    // finishes in milliseconds, so a generous ceiling is still a real guard.
+  it("examines a large stream once, not once per accumulated buffer", () => {
+    // Roughly 4 MB with no URL. Re-splitting the accumulated buffer on every
+    // chunk would examine tens of GB here; an incremental parser examines each
+    // character exactly once, which the scan counter asserts directly rather
+    // than inferring it from how fast the test ran.
     const scanner = createAuthUrlScanner();
     const chunk = `${"provider chatter ".repeat(12)}\n`;
-    const started = Date.now();
-    for (let i = 0; i < 20_000; i++) scanner.push(chunk);
-    expect(Date.now() - started).toBeLessThan(5_000);
+    const chunks = 20_000;
+    for (let i = 0; i < chunks; i++) scanner.push(chunk);
+    expect(scanner.scannedChars()).toBe(chunk.length * chunks);
     expect(scanner.retainedChars()).toBe(0);
   });
 });

--- a/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
+++ b/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
@@ -113,6 +113,45 @@ describe("auth URL scanner keeps retained state bounded", () => {
   });
 });
 
+describe("auth URL scanner rejects a candidate that carries its own auth material", () => {
+  // The published fallback link is a structured field, not error text, so it
+  // never goes through `redactErrorPreview` (see runtime-auth-login.ts) β€” this
+  // candidacy check is the only gate standing between a credential-shaped
+  // string in provider output and a rendered "sign in" link.
+  it("skips URL userinfo and finds the legitimate sign-in URL that follows", () => {
+    const scanner = createAuthUrlScanner();
+    expect(scanner.push("proxying through https://user:hunter2pwd@proxy.example/\n")).toBeNull();
+    expect(scanner.push("now visit https://auth.openai.com/oauth/authorize?x=1\n")).toBe(
+      "https://auth.openai.com/oauth/authorize?x=1",
+    );
+  });
+
+  it("skips a credential-bearing query parameter and finds a later legitimate URL", () => {
+    const scanner = createAuthUrlScanner();
+    expect(scanner.push("debug callback https://auth.example/cb?access_token=abc123def456\n")).toBeNull();
+    expect(scanner.push("sign in at https://auth.openai.com/oauth/authorize?client_id=cli\n")).toBe(
+      "https://auth.openai.com/oauth/authorize?client_id=cli",
+    );
+  });
+
+  it("does not treat an ordinary OAuth authorize query string as credential-bearing", () => {
+    // client_id / redirect_uri / state / scope / code_challenge are normal
+    // parts of an authorization URL and must not be mistaken for the
+    // credential-key set (in particular `client_id` must not match
+    // `client_secret`'s pattern).
+    const scanner = createAuthUrlScanner();
+    const url =
+      "https://auth.openai.com/oauth/authorize?client_id=cli&redirect_uri=http%3A%2F%2Flocalhost%3A1455&state=xyz&scope=openid";
+    expect(scanner.push(`${url}\n`)).toBe(url);
+  });
+
+  it("rejects a single-component userinfo token (bare `<token>@host`) the same way", () => {
+    const scanner = createAuthUrlScanner();
+    expect(scanner.push("cached at https://ghp_abcdef1234567890@raw.githubusercontent.com/x\n")).toBeNull();
+    expect(scanner.push("visit https://auth.openai.com/oauth?x=1\n")).toBe("https://auth.openai.com/oauth?x=1");
+  });
+});
+
 describe("runBrowserLogin does not retain the provider's output", () => {
   it("reports a cross-chunk external URL exactly once while streaming every chunk", async () => {
     const child = new FakeChild();
@@ -135,6 +174,23 @@ describe("runBrowserLogin does not retain the provider's output", () => {
     expect(urls).toEqual(["https://auth.openai.com/oauth?x=1"]);
     // Chunks keep streaming to the diagnostic hook; the login itself keeps none.
     expect(raw).toHaveLength(503);
+  });
+
+  it("never fires a credential-bearing stderr URL as the fallback link, even when it precedes the real one", async () => {
+    const child = new FakeChild();
+    const urls: string[] = [];
+    const run = runCodexBrowserLogin({
+      binary: "/bundled/codex",
+      onAuthUrl: (u) => urls.push(u),
+      spawnFn: fakeSpawn(child),
+    });
+
+    child.emitStderr("proxying through https://user:hunter2pwd@proxy.example/\n");
+    child.emitStdout("If it didn't open, visit https://auth.openai.com/oauth?x=1\n");
+    child.close(0);
+
+    await expect(run).resolves.toEqual({ ok: true });
+    expect(urls).toEqual(["https://auth.openai.com/oauth?x=1"]);
   });
 
   it("keeps only a bounded stderr tail in the failure message", async () => {

--- a/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
+++ b/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
@@ -51,6 +51,29 @@ describe("auth URL scanner keeps retained state bounded", () => {
     expect(scanner.retainedChars()).toBe(0);
   });
 
+  it("skips a token that only exceeds the cap once its chunks are joined", () => {
+    const scanner = createAuthUrlScanner();
+    // Each piece fits on its own, so the cap has to be judged on the completed
+    // token: otherwise a 2 KB carry plus a short segment is concatenated and
+    // parsed, and an over-long "URL" is handed to the browser.
+    scanner.push(`https://auth.example/${"a".repeat(2_000)}`);
+    expect(scanner.retainedChars()).toBeLessThanOrEqual(AUTH_URL_TOKEN_MAX);
+    expect(scanner.push(`${"b".repeat(100)} still waiting\n`)).toBeNull();
+    expect(scanner.retainedChars()).toBeLessThanOrEqual(AUTH_URL_TOKEN_MAX);
+
+    // The oversized token must not swallow what follows it.
+    expect(scanner.push("visit https://auth.example/ok\n")).toBe("https://auth.example/ok");
+  });
+
+  it("skips a single over-long token without letting it hide a later URL in the same chunk", () => {
+    const scanner = createAuthUrlScanner();
+    const scannedBefore = scanner.scannedChars();
+    const chunk = `https://auth.example/${"z".repeat(3_000)} then https://auth.example/real\n`;
+    expect(scanner.push(chunk)).toBe("https://auth.example/real");
+    expect(scanner.retainedChars()).toBe(0);
+    expect(scanner.scannedChars()).toBe(scannedBefore + chunk.length);
+  });
+
   it("recognises a URL split across chunk boundaries", () => {
     const scanner = createAuthUrlScanner();
     expect(scanner.push("If it didn't open, visit https://auth.open")).toBeNull();

--- a/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
+++ b/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
@@ -150,6 +150,31 @@ describe("auth URL scanner rejects a candidate that carries its own auth materia
     expect(scanner.push("cached at https://ghp_abcdef1234567890@raw.githubusercontent.com/x\n")).toBeNull();
     expect(scanner.push("visit https://auth.openai.com/oauth?x=1\n")).toBe("https://auth.openai.com/oauth?x=1");
   });
+
+  it("rejects a credential in a URL fragment, which has no query params at all", () => {
+    // A #fragment has no searchParams, so a check scoped to query-string keys
+    // misses this shape entirely even though redactErrorPreview's key=value
+    // rule (which does not care about URL syntax) still matches it.
+    const scanner = createAuthUrlScanner();
+    expect(scanner.push("stray redirect echo https://auth.example/#access_token=abc123def456\n")).toBeNull();
+    expect(scanner.push("sign in at https://auth.openai.com/oauth/authorize?client_id=cli\n")).toBe(
+      "https://auth.openai.com/oauth/authorize?client_id=cli",
+    );
+  });
+
+  it("rejects a vendor-prefixed token sitting under a neutral query key", () => {
+    // `context` is not a credential-shaped key name, so a check scoped to
+    // credential-NAMED keys misses this: the value itself is a GitHub PAT
+    // shape, which redactErrorPreview's vendor-token rule catches regardless
+    // of what key it is assigned to.
+    const scanner = createAuthUrlScanner();
+    expect(
+      scanner.push("callback https://auth.example/?context=ghp_AbCdEf0123456789abcdef0123456789abcd\n"),
+    ).toBeNull();
+    expect(scanner.push("sign in at https://auth.openai.com/oauth/authorize?client_id=cli\n")).toBe(
+      "https://auth.openai.com/oauth/authorize?client_id=cli",
+    );
+  });
 });
 
 describe("runBrowserLogin does not retain the provider's output", () => {

--- a/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
+++ b/packages/client/src/__tests__/runtime-login-bounded-output.test.ts
@@ -1,0 +1,128 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { runCodexBrowserLogin } from "../runtime/codex-login.js";
+import { AUTH_URL_TOKEN_MAX, createAuthUrlScanner, LOGIN_STDERR_TAIL_MAX } from "../runtime/runtime-login.js";
+
+/**
+ * Regression cover for #1720: a provider login may stream for the full
+ * five-minute browser-OAuth window, so neither the retained state nor the
+ * scanning work may grow with the volume of output.
+ */
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill(): boolean {
+    return true;
+  }
+  emitStdout(text: string): void {
+    this.stdout.emit("data", Buffer.from(text, "utf-8"));
+  }
+  emitStderr(text: string): void {
+    this.stderr.emit("data", Buffer.from(text, "utf-8"));
+  }
+  close(code: number): void {
+    this.emit("close", code);
+  }
+}
+
+function fakeSpawn(child: FakeChild): typeof import("node:child_process").spawn {
+  return (() => child) as unknown as typeof import("node:child_process").spawn;
+}
+
+describe("auth URL scanner keeps retained state bounded", () => {
+  it("retains nothing beyond the current partial token across a flood of chunks", () => {
+    const scanner = createAuthUrlScanner();
+    for (let i = 0; i < 5_000; i++) {
+      expect(scanner.push(`waiting for sign-in chunk ${i} `)).toBeNull();
+      expect(scanner.retainedChars()).toBe(0);
+    }
+  });
+
+  it("caps an over-long unterminated token instead of growing without bound", () => {
+    const scanner = createAuthUrlScanner();
+    // A single 200 KB run of non-whitespace: retention must stay at the cap.
+    for (let i = 0; i < 200; i++) {
+      scanner.push("x".repeat(1_000));
+      expect(scanner.retainedChars()).toBeLessThanOrEqual(AUTH_URL_TOKEN_MAX);
+    }
+    // The discarded token must not poison the next, real one.
+    scanner.push(" https://auth.openai.com/ok\n");
+    expect(scanner.retainedChars()).toBe(0);
+  });
+
+  it("recognises a URL split across chunk boundaries", () => {
+    const scanner = createAuthUrlScanner();
+    expect(scanner.push("If it didn't open, visit https://auth.open")).toBeNull();
+    expect(scanner.push("ai.com/oauth/authorize?x=1")).toBeNull();
+    expect(scanner.push("\nnext line\n")).toBe("https://auth.openai.com/oauth/authorize?x=1");
+  });
+
+  it("still skips the CLI's own loopback callback server", () => {
+    const scanner = createAuthUrlScanner();
+    expect(scanner.push("Starting local login server on http://localhost:1455.\n")).toBeNull();
+    expect(scanner.push("listening on http://127.0.0.1:1455\n")).toBeNull();
+    expect(scanner.push("visit https://auth.openai.com/x\n")).toBe("https://auth.openai.com/x");
+  });
+
+  it("stops growing and stops reporting once a URL is found", () => {
+    const scanner = createAuthUrlScanner();
+    expect(scanner.push("visit https://auth.openai.com/x\n")).toBe("https://auth.openai.com/x");
+    for (let i = 0; i < 1_000; i++) {
+      expect(scanner.push(`https://auth.example/later-${i} and a very long unterminated tail`)).toBeNull();
+      expect(scanner.retainedChars()).toBe(0);
+    }
+  });
+
+  it("scans a large stream in linear time (no cumulative full-buffer rescans)", () => {
+    // Roughly 4 MB with no URL. Re-splitting the accumulated buffer per chunk
+    // would be quadratic here (tens of GB of scanning); an incremental parser
+    // finishes in milliseconds, so a generous ceiling is still a real guard.
+    const scanner = createAuthUrlScanner();
+    const chunk = `${"provider chatter ".repeat(12)}\n`;
+    const started = Date.now();
+    for (let i = 0; i < 20_000; i++) scanner.push(chunk);
+    expect(Date.now() - started).toBeLessThan(5_000);
+    expect(scanner.retainedChars()).toBe(0);
+  });
+});
+
+describe("runBrowserLogin does not retain the provider's output", () => {
+  it("reports a cross-chunk external URL exactly once while streaming every chunk", async () => {
+    const child = new FakeChild();
+    const urls: string[] = [];
+    const raw: string[] = [];
+    const run = runCodexBrowserLogin({
+      binary: "/bundled/codex",
+      onAuthUrl: (u) => urls.push(u),
+      onRawOutput: (chunk) => raw.push(chunk),
+      spawnFn: fakeSpawn(child),
+    });
+
+    child.emitStdout("Starting local login server on http://localhost:1455.\n");
+    child.emitStdout("If it didn't open, visit https://auth.open");
+    child.emitStdout("ai.com/oauth?x=1\n");
+    for (let i = 0; i < 500; i++) child.emitStdout(`still waiting ${i} https://auth.example/other-${i}\n`);
+    child.close(0);
+
+    await expect(run).resolves.toEqual({ ok: true });
+    expect(urls).toEqual(["https://auth.openai.com/oauth?x=1"]);
+    // Chunks keep streaming to the diagnostic hook; the login itself keeps none.
+    expect(raw).toHaveLength(503);
+  });
+
+  it("keeps only a bounded stderr tail in the failure message", async () => {
+    const child = new FakeChild();
+    const run = runCodexBrowserLogin({ binary: "/bundled/codex", spawnFn: fakeSpawn(child) });
+
+    for (let i = 0; i < 200; i++) child.emitStderr(`noisy provider diagnostic line ${i}\n`);
+    child.emitStderr("could not open a browser on this host\n");
+    child.close(1);
+
+    const outcome = await run;
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) return;
+    expect(outcome.error.length).toBeLessThanOrEqual(LOGIN_STDERR_TAIL_MAX);
+    expect(outcome.error).toContain("could not open a browser on this host");
+  });
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -24,6 +24,7 @@ import {
   providerModelsListCommandSchema,
   RUNTIME_AUTH_START_TYPE,
   type RuntimeAuthMethod,
+  type RuntimeAuthProvider,
   type RuntimeProvider,
   type RuntimeState,
   runtimeAuthStartCommandSchema,
@@ -205,7 +206,14 @@ export type SessionReconcileResult = {
  * re-PATCHing capabilities. See `runtimeAuthStartCommandSchema` in shared.
  */
 export type RuntimeAuthCommand = {
-  provider: RuntimeProvider;
+  /**
+   * Narrower than `RuntimeProvider`: only the server-accepted in-product auth
+   * targets can start a login. The wire shape is unchanged - this is the same
+   * set `runtimeAuthStartCommandSchema` already parses, now visible in the
+   * type so the daemon dispatches by a key that cannot be a host-login-only
+   * provider.
+   */
+  provider: RuntimeAuthProvider;
   method?: RuntimeAuthMethod;
   ref: string;
 };

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -31,6 +31,14 @@ export {
   initClientSentry,
   rootLogger,
 } from "./observability/index.js";
+export type {
+  RuntimeAuthDriver,
+  RuntimeAuthLoginResolution,
+  RuntimeAuthLoginStart,
+  RuntimeAuthProbeResult,
+} from "./providers/auth-driver.js";
+export type { RuntimeAuthDriverTable } from "./providers/auth-drivers.js";
+export { RUNTIME_AUTH_DRIVERS } from "./providers/auth-drivers.js";
 export type { BuiltinProviderProbeTable, CapabilityProbe } from "./providers/builtin-probes.js";
 export { BUILTIN_PROVIDER_PROBES, probedRuntimeProviders } from "./providers/builtin-probes.js";
 export type { BuiltinHandlerRegistry, BuiltinHandlerRegistryDeps } from "./providers/builtin-registry.js";
@@ -87,14 +95,21 @@ export type {
 } from "./runtime/child-process-registry.js";
 export { CHILD_CATEGORIES, getChildProcessRegistry } from "./runtime/child-process-registry.js";
 export {
+  type ClaudeAuthDriverDeps,
   type ClaudeBrowserLoginOptions,
   type ClaudeLoginInvocation,
+  createClaudeAuthDriver,
   resolveClaudeLoginInvocation,
   runClaudeBrowserLogin,
 } from "./runtime/claude-login.js";
 export type { CliBinding } from "./runtime/cli-binding.js";
 export { setCliBinding } from "./runtime/cli-binding.js";
-export { type CodexBrowserLoginOptions, runCodexBrowserLogin } from "./runtime/codex-login.js";
+export {
+  type CodexAuthDriverDeps,
+  type CodexBrowserLoginOptions,
+  createCodexAuthDriver,
+  runCodexBrowserLogin,
+} from "./runtime/codex-login.js";
 export type { AgentSlotYamlConfig, RuntimeConfig, SessionConfig } from "./runtime/config.js";
 export { loadRuntimeConfig } from "./runtime/config.js";
 export {
@@ -104,7 +119,12 @@ export {
   formatCursorBinaryMissingMessage,
   resolveCursorRuntimeBinary,
 } from "./runtime/cursor-binary.js";
-export { type CursorBrowserLoginOptions, runCursorBrowserLogin } from "./runtime/cursor-login.js";
+export {
+  type CursorAuthDriverDeps,
+  type CursorBrowserLoginOptions,
+  createCursorAuthDriver,
+  runCursorBrowserLogin,
+} from "./runtime/cursor-login.js";
 export { Deduplicator } from "./runtime/deduplicator.js";
 export type { AttachmentUploader, SelfFence, WorkspaceFence } from "./runtime/doc-snapshots.js";
 export { buildMessageDocumentSnapshots } from "./runtime/doc-snapshots.js";
@@ -117,7 +137,12 @@ export {
   type GrokRuntimeBinaryResolution,
   resolveGrokRuntimeBinary,
 } from "./runtime/grok-binary.js";
-export { type GrokBrowserLoginOptions, runGrokBrowserLogin } from "./runtime/grok-login.js";
+export {
+  createGrokAuthDriver,
+  type GrokAuthDriverDeps,
+  type GrokBrowserLoginOptions,
+  runGrokBrowserLogin,
+} from "./runtime/grok-login.js";
 export type {
   AgentHandler,
   HandlerConfig,
@@ -159,10 +184,20 @@ export {
   type ProviderProcessSupervisor,
   type SupervisedProviderProcess,
 } from "./runtime/provider-process-supervisor.js";
+export { redactErrorPreview } from "./runtime/redact-error-preview.js";
 export type { AgentRuntimeOptions } from "./runtime/runtime.js";
 export { AgentRuntime } from "./runtime/runtime.js";
 // Runtime-auth (browser OAuth)
-export { BROWSER_LOGIN_TIMEOUT_MS, extractAuthUrl, type LoginOutcome, stripAnsi } from "./runtime/runtime-login.js";
+export {
+  AUTH_URL_TOKEN_MAX,
+  type AuthUrlScanner,
+  BROWSER_LOGIN_TIMEOUT_MS,
+  createAuthUrlScanner,
+  extractAuthUrl,
+  LOGIN_STDERR_TAIL_MAX,
+  type LoginOutcome,
+  stripAnsi,
+} from "./runtime/runtime-login.js";
 export { SessionManager } from "./runtime/session-manager.js";
 export { SessionRegistry } from "./runtime/session-registry.js";
 // Skills (slash-command discovery)

--- a/packages/client/src/providers/README.md
+++ b/packages/client/src/providers/README.md
@@ -75,6 +75,11 @@ provider id. A driver contributes only `logLabel` / `loginLabel` /
 `artifactLabel` copy plus `resolveLogin()` and `reprobe()`; it never publishes a
 capability entry, and it never owns retry, ordering, or error policy.
 
+Because the dispatcher owns ordering, a driver may resolve slowly, print its
+sign-in URL at any moment, or throw: entry writes are chained so the URL always
+lands before the terminal re-probe, and a thrown resolver or login is contained
+and reflected the same way a reported failure is.
+
 `reprobe()` returns rows in publish order and may return more than one when
 providers share a credential (a Claude login refreshes both Claude rows while
 the TUI is enabled, and neither probes nor writes the TUI row while it is

--- a/packages/client/src/providers/README.md
+++ b/packages/client/src/providers/README.md
@@ -15,6 +15,7 @@ ACK / Reset / auth / model / persistence protocol into shared catalog.
 | `createBuiltinHandlerRegistry` | Frozen `Record<RuntimeProvider, HandlerFactory>` (consumed once by `registerBuiltinHandlers`) |
 | `BUILTIN_PROVIDER_PROBES` | Frozen install-only capability probes |
 | `PROVIDER_SKILL_ROOTS` | Frozen native managed-skill roots |
+| `RUNTIME_AUTH_DRIVERS` | Frozen `Record<RuntimeAuthProvider, RuntimeAuthDriver>` for in-product login |
 
 Probe/skills paths do **not** consume a full installed handler registry.
 
@@ -54,6 +55,47 @@ capability gates — do not reverse-parse package strings.
   Claude Code target; every direct target maps to itself. Adding in-product
   OAuth requires extending the runtime-auth contract and its exact-target tests.
 
+## 2a. Runtime-auth driver (in-product login only)
+
+Only an `{ kind: "in-product", target }` provider gets a driver, and the target
+set is `runtimeAuthProviderSchema` — narrower than `runtimeProviderSchema`.
+Host-login providers (Kimi / OpenCode / Pi) never appear here, and
+`claude-code-tui` is not its own target because it shares Claude Code's
+keychain credential.
+
+| Layer | Owns | Where |
+| --- | --- | --- |
+| Daemon dispatcher | Announce, `pendingAuth`, `authUrl`, re-probe order, `lastAuthError`, redaction + truncation | `apps/cli/src/core/runtime-auth-login.ts` |
+| `RUNTIME_AUTH_DRIVERS` | Frozen projection of `RuntimeAuthProvider` → driver | `providers/auth-drivers.ts` |
+| `create<Provider>AuthDriver` | Resolve the artifact, spawn the official login, re-probe affected rows | `runtime/<provider>-login.ts` |
+
+The dispatcher must stay provider-neutral: no provider literal, no
+provider-specific resolver / probe / login import, no `if` / `switch` on a
+provider id. A driver contributes only `logLabel` / `loginLabel` /
+`artifactLabel` copy plus `resolveLogin()` and `reprobe()`; it never publishes a
+capability entry, and it never owns retry, ordering, or error policy.
+
+`reprobe()` returns rows in publish order and may return more than one when
+providers share a credential (a Claude login refreshes both Claude rows while
+the TUI is enabled, and neither probes nor writes the TUI row while it is
+centrally disabled). Only the row matching the login target carries
+`lastAuthError`.
+
+Adding an in-product provider therefore means: extend
+`runtimeAuthProviderSchema`, add a `create<Provider>AuthDriver` in that
+provider's own login module, and register it in `RUNTIME_AUTH_DRIVERS` — the
+`satisfies Record<RuntimeAuthProvider, RuntimeAuthDriver>` will not compile
+until you do. Inject a driver (or a whole table) for tests; there is no
+process-global mutable registry to install into.
+
+**Login output is bounded.** A browser login may stream for the whole
+five-minute window, so the subprocess retains no full output buffer: the
+fallback sign-in URL comes from an incremental scanner whose only carried state
+is the current partial token, and stderr keeps a bounded tail. Anything
+republished onto a capability entry passes through `redactErrorPreview` with a
+hard cap first. Do not put that cap on the shared wire schema — a `.max()`
+there breaks rolling daemon/server compatibility.
+
 ## 3. Handler V1 contract
 
 Each factory must provide `start` / `resume` / `inject` / `suspend` /
@@ -81,7 +123,8 @@ fallback to another provider or default config is forbidden.
 1. Handler factory in `createBuiltinHandlerRegistry`.
 2. Install probe in `BUILTIN_PROVIDER_PROBES`.
 3. Skill root in `PROVIDER_SKILL_ROOTS`.
-4. Binary remediation may re-export catalog install/login helpers; adapter
+4. Auth driver in `RUNTIME_AUTH_DRIVERS` — only for an in-product OAuth target.
+5. Binary remediation may re-export catalog install/login helpers; adapter
    protocol keywords stay local.
 
 ## 7. Minimum test gates

--- a/packages/client/src/providers/README.md
+++ b/packages/client/src/providers/README.md
@@ -97,9 +97,10 @@ process-global mutable registry to install into.
 five-minute window, so the subprocess retains no full output buffer: the
 fallback sign-in URL comes from an incremental scanner whose only carried state
 is the current partial token, and stderr keeps a bounded tail. Anything
-republished onto a capability entry passes through `redactErrorPreview` with a
-hard cap first. Do not put that cap on the shared wire schema — a `.max()`
-there breaks rolling daemon/server compatibility.
+republished onto a capability entry passes through `redactErrorPreview` first,
+under a hard ceiling that counts the helper's truncation ellipsis. Do not put
+that ceiling on the shared wire schema — a `.max()` there breaks rolling
+daemon/server compatibility.
 
 ## 3. Handler V1 contract
 

--- a/packages/client/src/providers/README.md
+++ b/packages/client/src/providers/README.md
@@ -96,11 +96,17 @@ process-global mutable registry to install into.
 **Login output is bounded.** A browser login may stream for the whole
 five-minute window, so the subprocess retains no full output buffer: the
 fallback sign-in URL comes from an incremental scanner whose only carried state
-is the current partial token, and stderr keeps a bounded tail. Anything
-republished onto a capability entry passes through `redactErrorPreview` first,
-under a hard ceiling that counts the helper's truncation ellipsis. Do not put
-that ceiling on the shared wire schema — a `.max()` there breaks rolling
-daemon/server compatibility.
+is the current partial token, and stderr keeps a bounded tail.
+
+Every free-text string the dispatcher publishes passes through
+`redactErrorPreview` under a hard ceiling that counts the helper's truncation
+ellipsis: the login's own `lastAuthError.message`, and the `error` of *each*
+row a `reprobe()` returns — including the extra rows of a shared-credential
+driver, whose detection text comes from the same hosts and subprocesses.
+Starting a login also drops the previous attempt's `error` and `lastAuthError`
+instead of carrying them onto the pending entry, so nothing escapes the
+boundary by riding an older snapshot. Do not put that ceiling on the shared
+wire schema — a `.max()` there breaks rolling daemon/server compatibility.
 
 ## 3. Handler V1 contract
 

--- a/packages/client/src/providers/README.md
+++ b/packages/client/src/providers/README.md
@@ -91,12 +91,25 @@ Adding an in-product provider therefore means: extend
 provider's own login module, and register it in `RUNTIME_AUTH_DRIVERS` — the
 `satisfies Record<RuntimeAuthProvider, RuntimeAuthDriver>` will not compile
 until you do. Inject a driver (or a whole table) for tests; there is no
-process-global mutable registry to install into.
+process-global mutable registry to install into. Every `create<Provider>AuthDriver`
+returns an `Object.freeze`d driver, and the `RuntimeAuthDriver` contract
+declares `resolveLogin` / `reprobe` as `readonly` properties (not TS method
+shorthand, which is not readonly) — so an importer of `RUNTIME_AUTH_DRIVERS`
+cannot repoint a driver's methods for the rest of the process, and the
+guarantee holds even for a driver constructed outside the table.
 
 **Login output is bounded.** A browser login may stream for the whole
 five-minute window, so the subprocess retains no full output buffer: the
 fallback sign-in URL comes from an incremental scanner whose only carried state
-is the current partial token, and stderr keeps a bounded tail.
+is the current partial token, and stderr keeps a bounded tail. `runLoginSubprocess`
+feeds both stdout and stderr to the same scanner, so a URL candidate can come
+from either stream. Because `pendingAuth.authUrl` is a structured field that
+never passes through `redactErrorPreview` (see below), URL candidacy is
+itself a no-secret boundary: a token carrying RFC-3986 userinfo or a
+credential-shaped query parameter (the same key set `redactErrorPreview`
+treats as unsafe, via the shared `CREDENTIAL_KEY_PATTERN`) is rejected outright
+rather than rewritten, and scanning continues to a later, legitimate URL in
+the same output.
 
 Every error/failure string the dispatcher republishes — `CapabilityEntry.error`
 and `lastAuthError.message`, and nothing else — passes through

--- a/packages/client/src/providers/README.md
+++ b/packages/client/src/providers/README.md
@@ -98,11 +98,14 @@ five-minute window, so the subprocess retains no full output buffer: the
 fallback sign-in URL comes from an incremental scanner whose only carried state
 is the current partial token, and stderr keeps a bounded tail.
 
-Every free-text string the dispatcher publishes passes through
+Every error/failure string the dispatcher republishes — `CapabilityEntry.error`
+and `lastAuthError.message`, and nothing else — passes through
 `redactErrorPreview` under a hard ceiling that counts the helper's truncation
-ellipsis: the login's own `lastAuthError.message`, and the `error` of *each*
-row a `reprobe()` returns — including the extra rows of a shared-credential
-driver, whose detection text comes from the same hosts and subprocesses.
+ellipsis. That covers the login's own verdict and the `error` of *each* row a
+`reprobe()` returns, including the extra rows of a shared-credential driver,
+whose detection text comes from the same hosts and subprocesses. Structured
+fields such as `pendingAuth.authUrl` or the detected version are not error text
+and are not redacted.
 Starting a login also drops the previous attempt's `error` and `lastAuthError`
 instead of carrying them onto the pending entry, so nothing escapes the
 boundary by riding an older snapshot. Do not put that ceiling on the shared

--- a/packages/client/src/providers/README.md
+++ b/packages/client/src/providers/README.md
@@ -104,12 +104,14 @@ fallback sign-in URL comes from an incremental scanner whose only carried state
 is the current partial token, and stderr keeps a bounded tail. `runLoginSubprocess`
 feeds both stdout and stderr to the same scanner, so a URL candidate can come
 from either stream. Because `pendingAuth.authUrl` is a structured field that
-never passes through `redactErrorPreview` (see below), URL candidacy is
-itself a no-secret boundary: a token carrying RFC-3986 userinfo or a
-credential-shaped query parameter (the same key set `redactErrorPreview`
-treats as unsafe, via the shared `CREDENTIAL_KEY_PATTERN`) is rejected outright
-rather than rewritten, and scanning continues to a later, legitimate URL in
-the same output.
+never passes through `redactErrorPreview` itself (see below), URL candidacy is
+itself a no-secret boundary: `hasCredentialShape` rejects a candidate the
+moment `redactErrorPreview` would change it — URL userinfo, a vendor-prefixed
+token shape under any key (or inside a URL fragment), an Authorization/Bearer
+shape, or a credential-named key=value pair — rather than re-checking a
+narrower subset of those rules that could fall behind. Rejection never
+rewrites the URL (an OAuth query string is part of the provider's protocol),
+and scanning continues to a later, legitimate URL in the same output.
 
 Every error/failure string the dispatcher republishes — `CapabilityEntry.error`
 and `lastAuthError.message`, and nothing else — passes through

--- a/packages/client/src/providers/auth-driver.ts
+++ b/packages/client/src/providers/auth-driver.ts
@@ -30,14 +30,19 @@ export type RuntimeAuthDriver = {
   /**
    * Resolve the login artifact. Returning `{ ok: false }` is the ordinary
    * "operator must install this first" path, not an exception.
+   *
+   * Declared as a `readonly` property (not TS method shorthand) so the
+   * contract itself blocks reassignment at the type level; every production
+   * driver is also `Object.freeze`d at construction so the same reassignment
+   * fails at runtime regardless of how it is typed at the call site.
    */
-  resolveLogin(): Promise<RuntimeAuthLoginResolution>;
+  readonly resolveLogin: () => Promise<RuntimeAuthLoginResolution>;
   /**
    * Re-detect every capability row this login can change, in publish order.
    * Claude returns two rows when the TUI is enabled because both read the same
    * keychain credential; the other providers return their own row only.
    */
-  reprobe(): Promise<readonly RuntimeAuthProbeResult[]>;
+  readonly reprobe: () => Promise<readonly RuntimeAuthProbeResult[]>;
 };
 
 export type RuntimeAuthLoginResolution = { ok: true; login: RuntimeAuthLoginStart } | { ok: false; error: string };

--- a/packages/client/src/providers/auth-driver.ts
+++ b/packages/client/src/providers/auth-driver.ts
@@ -1,0 +1,48 @@
+import type { CapabilityEntry, RuntimeProvider } from "@first-tree/shared";
+import type { LoginOutcome } from "../runtime/runtime-login.js";
+
+/**
+ * Provider-neutral contract for one in-product runtime-auth login.
+ *
+ * The daemon orchestrator owns the shape of the flow that is identical for
+ * every browser-OAuth provider (announce, resolve, publish `pendingAuth`, run,
+ * re-probe, stamp `lastAuthError`). A driver contributes only the three things
+ * that genuinely differ per provider: how the login artifact resolves, how the
+ * login is spawned, and which capability rows the result must refresh.
+ *
+ * A driver never publishes a capability entry itself and never decides retry,
+ * ordering, or error policy - keeping that in the orchestrator is what lets the
+ * generic dispatcher stay free of provider branches.
+ */
+export type RuntimeAuthDriver = {
+  /**
+   * Short provider word used in daemon status lines. Deliberately not the wire
+   * id: the Claude Code login reads as `claude` to an operator.
+   */
+  readonly logLabel: string;
+  /** The invocation as an operator would say it, e.g. `claude auth login`. */
+  readonly loginLabel: string;
+  /**
+   * What is missing when resolution fails. External CLIs resolve a `binary`;
+   * Claude may fall back to the SDK-bundled engine, so it reads as `CLI`.
+   */
+  readonly artifactLabel: string;
+  /**
+   * Resolve the login artifact. Returning `{ ok: false }` is the ordinary
+   * "operator must install this first" path, not an exception.
+   */
+  resolveLogin(): Promise<RuntimeAuthLoginResolution>;
+  /**
+   * Re-detect every capability row this login can change, in publish order.
+   * Claude returns two rows when the TUI is enabled because both read the same
+   * keychain credential; the other providers return their own row only.
+   */
+  reprobe(): Promise<readonly RuntimeAuthProbeResult[]>;
+};
+
+export type RuntimeAuthLoginResolution = { ok: true; login: RuntimeAuthLoginStart } | { ok: false; error: string };
+
+/** Spawn the resolved login; `onAuthUrl` fires at most once with a fallback link. */
+export type RuntimeAuthLoginStart = (hooks: { onAuthUrl: (url: string) => void }) => Promise<LoginOutcome>;
+
+export type RuntimeAuthProbeResult = { provider: RuntimeProvider; entry: CapabilityEntry };

--- a/packages/client/src/providers/auth-drivers.ts
+++ b/packages/client/src/providers/auth-drivers.ts
@@ -1,0 +1,31 @@
+import type { RuntimeAuthProvider } from "@first-tree/shared";
+import { createClaudeAuthDriver } from "../runtime/claude-login.js";
+import { createCodexAuthDriver } from "../runtime/codex-login.js";
+import { createCursorAuthDriver } from "../runtime/cursor-login.js";
+import { createGrokAuthDriver } from "../runtime/grok-login.js";
+import type { RuntimeAuthDriver } from "./auth-driver.js";
+
+/**
+ * Exhaustive over {@link RuntimeAuthProvider} - the narrow, server-accepted
+ * auth target set, not the full runtime-provider enum. Kimi, OpenCode and Pi
+ * keep provider-owned host login, and `claude-code-tui` shares Claude Code's
+ * credential rather than being its own target, so none of them is a key here.
+ */
+export type RuntimeAuthDriverTable = Readonly<Record<RuntimeAuthProvider, RuntimeAuthDriver>>;
+
+/**
+ * The one composition root allowed to name concrete runtime-auth providers.
+ *
+ * `satisfies Record<RuntimeAuthProvider, RuntimeAuthDriver>` makes the key set
+ * an exhaustive projection of `runtimeAuthProviderSchema`: extending that Zod
+ * enum fails this file to compile until a driver exists, and there is no second
+ * handwritten list of known auth providers to drift from it. Everything
+ * downstream dispatches by typed key, so no other module needs a provider
+ * branch.
+ */
+export const RUNTIME_AUTH_DRIVERS: RuntimeAuthDriverTable = Object.freeze({
+  "claude-code": createClaudeAuthDriver(),
+  codex: createCodexAuthDriver(),
+  cursor: createCursorAuthDriver(),
+  grok: createGrokAuthDriver(),
+} satisfies Record<RuntimeAuthProvider, RuntimeAuthDriver>);

--- a/packages/client/src/runtime/claude-login.ts
+++ b/packages/client/src/runtime/claude-login.ts
@@ -102,7 +102,11 @@ export function createClaudeAuthDriver(deps: ClaudeAuthDriverDeps = {}): Runtime
   const probeTui = deps.probeTui ?? probeClaudeCodeTuiCapability;
   const isProviderEnabled = deps.isProviderEnabled ?? isRuntimeProviderEnabled;
 
-  return {
+  // Frozen so this factory's promise ("a fresh, self-contained driver") holds
+  // even for a caller that never routes through RUNTIME_AUTH_DRIVERS: nothing
+  // downstream of this constructor can repoint resolveLogin/reprobe for the
+  // rest of the process.
+  return Object.freeze({
     logLabel: "claude",
     loginLabel: "claude auth login",
     // Claude can fall back to the SDK-bundled engine, so the operator-facing
@@ -127,5 +131,5 @@ export function createClaudeAuthDriver(deps: ClaudeAuthDriverDeps = {}): Runtime
         { provider: RUNTIME_PROVIDERS.CLAUDE_CODE_TUI, entry: tui },
       ];
     },
-  };
+  });
 }

--- a/packages/client/src/runtime/claude-login.ts
+++ b/packages/client/src/runtime/claude-login.ts
@@ -1,6 +1,13 @@
 import type { spawn } from "node:child_process";
+import { isRuntimeProviderEnabled, RUNTIME_PROVIDERS } from "@first-tree/shared";
 import { resolveClaudeCodeExecutable } from "../handlers/claude-executable.js";
-import { resolveBundledClaudeBinary } from "./capabilities/claude-code.js";
+import type {
+  RuntimeAuthDriver,
+  RuntimeAuthLoginResolution,
+  RuntimeAuthProbeResult,
+} from "../providers/auth-driver.js";
+import { probeClaudeCodeCapability, resolveBundledClaudeBinary } from "./capabilities/claude-code.js";
+import { probeClaudeCodeTuiCapability } from "./capabilities/claude-code-tui.js";
 import { BROWSER_LOGIN_TIMEOUT_MS, type LoginOutcome, runBrowserLogin } from "./runtime-login.js";
 
 /**
@@ -66,4 +73,59 @@ export function runClaudeBrowserLogin(options: ClaudeBrowserLoginOptions): Promi
     timeoutMs: options.timeoutMs ?? BROWSER_LOGIN_TIMEOUT_MS,
     spawnFn: options.spawnFn,
   });
+}
+
+/** Test seams; production composition passes nothing. */
+export type ClaudeAuthDriverDeps = {
+  resolveLogin?: typeof resolveClaudeLoginInvocation;
+  runBrowserLogin?: typeof runClaudeBrowserLogin;
+  probe?: typeof probeClaudeCodeCapability;
+  probeTui?: typeof probeClaudeCodeTuiCapability;
+  isProviderEnabled?: typeof isRuntimeProviderEnabled;
+};
+
+/**
+ * Claude Code's in-product auth driver.
+ *
+ * Claude auth is a single keychain credential shared by the SDK runtime and the
+ * TUI runtime, so one login authenticates both and the driver refreshes both
+ * rows - otherwise the TUI row keeps reading as a second, separate Claude login
+ * the user still has to perform until the next background poll. While the TUI
+ * provider is centrally disabled this path honours that switch exactly like the
+ * capability aggregator: it must not spawn the TUI probe (`claude` / tmux) or
+ * publish a TUI row.
+ */
+export function createClaudeAuthDriver(deps: ClaudeAuthDriverDeps = {}): RuntimeAuthDriver {
+  const resolveLogin = deps.resolveLogin ?? resolveClaudeLoginInvocation;
+  const browserLogin = deps.runBrowserLogin ?? runClaudeBrowserLogin;
+  const probe = deps.probe ?? probeClaudeCodeCapability;
+  const probeTui = deps.probeTui ?? probeClaudeCodeTuiCapability;
+  const isProviderEnabled = deps.isProviderEnabled ?? isRuntimeProviderEnabled;
+
+  return {
+    logLabel: "claude",
+    loginLabel: "claude auth login",
+    // Claude can fall back to the SDK-bundled engine, so the operator-facing
+    // gap is "a claude CLI to drive", not a single external binary.
+    artifactLabel: "CLI",
+    async resolveLogin(): Promise<RuntimeAuthLoginResolution> {
+      const invocation = resolveLogin();
+      if (!invocation.ok) return { ok: false, error: invocation.error };
+      return {
+        ok: true,
+        login: ({ onAuthUrl }) =>
+          browserLogin({ command: invocation.command, baseArgs: invocation.baseArgs, onAuthUrl }),
+      };
+    },
+    async reprobe(): Promise<readonly RuntimeAuthProbeResult[]> {
+      if (!isProviderEnabled(RUNTIME_PROVIDERS.CLAUDE_CODE_TUI)) {
+        return [{ provider: RUNTIME_PROVIDERS.CLAUDE_CODE, entry: await probe() }];
+      }
+      const [claudeCode, tui] = await Promise.all([probe(), probeTui()]);
+      return [
+        { provider: RUNTIME_PROVIDERS.CLAUDE_CODE, entry: claudeCode },
+        { provider: RUNTIME_PROVIDERS.CLAUDE_CODE_TUI, entry: tui },
+      ];
+    },
+  };
 }

--- a/packages/client/src/runtime/codex-login.ts
+++ b/packages/client/src/runtime/codex-login.ts
@@ -1,4 +1,11 @@
 import type { spawn } from "node:child_process";
+import { RUNTIME_PROVIDERS } from "@first-tree/shared";
+import type {
+  RuntimeAuthDriver,
+  RuntimeAuthLoginResolution,
+  RuntimeAuthProbeResult,
+} from "../providers/auth-driver.js";
+import { type CodexBinaryResolution, probeCodexCapability, resolveCodexRuntimeBinary } from "./capabilities/codex.js";
 import { BROWSER_LOGIN_TIMEOUT_MS, type LoginOutcome, runBrowserLogin } from "./runtime-login.js";
 
 /**
@@ -38,4 +45,36 @@ export function runCodexBrowserLogin(options: CodexBrowserLoginOptions): Promise
     timeoutMs: options.timeoutMs ?? BROWSER_LOGIN_TIMEOUT_MS,
     spawnFn: options.spawnFn,
   });
+}
+
+/** Test seams; production composition passes nothing. */
+export type CodexAuthDriverDeps = {
+  resolveBinary?: () => Promise<CodexBinaryResolution>;
+  runBrowserLogin?: typeof runCodexBrowserLogin;
+  probe?: typeof probeCodexCapability;
+};
+
+/**
+ * Codex's in-product auth driver. Login drives the SAME resolved binary the
+ * handler spawns, including its bounded `--version` smoke check, so a login
+ * cannot succeed against an artifact the runtime would not use.
+ */
+export function createCodexAuthDriver(deps: CodexAuthDriverDeps = {}): RuntimeAuthDriver {
+  const resolveBinary = deps.resolveBinary ?? resolveCodexRuntimeBinary;
+  const browserLogin = deps.runBrowserLogin ?? runCodexBrowserLogin;
+  const probe = deps.probe ?? probeCodexCapability;
+
+  return {
+    logLabel: "codex",
+    loginLabel: "codex login",
+    artifactLabel: "binary",
+    async resolveLogin(): Promise<RuntimeAuthLoginResolution> {
+      const resolved = await resolveBinary();
+      if (!resolved.ok) return { ok: false, error: resolved.error };
+      return { ok: true, login: ({ onAuthUrl }) => browserLogin({ binary: resolved.binary, onAuthUrl }) };
+    },
+    async reprobe(): Promise<readonly RuntimeAuthProbeResult[]> {
+      return [{ provider: RUNTIME_PROVIDERS.CODEX, entry: await probe() }];
+    },
+  };
 }

--- a/packages/client/src/runtime/codex-login.ts
+++ b/packages/client/src/runtime/codex-login.ts
@@ -64,7 +64,11 @@ export function createCodexAuthDriver(deps: CodexAuthDriverDeps = {}): RuntimeAu
   const browserLogin = deps.runBrowserLogin ?? runCodexBrowserLogin;
   const probe = deps.probe ?? probeCodexCapability;
 
-  return {
+  // Frozen so this factory's promise ("a fresh, self-contained driver") holds
+  // even for a caller that never routes through RUNTIME_AUTH_DRIVERS: nothing
+  // downstream of this constructor can repoint resolveLogin/reprobe for the
+  // rest of the process.
+  return Object.freeze({
     logLabel: "codex",
     loginLabel: "codex login",
     artifactLabel: "binary",
@@ -76,5 +80,5 @@ export function createCodexAuthDriver(deps: CodexAuthDriverDeps = {}): RuntimeAu
     async reprobe(): Promise<readonly RuntimeAuthProbeResult[]> {
       return [{ provider: RUNTIME_PROVIDERS.CODEX, entry: await probe() }];
     },
-  };
+  });
 }

--- a/packages/client/src/runtime/cursor-login.ts
+++ b/packages/client/src/runtime/cursor-login.ts
@@ -1,4 +1,12 @@
 import type { spawn } from "node:child_process";
+import { RUNTIME_PROVIDERS } from "@first-tree/shared";
+import type {
+  RuntimeAuthDriver,
+  RuntimeAuthLoginResolution,
+  RuntimeAuthProbeResult,
+} from "../providers/auth-driver.js";
+import { probeCursorCapability } from "./capabilities/cursor.js";
+import { type CursorRuntimeBinaryResolution, resolveCursorRuntimeBinary } from "./cursor-binary.js";
 import { BROWSER_LOGIN_TIMEOUT_MS, type LoginOutcome, runBrowserLogin } from "./runtime-login.js";
 
 /**
@@ -36,4 +44,36 @@ export function runCursorBrowserLogin(options: CursorBrowserLoginOptions): Promi
     timeoutMs: options.timeoutMs ?? BROWSER_LOGIN_TIMEOUT_MS,
     spawnFn: options.spawnFn,
   });
+}
+
+/** Test seams; production composition passes nothing. */
+export type CursorAuthDriverDeps = {
+  resolveBinary?: () => CursorRuntimeBinaryResolution;
+  runBrowserLogin?: typeof runCursorBrowserLogin;
+  probe?: typeof probeCursorCapability;
+};
+
+/**
+ * Cursor's in-product auth driver. Cursor is external-only, so login drives the
+ * SAME resolved binary the handler spawns, including its bounded `--version`
+ * smoke check.
+ */
+export function createCursorAuthDriver(deps: CursorAuthDriverDeps = {}): RuntimeAuthDriver {
+  const resolveBinary = deps.resolveBinary ?? resolveCursorRuntimeBinary;
+  const browserLogin = deps.runBrowserLogin ?? runCursorBrowserLogin;
+  const probe = deps.probe ?? probeCursorCapability;
+
+  return {
+    logLabel: "cursor",
+    loginLabel: "cursor login",
+    artifactLabel: "binary",
+    async resolveLogin(): Promise<RuntimeAuthLoginResolution> {
+      const resolved = resolveBinary();
+      if (!resolved.ok) return { ok: false, error: resolved.error };
+      return { ok: true, login: ({ onAuthUrl }) => browserLogin({ binary: resolved.binary, onAuthUrl }) };
+    },
+    async reprobe(): Promise<readonly RuntimeAuthProbeResult[]> {
+      return [{ provider: RUNTIME_PROVIDERS.CURSOR, entry: await probe() }];
+    },
+  };
 }

--- a/packages/client/src/runtime/cursor-login.ts
+++ b/packages/client/src/runtime/cursor-login.ts
@@ -63,7 +63,11 @@ export function createCursorAuthDriver(deps: CursorAuthDriverDeps = {}): Runtime
   const browserLogin = deps.runBrowserLogin ?? runCursorBrowserLogin;
   const probe = deps.probe ?? probeCursorCapability;
 
-  return {
+  // Frozen so this factory's promise ("a fresh, self-contained driver") holds
+  // even for a caller that never routes through RUNTIME_AUTH_DRIVERS: nothing
+  // downstream of this constructor can repoint resolveLogin/reprobe for the
+  // rest of the process.
+  return Object.freeze({
     logLabel: "cursor",
     loginLabel: "cursor login",
     artifactLabel: "binary",
@@ -75,5 +79,5 @@ export function createCursorAuthDriver(deps: CursorAuthDriverDeps = {}): Runtime
     async reprobe(): Promise<readonly RuntimeAuthProbeResult[]> {
       return [{ provider: RUNTIME_PROVIDERS.CURSOR, entry: await probe() }];
     },
-  };
+  });
 }

--- a/packages/client/src/runtime/grok-login.ts
+++ b/packages/client/src/runtime/grok-login.ts
@@ -1,4 +1,12 @@
 import type { spawn } from "node:child_process";
+import { RUNTIME_PROVIDERS } from "@first-tree/shared";
+import type {
+  RuntimeAuthDriver,
+  RuntimeAuthLoginResolution,
+  RuntimeAuthProbeResult,
+} from "../providers/auth-driver.js";
+import { probeGrokCapability } from "./capabilities/grok.js";
+import { type GrokRuntimeBinaryResolution, resolveGrokRuntimeBinary } from "./grok-binary.js";
 import { BROWSER_LOGIN_TIMEOUT_MS, type LoginOutcome, runBrowserLogin } from "./runtime-login.js";
 
 /**
@@ -49,4 +57,37 @@ export function runGrokBrowserLogin(options: GrokBrowserLoginOptions): Promise<L
     timeoutMs: options.timeoutMs ?? BROWSER_LOGIN_TIMEOUT_MS,
     spawnFn: options.spawnFn,
   });
+}
+
+/** Test seams; production composition passes nothing. */
+export type GrokAuthDriverDeps = {
+  resolveBinary?: () => GrokRuntimeBinaryResolution;
+  runBrowserLogin?: typeof runGrokBrowserLogin;
+  probe?: typeof probeGrokCapability;
+};
+
+/**
+ * Grok Build's in-product auth driver. Grok is external-only, so login drives
+ * the SAME resolved binary the handler spawns, including its bounded
+ * `--version` smoke check; the Windows fail-closed gate lives in the resolver
+ * and in {@link runGrokBrowserLogin}.
+ */
+export function createGrokAuthDriver(deps: GrokAuthDriverDeps = {}): RuntimeAuthDriver {
+  const resolveBinary = deps.resolveBinary ?? resolveGrokRuntimeBinary;
+  const browserLogin = deps.runBrowserLogin ?? runGrokBrowserLogin;
+  const probe = deps.probe ?? probeGrokCapability;
+
+  return {
+    logLabel: "grok",
+    loginLabel: "grok login",
+    artifactLabel: "binary",
+    async resolveLogin(): Promise<RuntimeAuthLoginResolution> {
+      const resolved = resolveBinary();
+      if (!resolved.ok) return { ok: false, error: resolved.error };
+      return { ok: true, login: ({ onAuthUrl }) => browserLogin({ binary: resolved.binary, onAuthUrl }) };
+    },
+    async reprobe(): Promise<readonly RuntimeAuthProbeResult[]> {
+      return [{ provider: RUNTIME_PROVIDERS.GROK, entry: await probe() }];
+    },
+  };
 }

--- a/packages/client/src/runtime/grok-login.ts
+++ b/packages/client/src/runtime/grok-login.ts
@@ -77,7 +77,11 @@ export function createGrokAuthDriver(deps: GrokAuthDriverDeps = {}): RuntimeAuth
   const browserLogin = deps.runBrowserLogin ?? runGrokBrowserLogin;
   const probe = deps.probe ?? probeGrokCapability;
 
-  return {
+  // Frozen so this factory's promise ("a fresh, self-contained driver") holds
+  // even for a caller that never routes through RUNTIME_AUTH_DRIVERS: nothing
+  // downstream of this constructor can repoint resolveLogin/reprobe for the
+  // rest of the process.
+  return Object.freeze({
     logLabel: "grok",
     loginLabel: "grok login",
     artifactLabel: "binary",
@@ -89,5 +93,5 @@ export function createGrokAuthDriver(deps: GrokAuthDriverDeps = {}): RuntimeAuth
     async reprobe(): Promise<readonly RuntimeAuthProbeResult[]> {
       return [{ provider: RUNTIME_PROVIDERS.GROK, entry: await probe() }];
     },
-  };
+  });
 }

--- a/packages/client/src/runtime/redact-error-preview.ts
+++ b/packages/client/src/runtime/redact-error-preview.ts
@@ -29,6 +29,16 @@
 const DEFAULT_MAX_LEN = 256;
 
 /**
+ * Query/form/env key names that make ANY value on them a credential.
+ * Exported so a second no-secret boundary — the fallback sign-in URL
+ * candidacy check in `runtime-login.ts`, which must reject a URL carrying
+ * one of these as a query parameter rather than redact it — shares this
+ * exact definition instead of maintaining its own list that could drift.
+ */
+export const CREDENTIAL_KEY_PATTERN =
+  "(?:token|access[_-]?token|api[_-]?key|apikey|private[_-]?token|password|passwd|secret|client[_-]?secret)";
+
+/**
  * Redact common credential shapes then truncate. Pure function — every input
  * deterministically maps to the same output, suitable for snapshot tests.
  *
@@ -130,16 +140,14 @@ export function redactErrorPreview(input: string, maxLen: number = DEFAULT_MAX_L
   //    `X-GitHub-Token` would otherwise let `token` match, then redact the
   //    `ghp_…` value the step-2 vendor pattern just turned into
   //    `[REDACTED:ghp]`, producing a stuttered double-redact.
-  const credKey =
-    "(?:token|access[_-]?token|api[_-]?key|apikey|private[_-]?token|password|passwd|secret|client[_-]?secret)";
   s = s.replace(
-    new RegExp(`(?<![\\w-])(${credKey})(["']?\\s*[:=]\\s*["']?)([A-Za-z0-9._\\-+/=~]{4,})`, "gi"),
+    new RegExp(`(?<![\\w-])(${CREDENTIAL_KEY_PATTERN})(["']?\\s*[:=]\\s*["']?)([A-Za-z0-9._\\-+/=~]{4,})`, "gi"),
     "$1$2[REDACTED]",
   );
   // URL query string form: `?token=...` / `&access_token=...` — distinct
   // from the key=value form because the credential charset there can include
   // url-encoded bytes that the above pattern's value class would reject.
-  s = s.replace(new RegExp(`([?&]${credKey}=)[^&\\s]{4,}`, "gi"), "$1[REDACTED]");
+  s = s.replace(new RegExp(`([?&]${CREDENTIAL_KEY_PATTERN}=)[^&\\s]{4,}`, "gi"), "$1[REDACTED]");
 
   return s.length > maxLen ? `${s.slice(0, maxLen)}…` : s;
 }

--- a/packages/client/src/runtime/redact-error-preview.ts
+++ b/packages/client/src/runtime/redact-error-preview.ts
@@ -28,14 +28,8 @@
 /** Default cap matches the resilience-event payload budget (256 chars). */
 const DEFAULT_MAX_LEN = 256;
 
-/**
- * Query/form/env key names that make ANY value on them a credential.
- * Exported so a second no-secret boundary — the fallback sign-in URL
- * candidacy check in `runtime-login.ts`, which must reject a URL carrying
- * one of these as a query parameter rather than redact it — shares this
- * exact definition instead of maintaining its own list that could drift.
- */
-export const CREDENTIAL_KEY_PATTERN =
+/** Query/form/env key names that make ANY value on them a credential. */
+const CREDENTIAL_KEY_PATTERN =
   "(?:token|access[_-]?token|api[_-]?key|apikey|private[_-]?token|password|passwd|secret|client[_-]?secret)";
 
 /**

--- a/packages/client/src/runtime/runtime-login.ts
+++ b/packages/client/src/runtime/runtime-login.ts
@@ -26,8 +26,9 @@ export const BROWSER_LOGIN_TIMEOUT_MS = 5 * 60_000;
 /**
  * Upper bound on the stderr we keep for a failure message. The login can stream
  * for the whole {@link BROWSER_LOGIN_TIMEOUT_MS} window, so only a tail is
- * retained; it also matches the budget the daemon publishes onto a capability
- * entry, so a bounded tail cannot become an unbounded `lastAuthError.message`.
+ * retained. This bound stands on its own: a consumer that republishes the
+ * failure applies its own ceiling, so the two need not agree exactly — what
+ * matters here is that the tail never grows with the volume of output.
  */
 export const LOGIN_STDERR_TAIL_MAX = 500;
 

--- a/packages/client/src/runtime/runtime-login.ts
+++ b/packages/client/src/runtime/runtime-login.ts
@@ -175,9 +175,10 @@ const WHITESPACE = /\s/;
  * Ceiling on any token the scanner will assemble or parse, whether it arrived
  * whole or across chunk boundaries. A sign-in URL that does not fit is not a
  * link worth handing to a browser anyway, so an over-long run of non-whitespace
- * is skipped rather than retained, concatenated, or matched. This is what keeps
- * both the retained state and the per-token work constant no matter how much a
- * provider prints during the five-minute login window.
+ * is skipped rather than retained, concatenated, or matched. This bounds the
+ * token state the scanner retains, assembles and URL-parses; finding token
+ * boundaries still reads each character, so total scan work stays linear in the
+ * bytes a provider prints during the five-minute login window.
  */
 export const AUTH_URL_TOKEN_MAX = 2048;
 

--- a/packages/client/src/runtime/runtime-login.ts
+++ b/packages/client/src/runtime/runtime-login.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { CREDENTIAL_KEY_PATTERN } from "./redact-error-preview.js";
 
 /**
  * Provider-agnostic plumbing for driving an official CLI login on the daemon
@@ -142,6 +143,32 @@ function isLoopbackHost(host: string): boolean {
   return host === "localhost" || host === "[::1]" || host === "::1" || /^127\./.test(host);
 }
 
+/** Matches a bare query-param name against the shared credential-key set. */
+const CREDENTIAL_QUERY_KEY = new RegExp(`^${CREDENTIAL_KEY_PATTERN}$`, "i");
+
+/**
+ * True if the URL carries its own auth material: RFC-3986 userinfo
+ * (`https://user:pass@host/...`), or a query parameter shaped like a
+ * credential (the same {@link CREDENTIAL_KEY_PATTERN} set `redactErrorPreview`
+ * treats as unsafe to publish). The provider's real sign-in link is, by
+ * definition, a URL the operator has NOT yet authenticated against, so a
+ * string with this shape in a login CLI's output is diagnostic noise (a proxy
+ * URL, a redirect echo, a copy-pasted example, …) rather than the fallback
+ * link. `pendingAuth.authUrl` is a structured field, not error text, so it
+ * never passes through `redactErrorPreview` (see `runtime-auth-login.ts`) —
+ * candidacy is the only gate here, and it rejects rather than rewrites: an
+ * OAuth URL's query string is part of the provider's protocol, so stripping
+ * or altering a matched parameter risks handing the browser a broken
+ * redirect instead of just declining to surface an unrelated string.
+ */
+function hasCredentialShape(url: URL): boolean {
+  if (url.username || url.password) return true;
+  for (const key of url.searchParams.keys()) {
+    if (CREDENTIAL_QUERY_KEY.test(key)) return true;
+  }
+  return false;
+}
+
 /**
  * Pull a usable fallback *sign-in* URL out of accumulated, ANSI-stripped login
  * output, or `null` if none is present yet. The fallback link exists for when
@@ -152,21 +179,25 @@ function isLoopbackHost(host: string): boolean {
  *   - only treat a whitespace-terminated token as complete (a trailing,
  *     unterminated token may still be streaming in across a stdout chunk
  *     boundary, so it is held back until the next chunk completes it),
- *   - strip trailing sentence punctuation (so the result parses), and
- *   - skip loopback origins.
+ *   - strip trailing sentence punctuation (so the result parses),
+ *   - skip loopback origins, and
+ *   - skip a candidate that carries its own auth material, so scanning moves
+ *     on to a later, legitimate URL in the same output instead of surfacing
+ *     one that never should have been a candidate.
  * Tokenising on whitespace keeps this linear in the output length.
  */
 function authUrlFromToken(token: string): string | null {
   if (!token || !URL_PREFIX.test(token)) return null;
   const url = stripTrailingPunct(token);
   if (!url) return null;
-  let hostname: string;
+  let parsed: URL;
   try {
-    hostname = new URL(url).hostname;
+    parsed = new URL(url);
   } catch {
     return null;
   }
-  return isLoopbackHost(hostname) ? null : url;
+  if (isLoopbackHost(parsed.hostname) || hasCredentialShape(parsed)) return null;
+  return url;
 }
 
 const WHITESPACE = /\s/;

--- a/packages/client/src/runtime/runtime-login.ts
+++ b/packages/client/src/runtime/runtime-login.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { CREDENTIAL_KEY_PATTERN } from "./redact-error-preview.js";
+import { redactErrorPreview } from "./redact-error-preview.js";
 
 /**
  * Provider-agnostic plumbing for driving an official CLI login on the daemon
@@ -143,30 +143,36 @@ function isLoopbackHost(host: string): boolean {
   return host === "localhost" || host === "[::1]" || host === "::1" || /^127\./.test(host);
 }
 
-/** Matches a bare query-param name against the shared credential-key set. */
-const CREDENTIAL_QUERY_KEY = new RegExp(`^${CREDENTIAL_KEY_PATTERN}$`, "i");
-
 /**
- * True if the URL carries its own auth material: RFC-3986 userinfo
- * (`https://user:pass@host/...`), or a query parameter shaped like a
- * credential (the same {@link CREDENTIAL_KEY_PATTERN} set `redactErrorPreview`
- * treats as unsafe to publish). The provider's real sign-in link is, by
- * definition, a URL the operator has NOT yet authenticated against, so a
- * string with this shape in a login CLI's output is diagnostic noise (a proxy
- * URL, a redirect echo, a copy-pasted example, …) rather than the fallback
- * link. `pendingAuth.authUrl` is a structured field, not error text, so it
- * never passes through `redactErrorPreview` (see `runtime-auth-login.ts`) —
- * candidacy is the only gate here, and it rejects rather than rewrites: an
- * OAuth URL's query string is part of the provider's protocol, so stripping
- * or altering a matched parameter risks handing the browser a broken
- * redirect instead of just declining to surface an unrelated string.
+ * True if the exact string we would publish as `pendingAuth.authUrl` carries
+ * a credential by ANY of `redactErrorPreview`'s detection rules: URL
+ * userinfo, a vendor-prefixed token shape (`ghp_...`, `sk-...`, ...)
+ * regardless of which key or fragment it sits under, an
+ * Authorization/Bearer shape, or a credential-named key=value pair anywhere
+ * in the string, including inside a `#fragment`. The provider's real sign-in
+ * link is, by definition, a URL the operator has NOT yet authenticated
+ * against, so a string with this shape in a login CLI's output is
+ * diagnostic noise (a proxy URL, a redirect echo, a copy-pasted example, ...)
+ * rather than the fallback link. `pendingAuth.authUrl` is a structured field,
+ * not error text, so it never passes through `redactErrorPreview` itself
+ * (see `runtime-auth-login.ts`) - candidacy is the only gate standing
+ * between such a string and the capability snapshot, and it rejects rather
+ * than rewrites: an OAuth URL's query string is part of the provider's
+ * protocol, so stripping or altering a matched parameter risks handing the
+ * browser a broken redirect instead of just declining to surface an
+ * unrelated string.
+ *
+ * Delegating to `redactErrorPreview` itself - rather than re-checking a
+ * subset of its rules (e.g. only credential-NAMED query keys, which misses a
+ * vendor token sitting under a neutral key like `?context=ghp_...`, and
+ * misses a `#access_token=...` fragment entirely) - is what keeps this
+ * candidacy gate provably at least as strict as the publication boundary
+ * `CapabilityEntry.error` / `lastAuthError.message` go through: a partial
+ * reimplementation would silently fall behind the moment that helper gains a
+ * new detection rule.
  */
-function hasCredentialShape(url: URL): boolean {
-  if (url.username || url.password) return true;
-  for (const key of url.searchParams.keys()) {
-    if (CREDENTIAL_QUERY_KEY.test(key)) return true;
-  }
-  return false;
+function hasCredentialShape(url: string): boolean {
+  return redactErrorPreview(url, Number.POSITIVE_INFINITY) !== url;
 }
 
 /**
@@ -196,7 +202,7 @@ function authUrlFromToken(token: string): string | null {
   } catch {
     return null;
   }
-  if (isLoopbackHost(parsed.hostname) || hasCredentialShape(parsed)) return null;
+  if (isLoopbackHost(parsed.hostname) || hasCredentialShape(url)) return null;
   return url;
 }
 

--- a/packages/client/src/runtime/runtime-login.ts
+++ b/packages/client/src/runtime/runtime-login.ts
@@ -193,6 +193,12 @@ export type AuthUrlScanner = {
   push(chunk: string): string | null;
   /** Characters currently held between chunks (diagnostics and tests). */
   retainedChars(): number;
+  /**
+   * Characters examined so far. Read-only seam that lets a test assert the
+   * work stays linear in the output and stops entirely once a URL is found,
+   * rather than inferring it from how fast the test ran.
+   */
+  scannedChars(): number;
 };
 
 export function createAuthUrlScanner(): AuthUrlScanner {
@@ -200,10 +206,12 @@ export function createAuthUrlScanner(): AuthUrlScanner {
   /** The in-progress token blew the cap: drop it until the next whitespace. */
   let discarding = false;
   let found = false;
+  let scanned = 0;
 
   return {
     push(chunk: string): string | null {
       if (found) return null;
+      scanned += chunk.length;
       let start = 0;
       for (let i = 0; i < chunk.length; i++) {
         if (!WHITESPACE.test(chunk[i] as string)) continue;
@@ -228,6 +236,7 @@ export function createAuthUrlScanner(): AuthUrlScanner {
       return null;
     },
     retainedChars: () => carry.length,
+    scannedChars: () => scanned,
   };
 }
 

--- a/packages/client/src/runtime/runtime-login.ts
+++ b/packages/client/src/runtime/runtime-login.ts
@@ -172,11 +172,12 @@ function authUrlFromToken(token: string): string | null {
 const WHITESPACE = /\s/;
 
 /**
- * Ceiling on the partial token carried across chunk boundaries. A sign-in URL
- * that does not fit is not a link worth handing to a browser anyway, so an
- * over-long run of non-whitespace is discarded instead of retained. This is
- * what keeps scanner state constant no matter how much a provider prints
- * during the five-minute login window.
+ * Ceiling on any token the scanner will assemble or parse, whether it arrived
+ * whole or across chunk boundaries. A sign-in URL that does not fit is not a
+ * link worth handing to a browser anyway, so an over-long run of non-whitespace
+ * is skipped rather than retained, concatenated, or matched. This is what keeps
+ * both the retained state and the per-token work constant no matter how much a
+ * provider prints during the five-minute login window.
  */
 export const AUTH_URL_TOKEN_MAX = 2048;
 
@@ -216,10 +217,17 @@ export function createAuthUrlScanner(): AuthUrlScanner {
       let start = 0;
       for (let i = 0; i < chunk.length; i++) {
         if (!WHITESPACE.test(chunk[i] as string)) continue;
-        const token = discarding ? "" : carry + chunk.slice(start, i);
+        // The cap applies to the completed token, not just to the tail we
+        // carried: a carry that fits and a segment that fits can still exceed
+        // it together, and a single over-long run inside one chunk must not be
+        // concatenated or parsed either. Measure first, then skip without
+        // building the string.
+        const overflowed = discarding || carry.length + (i - start) > AUTH_URL_TOKEN_MAX;
+        const token = overflowed ? "" : carry + chunk.slice(start, i);
         carry = "";
         discarding = false;
         start = i + 1;
+        if (overflowed) continue;
         const url = authUrlFromToken(token);
         if (url) {
           found = true;

--- a/packages/client/src/runtime/runtime-login.ts
+++ b/packages/client/src/runtime/runtime-login.ts
@@ -23,6 +23,14 @@ export type LoginOutcome =
 /** Default ceiling for the browser-OAuth flow: the user signs in interactively. */
 export const BROWSER_LOGIN_TIMEOUT_MS = 5 * 60_000;
 
+/**
+ * Upper bound on the stderr we keep for a failure message. The login can stream
+ * for the whole {@link BROWSER_LOGIN_TIMEOUT_MS} window, so only a tail is
+ * retained; it also matches the budget the daemon publishes onto a capability
+ * entry, so a bounded tail cannot become an unbounded `lastAuthError.message`.
+ */
+export const LOGIN_STDERR_TAIL_MAX = 500;
+
 export type LoginSubprocessOptions = {
   command: string;
   args: string[];
@@ -32,8 +40,12 @@ export type LoginSubprocessOptions = {
   spawnFn: typeof spawn;
   /** Human label for error messages, e.g. `codex login` / `claude auth login`. */
   label: string;
-  /** Called for every ANSI-stripped output chunk plus the full buffer so far. */
-  onOutput?: (cleanChunk: string, fullBuffer: string) => void;
+  /**
+   * Called for every ANSI-stripped output chunk. Deliberately chunk-only: the
+   * subprocess must not retain the whole stream so a chatty provider cannot
+   * accumulate minutes of output in memory.
+   */
+  onOutput?: (cleanChunk: string) => void;
   /** Map a non-zero exit to a failure outcome (exit 0 is always success). */
   classifyExit: (info: { code: number | null; stderrTail: string }) => Extract<LoginOutcome, { ok: false }>;
 };
@@ -61,7 +73,6 @@ export function runLoginSubprocess(opts: LoginSubprocessOptions): Promise<LoginO
       return;
     }
 
-    let buffer = "";
     let stderrTail = "";
     let settled = false;
 
@@ -83,15 +94,13 @@ export function runLoginSubprocess(opts: LoginSubprocessOptions): Promise<LoginO
     }
 
     function ingest(chunk: string): void {
-      const clean = stripAnsi(chunk);
-      buffer += clean;
-      onOutput?.(clean, buffer);
+      onOutput?.(stripAnsi(chunk));
     }
 
     child.stdout?.on("data", (data: Buffer) => ingest(data.toString("utf-8")));
     child.stderr?.on("data", (data: Buffer) => {
       const text = data.toString("utf-8");
-      stderrTail = stripAnsi(stderrTail + text).slice(-500);
+      stderrTail = stripAnsi(stderrTail + text).slice(-LOGIN_STDERR_TAIL_MAX);
       ingest(text);
     });
 
@@ -141,32 +150,93 @@ function isLoopbackHost(host: string): boolean {
  * URL" capture surfaces a link whose root 404s). We therefore:
  *   - only treat a whitespace-terminated token as complete (a trailing,
  *     unterminated token may still be streaming in across a stdout chunk
- *     boundary, so we skip it),
+ *     boundary, so it is held back until the next chunk completes it),
  *   - strip trailing sentence punctuation (so the result parses), and
- *   - skip loopback origins, returning the first external URL (or `null`).
- * Tokenising on whitespace keeps this linear in the buffer length. Exported for
- * unit tests.
+ *   - skip loopback origins.
+ * Tokenising on whitespace keeps this linear in the output length.
+ */
+function authUrlFromToken(token: string): string | null {
+  if (!token || !URL_PREFIX.test(token)) return null;
+  const url = stripTrailingPunct(token);
+  if (!url) return null;
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+  return isLoopbackHost(hostname) ? null : url;
+}
+
+const WHITESPACE = /\s/;
+
+/**
+ * Ceiling on the partial token carried across chunk boundaries. A sign-in URL
+ * that does not fit is not a link worth handing to a browser anyway, so an
+ * over-long run of non-whitespace is discarded instead of retained. This is
+ * what keeps scanner state constant no matter how much a provider prints
+ * during the five-minute login window.
+ */
+export const AUTH_URL_TOKEN_MAX = 2048;
+
+/**
+ * Incremental scanner for the fallback sign-in URL.
+ *
+ * Output is consumed chunk by chunk, and each complete token is judged exactly
+ * once, so a chatty login never re-scans text it has already seen. The only
+ * state kept between chunks is the trailing partial token, capped at
+ * {@link AUTH_URL_TOKEN_MAX}; a URL split across two chunks is still
+ * recognised, and once one is found the scanner retains nothing further.
+ */
+export type AuthUrlScanner = {
+  /** Feed one ANSI-stripped chunk; returns the URL the moment one completes. */
+  push(chunk: string): string | null;
+  /** Characters currently held between chunks (diagnostics and tests). */
+  retainedChars(): number;
+};
+
+export function createAuthUrlScanner(): AuthUrlScanner {
+  let carry = "";
+  /** The in-progress token blew the cap: drop it until the next whitespace. */
+  let discarding = false;
+  let found = false;
+
+  return {
+    push(chunk: string): string | null {
+      if (found) return null;
+      let start = 0;
+      for (let i = 0; i < chunk.length; i++) {
+        if (!WHITESPACE.test(chunk[i] as string)) continue;
+        const token = discarding ? "" : carry + chunk.slice(start, i);
+        carry = "";
+        discarding = false;
+        start = i + 1;
+        const url = authUrlFromToken(token);
+        if (url) {
+          found = true;
+          return url;
+        }
+      }
+      const tail = chunk.slice(start);
+      if (!tail) return null;
+      if (discarding || carry.length + tail.length > AUTH_URL_TOKEN_MAX) {
+        discarding = true;
+        carry = "";
+      } else {
+        carry += tail;
+      }
+      return null;
+    },
+    retainedChars: () => carry.length,
+  };
+}
+
+/**
+ * One-shot form of {@link createAuthUrlScanner} for callers and tests that
+ * already hold the whole output as a single string.
  */
 export function extractAuthUrl(buffer: string): string | null {
-  const terminated = /\s$/.test(buffer);
-  const tokens = buffer.split(/\s+/);
-  // The last token is only known-complete if the buffer ended on whitespace.
-  const completeCount = terminated ? tokens.length : tokens.length - 1;
-  for (let i = 0; i < completeCount; i++) {
-    const token = tokens[i];
-    if (!token || !URL_PREFIX.test(token)) continue;
-    const url = stripTrailingPunct(token);
-    if (!url) continue;
-    let hostname: string;
-    try {
-      hostname = new URL(url).hostname;
-    } catch {
-      continue;
-    }
-    if (isLoopbackHost(hostname)) continue;
-    return url;
-  }
-  return null;
+  return createAuthUrlScanner().push(buffer);
 }
 
 export type BrowserLoginOptions = {
@@ -194,6 +264,9 @@ export type BrowserLoginOptions = {
  */
 export function runBrowserLogin(options: BrowserLoginOptions): Promise<LoginOutcome> {
   const { command, args, label, onAuthUrl, onRawOutput, signal } = options;
+  // Built only when a caller wants the URL, and inert once it has produced one,
+  // so the fallback-link feature never becomes a reason to retain login output.
+  const scanner = onAuthUrl ? createAuthUrlScanner() : null;
   let urlFired = false;
   return runLoginSubprocess({
     command,
@@ -203,10 +276,10 @@ export function runBrowserLogin(options: BrowserLoginOptions): Promise<LoginOutc
     timeoutMs: options.timeoutMs ?? BROWSER_LOGIN_TIMEOUT_MS,
     spawnFn: options.spawnFn ?? spawn,
     label,
-    onOutput: (clean, full) => {
+    onOutput: (clean) => {
       onRawOutput?.(clean);
-      if (urlFired || !onAuthUrl) return;
-      const url = extractAuthUrl(full);
+      if (urlFired || !onAuthUrl || !scanner) return;
+      const url = scanner.push(clean);
       if (url) {
         urlFired = true;
         onAuthUrl(url);

--- a/packages/qa/cases/runtime/provider-boundary.md
+++ b/packages/qa/cases/runtime/provider-boundary.md
@@ -56,12 +56,31 @@ records the human cross-surface checks those tests cannot fully cover.
    - Confirm `first-tree daemon probe --json --no-upload` still returns entries
      for enabled providers only, and a single probe failure does not drop the
      rest of the snapshot.
+   - Confirm the runtime-auth driver projection covers exactly the
+     server-accepted in-product targets, with no host-login provider and no
+     separate entry for the shared-credential Claude Code CLI target.
 
-4. **Skill roots**
+4. **In-product login boundary**
+   - Confirm a Connect on each in-product target still walks pending → sign-in
+     URL (when the provider emits one) → re-probe, and that an unresolved
+     artifact, a failed or thrown login, and a thrown re-probe each end with a
+     published capability entry rather than a stuck pending row.
+   - Confirm a Claude Code login refreshes both Claude rows while the CLI/TUI
+     entry is enabled, and touches only the Claude Code row while it is
+     centrally disabled.
+   - Confirm a long or noisy login run does not grow daemon memory with
+     retained login output, reports an external sign-in URL exactly once even
+     when it arrives split across output chunks, and never reports a loopback
+     callback URL.
+   - Confirm every published `lastAuthError.message` is length-bounded and
+     carries no credential or token text, including errors originating from the
+     artifact resolver or a spawn failure.
+
+5. **Skill roots**
    - Confirm managed-skills reads `PROVIDER_SKILL_ROOTS` directly (Claude →
      `.claude/skills`, Codex/Pi → `.agents/skills`, etc.).
 
-5. **Architecture guard**
+6. **Architecture guard**
    - Confirm the committed provider-boundary guard remains green: generic
      modules stay free of provider-literal switches, guard tokens derive from
      `RUNTIME_PROVIDER_IDS`, and live consumers use catalog helpers.
@@ -81,8 +100,9 @@ provider-literal regression in the guarded generic modules.
 
 `FAIL` means a generic module regained concrete provider branches/lists, web
 reintroduced a parallel provider table, probe aggregation diverged from the
-enabled provider set, or skill-root / preference order drifted from catalog
-data.
+enabled provider set, skill-root / preference order drifted from catalog data,
+or an in-product login lost a lifecycle step, leaked credential text, or
+retained unbounded login output.
 
 `BLOCKED` means the run cell could not exercise probe/UI surfaces for
 environment reasons; record the gap and keep product-test evidence separate.

--- a/packages/qa/cases/runtime/provider-boundary.md
+++ b/packages/qa/cases/runtime/provider-boundary.md
@@ -56,34 +56,21 @@ records the human cross-surface checks those tests cannot fully cover.
    - Confirm `first-tree daemon probe --json --no-upload` still returns entries
      for enabled providers only, and a single probe failure does not drop the
      rest of the snapshot.
-   - Confirm the runtime-auth driver projection covers exactly the
-     server-accepted in-product targets, with no host-login provider and no
+   - Confirm the runtime-auth driver registry is frozen and exhaustive over the
+     server-accepted in-product targets: no host-login provider, and no
      separate entry for the shared-credential Claude Code CLI target.
 
-4. **In-product login boundary**
-   - Confirm a Connect on each in-product target still walks pending → sign-in
-     URL (when the provider emits one) → re-probe, and that an unresolved
-     artifact, a failed or thrown login, and a thrown re-probe each end with a
-     published capability entry rather than a stuck pending row.
-   - Confirm a Claude Code login refreshes both Claude rows while the CLI/TUI
-     entry is enabled, and touches only the Claude Code row while it is
-     centrally disabled.
-   - Confirm a long or noisy login run does not grow daemon memory with
-     retained login output, reports an external sign-in URL exactly once even
-     when it arrives split across output chunks, and never reports a loopback
-     callback URL.
-   - Confirm every published `lastAuthError.message` is length-bounded and
-     carries no credential or token text, including errors originating from the
-     artifact resolver or a spawn failure.
-
-5. **Skill roots**
+4. **Skill roots**
    - Confirm managed-skills reads `PROVIDER_SKILL_ROOTS` directly (Claude →
      `.claude/skills`, Codex/Pi → `.agents/skills`, etc.).
 
-6. **Architecture guard**
+5. **Architecture guard**
    - Confirm the committed provider-boundary guard remains green: generic
      modules stay free of provider-literal switches, guard tokens derive from
      `RUNTIME_PROVIDER_IDS`, and live consumers use catalog helpers.
+   - Confirm the generic daemon runtime-auth entry point stays provider-neutral:
+     no in-product provider literal, no provider-specific resolver / probe /
+     login import, and no branch on the requested provider.
 
 ## Evidence
 
@@ -101,8 +88,8 @@ provider-literal regression in the guarded generic modules.
 `FAIL` means a generic module regained concrete provider branches/lists, web
 reintroduced a parallel provider table, probe aggregation diverged from the
 enabled provider set, skill-root / preference order drifted from catalog data,
-or an in-product login lost a lifecycle step, leaked credential text, or
-retained unbounded login output.
+or the runtime-auth registry stopped being frozen and exhaustive while the
+generic daemon entry point regained provider knowledge.
 
 `BLOCKED` means the run cell could not exercise probe/UI surfaces for
 environment reasons; record the gap and keep product-test evidence separate.

--- a/packages/shared/src/__tests__/runtime-provider-catalog.test.ts
+++ b/packages/shared/src/__tests__/runtime-provider-catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   asRuntimeProvider,
+  capabilityEntrySchema,
   DISABLED_RUNTIME_PROVIDERS,
   enabledOkRuntimeProviders,
   enabledRuntimeProviders,
@@ -137,6 +138,20 @@ describe("runtime provider identity + catalog completeness", () => {
     expect(runtimeProviderInProductAuthTarget("kimi-code")).toBeNull();
     expect(runtimeProviderInProductAuthTarget("opencode")).toBeNull();
     expect(runtimeProviderInProductAuthTarget("pi")).toBeNull();
+  });
+
+  it("leaves the published auth-error message uncapped on the wire", () => {
+    // The daemon redacts and truncates before publishing, but the cap stays on
+    // the daemon: a `.max()` here would make a new server reject an older
+    // daemon's snapshot mid-rollout, which is exactly the compatibility break
+    // the capability map is designed to avoid.
+    const parsed = capabilityEntrySchema.safeParse({
+      state: "ok",
+      available: true,
+      detectedAt: "2026-06-22T12:00:00.000Z",
+      lastAuthError: { reason: "exit-nonzero", message: "x".repeat(5_000), at: "2026-06-22T12:00:00.000Z" },
+    });
+    expect(parsed.success).toBe(true);
   });
 
   it("narrows wire strings via safeParse and leaves unknown ids unlabeled", () => {


### PR DESCRIPTION
## Why

Two problems in the in-product runtime-auth path, both in the same flow:

1. `apps/cli/src/core/runtime-auth-login.ts` knew all four browser-OAuth providers by name — provider imports plus an `if`/`switch` chain for resolve, spawn and re-probe. Every new in-product target meant another branch in generic daemon code, and provider-specific probe wiring lived outside the provider's own module.
2. The login subprocess accumulated the entire ANSI-stripped stdout+stderr stream for the whole five-minute sign-in window and re-split/re-scanned that growing buffer on every chunk just to find the fallback sign-in URL. Any provider, resolver or spawn error text could also reach `lastAuthError.message` verbatim and unbounded, so a credential-bearing path or a huge stack trace went straight into the capability snapshot the daemon PATCHes. (#1720)

## What changed

**Driver boundary.** The daemon orchestrator is now provider-neutral: it owns announce → `pendingAuth` → `authUrl` → re-probe → `lastAuthError`, and dispatches by typed key into `RUNTIME_AUTH_DRIVERS`.

- `packages/client/src/providers/auth-driver.ts` — the provider-neutral contract. A driver contributes `logLabel` / `loginLabel` / `artifactLabel` plus `resolveLogin()` and `reprobe()`; it never publishes an entry and never owns retry, ordering or error policy.
- `packages/client/src/providers/auth-drivers.ts` — the single composition root: `Object.freeze({...} satisfies Record<RuntimeAuthProvider, RuntimeAuthDriver>)`, so the key set is an exhaustive projection of `runtimeAuthProviderSchema` and extending that enum fails to compile until a driver exists. No second handwritten known-provider list.
- `create{Claude,Codex,Cursor,Grok}AuthDriver` live in each provider's own `runtime/*-login.ts`, take pure factory deps for test injection, and there is no process-global mutable registry.
- Claude keeps its shared-credential behaviour inside its own driver: `reprobe()` refreshes both Claude rows while the TUI provider is enabled, and neither probes nor publishes the TUI row while it is centrally disabled.
- `RuntimeAuthCommand.provider` is narrowed from `RuntimeProvider` to `RuntimeAuthProvider`. The wire is unchanged — this is the same set `runtimeAuthStartCommandSchema` already parses at runtime, now visible in the type.
- Existing `@first-tree/client` resolver / probe / browser-login exports and behaviour are unchanged.

**Bounded login output (#1720).**

- `createAuthUrlScanner()` replaces whole-buffer rescans: output is consumed chunk by chunk, each complete whitespace-terminated token is judged exactly once, and the only retained state is the trailing partial token. `AUTH_URL_TOKEN_MAX` bounds any token the scanner will assemble or parse — measured on the *completed* token, so neither a carry plus a segment that only overflow together nor a single huge run inside one chunk is ever concatenated or matched, and a later legitimate URL is still found. A URL split across chunks is still found, loopback origins are still skipped, trailing punctuation is still stripped, an external URL still fires exactly once, and the scanner retains nothing more once it has produced one. `extractAuthUrl` stays as the one-shot wrapper.
- `runLoginSubprocess` keeps no full buffer at all; `onOutput` is chunk-only, so `onRawOutput` consumers still stream but nothing accumulates for them. stderr keeps a bounded tail (`LOGIN_STDERR_TAIL_MAX`).
- Every error/failure string the orchestrator republishes onto a capability entry — `CapabilityEntry.error` and `lastAuthError.message`, which is the whole of the free-text surface here — passes through `redactErrorPreview` under a hard `RUNTIME_AUTH_ERROR_MAX_LEN` of 500 characters, sized to the capability probe's error budget. That now means both publish paths, not just the login's own verdict: resolver failures, spawn failures, thrown logins and provider-reported failures reach `lastAuthError.message` sanitised, *and* the `error` of every row a driver's `reprobe()` returns is sanitised at the same boundary — including the extra row a shared-credential driver refreshes, whose detection text comes from the same hosts and subprocesses. Structured fields the daemon produces itself (`pendingAuth.authUrl`, the detected version, the labels) are not error text and deliberately do not pass through an error sanitizer. Starting a login also drops the prior attempt's `error` / `lastAuthError` rather than spreading them onto the pending entry, which both closes that bypass and matches the shared schema's documented "a new login start clears the previous failure" (carrying detection-failure text on an entry we force to `ok` contradicts itself anyway). The helper treats its argument as a *body* budget and appends an ellipsis when it truncates, so the call site passes one less and the published string is at most 500 including that ellipsis; the tests assert the exact length and the trailing ellipsis. Because a matched secret collapses into a short placeholder, every cap test — the probe-reported errors on both the target and the shared-credential extra row, and the thrown and unresolved-artifact failures — pairs its credential with redaction-proof diagnostic prose on the following line. Without that tail the redacted input is a few dozen characters, the truncation never runs, and the length assertion proves nothing. The ceiling lives in the daemon, deliberately not as a `.max()` on the shared wire schema, so an older daemon's payload is not rejected by a newer server.

**Ordering and containment.** Two related sharp edges the driver boundary made easy to fix: the sign-in URL write is chained behind the earlier pending write and drained before the terminal re-probe, so a slow capability PATCH cannot resurrect a pending marker on a finished login; and a resolver that *throws* (it reaches PATH and the filesystem) is now reflected exactly like a resolver that reports a missing artifact, instead of escaping an orchestrator documented as never throwing. The scanner also exposes a read-only `scannedChars()` so the #1720 bound is asserted directly rather than inferred from how fast a test ran.

**Docs / guard.** `packages/client/src/providers/README.md` documents the driver projection, allowed locations and the new-provider gate; `provider-boundary-guard` now asserts the table is frozen and schema-exhaustive, the contract is provider-neutral, the generic CLI file carries no provider literal / import / branch, and the login path uses the bounded scanner. The runtime-auth guard checks that file against tokens derived from `runtimeAuthProviderSchema.options` as well as the full provider set, so widening the in-product auth enum fails the guard until the dispatcher and the registry are widened with it. `packages/qa/cases/runtime/provider-boundary.md` gains stable verification questions only.

**Review fixes.** Two gaps `baixiaohang` found in review, both now closed:

- The fallback sign-in URL scanner accepted the first non-loopback `http(s)` token unconditionally, so a credential-bearing string in provider output (URL userinfo, or a token/secret elsewhere in the string) could be published verbatim as `pendingAuth.authUrl` and rendered as a link — even though the same text would be redacted in `CapabilityEntry.error` or `lastAuthError.message`. `authUrl` is a structured field and deliberately does not go through `redactErrorPreview`, so URL candidacy is the only gate standing between such a string and the capability snapshot. A first pass rejected userinfo and credential-NAMED query keys, but a follow-up review found that check still narrower than the publication boundary: it missed a credential inside a `#fragment` (no `searchParams` to scan) and a vendor-prefixed token (`ghp_…`, `sk-…`, …) sitting under a neutral key like `?context=`. `hasCredentialShape` now delegates to `redactErrorPreview` itself — a candidate is rejected the instant that helper would change the string — instead of re-checking a subset of its rules that could fall behind as that rule set grows. Rejection still never rewrites the URL, since an OAuth query string is part of the provider's protocol, and scanning continues to a later, legitimate URL in the same output. An ordinary OAuth authorize query string (`client_id`, `redirect_uri`, `state`, `scope`, …) is asserted NOT to trip this check.
- `Object.freeze` on `RUNTIME_AUTH_DRIVERS` only froze the table, not the four driver values inside it: every `create*AuthDriver()` returned a plain mutable object, and `RuntimeAuthDriver` declared `resolveLogin` / `reprobe` with TS method-shorthand syntax, which is not `readonly`. An importer could still repoint `RUNTIME_AUTH_DRIVERS.codex.resolveLogin` for the rest of the process — the exact process-global mutation path this design says it removes. Every `create*AuthDriver` factory now freezes its own return value (so the guarantee holds independent of composition into the table, for a driver a test or a future composition root constructs directly), and the contract declares both methods `readonly` so the type system also rejects reassignment. Tests assert every registered driver is frozen, every directly-constructed driver is frozen, and a reassignment attempt leaves the original method in place. Confirmed resolved on review.

## Scope

No Handler V2, no `AgentHandler` / SessionManager / delivery / ACK / retry / Reset / WS / DB / persistence change, no runtime-auth wire change. Capability probe stays artifact/platform-only. In-product targets remain Claude Code, Codex, Cursor and Grok; Kimi / OpenCode / Pi keep provider-owned host login. No real provider agent was started and no provider credential was read.

Closes #1720





