### PR TITLE
chore(e2e): rename Momentic environment first-tree-local to local

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -48,12 +48,12 @@ CI would additionally need a `MOMENTIC_API_KEY` secret.
 
 **What leaves your machine.** Resolving a natural-language step and evaluating a
 model-backed assertion sends page context — DOM snapshot and screenshot — to
-Momentic's service. Runs against `local` therefore transmit whatever
-is on screen in your local dev app. That is fine for the disposable
-`e2e-user-<ms>` identities these tests create, but do not point this suite at an
-environment holding real user data. `npx momentic results upload` additionally
-publishes a run's screenshots and video to the Momentic dashboard; nothing is
-uploaded unless you run that command.
+Momentic's service. Runs against `local` therefore transmit whatever is on
+screen in your local dev app. That is fine for the disposable `e2e-user-<ms>`
+identities these tests create, but do not point this suite at an environment
+holding real user data. `npx momentic results upload` additionally publishes a
+run's screenshots and video to the Momentic dashboard; nothing is uploaded
+unless you run that command.
 
 ### 2. Local First Tree stack
 
@@ -93,7 +93,7 @@ the local stack and the local tests do not touch staging.
 | --- | --- | --- |
 | `registration-new-user.test.yaml` | local | A brand-new account is created and lands on onboarding step 1 |
 | `onboarding-complete-setup.test.yaml` | local | The whole first-run journey: sign up → create team → connect a computer → create the first agent → start the kickoff chat → land in the workspace |
-| `dev-cloud-sign-in-available.test.yaml` | dev-cloud | Staging serves the landing page and offers Google + GitHub sign-in |
+| `dev-cloud-sign-in-available.test.yaml` | first-tree-dev-cloud | Staging serves the landing page and offers Google + GitHub sign-in |
 
 `modules/sign-up-fresh-user.module.yaml` holds the shared sign-up flow. Each run
 registers a **new** user (`e2e-user-<ms>`); reusing an identity would sign in as

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -48,7 +48,7 @@ CI would additionally need a `MOMENTIC_API_KEY` secret.
 
 **What leaves your machine.** Resolving a natural-language step and evaluating a
 model-backed assertion sends page context — DOM snapshot and screenshot — to
-Momentic's service. Runs against `first-tree-local` therefore transmit whatever
+Momentic's service. Runs against `local` therefore transmit whatever
 is on screen in your local dev app. That is fine for the disposable
 `e2e-user-<ms>` identities these tests create, but do not point this suite at an
 environment holding real user data. `npx momentic results upload` additionally
@@ -68,7 +68,7 @@ pnpm --filter @first-tree/server dev          # :8000, enables the dev callback
 pnpm --filter @first-tree/web dev --host 127.0.0.1   # :5173
 ```
 
-The `first-tree-local` environment in [momentic.config.yaml](../momentic.config.yaml)
+The `local` environment in [momentic.config.yaml](../momentic.config.yaml)
 points at `http://127.0.0.1:5173` (Vite proxies `/api/v1` to the server) and
 passes `DATABASE_URL` through for the fixtures below.
 
@@ -104,7 +104,7 @@ by design — they accumulate rows in the local dev database.
 
 | Environment | Target | Runs |
 | --- | --- | --- |
-| `first-tree-local` | `http://127.0.0.1:5173` | Registration + onboarding (needs the dev sign-in stub and database fixtures) |
+| `local` | `http://127.0.0.1:5173` | Registration + onboarding (needs the dev sign-in stub and database fixtures) |
 | `first-tree-dev-cloud` | `https://dev.cloud.first-tree.ai` | Deployment smoke check only |
 
 The registration and onboarding tests **cannot** run against a deployed

--- a/e2e/onboarding-complete-setup.test.yaml
+++ b/e2e/onboarding-complete-setup.test.yaml
@@ -1,7 +1,7 @@
 fileType: momentic/test/v2
 id: early-firm-harbor-dreams-poorly
 description: A new user completes onboarding end to end and lands in the workspace
-defaultEnv: first-tree-local
+defaultEnv: local
 steps:
   # ── Sign up ─────────────────────────────────────────────────────────────────
   - module:

--- a/e2e/registration-new-user.test.yaml
+++ b/e2e/registration-new-user.test.yaml
@@ -1,7 +1,7 @@
 fileType: momentic/test/v2
 id: circling-deep-speed-returns-linearly
 description: A brand-new user signs up and lands in onboarding
-defaultEnv: first-tree-local
+defaultEnv: local
 steps:
   - module:
       path: ./modules/sign-up-fresh-user.module.yaml

--- a/momentic.config.yaml
+++ b/momentic.config.yaml
@@ -29,7 +29,7 @@ ai:
 environments:
   # Local first-tree stack: web on :5173 (Vite proxies /api/v1 to the server
   # on :8000), postgres from docker-compose. See DEVELOPMENT.md Quickstart.
-  - name: first-tree-local
+  - name: local
     baseUrl: http://127.0.0.1:5173
     envVariables:
       DATABASE_URL: postgresql://firsttree:firsttree@localhost:5432/firsttree


### PR DESCRIPTION
Supersedes #2162 (branch name did not match the `chore/` convention; recreated rather than renamed to avoid auto-closing).

## Why

The team adopted a unified Momentic environment naming convention: every repo's `momentic.config.yaml` declares a `local` environment pointing at the machine-local dev stack, so every agent (on different machines that cannot reach each other's localhost) can uniformly run:

```bash
momentic run --env local --upload-results
```

This repo's env was named `first-tree-local`, which was blocking the agent-prompt rollouts on the yzw and baixiaohang sides (their new prompts mandate `--env local`).

## What

Pure rename `first-tree-local` → `local` in:
- `momentic.config.yaml` (env name only; baseUrl/envVariables unchanged)
- `e2e/*.test.yaml` `defaultEnv`
- `e2e/README.md` prose/table

`first-tree-dev-cloud` is untouched. The `first-tree-local` strings in `auth.test.ts` (token issuer) and `workspace-sandbox.ts` (`.first-tree-local` dir) are unrelated to Momentic and deliberately not changed.

## Verification

`momentic lint` (3.42.1): passed, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)