### PR TITLE
Safely co-locate SCM personnel target routes

### DIFF
--- a/packages/qa/cases/cross-surface/scm-entity-attention-parity.md
+++ b/packages/qa/cases/cross-surface/scm-entity-attention-parity.md
@@ -38,12 +38,31 @@ card significance, lifecycle projection, topic protection, and archive behavior.
 - Unfollow in one chat and redeliver an ordinary event. Confirm the old chat stays silent. Then deliver an explicit
   reviewer, assignee, or exact body/comment mention and confirm a fresh route may be established without reviving the
   removed line.
-- Exercise reviewer, assignee, and mention targets with equivalent identities. Only reviewer routing may reuse exactly one
-  eligible membership chat without writing a new line; assignee and mention routing establish the target's own line/chat.
-  Ambiguous membership reuse must fail closed. Also create an agent follow whose stable human carrier is the reviewer but
-  whose wake agent differs from that human's current delegate. Confirm the carrier line remains intact, the current
-  delegate is still addressed by exact pair, reviewer membership reuse happens only when both sides already speak in one
-  candidate chat, and the strict path otherwise creates a separate deliverable line without human-scoped fallback.
+- Exercise reviewer, assignee, and mention targets with equivalent identities. Confirm review-only routing reuses exactly
+  one chat only when the target human and current delegate are already speakers, and writes no new line. For assignment
+  and mention, create an agent follow whose stable human carrier has a different current delegate. Confirm one uniquely
+  safe entity chat is reused, the current delegate is atomically admitted when necessary, and an exact sibling line is
+  written without deleting or replacing the original follow line. The chat must receive one card and wake the fresh
+  delegate. Repeat with `review_requested` plus `assigned`; the card must display review priority while still persisting
+  the sibling line.
+- Repeat assignment and mention with zero candidates, two otherwise-safe candidates, another human speaker, another
+  owner's non-human speaker, and an invitation-denied target. Confirm every valid-but-unsafe or ambiguous case creates a
+  strict exact-pair home, never picks by human or manager, and never writes a personnel
+  `human_fallback`/`identity_target` into an unselected chat. Resolve the audience, then change the delegate, suspend the
+  human or delegate, or deactivate the human membership before placement; stale authority must be dropped without
+  accepting an old direct line or creating a new home. After unfollow, an explicit mention may create a fresh route but
+  must not revive the removed chat.
+- Race webhook personnel placement against unfollow and `--rebind` for the same entity. Confirm all operations serialize:
+  the final exact line follows the winning current state, no old chat is resurrected, membership never commits without
+  its sibling mapping, and concurrent fresh targets converge to at most one exact home. Also race placement against
+  removing the target delegate from the candidate chat and transferring an existing private speaker to another owner;
+  the result must either remain safely wakeable in the candidate or fail over to a strict home without exposing private
+  history. During explicit GitHub and GitLab follow/rebind, change the human's delegate or remove the wake agent from the
+  destination chat after request authorization but before persistence; both providers must reject the stale pair and
+  leave the previous line unchanged.
+- Rename a GitLab project after an entity has been observed, then race webhook observation using the new path against
+  follow/unfollow using the previously stored path or mapping id. Confirm the numeric project id keeps both paths in one
+  entity serialization boundary and the final active line reflects the winning operation without stale resurrection.
 - Have a delegate act through its human's provider identity in an entity followed by that human's line. Confirm every
   valid routed chat keeps one provider card, the matching existing line does not wake itself, eligible sibling lines still
   wake, and a chat with no eligible wake line receives a silent history card instead of losing the event.

--- a/packages/server/src/__tests__/github-delivery-unit.test.ts
+++ b/packages/server/src/__tests__/github-delivery-unit.test.ts
@@ -7,8 +7,8 @@ import type { ScmAudienceTarget } from "../services/scm-audience-composition.js"
 type MockFn = ReturnType<typeof vi.fn>;
 
 type MockBag = {
-  decideGithubPersonnelTargetChat: MockFn;
   refreshGithubChatTopic: MockFn;
+  resolveGithubExistingLineChat: MockFn;
   resolveTargetChat: MockFn;
   applyMembershipWrite: MockFn;
   setEntityTitle: MockFn;
@@ -76,7 +76,13 @@ function existingTarget(overrides: Partial<TargetOverrides> = {}): ScmAudienceTa
       },
     },
     ...(involveReason && involveLogin
-      ? { directedContext: { reason: involveReason, externalUsername: involveLogin } }
+      ? {
+          directedContext: {
+            reason: involveReason,
+            requiresPersistentLine: involveReason === "mentioned" || involveReason === "assigned",
+            externalUsername: involveLogin,
+          },
+        }
       : {}),
   };
 }
@@ -88,6 +94,10 @@ function newTarget(overrides: Partial<TargetOverrides> = {}): ScmAudienceTarget<
       humanAgentId: overrides.humanAgentId ?? "human-1",
       wakeAgentId: overrides.delegateAgentId ?? "delegate-1",
       reason: overrides.involveReason ?? "mentioned",
+      requiresPersistentLine:
+        overrides.involveReason === undefined ||
+        overrides.involveReason === "mentioned" ||
+        overrides.involveReason === "assigned",
       externalUsername: overrides.involveLogin ?? "alice",
     },
   };
@@ -113,8 +123,8 @@ async function loadDelivery(overrides: Partial<MockBag> = {}): Promise<{
   vi.resetModules();
 
   const mocks: MockBag = {
-    decideGithubPersonnelTargetChat: vi.fn(async () => ({ kind: "strict_new_line" })),
     refreshGithubChatTopic: vi.fn(async () => undefined),
+    resolveGithubExistingLineChat: vi.fn(async () => ({ chatId: "chat-existing", created: false })),
     resolveTargetChat: vi.fn(async () => ({ chatId: "chat-created", created: true, boundVia: "direct" })),
     applyMembershipWrite: vi.fn(async () => undefined),
     setEntityTitle: vi.fn(async () => undefined),
@@ -124,8 +134,9 @@ async function loadDelivery(overrides: Partial<MockBag> = {}): Promise<{
   };
 
   vi.doMock("../services/github-entity-chat.js", () => ({
-    decideGithubPersonnelTargetChat: mocks.decideGithubPersonnelTargetChat,
     refreshGithubChatTopic: mocks.refreshGithubChatTopic,
+    resolveGithubExistingLineChat: mocks.resolveGithubExistingLineChat,
+    resolveGithubPersonnelTargetChat: mocks.resolveTargetChat,
     resolveTargetChat: mocks.resolveTargetChat,
   }));
   vi.doMock("../services/github-entity-state.js", () => ({
@@ -180,7 +191,13 @@ describe("deliverGithubEvent dependency edge paths", () => {
       throw new Error("title store down");
     });
     const resolveTargetChat = vi.fn(async () => ({ chatId: "chat-shared", created: true, boundVia: "direct" }));
-    const { deliverGithubEvent, mocks } = await loadDelivery({ resolveTargetChat, sendMessage, setEntityTitle });
+    const resolveGithubExistingLineChat = vi.fn(async () => ({ chatId: "chat-shared", created: false }));
+    const { deliverGithubEvent, mocks } = await loadDelivery({
+      resolveTargetChat,
+      resolveGithubExistingLineChat,
+      sendMessage,
+      setEntityTitle,
+    });
 
     const stats = await deliverGithubEvent(makeApp(), makeEvent(), [
       existingTarget({
@@ -259,7 +276,11 @@ describe("deliverGithubEvent dependency edge paths", () => {
       .fn()
       .mockRejectedValueOnce("send failed")
       .mockResolvedValueOnce({ message: { id: "message-ok" }, recipients: ["recipient-ok"] });
-    const { deliverGithubEvent, mocks } = await loadDelivery({ sendMessage });
+    const resolveGithubExistingLineChat = vi.fn(async (_db: unknown, input: { humanAgentId: string }) => ({
+      chatId: input.humanAgentId === "human-a" ? "chat-a" : "chat-b",
+      created: false,
+    }));
+    const { deliverGithubEvent, mocks } = await loadDelivery({ sendMessage, resolveGithubExistingLineChat });
 
     const stats = await deliverGithubEvent(makeApp(), makeEvent({ action: "synchronize" }), [
       existingTarget({ humanAgentId: "human-a", delegateAgentId: "delegate-a", chatId: "chat-a" }),

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -10,6 +10,7 @@ import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
 import { users } from "../db/schema/users.js";
+import { createChat } from "../services/chat.js";
 import { type GithubProviderTaskContext, resolveGithubAudience } from "../services/github-audience.js";
 import { deliverGithubEvent } from "../services/github-delivery.js";
 import { resolveAgentScmBindingPair } from "../services/scm-attention-line.js";
@@ -38,7 +39,13 @@ function existingTarget(input: {
       },
     },
     ...(input.reason && input.externalUsername
-      ? { directedContext: { reason: input.reason, externalUsername: input.externalUsername } }
+      ? {
+          directedContext: {
+            reason: input.reason,
+            requiresPersistentLine: input.reason === "mentioned" || input.reason === "assigned",
+            externalUsername: input.externalUsername,
+          },
+        }
       : {}),
   };
 }
@@ -53,6 +60,7 @@ function personnelTarget(input: {
     entry: {
       kind: "personnel_target",
       reason: input.reason,
+      requiresPersistentLine: input.reason === "mentioned" || input.reason === "assigned",
       humanAgentId: input.humanAgentId,
       wakeAgentId: input.wakeAgentId,
       externalUsername: input.externalUsername,
@@ -1324,7 +1332,7 @@ describe("deliverGithubEvent", () => {
     expect(content.mentionedUser).toBe(humanName.toLowerCase());
   });
 
-  it("isolates per-target failures — second target succeeds even if first throws", async () => {
+  it("drops a stale existing-line projection while another target still succeeds", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -1365,12 +1373,76 @@ describe("deliverGithubEvent", () => {
 
     const stats = await deliverGithubEvent(app, event, [broken, ok]);
     expect(stats.delivered).toBe(1);
-    // M1 (#507): the broken target's exception must be counted, not
-    // silently swallowed by the per-target catch — operators dashboard
-    // off this counter to spot regressions in single-target reliability.
-    expect(stats.failed).toBe(1);
+    // Existing lines are re-read inside the entity serialization boundary.
+    // A projection that disappeared after audience composition is stale, not
+    // a delivery failure, and must not resurrect or count the removed line.
+    expect(stats.failed).toBe(0);
     const sent = await app.db.select().from(messages).where(eq(messages.chatId, goodChatId));
     expect(sent).toHaveLength(1);
+  });
+
+  it("reroutes directed context after unfollow without resurrecting the stale chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `stale-directed-${randomUUID().slice(0, 6)}`,
+    });
+    await app.db.update(agents).set({ delegateMention: delegate }).where(eq(agents.uuid, admin.humanAgentUuid));
+    const staleChat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [delegate],
+    });
+    const entityKey = "owner/repo#2202";
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entityType: "issue",
+      entityKey,
+      chatId: staleChat.id,
+      boundVia: "agent_declared",
+    });
+    const [human] = await app.db
+      .select({ name: agents.name })
+      .from(agents)
+      .where(eq(agents.uuid, admin.humanAgentUuid));
+    if (!human?.name) throw new Error("human name missing");
+    const composedBeforeUnfollow = existingTarget({
+      humanAgentId: admin.humanAgentUuid,
+      wakeAgentId: delegate,
+      chatId: staleChat.id,
+      reason: "assigned",
+      externalUsername: human.name,
+    });
+    await app.db
+      .delete(githubEntityChatMappings)
+      .where(and(eq(githubEntityChatMappings.entityKey, entityKey), eq(githubEntityChatMappings.chatId, staleChat.id)));
+
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "issue",
+      entityKey,
+      eventType: "issues",
+      action: "assigned",
+      kind: "assigned",
+    });
+    const stats = await deliverGithubEvent(app, event, [composedBeforeUnfollow]);
+
+    expect(stats).toEqual({ delivered: 1, newChats: 1, failed: 0 });
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, staleChat.id))).toHaveLength(0);
+    const [replacement] = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, entityKey));
+    expect(replacement).toMatchObject({
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      boundVia: "direct",
+    });
+    expect(replacement?.chatId).not.toBe(staleChat.id);
+    expect(await notifyCount(app, replacement?.chatId ?? "", delegate)).toBe(1);
   });
 
   it("reviewer-reuse + per-chat dedup: an involved member routes into the existing chat (one card, both delegates woken, no new chat/mapping)", async () => {
@@ -1610,10 +1682,7 @@ describe("deliverGithubEvent", () => {
     expect(await notifyCount(app, strictLine?.chatId ?? "", currentDelegate)).toBe(1);
   });
 
-  it("a `mentioned` involve does NOT reuse the entity chat — it mints a fresh chat (S5, reuse is review_requested-only)", async () => {
-    // S9 reuse is scoped to review_requested. An @mention of a human who is
-    // already a speaker of the entity's bound chat must still pierce into a
-    // FRESH chat (S5), never get routed back into the existing one.
+  it("co-locates a mentioned target in one exact-membership entity chat and writes its sibling line", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegateA = await seedAgent(app, {
@@ -1674,8 +1743,7 @@ describe("deliverGithubEvent", () => {
 
     const stats = await deliverGithubEvent(app, event, [involvedMention]);
 
-    // A fresh chat was minted for the mention (NOT reused into the bound chat).
-    expect(stats.newChats).toBe(1);
+    expect(stats.newChats).toBe(0);
     const mintedMappings = await app.db
       .select()
       .from(githubEntityChatMappings)
@@ -1686,7 +1754,82 @@ describe("deliverGithubEvent", () => {
         ),
       );
     expect(mintedMappings).toHaveLength(1);
-    expect(mintedMappings[0]?.chatId).not.toBe(chatId);
+    expect(mintedMappings[0]).toMatchObject({ chatId, boundVia: "human_fallback" });
+  });
+
+  it("co-locates an assignment with a different current delegate in the unique owner-private chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const follower = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `assignment-follower-${randomUUID().slice(0, 6)}`,
+    });
+    const currentDelegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `assignment-current-${randomUUID().slice(0, 6)}`,
+    });
+    await app.db.update(agents).set({ delegateMention: currentDelegate }).where(eq(agents.uuid, admin.humanAgentUuid));
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [follower],
+    });
+    const entityKey = "owner/repo#2145";
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: follower,
+      entityType: "issue",
+      entityKey,
+      chatId: chat.id,
+      boundVia: "agent_declared",
+    });
+    const [human] = await app.db
+      .select({ name: agents.name })
+      .from(agents)
+      .where(eq(agents.uuid, admin.humanAgentUuid));
+    if (!human?.name) throw new Error("assignment human name missing");
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "issue",
+      entityKey,
+      eventType: "issues",
+      action: "assigned",
+      kind: "assigned",
+      actorLogin: human.name,
+      targets: [{ externalUsername: human.name, reason: "assigned" }],
+    });
+
+    const resolution = await resolveGithubAudience(app.db, event);
+    const stats = await deliverGithubEvent(app, event, resolution.targets, {
+      actorHumanId: resolution.actorHumanId,
+    });
+
+    expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, chat.id))).toHaveLength(1);
+    const speakerIds = new Set(
+      (
+        await app.db
+          .select({ agentId: chatMembership.agentId })
+          .from(chatMembership)
+          .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.accessMode, "speaker")))
+      ).map((row) => row.agentId),
+    );
+    expect(speakerIds).toEqual(new Set([admin.humanAgentUuid, follower, currentDelegate]));
+    const mappings = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, entityKey));
+    expect(mappings).toHaveLength(2);
+    expect(mappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ delegateAgentId: follower, chatId: chat.id, boundVia: "agent_declared" }),
+        expect.objectContaining({ delegateAgentId: currentDelegate, chatId: chat.id, boundVia: "human_fallback" }),
+      ]),
+    );
+    expect(await notifyCount(app, chat.id, follower)).toBe(0);
+    expect(await notifyCount(app, chat.id, currentDelegate)).toBe(1);
   });
 
   // Regression: a GitHub-bound chat that has been expanded to >=3 speakers

--- a/packages/server/src/__tests__/github-entity-follow.test.ts
+++ b/packages/server/src/__tests__/github-entity-follow.test.ts
@@ -1,12 +1,19 @@
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
+import postgres from "postgres";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { connectDatabase, sslOptions } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { githubAppInstallations } from "../db/schema/github-app-installations.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
+import { members } from "../db/schema/members.js";
 import { BadRequestError, NotFoundError, ServiceUnavailableError, UnprocessableError } from "../errors.js";
+import { createChat, removeParticipant } from "../services/chat.js";
+import { lockChatMembershipMutation } from "../services/chat-membership-lock.js";
 import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
+import { resolveGithubPersonnelTargetChat } from "../services/github-entity-chat.js";
 import {
   declareEntityFollow,
   type FollowDeps,
@@ -17,6 +24,33 @@ import {
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
+
+function databaseUrlWithApplicationName(url: string, applicationName: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("application_name", applicationName);
+  return parsed.toString();
+}
+
+async function waitForPostgresLockWaits(
+  observer: ReturnType<typeof postgres>,
+  applicationNames: readonly string[],
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await observer<{ application_name: string; wait_event_type: string | null }[]>`
+      SELECT application_name, wait_event_type
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND application_name IN ${observer(applicationNames)}
+    `;
+    const waitingNames = new Set(
+      rows.filter((row) => row.wait_event_type === "Lock").map((row) => row.application_name),
+    );
+    if (applicationNames.every((name) => waitingNames.has(name))) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for PostgreSQL lock waits: ${applicationNames.join(", ")}`);
+}
 
 /**
  * Explicit follow / unfollow — the only agent-side wiring path after the
@@ -60,6 +94,16 @@ describe("github-entity-follow", () => {
     const id = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id, organizationId: orgId, type: "group", metadata: {} });
     return id;
+  }
+
+  async function seedPairMembership(app: App, chatId: string, humanAgentId: string, delegateAgentId: string) {
+    await app.db
+      .insert(chatMembership)
+      .values([
+        { chatId, agentId: humanAgentId, role: "owner", accessMode: "speaker" },
+        { chatId, agentId: delegateAgentId, role: "member", accessMode: "speaker" },
+      ])
+      .onConflictDoNothing();
   }
 
   async function seedInstallation(app: App, orgId: string): Promise<void> {
@@ -153,6 +197,7 @@ describe("github-entity-follow", () => {
     const human = await seedAgent(app, admin.organizationId, admin.memberId, "human");
     const delegate = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
     const chatId = await seedChat(app, admin.organizationId);
+    await seedPairMembership(app, chatId, human, delegate);
     await seedInstallation(app, admin.organizationId);
     return { admin, human, delegate, chatId };
   }
@@ -246,6 +291,7 @@ describe("github-entity-follow", () => {
     const app = getApp();
     const s = await setup(app);
     const otherChat = await seedChat(app, s.admin.organizationId);
+    await seedPairMembership(app, otherChat, s.human, s.delegate);
     await app.db.update(chats).set({ topic: "first home" }).where(eq(chats.id, s.chatId));
 
     await declareEntityFollow(app.db, deps(prFetcher()), followParams(s, "acme/api#42"));
@@ -263,6 +309,7 @@ describe("github-entity-follow", () => {
     const app = getApp();
     const s = await setup(app);
     const newChat = await seedChat(app, s.admin.organizationId);
+    await seedPairMembership(app, newChat, s.human, s.delegate);
 
     // Seed the existing row as a github-minted `direct` anchor.
     await app.db.insert(githubEntityChatMappings).values({
@@ -303,6 +350,7 @@ describe("github-entity-follow", () => {
     const app = getApp();
     const s = await setup(app);
     const newChat = await seedChat(app, s.admin.organizationId);
+    await seedPairMembership(app, newChat, s.human, s.delegate);
     await app.db.insert(githubEntityChatMappings).values({
       organizationId: s.admin.organizationId,
       humanAgentId: s.human,
@@ -723,6 +771,427 @@ describe("github-entity-follow", () => {
     });
   });
 
+  it("serializes unfollow against fresh personnel placement without resurrecting the old chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `attention-race-${randomUUID().slice(0, 8)}` });
+    const follower = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
+    const currentDelegate = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
+    await app.db.update(agents).set({ delegateMention: currentDelegate }).where(eq(agents.uuid, admin.humanAgentUuid));
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [follower],
+    });
+    await seedInstallation(app, admin.organizationId);
+    await declareEntityFollow(app.db, deps(prFetcher()), {
+      chatId: chat.id,
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: follower,
+      boundVia: "agent_declared",
+      entity: "acme/api#42",
+      rebind: false,
+    });
+
+    await Promise.all([
+      removeEntityFollow(app.db, { chatId: chat.id, entity: "acme/api#42" }),
+      resolveGithubPersonnelTargetChat(app.db, {
+        organizationId: admin.organizationId,
+        humanAgentId: admin.humanAgentUuid,
+        delegateAgentId: currentDelegate,
+        entity: { type: "pull_request", key: "Acme/Api#42", title: "Add follow command" },
+        relatedEntities: [],
+        eventType: "issues",
+        action: "assigned",
+        isMentionMatched: true,
+        requiresPersistentLine: true,
+      }),
+    ]);
+
+    const survivingRows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "Acme/Api#42"));
+    expect(survivingRows.every((row) => row.chatId !== chat.id)).toBe(true);
+    expect(survivingRows.length).toBeLessThanOrEqual(1);
+    if (survivingRows[0]) {
+      expect(survivingRows[0].delegateAgentId).toBe(currentDelegate);
+      expect(survivingRows[0].boundVia).toBe("direct");
+    }
+  });
+
+  it("serializes wake removal before personnel placement and commits only a wakeable sibling line", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `speaker-race-${randomUUID().slice(0, 8)}` });
+    const follower = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
+    const currentDelegate = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
+    await app.db.update(agents).set({ delegateMention: currentDelegate }).where(eq(agents.uuid, admin.humanAgentUuid));
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [follower, currentDelegate],
+    });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: follower,
+      entityType: "issue",
+      entityKey: "Acme/Api#401",
+      chatId: chat.id,
+      boundVia: "agent_declared",
+    });
+
+    let mutationLocked!: () => void;
+    let releaseMutation!: () => void;
+    const locked = new Promise<void>((resolve) => {
+      mutationLocked = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseMutation = resolve;
+    });
+    const removing = app.db.transaction(async (rawTx) => {
+      const tx = rawTx as unknown as typeof app.db;
+      await lockChatMembershipMutation(tx, [chat.id]);
+      await tx
+        .delete(chatMembership)
+        .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.agentId, currentDelegate)));
+      mutationLocked();
+      await release;
+    });
+    await locked;
+
+    const placing = resolveGithubPersonnelTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: currentDelegate,
+      entity: { type: "issue", key: "Acme/Api#401", title: "Speaker race" },
+      relatedEntities: [],
+      eventType: "issues",
+      action: "assigned",
+      isMentionMatched: true,
+      requiresPersistentLine: true,
+    });
+    releaseMutation();
+    await removing;
+    await expect(placing).resolves.toMatchObject({ chatId: chat.id, lineExisted: false });
+
+    expect(
+      await app.db
+        .select({ agentId: chatMembership.agentId })
+        .from(chatMembership)
+        .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.agentId, currentDelegate))),
+    ).toHaveLength(1);
+    expect(
+      await app.db
+        .select({ chatId: githubEntityChatMappings.chatId })
+        .from(githubEntityChatMappings)
+        .where(
+          and(
+            eq(githubEntityChatMappings.entityKey, "Acme/Api#401"),
+            eq(githubEntityChatMappings.delegateAgentId, currentDelegate),
+          ),
+        ),
+    ).toEqual([{ chatId: chat.id }]);
+  });
+
+  it("fails owner-private reuse closed when an existing speaker changes owner before placement", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `owner-race-${randomUUID().slice(0, 8)}` });
+    const foreignOwner = await createTestAdmin(app, { username: `foreign-owner-${randomUUID().slice(0, 8)}` });
+    const follower = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
+    const currentDelegate = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
+    await app.db.update(agents).set({ delegateMention: currentDelegate }).where(eq(agents.uuid, admin.humanAgentUuid));
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "group", participantIds: [follower] });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: follower,
+      entityType: "issue",
+      entityKey: "Acme/Api#402",
+      chatId: chat.id,
+      boundVia: "agent_declared",
+    });
+
+    let ownerChanged!: () => void;
+    let releaseOwnerChange!: () => void;
+    const changed = new Promise<void>((resolve) => {
+      ownerChanged = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseOwnerChange = resolve;
+    });
+    const transferring = app.db.transaction(async (rawTx) => {
+      const tx = rawTx as unknown as typeof app.db;
+      await tx.update(agents).set({ managerId: foreignOwner.memberId }).where(eq(agents.uuid, follower));
+      ownerChanged();
+      await release;
+    });
+    await changed;
+
+    const placing = resolveGithubPersonnelTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: currentDelegate,
+      entity: { type: "issue", key: "Acme/Api#402", title: "Owner race" },
+      relatedEntities: [],
+      eventType: "issues",
+      action: "assigned",
+      isMentionMatched: true,
+      requiresPersistentLine: true,
+    });
+    releaseOwnerChange();
+    await transferring;
+    const placed = await placing;
+    expect(placed?.chatId).not.toBe(chat.id);
+    expect(
+      await app.db
+        .select({ agentId: chatMembership.agentId })
+        .from(chatMembership)
+        .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.agentId, currentDelegate))),
+    ).toHaveLength(0);
+  });
+
+  it("locks overlapping candidate speakers once so concurrent personnel placements cannot deadlock", async () => {
+    const app = getApp();
+    const firstHuman = await createTestAdmin(app, {
+      username: `overlap-first-${randomUUID().slice(0, 8)}`,
+    });
+    const secondHuman = await createTestAdmin(app, {
+      username: `overlap-second-${randomUUID().slice(0, 8)}`,
+    });
+    const firstWake = await seedAgent(app, firstHuman.organizationId, firstHuman.memberId, "agent");
+    const secondWake = await seedAgent(app, secondHuman.organizationId, secondHuman.memberId, "agent");
+    await app.db.update(agents).set({ delegateMention: firstWake }).where(eq(agents.uuid, firstHuman.humanAgentUuid));
+    await app.db.update(agents).set({ delegateMention: secondWake }).where(eq(agents.uuid, secondHuman.humanAgentUuid));
+
+    const firstChat = await seedChat(app, firstHuman.organizationId);
+    const secondChat = await seedChat(app, firstHuman.organizationId);
+    for (const chatId of [firstChat, secondChat]) {
+      await app.db.insert(chatMembership).values([
+        { chatId, agentId: firstHuman.humanAgentUuid, role: "owner", accessMode: "speaker" },
+        { chatId, agentId: firstWake, role: "member", accessMode: "speaker" },
+        { chatId, agentId: secondHuman.humanAgentUuid, role: "member", accessMode: "speaker" },
+        { chatId, agentId: secondWake, role: "member", accessMode: "speaker" },
+      ]);
+    }
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: firstHuman.organizationId,
+        humanAgentId: secondHuman.humanAgentUuid,
+        delegateAgentId: secondWake,
+        entityType: "issue",
+        entityKey: "Acme/Api#501",
+        chatId: firstChat,
+        boundVia: "agent_declared",
+      },
+      {
+        organizationId: firstHuman.organizationId,
+        humanAgentId: firstHuman.humanAgentUuid,
+        delegateAgentId: firstWake,
+        entityType: "issue",
+        entityKey: "Acme/Api#502",
+        chatId: secondChat,
+        boundVia: "agent_declared",
+      },
+    ]);
+
+    const databaseUrl = process.env.DATABASE_URL ?? "";
+    if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+    const suffix = randomUUID().slice(0, 8);
+    const firstApplicationName = `scm_overlap_first_${suffix}`;
+    const secondApplicationName = `scm_overlap_second_${suffix}`;
+    const firstDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, firstApplicationName));
+    const secondDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, secondApplicationName));
+    const holder = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    let holderCommitted = false;
+    try {
+      await holder`BEGIN`;
+      await holder`
+        SELECT id
+        FROM chats
+        WHERE id IN ${holder([firstChat, secondChat])}
+        ORDER BY id
+        FOR UPDATE
+      `;
+
+      const placements = Promise.all([
+        resolveGithubPersonnelTargetChat(firstDb, {
+          organizationId: firstHuman.organizationId,
+          humanAgentId: firstHuman.humanAgentUuid,
+          delegateAgentId: firstWake,
+          entity: { type: "issue", key: "Acme/Api#501", title: "First overlap" },
+          relatedEntities: [],
+          eventType: "issues",
+          action: "assigned",
+          isMentionMatched: true,
+          requiresPersistentLine: true,
+        }),
+        resolveGithubPersonnelTargetChat(secondDb, {
+          organizationId: secondHuman.organizationId,
+          humanAgentId: secondHuman.humanAgentUuid,
+          delegateAgentId: secondWake,
+          entity: { type: "issue", key: "Acme/Api#502", title: "Second overlap" },
+          relatedEntities: [],
+          eventType: "issues",
+          action: "assigned",
+          isMentionMatched: true,
+          requiresPersistentLine: true,
+        }),
+      ]);
+      await waitForPostgresLockWaits(observer, [firstApplicationName, secondApplicationName]);
+      await holder`COMMIT`;
+      holderCommitted = true;
+
+      await expect(placements).resolves.toEqual([
+        { chatId: firstChat, created: false, boundVia: "human_fallback", lineExisted: false },
+        { chatId: secondChat, created: false, boundVia: "human_fallback", lineExisted: false },
+      ]);
+    } finally {
+      if (!holderCommitted) await holder`ROLLBACK`;
+      await firstDb.end();
+      await secondDb.end();
+      await holder.end();
+      await observer.end();
+    }
+  });
+
+  it("rejects a human-issued fresh follow when the delegate changes during GitHub resolution", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const replacement = await seedAgent(app, s.admin.organizationId, s.admin.memberId, "agent");
+    await seedPairMembership(app, s.chatId, s.human, replacement);
+    await app.db.update(agents).set({ delegateMention: s.delegate }).where(eq(agents.uuid, s.human));
+    let entityRequested!: () => void;
+    let releaseEntity!: () => void;
+    const requested = new Promise<void>((resolve) => {
+      entityRequested = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseEntity = resolve;
+    });
+    const baseFetcher = prFetcher();
+    const delayedFetcher = (async (input: string | URL | Request) => {
+      if (String(input).toLowerCase().includes("/repos/acme/api/issues/42")) {
+        entityRequested();
+        await release;
+      }
+      return baseFetcher(input);
+    }) as typeof fetch;
+
+    const following = declareEntityFollow(app.db, deps(delayedFetcher), {
+      ...followParams(s, "acme/api#42"),
+      boundVia: "human_declared",
+    });
+    await requested;
+    await app.db.update(agents).set({ delegateMention: replacement }).where(eq(agents.uuid, s.human));
+    releaseEntity();
+    await expect(following).rejects.toThrow("authority changed");
+    expect(
+      await app.db.select().from(githubEntityChatMappings).where(eq(githubEntityChatMappings.entityKey, "Acme/Api#42")),
+    ).toHaveLength(0);
+  });
+
+  it("rejects rebind when the wake agent leaves the destination chat during GitHub resolution", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const newChat = await seedChat(app, s.admin.organizationId);
+    await seedPairMembership(app, newChat, s.human, s.delegate);
+    await declareEntityFollow(app.db, deps(prFetcher()), followParams(s, "acme/api#42"));
+    let entityRequested!: () => void;
+    let releaseEntity!: () => void;
+    const requested = new Promise<void>((resolve) => {
+      entityRequested = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseEntity = resolve;
+    });
+    const baseFetcher = prFetcher();
+    const delayedFetcher = (async (input: string | URL | Request) => {
+      if (String(input).toLowerCase().includes("/repos/acme/api/issues/42")) {
+        entityRequested();
+        await release;
+      }
+      return baseFetcher(input);
+    }) as typeof fetch;
+
+    const rebinding = declareEntityFollow(app.db, deps(delayedFetcher), {
+      ...followParams(s, "acme/api#42", true),
+      chatId: newChat,
+    });
+    await requested;
+    await removeParticipant(app.db, newChat, s.human, s.delegate);
+    releaseEntity();
+    await expect(rebinding).rejects.toThrow("authority changed");
+    expect(
+      await app.db
+        .select({ chatId: githubEntityChatMappings.chatId })
+        .from(githubEntityChatMappings)
+        .where(eq(githubEntityChatMappings.entityKey, "Acme/Api#42")),
+    ).toEqual([{ chatId: s.chatId }]);
+  });
+
+  it.each([
+    "delegate",
+    "human_status",
+    "wake_status",
+    "member_status",
+  ] as const)("drops stale GitHub personnel authority after %s drift before accepting a direct hit", async (drift) => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `authority-drift-${drift}-${randomUUID().slice(0, 5)}` });
+    const originalDelegate = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
+    const replacementDelegate = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
+    await app.db.update(agents).set({ delegateMention: originalDelegate }).where(eq(agents.uuid, admin.humanAgentUuid));
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [originalDelegate],
+    });
+    const entityKey = `Acme/Api#${drift === "delegate" ? 301 : drift === "human_status" ? 302 : drift === "wake_status" ? 303 : 304}`;
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: originalDelegate,
+      entityType: "issue",
+      entityKey,
+      chatId: chat.id,
+      boundVia: "direct",
+    });
+    const chatsBefore = await app.db.select({ id: chats.id }).from(chats);
+
+    if (drift === "delegate") {
+      await app.db
+        .update(agents)
+        .set({ delegateMention: replacementDelegate })
+        .where(eq(agents.uuid, admin.humanAgentUuid));
+    } else if (drift === "human_status") {
+      await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, admin.humanAgentUuid));
+    } else if (drift === "wake_status") {
+      await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, originalDelegate));
+    } else {
+      await app.db.update(members).set({ status: "left" }).where(eq(members.agentId, admin.humanAgentUuid));
+    }
+
+    await expect(
+      resolveGithubPersonnelTargetChat(app.db, {
+        organizationId: admin.organizationId,
+        humanAgentId: admin.humanAgentUuid,
+        delegateAgentId: originalDelegate,
+        entity: { type: "issue", key: entityKey, title: "Authority drift" },
+        relatedEntities: [],
+        eventType: "issues",
+        action: "assigned",
+        isMentionMatched: true,
+        requiresPersistentLine: true,
+      }),
+    ).resolves.toBeNull();
+
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, entityKey));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ chatId: chat.id, delegateAgentId: originalDelegate });
+    expect(await app.db.select({ id: chats.id }).from(chats)).toHaveLength(chatsBefore.length);
+  });
+
   it("unfollow with a /pull/ URL also removes the auto-corrected issue row (follow/unfollow symmetry)", async () => {
     const app = getApp();
     const s = await setup(app);
@@ -817,6 +1286,7 @@ describe("github-entity-follow", () => {
     const app = getApp();
     const s = await setup(app);
     const newChat = await seedChat(app, s.admin.organizationId);
+    await seedPairMembership(app, newChat, s.human, s.delegate);
     await declareEntityFollow(app.db, deps(prFetcher()), followParams(s, "acme/api#42"));
 
     // Simulate the concurrent unfollow racing between the conflict read and
@@ -842,6 +1312,7 @@ describe("github-entity-follow", () => {
     const app = getApp();
     const s = await setup(app);
     const newChat = await seedChat(app, s.admin.organizationId);
+    await seedPairMembership(app, newChat, s.human, s.delegate);
     await declareEntityFollow(app.db, deps(prFetcher()), followParams(s, "acme/api#42"));
 
     const fnName = `test_gef_skip_update_${randomUUID().replace(/-/g, "_")}`;
@@ -896,6 +1367,8 @@ describe("github-entity-follow", () => {
     const s = await setup(app);
     const newChat = await seedChat(app, s.admin.organizationId);
     const thirdChat = await seedChat(app, s.admin.organizationId);
+    await seedPairMembership(app, newChat, s.human, s.delegate);
+    await seedPairMembership(app, thirdChat, s.human, s.delegate);
     await app.db.update(chats).set({ topic: "third winner" }).where(eq(chats.id, thirdChat));
     await declareEntityFollow(app.db, deps(prFetcher()), followParams(s, "acme/api#42"));
 
@@ -967,6 +1440,7 @@ describe("github-entity-follow", () => {
     const app = getApp();
     const s = await setup(app);
     const newChat = await seedChat(app, s.admin.organizationId);
+    await seedPairMembership(app, newChat, s.human, s.delegate);
     await declareEntityFollow(app.db, deps(prFetcher()), followParams(s, "acme/api#42"));
     const [before] = await app.db
       .select({ boundAt: githubEntityChatMappings.boundAt })

--- a/packages/server/src/__tests__/gitlab-identity-fencing.test.ts
+++ b/packages/server/src/__tests__/gitlab-identity-fencing.test.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
+import postgres from "postgres";
 import { describe, expect, it } from "vitest";
-import type { Database } from "../db/connection.js";
+import { connectDatabase, type Database, sslOptions } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { gitlabEntityChatMappings } from "../db/schema/gitlab-entity-chat-mappings.js";
 import { gitlabIdentityLinks } from "../db/schema/gitlab-identity-links.js";
@@ -29,6 +30,7 @@ import {
   resolveGitlabAudience,
 } from "../services/gitlab-webhook.js";
 import { deactivateMembership, MEMBER_STATUSES } from "../services/membership.js";
+import { lockAndResolveAgentScmBindingPair } from "../services/scm-attention-line.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
@@ -59,6 +61,46 @@ function deferredSignal() {
     resolve = done;
   });
   return { promise, resolve };
+}
+
+function databaseUrlWithApplicationName(url: string, applicationName: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("application_name", applicationName);
+  return parsed.toString();
+}
+
+async function waitForPostgresLockWait(observer: ReturnType<typeof postgres>, applicationName: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await observer<{ wait_event_type: string | null }[]>`
+      SELECT wait_event_type
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND application_name = ${applicationName}
+    `;
+    if (rows.some((row) => row.wait_event_type === "Lock")) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for PostgreSQL lock: ${applicationName}`);
+}
+
+async function waitForPostgresBlocker(
+  observer: ReturnType<typeof postgres>,
+  applicationName: string,
+  blockerPid: number,
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await observer<{ blocked: boolean }[]>`
+      SELECT ${blockerPid} = ANY(pg_blocking_pids(pid)) AS blocked
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND application_name = ${applicationName}
+    `;
+    if (rows.some((row) => row.blocked)) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for ${applicationName} to be blocked by backend ${blockerPid}`);
 }
 
 async function setup(app: App) {
@@ -252,6 +294,134 @@ describe("GitLab identity authority fencing", () => {
         .from(messages)
         .where(and(eq(messages.chatId, chat.id), eq(messages.source, "gitlab"))),
     ).toHaveLength(2);
+  }, 20_000);
+
+  it("keeps GitLab audience identity locks behind the membership fence used by GitHub-side follow resolution", async () => {
+    const app = getApp();
+    const fixture = await setup(app);
+    const follower = await createAgent(app.db, {
+      name: `cross-provider-follow-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Cross-provider follower",
+      managerId: fixture.admin.memberId,
+      organizationId: fixture.admin.organizationId,
+    });
+    const iid = 91;
+    const chat = await createChat(app.db, fixture.admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [fixture.delegate.uuid, follower.uuid],
+      topic: "Cross-provider authority lock",
+      metadata: {},
+    });
+    await declareGitlabEntityFollow(app.db, {
+      organizationId: fixture.admin.organizationId,
+      connectionId: fixture.connection.connectionId,
+      chatId: chat.id,
+      declaredByAgentId: follower.uuid,
+      humanAgentId: fixture.admin.humanAgentUuid,
+      delegateAgentId: follower.uuid,
+      boundVia: "agent_declared",
+      entityUrl: `https://gitlab.internal/Acme/Fenced/-/merge_requests/${iid}`,
+    });
+    const endpoint = await findActiveGitlabEndpoint(app.db, fixture.connection.bearer);
+    if (!endpoint) throw new Error("GitLab endpoint missing");
+    const normalized = normalizeGitlabWebhook({
+      organizationId: fixture.admin.organizationId,
+      connectionId: fixture.connection.connectionId,
+      instanceOrigin: "https://gitlab.internal",
+      stableDeliveryId: null,
+      eventHeader: "System Hook",
+      body: mrPayload([{ username: "Reviewer.One" }], "author", iid),
+    });
+    const applied = applyGitlabPersonnelEvidence(normalized, "reviewers");
+    const identity = normalized.entityIdentity;
+    const event = applied.event;
+    if (!identity || !event) throw new Error("normalized cross-provider MR missing");
+
+    const databaseUrl = process.env.DATABASE_URL ?? "";
+    if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+    const suffix = randomUUID().slice(0, 8);
+    const githubApplicationName = `github_follow_lock_${suffix}`;
+    const gitlabApplicationName = `gitlab_audience_lock_${suffix}`;
+    const githubDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, githubApplicationName));
+    const gitlabDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, gitlabApplicationName));
+    const membershipHolder = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    const agentHolder = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    let membershipHolderCommitted = false;
+    let agentHolderCommitted = false;
+    try {
+      await agentHolder`BEGIN`;
+      const [agentHolderBackend] = await agentHolder<{ pid: number }[]>`
+        SELECT pg_backend_pid()::int AS pid
+      `;
+      if (!agentHolderBackend) throw new Error("agent holder backend missing");
+      await agentHolder`
+        SELECT uuid
+        FROM agents
+        WHERE uuid = ${fixture.admin.humanAgentUuid}
+        FOR UPDATE
+      `;
+
+      await membershipHolder`BEGIN`;
+      await membershipHolder`
+        SELECT pg_advisory_xact_lock(
+          hashtext('chat_speaker_membership'),
+          hashtext(${chat.id})
+        )
+      `;
+
+      const githubFollowResolution = githubDb.transaction(async (rawTx) => {
+        const tx = rawTx as unknown as Database;
+        return lockAndResolveAgentScmBindingPair(tx, chat.id, follower.uuid);
+      });
+      await waitForPostgresLockWait(observer, githubApplicationName);
+
+      const gitlabDelivery = withGitlabIngressFence(
+        gitlabDb,
+        fixture.connection.connectionId,
+        endpoint.connection.tokenHash,
+        async (tx) => {
+          const audience = await resolveGitlabAudience(tx, {
+            organizationId: fixture.admin.organizationId,
+            connectionId: fixture.connection.connectionId,
+            event,
+            entityIdentity: identity,
+          });
+          return deliverGitlabCards(app, {
+            event,
+            identity,
+            audience,
+            organizationId: fixture.admin.organizationId,
+            connectionId: fixture.connection.connectionId,
+            database: tx,
+          });
+        },
+      );
+      await waitForPostgresLockWait(observer, gitlabApplicationName);
+
+      await membershipHolder`COMMIT`;
+      membershipHolderCommitted = true;
+      await waitForPostgresBlocker(observer, githubApplicationName, agentHolderBackend.pid);
+      await agentHolder`COMMIT`;
+      agentHolderCommitted = true;
+
+      const [pair, delivery] = await Promise.all([githubFollowResolution, gitlabDelivery]);
+      expect(pair).toEqual({
+        organizationId: fixture.admin.organizationId,
+        humanAgentId: fixture.admin.humanAgentUuid,
+        wakeAgentId: follower.uuid,
+      });
+      expect(delivery).toMatchObject({ delivered: 1, failed: 0 });
+    } finally {
+      if (!membershipHolderCommitted) await membershipHolder`ROLLBACK`;
+      if (!agentHolderCommitted) await agentHolder`ROLLBACK`;
+      await githubDb.end();
+      await gitlabDb.end();
+      await membershipHolder.end();
+      await agentHolder.end();
+      await observer.end();
+    }
   }, 20_000);
 
   it.each([

--- a/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
@@ -28,11 +28,15 @@ import {
 import * as gitlabEntityFollowService from "../services/gitlab-entity-follow.js";
 import { createOrganization } from "../services/organization.js";
 import * as scmCardDelivery from "../services/scm-card-delivery.js";
+import { lockGitlabEntityAttention } from "../services/scm-entity-attention-lock.js";
 import { getTeamSetupCapabilities } from "../services/setup-capabilities.js";
 import { createTestAdmin, createTestAgent, seedHealthyAgentRuntime, useTestApp } from "./helpers.js";
 
-const { declareGitlabEntityFollow, observeGitlabEntityAndResolveFollowers, removeGitlabEntityFollow } =
-  gitlabEntityFollowService;
+const {
+  declareGitlabEntityFollow: declareGitlabEntityFollowRaw,
+  observeGitlabEntityAndResolveFollowers,
+  removeGitlabEntityFollow,
+} = gitlabEntityFollowService;
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
 
@@ -149,6 +153,35 @@ async function postWebhook(
 describe("GitLab Stage 2A backend", () => {
   const getApp = useTestApp();
 
+  async function seedSameOrgAgent(app: App, organizationId: string, memberId: string, name: string): Promise<string> {
+    const agentId = randomUUID();
+    await app.db.insert(agents).values({
+      uuid: agentId,
+      name,
+      displayName: name,
+      organizationId,
+      type: "agent",
+      inboxId: `inbox_${agentId}`,
+      managerId: memberId,
+      status: "active",
+    });
+    return agentId;
+  }
+
+  async function declareGitlabEntityFollow(
+    db: Parameters<typeof declareGitlabEntityFollowRaw>[0],
+    input: Parameters<typeof declareGitlabEntityFollowRaw>[1],
+  ): ReturnType<typeof declareGitlabEntityFollowRaw> {
+    await db
+      .insert(chatMembership)
+      .values([
+        { chatId: input.chatId, agentId: input.humanAgentId, role: "owner", accessMode: "speaker" },
+        { chatId: input.chatId, agentId: input.delegateAgentId, role: "member", accessMode: "speaker" },
+      ])
+      .onConflictDoNothing();
+    return declareGitlabEntityFollowRaw(db, input);
+  }
+
   async function connection(app: App, options: { isolatedOrg?: boolean } = {}) {
     let admin = await createTestAdmin(app, { username: `gitlab-${randomUUID().slice(0, 8)}` });
     if (options.isolatedOrg) {
@@ -168,7 +201,13 @@ describe("GitLab Stage 2A backend", () => {
       displayName: "Private GitLab",
       instanceOrigin: "https://gitlab.internal",
     });
-    return { admin, ...created };
+    const followAgentId = await seedSameOrgAgent(
+      app,
+      admin.organizationId,
+      admin.memberId,
+      `gitlab-follow-${randomUUID().slice(0, 8)}`,
+    );
+    return { admin, followAgentId, ...created };
   }
 
   it("stores only one bearer hash per org and atomically replaces the binding", async () => {
@@ -249,9 +288,9 @@ describe("GitLab Stage 2A backend", () => {
       organizationId: first.admin.organizationId,
       connectionId: first.connectionId,
       chatId: followedChatId,
-      declaredByAgentId: first.admin.humanAgentUuid,
+      declaredByAgentId: first.followAgentId,
       humanAgentId: first.admin.humanAgentUuid,
-      delegateAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
       entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/52",
     });
     const replaced = await replaceGitlabConnection(app.db, {
@@ -415,9 +454,9 @@ describe("GitLab Stage 2A backend", () => {
         organizationId: first.admin.organizationId,
         connectionId: first.connectionId,
         chatId,
-        declaredByAgentId: first.admin.humanAgentUuid,
+        declaredByAgentId: first.followAgentId,
         humanAgentId: first.admin.humanAgentUuid,
-        delegateAgentId: first.admin.humanAgentUuid,
+        delegateAgentId: first.followAgentId,
         entityUrl: `https://gitlab.internal/Acme/API/-/merge_requests/${iid}`,
       });
     }
@@ -556,9 +595,9 @@ describe("GitLab Stage 2A backend", () => {
       organizationId: first.admin.organizationId,
       connectionId: first.connectionId,
       chatId,
-      declaredByAgentId: first.admin.humanAgentUuid,
+      declaredByAgentId: first.followAgentId,
       humanAgentId: first.admin.humanAgentUuid,
-      delegateAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
       entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/52",
     });
 
@@ -574,9 +613,9 @@ describe("GitLab Stage 2A backend", () => {
       organizationId: first.admin.organizationId,
       connectionId: first.connectionId,
       chatId,
-      declaredByAgentId: first.admin.humanAgentUuid,
+      declaredByAgentId: first.followAgentId,
       humanAgentId: first.admin.humanAgentUuid,
-      delegateAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
       entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/52",
     });
     expect(repeated?.projectId).toBe(501);
@@ -593,7 +632,7 @@ describe("GitLab Stage 2A backend", () => {
     expect(cards[0]).toMatchObject({ format: "card", senderId: first.admin.humanAgentUuid });
     expect(cards[0]?.content).toMatchObject({ type: "gitlab_event", project: "Acme/API" });
     expect(cards[0]?.metadata).toMatchObject({ source: "gitlab", systemSender: "gitlab" });
-    expect(cards[0]?.metadata).toMatchObject({ mentions: [first.admin.humanAgentUuid] });
+    expect(cards[0]?.metadata).toMatchObject({ mentions: [first.followAgentId] });
 
     const stableId = `dedup-${randomUUID()}`;
     expect((await postWebhook(app, first.bearer, mergeRequestPayload(), { stableId })).json()).toMatchObject({
@@ -626,9 +665,9 @@ describe("GitLab Stage 2A backend", () => {
       organizationId: first.admin.organizationId,
       connectionId: first.connectionId,
       chatId,
-      declaredByAgentId: first.admin.humanAgentUuid,
+      declaredByAgentId: first.followAgentId,
       humanAgentId: first.admin.humanAgentUuid,
-      delegateAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
       entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/52",
     });
     expect((await postWebhook(app, first.bearer, mergeRequestPayload())).json()).toMatchObject({
@@ -928,9 +967,9 @@ describe("GitLab Stage 2A backend", () => {
         organizationId: first.admin.organizationId,
         connectionId: first.connectionId,
         chatId,
-        declaredByAgentId: first.admin.humanAgentUuid,
+        declaredByAgentId: first.followAgentId,
         humanAgentId: first.admin.humanAgentUuid,
-        delegateAgentId: first.admin.humanAgentUuid,
+        delegateAgentId: first.followAgentId,
         entityUrl: `https://gitlab.internal/${projectPath}/-/merge_requests/42`,
       });
     }
@@ -1125,9 +1164,9 @@ describe("GitLab Stage 2A backend", () => {
       organizationId: first.admin.organizationId,
       connectionId: first.connectionId,
       chatId,
-      declaredByAgentId: first.admin.humanAgentUuid,
+      declaredByAgentId: first.followAgentId,
       humanAgentId: first.admin.humanAgentUuid,
-      delegateAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
       entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/52",
     });
     releaseFence();
@@ -1178,6 +1217,145 @@ describe("GitLab Stage 2A backend", () => {
     expect(replacement.connectionId).not.toBe(first.connectionId);
   });
 
+  it("rejects a human-issued GitLab follow when the delegate changes behind the entity fence", async () => {
+    const app = getApp();
+    const first = await connection(app);
+    const replacementAgentId = await seedSameOrgAgent(
+      app,
+      first.admin.organizationId,
+      first.admin.memberId,
+      `gitlab-replacement-${randomUUID().slice(0, 8)}`,
+    );
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({
+      id: chatId,
+      organizationId: first.admin.organizationId,
+      type: "group",
+      metadata: {},
+    });
+    await app.db.insert(chatMembership).values([
+      { chatId, agentId: first.admin.humanAgentUuid, role: "owner", accessMode: "speaker" },
+      { chatId, agentId: first.followAgentId, role: "member", accessMode: "speaker" },
+      { chatId, agentId: replacementAgentId, role: "member", accessMode: "speaker" },
+    ]);
+    await app.db
+      .update(agents)
+      .set({ delegateMention: first.followAgentId })
+      .where(eq(agents.uuid, first.admin.humanAgentUuid));
+
+    let entityLocked!: () => void;
+    let releaseEntity!: () => void;
+    const locked = new Promise<void>((resolve) => {
+      entityLocked = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseEntity = resolve;
+    });
+    const holding = app.db.transaction(async (rawTx) => {
+      const tx = rawTx as unknown as typeof app.db;
+      await lockGitlabEntityAttention(tx, {
+        connectionId: first.connectionId,
+        projectPathNormalized: "acme/api",
+        entityType: "pull_request",
+        entityIid: 81,
+      });
+      entityLocked();
+      await release;
+    });
+    await locked;
+
+    const following = declareGitlabEntityFollowRaw(app.db, {
+      organizationId: first.admin.organizationId,
+      connectionId: first.connectionId,
+      chatId,
+      declaredByAgentId: first.admin.humanAgentUuid,
+      humanAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
+      boundVia: "human_declared",
+      entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/81",
+    });
+    await app.db
+      .update(agents)
+      .set({ delegateMention: replacementAgentId })
+      .where(eq(agents.uuid, first.admin.humanAgentUuid));
+    releaseEntity();
+    await holding;
+    await expect(following).rejects.toThrow("authority changed");
+    expect(
+      await app.db.select().from(gitlabEntityChatMappings).where(eq(gitlabEntityChatMappings.entityIid, 81)),
+    ).toHaveLength(0);
+  });
+
+  it("rejects GitLab rebind when the wake agent leaves the destination chat behind the entity fence", async () => {
+    const app = getApp();
+    const first = await connection(app);
+    const originalChatId = `chat_${randomUUID()}`;
+    const destinationChatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values([
+      { id: originalChatId, organizationId: first.admin.organizationId, type: "group", metadata: {} },
+      { id: destinationChatId, organizationId: first.admin.organizationId, type: "group", metadata: {} },
+    ]);
+    for (const chatId of [originalChatId, destinationChatId]) {
+      await app.db.insert(chatMembership).values([
+        { chatId, agentId: first.admin.humanAgentUuid, role: "owner", accessMode: "speaker" },
+        { chatId, agentId: first.followAgentId, role: "member", accessMode: "speaker" },
+      ]);
+    }
+    await declareGitlabEntityFollowRaw(app.db, {
+      organizationId: first.admin.organizationId,
+      connectionId: first.connectionId,
+      chatId: originalChatId,
+      declaredByAgentId: first.followAgentId,
+      humanAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
+      entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/82",
+    });
+
+    let entityLocked!: () => void;
+    let releaseEntity!: () => void;
+    const locked = new Promise<void>((resolve) => {
+      entityLocked = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseEntity = resolve;
+    });
+    const holding = app.db.transaction(async (rawTx) => {
+      const tx = rawTx as unknown as typeof app.db;
+      await lockGitlabEntityAttention(tx, {
+        connectionId: first.connectionId,
+        projectPathNormalized: "acme/api",
+        entityType: "pull_request",
+        entityIid: 82,
+      });
+      entityLocked();
+      await release;
+    });
+    await locked;
+
+    const rebinding = declareGitlabEntityFollowRaw(app.db, {
+      organizationId: first.admin.organizationId,
+      connectionId: first.connectionId,
+      chatId: destinationChatId,
+      declaredByAgentId: first.followAgentId,
+      humanAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
+      entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/82",
+      rebind: true,
+    });
+    await app.db
+      .delete(chatMembership)
+      .where(and(eq(chatMembership.chatId, destinationChatId), eq(chatMembership.agentId, first.followAgentId)));
+    releaseEntity();
+    await holding;
+    await expect(rebinding).rejects.toThrow("authority changed");
+    expect(
+      await app.db
+        .select({ chatId: gitlabEntityChatMappings.chatId })
+        .from(gitlabEntityChatMappings)
+        .where(eq(gitlabEntityChatMappings.entityIid, 82)),
+    ).toEqual([{ chatId: originalChatId }]);
+  });
+
   it("does not persist an unfollowed webhook and resolves later pending follows on the next event", async () => {
     const app = getApp();
     const first = await connection(app);
@@ -1189,7 +1367,12 @@ describe("GitLab Stage 2A backend", () => {
     expect(unseen).toHaveLength(0);
 
     for (const suffix of ["a", "b"]) {
-      const routeAgent = await createTestAgent(app, { name: `pending-${suffix}-${randomUUID().slice(0, 8)}` });
+      const routeAgentId = await seedSameOrgAgent(
+        app,
+        first.admin.organizationId,
+        first.admin.memberId,
+        `pending-${suffix}-${randomUUID().slice(0, 8)}`,
+      );
       const chatId = `chat_${suffix}_${randomUUID()}`;
       await app.db.insert(chats).values({
         id: chatId,
@@ -1207,9 +1390,9 @@ describe("GitLab Stage 2A backend", () => {
         organizationId: first.admin.organizationId,
         connectionId: first.connectionId,
         chatId,
-        declaredByAgentId: first.admin.humanAgentUuid,
+        declaredByAgentId: routeAgentId,
         humanAgentId: first.admin.humanAgentUuid,
-        delegateAgentId: routeAgent.agent.uuid,
+        delegateAgentId: routeAgentId,
         entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/52",
       });
       expect(follow).toMatchObject({ projectId: null });
@@ -1245,9 +1428,9 @@ describe("GitLab Stage 2A backend", () => {
           organizationId: first.admin.organizationId,
           connectionId: first.connectionId,
           chatId,
-          declaredByAgentId: first.admin.humanAgentUuid,
+          declaredByAgentId: first.followAgentId,
           humanAgentId: first.admin.humanAgentUuid,
-          delegateAgentId: first.admin.humanAgentUuid,
+          delegateAgentId: first.followAgentId,
           entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/52",
         })
       )?.projectId,
@@ -1259,9 +1442,9 @@ describe("GitLab Stage 2A backend", () => {
           organizationId: first.admin.organizationId,
           connectionId: first.connectionId,
           chatId,
-          declaredByAgentId: first.admin.humanAgentUuid,
+          declaredByAgentId: first.followAgentId,
           humanAgentId: first.admin.humanAgentUuid,
-          delegateAgentId: first.admin.humanAgentUuid,
+          delegateAgentId: first.followAgentId,
           entityUrl: "https://gitlab.internal/Acme/Renamed/-/merge_requests/52",
         })
       )?.projectId,
@@ -1277,12 +1460,105 @@ describe("GitLab Stage 2A backend", () => {
     expect(mappings[0]).toMatchObject({ projectId: 501, projectPath: "Acme/Renamed" });
   });
 
+  it("serializes old-path unfollow with a renamed observed entity by numeric project identity", async () => {
+    const app = getApp();
+    const first = await connection(app);
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({
+      id: chatId,
+      organizationId: first.admin.organizationId,
+      type: "group",
+      metadata: {},
+    });
+    await app.db.insert(chatMembership).values({
+      chatId,
+      agentId: first.admin.humanAgentUuid,
+      role: "owner",
+      accessMode: "speaker",
+    });
+    const mapping = await declareGitlabEntityFollow(app.db, {
+      organizationId: first.admin.organizationId,
+      connectionId: first.connectionId,
+      chatId,
+      declaredByAgentId: first.followAgentId,
+      humanAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
+      entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/62",
+    });
+    await observeGitlabEntityAndResolveFollowers(app.db, first.connectionId, {
+      entityType: "pull_request",
+      entityIid: 62,
+      projectId: 501,
+      projectPath: "Acme/API",
+      entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/62",
+      title: "Before rename",
+      entityState: "open",
+    });
+
+    let renameLocked!: () => void;
+    let releaseRename!: () => void;
+    const renameLock = new Promise<void>((resolve) => {
+      renameLocked = resolve;
+    });
+    const renameRelease = new Promise<void>((resolve) => {
+      releaseRename = resolve;
+    });
+    const renaming = app.db.transaction(async (rawTx) => {
+      const tx = rawTx as unknown as App["db"];
+      await lockGitlabEntityAttention(tx, {
+        connectionId: first.connectionId,
+        projectPathNormalized: "acme/renamed",
+        projectIds: [501],
+        entityType: "pull_request",
+        entityIid: 62,
+      });
+      renameLocked();
+      await renameRelease;
+      return observeGitlabEntityAndResolveFollowers(tx, first.connectionId, {
+        entityType: "pull_request",
+        entityIid: 62,
+        projectId: 501,
+        projectPath: "Acme/Renamed",
+        entityUrl: "https://gitlab.internal/Acme/Renamed/-/merge_requests/62",
+        title: "After rename",
+        entityState: "open",
+      });
+    });
+    await renameLock;
+
+    let unfollowSettled = false;
+    const unfollowing = removeGitlabEntityFollow(app.db, {
+      organizationId: first.admin.organizationId,
+      chatId,
+      mappingId: mapping.id,
+    }).finally(() => {
+      unfollowSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(unfollowSettled).toBe(false);
+
+    releaseRename();
+    await renaming;
+    await expect(unfollowing).resolves.toBe(1);
+    expect(
+      await app.db
+        .select({ id: gitlabEntityChatMappings.id })
+        .from(gitlabEntityChatMappings)
+        .where(eq(gitlabEntityChatMappings.id, mapping.id)),
+    ).toHaveLength(0);
+  });
+
   it("isolates per-chat delivery failure and retains the whole-request stable claim", async () => {
     const app = getApp();
     const first = await connection(app);
     expect((await postWebhook(app, first.bearer, mergeRequestPayload(53))).statusCode).toBe(200);
     for (const suffix of ["a", "b"]) {
-      const routeAgent = await createTestAgent(app, { name: `failure-${suffix}-${randomUUID().slice(0, 8)}` });
+      const routeAgentId = await seedSameOrgAgent(
+        app,
+        first.admin.organizationId,
+        first.admin.memberId,
+        `failure-${suffix}-${randomUUID().slice(0, 8)}`,
+      );
       const chatId = `chat_${suffix}_${randomUUID()}`;
       await app.db.insert(chats).values({
         id: chatId,
@@ -1300,9 +1576,9 @@ describe("GitLab Stage 2A backend", () => {
         organizationId: first.admin.organizationId,
         connectionId: first.connectionId,
         chatId,
-        declaredByAgentId: first.admin.humanAgentUuid,
+        declaredByAgentId: routeAgentId,
         humanAgentId: first.admin.humanAgentUuid,
-        delegateAgentId: routeAgent.agent.uuid,
+        delegateAgentId: routeAgentId,
         entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/52",
       });
     }
@@ -1636,9 +1912,9 @@ describe("GitLab Stage 2A backend", () => {
       organizationId: first.admin.organizationId,
       connectionId: first.connectionId,
       chatId,
-      declaredByAgentId: first.admin.humanAgentUuid,
+      declaredByAgentId: first.followAgentId,
       humanAgentId: first.admin.humanAgentUuid,
-      delegateAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
       entityUrl: "https://gitlab.internal/Acme/API/-/merge_requests/47",
     });
     if (!pending) throw new Error("pending GitLab mapping missing");
@@ -1659,9 +1935,9 @@ describe("GitLab Stage 2A backend", () => {
       chatId,
       boundVia: "identity_target",
       identityLinkId,
-      declaredByAgentId: first.admin.humanAgentUuid,
+      declaredByAgentId: first.followAgentId,
       humanAgentId: first.admin.humanAgentUuid,
-      delegateAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.followAgentId,
       attentionMode: "paired",
       attentionBackfillVersion: 1,
       active: true,

--- a/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
@@ -51,6 +51,7 @@ function mergeRequestPayload(input: {
   actor?: string;
   projectPath?: string;
   title?: string;
+  description?: string;
   draft?: boolean;
   oldrev?: string;
 }) {
@@ -70,7 +71,7 @@ function mergeRequestPayload(input: {
       iid: input.iid ?? 17,
       ...(input.action === null ? {} : { action: input.action ?? "open" }),
       title: input.title ?? "Review this change",
-      description: "Please review",
+      description: input.description ?? "Please review",
       url: `https://gitlab.internal/${projectPath}/-/merge_requests/${input.iid ?? 17}`,
       state: "opened",
       updated_at: "2026-07-28T10:00:00.000Z",
@@ -1208,6 +1209,86 @@ describe("GitLab Stage 3 personnel routing", () => {
       .from(messages)
       .where(and(eq(messages.chatId, existingChat.id), eq(messages.source, "gitlab")));
     expect(card?.metadata).toMatchObject({ mentions: [setup.delegate.uuid] });
+  });
+
+  it("does not reuse a related exact-pair chat after the wake agent leaves", async () => {
+    const app = getApp();
+    const setup = await setupTarget(app);
+    const relatedChat = await createChat(app.db, setup.admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [setup.delegate.uuid],
+    });
+    await app.db.insert(gitlabEntityChatMappings).values({
+      id: randomUUID(),
+      organizationId: setup.admin.organizationId,
+      connectionId: setup.connection.connectionId,
+      chatId: relatedChat.id,
+      declaredByAgentId: setup.admin.humanAgentUuid,
+      boundVia: "identity_target",
+      identityLinkId: setup.link.id,
+      humanAgentId: setup.admin.humanAgentUuid,
+      delegateAgentId: setup.delegate.uuid,
+      attentionMode: "paired",
+      attentionBackfillVersion: 1,
+      active: true,
+      entityType: "issue",
+      entityIid: 42,
+      projectId: 801,
+      projectPath: "Acme/Reviews",
+      projectPathNormalized: "acme/reviews",
+      entityUrl: "https://gitlab.internal/Acme/Reviews/-/issues/42",
+      title: "Related issue",
+      entityState: "open",
+    });
+    await app.db
+      .delete(chatMembership)
+      .where(and(eq(chatMembership.chatId, relatedChat.id), eq(chatMembership.agentId, setup.delegate.uuid)));
+
+    const iid = 125;
+    expect(
+      (
+        await postMr(
+          app,
+          setup.connection.bearer,
+          mergeRequestPayload({
+            iid,
+            description: "Closes #42",
+            reviewers: [],
+            assignees: [{ username: "Reviewer.One" }],
+          }),
+        )
+      ).statusCode,
+    ).toBe(200);
+
+    const [targetLine] = await app.db
+      .select()
+      .from(gitlabEntityChatMappings)
+      .where(
+        and(
+          eq(gitlabEntityChatMappings.connectionId, setup.connection.connectionId),
+          eq(gitlabEntityChatMappings.entityType, "pull_request"),
+          eq(gitlabEntityChatMappings.entityIid, iid),
+        ),
+      );
+    expect(targetLine).toMatchObject({
+      boundVia: "identity_target",
+      humanAgentId: setup.admin.humanAgentUuid,
+      delegateAgentId: setup.delegate.uuid,
+      active: true,
+    });
+    expect(targetLine?.chatId).not.toBe(relatedChat.id);
+    expect(
+      await app.db
+        .select()
+        .from(chatMembership)
+        .where(
+          and(
+            eq(chatMembership.chatId, targetLine?.chatId ?? ""),
+            eq(chatMembership.agentId, setup.delegate.uuid),
+            eq(chatMembership.accessMode, "speaker"),
+          ),
+        ),
+    ).toHaveLength(1);
   });
 
   it("unfollows an automatic route and lets a later reviewer event create a fresh chat", async () => {

--- a/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
@@ -3,6 +3,7 @@ import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { clients } from "../db/schema/clients.js";
 import { gitlabConnections } from "../db/schema/gitlab-connections.js";
@@ -1067,7 +1068,7 @@ describe("GitLab Stage 3 personnel routing", () => {
     ).toHaveLength(1);
   });
 
-  it("does not reuse entity membership for an assignment target", async () => {
+  it("co-locates an assignment target in one exact-membership entity chat", async () => {
     const app = getApp();
     const setup = await setupTarget(app);
     const iid = 24;
@@ -1120,7 +1121,93 @@ describe("GitLab Stage 3 personnel routing", () => {
     expect(rows).toHaveLength(2);
     const targetLine = rows.find((row) => row.boundVia === "identity_target");
     expect(targetLine?.chatId).toBeTruthy();
-    expect(targetLine?.chatId).not.toBe(existingChat.id);
+    expect(targetLine?.chatId).toBe(existingChat.id);
+  });
+
+  it("atomically admits a different current delegate and co-locates its assignment line", async () => {
+    const app = getApp();
+    const setup = await setupTarget(app);
+    const follower = await createAgent(app.db, {
+      name: `gitlab-follower-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "GitLab Follower",
+      managerId: setup.admin.memberId,
+      organizationId: setup.admin.organizationId,
+      clientId: setup.clientId,
+    });
+    const iid = 124;
+    const existingChat = await createChat(app.db, setup.admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [follower.uuid],
+    });
+    await app.db.insert(gitlabEntityChatMappings).values({
+      id: randomUUID(),
+      organizationId: setup.admin.organizationId,
+      connectionId: setup.connection.connectionId,
+      chatId: existingChat.id,
+      declaredByAgentId: follower.uuid,
+      boundVia: "agent_declared",
+      humanAgentId: setup.admin.humanAgentUuid,
+      delegateAgentId: follower.uuid,
+      active: true,
+      entityType: "pull_request",
+      entityIid: iid,
+      projectId: 801,
+      projectPath: "Acme/Reviews",
+      projectPathNormalized: "acme/reviews",
+      entityUrl: `https://gitlab.internal/Acme/Reviews/-/merge_requests/${iid}`,
+      title: "Co-locate assignment",
+      entityState: "open",
+    });
+
+    expect(
+      (
+        await postMr(
+          app,
+          setup.connection.bearer,
+          mergeRequestPayload({
+            iid,
+            actor: "reviewer.one",
+            reviewers: [],
+            assignees: [{ username: "Reviewer.One" }],
+          }),
+        )
+      ).statusCode,
+    ).toBe(200);
+
+    const rows = await app.db
+      .select()
+      .from(gitlabEntityChatMappings)
+      .where(
+        and(
+          eq(gitlabEntityChatMappings.connectionId, setup.connection.connectionId),
+          eq(gitlabEntityChatMappings.entityIid, iid),
+        ),
+      );
+    expect(rows).toHaveLength(2);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ chatId: existingChat.id, delegateAgentId: follower.uuid }),
+        expect.objectContaining({
+          chatId: existingChat.id,
+          delegateAgentId: setup.delegate.uuid,
+          boundVia: "identity_target",
+          active: true,
+        }),
+      ]),
+    );
+    const speakers = await app.db
+      .select({ agentId: chatMembership.agentId })
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, existingChat.id), eq(chatMembership.accessMode, "speaker")));
+    expect(new Set(speakers.map((row) => row.agentId))).toEqual(
+      new Set([setup.admin.humanAgentUuid, follower.uuid, setup.delegate.uuid]),
+    );
+    const [card] = await app.db
+      .select()
+      .from(messages)
+      .where(and(eq(messages.chatId, existingChat.id), eq(messages.source, "gitlab")));
+    expect(card?.metadata).toMatchObject({ mentions: [setup.delegate.uuid] });
   });
 
   it("unfollows an automatic route and lets a later reviewer event create a fresh chat", async () => {

--- a/packages/server/src/__tests__/participant-invite.test.ts
+++ b/packages/server/src/__tests__/participant-invite.test.ts
@@ -1,15 +1,21 @@
 import { randomUUID } from "node:crypto";
 import { AGENT_VISIBILITY } from "@first-tree/shared";
 import { and, eq } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
+import { registerChatAudienceDispatcher, resetChatAudienceDispatcher } from "../services/chat-audience-cache.js";
 import * as memberService from "../services/member.js";
 import { sendMessage } from "../services/message.js";
-import { assertChatVisibleInOrgOrNotFound, inviteParticipantsToChat } from "../services/participant-invite.js";
+import {
+  assertChatVisibleInOrgOrNotFound,
+  inviteParticipantsToChat,
+  inviteParticipantsToChatInTransaction,
+} from "../services/participant-invite.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
@@ -295,6 +301,71 @@ describe("inviteParticipantsToChat", () => {
         ),
       );
     expect(silentRows.length).toBe(6);
+  });
+
+  it("rolls membership back with the caller transaction and emits no pre-commit cache invalidation", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app, { username: `atomic-owner-${randomUUID().slice(0, 8)}` });
+    const target = await createAgent(app.db, {
+      name: `atomic-target-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Atomic Target",
+      managerId: owner.memberId,
+      organizationId: owner.organizationId,
+    });
+    const chat = await createChat(app.db, owner.humanAgentUuid, { type: "group", participantIds: [] });
+    const invalidations = vi.fn();
+    registerChatAudienceDispatcher(invalidations);
+    try {
+      await expect(
+        app.db.transaction(async (tx) => {
+          await inviteParticipantsToChatInTransaction(tx as unknown as typeof app.db, {
+            chatId: chat.id,
+            callerAgentId: owner.humanAgentUuid,
+            targetAgentIds: [target.uuid],
+            errorOnAlreadySpeaker: false,
+          });
+          expect(invalidations).not.toHaveBeenCalled();
+          throw new Error("roll back the enclosing attention-line write");
+        }),
+      ).rejects.toThrow("roll back the enclosing attention-line write");
+      expect(invalidations).not.toHaveBeenCalled();
+    } finally {
+      resetChatAudienceDispatcher();
+    }
+
+    const membership = await app.db
+      .select()
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.agentId, target.uuid)));
+    expect(membership).toHaveLength(0);
+  });
+
+  it("invalidates the audience cache once after the public invite commits", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app, { username: `cache-owner-${randomUUID().slice(0, 8)}` });
+    const target = await createAgent(app.db, {
+      name: `cache-target-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Cache Target",
+      managerId: owner.memberId,
+      organizationId: owner.organizationId,
+    });
+    const chat = await createChat(app.db, owner.humanAgentUuid, { type: "group", participantIds: [] });
+    const invalidations = vi.fn();
+    registerChatAudienceDispatcher(invalidations);
+    try {
+      await inviteParticipantsToChat(app.db, {
+        chatId: chat.id,
+        callerAgentId: owner.humanAgentUuid,
+        targetAgentIds: [target.uuid],
+        errorOnAlreadySpeaker: false,
+      });
+      expect(invalidations).toHaveBeenCalledOnce();
+      expect(invalidations).toHaveBeenCalledWith(chat.id);
+    } finally {
+      resetChatAudienceDispatcher();
+    }
   });
 
   it("self-add of a private agent is permitted (owner-exclusive carve-out)", async () => {

--- a/packages/server/src/__tests__/resolve-target-chat.test.ts
+++ b/packages/server/src/__tests__/resolve-target-chat.test.ts
@@ -1,11 +1,15 @@
 import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import type { GithubEntity } from "../api/webhooks/github-entity.js";
 import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
-import { resolveTargetChat as resolveTargetChatRaw } from "../services/github-entity-chat.js";
+import {
+  resolveGithubPersonnelTargetChat,
+  resolveTargetChat as resolveTargetChatRaw,
+} from "../services/github-entity-chat.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 /**
@@ -159,6 +163,7 @@ describe("resolveTargetChat", () => {
       eventType: "pull_request",
       action: "opened",
       entityStateSeed: { entityType: "issue", entityKey: "owner/repo#42", state: "closed" },
+      intent: { kind: "provider_task_target" },
     });
 
     expect(prResolved.chatId).toBe(issueResolved.chatId);
@@ -258,6 +263,7 @@ describe("resolveTargetChat", () => {
       relatedEntities: [issue42],
       eventType: "pull_request",
       action: "opened",
+      intent: { kind: "provider_task_target" },
     });
 
     expect(prResolved.chatId).toBe(issueResolved.chatId);
@@ -269,6 +275,47 @@ describe("resolveTargetChat", () => {
       .where(eq(githubEntityChatMappings.entityKey, "owner/repo#50"));
     expect(prMapping).toHaveLength(1);
     expect(prMapping[0]?.boundVia).toBe("fixes_link");
+  });
+
+  it("does not reuse a related exact-pair chat after the wake agent leaves", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedDelegate(app, admin.organizationId, admin.memberId, `dlg-${randomUUID().slice(0, 6)}`);
+    await app.db.update(agents).set({ delegateMention: delegate }).where(eq(agents.uuid, admin.humanAgentUuid));
+
+    const issueResolved = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: issue42,
+      relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
+    });
+    await app.db
+      .delete(chatMembership)
+      .where(and(eq(chatMembership.chatId, issueResolved.chatId), eq(chatMembership.agentId, delegate)));
+
+    const prResolved = await resolveGithubPersonnelTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: pr50,
+      relatedEntities: [issue42],
+      eventType: "pull_request",
+      action: "opened",
+      isMentionMatched: true,
+      requiresPersistentLine: true,
+    });
+
+    expect(prResolved).toMatchObject({ created: true, boundVia: "direct", lineExisted: false });
+    expect(prResolved?.chatId).not.toBe(issueResolved.chatId);
+    expect(
+      await app.db
+        .select()
+        .from(chatMembership)
+        .where(and(eq(chatMembership.chatId, prResolved?.chatId ?? ""), eq(chatMembership.agentId, delegate))),
+    ).toMatchObject([{ accessMode: "speaker" }]);
   });
 
   it("does not link when no related entity has an existing mapping", async () => {
@@ -326,6 +373,7 @@ describe("resolveTargetChat", () => {
       relatedEntities: [issue42, issue43],
       eventType: "pull_request",
       action: "opened",
+      intent: { kind: "provider_task_target" },
     });
 
     expect(prResolved.chatId).toBe(issue42Resolved.chatId);

--- a/packages/server/src/__tests__/scm-audience-composition.test.ts
+++ b/packages/server/src/__tests__/scm-audience-composition.test.ts
@@ -24,6 +24,7 @@ function personnel(
     humanAgentId,
     wakeAgentId,
     reason,
+    requiresPersistentLine: reason === "mentioned" || reason === "assigned",
     externalUsername: humanAgentId,
   };
 }
@@ -39,7 +40,11 @@ describe("composeScmAudience", () => {
     expect(composed[0]).toEqual({ entry: existing("human-h", "agent-a", "chat-a") });
     expect(composed[1]).toEqual({
       entry: existing("human-h", "agent-b", "chat-b"),
-      directedContext: { reason: "review_requested", externalUsername: "human-h" },
+      directedContext: {
+        reason: "review_requested",
+        requiresPersistentLine: false,
+        externalUsername: "human-h",
+      },
     });
   });
 
@@ -97,7 +102,9 @@ describe("composeScmAudience", () => {
     });
 
     expect(first).toEqual(second);
-    expect(first[0]).toMatchObject({ directedContext: { reason: "review_requested" } });
+    expect(first[0]).toMatchObject({
+      directedContext: { reason: "review_requested", requiresPersistentLine: true },
+    });
   });
 
   it("keeps provider tasks discriminated and outside personnel dedupe", () => {

--- a/packages/server/src/__tests__/scm-provider-attention-contract.test.ts
+++ b/packages/server/src/__tests__/scm-provider-attention-contract.test.ts
@@ -156,6 +156,7 @@ it("keeps a fresh self-directed personnel target wake-eligible", async () => {
           humanAgentId: "actor-human",
           wakeAgentId: "actor-delegate",
           reason: "assigned",
+          requiresPersistentLine: true,
           externalUsername: "actor",
         },
       },
@@ -376,6 +377,10 @@ describe("GitHub/GitLab semantic webhook conformance", () => {
           target.entry.kind === "personnel_target" || target.entry.kind === "provider_task_target"
             ? target.entry.reason
             : target.directedContext?.reason,
+        requiresPersistentLine:
+          target.entry.kind === "personnel_target"
+            ? target.entry.requiresPersistentLine
+            : target.directedContext?.requiresPersistentLine,
         humanAgentId:
           target.entry.kind === "personnel_target" || target.entry.kind === "provider_task_target"
             ? target.entry.humanAgentId
@@ -393,6 +398,7 @@ describe("GitHub/GitLab semantic webhook conformance", () => {
       {
         kind: "personnel_target",
         reason: "mentioned",
+        requiresPersistentLine: true,
         humanAgentId: admin.humanAgentUuid,
         wakeAgentId: delegate.uuid,
       },

--- a/packages/server/src/__tests__/scm-target-chat-policy.test.ts
+++ b/packages/server/src/__tests__/scm-target-chat-policy.test.ts
@@ -1,12 +1,33 @@
 import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
 import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
-import { decideScmPersonnelTargetChat } from "../services/scm-target-chat-policy.js";
+import {
+  decideScmPersonnelTargetChat,
+  lockAndValidateScmPersonnelPlacement,
+} from "../services/scm-target-chat-policy.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 describe("SCM personnel target chat policy", () => {
   const getApp = useTestApp();
+
+  async function decideWithCurrentAuthority(
+    db: ReturnType<typeof getApp>["db"],
+    input: Omit<Parameters<typeof decideScmPersonnelTargetChat>[1], "authority" | "speakerSnapshot">,
+  ) {
+    return db.transaction(async (rawTx) => {
+      const tx = rawTx as unknown as ReturnType<typeof getApp>["db"];
+      const placement = await lockAndValidateScmPersonnelPlacement(tx, input);
+      if (!placement) return null;
+      return decideScmPersonnelTargetChat(tx, {
+        ...input,
+        authority: placement.authority,
+        speakerSnapshot: placement.speakerSnapshot,
+      });
+    });
+  }
 
   async function setupChat() {
     const app = getApp();
@@ -20,6 +41,7 @@ describe("SCM personnel target chat policy", () => {
       managerId: human.memberId,
       organizationId: human.organizationId,
     });
+    await app.db.update(agents).set({ delegateMention: wake.uuid }).where(eq(agents.uuid, human.humanAgentUuid));
     const chat = await createChat(app.db, human.humanAgentUuid, {
       type: "group",
       participantIds: [wake.uuid],
@@ -27,16 +49,50 @@ describe("SCM personnel target chat policy", () => {
     return { app, humanAgentId: human.humanAgentUuid, wakeAgentId: wake.uuid, chatId: chat.id };
   }
 
+  async function setupOwnerPrivateCandidate() {
+    const app = getApp();
+    const human = await createTestAdmin(app, {
+      username: `target-private-${randomUUID().slice(0, 8)}`,
+    });
+    const follower = await createAgent(app.db, {
+      name: `existing-follower-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Existing Follower",
+      managerId: human.memberId,
+      organizationId: human.organizationId,
+    });
+    const wake = await createAgent(app.db, {
+      name: `current-delegate-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Current Delegate",
+      managerId: human.memberId,
+      organizationId: human.organizationId,
+    });
+    await app.db.update(agents).set({ delegateMention: wake.uuid }).where(eq(agents.uuid, human.humanAgentUuid));
+    const chat = await createChat(app.db, human.humanAgentUuid, {
+      type: "group",
+      participantIds: [follower.uuid],
+    });
+    return {
+      app,
+      human,
+      followerAgentId: follower.uuid,
+      humanAgentId: human.humanAgentUuid,
+      wakeAgentId: wake.uuid,
+      chatId: chat.id,
+    };
+  }
+
   it("reuses exactly one reviewer membership chat", async () => {
     const setup = await setupChat();
     await expect(
-      decideScmPersonnelTargetChat(setup.app.db, {
-        reason: "review_requested",
+      decideWithCurrentAuthority(setup.app.db, {
+        requiresPersistentLine: false,
         candidateChatIds: [setup.chatId],
         humanAgentId: setup.humanAgentId,
         wakeAgentId: setup.wakeAgentId,
       }),
-    ).resolves.toEqual({ kind: "reuse", chatId: setup.chatId });
+    ).resolves.toEqual({ kind: "reuse_membership", chatId: setup.chatId });
   });
 
   it("fails closed for zero or multiple reviewer candidates", async () => {
@@ -46,16 +102,16 @@ describe("SCM personnel target chat policy", () => {
       participantIds: [first.wakeAgentId],
     });
     await expect(
-      decideScmPersonnelTargetChat(first.app.db, {
-        reason: "review_requested",
+      decideWithCurrentAuthority(first.app.db, {
+        requiresPersistentLine: false,
         candidateChatIds: [],
         humanAgentId: first.humanAgentId,
         wakeAgentId: first.wakeAgentId,
       }),
     ).resolves.toEqual({ kind: "strict_new_line" });
     await expect(
-      decideScmPersonnelTargetChat(first.app.db, {
-        reason: "review_requested",
+      decideWithCurrentAuthority(first.app.db, {
+        requiresPersistentLine: false,
         candidateChatIds: [first.chatId, second.id],
         humanAgentId: first.humanAgentId,
         wakeAgentId: first.wakeAgentId,
@@ -63,15 +119,100 @@ describe("SCM personnel target chat policy", () => {
     ).resolves.toEqual({ kind: "strict_new_line" });
   });
 
-  it.each(["mentioned", "assigned"] as const)("%s always establishes a strict line", async (reason) => {
+  it.each(["mentioned", "assigned"] as const)("%s reuses an exact membership chat with a line", async () => {
     const setup = await setupChat();
     await expect(
-      decideScmPersonnelTargetChat(setup.app.db, {
-        reason,
+      decideWithCurrentAuthority(setup.app.db, {
+        requiresPersistentLine: true,
         candidateChatIds: [setup.chatId],
         humanAgentId: setup.humanAgentId,
         wakeAgentId: setup.wakeAgentId,
       }),
+    ).resolves.toEqual({ kind: "reuse_with_line", chatId: setup.chatId, admitWakeAgent: false });
+  });
+
+  it("admits a persistent target only into one owner-private candidate", async () => {
+    const setup = await setupOwnerPrivateCandidate();
+    await expect(
+      decideWithCurrentAuthority(setup.app.db, {
+        requiresPersistentLine: true,
+        candidateChatIds: [setup.chatId],
+        humanAgentId: setup.humanAgentId,
+        wakeAgentId: setup.wakeAgentId,
+      }),
+    ).resolves.toEqual({ kind: "reuse_with_line", chatId: setup.chatId, admitWakeAgent: true });
+  });
+
+  it("fails closed when more than one owner-private candidate exists", async () => {
+    const setup = await setupOwnerPrivateCandidate();
+    const second = await createChat(setup.app.db, setup.humanAgentId, {
+      type: "group",
+      participantIds: [setup.followerAgentId],
+    });
+    await expect(
+      decideWithCurrentAuthority(setup.app.db, {
+        requiresPersistentLine: true,
+        candidateChatIds: [setup.chatId, second.id],
+        humanAgentId: setup.humanAgentId,
+        wakeAgentId: setup.wakeAgentId,
+      }),
     ).resolves.toEqual({ kind: "strict_new_line" });
+  });
+
+  it("does not treat a chat containing another owner's agent as owner-private", async () => {
+    const setup = await setupOwnerPrivateCandidate();
+    const otherOwner = await createTestAdmin(setup.app, {
+      username: `target-foreign-${randomUUID().slice(0, 8)}`,
+    });
+    const foreignAgent = await createAgent(setup.app.db, {
+      name: `foreign-agent-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Foreign Agent",
+      managerId: otherOwner.memberId,
+      organizationId: setup.human.organizationId,
+      visibility: "organization",
+    });
+    const chat = await createChat(setup.app.db, setup.humanAgentId, {
+      type: "group",
+      participantIds: [setup.followerAgentId, foreignAgent.uuid],
+    });
+    await expect(
+      decideWithCurrentAuthority(setup.app.db, {
+        requiresPersistentLine: true,
+        candidateChatIds: [chat.id],
+        humanAgentId: setup.humanAgentId,
+        wakeAgentId: setup.wakeAgentId,
+      }),
+    ).resolves.toEqual({ kind: "strict_new_line" });
+  });
+
+  it("fails closed after delegate drift or delegate suspension", async () => {
+    const setup = await setupOwnerPrivateCandidate();
+    await setup.app.db
+      .update(agents)
+      .set({ delegateMention: setup.followerAgentId })
+      .where(eq(agents.uuid, setup.humanAgentId));
+    await expect(
+      decideWithCurrentAuthority(setup.app.db, {
+        requiresPersistentLine: true,
+        candidateChatIds: [setup.chatId],
+        humanAgentId: setup.humanAgentId,
+        wakeAgentId: setup.wakeAgentId,
+      }),
+    ).resolves.toBeNull();
+
+    await setup.app.db
+      .update(agents)
+      .set({ delegateMention: setup.wakeAgentId })
+      .where(eq(agents.uuid, setup.humanAgentId));
+    await setup.app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, setup.wakeAgentId));
+    await expect(
+      decideWithCurrentAuthority(setup.app.db, {
+        requiresPersistentLine: true,
+        candidateChatIds: [setup.chatId],
+        humanAgentId: setup.humanAgentId,
+        wakeAgentId: setup.wakeAgentId,
+      }),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/server/src/api/webhooks/gitlab.ts
+++ b/packages/server/src/api/webhooks/gitlab.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { BadRequestError, NotFoundError } from "../../errors.js";
 import { createLogger } from "../../observability/index.js";
+import { invalidateChatAudience } from "../../services/chat-audience-cache.js";
 import { handleContextReviewerMrEvent } from "../../services/context-reviewer-mr.js";
 import {
   findActiveGitlabEndpoint,
@@ -20,6 +21,7 @@ import {
   withGitlabCrossHookDedupFence,
 } from "../../services/gitlab-cross-hook-dedup.js";
 import {
+  normalizeGitlabProjectPath,
   observeGitlabEntityAndResolveFollowers,
   refreshGitlabChatTopics,
 } from "../../services/gitlab-entity-follow.js";
@@ -34,6 +36,7 @@ import {
 import { runDeferredSendMessagePostCommitEffects } from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
 import { runDeferredScmCardPostCommitEffects } from "../../services/scm-card-delivery.js";
+import { lockGitlabEntityAttention } from "../../services/scm-entity-attention-lock.js";
 import { processScmWebhookDelivery } from "../../services/scm-webhook-processing.js";
 
 const MAX_GITLAB_WEBHOOK_BYTES = 512 * 1024;
@@ -134,6 +137,15 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
             endpoint.connection.id,
             endpoint.connection.tokenHash,
             async (tx, fencedConnection) => {
+              if (normalized.entityIdentity) {
+                await lockGitlabEntityAttention(tx, {
+                  connectionId: fencedConnection.id,
+                  projectPathNormalized: normalizeGitlabProjectPath(normalized.entityIdentity.projectPath),
+                  projectIds: [normalized.entityIdentity.projectId],
+                  entityType: normalized.entityIdentity.entityType,
+                  entityIid: normalized.entityIdentity.entityIid,
+                });
+              }
               if (normalized.crossHookFingerprint) {
                 crossHookDuplicate = isGitlabCrossHookDuplicate({
                   fingerprint: normalized.crossHookFingerprint,
@@ -222,7 +234,14 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
                   });
                 },
                 deliver: async (event, audience) => {
-                  if (!normalized.entityIdentity) return { delivered: 0, failed: 0, postCommitEffects: [] };
+                  if (!normalized.entityIdentity) {
+                    return {
+                      delivered: 0,
+                      failed: 0,
+                      postCommitEffects: [],
+                      audienceCacheInvalidationChatIds: [],
+                    };
+                  }
                   return deliverGitlabCards(app, {
                     event,
                     identity: normalized.entityIdentity,
@@ -284,6 +303,9 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
           );
 
           if (processed.outcome === "delivered") {
+            for (const chatId of processed.deliveryStats.audienceCacheInvalidationChatIds) {
+              invalidateChatAudience(chatId);
+            }
             for (const effects of processed.deliveryStats.postCommitEffects) {
               await runDeferredScmCardPostCommitEffects(app, effects);
             }

--- a/packages/server/src/services/chat-audience-cache.ts
+++ b/packages/server/src/services/chat-audience-cache.ts
@@ -13,11 +13,11 @@
  * would miss `chat:message` pushes for up to TTL_MS.
  *
  * Canonical bundles already enclose this step internally — callers that
- * route through `applyMembershipWrite` (used by `inviteParticipantsToChat`
- * / `ensureParticipant`) or through `joinAsParticipant` /
- * `leaveAsParticipant` do NOT need to call it themselves. Direct callers
- * of `addChatParticipants`, `recomputeChatWatchers`, or any other ad-hoc
- * speaker-row write are still responsible.
+ * route through `applyMembershipWrite`, public `inviteParticipantsToChat`,
+ * `joinAsParticipant`, or `leaveAsParticipant` do NOT need to call it
+ * themselves. Transaction-aware callers of the invite primitive, direct
+ * callers of `addChatParticipants`, `recomputeChatWatchers`, or any other
+ * ad-hoc speaker-row write are still responsible after commit.
  *
  * Cross-instance correctness: handled via a fan-out dispatcher.
  * `invalidateChatAudience` drops the LOCAL replica's entry AND fires a

--- a/packages/server/src/services/chat-membership-lock.ts
+++ b/packages/server/src/services/chat-membership-lock.ts
@@ -1,0 +1,108 @@
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chats } from "../db/schema/chats.js";
+
+// biome-ignore lint/suspicious/noExplicitAny: accepts both the root database and transaction clients
+type DbLike = PgDatabase<PgQueryResultHKT, any, any>;
+
+export type LockedChatSpeaker = {
+  chatId: string;
+  agentId: string;
+  organizationId: string;
+  type: string;
+  status: string;
+  managerId: string;
+  delegateMention: string | null;
+};
+
+export type LockedChatSpeakerSnapshot = {
+  chats: Array<{ id: string; organizationId: string }>;
+  speakers: LockedChatSpeaker[];
+};
+
+export type LockedChatSpeakerAndAgentSnapshot = LockedChatSpeakerSnapshot & {
+  agents: Omit<LockedChatSpeaker, "chatId">[];
+};
+
+/**
+ * Serialize every speaker insert, delete, downgrade, and routing snapshot for
+ * one chat. The transaction advisory lock also covers a not-yet-existing
+ * membership row, which a row-level lock alone cannot protect.
+ */
+export async function lockChatMembershipMutation(db: DbLike, chatIds: ReadonlyArray<string>): Promise<void> {
+  const stableChatIds = [...new Set(chatIds)].sort();
+  for (const chatId of stableChatIds) {
+    await db.execute(sql`SELECT pg_advisory_xact_lock(hashtext('chat_speaker_membership'), hashtext(${chatId}))`);
+  }
+}
+
+/**
+ * Lock a stable speaker/owner snapshot after taking the shared membership
+ * mutation fence. Agent rows are locked separately so manager transfers and
+ * status/delegate changes cannot invalidate owner or wake authority before
+ * the enclosing transaction commits.
+ */
+export async function lockChatSpeakerSnapshot(
+  db: DbLike,
+  chatIds: ReadonlyArray<string>,
+): Promise<LockedChatSpeakerSnapshot> {
+  const snapshot = await lockChatSpeakerAndAgentSnapshot(db, chatIds, []);
+  return { chats: snapshot.chats, speakers: snapshot.speakers };
+}
+
+/**
+ * Lock candidate speakers and additional authority agents as one UUID-sorted
+ * set. Callers that already hold required member rows can use this to avoid
+ * taking a pair lock first and expanding it later to overlapping chat
+ * speakers, which would permit cross-chat deadlocks.
+ */
+export async function lockChatSpeakerAndAgentSnapshot(
+  db: DbLike,
+  chatIds: ReadonlyArray<string>,
+  additionalAgentIds: ReadonlyArray<string>,
+): Promise<LockedChatSpeakerAndAgentSnapshot> {
+  const stableChatIds = [...new Set(chatIds)].sort();
+  if (stableChatIds.length > 0) await lockChatMembershipMutation(db, stableChatIds);
+
+  const chatRows =
+    stableChatIds.length === 0
+      ? []
+      : await db
+          .select({ id: chats.id, organizationId: chats.organizationId })
+          .from(chats)
+          .where(inArray(chats.id, stableChatIds))
+          .orderBy(asc(chats.id))
+          .for("update");
+  const membershipRows =
+    stableChatIds.length === 0
+      ? []
+      : await db
+          .select({ chatId: chatMembership.chatId, agentId: chatMembership.agentId })
+          .from(chatMembership)
+          .where(and(inArray(chatMembership.chatId, stableChatIds), eq(chatMembership.accessMode, "speaker")))
+          .orderBy(asc(chatMembership.chatId), asc(chatMembership.agentId))
+          .for("update");
+  const agentIds = [...new Set([...membershipRows.map((row) => row.agentId), ...additionalAgentIds])].sort();
+  if (agentIds.length === 0) return { chats: chatRows, speakers: [], agents: [] };
+  const agentRows = await db
+    .select({
+      agentId: agents.uuid,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      status: agents.status,
+      managerId: agents.managerId,
+      delegateMention: agents.delegateMention,
+    })
+    .from(agents)
+    .where(inArray(agents.uuid, agentIds))
+    .orderBy(asc(agents.uuid))
+    .for("update");
+  const agentById = new Map(agentRows.map((row) => [row.agentId, row]));
+  const speakers = membershipRows.flatMap((membership) => {
+    const agent = agentById.get(membership.agentId);
+    return agent ? [{ chatId: membership.chatId, ...agent }] : [];
+  });
+  return { chats: chatRows, speakers, agents: agentRows };
+}

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -21,6 +21,7 @@ import { users } from "../db/schema/users.js";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
 import { resolveAvatarImageUrl } from "./agent.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
+import { lockChatMembershipMutation } from "./chat-membership-lock.js";
 import { resolveChatTitle } from "./me-chat.js";
 import {
   type DeferredSendMessagePostCommitEffects,
@@ -1158,47 +1159,40 @@ export async function addParticipant(db: Database, chatId: string, requesterId: 
 }
 
 export async function removeParticipant(db: Database, chatId: string, requesterId: string, targetAgentId: string) {
-  const chat = await getChat(db, chatId);
-  if (parseLandingCampaignTrialChatMetadata(chat.metadata)) {
-    throw new ForbiddenError("Landing campaign trial chats are managed by First Tree.");
-  }
+  const speakers = await db.transaction(async (rawTx) => {
+    const tx = rawTx as unknown as Database;
+    await lockChatMembershipMutation(tx, [chatId]);
+    const chat = await getChat(tx, chatId);
+    if (parseLandingCampaignTrialChatMetadata(chat.metadata)) {
+      throw new ForbiddenError("Landing campaign trial chats are managed by First Tree.");
+    }
 
-  // Verify requester is a participant
-  await assertParticipant(db, chatId, requesterId);
+    await assertParticipant(tx, chatId, requesterId);
+    if (requesterId === targetAgentId) {
+      throw new BadRequestError("Cannot remove yourself from a chat");
+    }
 
-  // Cannot remove self (use leave instead, if implemented)
-  if (requesterId === targetAgentId) {
-    throw new BadRequestError("Cannot remove yourself from a chat");
-  }
-
-  // Only target the speaker row — leaving any watcher row to be handled
-  // by `recomputeChatWatchers` below (it will be dropped if its anchor
-  // condition no longer holds, or kept otherwise).
-  const [removed] = await db
-    .delete(chatMembership)
-    .where(
-      and(
-        eq(chatMembership.chatId, chatId),
-        eq(chatMembership.agentId, targetAgentId),
-        eq(chatMembership.accessMode, "speaker"),
-      ),
-    )
-    .returning();
-
-  if (!removed) {
-    throw new NotFoundError(`Agent "${targetAgentId}" is not a participant of this chat`);
-  }
-  // Reconcile watchers: a manager who was previously anchored to the
-  // removed agent may need their watcher row dropped (if no other
-  // managed agent remains in chat) or re-created (if the removed agent
-  // was a speaker but their manager is now eligible to watch).
-  await recomputeChatWatchers(db, chatId);
+    const [removed] = await tx
+      .delete(chatMembership)
+      .where(
+        and(
+          eq(chatMembership.chatId, chatId),
+          eq(chatMembership.agentId, targetAgentId),
+          eq(chatMembership.accessMode, "speaker"),
+        ),
+      )
+      .returning();
+    if (!removed) {
+      throw new NotFoundError(`Agent "${targetAgentId}" is not a participant of this chat`);
+    }
+    await recomputeChatWatchers(tx, chatId);
+    return tx
+      .select()
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
+  });
   invalidateChatAudience(chatId);
-
-  return db
-    .select()
-    .from(chatMembership)
-    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
+  return speakers;
 }
 
 /**

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -333,6 +333,7 @@ export async function resolveGithubAudience(
         personnelTargets.push({
           kind: "personnel_target",
           reason: target.reason,
+          requiresPersistentLine: target.reason === "assigned" || target.reason === "mentioned",
           humanAgentId: c.id,
           wakeAgentId: c.delegateMention,
           externalUsername: candidateLogin,

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -4,7 +4,12 @@ import type { GithubEntity } from "../api/webhooks/github-entity.js";
 import { createLogger } from "../observability/index.js";
 import { uuidv7 } from "../uuid.js";
 import type { GithubProviderTaskContext } from "./github-audience.js";
-import { decideGithubPersonnelTargetChat, refreshGithubChatTopic, resolveTargetChat } from "./github-entity-chat.js";
+import {
+  refreshGithubChatTopic,
+  resolveGithubExistingLineChat,
+  resolveGithubPersonnelTargetChat,
+  resolveTargetChat,
+} from "./github-entity-chat.js";
 import { type EntityStateSeed, setEntityTitle } from "./github-entity-state.js";
 import { applyMembershipWrite } from "./participant-mode.js";
 import type { ScmAudienceTarget } from "./scm-audience-composition.js";
@@ -71,10 +76,11 @@ export async function deliverGithubEvent(
   const actorHumanId = options.actorHumanId ?? null;
   const existingMappedChatIds = existingMappedChatIdsForProjection(audience);
   const entity = entityFromEvent(event);
+  const executableTargets = expandDirectedGithubTargets(audience);
 
   // Phase 1 — shared SCM planner owns echo wake policy and one-delivery-per-chat.
   const planned = await planScmChatDeliveries({
-    targets: audience,
+    targets: executableTargets,
     actorHumanId,
     resolveChat: (target) => resolveChatFor(app, event, target, options),
     onTargetError: (target, err) => {
@@ -233,6 +239,33 @@ export async function deliverGithubEvent(
   return stats;
 }
 
+/**
+ * Preserve an existing subscription route independently from fresh directed
+ * authority. The personnel half performs its own exact-line re-read and
+ * placement in one entity-locked transaction; the subscription half may be
+ * dropped if a concurrent unfollow removed it.
+ */
+function expandDirectedGithubTargets(
+  targets: ScmAudienceTarget<GithubProviderTaskContext>[],
+): ScmAudienceTarget<GithubProviderTaskContext>[] {
+  return targets.flatMap((target) => {
+    if (target.entry.kind !== "existing_line" || !target.directedContext) return [target];
+    return [
+      { entry: target.entry },
+      {
+        entry: {
+          kind: "personnel_target",
+          reason: target.directedContext.reason,
+          requiresPersistentLine: target.directedContext.requiresPersistentLine,
+          humanAgentId: target.entry.line.humanAgentId,
+          wakeAgentId: target.entry.line.wakeAgentId,
+          externalUsername: target.directedContext.externalUsername,
+        },
+      },
+    ];
+  });
+}
+
 function existingMappedChatIdsForProjection(audience: ScmAudienceTarget<GithubProviderTaskContext>[]): string[] {
   return [
     ...new Set(audience.flatMap((target) => (target.entry.kind === "existing_line" ? [target.entry.line.chatId] : []))),
@@ -248,7 +281,7 @@ function entityFromEvent(event: NormalizedScmEvent): GithubEntity {
   };
 }
 
-type ResolvedChat = { chatId: string; created: boolean };
+type ResolvedChat = { chatId: string; created: boolean; personnelLineExisted?: boolean };
 
 async function resolveChatFor(
   app: FastifyInstance,
@@ -257,36 +290,24 @@ async function resolveChatFor(
   options: DeliveryOptions,
 ): Promise<ResolvedChat | null> {
   if (target.entry.kind === "existing_line") {
-    return { chatId: target.entry.line.chatId, created: false };
+    return resolveGithubExistingLineChat(app.db, {
+      organizationId: event.source.organizationId,
+      humanAgentId: target.entry.line.humanAgentId,
+      delegateAgentId: target.entry.line.wakeAgentId,
+      entity: entityFromEvent(event),
+    });
   }
   if (target.entry.kind === "legacy_route") {
     return { chatId: target.entry.route.chatId, created: false };
   }
   const humanAgentId = target.entry.humanAgentId;
   const wakeAgentId = target.entry.wakeAgentId;
-  const entity: GithubEntity = {
-    type: event.entity.type,
-    key: event.entity.key,
-    title: event.entity.title,
-    url: event.entity.url,
-  };
-  const intent =
-    target.entry.kind === "provider_task_target"
-      ? ({ kind: "provider_task_target" } as const)
-      : await decideGithubPersonnelTargetChat(
-          app.db,
-          event.source.organizationId,
-          entity,
-          humanAgentId,
-          wakeAgentId,
-          target.entry.reason,
-        );
-
+  const entity = entityFromEvent(event);
   const relatedEntities: GithubEntity[] = event.relatedRefs.map((ref) => ({
     type: "issue",
     key: ref.key,
   }));
-  const resolved = await resolveTargetChat(app.db, {
+  const baseParams = {
     organizationId: event.source.organizationId,
     humanAgentId,
     delegateAgentId: wakeAgentId,
@@ -300,17 +321,31 @@ async function resolveChatFor(
     // opened creation event. Subscription targets short-circuit above; the
     // guard is still wired so any future caller is safe by default.
     isMentionMatched: true,
-    intent,
+  };
+  if (target.entry.kind === "provider_task_target") {
+    const resolved = await resolveTargetChat(app.db, { ...baseParams, intent: { kind: "provider_task_target" } });
+    if (!resolved) return null;
+    if (
+      target.entry.providerContext.kind === "github_app_task" &&
+      target.entry.providerContext.agentUuid === wakeAgentId
+    ) {
+      await applyMembershipWrite(app.db, resolved.chatId, [{ agentId: wakeAgentId }], {
+        upgradeWatcherToSpeaker: true,
+      });
+    }
+    return { chatId: resolved.chatId, created: resolved.created };
+  }
+
+  const resolved = await resolveGithubPersonnelTargetChat(app.db, {
+    ...baseParams,
+    requiresPersistentLine: target.entry.requiresPersistentLine,
   });
   if (!resolved) return null;
-  if (
-    target.entry.kind === "provider_task_target" &&
-    target.entry.providerContext.kind === "github_app_task" &&
-    target.entry.providerContext.agentUuid === wakeAgentId
-  ) {
-    await applyMembershipWrite(app.db, resolved.chatId, [{ agentId: wakeAgentId }], { upgradeWatcherToSpeaker: true });
-  }
-  return { chatId: resolved.chatId, created: resolved.created };
+  return {
+    chatId: resolved.chatId,
+    created: resolved.created,
+    personnelLineExisted: resolved.lineExisted,
+  };
 }
 
 /**

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -312,21 +312,26 @@ async function resolveTargetChatInTransaction(
     }
   }
 
-  // (b) Fixes-link reuse.
-  for (const ref of relatedEntities) {
-    const linked = await lookupMapping(db, organizationId, humanAgentId, delegateAgentId, ref);
-    if (!linked) continue;
-    const inserted = await insertMappingIfAbsent(db, {
-      organizationId,
-      humanAgentId,
-      delegateAgentId,
-      entity,
-      chatId: linked.chatId,
-      boundVia: "fixes_link",
-      entityState,
-    });
-    // If the insert lost a race, our re-read returns the winner's row.
-    return { chatId: inserted.chatId, created: false, boundVia: inserted.boundVia };
+  // (b) Fixes-link reuse remains a provider-task behavior. A strict personnel
+  // target has already failed safe co-location against its entity candidates;
+  // reusing an unrelated entity's mapping here would bypass the locked speaker
+  // snapshot and could persist a line whose wake agent is no longer a speaker.
+  if (intent.kind === "provider_task_target") {
+    for (const ref of relatedEntities) {
+      const linked = await lookupMapping(db, organizationId, humanAgentId, delegateAgentId, ref);
+      if (!linked) continue;
+      const inserted = await insertMappingIfAbsent(db, {
+        organizationId,
+        humanAgentId,
+        delegateAgentId,
+        entity,
+        chatId: linked.chatId,
+        boundVia: "fixes_link",
+        entityState,
+      });
+      // If the insert lost a race, our re-read returns the winner's row.
+      return { chatId: inserted.chatId, created: false, boundVia: inserted.boundVia };
+    }
   }
 
   // (b.5) Creation-event guard. `pull_request.opened` / `issues.opened` must

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -7,14 +7,21 @@ import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 import { createLogger } from "../observability/index.js";
 import { createChat } from "./chat.js";
+import { invalidateChatAudience } from "./chat-audience-cache.js";
 import {
   canonicalizeGithubEntityKey,
   githubEntityKeyCandidates,
   githubEntityKeysEquivalent,
 } from "./github-entity-key.js";
 import type { EntityState, EntityStateSeed } from "./github-entity-state.js";
+import { inviteParticipantsToChatInTransaction } from "./participant-invite.js";
 import { resolveAgentScmBindingPair } from "./scm-attention-line.js";
-import { decideScmPersonnelTargetChat, type ScmTargetChatDecision } from "./scm-target-chat-policy.js";
+import { githubEntityAttentionLockKey, withScmEntityAttentionTransaction } from "./scm-entity-attention-lock.js";
+import {
+  decideScmPersonnelTargetChat,
+  lockAndValidateScmPersonnelPlacement,
+  type ScmTargetChatDecision,
+} from "./scm-target-chat-policy.js";
 
 const log = createLogger("GithubEntityChat");
 
@@ -35,13 +42,12 @@ const log = createLogger("GithubEntityChat");
  *   - "human_declared"  — written by an explicit follow issued by a human
  *                         (user-scoped route); the delegate side comes from
  *                         the human's `delegate_mention`.
- *   - "human_fallback"  — sibling row written by step (a.5) when an event arrives
- *                         for a `(human, delegate)` pair that has no mapping yet,
- *                         but another delegate under the same `(human, entity)`
- *                         already does. Reuses the existing chat instead of
- *                         minting a fresh one. Surfaces in telemetry so we can
- *                         observe how often the involves→delegate mismatch path
- *                         actually fires in production.
+ *   - "human_fallback"  — sibling row written either by the provider-task
+ *                         human-scoped fallback in step (a.5), or by an
+ *                         explicit `reuse_with_line` personnel decision. The
+ *                         strict personnel path never performs a human lookup.
+ *                         Surfaces in telemetry so both controlled reuse paths
+ *                         remain auditable.
  *
  * Routing logic ignores the distinction; the column exists for audit and the
  * narrow `pull_request.opened` carve-out in `github-audience.ts`.
@@ -64,50 +70,110 @@ export function isCreationEvent(eventType: string, action: string): boolean {
   return (eventType === "pull_request" && action === "opened") || (eventType === "issues" && action === "opened");
 }
 
-/**
- * Reviewer-reuse routing (S9, deliver-once-per-chat). When an involved
- * `(human, delegate)` pair is NOT yet mapped to this entity but the entity
- * already has a **single** bound chat where BOTH the human and the delegate
- * are already speakers, the event routes into that chat instead of minting a
- * sibling one — and **no mapping row is written**. The pair sees the entity's
- * events through chat membership, and `deliverGithubEvent` dedups so the
- * chat receives one card whose wake-set includes this delegate.
- *
- * Returns a discriminated policy decision so the provider executor cannot
- * collapse `strict_new_line` into a nullable chat id and accidentally re-enter
- * human-scoped fallback. Preserves S1 (the chat follows, not the person) and
- * S7 (no followed chat is dropped).
- */
-export async function decideGithubPersonnelTargetChat(
-  db: Database,
-  organizationId: string,
-  entity: GithubEntity,
-  humanAgentId: string,
-  delegateAgentId: string,
-  reason: "review_requested" | "mentioned" | "assigned",
-): Promise<ScmTargetChatDecision> {
-  const candidateKeys = githubEntityKeyCandidates(entity.type, entity.key);
-  const boundChats = await db
-    .selectDistinct({ chatId: githubEntityChatMappings.chatId })
-    .from(githubEntityChatMappings)
-    .where(
-      and(
-        eq(githubEntityChatMappings.organizationId, organizationId),
-        eq(githubEntityChatMappings.entityType, entity.type),
-        inArray(githubEntityChatMappings.entityKey, candidateKeys),
-      ),
-    );
-  if (boundChats.length === 0) return { kind: "strict_new_line" };
+export type GithubTargetChatIntent = { kind: "provider_task_target" } | ScmTargetChatDecision;
 
-  return decideScmPersonnelTargetChat(db, {
-    reason,
-    candidateChatIds: boundChats.map((row) => row.chatId),
-    humanAgentId,
-    wakeAgentId: delegateAgentId,
-  });
+type ResolveTargetChatParams = Parameters<typeof resolveTargetChatInTransaction>[1];
+
+/** Re-read a composed existing line under the same entity lock as mutations. */
+export async function resolveGithubExistingLineChat(
+  db: Database,
+  params: {
+    organizationId: string;
+    humanAgentId: string;
+    delegateAgentId: string;
+    entity: GithubEntity;
+  },
+): Promise<{ chatId: string; created: false } | null> {
+  return withScmEntityAttentionTransaction(
+    db,
+    {
+      provider: "github",
+      scopeId: params.organizationId,
+      entityKey: githubEntityAttentionLockKey(params.entity.key),
+    },
+    async (tx) => {
+      const current = await lookupMapping(
+        tx,
+        params.organizationId,
+        params.humanAgentId,
+        params.delegateAgentId,
+        params.entity,
+      );
+      return current ? { chatId: current.chatId, created: false } : null;
+    },
+  );
 }
 
-export type GithubTargetChatIntent = { kind: "provider_task_target" } | ScmTargetChatDecision;
+/**
+ * Atomically place a fresh personnel target. Candidate selection, optional
+ * canonical membership admission, and the exact sibling mapping share one
+ * provider/entity transaction and serialization lock.
+ */
+export async function resolveGithubPersonnelTargetChat(
+  db: Database,
+  params: Omit<ResolveTargetChatParams, "intent"> & { requiresPersistentLine: boolean },
+): Promise<{ chatId: string; created: boolean; boundVia: BoundVia | null; lineExisted: boolean } | null> {
+  let membershipChangedChatId: string | null = null;
+  const result = await withScmEntityAttentionTransaction(
+    db,
+    {
+      provider: "github",
+      scopeId: params.organizationId,
+      entityKey: githubEntityAttentionLockKey(params.entity.key),
+    },
+    async (tx) => {
+      const candidateKeys = githubEntityKeyCandidates(params.entity.type, params.entity.key);
+      const candidateChats = await tx
+        .selectDistinct({ chatId: githubEntityChatMappings.chatId })
+        .from(githubEntityChatMappings)
+        .where(
+          and(
+            eq(githubEntityChatMappings.organizationId, params.organizationId),
+            eq(githubEntityChatMappings.entityType, params.entity.type),
+            inArray(githubEntityChatMappings.entityKey, candidateKeys),
+          ),
+        );
+      const candidateChatIds = candidateChats.map((row) => row.chatId);
+      const placement = await lockAndValidateScmPersonnelPlacement(tx, {
+        humanAgentId: params.humanAgentId,
+        wakeAgentId: params.delegateAgentId,
+        candidateChatIds,
+      });
+      if (!placement) return null;
+
+      const direct = await lookupMapping(
+        tx,
+        params.organizationId,
+        params.humanAgentId,
+        params.delegateAgentId,
+        params.entity,
+      );
+      if (direct) return { chatId: direct.chatId, created: false, boundVia: direct.boundVia, lineExisted: true };
+
+      const decision = await decideScmPersonnelTargetChat(tx, {
+        requiresPersistentLine: params.requiresPersistentLine,
+        candidateChatIds,
+        humanAgentId: params.humanAgentId,
+        wakeAgentId: params.delegateAgentId,
+        authority: placement.authority,
+        speakerSnapshot: placement.speakerSnapshot,
+      });
+      if (decision.kind === "reuse_with_line" && decision.admitWakeAgent) {
+        const changed = await inviteParticipantsToChatInTransaction(tx, {
+          chatId: decision.chatId,
+          callerAgentId: params.humanAgentId,
+          targetAgentIds: [params.delegateAgentId],
+          errorOnAlreadySpeaker: false,
+        });
+        if (changed) membershipChangedChatId = decision.chatId;
+      }
+      const placed = await resolveTargetChatInTransaction(tx, { ...params, intent: decision });
+      return placed ? { ...placed, lineExisted: false } : null;
+    },
+  );
+  if (membershipChangedChatId) invalidateChatAudience(membershipChangedChatId);
+  return result;
+}
 
 /**
  * Resolve which chat a GitHub event for (human, delegate, entity) belongs to.
@@ -120,10 +186,8 @@ export type GithubTargetChatIntent = { kind: "provider_task_target" } | ScmTarge
  *   c. Miss — create a fresh chat via the canonical `createChat` entrypoint
  *      and write a `direct` mapping row.
  *
- * Concurrent webhook deliveries for a never-before-seen entity race on (c);
- * the composite primary key + ON CONFLICT DO NOTHING ensures only one row
- * survives. The losing caller falls back to a re-read so the chat stays
- * unique.
+ * Every caller runs under the provider/entity attention lock, so a fresh
+ * exact pair has one serialized winner even before a mapping row exists.
  */
 export async function resolveTargetChat(
   db: Database,
@@ -164,6 +228,32 @@ export async function resolveTargetChat(
     entityStateSeed?: EntityStateSeed | null;
   },
 ): Promise<{ chatId: string; created: boolean; boundVia: BoundVia | null } | null> {
+  return withScmEntityAttentionTransaction(
+    db,
+    {
+      provider: "github",
+      scopeId: params.organizationId,
+      entityKey: githubEntityAttentionLockKey(params.entity.key),
+    },
+    (tx) => resolveTargetChatInTransaction(tx, params),
+  );
+}
+
+async function resolveTargetChatInTransaction(
+  db: Database,
+  params: {
+    organizationId: string;
+    humanAgentId: string;
+    delegateAgentId: string;
+    entity: GithubEntity;
+    relatedEntities: GithubEntity[];
+    eventType: string;
+    action: string;
+    isMentionMatched: boolean;
+    intent: GithubTargetChatIntent;
+    entityStateSeed?: EntityStateSeed | null;
+  },
+): Promise<{ chatId: string; created: boolean; boundVia: BoundVia | null } | null> {
   const {
     organizationId,
     humanAgentId,
@@ -179,14 +269,26 @@ export async function resolveTargetChat(
   const relatedEntities = rawRelatedEntities.map(normalizeGithubEntity);
   const entityState = stateSeedForEntity(params.entityStateSeed ?? null, entity);
 
-  if (intent.kind === "reuse") {
-    return { chatId: intent.chatId, created: false, boundVia: null };
-  }
-
   // (a) Direct hit.
   const direct = await lookupMapping(db, organizationId, humanAgentId, delegateAgentId, entity);
   if (direct) {
     return { chatId: direct.chatId, created: false, boundVia: direct.boundVia };
+  }
+
+  if (intent.kind === "reuse_membership") {
+    return { chatId: intent.chatId, created: false, boundVia: null };
+  }
+  if (intent.kind === "reuse_with_line") {
+    const inserted = await insertMappingIfAbsent(db, {
+      organizationId,
+      humanAgentId,
+      delegateAgentId,
+      entity,
+      chatId: intent.chatId,
+      boundVia: "human_fallback",
+      entityState,
+    });
+    return { chatId: inserted.chatId, created: false, boundVia: inserted.boundVia };
   }
 
   // (a.5) Provider-task human-scoped fallback. Personnel
@@ -239,12 +341,8 @@ export async function resolveTargetChat(
     return null;
   }
 
-  // (c) Miss — create a fresh chat. Two concurrent (c)-path callers for the
-  // same (org, human, delegate, entity) tuple cause two chats; the second one
-  // is unreachable because the primary key on the mapping row points at the
-  // first chat. The orphan chat is harmless (no participants beyond the two
-  // agents, no messages — we have not yet written one) and the design accepts
-  // it as the cost of avoiding a serialisable transaction on every webhook.
+  // (c) Miss — create a fresh chat. The entity attention lock serializes this
+  // path with other target placement, follow, rebind, and unfollow mutations.
   const chat = await createEntityChat(db, humanAgentId, delegateAgentId, entity, eventType, action);
   const inserted = await insertMappingIfAbsent(db, {
     organizationId,

--- a/packages/server/src/services/github-entity-follow.ts
+++ b/packages/server/src/services/github-entity-follow.ts
@@ -11,7 +11,13 @@ import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
-import { BadRequestError, NotFoundError, ServiceUnavailableError, UnprocessableError } from "../errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  ServiceUnavailableError,
+  UnprocessableError,
+} from "../errors.js";
 import { createLogger } from "../observability/index.js";
 import { GITHUB_API_BASE } from "./github-api-base.js";
 import type { GithubAppCredentials } from "./github-app.js";
@@ -21,7 +27,12 @@ import { insertMappingIfAbsent } from "./github-entity-chat.js";
 import { githubEntityDedupKey, githubEntityKeyCandidates, legacyDiscussionEntityKey } from "./github-entity-key.js";
 import { materializeChatGithubEntity } from "./github-entity-live.js";
 import { type EntityState, setEntityTitle } from "./github-entity-state.js";
-import { executeScmFollowLine } from "./scm-attention-line.js";
+import {
+  executeScmFollowLine,
+  lockAndResolveAgentScmBindingPair,
+  lockAndResolveHumanScmBindingPair,
+} from "./scm-attention-line.js";
+import { githubEntityAttentionLockKey, withScmEntityAttentionTransaction } from "./scm-entity-attention-lock.js";
 
 const log = createLogger("GithubEntityFollow");
 
@@ -427,138 +438,163 @@ export async function declareEntityFollow(
     number: entity.number,
   };
 
-  type GithubFollowLine = { chatId: string; boundVia: GithubEntityBoundVia; entityKey: string };
-  const entityKeyCandidates = githubEntityKeyCandidates(entity.entityType, entity.entityKey);
-  const listLines = async (): Promise<GithubFollowLine[]> => {
-    const rows = await db
-      .select({
-        chatId: githubEntityChatMappings.chatId,
-        boundVia: githubEntityChatMappings.boundVia,
-        entityKey: githubEntityChatMappings.entityKey,
-      })
-      .from(githubEntityChatMappings)
-      .where(
-        and(
-          eq(githubEntityChatMappings.organizationId, params.organizationId),
-          eq(githubEntityChatMappings.humanAgentId, params.humanAgentId),
-          eq(githubEntityChatMappings.delegateAgentId, params.delegateAgentId),
-          eq(githubEntityChatMappings.entityType, entity.entityType),
-          inArray(githubEntityChatMappings.entityKey, entityKeyCandidates),
-        ),
-      )
-      .orderBy(
-        desc(sql`${githubEntityChatMappings.entityKey} = ${entity.entityKey}`),
-        asc(githubEntityChatMappings.boundAt),
-      );
-    return rows.map((row) => {
-      const parsed = githubEntityBoundViaSchema.safeParse(row.boundVia);
-      return {
-        chatId: row.chatId,
-        boundVia: parsed.success ? parsed.data : "direct",
-        entityKey: row.entityKey,
-      };
-    });
-  };
+  return withScmEntityAttentionTransaction(
+    db,
+    {
+      provider: "github",
+      scopeId: params.organizationId,
+      entityKey: githubEntityAttentionLockKey(entity.entityKey),
+    },
+    async (tx) => {
+      const currentPair =
+        params.boundVia === "agent_declared"
+          ? await lockAndResolveAgentScmBindingPair(tx, params.chatId, params.delegateAgentId)
+          : await lockAndResolveHumanScmBindingPair(tx, params.chatId, params.humanAgentId);
+      if (
+        !currentPair ||
+        currentPair.organizationId !== params.organizationId ||
+        currentPair.humanAgentId !== params.humanAgentId ||
+        currentPair.wakeAgentId !== params.delegateAgentId
+      ) {
+        throw new ConflictError(
+          "GitHub follow authority changed while resolving the entity; retry from current chat state",
+        );
+      }
 
-  // Refresh an existing row before the shared state machine moves it. A
-  // vanished-row fallback insert seeds the same title through createLine.
-  if (entity.title && entity.title.length > 0) {
-    await setEntityTitle(db, {
-      organizationId: params.organizationId,
-      entityType: entity.entityType,
-      entityKey: entityKeyCandidates,
-      title: entity.title,
-    });
-  }
-
-  const result = await executeScmFollowLine({
-    targetChatId: params.chatId,
-    rebind: params.rebind,
-    storage: {
-      listLines,
-      removeLines: async (rows) => {
-        const keys = rows.map((row) => row.entityKey);
-        if (keys.length === 0) return;
-        await db
-          .delete(githubEntityChatMappings)
-          .where(
-            and(
-              eq(githubEntityChatMappings.organizationId, params.organizationId),
-              eq(githubEntityChatMappings.humanAgentId, params.humanAgentId),
-              eq(githubEntityChatMappings.delegateAgentId, params.delegateAgentId),
-              eq(githubEntityChatMappings.entityType, entity.entityType),
-              inArray(githubEntityChatMappings.entityKey, keys),
-            ),
-          );
-      },
-      getChatTopic: async (chatId) => {
-        const [chat] = await db.select({ topic: chats.topic }).from(chats).where(eq(chats.id, chatId)).limit(1);
-        return chat?.topic ?? null;
-      },
-      moveLine: async (row) => {
-        const [moved] = await db
-          .update(githubEntityChatMappings)
-          .set({
-            chatId: params.chatId,
-            boundVia: params.boundVia,
-            entityState: entity.entityState,
-            boundAt: new Date(),
-          })
-          .where(
-            and(
-              eq(githubEntityChatMappings.organizationId, params.organizationId),
-              eq(githubEntityChatMappings.humanAgentId, params.humanAgentId),
-              eq(githubEntityChatMappings.delegateAgentId, params.delegateAgentId),
-              eq(githubEntityChatMappings.entityType, entity.entityType),
-              eq(githubEntityChatMappings.entityKey, row.entityKey),
-            ),
-          )
-          .returning({
+      type GithubFollowLine = { chatId: string; boundVia: GithubEntityBoundVia; entityKey: string };
+      const entityKeyCandidates = githubEntityKeyCandidates(entity.entityType, entity.entityKey);
+      const listLines = async (): Promise<GithubFollowLine[]> => {
+        const rows = await tx
+          .select({
             chatId: githubEntityChatMappings.chatId,
             boundVia: githubEntityChatMappings.boundVia,
             entityKey: githubEntityChatMappings.entityKey,
-          });
-        return moved ? { ...moved, boundVia: params.boundVia } : null;
-      },
-      createLine: async () => {
-        const inserted = await insertMappingIfAbsent(db, {
-          organizationId: params.organizationId,
-          humanAgentId: params.humanAgentId,
-          delegateAgentId: params.delegateAgentId,
-          entity: {
-            type: entity.entityType,
-            key: entity.entityKey,
-            url: entity.htmlUrl,
-            title: entity.title ?? undefined,
-          },
-          chatId: params.chatId,
-          boundVia: params.boundVia,
-          entityState: entity.entityState,
+          })
+          .from(githubEntityChatMappings)
+          .where(
+            and(
+              eq(githubEntityChatMappings.organizationId, params.organizationId),
+              eq(githubEntityChatMappings.humanAgentId, params.humanAgentId),
+              eq(githubEntityChatMappings.delegateAgentId, params.delegateAgentId),
+              eq(githubEntityChatMappings.entityType, entity.entityType),
+              inArray(githubEntityChatMappings.entityKey, entityKeyCandidates),
+            ),
+          )
+          .orderBy(
+            desc(sql`${githubEntityChatMappings.entityKey} = ${entity.entityKey}`),
+            asc(githubEntityChatMappings.boundAt),
+          );
+        return rows.map((row) => {
+          const parsed = githubEntityBoundViaSchema.safeParse(row.boundVia);
+          return {
+            chatId: row.chatId,
+            boundVia: parsed.success ? parsed.data : "direct",
+            entityKey: row.entityKey,
+          };
         });
-        const lines = await listLines();
-        const record = lines.find((line) => line.chatId === inserted.chatId) ?? lines[0];
-        if (!record) throw new Error("GitHub follow insert completed without a surviving mapping");
-        return { record, inserted: inserted.inserted };
-      },
-    },
-  });
+      };
 
-  if (result.outcome === "conflict") return result;
-  if (result.outcome === "created") {
-    log.info(
-      { chatId: params.chatId, entityKey: entity.entityKey, boundVia: params.boundVia },
-      "github follow recorded",
-    );
-  } else if (result.outcome === "rebound") {
-    log.info({ toChatId: params.chatId, entityKey: entity.entityKey }, "github follow rebound");
-  }
-  return {
-    outcome: result.outcome,
-    entity: {
-      ...wireEntity,
-      ...(result.outcome === "already_following" ? { boundVia: result.record.boundVia } : {}),
+      // Refresh an existing row before the shared state machine moves it. A
+      // vanished-row fallback insert seeds the same title through createLine.
+      if (entity.title && entity.title.length > 0) {
+        await setEntityTitle(tx, {
+          organizationId: params.organizationId,
+          entityType: entity.entityType,
+          entityKey: entityKeyCandidates,
+          title: entity.title,
+        });
+      }
+
+      const result = await executeScmFollowLine({
+        targetChatId: params.chatId,
+        rebind: params.rebind,
+        storage: {
+          listLines,
+          removeLines: async (rows) => {
+            const keys = rows.map((row) => row.entityKey);
+            if (keys.length === 0) return;
+            await tx
+              .delete(githubEntityChatMappings)
+              .where(
+                and(
+                  eq(githubEntityChatMappings.organizationId, params.organizationId),
+                  eq(githubEntityChatMappings.humanAgentId, params.humanAgentId),
+                  eq(githubEntityChatMappings.delegateAgentId, params.delegateAgentId),
+                  eq(githubEntityChatMappings.entityType, entity.entityType),
+                  inArray(githubEntityChatMappings.entityKey, keys),
+                ),
+              );
+          },
+          getChatTopic: async (chatId) => {
+            const [chat] = await tx.select({ topic: chats.topic }).from(chats).where(eq(chats.id, chatId)).limit(1);
+            return chat?.topic ?? null;
+          },
+          moveLine: async (row) => {
+            const [moved] = await tx
+              .update(githubEntityChatMappings)
+              .set({
+                chatId: params.chatId,
+                boundVia: params.boundVia,
+                entityState: entity.entityState,
+                boundAt: new Date(),
+              })
+              .where(
+                and(
+                  eq(githubEntityChatMappings.organizationId, params.organizationId),
+                  eq(githubEntityChatMappings.humanAgentId, params.humanAgentId),
+                  eq(githubEntityChatMappings.delegateAgentId, params.delegateAgentId),
+                  eq(githubEntityChatMappings.entityType, entity.entityType),
+                  eq(githubEntityChatMappings.entityKey, row.entityKey),
+                ),
+              )
+              .returning({
+                chatId: githubEntityChatMappings.chatId,
+                boundVia: githubEntityChatMappings.boundVia,
+                entityKey: githubEntityChatMappings.entityKey,
+              });
+            return moved ? { ...moved, boundVia: params.boundVia } : null;
+          },
+          createLine: async () => {
+            const inserted = await insertMappingIfAbsent(tx, {
+              organizationId: params.organizationId,
+              humanAgentId: params.humanAgentId,
+              delegateAgentId: params.delegateAgentId,
+              entity: {
+                type: entity.entityType,
+                key: entity.entityKey,
+                url: entity.htmlUrl,
+                title: entity.title ?? undefined,
+              },
+              chatId: params.chatId,
+              boundVia: params.boundVia,
+              entityState: entity.entityState,
+            });
+            const lines = await listLines();
+            const record = lines.find((line) => line.chatId === inserted.chatId) ?? lines[0];
+            if (!record) throw new Error("GitHub follow insert completed without a surviving mapping");
+            return { record, inserted: inserted.inserted };
+          },
+        },
+      });
+
+      if (result.outcome === "conflict") return result;
+      if (result.outcome === "created") {
+        log.info(
+          { chatId: params.chatId, entityKey: entity.entityKey, boundVia: params.boundVia },
+          "github follow recorded",
+        );
+      } else if (result.outcome === "rebound") {
+        log.info({ toChatId: params.chatId, entityKey: entity.entityKey }, "github follow rebound");
+      }
+      return {
+        outcome: result.outcome,
+        entity: {
+          ...wireEntity,
+          ...(result.outcome === "already_following" ? { boundVia: result.record.boundVia } : {}),
+        },
+      };
     },
-  };
+  );
 }
 
 /**
@@ -578,60 +614,78 @@ export async function removeEntityFollow(
   params: { chatId: string; entity: string },
 ): Promise<{ removed: number }> {
   const ref = parseEntityReferenceOrThrow(params.entity);
+  const [chat] = await db
+    .select({ organizationId: chats.organizationId })
+    .from(chats)
+    .where(eq(chats.id, params.chatId))
+    .limit(1);
+  if (!chat) return { removed: 0 };
+  const entityLockKey =
+    ref.kind === "commit" ? `${ref.owner}/${ref.repo}@${ref.sha}` : `${ref.owner}/${ref.repo}#${ref.number}`;
 
-  const chatCond = eq(githubEntityChatMappings.chatId, params.chatId);
-  let removedRows: Array<{ entityKey: string }>;
-  if (ref.kind === "commit") {
-    // Prefix match so a short sha unfollows the full-sha row; LIKE
-    // metacharacters in owner/repo (GitHub allows `_`) are escaped so the
-    // pattern can't over-match sibling repos.
-    const prefix = escapeLikeLiteral(`${ref.owner}/${ref.repo}@${ref.sha}`.toLowerCase());
-    removedRows = await db
-      .delete(githubEntityChatMappings)
-      .where(
-        and(
-          chatCond,
-          eq(githubEntityChatMappings.entityType, "commit"),
-          sql`lower(${githubEntityChatMappings.entityKey}) LIKE ${`${prefix}%`}`,
-        ),
-      )
-      .returning({ entityKey: githubEntityChatMappings.entityKey });
-  } else {
-    const key = `${ref.owner}/${ref.repo}#${ref.number}`.toLowerCase();
-    // Type matching without a GitHub call (unfollow must not depend on
-    // GitHub being up):
-    //   - Issues and PRs share one numbering space, and follow auto-corrects
-    //     a `/pull/N` URL that actually points at an issue (and vice versa)
-    //     — so an explicit issue/PR reference matches BOTH types, otherwise
-    //     the row created through the auto-corrected follow could never be
-    //     removed with the same reference the caller used to create it.
-    //   - Discussions number independently; an explicit `/discussions/N`
-    //     URL matches only discussions, and only the bare `owner/repo#N`
-    //     form sweeps all three ("make this chat quiet about #N").
-    const types: GithubEntityType[] =
-      ref.explicitType === "discussion"
-        ? ["discussion"]
-        : ref.explicitType !== null
-          ? ["issue", "pull_request"]
-          : ["issue", "pull_request", "discussion"];
-    const lowerKeys = new Set([key]);
-    if (types.includes("discussion")) {
-      const legacyKey = legacyDiscussionEntityKey(key);
-      if (legacyKey) lowerKeys.add(legacyKey);
-    }
-    const keyConditions = [...lowerKeys].map(
-      (lowerKey) => sql`lower(${githubEntityChatMappings.entityKey}) = ${lowerKey}`,
-    );
-    removedRows = await db
-      .delete(githubEntityChatMappings)
-      .where(and(chatCond, inArray(githubEntityChatMappings.entityType, types), or(...keyConditions)))
-      .returning({ entityKey: githubEntityChatMappings.entityKey });
-  }
+  return withScmEntityAttentionTransaction(
+    db,
+    {
+      provider: "github",
+      scopeId: chat.organizationId,
+      entityKey: githubEntityAttentionLockKey(entityLockKey),
+    },
+    async (tx) => {
+      const chatCond = eq(githubEntityChatMappings.chatId, params.chatId);
+      let removedRows: Array<{ entityKey: string }>;
+      if (ref.kind === "commit") {
+        // Prefix match so a short sha unfollows the full-sha row; LIKE
+        // metacharacters in owner/repo (GitHub allows `_`) are escaped so the
+        // pattern can't over-match sibling repos.
+        const prefix = escapeLikeLiteral(`${ref.owner}/${ref.repo}@${ref.sha}`.toLowerCase());
+        removedRows = await tx
+          .delete(githubEntityChatMappings)
+          .where(
+            and(
+              chatCond,
+              eq(githubEntityChatMappings.entityType, "commit"),
+              sql`lower(${githubEntityChatMappings.entityKey}) LIKE ${`${prefix}%`}`,
+            ),
+          )
+          .returning({ entityKey: githubEntityChatMappings.entityKey });
+      } else {
+        const key = `${ref.owner}/${ref.repo}#${ref.number}`.toLowerCase();
+        // Type matching without a GitHub call (unfollow must not depend on
+        // GitHub being up):
+        //   - Issues and PRs share one numbering space, and follow auto-corrects
+        //     a `/pull/N` URL that actually points at an issue (and vice versa)
+        //     — so an explicit issue/PR reference matches BOTH types, otherwise
+        //     the row created through the auto-corrected follow could never be
+        //     removed with the same reference the caller used to create it.
+        //   - Discussions number independently; an explicit `/discussions/N`
+        //     URL matches only discussions, and only the bare `owner/repo#N`
+        //     form sweeps all three ("make this chat quiet about #N").
+        const types: GithubEntityType[] =
+          ref.explicitType === "discussion"
+            ? ["discussion"]
+            : ref.explicitType !== null
+              ? ["issue", "pull_request"]
+              : ["issue", "pull_request", "discussion"];
+        const lowerKeys = new Set([key]);
+        if (types.includes("discussion")) {
+          const legacyKey = legacyDiscussionEntityKey(key);
+          if (legacyKey) lowerKeys.add(legacyKey);
+        }
+        const keyConditions = [...lowerKeys].map(
+          (lowerKey) => sql`lower(${githubEntityChatMappings.entityKey}) = ${lowerKey}`,
+        );
+        removedRows = await tx
+          .delete(githubEntityChatMappings)
+          .where(and(chatCond, inArray(githubEntityChatMappings.entityType, types), or(...keyConditions)))
+          .returning({ entityKey: githubEntityChatMappings.entityKey });
+      }
 
-  if (removedRows.length > 0) {
-    log.info({ chatId: params.chatId, entity: params.entity, removed: removedRows.length }, "github unfollow");
-  }
-  return { removed: removedRows.length };
+      if (removedRows.length > 0) {
+        log.info({ chatId: params.chatId, entity: params.entity, removed: removedRows.length }, "github unfollow");
+      }
+      return { removed: removedRows.length };
+    },
+  );
 }
 
 /**

--- a/packages/server/src/services/gitlab-entity-follow.ts
+++ b/packages/server/src/services/gitlab-entity-follow.ts
@@ -13,7 +13,12 @@ import { gitlabEntityChatMappings } from "../db/schema/gitlab-entity-chat-mappin
 import { BadRequestError, ConflictError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
 import { withCurrentGitlabConnectionFence } from "./gitlab-connections.js";
-import { executeScmFollowLine } from "./scm-attention-line.js";
+import {
+  executeScmFollowLine,
+  lockAndResolveAgentScmBindingPair,
+  lockAndResolveHumanScmBindingPair,
+} from "./scm-attention-line.js";
+import { lockGitlabEntityAttention } from "./scm-entity-attention-lock.js";
 import { refreshGitlabEntityTopic } from "./scm-entity-chat-topic.js";
 
 export type GitlabEntityIdentity = {
@@ -126,12 +131,56 @@ export async function declareGitlabEntityFollowWithStatus(
       const parsed = parseGitlabEntityUrl(connection.instanceOrigin, input.entityUrl);
       const boundVia = input.boundVia ?? "agent_declared";
       const normalizedPath = normalizeGitlabProjectPath(parsed.projectPath);
-      const entityMatch = and(
+      const pathEntityMatch = and(
         eq(gitlabEntityChatMappings.connectionId, connection.id),
         eq(gitlabEntityChatMappings.projectPathNormalized, normalizedPath),
         eq(gitlabEntityChatMappings.entityType, parsed.entityType),
         eq(gitlabEntityChatMappings.entityIid, parsed.entityIid),
         eq(gitlabEntityChatMappings.active, true),
+      );
+      await lockGitlabEntityAttention(rawTx, {
+        connectionId: connection.id,
+        projectPathNormalized: normalizedPath,
+        entityType: parsed.entityType,
+        entityIid: parsed.entityIid,
+      });
+      const observedRows = await rawTx
+        .select({ projectId: gitlabEntityChatMappings.projectId })
+        .from(gitlabEntityChatMappings)
+        .where(pathEntityMatch);
+      const observedProjectIds = [
+        ...new Set(observedRows.flatMap((row) => (row.projectId === null ? [] : [row.projectId]))),
+      ].sort((a, b) => a - b);
+      await lockGitlabEntityAttention(rawTx, {
+        connectionId: connection.id,
+        projectPathNormalized: normalizedPath,
+        projectIds: observedProjectIds,
+        entityType: parsed.entityType,
+        entityIid: parsed.entityIid,
+      });
+      const currentPair =
+        boundVia === "agent_declared"
+          ? await lockAndResolveAgentScmBindingPair(rawTx, input.chatId, input.declaredByAgentId)
+          : await lockAndResolveHumanScmBindingPair(rawTx, input.chatId, input.declaredByAgentId);
+      if (
+        !currentPair ||
+        currentPair.organizationId !== input.organizationId ||
+        currentPair.humanAgentId !== input.humanAgentId ||
+        currentPair.wakeAgentId !== input.delegateAgentId
+      ) {
+        throw new ConflictError("GitLab follow authority changed before persistence; retry from current chat state");
+      }
+      const entityMatch = and(
+        eq(gitlabEntityChatMappings.connectionId, connection.id),
+        eq(gitlabEntityChatMappings.entityType, parsed.entityType),
+        eq(gitlabEntityChatMappings.entityIid, parsed.entityIid),
+        eq(gitlabEntityChatMappings.active, true),
+        observedProjectIds.length > 0
+          ? or(
+              eq(gitlabEntityChatMappings.projectPathNormalized, normalizedPath),
+              inArray(gitlabEntityChatMappings.projectId, observedProjectIds),
+            )
+          : eq(gitlabEntityChatMappings.projectPathNormalized, normalizedPath),
       );
       const pairMatch = and(
         entityMatch,
@@ -242,7 +291,7 @@ export async function declareGitlabEntityFollowWithStatus(
         },
       });
       if (result.outcome === "conflict") return result;
-      if (result.record.entityUrl !== parsed.entityUrl) {
+      if (result.record.projectId === null && result.record.entityUrl !== parsed.entityUrl) {
         const [updated] = await rawTx
           .update(gitlabEntityChatMappings)
           .set({
@@ -378,6 +427,7 @@ type GitlabEntityDeleteTarget = {
   | {
       scope: "entity";
       projectPathNormalized: string;
+      projectIds: number[];
       entityType: GitlabEntityIdentity["entityType"];
       entityIid: number;
     }
@@ -395,9 +445,14 @@ async function deleteGitlabEntityMappingsInChat(db: Database, target: GitlabEnti
         target.scope === "explicit_mapping"
           ? and(eq(gitlabEntityChatMappings.id, target.mappingId), explicitGitlabDeclarationPredicate())
           : and(
-              eq(gitlabEntityChatMappings.projectPathNormalized, target.projectPathNormalized),
               eq(gitlabEntityChatMappings.entityType, target.entityType),
               eq(gitlabEntityChatMappings.entityIid, target.entityIid),
+              target.projectIds.length > 0
+                ? or(
+                    eq(gitlabEntityChatMappings.projectPathNormalized, target.projectPathNormalized),
+                    inArray(gitlabEntityChatMappings.projectId, target.projectIds),
+                  )
+                : eq(gitlabEntityChatMappings.projectPathNormalized, target.projectPathNormalized),
             ),
       ),
     )
@@ -411,6 +466,26 @@ export async function removeGitlabEntityFollow(
   input: { organizationId: string; chatId: string; mappingId: string },
 ): Promise<number> {
   return withCurrentGitlabConnectionFence(db, { organizationId: input.organizationId }, async (tx, connection) => {
+    const [mapping] = await tx
+      .select({
+        projectPathNormalized: gitlabEntityChatMappings.projectPathNormalized,
+        projectId: gitlabEntityChatMappings.projectId,
+        entityType: gitlabEntityChatMappings.entityType,
+        entityIid: gitlabEntityChatMappings.entityIid,
+      })
+      .from(gitlabEntityChatMappings)
+      .where(
+        and(eq(gitlabEntityChatMappings.id, input.mappingId), eq(gitlabEntityChatMappings.connectionId, connection.id)),
+      )
+      .limit(1);
+    if (!mapping) return 0;
+    await lockGitlabEntityAttention(tx, {
+      connectionId: connection.id,
+      projectPathNormalized: mapping.projectPathNormalized,
+      projectIds: mapping.projectId === null ? [] : [mapping.projectId],
+      entityType: mapping.entityType as GitlabEntityIdentity["entityType"],
+      entityIid: mapping.entityIid,
+    });
     return deleteGitlabEntityMappingsInChat(tx, {
       scope: "explicit_mapping",
       connectionId: connection.id,
@@ -427,11 +502,41 @@ export async function removeCurrentGitlabEntityFollow(
 ): Promise<UnfollowChatGitlabEntityResponse> {
   return withCurrentGitlabConnectionFence(db, { organizationId: input.organizationId }, async (tx, connection) => {
     const parsed = parseGitlabEntityUrl(connection.instanceOrigin, input.entityUrl);
+    const normalizedPath = normalizeGitlabProjectPath(parsed.projectPath);
+    await lockGitlabEntityAttention(tx, {
+      connectionId: connection.id,
+      projectPathNormalized: normalizedPath,
+      entityType: parsed.entityType,
+      entityIid: parsed.entityIid,
+    });
+    const observedRows = await tx
+      .select({ projectId: gitlabEntityChatMappings.projectId })
+      .from(gitlabEntityChatMappings)
+      .where(
+        and(
+          eq(gitlabEntityChatMappings.connectionId, connection.id),
+          eq(gitlabEntityChatMappings.projectPathNormalized, normalizedPath),
+          eq(gitlabEntityChatMappings.entityType, parsed.entityType),
+          eq(gitlabEntityChatMappings.entityIid, parsed.entityIid),
+          eq(gitlabEntityChatMappings.active, true),
+        ),
+      );
+    const observedProjectIds = [
+      ...new Set(observedRows.flatMap((row) => (row.projectId === null ? [] : [row.projectId]))),
+    ].sort((a, b) => a - b);
+    await lockGitlabEntityAttention(tx, {
+      connectionId: connection.id,
+      projectPathNormalized: normalizedPath,
+      projectIds: observedProjectIds,
+      entityType: parsed.entityType,
+      entityIid: parsed.entityIid,
+    });
     const removed = await deleteGitlabEntityMappingsInChat(tx, {
       scope: "entity",
       connectionId: connection.id,
       chatId: input.chatId,
-      projectPathNormalized: normalizeGitlabProjectPath(parsed.projectPath),
+      projectPathNormalized: normalizedPath,
+      projectIds: observedProjectIds,
       entityType: parsed.entityType,
       entityIid: parsed.entityIid,
     });
@@ -447,6 +552,13 @@ export async function observeGitlabEntityAndResolveFollowers(
 ) {
   const normalizedPath = normalizeGitlabProjectPath(entity.projectPath);
   return db.transaction(async (tx) => {
+    await lockGitlabEntityAttention(tx as unknown as Database, {
+      connectionId,
+      projectPathNormalized: normalizedPath,
+      projectIds: [entity.projectId],
+      entityType: entity.entityType,
+      entityIid: entity.entityIid,
+    });
     const candidates = await tx
       .select()
       .from(gitlabEntityChatMappings)

--- a/packages/server/src/services/gitlab-identities.ts
+++ b/packages/server/src/services/gitlab-identities.ts
@@ -237,6 +237,7 @@ export async function lockGitlabIdentityAuthoritySet(
     connectionId: string;
     normalizedUsernames: string[];
     identityLinkIds: string[];
+    humanAgentIds?: string[];
   },
 ): Promise<void> {
   const selectors = [];
@@ -246,32 +247,42 @@ export async function lockGitlabIdentityAuthoritySet(
   if (input.identityLinkIds.length > 0) {
     selectors.push(inArray(gitlabIdentityLinks.id, [...new Set(input.identityLinkIds)].sort()));
   }
-  if (selectors.length === 0) return;
-  const snapshots = await db
-    .select({ id: gitlabIdentityLinks.id, membershipId: gitlabIdentityLinks.membershipId })
-    .from(gitlabIdentityLinks)
-    .where(
-      and(
-        eq(gitlabIdentityLinks.organizationId, input.organizationId),
-        eq(gitlabIdentityLinks.connectionId, input.connectionId),
-        eq(gitlabIdentityLinks.state, "active"),
-        or(...selectors),
-      ),
-    );
-  if (snapshots.length === 0) return;
+  const snapshots =
+    selectors.length === 0
+      ? []
+      : await db
+          .select({ id: gitlabIdentityLinks.id, membershipId: gitlabIdentityLinks.membershipId })
+          .from(gitlabIdentityLinks)
+          .where(
+            and(
+              eq(gitlabIdentityLinks.organizationId, input.organizationId),
+              eq(gitlabIdentityLinks.connectionId, input.connectionId),
+              eq(gitlabIdentityLinks.state, "active"),
+              or(...selectors),
+            ),
+          );
   const membershipIds = [...new Set(snapshots.map((row) => row.membershipId))].sort();
-  await db
-    .select({ id: members.id })
-    .from(members)
-    .where(inArray(members.id, membershipIds))
-    .orderBy(asc(members.id))
-    .for("update");
-  await db
-    .select({ id: gitlabIdentityLinks.id })
-    .from(gitlabIdentityLinks)
-    .where(inArray(gitlabIdentityLinks.id, snapshots.map((row) => row.id).sort()))
-    .orderBy(asc(gitlabIdentityLinks.id))
-    .for("update");
+  const humanAgentIds = [...new Set(input.humanAgentIds ?? [])].sort();
+  if (membershipIds.length > 0 || humanAgentIds.length > 0) {
+    const memberSelectors = [];
+    if (membershipIds.length > 0) memberSelectors.push(inArray(members.id, membershipIds));
+    if (humanAgentIds.length > 0) memberSelectors.push(inArray(members.agentId, humanAgentIds));
+    await db
+      .select({ id: members.id })
+      .from(members)
+      .where(and(eq(members.organizationId, input.organizationId), or(...memberSelectors)))
+      .orderBy(asc(members.id))
+      .for("update");
+  }
+  const identityLinkIds = snapshots.map((row) => row.id).sort();
+  if (identityLinkIds.length > 0) {
+    await db
+      .select({ id: gitlabIdentityLinks.id })
+      .from(gitlabIdentityLinks)
+      .where(inArray(gitlabIdentityLinks.id, identityLinkIds))
+      .orderBy(asc(gitlabIdentityLinks.id))
+      .for("update");
+  }
 }
 
 export async function resolveActiveGitlabIdentity(
@@ -282,6 +293,12 @@ export async function resolveActiveGitlabIdentity(
     normalizedUsername: string;
     /** Holds membership + identity authority through the caller's transaction commit. */
     lockForUpdate?: boolean;
+    /**
+     * Personnel placement locks the target pair together with candidate
+     * speakers, so it keeps identity/member locks but defers agent row locks
+     * to that stable union.
+     */
+    lockAgentRowsForUpdate?: boolean;
   },
 ): Promise<
   | { outcome: "ok"; identity: ResolvedGitlabIdentity }
@@ -347,7 +364,8 @@ export async function resolveActiveGitlabIdentity(
     link = lockedLink;
   }
 
-  const humanRows = input.lockForUpdate
+  const lockAgentRowsForUpdate = input.lockForUpdate && input.lockAgentRowsForUpdate !== false;
+  const humanRows = lockAgentRowsForUpdate
     ? await db
         .select({ status: agents.status, delegateAgentId: agents.delegateMention })
         .from(agents)
@@ -362,7 +380,7 @@ export async function resolveActiveGitlabIdentity(
   const [human] = humanRows;
   if (!human || human.status !== "active") return { outcome: "membership_not_active" };
   if (!human.delegateAgentId) return { outcome: "delegate_missing" };
-  const delegateRows = input.lockForUpdate
+  const delegateRows = lockAgentRowsForUpdate
     ? await db
         .select({ status: agents.status, organizationId: agents.organizationId, type: agents.type })
         .from(agents)

--- a/packages/server/src/services/gitlab-webhook.ts
+++ b/packages/server/src/services/gitlab-webhook.ts
@@ -1040,32 +1040,24 @@ async function resolveGitlabPersonnelTargetInTransaction(
       });
     }
   } else {
-    const relatedChatId = await findGitlabRelatedEntityChat(db, {
-      organizationId: input.organizationId,
-      connectionId: input.connectionId,
-      relatedRefs: input.event.relatedRefs,
-      humanAgentId,
-      wakeAgentId,
+    // `strict_new_line` means no locked current-entity candidate was safe.
+    // Related-entity mappings are outside that speaker snapshot, so they may
+    // not be used as an unchecked shortcut for a fresh personnel line.
+    const metadata = chatMetadataSchema.parse({
+      source: "gitlab",
+      entityType: input.entity.entityType,
+      entityKey: input.event.entity.key,
+      entityUrl: input.entity.entityUrl,
+      ...(input.target.entry.reason === "review_requested" ? { reviewRequestRouted: true } : {}),
     });
-    if (relatedChatId) {
-      chatId = relatedChatId;
-    } else {
-      const metadata = chatMetadataSchema.parse({
-        source: "gitlab",
-        entityType: input.entity.entityType,
-        entityKey: input.event.entity.key,
-        entityUrl: input.entity.entityUrl,
-        ...(input.target.entry.reason === "review_requested" ? { reviewRequestRouted: true } : {}),
-      });
-      const createdChat = await createChat(db, humanAgentId, {
-        type: "group",
-        participantIds: [wakeAgentId],
-        topic: formatGitlabEntityTopic(input.entity, input.target.entry.reason === "review_requested"),
-        metadata,
-      });
-      chatId = createdChat.id;
-      created = true;
-    }
+    const createdChat = await createChat(db, humanAgentId, {
+      type: "group",
+      participantIds: [wakeAgentId],
+      topic: formatGitlabEntityTopic(input.entity, input.target.entry.reason === "review_requested"),
+      metadata,
+    });
+    chatId = createdChat.id;
+    created = true;
   }
 
   await db.insert(gitlabEntityChatMappings).values({
@@ -1093,47 +1085,6 @@ async function resolveGitlabPersonnelTargetInTransaction(
     updatedAt: new Date(),
   });
   return { chatId, created, membershipChanged };
-}
-
-async function findGitlabRelatedEntityChat(
-  db: Database,
-  input: {
-    organizationId: string;
-    connectionId: string;
-    relatedRefs: NormalizedScmEvent["relatedRefs"];
-    humanAgentId: string;
-    wakeAgentId: string;
-  },
-): Promise<string | null> {
-  const issueRefs = input.relatedRefs.flatMap((ref) => {
-    if (ref.type !== "issue") return [];
-    const match = /^(\d+):issue:(\d+)$/.exec(ref.key);
-    if (!match?.[1] || !match[2]) return [];
-    return [{ projectId: Number(match[1]), issueIid: Number(match[2]) }];
-  });
-  if (issueRefs.length === 0) return null;
-
-  const candidateChatIds = new Set<string>();
-  for (const ref of issueRefs) {
-    const rows = await db
-      .select({ chatId: gitlabEntityChatMappings.chatId })
-      .from(gitlabEntityChatMappings)
-      .where(
-        and(
-          eq(gitlabEntityChatMappings.organizationId, input.organizationId),
-          eq(gitlabEntityChatMappings.connectionId, input.connectionId),
-          eq(gitlabEntityChatMappings.projectId, ref.projectId),
-          eq(gitlabEntityChatMappings.entityType, "issue"),
-          eq(gitlabEntityChatMappings.entityIid, ref.issueIid),
-          eq(gitlabEntityChatMappings.humanAgentId, input.humanAgentId),
-          eq(gitlabEntityChatMappings.delegateAgentId, input.wakeAgentId),
-          eq(gitlabEntityChatMappings.active, true),
-        ),
-      );
-    for (const row of rows) candidateChatIds.add(row.chatId);
-    if (candidateChatIds.size > 1) return null;
-  }
-  return candidateChatIds.size === 1 ? ([...candidateChatIds][0] ?? null) : null;
 }
 
 export async function deliverGitlabCards(

--- a/packages/server/src/services/gitlab-webhook.ts
+++ b/packages/server/src/services/gitlab-webhook.ts
@@ -19,6 +19,7 @@ import { BadRequestError } from "../errors.js";
 import { createLogger } from "../observability/index.js";
 import { uuidv7 } from "../uuid.js";
 import { createChat } from "./chat.js";
+import { lockChatMembershipMutation, lockChatSpeakerAndAgentSnapshot } from "./chat-membership-lock.js";
 import { buildClaimReadyGitlabDeliveryId } from "./gitlab-connections.js";
 import { buildGitlabCrossHookFingerprint, type GitlabHookSource } from "./gitlab-cross-hook-dedup.js";
 import {
@@ -31,6 +32,7 @@ import {
   normalizeGitlabUsername,
   resolveActiveGitlabIdentity,
 } from "./gitlab-identities.js";
+import { inviteParticipantsToChatInTransaction } from "./participant-invite.js";
 import { composeScmAudience, type ScmAudienceTarget, type ScmPersonnelTarget } from "./scm-audience-composition.js";
 import { type DeferredScmCardPostCommitEffects, sendScmSystemCard } from "./scm-card-delivery.js";
 import {
@@ -42,9 +44,10 @@ import {
   selectScmCardContext,
   selectScmSenderId,
 } from "./scm-chat-delivery-plan.js";
+import { lockGitlabEntityAttention } from "./scm-entity-attention-lock.js";
 import { formatGitlabEntityTopic } from "./scm-entity-chat-topic.js";
 import { parseSameProjectClosingIssueRefs } from "./scm-related-refs.js";
-import { decideScmPersonnelTargetChat } from "./scm-target-chat-policy.js";
+import { decideScmPersonnelTargetChat, lockAndValidateScmPersonnelPlacement } from "./scm-target-chat-policy.js";
 
 const log = createLogger("GitlabWebhook");
 
@@ -664,6 +667,36 @@ export type GitlabAudienceResolution = {
   actorHumanId: string | null;
 };
 
+type GitlabIdentityPairSnapshot = {
+  linkId: string;
+  humanAgentId: string;
+  delegateAgentId: string;
+};
+
+async function revalidateGitlabIdentityPair(
+  db: Database,
+  input: {
+    organizationId: string;
+    connectionId: string;
+    normalizedUsername: string;
+    expected: GitlabIdentityPairSnapshot;
+  },
+): Promise<boolean> {
+  const current = await resolveActiveGitlabIdentity(db, {
+    organizationId: input.organizationId,
+    connectionId: input.connectionId,
+    normalizedUsername: input.normalizedUsername,
+    lockForUpdate: true,
+    lockAgentRowsForUpdate: false,
+  });
+  return Boolean(
+    current.outcome === "ok" &&
+      current.identity.linkId === input.expected.linkId &&
+      current.identity.humanAgentId === input.expected.humanAgentId &&
+      current.identity.delegateAgentId === input.expected.delegateAgentId,
+  );
+}
+
 export async function resolveGitlabAudience(
   db: Database,
   input: {
@@ -675,38 +708,17 @@ export async function resolveGitlabAudience(
   },
 ): Promise<GitlabAudienceResolution> {
   const actorNormalizedUsername = normalizeGitlabUsername(input.event.actor.externalUsername).normalized;
-  let actorHumanId: string | null = null;
-  const identityRows = await db
-    .select({ identityLinkId: gitlabEntityChatMappings.identityLinkId })
-    .from(gitlabEntityChatMappings)
-    .where(
-      and(
-        eq(gitlabEntityChatMappings.connectionId, input.connectionId),
-        eq(gitlabEntityChatMappings.projectId, input.entityIdentity.projectId),
-        eq(gitlabEntityChatMappings.entityType, input.entityIdentity.entityType),
-        eq(gitlabEntityChatMappings.entityIid, input.entityIdentity.entityIid),
-        eq(gitlabEntityChatMappings.boundVia, "identity_target"),
-        eq(gitlabEntityChatMappings.active, true),
-      ),
-    );
-  await lockGitlabIdentityAuthoritySet(db, {
-    organizationId: input.organizationId,
-    connectionId: input.connectionId,
-    normalizedUsernames: input.event.targets
-      .map((target) => normalizeGitlabUsername(target.externalUsername).normalized)
-      .concat(actorNormalizedUsername),
-    identityLinkIds: identityRows.flatMap((row) => (row.identityLinkId ? [row.identityLinkId] : [])),
-  });
+  const rows =
+    input.followers ?? (await observeGitlabEntityAndResolveFollowers(db, input.connectionId, input.entityIdentity));
   const actor = await resolveActiveGitlabIdentity(db, {
     organizationId: input.organizationId,
     connectionId: input.connectionId,
     normalizedUsername: actorNormalizedUsername,
-    lockForUpdate: true,
   });
-  actorHumanId = actor.outcome === "ok" ? actor.identity.humanAgentId : null;
-  const rows =
-    input.followers ?? (await observeGitlabEntityAndResolveFollowers(db, input.connectionId, input.entityIdentity));
-  const existingEntries: Array<Exclude<ScmAudienceEntry, { kind: "personnel_target" }>> = [];
+  const provisionalExisting: Array<{
+    entry: Exclude<ScmAudienceEntry, { kind: "personnel_target" }>;
+    identity?: { normalizedUsername: string; expected: GitlabIdentityPairSnapshot };
+  }> = [];
   for (const row of rows) {
     if (row.boundVia === "identity_target") {
       if (!row.identityLinkId || !row.humanAgentId || !row.delegateAgentId) continue;
@@ -726,7 +738,6 @@ export async function resolveGitlabAudience(
         organizationId: input.organizationId,
         connectionId: input.connectionId,
         normalizedUsername: link.normalizedUsername,
-        lockForUpdate: true,
       });
       if (
         resolved.outcome !== "ok" ||
@@ -736,53 +747,70 @@ export async function resolveGitlabAudience(
       ) {
         continue;
       }
-      existingEntries.push({
-        kind: "existing_line",
-        line: {
-          kind: "attention_line",
-          humanAgentId: row.humanAgentId,
-          wakeAgentId: row.delegateAgentId,
-          chatId: row.chatId,
-          provenance: "identity_target",
+      provisionalExisting.push({
+        entry: {
+          kind: "existing_line",
+          line: {
+            kind: "attention_line",
+            humanAgentId: row.humanAgentId,
+            wakeAgentId: row.delegateAgentId,
+            chatId: row.chatId,
+            provenance: "identity_target",
+          },
+        },
+        identity: {
+          normalizedUsername: link.normalizedUsername,
+          expected: {
+            linkId: resolved.identity.linkId,
+            humanAgentId: resolved.identity.humanAgentId,
+            delegateAgentId: resolved.identity.delegateAgentId,
+          },
         },
       });
     } else {
       const humanAgentId = row.humanAgentId;
       const wakeAgentId = row.delegateAgentId;
       if (humanAgentId !== null && wakeAgentId !== null) {
-        existingEntries.push({
-          kind: "existing_line",
-          line: {
-            kind: "attention_line",
-            humanAgentId,
-            wakeAgentId,
-            chatId: row.chatId,
-            provenance: "explicit",
+        provisionalExisting.push({
+          entry: {
+            kind: "existing_line",
+            line: {
+              kind: "attention_line",
+              humanAgentId,
+              wakeAgentId,
+              chatId: row.chatId,
+              provenance: "explicit",
+            },
           },
         });
       } else {
-        existingEntries.push({
-          kind: "legacy_route",
-          route: {
-            kind: "legacy_route_only",
-            chatId: row.chatId,
-            senderAgentId: row.declaredByAgentId,
-            wakeAgentId: null,
-            provenance: "legacy_explicit",
+        provisionalExisting.push({
+          entry: {
+            kind: "legacy_route",
+            route: {
+              kind: "legacy_route_only",
+              chatId: row.chatId,
+              senderAgentId: row.declaredByAgentId,
+              wakeAgentId: null,
+              provenance: "legacy_explicit",
+            },
           },
         });
       }
     }
   }
 
-  const personnelTargets: ScmPersonnelTarget[] = [];
+  const provisionalPersonnel: Array<{
+    target: ScmPersonnelTarget;
+    normalizedUsername: string;
+    expected: GitlabIdentityPairSnapshot;
+  }> = [];
   for (const target of input.event.targets) {
     const normalizedUsername = normalizeGitlabUsername(target.externalUsername).normalized;
     const resolved = await resolveActiveGitlabIdentity(db, {
       organizationId: input.organizationId,
       connectionId: input.connectionId,
       normalizedUsername,
-      lockForUpdate: true,
     });
     if (resolved.outcome !== "ok") {
       logSkippedGitlabTarget({
@@ -795,13 +823,85 @@ export async function resolveGitlabAudience(
       });
       continue;
     }
-    personnelTargets.push({
-      kind: "personnel_target",
-      reason: target.reason,
-      humanAgentId: resolved.identity.humanAgentId,
-      wakeAgentId: resolved.identity.delegateAgentId,
-      externalUsername: normalizedUsername,
+    provisionalPersonnel.push({
+      target: {
+        kind: "personnel_target",
+        reason: target.reason,
+        requiresPersistentLine: target.reason === "assigned" || target.reason === "mentioned",
+        humanAgentId: resolved.identity.humanAgentId,
+        wakeAgentId: resolved.identity.delegateAgentId,
+        externalUsername: normalizedUsername,
+      },
+      normalizedUsername,
+      expected: {
+        linkId: resolved.identity.linkId,
+        humanAgentId: resolved.identity.humanAgentId,
+        delegateAgentId: resolved.identity.delegateAgentId,
+      },
     });
+  }
+
+  const candidateChatIds = [...new Set(rows.map((row) => row.chatId))].sort();
+  await lockChatMembershipMutation(db, candidateChatIds);
+  await lockGitlabIdentityAuthoritySet(db, {
+    organizationId: input.organizationId,
+    connectionId: input.connectionId,
+    normalizedUsernames: input.event.targets
+      .map((target) => normalizeGitlabUsername(target.externalUsername).normalized)
+      .concat(actorNormalizedUsername),
+    identityLinkIds: rows.flatMap((row) => (row.identityLinkId ? [row.identityLinkId] : [])),
+    humanAgentIds: rows.flatMap((row) => (row.humanAgentId ? [row.humanAgentId] : [])),
+  });
+  const authorityAgentIds = [
+    ...(actor.outcome === "ok" ? [actor.identity.humanAgentId, actor.identity.delegateAgentId] : []),
+    ...provisionalExisting.flatMap(({ entry }) =>
+      entry.kind === "existing_line" ? [entry.line.humanAgentId, entry.line.wakeAgentId] : [entry.route.senderAgentId],
+    ),
+    ...provisionalPersonnel.flatMap(({ target }) => [target.humanAgentId, target.wakeAgentId]),
+  ];
+  await lockChatSpeakerAndAgentSnapshot(db, candidateChatIds, authorityAgentIds);
+
+  let actorHumanId: string | null = null;
+  if (
+    actor.outcome === "ok" &&
+    (await revalidateGitlabIdentityPair(db, {
+      organizationId: input.organizationId,
+      connectionId: input.connectionId,
+      normalizedUsername: actorNormalizedUsername,
+      expected: actor.identity,
+    }))
+  ) {
+    actorHumanId = actor.identity.humanAgentId;
+  }
+
+  const existingEntries: Array<Exclude<ScmAudienceEntry, { kind: "personnel_target" }>> = [];
+  for (const provisional of provisionalExisting) {
+    if (
+      provisional.identity &&
+      !(await revalidateGitlabIdentityPair(db, {
+        organizationId: input.organizationId,
+        connectionId: input.connectionId,
+        normalizedUsername: provisional.identity.normalizedUsername,
+        expected: provisional.identity.expected,
+      }))
+    ) {
+      continue;
+    }
+    existingEntries.push(provisional.entry);
+  }
+
+  const personnelTargets: ScmPersonnelTarget[] = [];
+  for (const provisional of provisionalPersonnel) {
+    if (
+      await revalidateGitlabIdentityPair(db, {
+        organizationId: input.organizationId,
+        connectionId: input.connectionId,
+        normalizedUsername: provisional.normalizedUsername,
+        expected: provisional.expected,
+      })
+    ) {
+      personnelTargets.push(provisional.target);
+    }
   }
 
   return { targets: composeScmAudience({ existingEntries, personnelTargets }), actorHumanId };
@@ -816,6 +916,7 @@ async function resolveGitlabTargetChat(
     entity: GitlabEntityIdentity;
     target: ScmAudienceTarget;
   },
+  onMembershipChanged: (chatId: string) => void,
 ): Promise<{ chatId: string; created: boolean } | null> {
   if (input.target.entry.kind === "existing_line") {
     return { chatId: input.target.entry.line.chatId, created: false };
@@ -823,17 +924,35 @@ async function resolveGitlabTargetChat(
   if (input.target.entry.kind === "legacy_route") {
     return { chatId: input.target.entry.route.chatId, created: false };
   }
+  const result = await db.transaction(async (rawTx) => {
+    const tx = rawTx as unknown as Database;
+    await lockGitlabEntityAttention(tx, {
+      connectionId: input.connectionId,
+      projectPathNormalized: normalizeGitlabProjectPath(input.entity.projectPath),
+      projectIds: [input.entity.projectId],
+      entityType: input.entity.entityType,
+      entityIid: input.entity.entityIid,
+    });
+    return resolveGitlabPersonnelTargetInTransaction(tx, input);
+  });
+  if (result?.membershipChanged) onMembershipChanged(result.chatId);
+  return result ? { chatId: result.chatId, created: result.created } : null;
+}
+
+async function resolveGitlabPersonnelTargetInTransaction(
+  db: Database,
+  input: {
+    organizationId: string;
+    connectionId: string;
+    event: NormalizedScmEvent;
+    entity: GitlabEntityIdentity;
+    target: ScmAudienceTarget;
+  },
+): Promise<{ chatId: string; created: boolean; membershipChanged: boolean } | null> {
+  if (input.target.entry.kind !== "personnel_target") return null;
   const humanAgentId = input.target.entry.humanAgentId;
   const wakeAgentId = input.target.entry.wakeAgentId;
   const involveLogin = input.target.entry.externalUsername;
-  const resolvedIdentity = await resolveActiveGitlabIdentity(db, {
-    organizationId: input.organizationId,
-    connectionId: input.connectionId,
-    normalizedUsername: involveLogin,
-    lockForUpdate: true,
-  });
-  if (resolvedIdentity.outcome !== "ok") return null;
-
   const existingRows = await db
     .select()
     .from(gitlabEntityChatMappings)
@@ -845,6 +964,24 @@ async function resolveGitlabTargetChat(
         eq(gitlabEntityChatMappings.entityIid, input.entity.entityIid),
       ),
     );
+  await lockChatMembershipMutation(
+    db,
+    existingRows.filter((row) => row.active).map((row) => row.chatId),
+  );
+  const resolvedIdentity = await resolveActiveGitlabIdentity(db, {
+    organizationId: input.organizationId,
+    connectionId: input.connectionId,
+    normalizedUsername: involveLogin,
+    lockForUpdate: true,
+    lockAgentRowsForUpdate: false,
+  });
+  if (resolvedIdentity.outcome !== "ok") return null;
+  if (
+    resolvedIdentity.identity.humanAgentId !== humanAgentId ||
+    resolvedIdentity.identity.delegateAgentId !== wakeAgentId
+  ) {
+    return null;
+  }
   const activeOwn = existingRows.find(
     (row) =>
       row.active &&
@@ -852,55 +989,83 @@ async function resolveGitlabTargetChat(
       row.humanAgentId === humanAgentId &&
       row.delegateAgentId === wakeAgentId,
   );
-  if (activeOwn) return { chatId: activeOwn.chatId, created: false };
-
   const staleActiveOwnIds = existingRows
     .filter((row) => row.active && row.identityLinkId === resolvedIdentity.identity.linkId)
     .map((row) => row.id);
+  const staleActiveOwnIdSet = new Set(staleActiveOwnIds);
+  const activeChatIds = [
+    ...new Set(
+      existingRows
+        .filter((row) => row.active && (activeOwn || !staleActiveOwnIdSet.has(row.id)))
+        .map((row) => row.chatId),
+    ),
+  ];
+  const placement = await lockAndValidateScmPersonnelPlacement(db, {
+    humanAgentId,
+    wakeAgentId,
+    candidateChatIds: activeChatIds,
+  });
+  if (!placement) return null;
+  if (activeOwn) return { chatId: activeOwn.chatId, created: false, membershipChanged: false };
+
   if (staleActiveOwnIds.length > 0) {
     await db
       .update(gitlabEntityChatMappings)
       .set({ active: false, updatedAt: new Date() })
       .where(inArray(gitlabEntityChatMappings.id, staleActiveOwnIds));
   }
-  const activeChatIds = [...new Set(existingRows.filter((row) => row.active).map((row) => row.chatId))];
   const targetDecision = await decideScmPersonnelTargetChat(db, {
-    reason: input.target.entry.reason,
+    requiresPersistentLine: input.target.entry.requiresPersistentLine,
     candidateChatIds: activeChatIds,
     humanAgentId,
     wakeAgentId,
+    authority: placement.authority,
+    speakerSnapshot: placement.speakerSnapshot,
   });
-  if (targetDecision.kind === "reuse") {
-    return { chatId: targetDecision.chatId, created: false };
+  if (targetDecision.kind === "reuse_membership") {
+    return { chatId: targetDecision.chatId, created: false, membershipChanged: false };
   }
 
   let chatId: string;
   let created = false;
-  const relatedChatId = await findGitlabRelatedEntityChat(db, {
-    organizationId: input.organizationId,
-    connectionId: input.connectionId,
-    relatedRefs: input.event.relatedRefs,
-    humanAgentId,
-    wakeAgentId,
-  });
-  if (relatedChatId) {
-    chatId = relatedChatId;
+  let membershipChanged = false;
+  if (targetDecision.kind === "reuse_with_line") {
+    chatId = targetDecision.chatId;
+    if (targetDecision.admitWakeAgent) {
+      membershipChanged = await inviteParticipantsToChatInTransaction(db, {
+        chatId,
+        callerAgentId: humanAgentId,
+        targetAgentIds: [wakeAgentId],
+        errorOnAlreadySpeaker: false,
+      });
+    }
   } else {
-    const metadata = chatMetadataSchema.parse({
-      source: "gitlab",
-      entityType: input.entity.entityType,
-      entityKey: input.event.entity.key,
-      entityUrl: input.entity.entityUrl,
-      ...(input.target.entry.reason === "review_requested" ? { reviewRequestRouted: true } : {}),
+    const relatedChatId = await findGitlabRelatedEntityChat(db, {
+      organizationId: input.organizationId,
+      connectionId: input.connectionId,
+      relatedRefs: input.event.relatedRefs,
+      humanAgentId,
+      wakeAgentId,
     });
-    const createdChat = await createChat(db, humanAgentId, {
-      type: "group",
-      participantIds: [wakeAgentId],
-      topic: formatGitlabEntityTopic(input.entity, input.target.entry.reason === "review_requested"),
-      metadata,
-    });
-    chatId = createdChat.id;
-    created = true;
+    if (relatedChatId) {
+      chatId = relatedChatId;
+    } else {
+      const metadata = chatMetadataSchema.parse({
+        source: "gitlab",
+        entityType: input.entity.entityType,
+        entityKey: input.event.entity.key,
+        entityUrl: input.entity.entityUrl,
+        ...(input.target.entry.reason === "review_requested" ? { reviewRequestRouted: true } : {}),
+      });
+      const createdChat = await createChat(db, humanAgentId, {
+        type: "group",
+        participantIds: [wakeAgentId],
+        topic: formatGitlabEntityTopic(input.entity, input.target.entry.reason === "review_requested"),
+        metadata,
+      });
+      chatId = createdChat.id;
+      created = true;
+    }
   }
 
   await db.insert(gitlabEntityChatMappings).values({
@@ -927,7 +1092,7 @@ async function resolveGitlabTargetChat(
     createdAt: new Date(),
     updatedAt: new Date(),
   });
-  return { chatId, created };
+  return { chatId, created, membershipChanged };
 }
 
 async function findGitlabRelatedEntityChat(
@@ -987,18 +1152,24 @@ export async function deliverGitlabCards(
     newChats: number;
     failed: number;
     postCommitEffects: DeferredScmCardPostCommitEffects[];
-  } = { delivered: 0, newChats: 0, failed: 0, postCommitEffects: [] };
+    audienceCacheInvalidationChatIds: string[];
+  } = { delivered: 0, newChats: 0, failed: 0, postCommitEffects: [], audienceCacheInvalidationChatIds: [] };
+  const membershipChangedChatIds = new Set<string>();
   const planned = await planScmChatDeliveries({
     targets: input.audience.targets,
     actorHumanId: input.audience.actorHumanId,
     resolveChat: (target) =>
-      resolveGitlabTargetChat(input.database, {
-        organizationId: input.organizationId,
-        connectionId: input.connectionId,
-        event: input.event,
-        entity: input.identity,
-        target,
-      }),
+      resolveGitlabTargetChat(
+        input.database,
+        {
+          organizationId: input.organizationId,
+          connectionId: input.connectionId,
+          event: input.event,
+          entity: input.identity,
+          target,
+        },
+        (chatId) => membershipChangedChatIds.add(chatId),
+      ),
     onTargetError: (target, err) => {
       log.error(
         {
@@ -1072,5 +1243,6 @@ export async function deliverGitlabCards(
       );
     }
   }
+  stats.audienceCacheInvalidationChatIds = [...membershipChangedChatIds].sort();
   return stats;
 }

--- a/packages/server/src/services/participant-invite.ts
+++ b/packages/server/src/services/participant-invite.ts
@@ -55,9 +55,11 @@
  *     managerId reading after a product decision that "owner's agent
  *     acts on owner's behalf" — see that PR for the deliberation
  *     transcript.
- *   - the actual write goes through `applyMembershipWrite`, which encloses
- *     the silent-context backfill + watcher recompute invariants and the
- *     post-commit audience-cache invalidation.
+ *   - the actual write goes through `addChatParticipants`, which encloses
+ *     silent-context backfill + watcher recompute. The public service owns
+ *     the transaction and post-commit cache invalidation; transaction-aware
+ *     callers use the exported primitive and invalidate only after their
+ *     enclosing transaction commits.
  */
 
 import {
@@ -73,8 +75,16 @@ import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { members } from "../db/schema/members.js";
-import { BadRequestError, CallerNotSpeakerError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
-import { applyMembershipWrite } from "./participant-mode.js";
+import {
+  AppError,
+  BadRequestError,
+  CallerNotSpeakerError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "../errors.js";
+import { invalidateChatAudience } from "./chat-audience-cache.js";
+import { addChatParticipants } from "./participant-mode.js";
 
 export type InviteParticipantsArgs = {
   chatId: string;
@@ -167,7 +177,7 @@ export function rejectedPrivateTargets(
  * contract and the rationale for which checks live here vs. in Layer-3
  * adapter shells.
  */
-export async function inviteParticipantsToChat(db: Database, args: InviteParticipantsArgs): Promise<void> {
+async function prepareParticipantInviteInTransaction(db: Database, args: InviteParticipantsArgs): Promise<string[]> {
   const { chatId, callerAgentId, targetAgentIds, errorOnAlreadySpeaker } = args;
   const distinctTargets = [...new Set(targetAgentIds)];
   if (distinctTargets.length === 0) {
@@ -295,18 +305,57 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
     // skip. No row write needed; the watcher set is already consistent with
     // the speaker set (the most recent write that put these agents in has
     // already run recompute). Skip the round-trip.
-    return;
+    return [];
   }
+
+  return toWrite;
+}
+
+/**
+ * Run the canonical invite authorization and membership writer inside the
+ * caller's transaction. The caller owns commit and post-commit audience-cache
+ * invalidation, which lets SCM persist membership and its attention line
+ * atomically without copying any admission rule.
+ */
+export async function inviteParticipantsToChatInTransaction(
+  db: Database,
+  args: InviteParticipantsArgs,
+): Promise<boolean> {
+  const toWrite = await prepareParticipantInviteInTransaction(db, args);
+  if (toWrite.length === 0) return false;
 
   // 6. Delegate to the canonical write bundle. `upgradeWatcherToSpeaker:
   //    true` lets a pre-existing watcher row be promoted in place; for
   //    brand-new targets it's a regular INSERT.
-  await applyMembershipWrite(
+  await addChatParticipants(
     db,
-    chatId,
+    args.chatId,
     toWrite.map((agentId) => ({ agentId, role: "member" as const })),
     { upgradeWatcherToSpeaker: true },
   );
+  return true;
+}
+
+/** Read-only admission probe used by target-chat candidate selection. */
+export async function canInviteParticipantsToChatInTransaction(
+  db: Database,
+  args: InviteParticipantsArgs,
+): Promise<boolean> {
+  try {
+    await prepareParticipantInviteInTransaction(db, args);
+    return true;
+  } catch (error) {
+    if (error instanceof AppError) return false;
+    throw error;
+  }
+}
+
+export async function inviteParticipantsToChat(db: Database, args: InviteParticipantsArgs): Promise<void> {
+  let changed = false;
+  await db.transaction(async (rawTx) => {
+    changed = await inviteParticipantsToChatInTransaction(rawTx as unknown as Database, args);
+  });
+  if (changed) invalidateChatAudience(args.chatId);
 }
 
 /**

--- a/packages/server/src/services/participant-mode.ts
+++ b/packages/server/src/services/participant-mode.ts
@@ -54,6 +54,7 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { BadRequestError, NotFoundError } from "../errors.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
+import { lockChatMembershipMutation } from "./chat-membership-lock.js";
 import { backfillSilentContextForNewParticipants } from "./inbox.js";
 
 /**
@@ -131,6 +132,8 @@ export async function addChatParticipants(
   options: AddChatParticipantsOptions = {},
 ): Promise<void> {
   if (participants.length === 0) return;
+
+  await lockChatMembershipMutation(tx, [chatId]);
 
   // Confirm the chat exists AND lock the chats row for the duration of the
   // tx. We no longer SELECT `chats.type` — it's locked to 'group' and never
@@ -321,9 +324,11 @@ export async function recomputeChatWatchers(db: DbLike, chatId: string): Promise
  * bundle here makes the tx-boundary discipline a single decision instead
  * of N repeated decisions at each service entrypoint.
  *
- * Use this from service entrypoints (`inviteParticipantsToChat`,
- * `ensureParticipant`, the rebuild path of `joinAsParticipant`) rather
- * than spelling the three steps out yourself.
+ * Use this from service entrypoints that do not need to compose membership
+ * with another write (`ensureParticipant`, the rebuild path of
+ * `joinAsParticipant`). `inviteParticipantsToChat` owns an equivalent
+ * transaction-aware bundle so SCM routing can atomically add membership and
+ * persist its attention line.
  */
 export async function applyMembershipWrite(
   db: Database,

--- a/packages/server/src/services/scm-attention-line.ts
+++ b/packages/server/src/services/scm-attention-line.ts
@@ -3,6 +3,7 @@ import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
+import { type LockedChatSpeakerSnapshot, lockChatSpeakerSnapshot } from "./chat-membership-lock.js";
 
 export type ScmBindingPair = {
   organizationId: string;
@@ -141,6 +142,16 @@ export async function resolveAgentScmBindingPair(
   };
 }
 
+/** Resolve an agent-issued pair from a transaction-stable speaker snapshot. */
+export async function lockAndResolveAgentScmBindingPair(
+  db: Database,
+  chatId: string,
+  wakeAgentId: string,
+): Promise<ScmBindingPair | null> {
+  const snapshot = await lockChatSpeakerSnapshot(db, [chatId]);
+  return resolveAgentPairFromLockedSnapshot(snapshot, chatId, wakeAgentId);
+}
+
 /**
  * Resolve the pair for a human-issued follow. A configured delegate that is
  * not an active speaker would form a silent line, so this fails closed.
@@ -198,5 +209,73 @@ export async function resolveHumanScmBindingPair(
     organizationId: human.organizationId,
     humanAgentId,
     wakeAgentId: wakeAgent.id,
+  };
+}
+
+/** Resolve a human-issued pair from a transaction-stable speaker snapshot. */
+export async function lockAndResolveHumanScmBindingPair(
+  db: Database,
+  chatId: string,
+  humanAgentId: string,
+): Promise<ScmBindingPair | null> {
+  const snapshot = await lockChatSpeakerSnapshot(db, [chatId]);
+  const chat = snapshot.chats.find((row) => row.id === chatId);
+  const human = snapshot.speakers.find((row) => row.chatId === chatId && row.agentId === humanAgentId);
+  if (
+    !chat ||
+    !human ||
+    human.type !== "human" ||
+    human.status !== "active" ||
+    human.organizationId !== chat.organizationId ||
+    !human.delegateMention
+  ) {
+    return null;
+  }
+  const wake = snapshot.speakers.find(
+    (row) =>
+      row.chatId === chatId &&
+      row.agentId === human.delegateMention &&
+      row.type !== "human" &&
+      row.status === "active" &&
+      row.organizationId === chat.organizationId,
+  );
+  if (!wake) return null;
+  return {
+    organizationId: chat.organizationId,
+    humanAgentId,
+    wakeAgentId: wake.agentId,
+  };
+}
+
+function resolveAgentPairFromLockedSnapshot(
+  snapshot: LockedChatSpeakerSnapshot,
+  chatId: string,
+  wakeAgentId: string,
+): ScmBindingPair | null {
+  const chat = snapshot.chats.find((row) => row.id === chatId);
+  const wake = snapshot.speakers.find((row) => row.chatId === chatId && row.agentId === wakeAgentId);
+  if (
+    !chat ||
+    !wake ||
+    wake.type === "human" ||
+    wake.status !== "active" ||
+    wake.organizationId !== chat.organizationId
+  ) {
+    return null;
+  }
+  const humans = snapshot.speakers.filter(
+    (row) =>
+      row.chatId === chatId &&
+      row.type === "human" &&
+      row.status === "active" &&
+      row.organizationId === chat.organizationId,
+  );
+  const linkedHumans = humans.filter((human) => human.delegateMention === wakeAgentId);
+  const representative = linkedHumans.length === 1 ? linkedHumans[0] : linkedHumans.length === 0 ? humans[0] : null;
+  if (!representative) return null;
+  return {
+    organizationId: chat.organizationId,
+    humanAgentId: representative.agentId,
+    wakeAgentId,
   };
 }

--- a/packages/server/src/services/scm-audience-composition.ts
+++ b/packages/server/src/services/scm-audience-composition.ts
@@ -5,6 +5,7 @@ export type ScmPersonnelTarget = Extract<ScmAudienceEntry, { kind: "personnel_ta
 
 export type ScmDirectedContext = {
   reason: InvolveReason;
+  requiresPersistentLine: boolean;
   externalUsername: string;
 };
 
@@ -50,7 +51,15 @@ export function composeScmAudience<TProviderContext = never>(input: {
   for (const target of input.personnelTargets) {
     const pair = attentionPairKey(target.humanAgentId, target.wakeAgentId);
     const current = personnelByPair.get(pair);
-    if (!current || comparePersonnelTargets(target, current) < 0) personnelByPair.set(pair, target);
+    if (!current) {
+      personnelByPair.set(pair, target);
+      continue;
+    }
+    const displayTarget = comparePersonnelTargets(target, current) < 0 ? target : current;
+    personnelByPair.set(pair, {
+      ...displayTarget,
+      requiresPersistentLine: current.requiresPersistentLine || target.requiresPersistentLine,
+    });
   }
 
   for (const [pair, personnelTarget] of [...personnelByPair.entries()].sort(([a], [b]) => a.localeCompare(b))) {
@@ -63,6 +72,7 @@ export function composeScmAudience<TProviderContext = never>(input: {
       matched = true;
       target.directedContext = {
         reason: personnelTarget.reason,
+        requiresPersistentLine: personnelTarget.requiresPersistentLine,
         externalUsername: personnelTarget.externalUsername,
       };
     }

--- a/packages/server/src/services/scm-chat-delivery-plan.ts
+++ b/packages/server/src/services/scm-chat-delivery-plan.ts
@@ -22,7 +22,12 @@ export type ScmPlannedChatDelivery<TProviderContext = never> = {
   entries: Map<string, ScmDeliveryEntry<TProviderContext>>;
 };
 
-export type ResolvedScmChat = { chatId: string; created: boolean };
+export type ResolvedScmChat = {
+  chatId: string;
+  created: boolean;
+  /** Personnel resolution re-used an exact line that predated this event. */
+  personnelLineExisted?: boolean;
+};
 
 /**
  * Provider-neutral per-processing-pass audience planner.
@@ -61,7 +66,7 @@ export async function planScmChatDeliveries<TProviderContext = never>(input: {
     } else if (resolved.created) {
       delivery.created = true;
     }
-    addScmDeliveryEntry(delivery, target, input.actorHumanId);
+    addScmDeliveryEntry(delivery, target, input.actorHumanId, resolved);
   }
   return { deliveries, failed };
 }
@@ -70,6 +75,7 @@ function addScmDeliveryEntry<TProviderContext>(
   delivery: ScmPlannedChatDelivery<TProviderContext>,
   target: ScmAudienceTarget<TProviderContext>,
   actorHumanId: string | null,
+  resolved: ResolvedScmChat,
 ): void {
   const senderAgentId = scmTargetSenderAgentId(target);
   const humanAgentId = scmTargetHumanAgentId(target);
@@ -83,7 +89,7 @@ function addScmDeliveryEntry<TProviderContext>(
       ? target.entry.externalUsername
       : (target.directedContext?.externalUsername ?? null);
   const providerContext = target.entry.kind === "provider_task_target" ? target.entry.providerContext : null;
-  const wakeEligibility = scmWakeEligibility(target, actorHumanId);
+  const wakeEligibility = scmWakeEligibility(target, actorHumanId, resolved);
   const key = `${senderAgentId}:${humanAgentId ?? "-"}:${wakeAgentId ?? "-"}`;
   const reasons = new Set<"follow" | InvolveReason>();
   if (target.entry.kind === "existing_line" || target.entry.kind === "legacy_route") reasons.add("follow");
@@ -119,12 +125,13 @@ function addScmDeliveryEntry<TProviderContext>(
 function scmWakeEligibility<TProviderContext>(
   target: ScmAudienceTarget<TProviderContext>,
   actorHumanId: string | null,
+  resolved: ResolvedScmChat,
 ): ScmWakeEligibility {
   if (target.entry.kind === "legacy_route") return "route_only";
   if (
-    target.entry.kind === "existing_line" &&
+    (target.entry.kind === "existing_line" || resolved.personnelLineExisted === true) &&
     actorHumanId !== null &&
-    target.entry.line.humanAgentId === actorHumanId
+    scmTargetHumanAgentId(target) === actorHumanId
   ) {
     return "actor_echo_suppressed";
   }

--- a/packages/server/src/services/scm-entity-attention-lock.ts
+++ b/packages/server/src/services/scm-entity-attention-lock.ts
@@ -1,0 +1,85 @@
+import { sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+
+export type ScmEntityAttentionLock = {
+  provider: "github" | "gitlab";
+  scopeId: string;
+  entityKey: string;
+};
+
+/** Commit refs may be abbreviated by unfollow, so serialize them per repo. */
+export function githubEntityAttentionLockKey(entityKey: string): string {
+  const commitSeparator = entityKey.lastIndexOf("@");
+  return commitSeparator > 0 ? `${entityKey.slice(0, commitSeparator)}@commit` : entityKey;
+}
+
+export function gitlabPathEntityAttentionLockKey(
+  projectPathNormalized: string,
+  entityType: "issue" | "pull_request",
+  entityIid: number,
+): string {
+  return `path:${projectPathNormalized}:${entityType}:${entityIid}`;
+}
+
+export function gitlabObservedEntityAttentionLockKey(
+  projectId: number,
+  entityType: "issue" | "pull_request",
+  entityIid: number,
+): string {
+  return `project:${projectId}:${entityType}:${entityIid}`;
+}
+
+/**
+ * Bridge pending path identity to GitLab's stable numeric project identity.
+ * Every caller locks path first, then numeric project ids in ascending order.
+ */
+export async function lockGitlabEntityAttention(
+  db: Database,
+  input: {
+    connectionId: string;
+    projectPathNormalized: string;
+    projectIds?: ReadonlyArray<number>;
+    entityType: "issue" | "pull_request";
+    entityIid: number;
+  },
+): Promise<void> {
+  await lockScmEntityAttention(db, {
+    provider: "gitlab",
+    scopeId: input.connectionId,
+    entityKey: gitlabPathEntityAttentionLockKey(input.projectPathNormalized, input.entityType, input.entityIid),
+  });
+  const projectIds = [...new Set(input.projectIds ?? [])].sort((a, b) => a - b);
+  for (const projectId of projectIds) {
+    await lockScmEntityAttention(db, {
+      provider: "gitlab",
+      scopeId: input.connectionId,
+      entityKey: gitlabObservedEntityAttentionLockKey(projectId, input.entityType, input.entityIid),
+    });
+  }
+}
+
+/**
+ * Serialize every mutation of one provider entity's attention state.
+ *
+ * Callers must already be inside the provider lifecycle fence when one
+ * exists (GitLab connection row, for example). The transaction-scoped lock
+ * then precedes chat-row and mapping locks, giving follow, rebind, unfollow,
+ * and webhook placement one stable ordering boundary even before a mapping
+ * row exists.
+ */
+export async function lockScmEntityAttention(db: Database, input: ScmEntityAttentionLock): Promise<void> {
+  const key = JSON.stringify([input.provider, input.scopeId, input.entityKey.toLocaleLowerCase("en-US")]);
+  await db.execute(sql`SELECT pg_advisory_xact_lock(hashtext('scm_entity_attention'), hashtext(${key}))`);
+}
+
+export async function withScmEntityAttentionTransaction<T>(
+  db: Database,
+  input: ScmEntityAttentionLock,
+  callback: (tx: Database) => Promise<T>,
+): Promise<T> {
+  return db.transaction(async (rawTx) => {
+    const tx = rawTx as unknown as Database;
+    await lockScmEntityAttention(tx, input);
+    return callback(tx);
+  });
+}

--- a/packages/server/src/services/scm-target-chat-policy.ts
+++ b/packages/server/src/services/scm-target-chat-policy.ts
@@ -1,40 +1,182 @@
-import type { InvolveReason } from "@first-tree/shared";
-import { and, eq, inArray } from "drizzle-orm";
+import { AGENT_STATUSES, AGENT_TYPES } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
-import { chatMembership } from "../db/schema/chat-membership.js";
+import { members } from "../db/schema/members.js";
+import {
+  type LockedChatSpeakerSnapshot,
+  lockChatMembershipMutation,
+  lockChatSpeakerAndAgentSnapshot,
+} from "./chat-membership-lock.js";
+import { canInviteParticipantsToChatInTransaction } from "./participant-invite.js";
 
-export type ScmTargetChatDecision = { kind: "reuse"; chatId: string } | { kind: "strict_new_line" };
+export type ScmTargetChatDecision =
+  | { kind: "reuse_membership"; chatId: string }
+  | { kind: "reuse_with_line"; chatId: string; admitWakeAgent: boolean }
+  | { kind: "strict_new_line" };
+
+type AgentSnapshot = {
+  uuid: string;
+  organizationId: string;
+  type: string;
+  status: string;
+  managerId: string;
+  delegateMention: string | null;
+};
+
+export type ScmPersonnelAuthority = {
+  humanAgentId: string;
+  wakeAgentId: string;
+  organizationId: string;
+  ownerMemberId: string;
+  wakeOwnerMemberId: string;
+};
+
+export type LockedScmPersonnelPlacement = {
+  authority: ScmPersonnelAuthority;
+  speakerSnapshot: LockedChatSpeakerSnapshot;
+};
 
 /**
- * Only reviewer routing may reuse chat membership without writing a line.
- * Mentions and assignments are directed calls and always establish a strict
- * new attention home.
+ * Lock and revalidate personnel authority plus candidate speakers without
+ * expanding an already-held pair lock. The membership fence comes first,
+ * then the human member row, then one UUID-sorted union of the target pair
+ * and every candidate speaker agent row.
+ */
+export async function lockAndValidateScmPersonnelPlacement(
+  db: Database,
+  input: { humanAgentId: string; wakeAgentId: string; candidateChatIds: string[] },
+): Promise<LockedScmPersonnelPlacement | null> {
+  const candidateChatIds = [...new Set(input.candidateChatIds)].sort();
+  await lockChatMembershipMutation(db, candidateChatIds);
+
+  // Match the global membership lifecycle order: members before agent mirrors.
+  const [humanMember] = await db
+    .select({ id: members.id, status: members.status })
+    .from(members)
+    .where(eq(members.agentId, input.humanAgentId))
+    .for("update")
+    .limit(1);
+
+  const lockedSnapshot = await lockChatSpeakerAndAgentSnapshot(db, candidateChatIds, [
+    input.humanAgentId,
+    input.wakeAgentId,
+  ]);
+  const pairById = new Map(
+    lockedSnapshot.agents.map((row) => [row.agentId, { ...row, uuid: row.agentId }] satisfies [string, AgentSnapshot]),
+  );
+  const human = pairById.get(input.humanAgentId);
+  const wake = pairById.get(input.wakeAgentId);
+  if (!human || !wake) return null;
+  if (
+    !isCurrentEligiblePair(human, wake, input.wakeAgentId, humanMember?.status ?? null) ||
+    human.managerId !== humanMember?.id
+  ) {
+    return null;
+  }
+  return {
+    authority: {
+      humanAgentId: input.humanAgentId,
+      wakeAgentId: input.wakeAgentId,
+      organizationId: human.organizationId,
+      ownerMemberId: human.managerId,
+      wakeOwnerMemberId: wake.managerId,
+    },
+    speakerSnapshot: {
+      chats: lockedSnapshot.chats,
+      speakers: lockedSnapshot.speakers,
+    },
+  };
+}
+
+/**
+ * Select a personnel target's chat without merging attention identities.
+ *
+ * The caller holds the provider/entity attention lock and supplies the
+ * transaction-stable speaker snapshot produced with the authority lock set.
  */
 export async function decideScmPersonnelTargetChat(
   db: Database,
   input: {
-    reason: InvolveReason;
+    requiresPersistentLine: boolean;
     candidateChatIds: string[];
     humanAgentId: string;
     wakeAgentId: string;
+    authority: ScmPersonnelAuthority;
+    speakerSnapshot: LockedChatSpeakerSnapshot;
   },
 ): Promise<ScmTargetChatDecision> {
-  if (input.reason !== "review_requested") return { kind: "strict_new_line" };
-  const reusable: string[] = [];
-  for (const chatId of [...new Set(input.candidateChatIds)]) {
-    const speakers = await db
-      .select({ agentId: chatMembership.agentId })
-      .from(chatMembership)
-      .where(
-        and(
-          eq(chatMembership.chatId, chatId),
-          eq(chatMembership.accessMode, "speaker"),
-          inArray(chatMembership.agentId, [input.humanAgentId, input.wakeAgentId]),
-        ),
-      );
-    const ids = new Set(speakers.map((speaker) => speaker.agentId));
-    if (ids.has(input.humanAgentId) && ids.has(input.wakeAgentId)) reusable.push(chatId);
-    if (reusable.length > 1) return { kind: "strict_new_line" };
+  const authority = input.authority;
+  if (authority.humanAgentId !== input.humanAgentId || authority.wakeAgentId !== input.wakeAgentId) {
+    throw new Error("SCM personnel authority does not match the target pair");
   }
-  return reusable.length === 1 && reusable[0] ? { kind: "reuse", chatId: reusable[0] } : { kind: "strict_new_line" };
+  const candidateChatIds = [...new Set(input.candidateChatIds)].sort();
+  if (candidateChatIds.length === 0) return { kind: "strict_new_line" };
+
+  const lockedSnapshot = input.speakerSnapshot;
+  const chatById = new Map(lockedSnapshot.chats.map((chat) => [chat.id, chat]));
+  const speakerRows = lockedSnapshot.speakers;
+  const speakersByChat = new Map<string, typeof speakerRows>();
+  for (const row of speakerRows) {
+    const current = speakersByChat.get(row.chatId);
+    if (current) current.push(row);
+    else speakersByChat.set(row.chatId, [row]);
+  }
+
+  const exactMembershipChats = candidateChatIds.filter((chatId) => {
+    const chat = chatById.get(chatId);
+    if (!chat || chat.organizationId !== authority.organizationId) return false;
+    const speakerIds = new Set((speakersByChat.get(chatId) ?? []).map((speaker) => speaker.agentId));
+    return speakerIds.has(input.humanAgentId) && speakerIds.has(input.wakeAgentId);
+  });
+  if (exactMembershipChats.length > 1) return { kind: "strict_new_line" };
+  const exactMembershipChat = exactMembershipChats[0];
+  if (exactMembershipChat) {
+    return input.requiresPersistentLine
+      ? { kind: "reuse_with_line", chatId: exactMembershipChat, admitWakeAgent: false }
+      : { kind: "reuse_membership", chatId: exactMembershipChat };
+  }
+  if (!input.requiresPersistentLine) return { kind: "strict_new_line" };
+  if (authority.wakeOwnerMemberId !== authority.ownerMemberId) return { kind: "strict_new_line" };
+  const ownerPrivateChats: string[] = [];
+  for (const chatId of candidateChatIds) {
+    const chat = chatById.get(chatId);
+    if (!chat || chat.organizationId !== authority.organizationId) continue;
+    const speakers = speakersByChat.get(chatId) ?? [];
+    const humanSpeakers = speakers.filter((speaker) => speaker.type === AGENT_TYPES.HUMAN);
+    if (humanSpeakers.length !== 1 || humanSpeakers[0]?.agentId !== input.humanAgentId) continue;
+    if (
+      speakers.some((speaker) => speaker.type !== AGENT_TYPES.HUMAN && speaker.managerId !== authority.ownerMemberId)
+    ) {
+      continue;
+    }
+    const canAdmit = await canInviteParticipantsToChatInTransaction(db, {
+      chatId,
+      callerAgentId: input.humanAgentId,
+      targetAgentIds: [input.wakeAgentId],
+      errorOnAlreadySpeaker: false,
+    });
+    if (canAdmit) ownerPrivateChats.push(chatId);
+    if (ownerPrivateChats.length > 1) return { kind: "strict_new_line" };
+  }
+  const ownerPrivateChat = ownerPrivateChats[0];
+  return ownerPrivateChat
+    ? { kind: "reuse_with_line", chatId: ownerPrivateChat, admitWakeAgent: true }
+    : { kind: "strict_new_line" };
+}
+
+function isCurrentEligiblePair(
+  human: AgentSnapshot,
+  wake: AgentSnapshot,
+  wakeAgentId: string,
+  humanMemberStatus: string | null,
+): boolean {
+  return Boolean(
+    human.type === AGENT_TYPES.HUMAN &&
+      human.status === AGENT_STATUSES.ACTIVE &&
+      humanMemberStatus === "active" &&
+      human.delegateMention === wakeAgentId &&
+      wake.type !== AGENT_TYPES.HUMAN &&
+      wake.status === AGENT_STATUSES.ACTIVE &&
+      human.organizationId === wake.organizationId,
+  );
 }

--- a/packages/server/src/services/watcher.ts
+++ b/packages/server/src/services/watcher.ts
@@ -34,6 +34,7 @@ import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
+import { lockChatMembershipMutation } from "./chat-membership-lock.js";
 import { addChatParticipants, recomputeChatWatchers } from "./participant-mode.js";
 
 // Re-export so historical callers that reach for
@@ -189,6 +190,7 @@ export type LeaveResult = {
  */
 export async function leaveAsParticipant(db: Database, chatId: string, humanAgentId: string): Promise<LeaveResult> {
   const outcome = await db.transaction(async (tx): Promise<LeaveResult> => {
+    await lockChatMembershipMutation(tx, [chatId]);
     const [existing] = await tx
       .select({ accessMode: chatMembership.accessMode })
       .from(chatMembership)

--- a/packages/shared/src/schemas/scm-attention.ts
+++ b/packages/shared/src/schemas/scm-attention.ts
@@ -34,6 +34,7 @@ export const scmAudienceEntrySchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("personnel_target"),
     reason: involveReasonSchema,
+    requiresPersistentLine: z.boolean(),
     humanAgentId: z.string().min(1),
     wakeAgentId: z.string().min(1),
     externalUsername: z.string().min(1),


### PR DESCRIPTION
## Summary

- preserve exact `(humanAgentId, wakeAgentId)` SCM attention identities while safely co-locating assignment and mention targets in one uniquely eligible entity chat
- split card display priority from persistent-line requirements and introduce explicit `reuse_membership`, `reuse_with_line`, and `strict_new_line` placement outcomes
- serialize GitHub and GitLab entity mutations with atomic membership admission, exact mapping persistence, authority revalidation, and commit-time cache invalidation
- make chat membership and provider identity lock ordering stable across follow, rebind, unfollow, webhook placement, and cross-provider concurrency
- extend GitHub/GitLab regression coverage and the static SCM attention parity QA case

## Risk

This is a high-risk cross-surface change spanning provider routing, private-agent membership, attention-line persistence, and concurrency. Unsafe, ambiguous, stale-authority, cross-owner, or multi-candidate cases fail closed to strict placement instead of guessing a chat. Existing lines are never deduplicated by human or manager identity.

The durable routing and membership contracts were approved and merged in agent-team-foundation/first-tree-context#880 before this code PR.

## Validation

- `pnpm check` (passes with the repository baseline of 18 warnings and 7 infos)
- `pnpm typecheck` (11/11 tasks)
- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2` (263 files, 3075 tests)
- `git diff --check`
- independent static code review: passed with no blockers

Formal agent-run QA was not executed. The cross-surface static QA case was updated for a future authorized run.
