### PR TITLE
refactor: isolate Claude handler internals

### DIFF
--- a/packages/client/src/__tests__/claude-code-config.test.ts
+++ b/packages/client/src/__tests__/claude-code-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { isSameModelFamily, mapMcpServers } from "../handlers/claude-code.js";
+import { mapMcpServers } from "../handlers/claude/mcp-config.js";
+import { isSameModelFamily } from "../handlers/claude/sdk-query-options.js";
 
 describe("claude-code handler helpers (Step 6)", () => {
   describe("mapMcpServers", () => {

--- a/packages/client/src/__tests__/claude-code-tool-events-search-edge.test.ts
+++ b/packages/client/src/__tests__/claude-code-tool-events-search-edge.test.ts
@@ -1,6 +1,6 @@
 import type { SessionEvent } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
-import { createToolCallProcessor } from "../handlers/claude-code.js";
+import { createToolCallProcessor } from "../handlers/claude/tool-call-processor.js";
 
 function assistantToolUse(id: string, name: string, input: unknown) {
   return {

--- a/packages/client/src/__tests__/claude-code-tool-events.test.ts
+++ b/packages/client/src/__tests__/claude-code-tool-events.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createToolCallProcessor, treeNodePathOf } from "../handlers/claude-code.js";
+import { createToolCallProcessor, treeNodePathOf } from "../handlers/claude/tool-call-processor.js";
 import type { ContextTreeGitWriteTracker } from "../runtime/context-tree-git-status.js";
 import { clearGitRepoIdentityCacheForTests } from "../runtime/git-repo-identity.js";
 
@@ -19,9 +19,9 @@ import { clearGitRepoIdentityCacheForTests } from "../runtime/git-repo-identity.
  *   4. tool_result with an array-shaped `content` (mixed blocks) ⇒ text blocks
  *      are concatenated into `resultPreview`.
  *
- * The processor is extracted from the for-await consumer loop in
- * `claude-code.ts`, so these fixtures lock its behavior down without
- * needing to boot the whole handler + SDK + workspace.
+ * The processor lives in `handlers/claude/tool-call-processor.ts`, shared by
+ * the SDK stream handler and the Claude TUI handler, so these fixtures lock
+ * its behavior down without needing to boot either handler + SDK + workspace.
  */
 
 function assistantToolUse(id: string, name: string, input: unknown) {

--- a/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
+++ b/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
@@ -6,28 +6,57 @@ import { describe, expect, it } from "vitest";
 const here = dirname(fileURLToPath(import.meta.url));
 const clientSrc = join(here, "..");
 
+function escapeForRegex(spec: string): string {
+  return spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
- * Matches a real `import`/`export ... from "<spec>"` declaration whose module
- * specifier is exactly `spec` — anchored to the start of a line so a comment
- * or doc-string merely mentioning the same text cannot satisfy it. `[^;]*`
- * intentionally excludes `;` (not newlines) so multi-line named-import lists
+ * Matches a real `import`/`export ... from "<spec>"` declaration (covers both
+ * a binding import and a re-export-from) whose module specifier is exactly
+ * `spec` — anchored to the start of a line so a comment or doc-string merely
+ * mentioning the same text cannot satisfy it. `[^;]*` intentionally excludes
+ * `;` (not newlines) so multi-line named-import lists
  * (`import {\n  a,\n  b,\n} from "spec";`) still match.
  */
-function staticImportOrExportOf(spec: string): RegExp {
-  const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function fromImportOrExportOf(spec: string): RegExp {
+  const escaped = escapeForRegex(spec);
   return new RegExp(`^\\s*(?:import|export)\\b[^;]*from\\s*["']${escaped}["']`, "m");
+}
+
+/**
+ * Matches a bare side-effect `import "<spec>";` (no bindings, no `from`) —
+ * the ESM form that runs a module purely for its top-level side effects.
+ */
+function sideEffectImportOf(spec: string): RegExp {
+  const escaped = escapeForRegex(spec);
+  return new RegExp(`^\\s*import\\s*["']${escaped}["']`, "m");
 }
 
 /** Matches a dynamic `import("<spec>")` / `import('<spec>')` call anywhere in the source. */
 function dynamicImportOf(spec: string): RegExp {
-  const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escaped = escapeForRegex(spec);
   return new RegExp(`import\\(\\s*["']${escaped}["']`);
 }
 
 /** Matches a real named import of `name` from the exact module specifier `spec`. */
 function namedImportOf(name: string, spec: string): RegExp {
-  const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escaped = escapeForRegex(spec);
   return new RegExp(`^\\s*import\\s*\\{[^}]*\\b${name}\\b[^}]*\\}\\s*from\\s*["']${escaped}["']`, "m");
+}
+
+/**
+ * True if `source` references module `spec` through ANY real ESM form: a
+ * binding import, a re-export-from, a bare side-effect import, or a dynamic
+ * `import()` call. This is the single predicate the "must not depend on X"
+ * checks below use, so a forbidden edge cannot sneak back in through a form
+ * the guard forgot to check.
+ */
+function referencesModuleSpecifier(source: string, spec: string): boolean {
+  return (
+    fromImportOrExportOf(spec).test(source) ||
+    sideEffectImportOf(spec).test(source) ||
+    dynamicImportOf(spec).test(source)
+  );
 }
 
 /**
@@ -40,23 +69,26 @@ function namedImportOf(name: string, spec: string): RegExp {
  * modules directly. Before this split, the TUI handler imported them FROM the
  * SDK handler entry point — a reverse dependency that made the TUI handler's
  * load graph include the entire SDK lifecycle module. This guard fails if
- * that reverse dependency ever comes back (static or dynamic), and if the SDK
- * handler entry stops re-exporting the same names (which would silently
+ * that reverse dependency ever comes back — as a binding import, a
+ * re-export-from, a side-effect import, or a dynamic `import()` — and if the
+ * SDK handler entry stops re-exporting the same names (which would silently
  * break any existing internal/package import of them from `claude-code.js`).
  *
  * All checks below match actual `import`/`export`/dynamic-`import()` syntax
  * (anchored to a statement, not a bare substring), so a comment or doc-string
- * mentioning the forbidden/required path cannot flip the assertion either way.
+ * mentioning the forbidden/required path cannot flip the assertion either
+ * way. The "specifier-matching helpers stay precise" block below proves this
+ * directly against synthetic snippets, so the guard's own detection logic
+ * does not rest solely on the fact that it happens to pass against current
+ * source.
  */
 describe("Claude provider-family boundary", () => {
   it("TUI handler depends on the provider-family modules directly, never on the SDK handler entry", () => {
     const tui = readFileSync(join(clientSrc, "handlers/claude-code-tui/index.ts"), "utf8");
 
     // The reverse dependency this split removes: the TUI handler must never
-    // import from its sibling SDK handler entry point again, statically or
-    // dynamically.
-    expect(tui).not.toMatch(staticImportOrExportOf("../claude-code.js"));
-    expect(tui).not.toMatch(dynamicImportOf("../claude-code.js"));
+    // reference its sibling SDK handler entry point again, in any ESM form.
+    expect(referencesModuleSpecifier(tui, "../claude-code.js")).toBe(false);
 
     // It must import the provider-family modules it actually uses via real
     // named-import declarations (not merely mention them in a comment).
@@ -64,21 +96,18 @@ describe("Claude provider-family boundary", () => {
     expect(tui).toMatch(namedImportOf("mapMcpServers", "../claude/mcp-config.js"));
   });
 
-  it("provider-family modules stay self-contained (no static or dynamic import back into either handler)", () => {
+  it("provider-family modules stay self-contained (no import back into either handler, in any ESM form)", () => {
     for (const file of ["tool-call-processor.ts", "mcp-config.ts", "sdk-query-options.ts"]) {
       const source = readFileSync(join(clientSrc, "handlers/claude", file), "utf8");
       for (const spec of ["../claude-code.js", "./claude-code.js", "../../handlers/claude-code.js"]) {
-        expect(source, `${file} must not import the SDK handler entry (${spec})`).not.toMatch(
-          staticImportOrExportOf(spec),
-        );
-        expect(source, `${file} must not dynamically import the SDK handler entry (${spec})`).not.toMatch(
-          dynamicImportOf(spec),
-        );
+        expect(
+          referencesModuleSpecifier(source, spec),
+          `${file} must not reference the SDK handler entry (${spec})`,
+        ).toBe(false);
       }
       for (const spec of ["../claude-code-tui/index.js", "./claude-code-tui/index.js"]) {
-        expect(source, `${file} must not import the TUI handler (${spec})`).not.toMatch(staticImportOrExportOf(spec));
-        expect(source, `${file} must not dynamically import the TUI handler (${spec})`).not.toMatch(
-          dynamicImportOf(spec),
+        expect(referencesModuleSpecifier(source, spec), `${file} must not reference the TUI handler (${spec})`).toBe(
+          false,
         );
       }
     }
@@ -95,9 +124,9 @@ describe("Claude provider-family boundary", () => {
 
     // The three modules stay the actual owners; claude-code.ts is now a thin
     // SDK-lifecycle-only facade that imports and re-exports them.
-    expect(source).toMatch(staticImportOrExportOf("./claude/tool-call-processor.js"));
-    expect(source).toMatch(staticImportOrExportOf("./claude/mcp-config.js"));
-    expect(source).toMatch(staticImportOrExportOf("./claude/sdk-query-options.js"));
+    expect(source).toMatch(fromImportOrExportOf("./claude/tool-call-processor.js"));
+    expect(source).toMatch(fromImportOrExportOf("./claude/mcp-config.js"));
+    expect(source).toMatch(fromImportOrExportOf("./claude/sdk-query-options.js"));
 
     // Every name any existing import site (internal call sites, tests, and —
     // pre-decoupling — the TUI handler) could previously reach via
@@ -134,7 +163,9 @@ describe("Claude provider-family boundary", () => {
     // `export { name } from "./leaf.js"` after `import { name } from "./leaf.js"`
     // re-exports the same binding under ESM semantics; asserting reference
     // identity (not just equal behavior) is what rules out a wrapper or a
-    // copy-pasted second implementation living behind the facade.
+    // copy-pasted second implementation living behind the facade — importing
+    // the same names from both the facade and each leaf and comparing `toBe`
+    // proves it directly, rather than inferring it from source text.
     expect(facade.createToolCallProcessor).toBe(toolCallProcessor.createToolCallProcessor);
     expect(facade.treeNodePathOf).toBe(toolCallProcessor.treeNodePathOf);
     expect(facade.mapMcpServers).toBe(mcpConfig.mapMcpServers);
@@ -146,5 +177,62 @@ describe("Claude provider-family boundary", () => {
     // identity on. `tsc` is the proof for those: every `import type` of them
     // from either the facade or the leaf module must resolve to the same
     // declaration, which the repo-wide typecheck run already exercises.
+  });
+
+  describe("specifier-matching helpers stay precise", () => {
+    const spec = "../claude-code.js";
+
+    it('detects a static binding import (`import { x } from "spec"`)', () => {
+      const snippet = 'import { createToolCallProcessor } from "../claude-code.js";';
+      expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
+      expect(fromImportOrExportOf(spec).test(snippet)).toBe(true);
+    });
+
+    it("detects a multi-line static binding import", () => {
+      const snippet = 'import {\n  createToolCallProcessor,\n  mapMcpServers,\n} from "../claude-code.js";';
+      expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
+    });
+
+    it('detects a re-export-from (`export { x } from "spec"`)', () => {
+      const snippet = 'export { createToolCallProcessor } from "../claude-code.js";';
+      expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
+      expect(fromImportOrExportOf(spec).test(snippet)).toBe(true);
+    });
+
+    it('detects a bare side-effect import (`import "spec"`, no bindings)', () => {
+      const snippet = 'import "../claude-code.js";';
+      expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
+      expect(sideEffectImportOf(spec).test(snippet)).toBe(true);
+      // The `from`-anchored and dynamic-import checks are correctly blind to
+      // this form on their own — it's the combinator that must catch it.
+      expect(fromImportOrExportOf(spec).test(snippet)).toBe(false);
+      expect(dynamicImportOf(spec).test(snippet)).toBe(false);
+    });
+
+    it('detects a dynamic import (`import("spec")`), including when awaited', () => {
+      for (const snippet of [
+        'const m = await import("../claude-code.js");',
+        'import("../claude-code.js").then((m) => m);',
+        "import('../claude-code.js');",
+      ]) {
+        expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
+        expect(dynamicImportOf(spec).test(snippet)).toBe(true);
+      }
+    });
+
+    it("does NOT flag a comment or doc-string merely mentioning the specifier", () => {
+      for (const snippet of [
+        '// see ../claude-code.js for the pre-split behaviour\nimport { mapMcpServers } from "./mcp-config.js";',
+        '/**\n * Used to import from "../claude-code.js" before this split.\n */\nexport const x = 1;',
+        'const message = "this string contains ../claude-code.js but is not an import";',
+      ]) {
+        expect(referencesModuleSpecifier(snippet, spec)).toBe(false);
+      }
+    });
+
+    it("does NOT flag an import from an unrelated specifier that merely shares a suffix", () => {
+      const snippet = 'import { x } from "../not-claude-code.js";';
+      expect(referencesModuleSpecifier(snippet, spec)).toBe(false);
+    });
   });
 });

--- a/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
+++ b/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
@@ -182,57 +182,85 @@ describe("Claude provider-family boundary", () => {
   describe("specifier-matching helpers stay precise", () => {
     const spec = "../claude-code.js";
 
-    it('detects a static binding import (`import { x } from "spec"`)', () => {
-      const snippet = 'import { createToolCallProcessor } from "../claude-code.js";';
-      expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
-      expect(fromImportOrExportOf(spec).test(snippet)).toBe(true);
+    /**
+     * Table-driven characterization of `referencesModuleSpecifier()` against
+     * every real ESM form that could re-introduce the forbidden dependency,
+     * plus the near-miss shapes (comments, doc-strings, string literals, a
+     * similar-but-unequal specifier) that must never trip a false positive.
+     * This is what proves the detection logic itself — the guard elsewhere
+     * in this file only proves today's real source happens to satisfy it.
+     */
+    const SPECIFIER_CASES: ReadonlyArray<{ label: string; snippet: string; expected: boolean }> = [
+      {
+        label: "static named import",
+        snippet: 'import { createToolCallProcessor } from "../claude-code.js";',
+        expected: true,
+      },
+      { label: "static default import", snippet: 'import ClaudeCode from "../claude-code.js";', expected: true },
+      { label: "static namespace import", snippet: 'import * as claudeCode from "../claude-code.js";', expected: true },
+      {
+        label: "multi-line static named import",
+        snippet: 'import {\n  createToolCallProcessor,\n  mapMcpServers,\n} from "../claude-code.js";',
+        expected: true,
+      },
+      {
+        label: "bare side-effect import (no bindings, no `from`)",
+        snippet: 'import "../claude-code.js";',
+        expected: true,
+      },
+      {
+        label: "re-export-from",
+        snippet: 'export { createToolCallProcessor } from "../claude-code.js";',
+        expected: true,
+      },
+      {
+        label: "dynamic import(), awaited",
+        snippet: 'const m = await import("../claude-code.js");',
+        expected: true,
+      },
+      {
+        label: "dynamic import(), chained .then()",
+        snippet: 'import("../claude-code.js").then((m) => m);',
+        expected: true,
+      },
+      { label: "dynamic import(), single-quoted", snippet: "import('../claude-code.js');", expected: true },
+      {
+        label: "comment-only mention",
+        snippet:
+          '// see ../claude-code.js for the pre-split behaviour\nimport { mapMcpServers } from "./mcp-config.js";',
+        expected: false,
+      },
+      {
+        label: "doc-string mention",
+        snippet: '/**\n * Used to import from "../claude-code.js" before this split.\n */\nexport const x = 1;',
+        expected: false,
+      },
+      {
+        label: "string-literal mention",
+        snippet: 'const message = "this string contains ../claude-code.js but is not an import";',
+        expected: false,
+      },
+      {
+        label: "similar-but-unequal specifier (shares a suffix)",
+        snippet: 'import { x } from "../not-claude-code.js";',
+        expected: false,
+      },
+    ];
+
+    it.each(SPECIFIER_CASES)("$label -> referencesModuleSpecifier === $expected", ({ snippet, expected }) => {
+      expect(referencesModuleSpecifier(snippet, spec)).toBe(expected);
     });
 
-    it("detects a multi-line static binding import", () => {
-      const snippet = 'import {\n  createToolCallProcessor,\n  mapMcpServers,\n} from "../claude-code.js";';
-      expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
-    });
-
-    it('detects a re-export-from (`export { x } from "spec"`)', () => {
-      const snippet = 'export { createToolCallProcessor } from "../claude-code.js";';
-      expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
-      expect(fromImportOrExportOf(spec).test(snippet)).toBe(true);
-    });
-
-    it('detects a bare side-effect import (`import "spec"`, no bindings)', () => {
-      const snippet = 'import "../claude-code.js";';
-      expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
-      expect(sideEffectImportOf(spec).test(snippet)).toBe(true);
-      // The `from`-anchored and dynamic-import checks are correctly blind to
-      // this form on their own — it's the combinator that must catch it.
-      expect(fromImportOrExportOf(spec).test(snippet)).toBe(false);
-      expect(dynamicImportOf(spec).test(snippet)).toBe(false);
-    });
-
-    it('detects a dynamic import (`import("spec")`), including when awaited', () => {
-      for (const snippet of [
-        'const m = await import("../claude-code.js");',
-        'import("../claude-code.js").then((m) => m);',
-        "import('../claude-code.js');",
-      ]) {
-        expect(referencesModuleSpecifier(snippet, spec)).toBe(true);
-        expect(dynamicImportOf(spec).test(snippet)).toBe(true);
-      }
-    });
-
-    it("does NOT flag a comment or doc-string merely mentioning the specifier", () => {
-      for (const snippet of [
-        '// see ../claude-code.js for the pre-split behaviour\nimport { mapMcpServers } from "./mcp-config.js";',
-        '/**\n * Used to import from "../claude-code.js" before this split.\n */\nexport const x = 1;',
-        'const message = "this string contains ../claude-code.js but is not an import";',
-      ]) {
-        expect(referencesModuleSpecifier(snippet, spec)).toBe(false);
-      }
-    });
-
-    it("does NOT flag an import from an unrelated specifier that merely shares a suffix", () => {
-      const snippet = 'import { x } from "../not-claude-code.js";';
-      expect(referencesModuleSpecifier(snippet, spec)).toBe(false);
+    it("the side-effect-import case is exactly the regression the guard used to miss: the pre-fix from-anchored matcher alone stays blind to it, and the dynamic-import matcher alone stays blind to it too — only the combinator catches it", () => {
+      const sideEffectSnippet = 'import "../claude-code.js";';
+      // `fromImportOrExportOf` is the pre-fix matcher (it required a `from`
+      // clause): it correctly does NOT see a bare side-effect import, which
+      // is exactly why relying on it alone let this reverse-dependency form
+      // through undetected before this test file added `sideEffectImportOf`.
+      expect(fromImportOrExportOf(spec).test(sideEffectSnippet)).toBe(false);
+      expect(dynamicImportOf(spec).test(sideEffectSnippet)).toBe(false);
+      // The combined predicate closes the gap.
+      expect(referencesModuleSpecifier(sideEffectSnippet, spec)).toBe(true);
     });
   });
 });

--- a/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
+++ b/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
@@ -7,6 +7,30 @@ const here = dirname(fileURLToPath(import.meta.url));
 const clientSrc = join(here, "..");
 
 /**
+ * Matches a real `import`/`export ... from "<spec>"` declaration whose module
+ * specifier is exactly `spec` — anchored to the start of a line so a comment
+ * or doc-string merely mentioning the same text cannot satisfy it. `[^;]*`
+ * intentionally excludes `;` (not newlines) so multi-line named-import lists
+ * (`import {\n  a,\n  b,\n} from "spec";`) still match.
+ */
+function staticImportOrExportOf(spec: string): RegExp {
+  const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^\\s*(?:import|export)\\b[^;]*from\\s*["']${escaped}["']`, "m");
+}
+
+/** Matches a dynamic `import("<spec>")` / `import('<spec>')` call anywhere in the source. */
+function dynamicImportOf(spec: string): RegExp {
+  const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`import\\(\\s*["']${escaped}["']`);
+}
+
+/** Matches a real named import of `name` from the exact module specifier `spec`. */
+function namedImportOf(name: string, spec: string): RegExp {
+  const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^\\s*import\\s*\\{[^}]*\\b${name}\\b[^}]*\\}\\s*from\\s*["']${escaped}["']`, "m");
+}
+
+/**
  * Architectural guard for the Claude provider-family split
  * (`handlers/claude/tool-call-processor.ts`, `handlers/claude/mcp-config.ts`,
  * `handlers/claude/sdk-query-options.ts`).
@@ -16,36 +40,53 @@ const clientSrc = join(here, "..");
  * modules directly. Before this split, the TUI handler imported them FROM the
  * SDK handler entry point — a reverse dependency that made the TUI handler's
  * load graph include the entire SDK lifecycle module. This guard fails if
- * that reverse dependency ever comes back, and if the SDK handler entry stops
- * re-exporting the same names (which would silently break any existing
- * internal/package import of them from `claude-code.js`).
+ * that reverse dependency ever comes back (static or dynamic), and if the SDK
+ * handler entry stops re-exporting the same names (which would silently
+ * break any existing internal/package import of them from `claude-code.js`).
+ *
+ * All checks below match actual `import`/`export`/dynamic-`import()` syntax
+ * (anchored to a statement, not a bare substring), so a comment or doc-string
+ * mentioning the forbidden/required path cannot flip the assertion either way.
  */
 describe("Claude provider-family boundary", () => {
   it("TUI handler depends on the provider-family modules directly, never on the SDK handler entry", () => {
     const tui = readFileSync(join(clientSrc, "handlers/claude-code-tui/index.ts"), "utf8");
 
     // The reverse dependency this split removes: the TUI handler must never
-    // import from its sibling SDK handler entry point again.
-    expect(tui).not.toMatch(/from ["']\.\.\/claude-code\.js["']/);
+    // import from its sibling SDK handler entry point again, statically or
+    // dynamically.
+    expect(tui).not.toMatch(staticImportOrExportOf("../claude-code.js"));
+    expect(tui).not.toMatch(dynamicImportOf("../claude-code.js"));
 
-    // It must import the provider-family modules it actually uses.
-    expect(tui).toMatch(/createToolCallProcessor.*from ["']\.\.\/claude\/tool-call-processor\.js["']/);
-    expect(tui).toMatch(/mapMcpServers.*from ["']\.\.\/claude\/mcp-config\.js["']/);
+    // It must import the provider-family modules it actually uses via real
+    // named-import declarations (not merely mention them in a comment).
+    expect(tui).toMatch(namedImportOf("createToolCallProcessor", "../claude/tool-call-processor.js"));
+    expect(tui).toMatch(namedImportOf("mapMcpServers", "../claude/mcp-config.js"));
   });
 
-  it("provider-family modules stay self-contained (no import back into either handler)", () => {
+  it("provider-family modules stay self-contained (no static or dynamic import back into either handler)", () => {
     for (const file of ["tool-call-processor.ts", "mcp-config.ts", "sdk-query-options.ts"]) {
       const source = readFileSync(join(clientSrc, "handlers/claude", file), "utf8");
-      expect(source, `${file} must not import the SDK handler entry`).not.toMatch(/from ["'].*\/claude-code\.js["']/);
-      expect(source, `${file} must not import the TUI handler`).not.toMatch(
-        /from ["'].*claude-code-tui\/index\.js["']/,
-      );
+      for (const spec of ["../claude-code.js", "./claude-code.js", "../../handlers/claude-code.js"]) {
+        expect(source, `${file} must not import the SDK handler entry (${spec})`).not.toMatch(
+          staticImportOrExportOf(spec),
+        );
+        expect(source, `${file} must not dynamically import the SDK handler entry (${spec})`).not.toMatch(
+          dynamicImportOf(spec),
+        );
+      }
+      for (const spec of ["../claude-code-tui/index.js", "./claude-code-tui/index.js"]) {
+        expect(source, `${file} must not import the TUI handler (${spec})`).not.toMatch(staticImportOrExportOf(spec));
+        expect(source, `${file} must not dynamically import the TUI handler (${spec})`).not.toMatch(
+          dynamicImportOf(spec),
+        );
+      }
     }
   });
 
   it("sdk-query-options.ts composes mcp-config.ts rather than re-deriving MCP mapping", () => {
     const source = readFileSync(join(clientSrc, "handlers/claude/sdk-query-options.ts"), "utf8");
-    expect(source).toContain('from "./mcp-config.js"');
+    expect(source).toMatch(namedImportOf("mapMcpServers", "./mcp-config.js"));
     expect(source).not.toMatch(/for \(const s of payload\.mcpServers\)/);
   });
 
@@ -54,13 +95,14 @@ describe("Claude provider-family boundary", () => {
 
     // The three modules stay the actual owners; claude-code.ts is now a thin
     // SDK-lifecycle-only facade that imports and re-exports them.
-    expect(source).toContain('from "./claude/tool-call-processor.js"');
-    expect(source).toContain('from "./claude/mcp-config.js"');
-    expect(source).toContain('from "./claude/sdk-query-options.js"');
+    expect(source).toMatch(staticImportOrExportOf("./claude/tool-call-processor.js"));
+    expect(source).toMatch(staticImportOrExportOf("./claude/mcp-config.js"));
+    expect(source).toMatch(staticImportOrExportOf("./claude/sdk-query-options.js"));
 
     // Every name any existing import site (internal call sites, tests, and —
     // pre-decoupling — the TUI handler) could previously reach via
-    // `handlers/claude-code.js` must still resolve from there.
+    // `handlers/claude-code.js` must still resolve from there, via a real
+    // `export { ... }` statement (not a mention in prose).
     for (const name of [
       "createToolCallProcessor",
       "treeNodePathOf",
@@ -71,7 +113,9 @@ describe("Claude provider-family boundary", () => {
       "isSameModelFamily",
       "ClaudeQueryConfigOptions",
     ]) {
-      expect(source, `claude-code.ts must still export ${name}`).toMatch(new RegExp(`export \\{[^}]*\\b${name}\\b`));
+      expect(source, `claude-code.ts must still export ${name}`).toMatch(
+        new RegExp(`^export\\s*\\{[^}]*\\b${name}\\b`, "m"),
+      );
     }
 
     // The extracted logic itself must not still be defined inline here —
@@ -79,5 +123,28 @@ describe("Claude provider-family boundary", () => {
     expect(source).not.toMatch(/^export function createToolCallProcessor/m);
     expect(source).not.toMatch(/^export function mapMcpServers/m);
     expect(source).not.toMatch(/^export function buildClaudeQueryOptions/m);
+  });
+
+  it("re-exported runtime helpers are the exact same function references the leaf modules export, not a second implementation", async () => {
+    const facade = await import("../handlers/claude-code.js");
+    const toolCallProcessor = await import("../handlers/claude/tool-call-processor.js");
+    const mcpConfig = await import("../handlers/claude/mcp-config.js");
+    const sdkQueryOptions = await import("../handlers/claude/sdk-query-options.js");
+
+    // `export { name } from "./leaf.js"` after `import { name } from "./leaf.js"`
+    // re-exports the same binding under ESM semantics; asserting reference
+    // identity (not just equal behavior) is what rules out a wrapper or a
+    // copy-pasted second implementation living behind the facade.
+    expect(facade.createToolCallProcessor).toBe(toolCallProcessor.createToolCallProcessor);
+    expect(facade.treeNodePathOf).toBe(toolCallProcessor.treeNodePathOf);
+    expect(facade.mapMcpServers).toBe(mcpConfig.mapMcpServers);
+    expect(facade.buildClaudeQueryOptions).toBe(sdkQueryOptions.buildClaudeQueryOptions);
+    expect(facade.isSameModelFamily).toBe(sdkQueryOptions.isSameModelFamily);
+
+    // `ContextTreeBinding`, `ToolCallProcessor`, `ClaudeQueryConfigOptions` are
+    // type-only exports erased at runtime — there is no value to assert
+    // identity on. `tsc` is the proof for those: every `import type` of them
+    // from either the facade or the leaf module must resolve to the same
+    // declaration, which the repo-wide typecheck run already exercises.
   });
 });

--- a/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
+++ b/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const clientSrc = join(here, "..");
+
+/**
+ * Architectural guard for the Claude provider-family split
+ * (`handlers/claude/tool-call-processor.ts`, `handlers/claude/mcp-config.ts`,
+ * `handlers/claude/sdk-query-options.ts`).
+ *
+ * The SDK stream handler (`handlers/claude-code.ts`) and the Claude TUI
+ * transcript handler (`handlers/claude-code-tui/index.ts`) both consume these
+ * modules directly. Before this split, the TUI handler imported them FROM the
+ * SDK handler entry point — a reverse dependency that made the TUI handler's
+ * load graph include the entire SDK lifecycle module. This guard fails if
+ * that reverse dependency ever comes back, and if the SDK handler entry stops
+ * re-exporting the same names (which would silently break any existing
+ * internal/package import of them from `claude-code.js`).
+ */
+describe("Claude provider-family boundary", () => {
+  it("TUI handler depends on the provider-family modules directly, never on the SDK handler entry", () => {
+    const tui = readFileSync(join(clientSrc, "handlers/claude-code-tui/index.ts"), "utf8");
+
+    // The reverse dependency this split removes: the TUI handler must never
+    // import from its sibling SDK handler entry point again.
+    expect(tui).not.toMatch(/from ["']\.\.\/claude-code\.js["']/);
+
+    // It must import the provider-family modules it actually uses.
+    expect(tui).toMatch(/createToolCallProcessor.*from ["']\.\.\/claude\/tool-call-processor\.js["']/);
+    expect(tui).toMatch(/mapMcpServers.*from ["']\.\.\/claude\/mcp-config\.js["']/);
+  });
+
+  it("provider-family modules stay self-contained (no import back into either handler)", () => {
+    for (const file of ["tool-call-processor.ts", "mcp-config.ts", "sdk-query-options.ts"]) {
+      const source = readFileSync(join(clientSrc, "handlers/claude", file), "utf8");
+      expect(source, `${file} must not import the SDK handler entry`).not.toMatch(/from ["'].*\/claude-code\.js["']/);
+      expect(source, `${file} must not import the TUI handler`).not.toMatch(
+        /from ["'].*claude-code-tui\/index\.js["']/,
+      );
+    }
+  });
+
+  it("sdk-query-options.ts composes mcp-config.ts rather than re-deriving MCP mapping", () => {
+    const source = readFileSync(join(clientSrc, "handlers/claude/sdk-query-options.ts"), "utf8");
+    expect(source).toContain('from "./mcp-config.js"');
+    expect(source).not.toMatch(/for \(const s of payload\.mcpServers\)/);
+  });
+
+  it("the SDK handler entry re-exports every migrated helper/type for backward-compatible imports", () => {
+    const source = readFileSync(join(clientSrc, "handlers/claude-code.ts"), "utf8");
+
+    // The three modules stay the actual owners; claude-code.ts is now a thin
+    // SDK-lifecycle-only facade that imports and re-exports them.
+    expect(source).toContain('from "./claude/tool-call-processor.js"');
+    expect(source).toContain('from "./claude/mcp-config.js"');
+    expect(source).toContain('from "./claude/sdk-query-options.js"');
+
+    // Every name any existing import site (internal call sites, tests, and —
+    // pre-decoupling — the TUI handler) could previously reach via
+    // `handlers/claude-code.js` must still resolve from there.
+    for (const name of [
+      "createToolCallProcessor",
+      "treeNodePathOf",
+      "ContextTreeBinding",
+      "ToolCallProcessor",
+      "mapMcpServers",
+      "buildClaudeQueryOptions",
+      "isSameModelFamily",
+      "ClaudeQueryConfigOptions",
+    ]) {
+      expect(source, `claude-code.ts must still export ${name}`).toMatch(new RegExp(`export \\{[^}]*\\b${name}\\b`));
+    }
+
+    // The extracted logic itself must not still be defined inline here —
+    // only imported/re-exported — so there is exactly one source of truth.
+    expect(source).not.toMatch(/^export function createToolCallProcessor/m);
+    expect(source).not.toMatch(/^export function mapMcpServers/m);
+    expect(source).not.toMatch(/^export function buildClaudeQueryOptions/m);
+  });
+});

--- a/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
+++ b/packages/client/src/__tests__/claude-provider-family-boundary.test.ts
@@ -1,47 +1,93 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const clientSrc = join(here, "..");
 
-function escapeForRegex(spec: string): string {
-  return spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+/**
+ * Every literal module specifier a source file references through a real
+ * ESM import/export/dynamic-import syntax node, plus the named bindings
+ * imported from each specifier (`import { name } from "spec"`).
+ *
+ * Built by walking a real TypeScript AST (`ts.createSourceFile` +
+ * `ts.forEachChild`) rather than by pattern-matching source text. This is
+ * what a regex-based matcher cannot give you: comments are trivia the parser
+ * discards before producing nodes, and a string/template-literal expression
+ * is never classified as an `ImportDeclaration`, `ExportDeclaration`, or a
+ * dynamic `import()` call — so text that merely *looks like* import syntax
+ * inside a comment, doc-string, or string/template literal can never be
+ * misread as a real dependency edge, regardless of how closely it resembles
+ * real syntax. A previous regex-based version of this guard (any version up
+ * to and including commit `5b1cd66c`) was fooled by exactly this: a
+ * global, unanchored `import\(...\)` pattern matched `import("...")` text
+ * inside line comments, doc-comments, plain strings, and template literals
+ * alike. The "module-specifier detection stays precise" block below
+ * reproduces that exact class of near-miss against this AST-based
+ * implementation to prove it no longer happens.
+ */
+interface ModuleReferences {
+  specifiers: Set<string>;
+  namedImportsBySpecifier: Map<string, Set<string>>;
 }
 
 /**
- * Matches a real `import`/`export ... from "<spec>"` declaration (covers both
- * a binding import and a re-export-from) whose module specifier is exactly
- * `spec` — anchored to the start of a line so a comment or doc-string merely
- * mentioning the same text cannot satisfy it. `[^;]*` intentionally excludes
- * `;` (not newlines) so multi-line named-import lists
- * (`import {\n  a,\n  b,\n} from "spec";`) still match.
+ * `ts.isImportCall` (the TS compiler's own dynamic-`import()`-call
+ * predicate) is `@internal` and not part of the public `.d.ts`, so it's
+ * unusable under `tsc --noEmit`. A dynamic import call is, in the public
+ * AST shape, simply a `CallExpression` whose callee is the bare `import`
+ * keyword token — that's the one fact this local check relies on.
  */
-function fromImportOrExportOf(spec: string): RegExp {
-  const escaped = escapeForRegex(spec);
-  return new RegExp(`^\\s*(?:import|export)\\b[^;]*from\\s*["']${escaped}["']`, "m");
+function isDynamicImportCall(node: ts.Node): node is ts.CallExpression {
+  return ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword;
 }
 
-/**
- * Matches a bare side-effect `import "<spec>";` (no bindings, no `from`) —
- * the ESM form that runs a module purely for its top-level side effects.
- */
-function sideEffectImportOf(spec: string): RegExp {
-  const escaped = escapeForRegex(spec);
-  return new RegExp(`^\\s*import\\s*["']${escaped}["']`, "m");
-}
+function parseModuleReferences(source: string): ModuleReferences {
+  const sourceFile = ts.createSourceFile("source.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const specifiers = new Set<string>();
+  const namedImportsBySpecifier = new Map<string, Set<string>>();
 
-/** Matches a dynamic `import("<spec>")` / `import('<spec>')` call anywhere in the source. */
-function dynamicImportOf(spec: string): RegExp {
-  const escaped = escapeForRegex(spec);
-  return new RegExp(`import\\(\\s*["']${escaped}["']`);
-}
+  function recordNamedImport(spec: string, name: string): void {
+    let names = namedImportsBySpecifier.get(spec);
+    if (!names) {
+      names = new Set();
+      namedImportsBySpecifier.set(spec, names);
+    }
+    names.add(name);
+  }
 
-/** Matches a real named import of `name` from the exact module specifier `spec`. */
-function namedImportOf(name: string, spec: string): RegExp {
-  const escaped = escapeForRegex(spec);
-  return new RegExp(`^\\s*import\\s*\\{[^}]*\\b${name}\\b[^}]*\\}\\s*from\\s*["']${escaped}["']`, "m");
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteralLike(node.moduleSpecifier)) {
+      // Covers named, default, namespace, type-only, and bare side-effect
+      // imports alike — all of them are `ImportDeclaration` nodes; only the
+      // (optional) `importClause` shape differs, and a side-effect import
+      // simply has no `importClause` at all.
+      const spec = node.moduleSpecifier.text;
+      specifiers.add(spec);
+      const namedBindings = node.importClause?.namedBindings;
+      if (namedBindings && ts.isNamedImports(namedBindings)) {
+        for (const element of namedBindings.elements) {
+          recordNamedImport(spec, element.name.text);
+        }
+      }
+    } else if (ts.isExportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteralLike(node.moduleSpecifier)) {
+      // `export { name } from "spec"` / `export * from "spec"`.
+      specifiers.add(node.moduleSpecifier.text);
+    } else if (isDynamicImportCall(node)) {
+      // Dynamic `import("spec")`, however it's used (awaited, `.then()`-
+      // chained, bare statement, single- or double-quoted).
+      const [arg] = node.arguments;
+      if (arg && ts.isStringLiteralLike(arg)) {
+        specifiers.add(arg.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return { specifiers, namedImportsBySpecifier };
 }
 
 /**
@@ -52,11 +98,56 @@ function namedImportOf(name: string, spec: string): RegExp {
  * the guard forgot to check.
  */
 function referencesModuleSpecifier(source: string, spec: string): boolean {
-  return (
-    fromImportOrExportOf(spec).test(source) ||
-    sideEffectImportOf(spec).test(source) ||
-    dynamicImportOf(spec).test(source)
-  );
+  return parseModuleReferences(source).specifiers.has(spec);
+}
+
+/** True if `source` has a real named-import binding of `name` from the exact module specifier `spec`. */
+function hasNamedImport(source: string, name: string, spec: string): boolean {
+  return parseModuleReferences(source).namedImportsBySpecifier.get(spec)?.has(name) ?? false;
+}
+
+/**
+ * Every name a source file re-exports via `export { name }` or
+ * `export { name } from "spec"` (both are `ExportDeclaration` nodes with a
+ * `NamedExports` `exportClause`; only the presence of `moduleSpecifier`
+ * differs) — i.e. every name reachable by importing this file, regardless of
+ * whether it re-exports a name imported from elsewhere or one declared here.
+ */
+function collectNamedExports(source: string): Set<string> {
+  const sourceFile = ts.createSourceFile("source.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const names = new Set<string>();
+
+  function visit(node: ts.Node): void {
+    if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
+      for (const element of node.exportClause.elements) {
+        names.add(element.name.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return names;
+}
+
+/** Every top-level function name declared with `export function name(...)` in `source`. */
+function collectExportedFunctionDeclarationNames(source: string): Set<string> {
+  const sourceFile = ts.createSourceFile("source.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const names = new Set<string>();
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name &&
+      node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      names.add(node.name.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return names;
 }
 
 /**
@@ -74,13 +165,13 @@ function referencesModuleSpecifier(source: string, spec: string): boolean {
  * SDK handler entry stops re-exporting the same names (which would silently
  * break any existing internal/package import of them from `claude-code.js`).
  *
- * All checks below match actual `import`/`export`/dynamic-`import()` syntax
- * (anchored to a statement, not a bare substring), so a comment or doc-string
- * mentioning the forbidden/required path cannot flip the assertion either
- * way. The "specifier-matching helpers stay precise" block below proves this
- * directly against synthetic snippets, so the guard's own detection logic
- * does not rest solely on the fact that it happens to pass against current
- * source.
+ * Every check below is driven by a real TypeScript AST parse of the file
+ * under test, not text pattern-matching, so a comment, doc-string, or
+ * string/template literal that merely *contains* the forbidden/required
+ * import syntax cannot flip the assertion either way. The "module-specifier
+ * detection stays precise" block below proves this directly against
+ * synthetic snippets, so the guard's own detection logic does not rest
+ * solely on the fact that it happens to pass against current source.
  */
 describe("Claude provider-family boundary", () => {
   it("TUI handler depends on the provider-family modules directly, never on the SDK handler entry", () => {
@@ -92,8 +183,8 @@ describe("Claude provider-family boundary", () => {
 
     // It must import the provider-family modules it actually uses via real
     // named-import declarations (not merely mention them in a comment).
-    expect(tui).toMatch(namedImportOf("createToolCallProcessor", "../claude/tool-call-processor.js"));
-    expect(tui).toMatch(namedImportOf("mapMcpServers", "../claude/mcp-config.js"));
+    expect(hasNamedImport(tui, "createToolCallProcessor", "../claude/tool-call-processor.js")).toBe(true);
+    expect(hasNamedImport(tui, "mapMcpServers", "../claude/mcp-config.js")).toBe(true);
   });
 
   it("provider-family modules stay self-contained (no import back into either handler, in any ESM form)", () => {
@@ -115,7 +206,7 @@ describe("Claude provider-family boundary", () => {
 
   it("sdk-query-options.ts composes mcp-config.ts rather than re-deriving MCP mapping", () => {
     const source = readFileSync(join(clientSrc, "handlers/claude/sdk-query-options.ts"), "utf8");
-    expect(source).toMatch(namedImportOf("mapMcpServers", "./mcp-config.js"));
+    expect(hasNamedImport(source, "mapMcpServers", "./mcp-config.js")).toBe(true);
     expect(source).not.toMatch(/for \(const s of payload\.mcpServers\)/);
   });
 
@@ -124,14 +215,15 @@ describe("Claude provider-family boundary", () => {
 
     // The three modules stay the actual owners; claude-code.ts is now a thin
     // SDK-lifecycle-only facade that imports and re-exports them.
-    expect(source).toMatch(fromImportOrExportOf("./claude/tool-call-processor.js"));
-    expect(source).toMatch(fromImportOrExportOf("./claude/mcp-config.js"));
-    expect(source).toMatch(fromImportOrExportOf("./claude/sdk-query-options.js"));
+    expect(referencesModuleSpecifier(source, "./claude/tool-call-processor.js")).toBe(true);
+    expect(referencesModuleSpecifier(source, "./claude/mcp-config.js")).toBe(true);
+    expect(referencesModuleSpecifier(source, "./claude/sdk-query-options.js")).toBe(true);
 
     // Every name any existing import site (internal call sites, tests, and —
     // pre-decoupling — the TUI handler) could previously reach via
     // `handlers/claude-code.js` must still resolve from there, via a real
-    // `export { ... }` statement (not a mention in prose).
+    // `export { ... }` declaration (not a mention in prose).
+    const exportedNames = collectNamedExports(source);
     for (const name of [
       "createToolCallProcessor",
       "treeNodePathOf",
@@ -142,16 +234,17 @@ describe("Claude provider-family boundary", () => {
       "isSameModelFamily",
       "ClaudeQueryConfigOptions",
     ]) {
-      expect(source, `claude-code.ts must still export ${name}`).toMatch(
-        new RegExp(`^export\\s*\\{[^}]*\\b${name}\\b`, "m"),
-      );
+      expect(exportedNames.has(name), `claude-code.ts must still export ${name}`).toBe(true);
     }
 
     // The extracted logic itself must not still be defined inline here —
     // only imported/re-exported — so there is exactly one source of truth.
-    expect(source).not.toMatch(/^export function createToolCallProcessor/m);
-    expect(source).not.toMatch(/^export function mapMcpServers/m);
-    expect(source).not.toMatch(/^export function buildClaudeQueryOptions/m);
+    const exportedFunctionDeclarations = collectExportedFunctionDeclarationNames(source);
+    for (const name of ["createToolCallProcessor", "mapMcpServers", "buildClaudeQueryOptions"]) {
+      expect(exportedFunctionDeclarations.has(name), `claude-code.ts must not still declare ${name} inline`).toBe(
+        false,
+      );
+    }
   });
 
   it("re-exported runtime helpers are the exact same function references the leaf modules export, not a second implementation", async () => {
@@ -179,16 +272,20 @@ describe("Claude provider-family boundary", () => {
     // declaration, which the repo-wide typecheck run already exercises.
   });
 
-  describe("specifier-matching helpers stay precise", () => {
+  describe("module-specifier detection stays precise", () => {
     const spec = "../claude-code.js";
 
     /**
      * Table-driven characterization of `referencesModuleSpecifier()` against
      * every real ESM form that could re-introduce the forbidden dependency,
-     * plus the near-miss shapes (comments, doc-strings, string literals, a
-     * similar-but-unequal specifier) that must never trip a false positive.
-     * This is what proves the detection logic itself — the guard elsewhere
-     * in this file only proves today's real source happens to satisfy it.
+     * plus the near-miss shapes that must never trip a false positive:
+     * comments, doc-strings, plain strings, and template literals — each
+     * tested both as a bare specifier mention AND as a full import/dynamic-
+     * import statement written out inside them (the latter is exactly the
+     * class of false positive a text-pattern matcher is prone to, and an
+     * AST-based check is not). This is what proves the detection logic
+     * itself — the guard tests above only prove today's real source happens
+     * to satisfy it.
      */
     const SPECIFIER_CASES: ReadonlyArray<{ label: string; snippet: string; expected: boolean }> = [
       {
@@ -198,6 +295,7 @@ describe("Claude provider-family boundary", () => {
       },
       { label: "static default import", snippet: 'import ClaudeCode from "../claude-code.js";', expected: true },
       { label: "static namespace import", snippet: 'import * as claudeCode from "../claude-code.js";', expected: true },
+      { label: "static type-only import", snippet: 'import type { Foo } from "../claude-code.js";', expected: true },
       {
         label: "multi-line static named import",
         snippet: 'import {\n  createToolCallProcessor,\n  mapMcpServers,\n} from "../claude-code.js";',
@@ -213,6 +311,7 @@ describe("Claude provider-family boundary", () => {
         snippet: 'export { createToolCallProcessor } from "../claude-code.js";',
         expected: true,
       },
+      { label: "namespace re-export-from", snippet: 'export * from "../claude-code.js";', expected: true },
       {
         label: "dynamic import(), awaited",
         snippet: 'const m = await import("../claude-code.js");',
@@ -225,19 +324,44 @@ describe("Claude provider-family boundary", () => {
       },
       { label: "dynamic import(), single-quoted", snippet: "import('../claude-code.js');", expected: true },
       {
-        label: "comment-only mention",
+        label: "comment-only mention (bare specifier text)",
         snippet:
           '// see ../claude-code.js for the pre-split behaviour\nimport { mapMcpServers } from "./mcp-config.js";',
         expected: false,
       },
       {
-        label: "doc-string mention",
+        label: "doc-string mention (bare specifier text)",
         snippet: '/**\n * Used to import from "../claude-code.js" before this split.\n */\nexport const x = 1;',
         expected: false,
       },
       {
-        label: "string-literal mention",
+        label: "string-literal mention (bare specifier text)",
         snippet: 'const message = "this string contains ../claude-code.js but is not an import";',
+        expected: false,
+      },
+      {
+        label: "line comment containing a full dynamic-import statement",
+        snippet: 'const x = 1;\n// do not use import("../claude-code.js")\nconst y = 2;',
+        expected: false,
+      },
+      {
+        label: "block comment containing a full static-import statement",
+        snippet: '/* import { createToolCallProcessor } from "../claude-code.js"; */\nconst y = 2;',
+        expected: false,
+      },
+      {
+        label: "doc comment containing a full dynamic-import statement",
+        snippet: '/**\n * Used to do: import("../claude-code.js")\n */\nexport const x = 1;',
+        expected: false,
+      },
+      {
+        label: "plain string literal containing a full dynamic-import statement",
+        snippet: "const s = 'import(\"../claude-code.js\")';",
+        expected: false,
+      },
+      {
+        label: "multi-line template literal containing a full static-import statement",
+        snippet: 'const s = `\n  import { x } from "../claude-code.js";\n`;',
         expected: false,
       },
       {
@@ -249,18 +373,6 @@ describe("Claude provider-family boundary", () => {
 
     it.each(SPECIFIER_CASES)("$label -> referencesModuleSpecifier === $expected", ({ snippet, expected }) => {
       expect(referencesModuleSpecifier(snippet, spec)).toBe(expected);
-    });
-
-    it("the side-effect-import case is exactly the regression the guard used to miss: the pre-fix from-anchored matcher alone stays blind to it, and the dynamic-import matcher alone stays blind to it too — only the combinator catches it", () => {
-      const sideEffectSnippet = 'import "../claude-code.js";';
-      // `fromImportOrExportOf` is the pre-fix matcher (it required a `from`
-      // clause): it correctly does NOT see a bare side-effect import, which
-      // is exactly why relying on it alone let this reverse-dependency form
-      // through undetected before this test file added `sideEffectImportOf`.
-      expect(fromImportOrExportOf(spec).test(sideEffectSnippet)).toBe(false);
-      expect(dynamicImportOf(spec).test(sideEffectSnippet)).toBe(false);
-      // The combined predicate closes the gap.
-      expect(referencesModuleSpecifier(sideEffectSnippet, spec)).toBe(true);
     });
   });
 });

--- a/packages/client/src/__tests__/claude-query-options.test.ts
+++ b/packages/client/src/__tests__/claude-query-options.test.ts
@@ -1,6 +1,6 @@
 import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
-import { buildClaudeQueryOptions } from "../handlers/claude-code.js";
+import { buildClaudeQueryOptions } from "../handlers/claude/sdk-query-options.js";
 
 function claudePayload(
   overrides: Partial<Extract<AgentRuntimeConfigPayload, { kind: "claude-code" }>> = {},

--- a/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
+++ b/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
@@ -46,11 +46,14 @@ vi.mock("../runtime/workspace.js", () => ({
   markWorkspaceInitComplete: vi.fn(),
 }));
 
-vi.mock("../handlers/claude-code.js", () => ({
+vi.mock("../handlers/claude/tool-call-processor.js", () => ({
   createToolCallProcessor: vi.fn(() => ({
     flush: vi.fn(),
     onMessage: vi.fn(),
   })),
+}));
+
+vi.mock("../handlers/claude/mcp-config.js", () => ({
   mapMcpServers: vi.fn(() => []),
 }));
 

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -21,7 +21,8 @@ import { type ReconciledTeamSkill, reconcileManagedSkillsForConfig } from "../..
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../../runtime/source-repos.js";
 import { teamSkillBundleResolverFromSdk } from "../../runtime/team-skill-bundle-resolver.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
-import { createToolCallProcessor, mapMcpServers } from "../claude-code.js";
+import { mapMcpServers } from "../claude/mcp-config.js";
+import { createToolCallProcessor } from "../claude/tool-call-processor.js";
 import { resolveClaudeCodeExecutable } from "../claude-executable.js";
 import {
   capturePane,

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1,15 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
-import type {
-  EffortLevel,
-  McpServerConfig,
-  PermissionMode,
-  Query,
-  SDKUserMessage,
-} from "@anthropic-ai/claude-agent-sdk";
+import { join } from "node:path";
+import type { PermissionMode, Query, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
 import type {
   AgentRuntimeConfigPayload,
@@ -17,7 +11,6 @@ import type {
   RuntimeProvider,
   SessionEvent,
   SupportedImageMime,
-  ToolFileRef,
 } from "@first-tree/shared";
 import {
   encodeProviderRetryEventMessage,
@@ -32,16 +25,7 @@ import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { renderDocumentAttachmentsForLLM } from "../runtime/agent-io.js";
 import { type PredeclaredSourceRepo, writeAgentBriefing } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
-import { renderChatContextPrompt, renderRuntimeOutputContract } from "../runtime/chat-context-section.js";
-import {
-  resolveContextTreeRelativePath,
-  toolFileRefsFromShellCommand,
-  withContextTreeRepoHeadCommit,
-} from "../runtime/context-tree-file-refs.js";
-import {
-  type ContextTreeGitWriteTracker,
-  createContextTreeGitWriteTracker,
-} from "../runtime/context-tree-git-status.js";
+import { createContextTreeGitWriteTracker } from "../runtime/context-tree-git-status.js";
 import {
   type AgentHandler,
   type DeliveryToken,
@@ -72,8 +56,19 @@ import {
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../runtime/source-repos.js";
 import { teamSkillBundleResolverFromSdk } from "../runtime/team-skill-bundle-resolver.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
-import { chunkAssistantText } from "./assistant-text.js";
 import { formatAuthHint, isClaudeAuthError } from "./auth-error-hint.js";
+import { mapMcpServers } from "./claude/mcp-config.js";
+import {
+  buildClaudeQueryOptions,
+  type ClaudeQueryConfigOptions,
+  isSameModelFamily,
+} from "./claude/sdk-query-options.js";
+import {
+  type ContextTreeBinding,
+  createToolCallProcessor,
+  type ToolCallProcessor,
+  treeNodePathOf,
+} from "./claude/tool-call-processor.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
 import {
   type ClaudeProviderFailure,
@@ -83,6 +78,21 @@ import {
   mergeClaudeProviderFailures,
 } from "./claude-provider-error.js";
 import { consumedErrorOutcome } from "./turn-settlement.js";
+
+// Re-exported so `./claude/*` stays the source of truth for these
+// provider-family helpers while every existing import of them from this
+// SDK handler entry point (internal call sites, tests, the Claude TUI
+// handler pre-decoupling) keeps working unchanged.
+export {
+  buildClaudeQueryOptions,
+  type ClaudeQueryConfigOptions,
+  type ContextTreeBinding,
+  createToolCallProcessor,
+  isSameModelFamily,
+  mapMcpServers,
+  type ToolCallProcessor,
+  treeNodePathOf,
+};
 
 type PendingAckMessage = {
   message: SessionMessage;
@@ -188,13 +198,6 @@ export function detectClaudeSessionLimitResult(text: string): { message: string 
   return CLAUDE_SESSION_LIMIT_RESULT_RE.test(firstLine) ? { message: firstLine } : null;
 }
 
-const TOOL_RESULT_PREVIEW_LIMIT = 400;
-
-type ToolUseBlock = { type: "tool_use"; id: string; name: string; input: unknown };
-type ToolResultBlock = { type: "tool_result"; tool_use_id: string; content: unknown; is_error?: boolean };
-type TextBlock = { type: "text"; text: string };
-type ThinkingBlock = { type: "thinking"; thinking?: string };
-
 const SUPPORTED_IMAGE_MIMES: ReadonlySet<SupportedImageMime> = new Set<SupportedImageMime>(
   SHARED_SUPPORTED_IMAGE_MIMES,
 );
@@ -246,38 +249,6 @@ async function writeLegacyImageToTempFile(content: LegacyImageFileContent, chatI
   const path = join(dir, `${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`);
   await writeFile(path, Buffer.from(content.data, "base64"));
   return path;
-}
-
-function extractContentBlocks(message: unknown): unknown[] {
-  if (!message || typeof message !== "object") return [];
-  const inner = (message as { message?: unknown }).message;
-  if (!inner || typeof inner !== "object") return [];
-  const content = (inner as { content?: unknown }).content;
-  return Array.isArray(content) ? content : [];
-}
-
-function isToolUseBlock(block: unknown): block is ToolUseBlock {
-  if (!block || typeof block !== "object") return false;
-  const b = block as Record<string, unknown>;
-  return b.type === "tool_use" && typeof b.id === "string" && typeof b.name === "string";
-}
-
-function isToolResultBlock(block: unknown): block is ToolResultBlock {
-  if (!block || typeof block !== "object") return false;
-  const b = block as Record<string, unknown>;
-  return b.type === "tool_result" && typeof b.tool_use_id === "string";
-}
-
-function isTextBlock(block: unknown): block is TextBlock {
-  if (!block || typeof block !== "object") return false;
-  const b = block as Record<string, unknown>;
-  return b.type === "text" && typeof b.text === "string";
-}
-
-function isThinkingBlock(block: unknown): block is ThinkingBlock {
-  if (!block || typeof block !== "object") return false;
-  const b = block as Record<string, unknown>;
-  return b.type === "thinking";
 }
 
 function eventMakesReplayUnsafe(event: SessionEvent): boolean {
@@ -412,392 +383,6 @@ function emitTokenUsageFromResult(
       sessionCtx.log(`Failed to emit token_usage: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
-}
-
-function extractToolResultText(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  const parts: string[] = [];
-  for (const part of content) {
-    if (!part || typeof part !== "object") continue;
-    const p = part as Record<string, unknown>;
-    if (p.type === "text" && typeof p.text === "string") parts.push(p.text);
-  }
-  return parts.join("\n");
-}
-
-/** Tools whose `file_path` / `notebook_path` argument names a single file. */
-const TREE_READ_TOOL_NAMES: ReadonlySet<string> = new Set(["Read", "NotebookRead"]);
-const TREE_WRITE_TOOL_NAMES: ReadonlySet<string> = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
-/**
- * Search/discovery tools scan a search root rather than open one file. They
- * carry directory-level evidence (the explicit `path` argument), deliberately
- * NOT one ref per matched file — a recursive search "touching" every node
- * would drown the Context tab feed in noise.
- */
-const TREE_SEARCH_TOOL_NAMES: ReadonlySet<string> = new Set(["Grep", "Glob"]);
-
-/**
- * Extract a string `file_path` argument from a tool_use input, if present.
- * Notebook tools (NotebookRead / NotebookEdit) spell the same argument
- * `notebook_path`; accept either so notebook IO carries refs too.
- */
-function readFilePathArg(input: unknown): string | null {
-  if (!input || typeof input !== "object") return null;
-  const record = input as { file_path?: unknown; notebook_path?: unknown };
-  const fp = record.file_path ?? record.notebook_path;
-  return typeof fp === "string" ? fp : null;
-}
-
-/**
- * If `filePath` lives under `contextTreePath`, return its tree-root-relative
- * path (e.g. `members/Gandy2025/NODE.md`); otherwise null. The agent reads
- * tree files by absolute path (CLAUDE.md points it at the full tree at
- * `contextTreePath`), so a prefix match on the normalised root is the filter.
- * The trailing-slash trim keeps `/a/tree` from matching `/a/tree-other/x`.
- *
- * Invariant: both `filePath` and `contextTreePath` are expected to be
- * absolute. A relative `filePath` will not match the absolute root and returns
- * null — i.e. it silently under-counts (fails safe) rather than mis-attributing.
- *
- * Callers that may receive symlink aliases of the tree (the W1 cloud layout
- * exposes the shared clone as a `<workspace>/context-tree` link) must pass
- * both arguments through `canonicalizeFsPath` first — this function compares
- * strings only.
- */
-export function treeNodePathOf(filePath: string, contextTreePath: string): string | null {
-  if (!filePath || !contextTreePath) return null;
-  const root = contextTreePath.endsWith("/") ? contextTreePath.slice(0, -1) : contextTreePath;
-  if (!filePath.startsWith(`${root}/`)) return null;
-  const rel = filePath.slice(root.length + 1);
-  return rel.length > 0 ? rel : null;
-}
-
-/** Local Context Tree repo mapping available to the tool-call processor. */
-export type ContextTreeBinding = { path: string | null; repoUrl: string | null; branch?: string | null };
-
-function toolFileRef(toolName: string, input: unknown, contextTree?: ContextTreeBinding): ToolFileRef | null {
-  if (!TREE_READ_TOOL_NAMES.has(toolName) && !TREE_WRITE_TOOL_NAMES.has(toolName)) return null;
-  const filePath = readFilePathArg(input);
-  if (filePath === null) return null;
-  // Containment (canonical, symlink-safe) or repo identity (tree PR
-  // worktrees — any checkout whose origin remote IS the Context Tree repo).
-  // Relative paths keep the fail-safe null mapping — canonicalizing them
-  // would resolve against the daemon's cwd and risk mis-attribution.
-  const repoRelativePath =
-    contextTree && isAbsolute(filePath)
-      ? resolveContextTreeRelativePath(filePath, {
-          contextTreePath: contextTree.path,
-          contextTreeRepoUrl: contextTree.repoUrl,
-        })
-      : null;
-  const ref: ToolFileRef = {
-    origin: "tool_arg",
-    localPath: filePath,
-    pathKind: "file",
-    ...(contextTree?.repoUrl && repoRelativePath !== null
-      ? {
-          repoUrl: contextTree.repoUrl,
-          ...(contextTree.branch ? { repoBranch: contextTree.branch } : {}),
-          repoRelativePath,
-        }
-      : {}),
-  };
-  return TREE_READ_TOOL_NAMES.has(toolName) && isAbsolute(filePath)
-    ? withContextTreeRepoHeadCommit(ref, filePath)
-    : ref;
-}
-
-function statIsFile(absolutePath: string): boolean {
-  try {
-    return statSync(absolutePath).isFile();
-  } catch {
-    return false;
-  }
-}
-
-/** Extract a string `path` argument from a search tool_use input, if present. */
-function searchPathArg(input: unknown): string | null {
-  if (!input || typeof input !== "object") return null;
-  const p = (input as { path?: unknown }).path;
-  return typeof p === "string" ? p : null;
-}
-
-/**
- * Directory-level ref for a Grep/Glob call whose explicit `path` argument
- * targets the Context Tree. Calls without a `path` argument default to the
- * session cwd (the workspace root, not the tree) and carry no ref — fail-safe
- * under-counting over mis-attribution, same stance as `toolFileRef`.
- */
-function searchToolFileRef(
-  toolName: string,
-  input: unknown,
-  contextTree: ContextTreeBinding | undefined,
-  cwd: string | null | undefined,
-): ToolFileRef | null {
-  if (!TREE_SEARCH_TOOL_NAMES.has(toolName)) return null;
-  const rawPath = searchPathArg(input);
-  if (rawPath === null) return null;
-  if (!isAbsolute(rawPath) && !cwd) return null;
-  const absolutePath = isAbsolute(rawPath) ? resolve(rawPath) : resolve(cwd ?? "", rawPath);
-  const repoRelativePath = contextTree
-    ? resolveContextTreeRelativePath(absolutePath, {
-        contextTreePath: contextTree.path,
-        contextTreeRepoUrl: contextTree.repoUrl,
-      })
-    : null;
-  return withContextTreeRepoHeadCommit(
-    {
-      origin: "tool_arg",
-      localPath: absolutePath,
-      // Grep accepts a file as its search root; everything else is a directory.
-      pathKind: repoRelativePath === "/" ? "repo" : statIsFile(absolutePath) ? "file" : "directory",
-      ...(contextTree?.repoUrl && repoRelativePath !== null
-        ? {
-            repoUrl: contextTree.repoUrl,
-            ...(contextTree.branch ? { repoBranch: contextTree.branch } : {}),
-            repoRelativePath,
-          }
-        : {}),
-    },
-    absolutePath,
-  );
-}
-
-function readCommandArg(input: unknown): string | null {
-  if (!input || typeof input !== "object") return null;
-  const command = (input as { command?: unknown }).command;
-  return typeof command === "string" ? command : null;
-}
-
-function toolFileRefs(
-  toolName: string,
-  input: unknown,
-  contextTree: ContextTreeBinding | undefined,
-  cwd: string | null | undefined,
-): ToolFileRef[] {
-  const directRef = toolFileRef(toolName, input, contextTree);
-  if (directRef) return [directRef];
-  const searchRef = searchToolFileRef(toolName, input, contextTree, cwd);
-  if (searchRef) return [searchRef];
-  if (toolName !== "Bash" || !cwd) return [];
-  const command = readCommandArg(input);
-  if (command === null) return [];
-  return toolFileRefsFromShellCommand({
-    command,
-    cwd,
-    contextTreePath: contextTree?.path ?? null,
-    contextTreeRepoUrl: contextTree?.repoUrl ?? null,
-    contextTreeBranch: contextTree?.branch ?? null,
-  });
-}
-
-/**
- * Pair `tool_use` (assistant) with `tool_result` (user) blocks and emit a
- * `tool_call` event per pair. Unpaired entries are flushed as `status: "pending"`.
- *
- * Successful single-file read/write tools carry generic `toolFileRefs`
- * evidence. When the local path can be mapped to a known repo checkout, the ref
- * includes repo evidence. The server derives Context Tree IO from that evidence
- * and the actual runtime/tool.
- */
-export type ToolCallProcessor = {
-  onMessage(message: unknown): void;
-  flush(): void;
-};
-
-export function createToolCallProcessor(
-  emit: (event: SessionEvent) => void,
-  contextTree?: ContextTreeBinding,
-  options: { cwd?: string | null; gitWriteTracker?: ContextTreeGitWriteTracker } = {},
-): ToolCallProcessor {
-  type Pending = { toolUseId: string; name: string; args: unknown; startedAt: number };
-  const pending = new Map<string, Pending>();
-
-  function pairResult(block: ToolResultBlock): void {
-    const entry = pending.get(block.tool_use_id);
-    if (!entry) return;
-    const status: "ok" | "error" = block.is_error === true ? "error" : "ok";
-    const durationMs = Date.now() - entry.startedAt;
-    const previewRaw = extractToolResultText(block.content);
-    const resultPreview = previewRaw.length > 0 ? previewRaw.slice(0, TOOL_RESULT_PREVIEW_LIMIT) : undefined;
-    if (status === "error") options.gitWriteTracker?.captureBaseline();
-    const refs = status === "ok" ? toolFileRefs(entry.name, entry.args, contextTree, options.cwd) : [];
-    const gitStatusRefs =
-      status === "ok"
-        ? (options.gitWriteTracker?.refsForSuccessfulToolCall({
-            toolName: entry.name,
-            toolUseId: entry.toolUseId,
-            existingRefs: refs,
-          }) ?? [])
-        : [];
-    const allRefs = [...refs, ...gitStatusRefs];
-
-    emit({
-      kind: "tool_call",
-      payload: {
-        toolUseId: entry.toolUseId,
-        name: entry.name,
-        args: entry.args,
-        status,
-        durationMs,
-        ...(resultPreview !== undefined ? { resultPreview } : {}),
-        ...(allRefs.length > 0 ? { toolFileRefs: allRefs } : {}),
-      },
-    });
-
-    pending.delete(block.tool_use_id);
-  }
-
-  return {
-    onMessage(message: unknown): void {
-      if (!message || typeof message !== "object") return;
-      const type = (message as { type?: unknown }).type;
-      if (type === "assistant") {
-        for (const block of extractContentBlocks(message)) {
-          if (isToolUseBlock(block)) {
-            options.gitWriteTracker?.captureBaseline();
-            pending.set(block.id, {
-              toolUseId: block.id,
-              name: block.name,
-              args: block.input,
-              startedAt: Date.now(),
-            });
-            // Emit a pending row the moment the tool_use appears — otherwise
-            // long-running tools (Bash sleep, network fetches) show nothing
-            // live and the chat jumps straight from silence to `used <tool>`
-            // after completion. Frontend dedupes by toolUseId against the
-            // final ok/error emit (see filterEventsForTimeline).
-            emit({
-              kind: "tool_call",
-              payload: {
-                toolUseId: block.id,
-                name: block.name,
-                args: block.input,
-                status: "pending",
-              },
-            });
-          } else if (isTextBlock(block)) {
-            const text = block.text.trim();
-            if (text.length === 0) continue;
-            // Chunk so the FULL assistant text is preserved across one or more
-            // events — the durable troubleshooting record now that the
-            // per-turn final-text chat mirror is retired.
-            for (const chunk of chunkAssistantText(text)) {
-              emit({ kind: "assistant_text", payload: { text: chunk } });
-            }
-          } else if (isThinkingBlock(block)) {
-            emit({ kind: "thinking", payload: {} });
-          }
-        }
-      } else if (type === "user") {
-        for (const block of extractContentBlocks(message)) {
-          if (isToolResultBlock(block)) pairResult(block);
-        }
-      }
-    },
-    flush(): void {
-      // `pending` rows were already emitted up-front when each tool_use
-      // arrived, so flush is now just a bookkeeping reset — no second emit.
-      // Unpaired entries stay visible as "pending" in the UI until the next
-      // turn_end collapses them with the rest of the abandoned turn.
-      pending.clear();
-    },
-  };
-}
-
-/**
- * Map a payload's MCP server list to the SDK's record type. Handles all three
- * transports (stdio/http/sse) defined in the M1 schema.
- */
-export function mapMcpServers(payload: AgentRuntimeConfigPayload): Record<string, McpServerConfig> {
-  const out: Record<string, McpServerConfig> = {};
-  for (const s of payload.mcpServers) {
-    if (s.transport === "stdio") {
-      out[s.name] = { type: "stdio", command: s.command, args: s.args };
-    } else if (s.transport === "http") {
-      out[s.name] = { type: "http", url: s.url, headers: s.headers };
-    } else {
-      out[s.name] = { type: "sse", url: s.url, headers: s.headers };
-    }
-  }
-  return out;
-}
-
-/** Payload-derived slice of the Claude Code SDK query options. */
-export type ClaudeQueryConfigOptions = {
-  model?: string;
-  mcpServers?: Record<string, McpServerConfig>;
-  effort?: EffortLevel;
-  systemPrompt?: {
-    type: "preset";
-    preset: "claude_code";
-    append?: string;
-  };
-};
-
-/**
- * Build the config-derived slice of the SDK query options (model, MCP
- * servers, reasoning effort). Kept pure and exported so these mappings are
- * unit-testable; the session-bound options (env, canUseTool, abortController,
- * sessionId/resume) stay inline in `buildQuery`.
- *
- * Per-agent prompt instructions, working-directory convention, and source-repo
- * list land in `<cwd>/AGENTS.md` (which `CLAUDE.md` symlinks to). Per-chat
- * Current Chat Context is appended through the SDK `systemPrompt` channel so
- * concurrent chats sharing one agent home cannot overwrite each other's
- * context in the shared briefing file.
- *
- * Reasoning effort: the claude variant's `""` is an inherit sentinel — when
- * set we omit the `effort` option so the SDK falls back to the operator's local
- * `~/.claude/settings.json` effortLevel (preserving pre-feature behavior). A
- * non-empty value is passed explicitly and overrides that local setting.
- */
-export function buildClaudeQueryOptions(
-  payload: AgentRuntimeConfigPayload | undefined,
-  chatContext?: ChatContext,
-): ClaudeQueryConfigOptions {
-  const options: ClaudeQueryConfigOptions = {};
-  if (payload?.model) options.model = payload.model;
-  if (payload?.mcpServers.length) options.mcpServers = mapMcpServers(payload);
-  if (payload?.kind === "claude-code" && payload.reasoningEffort) {
-    options.effort = payload.reasoningEffort;
-  }
-  // The runtime output contract always rides along (it does not depend on
-  // chatContext); the per-chat context block is appended after it when present.
-  // Both live in `systemPrompt.append`, which the SDK places after the
-  // `claude_code` base preset but at higher salience than the project CLAUDE.md.
-  const append = [renderRuntimeOutputContract(), renderChatContextPrompt(chatContext)]
-    .filter((part): part is string => Boolean(part))
-    .join("\n\n");
-  if (append) {
-    options.systemPrompt = {
-      type: "preset",
-      preset: "claude_code",
-      append,
-    };
-  }
-  return options;
-}
-
-/**
- * Decide whether a model swap can use `query.setModel()` (in-flight, ~0ms)
- * vs needing a `resume` restart (~5–10s cold start).
- *
- * "Same family" = model id share the `claude-<family>-<series>` prefix
- * (e.g. `claude-opus-4-5` ↔ `claude-opus-4-6` are same family; `claude-opus-*`
- * ↔ `claude-haiku-*` are not). The SDK's `setModel` handles within-family
- * swaps cleanly; cross-family ones should restart to avoid context-window
- * mismatches.
- */
-export function isSameModelFamily(a: string, b: string): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  const segA = a.split("-");
-  const segB = b.split("-");
-  // claude-<family>-<series>-<rev>
-  if (segA.length < 3 || segB.length < 3) return false;
-  return segA[0] === segB[0] && segA[1] === segB[1] && segA[2] === segB[2];
 }
 
 /**

--- a/packages/client/src/handlers/claude/mcp-config.ts
+++ b/packages/client/src/handlers/claude/mcp-config.ts
@@ -1,0 +1,20 @@
+import type { McpServerConfig } from "@anthropic-ai/claude-agent-sdk";
+import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
+
+/**
+ * Map a payload's MCP server list to the SDK's record type. Handles all three
+ * transports (stdio/http/sse) defined in the M1 schema.
+ */
+export function mapMcpServers(payload: AgentRuntimeConfigPayload): Record<string, McpServerConfig> {
+  const out: Record<string, McpServerConfig> = {};
+  for (const s of payload.mcpServers) {
+    if (s.transport === "stdio") {
+      out[s.name] = { type: "stdio", command: s.command, args: s.args };
+    } else if (s.transport === "http") {
+      out[s.name] = { type: "http", url: s.url, headers: s.headers };
+    } else {
+      out[s.name] = { type: "sse", url: s.url, headers: s.headers };
+    }
+  }
+  return out;
+}

--- a/packages/client/src/handlers/claude/sdk-query-options.ts
+++ b/packages/client/src/handlers/claude/sdk-query-options.ts
@@ -1,0 +1,81 @@
+import type { EffortLevel, McpServerConfig } from "@anthropic-ai/claude-agent-sdk";
+import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
+import type { ChatContext } from "../../runtime/chat-context.js";
+import { renderChatContextPrompt, renderRuntimeOutputContract } from "../../runtime/chat-context-section.js";
+import { mapMcpServers } from "./mcp-config.js";
+
+/** Payload-derived slice of the Claude Code SDK query options. */
+export type ClaudeQueryConfigOptions = {
+  model?: string;
+  mcpServers?: Record<string, McpServerConfig>;
+  effort?: EffortLevel;
+  systemPrompt?: {
+    type: "preset";
+    preset: "claude_code";
+    append?: string;
+  };
+};
+
+/**
+ * Build the config-derived slice of the SDK query options (model, MCP
+ * servers, reasoning effort). Kept pure and exported so these mappings are
+ * unit-testable; the session-bound options (env, canUseTool, abortController,
+ * sessionId/resume) stay inline in `buildQuery`.
+ *
+ * Per-agent prompt instructions, working-directory convention, and source-repo
+ * list land in `<cwd>/AGENTS.md` (which `CLAUDE.md` symlinks to). Per-chat
+ * Current Chat Context is appended through the SDK `systemPrompt` channel so
+ * concurrent chats sharing one agent home cannot overwrite each other's
+ * context in the shared briefing file.
+ *
+ * Reasoning effort: the claude variant's `""` is an inherit sentinel — when
+ * set we omit the `effort` option so the SDK falls back to the operator's local
+ * `~/.claude/settings.json` effortLevel (preserving pre-feature behavior). A
+ * non-empty value is passed explicitly and overrides that local setting.
+ */
+export function buildClaudeQueryOptions(
+  payload: AgentRuntimeConfigPayload | undefined,
+  chatContext?: ChatContext,
+): ClaudeQueryConfigOptions {
+  const options: ClaudeQueryConfigOptions = {};
+  if (payload?.model) options.model = payload.model;
+  if (payload?.mcpServers.length) options.mcpServers = mapMcpServers(payload);
+  if (payload?.kind === "claude-code" && payload.reasoningEffort) {
+    options.effort = payload.reasoningEffort;
+  }
+  // The runtime output contract always rides along (it does not depend on
+  // chatContext); the per-chat context block is appended after it when present.
+  // Both live in `systemPrompt.append`, which the SDK places after the
+  // `claude_code` base preset but at higher salience than the project CLAUDE.md.
+  const append = [renderRuntimeOutputContract(), renderChatContextPrompt(chatContext)]
+    .filter((part): part is string => Boolean(part))
+    .join("\n\n");
+  if (append) {
+    options.systemPrompt = {
+      type: "preset",
+      preset: "claude_code",
+      append,
+    };
+  }
+  return options;
+}
+
+/**
+ * Decide whether a model swap can use `query.setModel()` (in-flight, ~0ms)
+ * vs needing a `resume` restart (~5–10s cold start).
+ *
+ * "Same family" = model id share the `claude-<family>-<series>` prefix
+ * (e.g. `claude-opus-4-5` ↔ `claude-opus-4-6` are same family; `claude-opus-*`
+ * ↔ `claude-haiku-*` are not). The SDK's `setModel` handles within-family
+ * swaps cleanly; cross-family ones should restart to avoid context-window
+ * mismatches.
+ */
+export function isSameModelFamily(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const segA = a.split("-");
+  const segB = b.split("-");
+  // claude-<family>-<series>-<rev>
+  if (segA.length < 3 || segB.length < 3) return false;
+  return segA[0] === segB[0] && segA[1] === segB[1] && segA[2] === segB[2];
+}

--- a/packages/client/src/handlers/claude/tool-call-processor.ts
+++ b/packages/client/src/handlers/claude/tool-call-processor.ts
@@ -1,0 +1,353 @@
+import { statSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import type { SessionEvent, ToolFileRef } from "@first-tree/shared";
+import {
+  resolveContextTreeRelativePath,
+  toolFileRefsFromShellCommand,
+  withContextTreeRepoHeadCommit,
+} from "../../runtime/context-tree-file-refs.js";
+import type { ContextTreeGitWriteTracker } from "../../runtime/context-tree-git-status.js";
+import { chunkAssistantText } from "../assistant-text.js";
+
+/**
+ * Claude provider-family tool-call processor.
+ *
+ * Shared by the SDK stream handler (`../claude-code.ts`) and the Claude TUI
+ * transcript handler (`../claude-code-tui/index.ts`) — both feed raw provider
+ * messages through `createToolCallProcessor` to project Claude's protocol
+ * shapes (assistant/user message blocks) onto First Tree `SessionEvent`s.
+ * This is provider-protocol → event projection shared across both Claude
+ * entry points, not SDK handler lifecycle, so it lives in this provider-family
+ * module rather than inside either handler.
+ */
+
+const TOOL_RESULT_PREVIEW_LIMIT = 400;
+
+type ToolUseBlock = { type: "tool_use"; id: string; name: string; input: unknown };
+type ToolResultBlock = { type: "tool_result"; tool_use_id: string; content: unknown; is_error?: boolean };
+type TextBlock = { type: "text"; text: string };
+type ThinkingBlock = { type: "thinking"; thinking?: string };
+
+function extractContentBlocks(message: unknown): unknown[] {
+  if (!message || typeof message !== "object") return [];
+  const inner = (message as { message?: unknown }).message;
+  if (!inner || typeof inner !== "object") return [];
+  const content = (inner as { content?: unknown }).content;
+  return Array.isArray(content) ? content : [];
+}
+
+function isToolUseBlock(block: unknown): block is ToolUseBlock {
+  if (!block || typeof block !== "object") return false;
+  const b = block as Record<string, unknown>;
+  return b.type === "tool_use" && typeof b.id === "string" && typeof b.name === "string";
+}
+
+function isToolResultBlock(block: unknown): block is ToolResultBlock {
+  if (!block || typeof block !== "object") return false;
+  const b = block as Record<string, unknown>;
+  return b.type === "tool_result" && typeof b.tool_use_id === "string";
+}
+
+function isTextBlock(block: unknown): block is TextBlock {
+  if (!block || typeof block !== "object") return false;
+  const b = block as Record<string, unknown>;
+  return b.type === "text" && typeof b.text === "string";
+}
+
+function isThinkingBlock(block: unknown): block is ThinkingBlock {
+  if (!block || typeof block !== "object") return false;
+  const b = block as Record<string, unknown>;
+  return b.type === "thinking";
+}
+
+function extractToolResultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    const p = part as Record<string, unknown>;
+    if (p.type === "text" && typeof p.text === "string") parts.push(p.text);
+  }
+  return parts.join("\n");
+}
+
+/** Tools whose `file_path` / `notebook_path` argument names a single file. */
+const TREE_READ_TOOL_NAMES: ReadonlySet<string> = new Set(["Read", "NotebookRead"]);
+const TREE_WRITE_TOOL_NAMES: ReadonlySet<string> = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
+/**
+ * Search/discovery tools scan a search root rather than open one file. They
+ * carry directory-level evidence (the explicit `path` argument), deliberately
+ * NOT one ref per matched file — a recursive search "touching" every node
+ * would drown the Context tab feed in noise.
+ */
+const TREE_SEARCH_TOOL_NAMES: ReadonlySet<string> = new Set(["Grep", "Glob"]);
+
+/**
+ * Extract a string `file_path` argument from a tool_use input, if present.
+ * Notebook tools (NotebookRead / NotebookEdit) spell the same argument
+ * `notebook_path`; accept either so notebook IO carries refs too.
+ */
+function readFilePathArg(input: unknown): string | null {
+  if (!input || typeof input !== "object") return null;
+  const record = input as { file_path?: unknown; notebook_path?: unknown };
+  const fp = record.file_path ?? record.notebook_path;
+  return typeof fp === "string" ? fp : null;
+}
+
+/**
+ * If `filePath` lives under `contextTreePath`, return its tree-root-relative
+ * path (e.g. `members/Gandy2025/NODE.md`); otherwise null. The agent reads
+ * tree files by absolute path (CLAUDE.md points it at the full tree at
+ * `contextTreePath`), so a prefix match on the normalised root is the filter.
+ * The trailing-slash trim keeps `/a/tree` from matching `/a/tree-other/x`.
+ *
+ * Invariant: both `filePath` and `contextTreePath` are expected to be
+ * absolute. A relative `filePath` will not match the absolute root and returns
+ * null — i.e. it silently under-counts (fails safe) rather than mis-attributing.
+ *
+ * Callers that may receive symlink aliases of the tree (the W1 cloud layout
+ * exposes the shared clone as a `<workspace>/context-tree` link) must pass
+ * both arguments through `canonicalizeFsPath` first — this function compares
+ * strings only.
+ */
+export function treeNodePathOf(filePath: string, contextTreePath: string): string | null {
+  if (!filePath || !contextTreePath) return null;
+  const root = contextTreePath.endsWith("/") ? contextTreePath.slice(0, -1) : contextTreePath;
+  if (!filePath.startsWith(`${root}/`)) return null;
+  const rel = filePath.slice(root.length + 1);
+  return rel.length > 0 ? rel : null;
+}
+
+/** Local Context Tree repo mapping available to the tool-call processor. */
+export type ContextTreeBinding = { path: string | null; repoUrl: string | null; branch?: string | null };
+
+function toolFileRef(toolName: string, input: unknown, contextTree?: ContextTreeBinding): ToolFileRef | null {
+  if (!TREE_READ_TOOL_NAMES.has(toolName) && !TREE_WRITE_TOOL_NAMES.has(toolName)) return null;
+  const filePath = readFilePathArg(input);
+  if (filePath === null) return null;
+  // Containment (canonical, symlink-safe) or repo identity (tree PR
+  // worktrees — any checkout whose origin remote IS the Context Tree repo).
+  // Relative paths keep the fail-safe null mapping — canonicalizing them
+  // would resolve against the daemon's cwd and risk mis-attribution.
+  const repoRelativePath =
+    contextTree && isAbsolute(filePath)
+      ? resolveContextTreeRelativePath(filePath, {
+          contextTreePath: contextTree.path,
+          contextTreeRepoUrl: contextTree.repoUrl,
+        })
+      : null;
+  const ref: ToolFileRef = {
+    origin: "tool_arg",
+    localPath: filePath,
+    pathKind: "file",
+    ...(contextTree?.repoUrl && repoRelativePath !== null
+      ? {
+          repoUrl: contextTree.repoUrl,
+          ...(contextTree.branch ? { repoBranch: contextTree.branch } : {}),
+          repoRelativePath,
+        }
+      : {}),
+  };
+  return TREE_READ_TOOL_NAMES.has(toolName) && isAbsolute(filePath)
+    ? withContextTreeRepoHeadCommit(ref, filePath)
+    : ref;
+}
+
+function statIsFile(absolutePath: string): boolean {
+  try {
+    return statSync(absolutePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Extract a string `path` argument from a search tool_use input, if present. */
+function searchPathArg(input: unknown): string | null {
+  if (!input || typeof input !== "object") return null;
+  const p = (input as { path?: unknown }).path;
+  return typeof p === "string" ? p : null;
+}
+
+/**
+ * Directory-level ref for a Grep/Glob call whose explicit `path` argument
+ * targets the Context Tree. Calls without a `path` argument default to the
+ * session cwd (the workspace root, not the tree) and carry no ref — fail-safe
+ * under-counting over mis-attribution, same stance as `toolFileRef`.
+ */
+function searchToolFileRef(
+  toolName: string,
+  input: unknown,
+  contextTree: ContextTreeBinding | undefined,
+  cwd: string | null | undefined,
+): ToolFileRef | null {
+  if (!TREE_SEARCH_TOOL_NAMES.has(toolName)) return null;
+  const rawPath = searchPathArg(input);
+  if (rawPath === null) return null;
+  if (!isAbsolute(rawPath) && !cwd) return null;
+  const absolutePath = isAbsolute(rawPath) ? resolve(rawPath) : resolve(cwd ?? "", rawPath);
+  const repoRelativePath = contextTree
+    ? resolveContextTreeRelativePath(absolutePath, {
+        contextTreePath: contextTree.path,
+        contextTreeRepoUrl: contextTree.repoUrl,
+      })
+    : null;
+  return withContextTreeRepoHeadCommit(
+    {
+      origin: "tool_arg",
+      localPath: absolutePath,
+      // Grep accepts a file as its search root; everything else is a directory.
+      pathKind: repoRelativePath === "/" ? "repo" : statIsFile(absolutePath) ? "file" : "directory",
+      ...(contextTree?.repoUrl && repoRelativePath !== null
+        ? {
+            repoUrl: contextTree.repoUrl,
+            ...(contextTree.branch ? { repoBranch: contextTree.branch } : {}),
+            repoRelativePath,
+          }
+        : {}),
+    },
+    absolutePath,
+  );
+}
+
+function readCommandArg(input: unknown): string | null {
+  if (!input || typeof input !== "object") return null;
+  const command = (input as { command?: unknown }).command;
+  return typeof command === "string" ? command : null;
+}
+
+function toolFileRefs(
+  toolName: string,
+  input: unknown,
+  contextTree: ContextTreeBinding | undefined,
+  cwd: string | null | undefined,
+): ToolFileRef[] {
+  const directRef = toolFileRef(toolName, input, contextTree);
+  if (directRef) return [directRef];
+  const searchRef = searchToolFileRef(toolName, input, contextTree, cwd);
+  if (searchRef) return [searchRef];
+  if (toolName !== "Bash" || !cwd) return [];
+  const command = readCommandArg(input);
+  if (command === null) return [];
+  return toolFileRefsFromShellCommand({
+    command,
+    cwd,
+    contextTreePath: contextTree?.path ?? null,
+    contextTreeRepoUrl: contextTree?.repoUrl ?? null,
+    contextTreeBranch: contextTree?.branch ?? null,
+  });
+}
+
+/**
+ * Pair `tool_use` (assistant) with `tool_result` (user) blocks and emit a
+ * `tool_call` event per pair. Unpaired entries are flushed as `status: "pending"`.
+ *
+ * Successful single-file read/write tools carry generic `toolFileRefs`
+ * evidence. When the local path can be mapped to a known repo checkout, the ref
+ * includes repo evidence. The server derives Context Tree IO from that evidence
+ * and the actual runtime/tool.
+ */
+export type ToolCallProcessor = {
+  onMessage(message: unknown): void;
+  flush(): void;
+};
+
+export function createToolCallProcessor(
+  emit: (event: SessionEvent) => void,
+  contextTree?: ContextTreeBinding,
+  options: { cwd?: string | null; gitWriteTracker?: ContextTreeGitWriteTracker } = {},
+): ToolCallProcessor {
+  type Pending = { toolUseId: string; name: string; args: unknown; startedAt: number };
+  const pending = new Map<string, Pending>();
+
+  function pairResult(block: ToolResultBlock): void {
+    const entry = pending.get(block.tool_use_id);
+    if (!entry) return;
+    const status: "ok" | "error" = block.is_error === true ? "error" : "ok";
+    const durationMs = Date.now() - entry.startedAt;
+    const previewRaw = extractToolResultText(block.content);
+    const resultPreview = previewRaw.length > 0 ? previewRaw.slice(0, TOOL_RESULT_PREVIEW_LIMIT) : undefined;
+    if (status === "error") options.gitWriteTracker?.captureBaseline();
+    const refs = status === "ok" ? toolFileRefs(entry.name, entry.args, contextTree, options.cwd) : [];
+    const gitStatusRefs =
+      status === "ok"
+        ? (options.gitWriteTracker?.refsForSuccessfulToolCall({
+            toolName: entry.name,
+            toolUseId: entry.toolUseId,
+            existingRefs: refs,
+          }) ?? [])
+        : [];
+    const allRefs = [...refs, ...gitStatusRefs];
+
+    emit({
+      kind: "tool_call",
+      payload: {
+        toolUseId: entry.toolUseId,
+        name: entry.name,
+        args: entry.args,
+        status,
+        durationMs,
+        ...(resultPreview !== undefined ? { resultPreview } : {}),
+        ...(allRefs.length > 0 ? { toolFileRefs: allRefs } : {}),
+      },
+    });
+
+    pending.delete(block.tool_use_id);
+  }
+
+  return {
+    onMessage(message: unknown): void {
+      if (!message || typeof message !== "object") return;
+      const type = (message as { type?: unknown }).type;
+      if (type === "assistant") {
+        for (const block of extractContentBlocks(message)) {
+          if (isToolUseBlock(block)) {
+            options.gitWriteTracker?.captureBaseline();
+            pending.set(block.id, {
+              toolUseId: block.id,
+              name: block.name,
+              args: block.input,
+              startedAt: Date.now(),
+            });
+            // Emit a pending row the moment the tool_use appears — otherwise
+            // long-running tools (Bash sleep, network fetches) show nothing
+            // live and the chat jumps straight from silence to `used <tool>`
+            // after completion. Frontend dedupes by toolUseId against the
+            // final ok/error emit (see filterEventsForTimeline).
+            emit({
+              kind: "tool_call",
+              payload: {
+                toolUseId: block.id,
+                name: block.name,
+                args: block.input,
+                status: "pending",
+              },
+            });
+          } else if (isTextBlock(block)) {
+            const text = block.text.trim();
+            if (text.length === 0) continue;
+            // Chunk so the FULL assistant text is preserved across one or more
+            // events — the durable troubleshooting record now that the
+            // per-turn final-text chat mirror is retired.
+            for (const chunk of chunkAssistantText(text)) {
+              emit({ kind: "assistant_text", payload: { text: chunk } });
+            }
+          } else if (isThinkingBlock(block)) {
+            emit({ kind: "thinking", payload: {} });
+          }
+        }
+      } else if (type === "user") {
+        for (const block of extractContentBlocks(message)) {
+          if (isToolResultBlock(block)) pairResult(block);
+        }
+      }
+    },
+    flush(): void {
+      // `pending` rows were already emitted up-front when each tool_use
+      // arrived, so flush is now just a bookkeeping reset — no second emit.
+      // Unpaired entries stay visible as "pending" in the UI until the next
+      // turn_end collapses them with the rest of the abandoned turn.
+      pending.clear();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Pure maintainability refactor — no behavior change and no issue closure. It splits provider-family mechanics out of the 2,448-line `packages/client/src/handlers/claude-code.ts` and removes the Claude TUI handler's reverse dependency on the SDK handler entry.

Independent QA passed on exact head `f982f193ee56861d8ad732688a9b6470ac246f4b` against merge-base `ff37519d56fff2ffcfb516f4564d015709866f83`.

## What moved

New private modules under `packages/client/src/handlers/claude/`:

- `tool-call-processor.ts` (353 lines) — `createToolCallProcessor`, `ToolCallProcessor`, `ContextTreeBinding`, `treeNodePathOf`, and the block parsing, tool-result preview, and Context Tree file-ref helpers used by that projection.
- `mcp-config.ts` (20 lines) — `mapMcpServers`.
- `sdk-query-options.ts` (81 lines) — `ClaudeQueryConfigOptions`, `buildClaudeQueryOptions`, and `isSameModelFamily`; it composes `mcp-config.ts`.

`claude-code.ts` is now 2,033 lines (−415, −17%). Its SDK lifecycle factory remains in place, while the moved helpers are imported from the provider-family modules and re-exported under their existing names.

## Dependency direction

Before:

```text
claude-code-tui/index.ts → claude-code.ts → SDK lifecycle and shared helpers
```

After:

```text
claude-code.ts ───────────────┐
                             ├→ handlers/claude/*
claude-code-tui/index.ts ─────┘
```

The SDK and TUI handlers now depend on provider-family leaf modules directly; neither handler depends on the other. The only leaf-to-leaf edge is `sdk-query-options.ts → mcp-config.ts`.

## Compatibility and behavior preservation

- `claude-code.ts` continues to export `treeNodePathOf`, `ContextTreeBinding`, `ToolCallProcessor`, `createToolCallProcessor`, `mapMcpServers`, `ClaudeQueryConfigOptions`, `buildClaudeQueryOptions`, and `isSameModelFamily`.
- Runtime identity tests prove each moved runtime helper exported by the facade is the exact same function binding exported by its leaf module, not a wrapper or duplicate implementation. Client/repo typecheck covers the type-only facade exports.
- `createClaudeCodeHandler` from its declaration through EOF is byte-for-byte identical to the baseline: 77,035 characters and SHA-256 `ca637781081e1af22bc8adbf5a80d96421358ff2def175b80433435075dfbc43` on both sides.
- Therefore `start`, `resume`, `inject`, `suspend`, `shutdown`, custody, ACK/settlement, retry/recovery, queueing, abort/close, and session behavior are unchanged.
- The TUI product diff is only the import swap from the SDK facade to `claude/tool-call-processor.js` and `claude/mcp-config.js`; its mocks now target those real leaf seams.
- Tool event payloads, Context Tree refs, git-baseline capture, the 400-character result preview, MCP transport shapes, query-option defaults, prompt ordering, and `undefined` field shapes are unchanged moves rather than rewrites.
- The `@first-tree/client` package public export set is unchanged.

## Architectural guard

`claude-provider-family-boundary.test.ts` protects the split with a TypeScript AST parse rather than source-text regexes. It recognizes real named/default/namespace/type/side-effect imports, export-from declarations, and dynamic `import()` calls while ignoring identical syntax written inside comments, strings, or template literals.

The guard enforces:

- no TUI → SDK handler reverse dependency;
- no provider-family leaf → handler back-edge;
- direct TUI imports from the expected leaf modules;
- the intended `sdk-query-options.ts → mcp-config.ts` composition;
- continued facade re-exports with one runtime implementation;
- exact module-specifier matching, including comment/string/template-literal and near-name negative cases.

## Verification

Independent QA verdict: **PASS — `test-only`**, bound only to `f982f193ee56861d8ad732688a9b6470ac246f4b`.

- Focused Claude/TUI matrix: 26 files, 202/202 tests passed.
- Client full suite: 186 files passed, 2 skipped; 2,376 tests passed, 7 skipped, 0 failed.
- AST boundary suite: 25/25 passed; `typescript@5.9.3` resolved in the fresh workspace.
- `pnpm --filter @first-tree/client typecheck`: passed.
- Baseline and candidate Client builds: passed after symmetrically building `@first-tree/shared` first; output scale matched.
- `pnpm typecheck`: 11/11 tasks passed.
- `pnpm check`: 0 errors; 18 warnings and 7 infos are pre-existing in untouched files.
- Built ESM smoke: baseline and candidate each expose the same 126 public keys; `detectStreamApiError` remains a function and `StreamApiTransientError` remains an instantiable `Error` subclass.
- GitHub CI: all required checks green, including CodeQL, lint/typecheck, Client/Web, CLI, Server, and portable CLI smoke.

No real provider process/session was started, no credential was read, no OAuth flow was executed, and no provider network was accessed.

## Scope

No change to the Handler contract, SessionManager, AgentSlot, runtime lifecycle, delivery/ACK, retry/Reset, WebSocket, database, persistence, wire schema, auth, binary resolution, capability probing, or error taxonomy. No Context Tree change is required because this is an implementation-only, behavior-preserving refactor.
