### PR TITLE
refactor(client): clear retired result-sink deps and inbox ACK docs

### DIFF
--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -196,7 +196,7 @@ describe("ClientConnection — additional branch coverage", () => {
     const commands: unknown[] = [];
     const pins: unknown[] = [];
     const runtimeAuthStarts: unknown[] = [];
-    connection.on("inbox:deliver", (agentId, frame) => delivered.push({ agentId, frame }));
+    connection.on("inbox:deliver", (inboxId, frame) => delivered.push({ inboxId, frame }));
     connection.on("session:command", (command) => commands.push(command));
     connection.on("agent:pinned", (message) => pins.push(message));
     connection.on("runtime-auth:start", (command) => runtimeAuthStarts.push(command));
@@ -270,7 +270,7 @@ describe("ClientConnection — additional branch coverage", () => {
       },
     };
     socket.emitMessage(deliveredFrame);
-    expect(delivered).toEqual([{ agentId: "inbox-agent-1", frame: deliveredFrame }]);
+    expect(delivered).toEqual([{ inboxId: "inbox-agent-1", frame: deliveredFrame }]);
 
     socket.emitMessage({
       type: "session:event:accepted",

--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import { createResultSink, type Trigger } from "../runtime/result-sink.js";
-import type { FirstTreeHubSDK } from "../sdk.js";
+import { describe, expect, it } from "vitest";
+import { createResultSink } from "../runtime/result-sink.js";
 
 /**
  * Contract tests for the turn-completion sink.
@@ -11,52 +10,36 @@ import type { FirstTreeHubSDK } from "../sdk.js";
  * turn trigger so the next inject() starts clean.
  */
 
-const ME = "agent-me";
-
-function buildSink(initialTrigger: Trigger | null) {
-  const sendMessage = vi.fn().mockResolvedValue(undefined);
+function buildSink(initialTrigger: { messageId: string; senderId: string } | null) {
   const logs: string[] = [];
   let trigger = initialTrigger;
 
-  const sdk = { serverUrl: "http://test", sendMessage } as unknown as FirstTreeHubSDK;
-
   const sink = createResultSink({
-    sdk,
-    agent: {
-      agentId: ME,
-      inboxId: "inbox-me",
-      displayName: "test-agent",
-      type: "agent",
-      visibility: "organization",
-      delegateMention: null,
-      metadata: {},
-    },
-    chatId: "chat-1",
-    getTrigger: () => trigger,
     clearTrigger: () => {
       trigger = null;
     },
     log: (msg) => logs.push(msg),
   });
 
-  return { sink, sendMessage, logs, readTrigger: () => trigger };
+  return { sink, logs, readTrigger: () => trigger };
 }
 
 describe("createResultSink — final-text delivery retired", () => {
-  it("does NOT deliver a non-empty final text to chat", async () => {
-    const { sink, sendMessage } = buildSink({ messageId: "m1", senderId: "agent-peer" });
+  it("clears trigger and logs retired delivery for a non-empty turn", async () => {
+    const { sink, logs, readTrigger } = buildSink({ messageId: "m1", senderId: "agent-peer" });
 
     await sink("final answer");
 
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(readTrigger()).toBeNull();
+    expect(logs.some((m) => /retired/.test(m))).toBe(true);
   });
 
-  it("does NOT deliver an empty / whitespace-only (silent) turn either", async () => {
-    const { sink, sendMessage } = buildSink(null);
+  it("logs a silent turn for empty / whitespace-only output", async () => {
+    const { sink, logs } = buildSink(null);
 
     await sink("   ");
 
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(logs.some((m) => /silent turn/.test(m))).toBe(true);
   });
 
   it("clears the turn trigger so a concurrent inject() starts clean", async () => {
@@ -66,13 +49,5 @@ describe("createResultSink — final-text delivery retired", () => {
     await sink("final answer");
 
     expect(readTrigger()).toBeNull();
-  });
-
-  it("logs that final-text delivery is retired on a non-empty turn", async () => {
-    const { sink, logs } = buildSink(null);
-
-    await sink("did the thing");
-
-    expect(logs.some((m) => /retired/.test(m))).toBe(true);
   });
 });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -107,11 +107,6 @@ type SessionManagerInternals = {
   recomputeRuntimeState(): void;
   buildSessionContext(chatId: string): SessionContext;
   confirmSessionEventOrThrow(chatId: string, event: SessionEvent): Promise<void>;
-  resolveSelfFence(
-    log: (msg: string) => void,
-    chatId: string,
-  ): Promise<{ agentHome: string; singleRepoLocalPath?: string }>;
-  resolveChatOrgId(log: (msg: string) => void, chatId: string): Promise<string | null>;
   reaffirmRuntimeStates(): void;
   persistRegistry(): void;
 };
@@ -6650,62 +6645,6 @@ describe("SessionManager edge coverage", () => {
     await confirmedCtx.emitEventConfirmed(event);
     expect(confirmSessionEvent).toHaveBeenCalledWith("chat-confirmed", event);
     await confirmed.shutdown();
-  });
-
-  it("resolves document self fences from runtime config and falls back on refresh failure", async () => {
-    const workspaceRoot = "/tmp/test-edge/fence-agent";
-    const config = runtimeConfig({
-      payload: {
-        ...runtimeConfig().payload,
-        gitRepos: [{ url: "https://github.com/acme/repo.git", localPath: "repo" }],
-      },
-    });
-    const sm = makeManager({ workspaceRoot, agentConfigCache: makeCache({ config }) });
-    const logs: string[] = [];
-
-    await expect(internals(sm).resolveSelfFence((msg) => logs.push(msg), "chat-fence")).resolves.toEqual({
-      agentHome: workspaceRoot,
-      singleRepoLocalPath: "source-repos/repo",
-    });
-    expect(logs).toEqual([]);
-    await sm.shutdown();
-
-    const failing = makeManager({
-      workspaceRoot,
-      agentConfigCache: makeCache({
-        refreshIfNewer: async () => {
-          throw new Error("config unavailable");
-        },
-      }),
-    });
-    await expect(internals(failing).resolveSelfFence((msg) => logs.push(msg), "chat-fence-fallback")).resolves.toEqual({
-      agentHome: workspaceRoot,
-    });
-    expect(logs.some((msg) => msg.includes("config unavailable"))).toBe(true);
-    await failing.shutdown();
-  });
-
-  it("resolves chat org ids with caching and degrades lookup failures to null", async () => {
-    const getChatDetail = vi.fn(async (chatId: string) => {
-      if (chatId === "chat-org") return { organizationId: "org-1" };
-      if (chatId === "chat-empty-org") return { organizationId: "" };
-      throw new Error("lookup failed");
-    });
-    const sdk = { ...mockSdk(), getChatDetail } as unknown as FirstTreeHubSDK;
-    const sm = makeManager({ sdk });
-    const logs: string[] = [];
-    const log = (msg: string): void => {
-      logs.push(msg);
-    };
-
-    await expect(internals(sm).resolveChatOrgId(log, "chat-org")).resolves.toBe("org-1");
-    await expect(internals(sm).resolveChatOrgId(log, "chat-org")).resolves.toBe("org-1");
-    expect(getChatDetail).toHaveBeenCalledTimes(1);
-
-    await expect(internals(sm).resolveChatOrgId(log, "chat-empty-org")).resolves.toBeNull();
-    await expect(internals(sm).resolveChatOrgId(log, "chat-fail")).resolves.toBeNull();
-    expect(logs.some((msg) => msg.includes("lookup failed"))).toBe(true);
-    await sm.shutdown();
   });
 
   it("uses idle fallback in evictIdle logging when no runtime state was recorded", async () => {

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -245,10 +245,11 @@ type ClientConnectionEvents = {
   "agent:unbound": [agentId: string, reason?: string];
   /**
    * Server pushed a fully-assembled inbox entry over the WS data plane.
-   * Listeners must call `connection.sendInboxAck(frame.entryId)` once the
-   * entry has been durably handed to the session manager.
+   * First arg is `frame.inboxId` (not agentId). ACK is deferred until the
+   * handler turn closes inside SessionManager — do not ACK from this listener
+   * merely because the frame reached the session manager / early buffer.
    */
-  "inbox:deliver": [agentId: string, frame: InboxDeliverFrame];
+  "inbox:deliver": [inboxId: string, frame: InboxDeliverFrame];
   "agent:bind:rejected": [reason: AgentBindRejectReason, agentId: string];
   /**
    * Server announced that an agent has been pinned to this client (either

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -1,7 +1,3 @@
-import type { FirstTreeHubSDK } from "../sdk.js";
-import type { SelfFence } from "./doc-snapshots.js";
-import type { AgentIdentity } from "./handler.js";
-
 /**
  * Turn-completion sink the runtime calls when a handler finishes a turn.
  *
@@ -13,39 +9,20 @@ import type { AgentIdentity } from "./handler.js";
  * is always an explicit `chat send` (agent or human) or `chat ask` (a human
  * decision); there is no implicit final-text delivery to fall back on.
  *
- * The sink is kept as the single hook every handler (Claude Code today,
- * Gemini / Cursor / custom tomorrow) calls at turn end; it now only clears the
- * turn trigger and never writes to chat. The enrichment deps in
- * `ResultSinkDeps` (sdk / self-fence / org / doc-snapshot inputs) are inert
- * now — they are retained to keep the wiring stable and are cleaned up
- * together with the turn-trigger machinery in a follow-up.
+ * The sink remains the single hook every built-in handler calls at turn end; it
+ * only clears the turn trigger and never writes to chat. Replacing this hook
+ * with a dedicated turn-end API (and retiring `currentTrigger` with it) is a
+ * follow-up — not this cleanup.
  */
 
 export type Trigger = { messageId: string; senderId: string };
 
 export type ResultSinkDeps = {
-  sdk: FirstTreeHubSDK;
-  agent: AgentIdentity;
-  chatId: string;
-  /** Reads the current trigger (managed by session-manager). Returning
-   *  `null` means the handler's reply is unprompted — typically on resume
-   *  with no new message, or post-shutdown. */
-  getTrigger: () => Trigger | null;
-  /** Called by the sink to clear the trigger before awaiting the transport,
-   *  so a concurrently-arriving inject() can set a fresh trigger without this
+  /** Called by the sink to clear the trigger before returning, so a
+   *  concurrently-arriving inject() can set a fresh trigger without this
    *  reply consuming it. */
   clearTrigger: () => void;
   log: (msg: string) => void;
-  /**
-   * INERT (see the module note): these fed the retired doc-capture/snapshot
-   * enrichment that ran when the sink delivered the final-text mirror. The sink
-   * no longer writes to chat, so they are never read; they are retained only to
-   * keep the wiring stable and are cleaned up with the turn-trigger machinery.
-   */
-  getSelfFence?: () => Promise<SelfFence | null>;
-  getOrgId?: () => Promise<string | null>;
-  workspacesRoot?: string;
-  selfSlug?: string;
 };
 
 export type ResultSink = (text: string) => Promise<void>;

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -692,7 +692,6 @@ export class SessionManager {
   /** Cache of chatId → organizationId, resolved via `getChatDetail`. A chat's
    *  org is immutable, so this is a cheap permanent memo that keeps doc-capture
    *  uploads off the hot path after the first lookup. */
-  private readonly chatOrgIds = new Map<string, string>();
   private lastReportedRuntimeState: RuntimeState | null = null;
   private idleTimer: ReturnType<typeof setInterval> | null = null;
   private runtimeReaffirmTimer: ReturnType<typeof setTimeout> | null = null;
@@ -4616,18 +4615,10 @@ export class SessionManager {
       : sessionRoot;
 
     const forwardResult = createResultSink({
-      sdk: this.config.sdk,
-      agent: this.config.agentIdentity,
-      chatId,
-      getTrigger: () => this.currentTrigger.get(chatId) ?? null,
       clearTrigger: () => {
         this.currentTrigger.delete(chatId);
       },
       log,
-      getSelfFence: () => this.resolveSelfFence(log, chatId),
-      getOrgId: () => this.resolveChatOrgId(log, chatId),
-      workspacesRoot,
-      selfSlug,
     });
 
     const envCtx = {
@@ -4763,50 +4754,6 @@ export class SessionManager {
       throw new Error("route transition invalidated");
     }
     this.captureRuntimeFailureNotice(chatId, event, mutationLeaseValid);
-  }
-
-  private async resolveSelfFence(log: (msg: string) => void, chatId: string): Promise<SelfFence> {
-    // Session doc root: the dir the handler actually hands the agent as cwd —
-    // the per-agent home for new chats, the legacy `<workspaceRoot>/<chatId>/`
-    // dir for pre-#506 chats. See `resolveSessionDocRoot` (read-only existsSync;
-    // no acquire* side effects on every outbound message).
-    const workspaceRoot = this.config.handlerConfig.workspaceRoot;
-    const sessionRoot = resolveSessionDocRoot(workspaceRoot, chatId);
-    if (!this.config.agentConfigCache) return { agentHome: sessionRoot };
-    try {
-      const { payload } = await this.config.agentConfigCache.refreshIfNewer(this.config.agentIdentity.agentId, 0);
-      return selfFenceFromRuntimeConfig(payload, sessionRoot, workspaceRoot);
-    } catch (err) {
-      log(
-        `document preview self-fence: config unavailable, using agent home only: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return { agentHome: sessionRoot };
-    }
-  }
-
-  /**
-   * Resolve the organization id a chat belongs to, for doc-capture uploads
-   * (`POST /orgs/:orgId/attachments`). Cached permanently (a chat's org never
-   * changes). Returns `null` when the lookup fails so the sink degrades doc
-   * mentions to plain text instead of blocking the message.
-   */
-  private async resolveChatOrgId(log: (msg: string) => void, chatId: string): Promise<string | null> {
-    const cached = this.chatOrgIds.get(chatId);
-    if (cached) return cached;
-    try {
-      const detail = await this.config.sdk.getChatDetail(chatId);
-      const orgId = detail.organizationId;
-      if (typeof orgId === "string" && orgId.length > 0) {
-        this.chatOrgIds.set(chatId, orgId);
-        return orgId;
-      }
-      return null;
-    } catch (err) {
-      log(
-        `doc capture: org lookup failed, doc mentions stay plain text: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return null;
-    }
   }
 
   private projectSessionRuntime(chatId: string, opts: { drainPendingOnIdle?: boolean } = {}): void {


### PR DESCRIPTION
## Summary
- Strip inert `ResultSinkDeps` (sdk / agent / getTrigger / doc-fence / org lookup) left after the agent-final-text mirror was retired; delete the SessionManager-only resolvers that existed solely to feed them.
- Keep `forwardResult` as the shared turn-end hook that clears `currentTrigger` (full turn-end API + trigger retirement is a follow-up).
- Rename `inbox:deliver` event tuple `agentId` → `inboxId` and correct the ACK comment to match deferred ACK until handler turn close (Context Tree Delivery And ACK).

## Test plan
- [x] `pnpm exec vitest run src/__tests__/result-sink.test.ts src/__tests__/client-connection-more-coverage.test.ts`
- [x] `pnpm run typecheck` in `packages/client`
- [x] Smoke-load `session-manager-edge-coverage.test.ts` after removing the dead resolver tests
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)