### PR TITLE
fix: rename Settings Setup to Getting Started

### DIFF
--- a/apps/cli/src/core/context-tree-write.ts
+++ b/apps/cli/src/core/context-tree-write.ts
@@ -311,9 +311,9 @@ function serverPreflightFailure(
       "The selected Team does not currently have Context Reviewer enabled with an assigned Reviewer.",
     CONTEXT_TREE_WRITE_REVIEWER_UNAVAILABLE: "The selected Team's current Reviewer is unavailable.",
     CONTEXT_TREE_WRITE_REVIEW_NOT_CONFIGURED:
-      "Automatic Review is not configured. Ask a Team Admin to assign a Reviewer in Settings → Setup; Context reads and local code work remain available.",
+      "Automatic Review is not configured. Ask a Team Admin to assign a Reviewer in Settings → Getting Started; Context reads and local code work remain available.",
     CONTEXT_TREE_WRITE_REVIEW_DISABLED:
-      "Automatic Review is disabled. Ask a Team Admin to enable it in Settings → Setup; Context reads and local code work remain available.",
+      "Automatic Review is disabled. Ask a Team Admin to enable it in Settings → Getting Started; Context reads and local code work remain available.",
     CONTEXT_TREE_WRITE_REVIEW_PREREQUISITES_MISSING:
       "Automatic Review prerequisites are incomplete. Ask a Team Admin to repair the Reviewer Agent, Computer, or provider before creating a Context Tree PR/MR.",
     CONTEXT_TREE_WRITE_REVIEWER_OFFLINE:

--- a/e2e/onboarding-complete-setup.test.yaml
+++ b/e2e/onboarding-complete-setup.test.yaml
@@ -42,3 +42,9 @@ steps:
   - assert: the workspace is open on a chat named Get started with First Tree,
       whose first message asks the user's new assistant agent for help getting
       started, and a message composer addressed to that agent is available
+
+  # ── Settings — the permanent readiness overview keeps its stable route ────
+  - click: Settings link in the top navigation
+  - waitForUrl: /settings/account
+  - assert: the Settings sidebar contains a Getting Started entry and does not
+      contain an entry named Setup

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -653,7 +653,7 @@ describe("buildAgentBriefing — asking humans, GitHub, and CLI overview", () =>
     expect(briefing).toMatch(/human explicitly asks to stop tracking/);
     expect(briefing).toContain("first-tree github follow --help");
     expect(briefing).not.toContain("`first-tree-github` skill");
-    expect(briefing).toContain("enables **Settings → Setup**");
+    expect(briefing).toContain("enables **Settings → Getting Started**");
     expect(briefing).toContain("missing,\n  suspended, or does not cover the repo");
     expect(briefing).toContain("Give this handoff once");
     expect(briefing).not.toContain("enables **Settings → GitHub**");

--- a/packages/client/src/runtime/templates/agent-briefing.ejs
+++ b/packages/client/src/runtime/templates/agent-briefing.ejs
@@ -207,7 +207,7 @@ Creating a PR or issue **never** follows it; `gh pr create`, curl, GitHub MCP, a
 - **If the follow fails because the First Tree GitHub App is missing,
   suspended, or does not cover the repo**, explain the optional value upgrade
   in product language: live PR/issue activity (CI, reviews, merge) can flow back
-  into this chat after an org admin enables **Settings → Setup** in the web app. Do not
+  into this chat after an org admin enables **Settings → Getting Started** in the web app. Do not
   expose raw error codes or `github follow` mechanics; say the PR/issue still
   works either way. Give this handoff once, unless a loaded workflow consolidates
   repository coverage with another Setup capability.

--- a/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
+++ b/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
@@ -22,7 +22,7 @@ together without a GitHub-specific post-delivery branch.
   the run cell.
 - Create a chat with an eligible human/delegate pair and follow one disposable issue or pull request in that chat.
 - Select different active, organization-visible managed Agents for Context Reviewer and GitHub Task Agent. Use Settings
-  → Setup for Context Reviewer and Settings → Integrations → GitHub → Task routing for GitHub Task Agent; confirm each
+  → Getting Started for Context Reviewer and Settings → Integrations → GitHub → Task routing for GitHub Task Agent; confirm each
   surface rejects an assignment that would reuse the other role's Agent. Leave Automatic Review off for the first non-Context
   repository observations so ordinary delegation is proven independently from Context Review.
 - Bind the Team's Context Tree to one GitHub repository. Use a second disposable GitHub repository for GitHub Task Agent

--- a/packages/qa/cases/cross-surface/gitlab-context-tree-lifecycle.md
+++ b/packages/qa/cases/cross-surface/gitlab-context-tree-lifecycle.md
@@ -72,7 +72,7 @@ runtime, network, credential, and cross-surface behavior.
   and confirm the documented fail-open duplicate risk rather than false
   suppression.
   Generic GitLab entity attention remains independently observable.
-- Observe connection health in Web Settings and Setup with only a Project Hook,
+- Observe connection health in Web Settings and Getting Started with only a Project Hook,
   only a System Hook, and both hooks. Require each observed source to appear
   independently. A Project-only Issue or Note must show the Project Hook as
   observed without claiming untested event types, and without a System Hook

--- a/packages/qa/cases/cross-surface/member-work-mode-onboarding.md
+++ b/packages/qa/cases/cross-surface/member-work-mode-onboarding.md
@@ -64,7 +64,7 @@ provider project, reload behavior, and the absence of accidental personal-agent 
    fail-closed verification rejects stale authority while ordinary coding continues.
 10. Return to First Tree after external setup. The member can use the product normally because onboarding auto-open was
     suppressed only by their explicit continue-without action, while the personal-agent journey remains resumable.
-11. Verify the Context Tree entry already present in Settings → Setup remains unchanged and can issue a fresh
+11. Verify the Context Tree entry already present in Settings → Getting Started remains unchanged and can issue a fresh
     settings-intent handoff without implying onboarding completion.
 
 ## Non-goals

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
@@ -159,14 +159,14 @@ describe("first-tree-seed floor invariants", () => {
     expect(skillMarkdown).toMatch(/Do not repeat the Review Agent\s+handoff from Phase 1/u);
 
     const handoffRows = [
-      "| GitHub coverage missing | No selected Agent | One combined handoff: authoritative coverage recovery plus select and enable Automatic Review in Settings → Setup |",
-      "| GitHub coverage missing | Selected but off | One combined handoff: authoritative coverage recovery plus enable Automatic Review in Settings → Setup |",
+      "| GitHub coverage missing | No selected Agent | One combined handoff: authoritative coverage recovery plus select and enable Automatic Review in Settings → Getting Started |",
+      "| GitHub coverage missing | Selected but off | One combined handoff: authoritative coverage recovery plus enable Automatic Review in Settings → Getting Started |",
       "| GitHub coverage missing | Enabled or read failed/ambiguous | Coverage recovery only; infer no Review debt |",
-      "| GitHub covered | No selected Agent | Select and enable Automatic Review in Settings → Setup only |",
-      "| GitHub covered | Selected but off | Enable Automatic Review in Settings → Setup only |",
+      "| GitHub covered | No selected Agent | Select and enable Automatic Review in Settings → Getting Started only |",
+      "| GitHub covered | Selected but off | Enable Automatic Review in Settings → Getting Started only |",
       "| GitHub covered | Enabled or read failed/ambiguous | No setup handoff |",
-      "| GitLab | No selected Agent | Select and enable Automatic Review in Settings → Setup only; no GitHub App guidance |",
-      "| GitLab | Selected but off | Enable Automatic Review in Settings → Setup only; no GitHub App guidance |",
+      "| GitLab | No selected Agent | Select and enable Automatic Review in Settings → Getting Started only; no GitHub App guidance |",
+      "| GitLab | Selected but off | Enable Automatic Review in Settings → Getting Started only; no GitHub App guidance |",
       "| GitLab | Enabled or read failed/ambiguous | No setup handoff |",
     ];
     for (const row of handoffRows) {
@@ -183,7 +183,7 @@ describe("first-tree-seed floor invariants", () => {
     expect(skillMarkdown).toContain("failure does not invalidate the MR");
     expect(skillMarkdown).toContain("no GitHub App coverage guidance applies");
     expect(skillMarkdown).toContain("Never substitute a GitHub App URL");
-    expect(skillMarkdown).toContain("Use **Settings → Setup** only for an actual Team capability");
+    expect(skillMarkdown).toContain("Use **Settings → Getting Started** only for an actual Team capability");
   });
 
   it("gates only Welcome-launched Content PRs on a selected enabled Reviewer", () => {

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
@@ -146,7 +146,8 @@ describe("first-tree-seed floor invariants", () => {
     expect(skillMarkdown).toContain("Use only the JSON `enabled` and `agentUuid` fields");
     expect(skillMarkdown).toMatch(/selecting an eligible managed Review Agent and\s+enabling Automatic Review/u);
     expect(skillMarkdown).toContain("the selection is retained");
-    expect(skillMarkdown).toMatch(/Getting Started owns\s+provider prerequisites and the Team mutation/u);
+    expect(skillMarkdown).toMatch(/The owning Settings surfaces hold provider prerequisites and the\s+Team mutation/u);
+    expect(skillMarkdown).toContain("Getting Started only summarizes readiness and links there");
     expect(skillMarkdown).toContain("This is not a health or readiness check");
     expect(skillMarkdown).toContain("first perform the Review Agent read");
     expect(skillMarkdown).toContain("send at most one combined setup handoff");

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
@@ -140,13 +140,13 @@ describe("first-tree-seed floor invariants", () => {
     expect(skillMarkdown).toMatch(/collect any uncovered\s+tree-repo recovery returned/u);
   });
 
-  it("hands off Review Agent configuration to Setup without blocking ordinary Seed", () => {
+  it("hands off Review Agent configuration to Getting Started without blocking ordinary Seed", () => {
     expect(skillMarkdown).toContain("After the Phase 1 PR/MR is open, check Review Agent configuration once");
     expect(skillMarkdown).toContain('first-tree org context-tree review-config --as-member --org "<team-id>" --json');
     expect(skillMarkdown).toContain("Use only the JSON `enabled` and `agentUuid` fields");
     expect(skillMarkdown).toMatch(/selecting an eligible managed Review Agent and\s+enabling Automatic Review/u);
     expect(skillMarkdown).toContain("the selection is retained");
-    expect(skillMarkdown).toMatch(/Setup owns\s+provider prerequisites and the Team mutation/u);
+    expect(skillMarkdown).toMatch(/Getting Started owns\s+provider prerequisites and the Team mutation/u);
     expect(skillMarkdown).toContain("This is not a health or readiness check");
     expect(skillMarkdown).toContain("first perform the Review Agent read");
     expect(skillMarkdown).toContain("send at most one combined setup handoff");

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
@@ -128,7 +128,7 @@ describe("first-tree-welcome floor invariants", () => {
     expect(skillMarkdown).not.toContain("A GitLab MR has no documented equivalent here");
   });
 
-  it("keeps capability setup milestone-gated, role-aware, and owned by Setup", () => {
+  it("keeps capability setup milestone-gated, role-aware, and owned by Getting Started", () => {
     expect(skillMarkdown).toContain("After a pre-existing Context Tree milestone: guide Review setup once");
     expect(skillMarkdown).toContain("first-tree org context-tree review-config --json");
     expect(skillMarkdown).toContain("its default Team can differ from this Agent/chat's Team");
@@ -136,7 +136,9 @@ describe("first-tree-welcome floor invariants", () => {
     expect(skillMarkdown).toMatch(
       /\*\*Settings → Getting Started\*\* can select an eligible managed Review Agent\s+and enable Automatic Review/u,
     );
-    expect(skillMarkdown).toContain("the Agent is already\n  selected");
+    expect(skillMarkdown).toMatch(
+      /\*\*Settings → Getting Started\*\* can enable Automatic Review; the Agent is already\s+selected/u,
+    );
     expect(skillMarkdown).toContain("launcher performs no Team mutation");
     expect(skillMarkdown).toContain("This is not a health or readiness check");
     expect(skillMarkdown).toMatch(/infer debt when the read is invalid, fails, or is\s+ambiguous/u);

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
@@ -128,7 +128,7 @@ describe("first-tree-welcome floor invariants", () => {
     expect(skillMarkdown).not.toContain("A GitLab MR has no documented equivalent here");
   });
 
-  it("keeps capability setup milestone-gated, role-aware, and owned by Getting Started", () => {
+  it("keeps capability setup milestone-gated, role-aware, and owned by capability settings", () => {
     expect(skillMarkdown).toContain("After a pre-existing Context Tree milestone: guide Review setup once");
     expect(skillMarkdown).toContain("first-tree org context-tree review-config --json");
     expect(skillMarkdown).toContain("its default Team can differ from this Agent/chat's Team");
@@ -139,6 +139,8 @@ describe("first-tree-welcome floor invariants", () => {
     expect(skillMarkdown).toMatch(
       /\*\*Settings → Getting Started\*\* can enable Automatic Review; the Agent is already\s+selected/u,
     );
+    expect(skillMarkdown).toMatch(/Settings → Context Tree owns Reviewer selection and health/u);
+    expect(skillMarkdown).toContain("Getting Started only summarizes\n  readiness and links to those surfaces");
     expect(skillMarkdown).toContain("launcher performs no Team mutation");
     expect(skillMarkdown).toContain("This is not a health or readiness check");
     expect(skillMarkdown).toMatch(/infer debt when the read is invalid, fails, or is\s+ambiguous/u);

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
@@ -122,7 +122,7 @@ describe("first-tree-welcome floor invariants", () => {
     expect(skillMarkdown).toMatch(/A follow failure does not\s+invalidate the MR/u);
     expect(skillMarkdown).toMatch(/report\s+only the First Tree chat attention gap/u);
     expect(skillMarkdown).toContain(
-      "do not call\n`first-tree github follow`, send the user to **Settings → Setup** for GitHub App",
+      "do not call\n`first-tree github follow`, send the user to **Settings → Getting Started** for GitHub App",
     );
     expect(skillMarkdown).toContain("Never substitute `first-tree github follow`");
     expect(skillMarkdown).not.toContain("A GitLab MR has no documented equivalent here");
@@ -134,7 +134,7 @@ describe("first-tree-welcome floor invariants", () => {
     expect(skillMarkdown).toContain("its default Team can differ from this Agent/chat's Team");
     expect(skillMarkdown).toContain("JSON `enabled` and `agentUuid` fields");
     expect(skillMarkdown).toMatch(
-      /\*\*Settings → Setup\*\* can select an eligible managed Review Agent\s+and enable Automatic Review/u,
+      /\*\*Settings → Getting Started\*\* can select an eligible managed Review Agent\s+and enable Automatic Review/u,
     );
     expect(skillMarkdown).toContain("the Agent is already\n  selected");
     expect(skillMarkdown).toContain("launcher performs no Team mutation");
@@ -148,8 +148,8 @@ describe("first-tree-welcome floor invariants", () => {
 
     const handoffRows = [
       "| GitHub value PR | Task chat reported missing App coverage | Summarize the blocked live updates; do not repeat its Setup handoff |",
-      "| Pre-existing populated tree after value | Confirmed admin; no selected Agent | Hand off once to select and enable Automatic Review in Settings → Setup |",
-      "| Pre-existing populated tree after value | Confirmed admin; Agent selected but Review off | Hand off once to enable Automatic Review in Settings → Setup |",
+      "| Pre-existing populated tree after value | Confirmed admin; no selected Agent | Hand off once to select and enable Automatic Review in Settings → Getting Started |",
+      "| Pre-existing populated tree after value | Confirmed admin; Agent selected but Review off | Hand off once to enable Automatic Review in Settings → Getting Started |",
       "| Pre-existing populated tree after value | Review enabled, read failed/ambiguous, member, or unclear role | No Review setup handoff |",
       "| Dedicated tree task's first PR/MR | Any | Seed owns the handoff; consume its result and do not repeat |",
     ];

--- a/packages/web/src/api/onboarding-events.ts
+++ b/packages/web/src/api/onboarding-events.ts
@@ -94,7 +94,7 @@ export async function reportOnboardingEvent(
  * Stamp the terminal-state `onboarding_completed_at` column. Called when
  * the user walks Step 3 to success (admin Continue, invitee Confirm /
  * Continue). Once stamped, first-run onboarding no longer auto-opens; the
- * permanent Settings → Setup overview remains available.
+ * permanent Settings → Getting Started overview remains available.
  *
  * Distinct from `dismissOnboarding()`, which only hides the stepper UI
  * and stays reversible. Idempotent on the server (only writes when the

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -32,7 +32,7 @@ type MeResponse = {
      * ISO timestamp when the user finished the kickoff (Context Tree) step.
      * Distinct from `dismissedAt` (which only hides onboarding, leaving it
      * resumable). This completes first-run routing but does not hide the
-     * permanent Settings → Setup overview.
+     * permanent Settings → Getting Started overview.
      */
     completedAt?: string | null;
   };
@@ -115,7 +115,7 @@ type AuthContextValue = {
   onboardingDismissedAt: string | null;
   /**
    * ISO timestamp when the user finished the first-run flow. This controls
-   * onboarding redirects only; the permanent Settings → Setup overview remains
+   * onboarding redirects only; the permanent Settings → Getting Started overview remains
    * available after completion. `null` while onboarding is incomplete or only
    * dismissed.
    */
@@ -128,7 +128,7 @@ type AuthContextValue = {
   /**
    * PATCH `/me/onboarding { dismissed: false }`. Clears `onboardingDismissedAt`
    * so onboarding is pending again (the root redirects into `/onboarding`).
-   * Used by the Settings → Setup "Resume setup" toggle.
+   * Used by the Settings → Getting Started "Resume setup" toggle.
    */
   restoreOnboarding: () => Promise<void>;
   /**

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -3,7 +3,7 @@ import { createContext, type ReactNode, useCallback, useContext, useEffect, useR
 
 /**
  * Minimal toast system — used for transient informational nudges (e.g.
- * "Setup hidden — resume any time in Settings → Setup"). Mount `<Toaster>`
+ * "Setup hidden — resume any time in Settings → Getting Started"). Mount `<Toaster>`
  * once at the app root and call `useToast().addToast(...)` anywhere under
  * it. Auto-dismisses after `durationMs` (default 5s) unless the toast is
  * persistent (`durationMs: null`).

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -409,7 +409,7 @@ describe("settings panels", () => {
     );
     expect(desktopLinks).toEqual([
       "Account",
-      "Setup",
+      "Getting Started",
       "Computers",
       "Repositories",
       "Context Tree",
@@ -434,16 +434,16 @@ describe("settings panels", () => {
     expect(narrow.container.textContent).toContain("Context Tree");
     expect(narrow.container.textContent).toContain("TEAM");
     expect(narrow.container.textContent).toContain("GitHub & GitLab");
-    expect(narrow.container.textContent).not.toContain("Setup");
+    expect(narrow.container.textContent).not.toContain("Getting Started");
     expect(narrow.container.querySelector('a[href="/settings/setup"]')).toBeNull();
     await act(async () => narrow.root.unmount());
 
     viewportMock.value = "xl";
     const completedDesktop = await renderDom(<SettingsLayout />, "/settings/setup");
     expect(completedDesktop.container.querySelector('aside a[href="/settings/setup"]')).not.toBeNull();
-    expect(completedDesktop.container.textContent).toContain("Setup");
+    expect(completedDesktop.container.textContent).toContain("Getting Started");
     const setupHeading = completedDesktop.container.querySelector("h1");
-    expect(setupHeading?.textContent).toBe("Setup");
+    expect(setupHeading?.textContent).toBe("Getting Started");
     expect(setupHeading?.classList.contains("sr-only")).toBe(true);
     await act(async () => completedDesktop.root.unmount());
 
@@ -462,7 +462,7 @@ describe("settings panels", () => {
     await act(async () => repositories.root.unmount());
   });
 
-  it("marks desktop Setup only for role-actionable Team or personal attention", async () => {
+  it("marks desktop Getting Started only for role-actionable Team or personal attention", async () => {
     const { SettingsLayout } = await import("../settings.js");
     const blocked = teamSetupCapabilities();
     const blockedGithub = blocked.repositoryAutomation.providers[0];
@@ -483,7 +483,7 @@ describe("settings panels", () => {
       "Expected Setup attention after the Team projection loads",
     );
     const adminSetupLink = admin.container.querySelector<HTMLAnchorElement>('aside a[href="/settings/setup"]');
-    expect(adminSetupLink?.getAttribute("aria-label")).toBe("Setup — Needs you");
+    expect(adminSetupLink?.getAttribute("aria-label")).toBe("Getting Started — Needs you");
     expect(setupCapabilitiesMocks.getTeamSetupCapabilitiesAt).toHaveBeenCalledWith("org-1");
     await act(async () => admin.root.unmount());
 
@@ -535,7 +535,7 @@ describe("settings panels", () => {
 
     expect(contextApiMocks.getContextTreeSnapshot).toHaveBeenCalledWith("org-1", "7d");
     expect(admin.container.querySelector('aside a[href="/settings/setup"]')?.getAttribute("aria-label")).toBe(
-      "Setup — Needs you",
+      "Getting Started — Needs you",
     );
     await act(async () => admin.root.unmount());
   });

--- a/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
@@ -199,7 +199,11 @@ describe("onboarding shell and team step", () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("finish later")) ?? null,
     );
     expect(toastMock.addToast).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Setup paused", action: expect.objectContaining({ label: "Open Settings" }) }),
+      expect.objectContaining({
+        title: "Setup paused",
+        description: "Pick up where you left off anytime in Settings → Getting Started.",
+        action: expect.objectContaining({ label: "Open Settings" }),
+      }),
     );
     expect(flowMock.value.finishLater).toHaveBeenCalled();
 
@@ -227,7 +231,7 @@ describe("onboarding shell and team step", () => {
   });
 
   it("keeps finish-later for a quick-start member (no personal agent, usable team agent)", async () => {
-    // The team-agent quick-start case: Settings -> Setup resume cleared the
+    // The team-agent quick-start case: Settings -> Getting Started resume cleared the
     // suppressor, the member has no personal agent, but the org has a usable
     // team agent — leaving is NOT a dead end, so the pause stays available.
     authMock.currentOrgHasUsableAgent = true;

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -89,10 +89,10 @@ export function OnboardingShell({
               onClick={() => {
                 // Tell the user where setup lives before dropping them into the
                 // still-incomplete workspace — otherwise "finish later" reads as
-                // "lose my progress". Settings → Setup has the Resume path.
+                // "lose my progress". Settings → Getting Started has the Resume path.
                 addToast({
                   title: "Setup paused",
-                  description: "Pick up where you left off anytime in Settings → Setup.",
+                  description: "Pick up where you left off anytime in Settings → Getting Started.",
                   action: { label: "Open Settings", onClick: () => navigate("/settings/setup") },
                 });
                 void finishLater();

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -42,7 +42,7 @@ const ACCOUNT_ITEM: Item = {
   label: "Account",
   description: "Manage your profile and ways to sign in. These settings follow you across all your teams.",
 };
-const SETUP_ITEM: Item = { to: "/settings/setup", label: "Setup" };
+const SETUP_ITEM: Item = { to: "/settings/setup", label: "Getting Started" };
 const COMPUTERS_ITEM: Item = { to: "/settings/computers", label: "Computers" };
 const REPOSITORIES_ITEM: Item = {
   to: "/settings/repositories",

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -329,7 +329,7 @@ PRs/MRs; report the attention gap, but consolidate the action here.
   installation or repository coverage there.
   This assumes the web console shares the server's origin (the standard
   deployment); if it does not, the link may not resolve — then name the
-  destination in words: **Settings → Setup** in the web app. Do **not**
+  destination in words: **Settings → Getting Started** in the web app. Do **not**
   fabricate a raw GitHub App install URL yourself — the install must run
   through the web console so it binds back to your org. Add the **placement
   caveat**: the tree repo was created under the GitHub account shown as
@@ -342,7 +342,7 @@ PRs/MRs; report the attention gap, but consolidate the action here.
   attention uses `first-tree gitlab follow` after creation or recovery/reuse.
   Relay any separate recovery target only when First Tree returns it explicitly.
   Never substitute a GitHub App URL or tell the user to install the GitHub App
-  for GitLab. Use **Settings → Setup** only for an actual Team capability
+  for GitLab. Use **Settings → Getting Started** only for an actual Team capability
   handoff after the milestone below; do not invent a GitLab-specific product
   path.
 
@@ -357,14 +357,14 @@ first-tree org context-tree review-config --as-member --org "<team-id>" --json
 - Use only the JSON `enabled` and `agentUuid` fields to distinguish three
   durable configuration states. This is not a health or readiness check:
   - `agentUuid` is null: include selecting an eligible managed Review Agent and
-    enabling Automatic Review through **Settings → Setup**. Under the explicit
+    enabling Automatic Review through **Settings → Getting Started**. Under the explicit
     Welcome Reviewer contract, during this same Phase 1 process name the Agent
     that opened the Structure PR/MR as the default choice; do not replace a
     later human selection. A fresh-process Phase 2 recovery does not know that
     original Agent from durable progress and must not substitute the recovery
     Agent.
   - `agentUuid` is present and `enabled` is false: the selection is retained;
-    include only enabling Automatic Review through **Settings → Setup**.
+    include only enabling Automatic Review through **Settings → Getting Started**.
   - `agentUuid` is present and `enabled` is true: add no Review setup handoff
     and infer no Reviewer health from this command.
   Any other or ambiguous result creates no inferred debt.
@@ -386,14 +386,14 @@ Use this response matrix after the milestone:
 
 | Tree provider / coverage | Review config read | User-facing setup action |
 | --- | --- | --- |
-| GitHub coverage missing | No selected Agent | One combined handoff: authoritative coverage recovery plus select and enable Automatic Review in Settings → Setup |
-| GitHub coverage missing | Selected but off | One combined handoff: authoritative coverage recovery plus enable Automatic Review in Settings → Setup |
+| GitHub coverage missing | No selected Agent | One combined handoff: authoritative coverage recovery plus select and enable Automatic Review in Settings → Getting Started |
+| GitHub coverage missing | Selected but off | One combined handoff: authoritative coverage recovery plus enable Automatic Review in Settings → Getting Started |
 | GitHub coverage missing | Enabled or read failed/ambiguous | Coverage recovery only; infer no Review debt |
-| GitHub covered | No selected Agent | Select and enable Automatic Review in Settings → Setup only |
-| GitHub covered | Selected but off | Enable Automatic Review in Settings → Setup only |
+| GitHub covered | No selected Agent | Select and enable Automatic Review in Settings → Getting Started only |
+| GitHub covered | Selected but off | Enable Automatic Review in Settings → Getting Started only |
 | GitHub covered | Enabled or read failed/ambiguous | No setup handoff |
-| GitLab | No selected Agent | Select and enable Automatic Review in Settings → Setup only; no GitHub App guidance |
-| GitLab | Selected but off | Enable Automatic Review in Settings → Setup only; no GitHub App guidance |
+| GitLab | No selected Agent | Select and enable Automatic Review in Settings → Getting Started only; no GitHub App guidance |
+| GitLab | Selected but off | Enable Automatic Review in Settings → Getting Started only; no GitHub App guidance |
 | GitLab | Enabled or read failed/ambiguous | No setup handoff |
 
 **B — Bound but unseeded.** The tree is bound and holds at most non-normal
@@ -1099,13 +1099,13 @@ After all sub-agents return:
   `review-config --as-member` read immediately before PR/MR creation. Require
   unambiguous JSON with a non-null `agentUuid` and `enabled: true`. Otherwise,
   do not open the Content PR/MR and handle only the observed state:
-  - `agentUuid` is null: guide the Admin to **Settings → Setup** to select and
+  - `agentUuid` is null: guide the Admin to **Settings → Getting Started** to select and
     enable a Reviewer. Repeat the Structure-PR Agent as the default only when
     this is still the same Phase 1 process and its identity remains explicit in
     working context; a fresh-process recovery asks the Admin to choose without
     naming the recovery Agent as that default.
   - `agentUuid` is present and `enabled` is false: preserve the selection and
-    guide the Admin only to enable Automatic Review in **Settings → Setup**.
+    guide the Admin only to enable Automatic Review in **Settings → Getting Started**.
   - the read fails or is ambiguous: say that Reviewer configuration could not
     be confirmed and retry the read; infer no selection or enablement action.
   This gate delays only the Content PR/MR remote mutation, not Structure

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -321,7 +321,7 @@ PRs/MRs; report the attention gap, but consolidate the action here.
   prints a GitHub installation-settings URL — an absolute `https://` link, so
   it renders clickable in chat. Relay it and say to add the tree repo there.
 - **GitHub tree, no App installed:** give the admin a clickable link to the web
-  console's Setup surface, built from the server URL the agent knows — take
+  console's Getting Started surface, built from the server URL the agent knows — take
   the `Server:` value from `first-tree agent status` and append
   `/settings/setup` (an absolute `https://…/settings/setup` renders
   clickable; a bare `/settings/setup` path does **not** — the chat link guard
@@ -371,7 +371,7 @@ first-tree org context-tree review-config --as-member --org "<team-id>" --json
 - Send one milestone response: combine any GitHub App recovery or repository
   coverage action with the applicable Review setup action above. If only one is
   missing, mention only that action. If neither is missing, add no setup
-  guidance. Setup owns provider prerequisites and the Team mutation.
+  guidance. Getting Started owns provider prerequisites and the Team mutation.
 - A failed or ambiguous read creates no inferred debt. It does not block
   ordinary Seed. Context Review remains optional for Team, Chat, basic Tree use,
   and ordinary Seed completion. Under the explicit Welcome Reviewer contract,

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -371,7 +371,8 @@ first-tree org context-tree review-config --as-member --org "<team-id>" --json
 - Send one milestone response: combine any GitHub App recovery or repository
   coverage action with the applicable Review setup action above. If only one is
   missing, mention only that action. If neither is missing, add no setup
-  guidance. Getting Started owns provider prerequisites and the Team mutation.
+  guidance. The owning Settings surfaces hold provider prerequisites and the
+  Team mutation; Getting Started only summarizes readiness and links there.
 - A failed or ambiguous read creates no inferred debt. It does not block
   ordinary Seed. Context Review remains optional for Team, Chat, basic Tree use,
   and ordinary Seed completion. Under the explicit Welcome Reviewer contract,

--- a/skills/first-tree-welcome/SKILL.md
+++ b/skills/first-tree-welcome/SKILL.md
@@ -486,8 +486,9 @@ run. The dedicated tree task owns its own post-PR/MR handoff through
 - This is not a health or readiness check. Do not prompt a member, infer
   Reviewer health, or infer debt when the read is invalid, fails, or is
   ambiguous. None of these states blocks onboarding.
-- Getting Started owns provider prerequisites, Reviewer selection and health; this
-  launcher performs no Team mutation.
+- Settings → Context Tree owns Reviewer selection and health, while Settings →
+  GitHub & GitLab owns provider prerequisites. Getting Started only summarizes
+  readiness and links to those surfaces; this launcher performs no Team mutation.
 
 The ownership matrix is intentionally small:
 

--- a/skills/first-tree-welcome/SKILL.md
+++ b/skills/first-tree-welcome/SKILL.md
@@ -481,12 +481,12 @@ run. The dedicated tree task owns its own post-PR/MR handoff through
   Read only the JSON `enabled` and `agentUuid` fields. If `agentUuid` is null,
   say once that **Settings → Getting Started** can select an eligible managed Review Agent
   and enable Automatic Review. If `agentUuid` is present while `enabled` is
-  false, say only that Setup can enable Automatic Review; the Agent is already
+  false, say only that **Settings → Getting Started** can enable Automatic Review; the Agent is already
   selected. If both are present/enabled, add no Review setup handoff.
 - This is not a health or readiness check. Do not prompt a member, infer
   Reviewer health, or infer debt when the read is invalid, fails, or is
   ambiguous. None of these states blocks onboarding.
-- Setup owns provider prerequisites, Reviewer selection and health; this
+- Getting Started owns provider prerequisites, Reviewer selection and health; this
   launcher performs no Team mutation.
 
 The ownership matrix is intentionally small:

--- a/skills/first-tree-welcome/SKILL.md
+++ b/skills/first-tree-welcome/SKILL.md
@@ -387,7 +387,7 @@ Key mechanics — read these carefully, they are easy to get wrong:
   Context Tree from the connected code — propose an initial structure for me to
   review, then fill it in. Open the Structure PR/MR first. After that milestone,
   preserve any existing Reviewer; if none is selected, guide me to use this same
-  Agent as the default and enable Automatic Review in Settings → Setup. Draft
+  Agent as the default and enable Automatic Review in Settings → Getting Started. Draft
   the initial content, but do not open its PR/MR until a selected Reviewer is
   enabled so that PR/MR can exercise Automatic Review." This explicit
   Reviewer-handoff sentence is part of the brief only for the admin tree-build
@@ -412,7 +412,7 @@ handoff in its task chat. The welcome launcher consumes that result and must not
 send the same Setup prompt again.
 
 This section's App-install guidance is GitHub-only. For a GitLab MR, do not call
-`first-tree github follow`, send the user to **Settings → Setup** for GitHub App
+`first-tree github follow`, send the user to **Settings → Getting Started** for GitHub App
 installation, or imply
 that the First Tree GitHub App is involved. Instead, consume the spawned task's
 `first-tree gitlab follow <url>` result and preserve its returned pending or
@@ -479,7 +479,7 @@ run. The dedicated tree task owns its own post-PR/MR handoff through
   `first-tree org context-tree review-config --json`. Do not switch to
   `--as-member`: its default Team can differ from this Agent/chat's Team.
   Read only the JSON `enabled` and `agentUuid` fields. If `agentUuid` is null,
-  say once that **Settings → Setup** can select an eligible managed Review Agent
+  say once that **Settings → Getting Started** can select an eligible managed Review Agent
   and enable Automatic Review. If `agentUuid` is present while `enabled` is
   false, say only that Setup can enable Automatic Review; the Agent is already
   selected. If both are present/enabled, add no Review setup handoff.
@@ -494,8 +494,8 @@ The ownership matrix is intentionally small:
 | Observed milestone | State | This launcher's action |
 | --- | --- | --- |
 | GitHub value PR | Task chat reported missing App coverage | Summarize the blocked live updates; do not repeat its Setup handoff |
-| Pre-existing populated tree after value | Confirmed admin; no selected Agent | Hand off once to select and enable Automatic Review in Settings → Setup |
-| Pre-existing populated tree after value | Confirmed admin; Agent selected but Review off | Hand off once to enable Automatic Review in Settings → Setup |
+| Pre-existing populated tree after value | Confirmed admin; no selected Agent | Hand off once to select and enable Automatic Review in Settings → Getting Started |
+| Pre-existing populated tree after value | Confirmed admin; Agent selected but Review off | Hand off once to enable Automatic Review in Settings → Getting Started |
 | Pre-existing populated tree after value | Review enabled, read failed/ambiguous, member, or unclear role | No Review setup handoff |
 | Dedicated tree task's first PR/MR | Any | Seed owns the handoff; consume its result and do not repeat |
 
@@ -597,7 +597,7 @@ milestone makes the capability relevant, then
 guide that one step to completion — do not raise setup as an opening menu, and do
 not give brittle click-by-click paths. When you do hand off, give the most
 specific stable target available (product deep link when authoritative;
-otherwise **Settings → Setup**). Do not guess slugs or URLs, and do not expose
+otherwise **Settings → Getting Started**). Do not guess slugs or URLs, and do not expose
 tokens or secrets. If the human is not an admin, do not send them into an
 admin-only surface; involve the responsible admin.
 
@@ -630,12 +630,12 @@ admin-only surface; involve the responsible admin.
   active state. Attention is inbound-only; only pending waits for a matching
   valid webhook. If follow failed, report only that chat attention gap and do
   not treat the MR as invalid. Never substitute `first-tree github follow`,
-  **Settings → Setup** for GitHub App installation, or other GitHub App
+  **Settings → Getting Started** for GitHub App installation, or other GitHub App
   guidance. This does not replace
   the tree offer; if both apply, keep each to a short sentence and do not repeat
   either later.
 - After value against a pre-existing populated tree, check Context Review
-  configuration and give a confirmed admin at most one **Settings → Setup**
+  configuration and give a confirmed admin at most one **Settings → Getting Started**
   handoff when no eligible Reviewer is selected or the retained selection is
   disabled. Distinguish those states: do not tell an admin to select another
   Agent when one is already retained. A dedicated tree task owns this handoff


### PR DESCRIPTION
## Summary

- rename the user-visible Settings `Setup` entry to `Getting Started`
- preserve the stable `/settings/setup` route and permanent readiness-summary behavior
- update product copy, CLI and agent guidance, bundled skills, tests, and QA wording that direct users to the renamed entry
- extend the onboarding Momentic flow to assert the new sidebar label and absence of the old label

## Validation

- `pnpm check`
- `pnpm typecheck`
- targeted Web tests: 41 passed
- targeted Client tests: 34 passed
- targeted skill floor tests: 32 passed
- `npx momentic@3.42.0 lint e2e/onboarding-complete-setup.test.yaml`
- Momentic local exact-head E2E: [passed and uploaded](https://app.momentic.ai/run-groups/890a1a6a-fca0-4279-acd0-3ecbf17cb8fe)

`pnpm test` was also attempted locally. The run was interrupted by the host reaching zero free disk space while the server test container was starting; affected deterministic suites and the exact-head browser flow passed independently, and CI remains the authoritative full-suite gate.

## Product boundary

This is a display-name change only. It does not migrate `/settings/setup`, change onboarding completion or resume semantics, or move capability ownership out of the permanent readiness summary.

## Context Tree

- agent-team-foundation/first-tree-context#889
