### PR TITLE
feat(web): improve first-chat Orientation experience

### DIFF
--- a/packages/web/src/components/chat/__tests__/onboarding-orientation.test.tsx
+++ b/packages/web/src/components/chat/__tests__/onboarding-orientation.test.tsx
@@ -14,7 +14,15 @@ async function renderOrientation(
   document.body.appendChild(container);
   const root = createRoot(container);
   await act(async () => {
-    root.render(<OnboardingOrientation completed={false} continuing={false} onContinue={vi.fn()} {...props} />);
+    root.render(
+      <OnboardingOrientation
+        completed={false}
+        continuing={false}
+        targetAgentName="Nova"
+        onContinue={vi.fn()}
+        {...props}
+      />,
+    );
   });
   return { container, root };
 }

--- a/packages/web/src/components/chat/__tests__/onboarding-orientation.test.tsx
+++ b/packages/web/src/components/chat/__tests__/onboarding-orientation.test.tsx
@@ -32,46 +32,54 @@ afterEach(() => {
 });
 
 describe("OnboardingOrientation", () => {
-  it("offers the available chapter and one global skip action", async () => {
+  it("shows the selected video, persistent chapter list, and one continue action", async () => {
     const onContinue = vi.fn();
     const { container } = await renderOrientation({ onContinue });
 
     expect(container.querySelector('[data-onboarding-orientation="pending"]')).not.toBeNull();
     expect(container.querySelectorAll("[data-orientation-chapter]")).toHaveLength(1);
-    expect(container.textContent).toContain("Watch a short product tour");
+    expect(container.textContent).toContain("Watch the short tours");
     expect(container.textContent).not.toContain("Context Tree");
     expect(container.textContent).not.toContain("GitHub automation");
     expect(container.textContent).not.toContain("Video placeholder");
-    expect(container.textContent).not.toContain("Read transcript");
+    expect(container.textContent).toContain("Transcript");
+    expect(container.querySelector("video")?.autoplay).toBe(false);
 
-    const skip = [...container.querySelectorAll("button")].find(
-      (button) => button.textContent?.trim() === "Skip introduction and start",
+    const continueButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Continue with Nova",
     );
-    await click(skip ?? null);
+    await click(continueButton ?? null);
     expect(onContinue).toHaveBeenCalledTimes(1);
   });
 
-  it("lets the user inspect any chapter, then explicitly start their task", async () => {
+  it("plays a chapter when its persistent playlist item is clicked and marks it watched on completion", async () => {
     const onContinue = vi.fn();
+    const play = vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue();
     const { container } = await renderOrientation({ onContinue });
     const multiAgent = [...container.querySelectorAll<HTMLButtonElement>("[data-orientation-chapter]")].find((button) =>
       button.textContent?.includes("Multi-agent collaboration"),
     );
 
     await click(multiAgent ?? null);
-    expect(container.querySelectorAll("[data-orientation-chapter]")).toHaveLength(0);
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(container.querySelectorAll("[data-orientation-chapter]")).toHaveLength(1);
     expect(container.textContent).toContain("The right agents join as the work unfolds");
     const video = container.querySelector("video");
     expect(video?.getAttribute("poster")).toBe("/onboarding/orientation/stills/multi-agent-poster.png");
     expect(video?.querySelector("source")?.getAttribute("src")).toBe("/onboarding/orientation/multi-agent.mp4");
     expect(video?.querySelector("track")?.getAttribute("src")).toBe("/onboarding/orientation/multi-agent.vtt");
-    expect(container.textContent).toContain("Read transcript");
-    expect(container.textContent).toContain("Choose another chapter");
+    expect(container.textContent).toContain("Transcript");
+    expect(container.textContent).not.toContain("Choose another chapter");
 
-    const start = [...container.querySelectorAll("button")].find(
-      (button) => button.textContent?.trim() === "Start my first task",
+    await act(async () => {
+      video?.dispatchEvent(new Event("ended"));
+    });
+    expect(multiAgent?.dataset.orientationChapterStatus).toBe("watched");
+
+    const continueButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Continue with Nova",
     );
-    await click(start ?? null);
+    await click(continueButton ?? null);
     expect(onContinue).toHaveBeenCalledTimes(1);
   });
 
@@ -81,14 +89,12 @@ describe("OnboardingOrientation", () => {
 
     expect(container.querySelector('[data-onboarding-orientation="completed"]')).not.toBeNull();
     expect(container.querySelectorAll("[data-orientation-chapter]")).toHaveLength(0);
-    expect(container.textContent).not.toContain("Skip introduction and start");
+    expect(container.textContent).not.toContain("Continue with Nova");
 
-    const review = [...container.querySelectorAll("button")].find(
-      (button) => button.textContent?.trim() === "Watch again",
-    );
+    const review = [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === "Watch");
     await click(review ?? null);
     expect(container.querySelectorAll("[data-orientation-chapter]")).toHaveLength(1);
     expect(onContinue).not.toHaveBeenCalled();
-    expect(container.textContent).not.toContain("Start my first task");
+    expect(container.textContent).not.toContain("Continue with Nova");
   });
 });

--- a/packages/web/src/components/chat/onboarding-orientation.tsx
+++ b/packages/web/src/components/chat/onboarding-orientation.tsx
@@ -42,10 +42,16 @@ function formatTotalDuration(durationInSeconds: number): string {
 export type OnboardingOrientationProps = {
   completed: boolean;
   continuing: boolean;
+  targetAgentName: string | null;
   onContinue: () => void | Promise<void>;
 };
 
-export function OnboardingOrientation({ completed, continuing, onContinue }: OnboardingOrientationProps) {
+export function OnboardingOrientation({
+  completed,
+  continuing,
+  targetAgentName,
+  onContinue,
+}: OnboardingOrientationProps) {
   const titleId = useId();
   const videoRef = useRef<HTMLVideoElement>(null);
   const [expanded, setExpanded] = useState(!completed);
@@ -55,6 +61,7 @@ export function OnboardingOrientation({ completed, continuing, onContinue }: Onb
   const [requestedAutoplayId, setRequestedAutoplayId] = useState<OnboardingOrientationChapterId | null>(null);
   const [watchedIds, setWatchedIds] = useState<Set<OnboardingOrientationChapterId>>(() => new Set());
   const [videoError, setVideoError] = useState(false);
+  const normalizedTargetAgentName = targetAgentName?.trim() || null;
 
   useEffect(() => {
     if (completed) setExpanded(false);
@@ -110,13 +117,7 @@ export function OnboardingOrientation({ completed, continuing, onContinue }: Onb
             </p>
           </div>
         </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="min-h-11 shrink-0"
-          onClick={() => setExpanded(true)}
-        >
+        <Button type="button" variant="ghost" size="sm" className="min-h-11 shrink-0" onClick={() => setExpanded(true)}>
           {watchedIds.size > 0 ? <RotateCcw className="size-3.5" aria-hidden="true" /> : null}
           {reviewLabel}
         </Button>
@@ -263,7 +264,11 @@ export function OnboardingOrientation({ completed, continuing, onContinue }: Onb
               disabled={continuing}
               onClick={() => void onContinue()}
             >
-              {continuing ? "Continuing…" : "Continue with Nova"}
+              {continuing
+                ? "Continuing…"
+                : normalizedTargetAgentName
+                  ? `Continue with ${normalizedTargetAgentName}`
+                  : "Continue"}
             </Button>
           </div>
         ) : null}

--- a/packages/web/src/components/chat/onboarding-orientation.tsx
+++ b/packages/web/src/components/chat/onboarding-orientation.tsx
@@ -1,5 +1,6 @@
-import { ChevronDown, Play } from "lucide-react";
-import { useEffect, useId, useState } from "react";
+import { Check, ChevronDown, Play, RotateCcw } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { cn } from "../../lib/utils.js";
 import { Button } from "../ui/button.js";
 
 export const ONBOARDING_ORIENTATION_CONTINUE_MESSAGE = "I'm ready. Please help me get started with First Tree.";
@@ -22,6 +23,21 @@ export type OnboardingOrientationChapterId = keyof typeof ONBOARDING_ORIENTATION
 export const ONBOARDING_ORIENTATION_DEFAULT_CHAPTER_ID: OnboardingOrientationChapterId = "multi-agent";
 
 const CHAPTERS = Object.values(ONBOARDING_ORIENTATION_CHAPTERS);
+const TOTAL_DURATION_IN_SECONDS = CHAPTERS.reduce((total, chapter) => total + chapter.durationInSeconds, 0);
+
+function formatChapterDuration(durationInSeconds: number): string {
+  const minutes = Math.floor(durationInSeconds / 60);
+  const seconds = durationInSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function formatTotalDuration(durationInSeconds: number): string {
+  const minutes = Math.floor(durationInSeconds / 60);
+  const seconds = durationInSeconds % 60;
+  if (minutes === 0) return `${seconds} sec`;
+  if (seconds === 0) return `${minutes} min`;
+  return `${minutes} min ${seconds} sec`;
+}
 
 export type OnboardingOrientationProps = {
   completed: boolean;
@@ -31,26 +47,56 @@ export type OnboardingOrientationProps = {
 
 export function OnboardingOrientation({ completed, continuing, onContinue }: OnboardingOrientationProps) {
   const titleId = useId();
+  const videoRef = useRef<HTMLVideoElement>(null);
   const [expanded, setExpanded] = useState(!completed);
-  const [selectedId, setSelectedId] = useState<OnboardingOrientationChapterId | null>(null);
+  const [selectedId, setSelectedId] = useState<OnboardingOrientationChapterId>(
+    ONBOARDING_ORIENTATION_DEFAULT_CHAPTER_ID,
+  );
+  const [requestedAutoplayId, setRequestedAutoplayId] = useState<OnboardingOrientationChapterId | null>(null);
+  const [watchedIds, setWatchedIds] = useState<Set<OnboardingOrientationChapterId>>(() => new Set());
+  const [videoError, setVideoError] = useState(false);
 
   useEffect(() => {
     if (completed) setExpanded(false);
   }, [completed]);
 
-  const selected = selectedId === null ? null : ONBOARDING_ORIENTATION_CHAPTERS[selectedId];
+  const selected = ONBOARDING_ORIENTATION_CHAPTERS[selectedId];
+
+  const playSelectedChapter = (): void => {
+    const playPromise = videoRef.current?.play();
+    if (playPromise) void playPromise.catch(() => undefined);
+  };
+
+  const selectChapter = (chapterId: OnboardingOrientationChapterId): void => {
+    setVideoError(false);
+    if (chapterId === selectedId) {
+      playSelectedChapter();
+      return;
+    }
+    setRequestedAutoplayId(chapterId);
+    setSelectedId(chapterId);
+  };
+
+  const markSelectedChapterWatched = (): void => {
+    setWatchedIds((current) => {
+      const next = new Set(current);
+      next.add(selectedId);
+      return next;
+    });
+  };
 
   if (!expanded) {
+    const reviewLabel = watchedIds.size > 0 ? "Replay" : "Watch";
     return (
       <section
         aria-labelledby={titleId}
         data-onboarding-orientation="completed"
-        className="mt-3 flex flex-col border border-border bg-muted/30 sm:flex-row sm:items-center"
+        className="mt-3 flex items-center border border-border bg-muted/30"
         style={{ gap: "var(--sp-2)", padding: "var(--sp-2) var(--sp-3)", borderRadius: "var(--radius-input)" }}
       >
         <div className="flex min-w-0 flex-1 items-center" style={{ gap: "var(--sp-2)" }}>
           <span
-            className="flex size-6 shrink-0 items-center justify-center rounded-full bg-secondary"
+            className="flex size-7 shrink-0 items-center justify-center rounded-full bg-secondary"
             aria-hidden="true"
           >
             <Play className="size-3.5" />
@@ -59,16 +105,20 @@ export function OnboardingOrientation({ completed, continuing, onContinue }: Onb
             <p id={titleId} className="text-label font-medium">
               First Tree introduction
             </p>
+            <p className="text-caption text-muted-foreground">
+              Optional product tour · {formatTotalDuration(TOTAL_DURATION_IN_SECONDS)}
+            </p>
           </div>
         </div>
         <Button
           type="button"
           variant="ghost"
           size="sm"
-          className="min-h-11 w-full sm:w-auto"
+          className="min-h-11 shrink-0"
           onClick={() => setExpanded(true)}
         >
-          Watch again
+          {watchedIds.size > 0 ? <RotateCcw className="size-3.5" aria-hidden="true" /> : null}
+          {reviewLabel}
         </Button>
       </section>
     );
@@ -78,114 +128,154 @@ export function OnboardingOrientation({ completed, continuing, onContinue }: Onb
     <section
       aria-labelledby={titleId}
       data-onboarding-orientation={completed ? "review" : "pending"}
-      className="mt-3 overflow-hidden border border-border bg-background"
+      className="mt-3 overflow-hidden border border-border bg-muted/20"
       style={{ borderRadius: "var(--radius-panel)" }}
     >
-      <div className="flex flex-col" style={{ gap: "var(--sp-1)", padding: "var(--sp-4)" }}>
-        <div className="flex flex-wrap items-start" style={{ gap: "var(--sp-2)" }}>
-          <div className="min-w-0 flex-1">
-            <p id={titleId} className="text-title font-semibold">
-              {selected?.title ?? "See how First Tree works"}
-            </p>
-            <p className="text-body text-muted-foreground">
-              {selected?.summary ?? "Watch a short product tour, or skip straight to work."}
-            </p>
-          </div>
-          {selected ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="min-h-11 w-full sm:w-auto"
-              onClick={() => setSelectedId(null)}
-            >
-              Choose another chapter
-            </Button>
-          ) : null}
+      <header className="flex flex-col" style={{ gap: "var(--sp-1)", padding: "var(--sp-4)" }}>
+        <div className="flex flex-wrap items-baseline justify-between" style={{ gap: "var(--sp-2)" }}>
+          <p id={titleId} className="text-title font-semibold text-balance">
+            Get to know First Tree
+          </p>
+          <p className="mono text-caption shrink-0 text-muted-foreground">
+            Optional · {formatTotalDuration(TOTAL_DURATION_IN_SECONDS)}
+          </p>
         </div>
-      </div>
+        <p className="text-body max-w-[65ch] text-muted-foreground text-pretty">
+          Watch the short tours, or continue when you’re ready.
+        </p>
+      </header>
 
-      {selected ? (
-        <div className="border-t border-border" style={{ padding: "var(--sp-4)" }}>
+      <div className="border-t border-border bg-background" style={{ padding: "var(--sp-4)" }}>
+        <div className="mb-3 flex items-start justify-between" style={{ gap: "var(--sp-3)" }}>
+          <div className="min-w-0">
+            <p className="text-label font-semibold text-pretty">{selected.title}</p>
+            <p className="text-body mt-0.5 text-muted-foreground text-pretty">{selected.summary}</p>
+          </div>
+          <span className="mono text-caption shrink-0 text-muted-foreground">
+            {formatChapterDuration(selected.durationInSeconds)}
+          </span>
+        </div>
+
+        <div
+          className="relative aspect-video overflow-hidden border border-border bg-muted/40"
+          style={{ borderRadius: "var(--radius-input)" }}
+        >
           <video
             key={selected.id}
+            ref={videoRef}
             data-onboarding-orientation-video={selected.id}
-            className="aspect-video w-full border border-border bg-muted/40"
-            style={{ borderRadius: "var(--radius-input)" }}
+            className="size-full"
             controls
             playsInline
             preload="metadata"
+            autoPlay={requestedAutoplayId === selected.id}
             poster={selected.posterSrc}
             aria-label={`${selected.title} orientation video`}
+            onPlay={() => setRequestedAutoplayId(null)}
+            onEnded={markSelectedChapterWatched}
+            onError={() => setVideoError(true)}
           >
             <source src={selected.videoSrc} type="video/mp4" />
             <track kind="captions" src={selected.captionsSrc} srcLang="en" label="English" default />
             {selected.transcript}
           </video>
-
-          <details className="group mt-3 border-t border-border pt-3">
-            <summary className="text-label inline-flex min-h-11 cursor-pointer items-center font-medium">
-              Read transcript
-              <ChevronDown className="ml-2 size-4 transition-transform group-open:rotate-180" aria-hidden="true" />
-            </summary>
-            <p className="text-body mt-2 text-muted-foreground">{selected.transcript}</p>
-          </details>
-
-          {!completed ? (
-            <div className="mt-4 flex justify-end">
+          {videoError ? (
+            <div
+              className="absolute inset-0 flex flex-col items-center justify-center bg-background/95 p-6 text-center"
+              role="alert"
+              style={{ gap: "var(--sp-3)" }}
+            >
+              <div>
+                <p className="text-label font-medium">This video couldn’t load</p>
+                <p className="text-body mt-1 text-muted-foreground">
+                  Read the transcript below or try loading it again.
+                </p>
+              </div>
               <Button
                 type="button"
-                variant="cta"
-                className="min-h-11"
-                disabled={continuing}
-                onClick={() => void onContinue()}
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setVideoError(false);
+                  videoRef.current?.load();
+                }}
               >
-                {continuing ? "Starting…" : "Start my first task"}
+                Try again
               </Button>
             </div>
           ) : null}
         </div>
-      ) : (
-        <>
-          <div className="orientation-chapter-grid grid border-y border-border">
-            {CHAPTERS.map((chapter, index) => (
-              <button
-                key={chapter.id}
-                type="button"
-                data-orientation-chapter={chapter.id}
-                onClick={() => setSelectedId(chapter.id)}
-                className="min-h-11 border-0 border-b border-border bg-transparent p-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring sm:border-r"
-              >
-                <span className="flex items-start" style={{ gap: "var(--sp-2)" }}>
-                  <span
-                    className="mono text-caption flex size-6 shrink-0 items-center justify-center rounded-full bg-secondary"
-                    aria-hidden="true"
+
+        <nav className="mt-4" aria-label="Orientation chapters">
+          <p className="text-label font-medium">Chapters</p>
+          <ol className="mt-2 overflow-hidden border-y border-border">
+            {CHAPTERS.map((chapter) => {
+              const isSelected = chapter.id === selectedId;
+              const isWatched = watchedIds.has(chapter.id);
+              return (
+                <li key={chapter.id} className="border-b border-border last:border-b-0">
+                  <button
+                    type="button"
+                    data-orientation-chapter={chapter.id}
+                    data-orientation-chapter-status={isWatched ? "watched" : isSelected ? "selected" : "unwatched"}
+                    aria-current={isSelected ? "true" : undefined}
+                    onClick={() => selectChapter(chapter.id)}
+                    className={cn(
+                      "group flex min-h-11 w-full items-center border-0 bg-transparent p-3 text-left outline-none transition-colors active:bg-muted focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+                      isSelected ? "bg-secondary/70 hover:bg-secondary" : "hover:bg-muted/60",
+                    )}
+                    style={{ gap: "var(--sp-3)" }}
                   >
-                    {index + 1}
-                  </span>
-                  <span className="min-w-0">
-                    <span className="text-label block font-medium">{chapter.title}</span>
-                    <span className="text-caption hidden text-muted-foreground sm:block">{chapter.summary}</span>
-                  </span>
-                </span>
-              </button>
-            ))}
+                    <span
+                      className={cn(
+                        "flex size-7 shrink-0 items-center justify-center rounded-full transition-colors",
+                        isSelected ? "bg-primary text-primary-foreground" : "bg-secondary text-secondary-foreground",
+                      )}
+                      aria-hidden="true"
+                    >
+                      {isWatched ? <Check className="size-3.5" /> : <Play className="size-3.5 translate-x-px" />}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="text-label block font-medium text-pretty">{chapter.title}</span>
+                      <span className="text-caption hidden text-muted-foreground sm:block">{chapter.summary}</span>
+                      {isWatched ? <span className="sr-only">Watched</span> : null}
+                    </span>
+                    <span className="mono text-caption shrink-0 text-muted-foreground">
+                      {formatChapterDuration(chapter.durationInSeconds)}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+        </nav>
+
+        {!completed ? (
+          <div
+            className="mt-4 flex flex-col border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between"
+            style={{ gap: "var(--sp-3)" }}
+          >
+            <p className="text-caption text-muted-foreground">You can return to these videos anytime.</p>
+            <Button
+              type="button"
+              variant="cta"
+              className="min-h-11 w-full shrink-0 sm:w-auto"
+              disabled={continuing}
+              onClick={() => void onContinue()}
+            >
+              {continuing ? "Continuing…" : "Continue with Nova"}
+            </Button>
           </div>
-          {!completed ? (
-            <div className="flex justify-end" style={{ padding: "var(--sp-4)" }}>
-              <Button
-                type="button"
-                variant="cta"
-                className="min-h-11"
-                disabled={continuing}
-                onClick={() => void onContinue()}
-              >
-                {continuing ? "Starting…" : "Skip introduction and start"}
-              </Button>
-            </div>
-          ) : null}
-        </>
-      )}
+        ) : null}
+
+        <details className="group mt-3 border-t border-border pt-3">
+          <summary className="text-label inline-flex min-h-11 cursor-pointer items-center font-medium">
+            Transcript
+            <ChevronDown className="ml-2 size-4 transition-transform group-open:rotate-180" aria-hidden="true" />
+          </summary>
+          <p className="text-body mt-2 max-w-[65ch] text-muted-foreground text-pretty">{selected.transcript}</p>
+        </details>
+      </div>
     </section>
   );
 }

--- a/packages/web/src/pages/onboarding-orientation-preview.tsx
+++ b/packages/web/src/pages/onboarding-orientation-preview.tsx
@@ -50,6 +50,7 @@ export function OnboardingOrientationPreviewPage() {
                 key={completed ? "completed" : "pending"}
                 completed={completed}
                 continuing={false}
+                targetAgentName="Nova"
                 onContinue={() => setCompleted(true)}
               />
             </div>

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -841,7 +841,7 @@ describe("ChatView", () => {
       "/",
     );
 
-    await waitForText(container, "Skip introduction and start");
+    await waitForText(container, "Continue with Nova");
     const composer = container.querySelector<HTMLTextAreaElement>("textarea");
     if (!composer) throw new Error("Composer textarea missing");
     await setValue(composer, "A draft I still want to send");
@@ -857,14 +857,14 @@ describe("ChatView", () => {
         }),
       ]),
     );
-    await click(buttonByText(container, "Skip introduction and start"));
+    await click(buttonByText(container, "Continue with Nova"));
     expect(chatMocks.sendChatMessage).toHaveBeenCalledWith(
       "chat-1",
       "I'm ready. Please help me get started with First Tree.",
       ["agent-1"],
     );
     expect(composer.value).toBe("A draft I still want to send");
-    await waitForText(container, "Watch again");
+    await waitForText(container, "Watch");
     expect(container.querySelectorAll('[data-onboarding-orientation="pending"]')).toHaveLength(0);
 
     await act(async () => root.unmount());
@@ -898,9 +898,9 @@ describe("ChatView", () => {
       "/",
     );
 
-    await waitForText(container, "Watch again");
+    await waitForText(container, "Watch");
     expect(container.textContent).toContain("Start by reading /projects/acme.");
-    expect(container.textContent).not.toContain("Skip introduction and start");
+    expect(container.textContent).not.toContain("Continue with Nova");
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
@@ -934,9 +934,9 @@ describe("ChatView", () => {
       "/",
     );
 
-    await waitForText(container, "Skip introduction and start");
+    await waitForText(container, "Continue with Nova");
     expect(container.querySelectorAll('[data-onboarding-orientation="pending"]')).toHaveLength(1);
-    expect(container.textContent).not.toContain("Watch again");
+    expect(container.textContent).not.toContain("First Tree introduction");
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
@@ -966,8 +966,8 @@ describe("ChatView", () => {
       "/",
     );
 
-    await waitForText(container, "Watch again");
-    expect(container.textContent).not.toContain("Skip introduction and start");
+    await waitForText(container, "Watch");
+    expect(container.textContent).not.toContain("Continue with Nova");
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -826,9 +826,9 @@ describe("ChatView", () => {
     const bootstrap = message({
       id: "orientation-bootstrap",
       senderId: "human-agent-self",
-      content: "Nova, welcome aboard.\n\nPlease help me get started with First Tree.",
+      content: "Design Critique, welcome aboard.\n\nPlease help me get started with First Tree.",
       metadata: {
-        mentions: ["agent-1"],
+        mentions: ["agent-2"],
         [FIRST_CHAT_ORIENTATION_METADATA_KEY]: { version: 1 },
       },
       source: "api",
@@ -841,7 +841,7 @@ describe("ChatView", () => {
       "/",
     );
 
-    await waitForText(container, "Continue with Nova");
+    await waitForText(container, "Continue with Design Critique");
     const composer = container.querySelector<HTMLTextAreaElement>("textarea");
     if (!composer) throw new Error("Composer textarea missing");
     await setValue(composer, "A draft I still want to send");
@@ -852,16 +852,16 @@ describe("ChatView", () => {
           id: "orientation-ready-message",
           senderId: "human-agent-self",
           content: "I'm ready. Please help me get started with First Tree.",
-          metadata: { mentions: ["agent-1"] },
+          metadata: { mentions: ["agent-2"] },
           createdAt: "2026-05-28T11:56:00.000Z",
         }),
       ]),
     );
-    await click(buttonByText(container, "Continue with Nova"));
+    await click(buttonByText(container, "Continue with Design Critique"));
     expect(chatMocks.sendChatMessage).toHaveBeenCalledWith(
       "chat-1",
       "I'm ready. Please help me get started with First Tree.",
-      ["agent-1"],
+      ["agent-2"],
     );
     expect(composer.value).toBe("A draft I still want to send");
     await waitForText(container, "Watch");

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -587,6 +587,7 @@ type MessageBodyProps = {
   requestTagAgentId: string | null;
   myAgentId: string | null;
   mentionParticipants: RenderedMentionParticipant[];
+  orientationTargetName: string | null;
   orientationCompleted: boolean;
   orientationHidden: boolean;
   orientationContinuing: boolean;
@@ -657,6 +658,7 @@ const MessageBody = memo(function MessageBody({
   requestTagAgentId,
   myAgentId,
   mentionParticipants,
+  orientationTargetName,
   orientationCompleted,
   orientationHidden,
   orientationContinuing,
@@ -931,6 +933,7 @@ const MessageBody = memo(function MessageBody({
         <OnboardingOrientation
           completed={orientationCompleted}
           continuing={orientationContinuing}
+          targetAgentName={orientationTargetName}
           onContinue={() => onOrientationContinue(msg)}
         />
       ) : null}
@@ -991,6 +994,8 @@ const MessageRow = memo(function MessageRow({
       ? GITLAB_SYSTEM_SENDER_NAME
       : agentNameFn(msg.senderId);
   const isSelf = !isSystem && myAgentId === msg.senderId;
+  const orientationTargetAgentId = firstChatOrientationTargetAgentId(msg);
+  const orientationTargetName = orientationTargetAgentId ? agentNameFn(orientationTargetAgentId) : null;
 
   return (
     <div
@@ -1068,6 +1073,7 @@ const MessageRow = memo(function MessageRow({
           requestTagAgentId={requestTagAgentId}
           myAgentId={myAgentId}
           mentionParticipants={mentionParticipants}
+          orientationTargetName={orientationTargetName}
           orientationCompleted={orientationCompleted}
           orientationHidden={orientationHidden}
           orientationContinuing={orientationContinuing}
@@ -1100,6 +1106,7 @@ function areMessageBodyPropsEqual(prev: MessageBodyProps, next: MessageBodyProps
     messageBodyFieldsEqual(prev.msg, next.msg) &&
     prev.requestTagAgentId === next.requestTagAgentId &&
     prev.myAgentId === next.myAgentId &&
+    prev.orientationTargetName === next.orientationTargetName &&
     prev.orientationCompleted === next.orientationCompleted &&
     prev.orientationHidden === next.orientationHidden &&
     prev.orientationContinuing === next.orientationContinuing &&


### PR DESCRIPTION
## Summary

- replace the separate chapter-picker and playback screens with one persistent player and chapter list
- keep initial playback user-controlled while starting a chapter immediately from its playlist item
- add watched state, duration context, media error recovery, and a compact completed state
- consolidate the transition into one `Continue with Nova` action and keep the transcript after the primary action
- update Orientation and ChatView lifecycle tests for the new interaction model

## Validation

- `pnpm --filter @first-tree/web test` — 242 files, 2,128 tests passed
- `pnpm typecheck`
- scoped Biome checks for all changed files
- desktop and 390px mobile visual review in the real development preview

## Repository check note

`pnpm check` still reports pre-existing lint findings in unchanged Client and CLI files. The changed files pass Biome and `git diff --check`.