### PR TITLE
fix(web): hide empty Agent Template Responsibilities entry

### DIFF
--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -40,7 +40,12 @@ import { AgentSwitcherStrip } from "./agent-detail/agent-switcher-strip.js";
 import { useAgentResources } from "./agent-detail/capability-section.js";
 import { ContextBar } from "./agent-detail/context-bar.js";
 import type { AgentDetailContext, RuntimeSwitchClaimView } from "./agent-detail/layout-context.js";
-import { buildTabs, shouldShowResponsibilitiesTab, type TabDef } from "./agent-detail/tabs.js";
+import {
+  buildTabs,
+  responsibilitiesSideFromQuery,
+  shouldShowResponsibilitiesTab,
+  type TabDef,
+} from "./agent-detail/tabs.js";
 import { useAgentConfigSave } from "./agent-detail/use-agent-config-save.js";
 import { useLegacyAnchorRedirect } from "./agent-detail/use-legacy-anchor-redirect.js";
 import { PROVIDER_ORDER, runtimeProviderLabel } from "./clients/cards/shared/providers.js";
@@ -276,20 +281,25 @@ function AgentDetailPageView() {
   const showResponsibilities = useMemo(
     () =>
       shouldShowResponsibilitiesTab(isHumanLocal, {
-        catalogFetched: templateCatalogQuery.isSuccess,
-        catalogError: templateCatalogQuery.isError,
-        catalogCount: templateCatalogQuery.data?.templates.length ?? 0,
-        agentResourcesFetched: toolsResources.data != null,
-        agentResourcesError: toolsResources.error != null && toolsResources.data == null,
-        agentTemplateIdCount: toolsResources.data?.templateIds.length ?? 0,
+        catalog: responsibilitiesSideFromQuery({
+          count: templateCatalogQuery.data ? templateCatalogQuery.data.templates.length : null,
+          isFetching: templateCatalogQuery.isFetching,
+          isError: templateCatalogQuery.isError,
+        }),
+        agentResources: responsibilitiesSideFromQuery({
+          count: toolsResources.data ? toolsResources.data.templateIds.length : null,
+          isFetching: toolsResources.isFetching,
+          isError: toolsResources.isError,
+        }),
       }),
     [
       isHumanLocal,
-      templateCatalogQuery.isSuccess,
+      templateCatalogQuery.data,
+      templateCatalogQuery.isFetching,
       templateCatalogQuery.isError,
-      templateCatalogQuery.data?.templates.length,
       toolsResources.data,
-      toolsResources.error,
+      toolsResources.isFetching,
+      toolsResources.isError,
     ],
   );
   const tabs = useMemo(

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router";
 import { type HubClient, listClients } from "./../api/activity.js";
 import { type ClientStatusInfo, getAgentClientStatus, getAgentConfig } from "./../api/agent-config.js";
+import { listAgentTemplates } from "./../api/agent-templates.js";
 import {
   deleteAgent,
   getAgent,
@@ -39,7 +40,7 @@ import { AgentSwitcherStrip } from "./agent-detail/agent-switcher-strip.js";
 import { useAgentResources } from "./agent-detail/capability-section.js";
 import { ContextBar } from "./agent-detail/context-bar.js";
 import type { AgentDetailContext, RuntimeSwitchClaimView } from "./agent-detail/layout-context.js";
-import { buildTabs, type TabDef } from "./agent-detail/tabs.js";
+import { buildTabs, shouldShowResponsibilitiesTab, type TabDef } from "./agent-detail/tabs.js";
 import { useAgentConfigSave } from "./agent-detail/use-agent-config-save.js";
 import { useLegacyAnchorRedirect } from "./agent-detail/use-legacy-anchor-redirect.js";
 import { PROVIDER_ORDER, runtimeProviderLabel } from "./clients/cards/shared/providers.js";
@@ -120,8 +121,18 @@ function AgentDetailPageView() {
   // click". One light query in the same tier as agent-config / client-status;
   // Responsibilities, Tools & skills, and Repositories then read+write this same
   // ["agent-resources", uuid] cache, so their useAgentResources calls become
-  // cache hits.
+  // cache hits. Also feeds Responsibilities tab visibility (adopted templateIds).
   const toolsResources = useAgentResources(uuid, { enabled: !!uuid && agentQuery.data?.type !== "human" });
+
+  // Public official Template catalog — same key as the Responsibilities editor
+  // so the shell and the edit dialog share one cache. Drives whether the
+  // Responsibilities tab exists when the agent has no adopted templates yet.
+  const templateCatalogQuery = useQuery({
+    queryKey: ["agent-templates-catalog"],
+    queryFn: listAgentTemplates,
+    enabled: !!uuid && agentQuery.data?.type !== "human",
+    retry: 1,
+  });
 
   // Immediate-save controller for model / reasoning effort / env. Lives in the
   // shell (not the Runtime tab) so its "Saved" flash and pending state survive a
@@ -262,7 +273,29 @@ function AgentDetailPageView() {
     return badges;
   }, [toolsResources.data]);
 
-  const tabs = useMemo(() => buildTabs(canEditConfig, isHumanLocal), [canEditConfig, isHumanLocal]);
+  const showResponsibilities = useMemo(
+    () =>
+      shouldShowResponsibilitiesTab(isHumanLocal, {
+        catalogFetched: templateCatalogQuery.isSuccess,
+        catalogError: templateCatalogQuery.isError,
+        catalogCount: templateCatalogQuery.data?.templates.length ?? 0,
+        agentResourcesFetched: toolsResources.data != null,
+        agentResourcesError: toolsResources.error != null && toolsResources.data == null,
+        agentTemplateIdCount: toolsResources.data?.templateIds.length ?? 0,
+      }),
+    [
+      isHumanLocal,
+      templateCatalogQuery.isSuccess,
+      templateCatalogQuery.isError,
+      templateCatalogQuery.data?.templates.length,
+      toolsResources.data,
+      toolsResources.error,
+    ],
+  );
+  const tabs = useMemo(
+    () => buildTabs(canEditConfig, isHumanLocal, showResponsibilities),
+    [canEditConfig, isHumanLocal, showResponsibilities],
+  );
   const currentTabKey = useMemo(() => {
     const segments = location.pathname.split("/");
     const last = segments[segments.length - 1] ?? "";

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -935,6 +935,7 @@ describe("agent detail pure helpers", () => {
     );
     expect(resolveTabPath(agent(), "member-other", "member", "usage")).toBe("usage");
     expect(resolveTabPath(agent(), "member-other", "member", "responsibilities")).toBe("responsibilities");
+    expect(resolveTabPath(agent(), "member-other", "member", "responsibilities", false)).toBe("profile");
     expect(resolveTabPath(agent(), "member-other", "member", "runtime")).toBe("profile");
     expect(buildTabs(false, false).map((tab) => tab.path)).toEqual([
       "profile",
@@ -942,6 +943,7 @@ describe("agent detail pure helpers", () => {
       "capabilities",
       "usage",
     ]);
+    expect(buildTabs(false, false, false).map((tab) => tab.path)).toEqual(["profile", "capabilities", "usage"]);
 
     expect(isBindableClient({ status: "connected" })).toBe(true);
     expect(isBindableClient({ status: "retired" })).toBe(false);

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -333,7 +333,11 @@ async function waitForCondition(predicate: () => boolean, message: string, timeo
   throw new Error(message);
 }
 
-async function renderDom(route: string, child: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+async function renderDom(
+  route: string,
+  child: ReactElement,
+  setup?: (queryClient: QueryClient) => void | Promise<void>,
+): Promise<{ container: HTMLElement; root: Root; queryClient: QueryClient }> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -343,6 +347,7 @@ async function renderDom(route: string, child: ReactElement): Promise<{ containe
       mutations: { retry: false },
     },
   });
+  await setup?.(queryClient);
   const { AgentDetailPage } = await import("../../agent-detail.js");
   await act(async () => {
     root.render(
@@ -368,7 +373,7 @@ async function renderDom(route: string, child: ReactElement): Promise<{ containe
     );
   });
   await flush();
-  return { container, root };
+  return { container, root, queryClient };
 }
 
 function LocationEcho() {
@@ -640,6 +645,116 @@ describe("AgentDetailPage", () => {
     expect(view.container.textContent).not.toContain("No template responsibilities are assigned to this agent.");
     expect([...view.container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).not.toContain(
       "Responsibilities",
+    );
+    await act(async () => view.root.unmount());
+  });
+
+  it("fail-opens Responsibilities when cached-empty agent-resources background refetch fails", async () => {
+    templateMocks.listAgentTemplates.mockResolvedValue({ templates: [] });
+    agentResourceMocks.getAgentResources.mockResolvedValue(agentResources({ templateIds: [], adoptedTemplates: [] }));
+
+    const view = await renderDom("/agents/agent-1/responsibilities", <div>Empty-gate Profile route</div>);
+    await waitForText(view.container, "Empty-gate Profile route");
+    await waitForCondition(
+      () =>
+        ![...view.container.querySelectorAll('[role="tab"]')]
+          .map((tab) => tab.textContent?.trim())
+          .includes("Responsibilities"),
+      "Expected Responsibilities to close after confirmed empty catalog + resources",
+    );
+
+    agentResourceMocks.getAgentResources.mockRejectedValue(new Error("refetch boom"));
+    await act(async () => {
+      await view.queryClient.invalidateQueries({ queryKey: ["agent-resources", "agent-1"] });
+    });
+    await waitForCondition(
+      () =>
+        [...view.container.querySelectorAll('[role="tab"]')]
+          .map((tab) => tab.textContent?.trim())
+          .includes("Responsibilities"),
+      "Expected Responsibilities to fail-open after a cached-empty refetch error",
+    );
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps a Responsibilities deep link when opening with cached-empty data and a failing refetch", async () => {
+    templateMocks.listAgentTemplates.mockResolvedValue({ templates: [] });
+    agentResourceMocks.getAgentResources.mockRejectedValue(new Error("refetch boom"));
+
+    const view = await renderDom(
+      "/agents/agent-1/responsibilities",
+      <div>Must not redirect</div>,
+      async (queryClient) => {
+        queryClient.setQueryData(["agent-templates-catalog"], { templates: [] });
+        queryClient.setQueryData(
+          ["agent-resources", "agent-1"],
+          agentResources({ templateIds: [], adoptedTemplates: [] }),
+        );
+        // Leave the resources query in the retained-data + error state RQ produces
+        // after a background refetch failure, before the page mounts.
+        try {
+          await queryClient.fetchQuery({
+            queryKey: ["agent-resources", "agent-1"],
+            queryFn: () => agentResourceMocks.getAgentResources("agent-1"),
+          });
+        } catch {
+          // expected — keeps cached empty data with isError=true
+        }
+      },
+    );
+
+    await waitForCondition(
+      () =>
+        [...view.container.querySelectorAll('[role="tab"]')]
+          .map((tab) => tab.textContent?.trim())
+          .includes("Responsibilities"),
+      "Expected deep link to keep Responsibilities under cached-empty refetch error",
+    );
+    expect(view.container.textContent).not.toContain("Must not redirect");
+    await act(async () => view.root.unmount());
+  });
+
+  it("fail-opens while cached-empty resources refetch is in flight, then closes after settled empty", async () => {
+    templateMocks.listAgentTemplates.mockResolvedValue({ templates: [] });
+    agentResourceMocks.getAgentResources.mockResolvedValue(agentResources({ templateIds: [], adoptedTemplates: [] }));
+
+    const view = await renderDom("/agents/agent-1/profile", <div>Profile route</div>);
+    await waitForText(view.container, "Profile route");
+    await waitForCondition(
+      () =>
+        ![...view.container.querySelectorAll('[role="tab"]')]
+          .map((tab) => tab.textContent?.trim())
+          .includes("Responsibilities"),
+      "Expected Responsibilities to close after confirmed empty",
+    );
+
+    let releaseRefetch: ((value: ReturnType<typeof agentResources>) => void) | null = null;
+    agentResourceMocks.getAgentResources.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseRefetch = resolve;
+        }),
+    );
+    await act(async () => {
+      void view.queryClient.invalidateQueries({ queryKey: ["agent-resources", "agent-1"] });
+    });
+    await waitForCondition(
+      () =>
+        [...view.container.querySelectorAll('[role="tab"]')]
+          .map((tab) => tab.textContent?.trim())
+          .includes("Responsibilities"),
+      "Expected Responsibilities to fail-open while empty resources are refetching",
+    );
+
+    await act(async () => {
+      releaseRefetch?.(agentResources({ templateIds: [], adoptedTemplates: [] }));
+    });
+    await waitForCondition(
+      () =>
+        ![...view.container.querySelectorAll('[role="tab"]')]
+          .map((tab) => tab.textContent?.trim())
+          .includes("Responsibilities"),
+      "Expected Responsibilities to close again after settled empty refetch",
     );
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -42,6 +42,11 @@ const agentResourceMocks = vi.hoisted(() => ({
   updateAgentResources: vi.fn(),
 }));
 
+const templateMocks = vi.hoisted(() => ({
+  listAgentTemplates: vi.fn(),
+  updateAgentTemplates: vi.fn(),
+}));
+
 const sessionMocks = vi.hoisted(() => ({
   listAgentSessions: vi.fn(),
 }));
@@ -76,6 +81,8 @@ vi.mock("../../../api/agents.js", async (importOriginal) => ({
 }));
 
 vi.mock("../../../api/agent-resources.js", () => agentResourceMocks);
+
+vi.mock("../../../api/agent-templates.js", () => templateMocks);
 
 vi.mock("../../../api/sessions.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../api/sessions.js")>()),
@@ -218,6 +225,26 @@ function adoptedTemplate(): AgentResourcesOutput["adoptedTemplates"][number] {
       instructionsSummary: "Review, implement, and verify",
       toolsAndSkillsSummary: "Code review and repository tools",
     },
+    replacement: null,
+  };
+}
+
+function publicCatalogTemplate() {
+  const adopted = adoptedTemplate();
+  return {
+    id: adopted.id,
+    slug: "pr-engineer",
+    name: "PR Engineer",
+    status: "active" as const,
+    public: {
+      tagline: "Ship review-ready pull requests",
+      purpose: "Review and implement focused changes",
+      targetUsers: "Software teams",
+      userValue: "Move pull requests forward safely",
+      instructionsSummary: "Review, implement, and verify",
+      toolsAndSkillsSummary: "Code review and repository tools",
+    },
+    updatedAt: NOW,
     replacement: null,
   };
 }
@@ -432,6 +459,10 @@ beforeEach(() => {
   // same state — so per-test overrides below also use mockResolvedValue; a
   // one-shot mock with an empty fallback would clobber the cache on refetch.
   agentResourceMocks.getAgentResources.mockResolvedValue(agentResources());
+  // Non-empty public catalog by default so Responsibilities stays visible even
+  // when the agent has zero adopted templateIds (the empty-entry gate needs
+  // both sides confirmed empty).
+  templateMocks.listAgentTemplates.mockResolvedValue({ templates: [publicCatalogTemplate()] });
   agentResourceMocks.updateAgentResources.mockImplementation(
     async (_agentId: string, body: { bindings: AgentResourcesOutput["bindings"] }) =>
       agentResources({ version: 8, bindings: body.bindings }),
@@ -542,6 +573,74 @@ describe("AgentDetailPage", () => {
     await waitForText(view.container, "Human Profile route");
     expect(view.container.querySelector('[role="tablist"]')).toBeNull();
     expect(view.container.textContent).not.toContain("Responsibilities");
+    await act(async () => view.root.unmount());
+  });
+
+  it("hides Responsibilities when the public catalog and agent templateIds are both empty", async () => {
+    templateMocks.listAgentTemplates.mockResolvedValue({ templates: [] });
+    agentResourceMocks.getAgentResources.mockResolvedValue(agentResources({ templateIds: [], adoptedTemplates: [] }));
+
+    const view = await renderDom("/agents/agent-1/profile", <div>Profile route</div>);
+    await waitForText(view.container, "Profile route");
+    await waitForCondition(
+      () => templateMocks.listAgentTemplates.mock.calls.length >= 1,
+      "Expected the public template catalog to load",
+    );
+    expect([...view.container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toEqual([
+      "Profile",
+      "Runtime",
+      "Instructions",
+      "Tools & skills",
+      "Repositories",
+      "Usage",
+    ]);
+    expect(view.container.textContent).not.toContain("Responsibilities");
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps Responsibilities when the catalog is empty but the agent still has adopted templates", async () => {
+    templateMocks.listAgentTemplates.mockResolvedValue({ templates: [] });
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        templateIds: [adoptedTemplate().id],
+        adoptedTemplates: [adoptedTemplate()],
+      }),
+    );
+
+    const view = await renderDom("/agents/agent-1/responsibilities", <div>Profile route</div>);
+    await waitForText(view.container, "PR Engineer");
+    expect([...view.container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toContain(
+      "Responsibilities",
+    );
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps Responsibilities while the catalog request is failing", async () => {
+    templateMocks.listAgentTemplates.mockRejectedValue(new Error("catalog down"));
+    agentResourceMocks.getAgentResources.mockResolvedValue(agentResources({ templateIds: [], adoptedTemplates: [] }));
+
+    const view = await renderDom("/agents/agent-1/profile", <div>Profile route</div>);
+    await waitForText(view.container, "Profile route");
+    await waitForCondition(
+      () => templateMocks.listAgentTemplates.mock.calls.length >= 1,
+      "Expected the catalog request to run",
+    );
+    expect([...view.container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toContain(
+      "Responsibilities",
+    );
+    await act(async () => view.root.unmount());
+  });
+
+  it("redirects a Responsibilities deep link to Profile when the empty-catalog gate is closed", async () => {
+    templateMocks.listAgentTemplates.mockResolvedValue({ templates: [] });
+    agentResourceMocks.getAgentResources.mockResolvedValue(agentResources({ templateIds: [], adoptedTemplates: [] }));
+
+    const view = await renderDom("/agents/agent-1/responsibilities", <div>Empty-gate Profile route</div>);
+    await waitForText(view.container, "Empty-gate Profile route");
+    expect(view.container.textContent).not.toContain("No template responsibilities are assigned to this agent.");
+    expect([...view.container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).not.toContain(
+      "Responsibilities",
+    );
     await act(async () => view.root.unmount());
   });
 

--- a/packages/web/src/pages/agent-detail/__tests__/tabs.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/tabs.test.ts
@@ -1,23 +1,57 @@
 import { describe, expect, it } from "vitest";
 import {
   buildTabs,
+  isConfirmedEmptyResponsibilitiesSide,
+  type ResponsibilitiesSideState,
   type ResponsibilitiesVisibilityInput,
   resolveTabPath,
+  responsibilitiesSideFromQuery,
   shouldShowResponsibilitiesTab,
   tabKeysFor,
 } from "../tabs.js";
 
-function visibility(overrides: Partial<ResponsibilitiesVisibilityInput> = {}): ResponsibilitiesVisibilityInput {
+function side(overrides: Partial<ResponsibilitiesSideState> = {}): ResponsibilitiesSideState {
   return {
-    catalogFetched: true,
-    catalogError: false,
-    catalogCount: 1,
-    agentResourcesFetched: true,
-    agentResourcesError: false,
-    agentTemplateIdCount: 0,
+    hasData: true,
+    isFetching: false,
+    hasError: false,
+    count: 0,
     ...overrides,
   };
 }
+
+function visibility(
+  overrides: { catalog?: Partial<ResponsibilitiesSideState>; agentResources?: Partial<ResponsibilitiesSideState> } = {},
+): ResponsibilitiesVisibilityInput {
+  return {
+    catalog: side({ count: 1, ...overrides.catalog }),
+    agentResources: side({ count: 0, ...overrides.agentResources }),
+  };
+}
+
+const agent = {
+  uuid: "agent-1",
+  name: "vega",
+  displayName: "Vega",
+  type: "agent" as const,
+  managerId: "member-self",
+  visibility: "organization" as const,
+  avatarColorToken: null,
+  avatarImageUrl: null,
+  status: "active" as const,
+  organizationId: "org-1",
+  delegateMention: null,
+  inboxId: "inbox-1",
+  metadata: {},
+  source: "portal" as const,
+  clientId: "client-1",
+  runtimeProvider: "claude-code" as const,
+  runtimeState: "idle" as const,
+  createdAt: "2026-05-28T12:00:00.000Z",
+  updatedAt: "2026-05-28T12:00:00.000Z",
+};
+
+const human = { ...agent, type: "human" as const, clientId: null };
 
 describe("agent-detail tabs", () => {
   it("gives an editor the 7-tab set with Responsibilities after Profile", () => {
@@ -65,6 +99,12 @@ describe("agent-detail tabs", () => {
     expect(tabKeysFor(false, true).map((t) => t.key)).toEqual(["profile"]);
   });
 
+  it("never grants Responsibilities to a human even when the caller passes true", () => {
+    expect(tabKeysFor(false, true, true).map((t) => t.key)).toEqual(["profile"]);
+    expect(buildTabs(false, true, true).map((t) => t.key)).toEqual(["profile"]);
+    expect(resolveTabPath(human, "member-self", "admin", "responsibilities", true)).toBe("profile");
+  });
+
   it("omits Responsibilities when the empty-catalog gate is closed", () => {
     expect(tabKeysFor(true, false, false).map((t) => t.key)).toEqual([
       "profile",
@@ -80,40 +120,30 @@ describe("agent-detail tabs", () => {
 
 describe("shouldShowResponsibilitiesTab", () => {
   it("never shows for humans", () => {
-    expect(shouldShowResponsibilitiesTab(true, visibility({ catalogCount: 3, agentTemplateIdCount: 2 }))).toBe(false);
+    expect(
+      shouldShowResponsibilitiesTab(true, visibility({ catalog: { count: 3 }, agentResources: { count: 2 } })),
+    ).toBe(false);
   });
 
   it("hides only when catalog and agent templateIds are both confirmed empty", () => {
-    expect(shouldShowResponsibilitiesTab(false, visibility({ catalogCount: 0, agentTemplateIdCount: 0 }))).toBe(false);
+    expect(
+      shouldShowResponsibilitiesTab(false, visibility({ catalog: { count: 0 }, agentResources: { count: 0 } })),
+    ).toBe(false);
   });
 
   it("keeps the tab when the agent still has adopted templateIds even if the catalog is empty", () => {
-    expect(shouldShowResponsibilitiesTab(false, visibility({ catalogCount: 0, agentTemplateIdCount: 2 }))).toBe(true);
+    expect(
+      shouldShowResponsibilitiesTab(false, visibility({ catalog: { count: 0 }, agentResources: { count: 2 } })),
+    ).toBe(true);
   });
 
   it("keeps the tab while the catalog is loading or errored", () => {
     expect(
       shouldShowResponsibilitiesTab(
         false,
-        visibility({ catalogFetched: false, catalogCount: 0, agentTemplateIdCount: 0 }),
-      ),
-    ).toBe(true);
-    expect(
-      shouldShowResponsibilitiesTab(
-        false,
-        visibility({ catalogError: true, catalogCount: 0, agentTemplateIdCount: 0 }),
-      ),
-    ).toBe(true);
-  });
-
-  it("keeps the tab while agent resources are loading or errored (page fail-open)", () => {
-    expect(
-      shouldShowResponsibilitiesTab(
-        false,
         visibility({
-          catalogCount: 0,
-          agentResourcesFetched: false,
-          agentTemplateIdCount: 0,
+          catalog: { hasData: false, isFetching: true, count: 0 },
+          agentResources: { count: 0 },
         }),
       ),
     ).toBe(true);
@@ -121,58 +151,132 @@ describe("shouldShowResponsibilitiesTab", () => {
       shouldShowResponsibilitiesTab(
         false,
         visibility({
-          catalogCount: 0,
-          agentResourcesError: true,
-          agentResourcesFetched: false,
-          agentTemplateIdCount: 0,
+          catalog: { hasData: false, hasError: true, count: 0 },
+          agentResources: { count: 0 },
         }),
       ),
     ).toBe(true);
   });
 
-  it("fail-closes for the switcher when catalog is empty and agent resources are unknown", () => {
+  it("keeps the tab while agent resources are loading or initially errored", () => {
     expect(
       shouldShowResponsibilitiesTab(
         false,
         visibility({
-          catalogCount: 0,
-          agentResourcesFetched: false,
-          agentTemplateIdCount: 0,
+          catalog: { count: 0 },
+          agentResources: { hasData: false, isFetching: true, count: 0 },
         }),
-        { assumeShowWhenAgentUnknown: false },
       ),
+    ).toBe(true);
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalog: { count: 0 },
+          agentResources: { hasData: false, hasError: true, count: 0 },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("fail-opens when cached-empty agent-resources has a background refetch error", () => {
+    // React Query retains empty data and sets isError on refetch failure.
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalog: { count: 0 },
+          agentResources: { hasData: true, hasError: true, count: 0 },
+        }),
+      ),
+    ).toBe(true);
+    expect(isConfirmedEmptyResponsibilitiesSide(side({ hasData: true, hasError: true, count: 0 }))).toBe(false);
+  });
+
+  it("fail-opens while a cached-empty side is refetching, then can close after settled empty", () => {
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalog: { count: 0 },
+          agentResources: { hasData: true, isFetching: true, count: 0 },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalog: { hasData: true, isFetching: true, count: 0 },
+          agentResources: { count: 0 },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowResponsibilitiesTab(false, visibility({ catalog: { count: 0 }, agentResources: { count: 0 } })),
     ).toBe(false);
+  });
+
+  it("fail-opens for the switcher when target agent-resources are unknown, loading, or errored", () => {
+    // Keep the Responsibilities path; the destination page decides once settled.
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalog: { count: 0 },
+          agentResources: { hasData: false, count: 0 },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalog: { count: 0 },
+          agentResources: { hasData: false, isFetching: true, count: 0 },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalog: { count: 0 },
+          agentResources: { hasData: false, hasError: true, count: 0 },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("maps React Query observations without treating retained data as settled success on error", () => {
+    const cachedEmptyWithRefetchError = responsibilitiesSideFromQuery({
+      count: 0,
+      isFetching: false,
+      isError: true,
+    });
+    expect(cachedEmptyWithRefetchError).toEqual({
+      hasData: true,
+      isFetching: false,
+      hasError: true,
+      count: 0,
+    });
+    expect(isConfirmedEmptyResponsibilitiesSide(cachedEmptyWithRefetchError)).toBe(false);
+
+    const settledEmpty = responsibilitiesSideFromQuery({
+      count: 0,
+      isFetching: false,
+      isError: false,
+    });
+    expect(isConfirmedEmptyResponsibilitiesSide(settledEmpty)).toBe(true);
   });
 });
 
 describe("resolveTabPath responsibilities gate", () => {
-  const agent = {
-    uuid: "agent-1",
-    name: "vega",
-    displayName: "Vega",
-    type: "agent" as const,
-    managerId: "member-self",
-    visibility: "organization" as const,
-    avatarColorToken: null,
-    avatarImageUrl: null,
-    status: "active" as const,
-    organizationId: "org-1",
-    delegateMention: null,
-    inboxId: "inbox-1",
-    metadata: {},
-    source: "portal" as const,
-    clientId: "client-1",
-    runtimeProvider: "claude-code" as const,
-    runtimeState: "idle" as const,
-    createdAt: "2026-05-28T12:00:00.000Z",
-    updatedAt: "2026-05-28T12:00:00.000Z",
-  };
-
   it("falls back to profile when Responsibilities is closed for the target", () => {
     expect(resolveTabPath(agent, "member-self", "admin", "responsibilities", false)).toBe("profile");
   });
 
-  it("preserves Responsibilities when the target still exposes it", () => {
+  it("preserves Responsibilities when the target still exposes it (including uncertain targets)", () => {
     expect(resolveTabPath(agent, "member-self", "admin", "responsibilities", true)).toBe("responsibilities");
   });
 });

--- a/packages/web/src/pages/agent-detail/__tests__/tabs.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/tabs.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { buildTabs, tabKeysFor } from "../tabs.js";
+import {
+  buildTabs,
+  type ResponsibilitiesVisibilityInput,
+  resolveTabPath,
+  shouldShowResponsibilitiesTab,
+  tabKeysFor,
+} from "../tabs.js";
+
+function visibility(overrides: Partial<ResponsibilitiesVisibilityInput> = {}): ResponsibilitiesVisibilityInput {
+  return {
+    catalogFetched: true,
+    catalogError: false,
+    catalogCount: 1,
+    agentResourcesFetched: true,
+    agentResourcesError: false,
+    agentTemplateIdCount: 0,
+    ...overrides,
+  };
+}
 
 describe("agent-detail tabs", () => {
   it("gives an editor the 7-tab set with Responsibilities after Profile", () => {
@@ -45,5 +63,116 @@ describe("agent-detail tabs", () => {
   it("gives a human agent only Profile", () => {
     // A human is always canEditConfig=false (it derives from type !== "human").
     expect(tabKeysFor(false, true).map((t) => t.key)).toEqual(["profile"]);
+  });
+
+  it("omits Responsibilities when the empty-catalog gate is closed", () => {
+    expect(tabKeysFor(true, false, false).map((t) => t.key)).toEqual([
+      "profile",
+      "runtime",
+      "prompt",
+      "capabilities",
+      "repositories",
+      "usage",
+    ]);
+    expect(tabKeysFor(false, false, false).map((t) => t.key)).toEqual(["profile", "capabilities", "usage"]);
+  });
+});
+
+describe("shouldShowResponsibilitiesTab", () => {
+  it("never shows for humans", () => {
+    expect(shouldShowResponsibilitiesTab(true, visibility({ catalogCount: 3, agentTemplateIdCount: 2 }))).toBe(false);
+  });
+
+  it("hides only when catalog and agent templateIds are both confirmed empty", () => {
+    expect(shouldShowResponsibilitiesTab(false, visibility({ catalogCount: 0, agentTemplateIdCount: 0 }))).toBe(false);
+  });
+
+  it("keeps the tab when the agent still has adopted templateIds even if the catalog is empty", () => {
+    expect(shouldShowResponsibilitiesTab(false, visibility({ catalogCount: 0, agentTemplateIdCount: 2 }))).toBe(true);
+  });
+
+  it("keeps the tab while the catalog is loading or errored", () => {
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({ catalogFetched: false, catalogCount: 0, agentTemplateIdCount: 0 }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({ catalogError: true, catalogCount: 0, agentTemplateIdCount: 0 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps the tab while agent resources are loading or errored (page fail-open)", () => {
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalogCount: 0,
+          agentResourcesFetched: false,
+          agentTemplateIdCount: 0,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalogCount: 0,
+          agentResourcesError: true,
+          agentResourcesFetched: false,
+          agentTemplateIdCount: 0,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("fail-closes for the switcher when catalog is empty and agent resources are unknown", () => {
+    expect(
+      shouldShowResponsibilitiesTab(
+        false,
+        visibility({
+          catalogCount: 0,
+          agentResourcesFetched: false,
+          agentTemplateIdCount: 0,
+        }),
+        { assumeShowWhenAgentUnknown: false },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("resolveTabPath responsibilities gate", () => {
+  const agent = {
+    uuid: "agent-1",
+    name: "vega",
+    displayName: "Vega",
+    type: "agent" as const,
+    managerId: "member-self",
+    visibility: "organization" as const,
+    avatarColorToken: null,
+    avatarImageUrl: null,
+    status: "active" as const,
+    organizationId: "org-1",
+    delegateMention: null,
+    inboxId: "inbox-1",
+    metadata: {},
+    source: "portal" as const,
+    clientId: "client-1",
+    runtimeProvider: "claude-code" as const,
+    runtimeState: "idle" as const,
+    createdAt: "2026-05-28T12:00:00.000Z",
+    updatedAt: "2026-05-28T12:00:00.000Z",
+  };
+
+  it("falls back to profile when Responsibilities is closed for the target", () => {
+    expect(resolveTabPath(agent, "member-self", "admin", "responsibilities", false)).toBe("profile");
+  });
+
+  it("preserves Responsibilities when the target still exposes it", () => {
+    expect(resolveTabPath(agent, "member-self", "admin", "responsibilities", true)).toBe("responsibilities");
   });
 });

--- a/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
+++ b/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "../../auth/auth-context.js";
 import { Avatar } from "../../components/avatar.js";
 import { matchesAgentScope, readAgentFilterPreference } from "../team/agent-filter.js";
 import { fetchAllAgents } from "../team/index.js";
-import { resolveTabPath, shouldShowResponsibilitiesTab } from "./tabs.js";
+import { resolveTabPath, responsibilitiesSideFromQuery, shouldShowResponsibilitiesTab } from "./tabs.js";
 
 /**
  * Agent switcher (vertical-B): replaces the breadcrumb at the top of agent
@@ -95,25 +95,27 @@ export function AgentSwitcherStrip({
   }, [updateEdges]);
 
   const tabPathFor = (target: Agent): string => {
-    // Prefer React Query cache already warmed by Agent Detail. When the public
-    // catalog is confirmed empty and the target's resources are unknown, fail
-    // closed so we never preserve `/responsibilities` into a closed entry.
+    // Prefer React Query cache already warmed by Agent Detail. Fall back to
+    // Profile only when the target's resources are confirmed empty (with an
+    // empty catalog). Unknown / loading / error for the target keeps the
+    // Responsibilities path; the destination page re-evaluates and redirects
+    // once it has a settled answer.
     const catalogState = queryClient.getQueryState<AgentTemplatePublicList>(["agent-templates-catalog"]);
     const catalog = queryClient.getQueryData<AgentTemplatePublicList>(["agent-templates-catalog"]);
     const resourcesState = queryClient.getQueryState<AgentResourcesOutput>(["agent-resources", target.uuid]);
     const resources = queryClient.getQueryData<AgentResourcesOutput>(["agent-resources", target.uuid]);
-    const showResponsibilities = shouldShowResponsibilitiesTab(
-      target.type === "human",
-      {
-        catalogFetched: catalogState?.status === "success",
-        catalogError: catalogState?.status === "error",
-        catalogCount: catalog?.templates.length ?? 0,
-        agentResourcesFetched: resources != null,
-        agentResourcesError: resourcesState?.status === "error" && resources == null,
-        agentTemplateIdCount: resources?.templateIds.length ?? 0,
-      },
-      { assumeShowWhenAgentUnknown: false },
-    );
+    const showResponsibilities = shouldShowResponsibilitiesTab(target.type === "human", {
+      catalog: responsibilitiesSideFromQuery({
+        count: catalog ? catalog.templates.length : null,
+        isFetching: catalogState?.fetchStatus === "fetching",
+        isError: catalogState?.status === "error",
+      }),
+      agentResources: responsibilitiesSideFromQuery({
+        count: resources ? resources.templateIds.length : null,
+        isFetching: resourcesState?.fetchStatus === "fetching",
+        isError: resourcesState?.status === "error",
+      }),
+    });
     return resolveTabPath(target, memberId, role, currentTabPath, showResponsibilities);
   };
 

--- a/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
+++ b/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
@@ -1,5 +1,5 @@
-import type { Agent } from "@first-tree/shared";
-import { useQuery } from "@tanstack/react-query";
+import type { Agent, AgentResourcesOutput, AgentTemplatePublicList } from "@first-tree/shared";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronLeft } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { listAgents, listAllAgents } from "../../api/agents.js";
@@ -7,7 +7,7 @@ import { useAuth } from "../../auth/auth-context.js";
 import { Avatar } from "../../components/avatar.js";
 import { matchesAgentScope, readAgentFilterPreference } from "../team/agent-filter.js";
 import { fetchAllAgents } from "../team/index.js";
-import { resolveTabPath } from "./tabs.js";
+import { resolveTabPath, shouldShowResponsibilitiesTab } from "./tabs.js";
 
 /**
  * Agent switcher (vertical-B): replaces the breadcrumb at the top of agent
@@ -33,6 +33,7 @@ export function AgentSwitcherStrip({
   onNavigate: (to: string) => void;
 }) {
   const { memberId, role } = useAuth();
+  const queryClient = useQueryClient();
   const isAdmin = role === "admin";
   // Read-on-mount (see header comment): the All/Mine toggle lives on the Team
   // page; while this strip is mounted the preference cannot change.
@@ -93,6 +94,29 @@ export function AgentSwitcherStrip({
     return () => ro.disconnect();
   }, [updateEdges]);
 
+  const tabPathFor = (target: Agent): string => {
+    // Prefer React Query cache already warmed by Agent Detail. When the public
+    // catalog is confirmed empty and the target's resources are unknown, fail
+    // closed so we never preserve `/responsibilities` into a closed entry.
+    const catalogState = queryClient.getQueryState<AgentTemplatePublicList>(["agent-templates-catalog"]);
+    const catalog = queryClient.getQueryData<AgentTemplatePublicList>(["agent-templates-catalog"]);
+    const resourcesState = queryClient.getQueryState<AgentResourcesOutput>(["agent-resources", target.uuid]);
+    const resources = queryClient.getQueryData<AgentResourcesOutput>(["agent-resources", target.uuid]);
+    const showResponsibilities = shouldShowResponsibilitiesTab(
+      target.type === "human",
+      {
+        catalogFetched: catalogState?.status === "success",
+        catalogError: catalogState?.status === "error",
+        catalogCount: catalog?.templates.length ?? 0,
+        agentResourcesFetched: resources != null,
+        agentResourcesError: resourcesState?.status === "error" && resources == null,
+        agentTemplateIdCount: resources?.templateIds.length ?? 0,
+      },
+      { assumeShowWhenAgentUnknown: false },
+    );
+    return resolveTabPath(target, memberId, role, currentTabPath, showResponsibilities);
+  };
+
   return (
     // Pinned Team anchor + an independently-scrolling agent strip beside it.
     <div className="flex items-start" style={{ gap: "var(--sp-2)" }}>
@@ -132,11 +156,7 @@ export function AgentSwitcherStrip({
                 // Clicking the already-selected agent is a no-op — it isn't a
                 // "leave", so it must not trip the leave guard (which would offer to
                 // discard the draft for a navigation back to the same page).
-                onClick={
-                  selected
-                    ? undefined
-                    : () => onNavigate(`/agents/${a.uuid}/${resolveTabPath(a, memberId, role, currentTabPath)}`)
-                }
+                onClick={selected ? undefined : () => onNavigate(`/agents/${a.uuid}/${tabPathFor(a)}`)}
               >
                 {/* Demoted switcher (the page header's title row is the primary
                   identity, with a larger avatar): these nav avatars are deliberately

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -41,6 +41,10 @@ import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
 export type AgentResourcesController = {
   data: AgentResourcesOutput | undefined;
   isLoading: boolean;
+  /** True for the initial load and for background refetches (shared cache observers). */
+  isFetching: boolean;
+  /** True for hard failures and for background refetch failures that retain cached data. */
+  isError: boolean;
   error: unknown;
   /** Submit the full bindings array; saves immediately. */
   mutateBindings: (bindings: AgentResourceBindingInput[]) => void;
@@ -100,6 +104,8 @@ export function useAgentResources(uuid: string, opts: { enabled: boolean }): Age
   return {
     data: resourcesQuery.data,
     isLoading: resourcesQuery.isLoading,
+    isFetching: resourcesQuery.isFetching,
+    isError: resourcesQuery.isError,
     error: resourcesQuery.error,
     mutateBindings: updateMut.mutate,
     pending: updateMut.isPending,

--- a/packages/web/src/pages/agent-detail/responsibilities-tab.tsx
+++ b/packages/web/src/pages/agent-detail/responsibilities-tab.tsx
@@ -1,13 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
 import { Navigate } from "react-router";
+import { listAgentTemplates } from "../../api/agent-templates.js";
 import { useAgentResources } from "./capability-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { ResponsibilitiesSection } from "./responsibilities-section.js";
+import { shouldShowResponsibilitiesTab } from "./tabs.js";
 
 export function ResponsibilitiesTab() {
   const ctx = useAgentDetailContext();
   const resources = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && !ctx.isHuman });
+  // Same catalog key as the Agent Detail shell / edit dialog — hide this route
+  // when the public catalog and this agent's adopted templateIds are both empty.
+  const catalogQuery = useQuery({
+    queryKey: ["agent-templates-catalog"],
+    queryFn: listAgentTemplates,
+    enabled: !!ctx.uuid && !ctx.isHuman,
+    retry: 1,
+  });
 
-  if (ctx.isHuman) return <Navigate to="../profile" replace />;
+  const showResponsibilities = shouldShowResponsibilitiesTab(ctx.isHuman, {
+    catalogFetched: catalogQuery.isSuccess,
+    catalogError: catalogQuery.isError,
+    catalogCount: catalogQuery.data?.templates.length ?? 0,
+    agentResourcesFetched: resources.data != null,
+    agentResourcesError: resources.error != null && resources.data == null,
+    agentTemplateIdCount: resources.data?.templateIds.length ?? 0,
+  });
+
+  if (ctx.isHuman || !showResponsibilities) return <Navigate to="../profile" replace />;
   if (resources.isLoading) {
     return (
       <p className="text-body" style={{ color: "var(--fg-3)" }}>

--- a/packages/web/src/pages/agent-detail/responsibilities-tab.tsx
+++ b/packages/web/src/pages/agent-detail/responsibilities-tab.tsx
@@ -4,7 +4,7 @@ import { listAgentTemplates } from "../../api/agent-templates.js";
 import { useAgentResources } from "./capability-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { ResponsibilitiesSection } from "./responsibilities-section.js";
-import { shouldShowResponsibilitiesTab } from "./tabs.js";
+import { responsibilitiesSideFromQuery, shouldShowResponsibilitiesTab } from "./tabs.js";
 
 export function ResponsibilitiesTab() {
   const ctx = useAgentDetailContext();
@@ -19,12 +19,16 @@ export function ResponsibilitiesTab() {
   });
 
   const showResponsibilities = shouldShowResponsibilitiesTab(ctx.isHuman, {
-    catalogFetched: catalogQuery.isSuccess,
-    catalogError: catalogQuery.isError,
-    catalogCount: catalogQuery.data?.templates.length ?? 0,
-    agentResourcesFetched: resources.data != null,
-    agentResourcesError: resources.error != null && resources.data == null,
-    agentTemplateIdCount: resources.data?.templateIds.length ?? 0,
+    catalog: responsibilitiesSideFromQuery({
+      count: catalogQuery.data ? catalogQuery.data.templates.length : null,
+      isFetching: catalogQuery.isFetching,
+      isError: catalogQuery.isError,
+    }),
+    agentResources: responsibilitiesSideFromQuery({
+      count: resources.data ? resources.data.templateIds.length : null,
+      isFetching: resources.isFetching,
+      isError: resources.isError,
+    }),
   });
 
   if (ctx.isHuman || !showResponsibilities) return <Navigate to="../profile" replace />;

--- a/packages/web/src/pages/agent-detail/tabs.ts
+++ b/packages/web/src/pages/agent-detail/tabs.ts
@@ -17,47 +17,68 @@ const TAB_LABELS: Record<string, string> = {
 };
 
 /**
- * Inputs for whether the Responsibilities tab should appear. Hide only when
- * both the public official Template catalog and the agent's adopted
- * `templateIds` are confirmed empty. Loading and request failures must fail
- * open (keep the tab) so uncertainty is never treated as "no data".
+ * One side of the empty-entry gate (public catalog or agent-resources).
+ *
+ * Confirmed empty requires: data present from a successful response, no
+ * in-flight fetch/refetch, no error (including background refetch errors that
+ * retain cached data), and a zero count. Anything else is uncertain → fail open.
  */
-export type ResponsibilitiesVisibilityInput = {
-  catalogFetched: boolean;
-  catalogError: boolean;
-  catalogCount: number;
-  agentResourcesFetched: boolean;
-  agentResourcesError: boolean;
-  agentTemplateIdCount: number;
+export type ResponsibilitiesSideState = {
+  hasData: boolean;
+  isFetching: boolean;
+  hasError: boolean;
+  count: number;
 };
+
+export type ResponsibilitiesVisibilityInput = {
+  catalog: ResponsibilitiesSideState;
+  agentResources: ResponsibilitiesSideState;
+};
+
+/** Build a side state from a live React Query observation. */
+export function responsibilitiesSideFromQuery(args: {
+  /** `null` when the query has never produced data (or cache miss). */
+  count: number | null;
+  isFetching: boolean;
+  isError: boolean;
+}): ResponsibilitiesSideState {
+  return {
+    hasData: args.count != null,
+    isFetching: args.isFetching,
+    hasError: args.isError,
+    count: args.count ?? 0,
+  };
+}
+
+export function isConfirmedEmptyResponsibilitiesSide(side: ResponsibilitiesSideState): boolean {
+  return side.hasData && !side.isFetching && !side.hasError && side.count === 0;
+}
 
 /**
  * Whether Agent Detail should expose the Responsibilities tab.
  *
- * - Humans never see it.
- * - Non-humans see it whenever the public catalog has any templates, or the
- *   agent already carries adopted Template ids (active / retired / missing
- *   provenance still needs a home).
- * - Hide only when both sides are confirmed empty.
- * - When the agent's resources are still unknown, `assumeShowWhenAgentUnknown`
- *   controls fail-open (page chrome) vs fail-closed (switcher path preservation
- *   must not send the user into an entry that will immediately close).
+ * Hide only when both the public catalog and the agent's adopted `templateIds`
+ * are confirmed empty (latest request succeeded, not fetching/refetching, empty
+ * arrays). Loading, in-flight background refetch, initial errors, and cached
+ * data with a refetch error all fail open. Non-empty `templateIds` keep the tab
+ * for provenance even when the official catalog is empty.
  */
 export function shouldShowResponsibilitiesTab(
   isHuman: boolean,
   input: ResponsibilitiesVisibilityInput | null,
-  opts?: { assumeShowWhenAgentUnknown?: boolean },
 ): boolean {
   if (isHuman) return false;
   if (!input) return true;
-  if (!input.catalogFetched || input.catalogError) return true;
-  if (input.catalogCount > 0) return true;
-  // Catalog is confirmed empty — keep the tab only when this agent still has
-  // adopted Template responsibilities (including retired / missing provenance).
-  if (!input.agentResourcesFetched || input.agentResourcesError) {
-    return opts?.assumeShowWhenAgentUnknown ?? true;
+  // Provenance / available catalog: any known non-empty side keeps the entry.
+  if (input.agentResources.hasData && input.agentResources.count > 0) return true;
+  if (input.catalog.hasData && input.catalog.count > 0) return true;
+  if (
+    isConfirmedEmptyResponsibilitiesSide(input.catalog) &&
+    isConfirmedEmptyResponsibilitiesSide(input.agentResources)
+  ) {
+    return false;
   }
-  return input.agentTemplateIdCount > 0;
+  return true;
 }
 
 /**
@@ -65,6 +86,8 @@ export function shouldShowResponsibilitiesTab(
  * independent of label/order. `buildTabs` adds the display label on top, and the
  * agent switcher uses this to know whether a target agent supports the current
  * tab — so the two can never drift on tab availability.
+ *
+ * Humans never receive Responsibilities, even when a caller passes `true`.
  */
 export function tabKeysFor(
   canEditConfig: boolean,
@@ -72,7 +95,7 @@ export function tabKeysFor(
   showResponsibilities: boolean = !isHuman,
 ): { key: string; path: string }[] {
   const tabs: { key: string; path: string }[] = [{ key: "profile", path: "profile" }];
-  if (showResponsibilities) {
+  if (!isHuman && showResponsibilities) {
     tabs.push({ key: "responsibilities", path: "responsibilities" });
   }
   if (canEditConfig) {
@@ -117,6 +140,8 @@ export function canEditConfigFor(agent: Agent, memberId: string | null, role: st
  * Which tab PATH to open when switching to `agent`: keep the current tab when the
  * target supports it, else fall back to profile. (Some tabs render blank rather
  * than redirect for unsupported agents, so we resolve this up front.)
+ *
+ * Humans never keep a Responsibilities path, even if `showResponsibilities` is true.
  */
 export function resolveTabPath(
   agent: Agent,

--- a/packages/web/src/pages/agent-detail/tabs.ts
+++ b/packages/web/src/pages/agent-detail/tabs.ts
@@ -17,14 +17,62 @@ const TAB_LABELS: Record<string, string> = {
 };
 
 /**
+ * Inputs for whether the Responsibilities tab should appear. Hide only when
+ * both the public official Template catalog and the agent's adopted
+ * `templateIds` are confirmed empty. Loading and request failures must fail
+ * open (keep the tab) so uncertainty is never treated as "no data".
+ */
+export type ResponsibilitiesVisibilityInput = {
+  catalogFetched: boolean;
+  catalogError: boolean;
+  catalogCount: number;
+  agentResourcesFetched: boolean;
+  agentResourcesError: boolean;
+  agentTemplateIdCount: number;
+};
+
+/**
+ * Whether Agent Detail should expose the Responsibilities tab.
+ *
+ * - Humans never see it.
+ * - Non-humans see it whenever the public catalog has any templates, or the
+ *   agent already carries adopted Template ids (active / retired / missing
+ *   provenance still needs a home).
+ * - Hide only when both sides are confirmed empty.
+ * - When the agent's resources are still unknown, `assumeShowWhenAgentUnknown`
+ *   controls fail-open (page chrome) vs fail-closed (switcher path preservation
+ *   must not send the user into an entry that will immediately close).
+ */
+export function shouldShowResponsibilitiesTab(
+  isHuman: boolean,
+  input: ResponsibilitiesVisibilityInput | null,
+  opts?: { assumeShowWhenAgentUnknown?: boolean },
+): boolean {
+  if (isHuman) return false;
+  if (!input) return true;
+  if (!input.catalogFetched || input.catalogError) return true;
+  if (input.catalogCount > 0) return true;
+  // Catalog is confirmed empty — keep the tab only when this agent still has
+  // adopted Template responsibilities (including retired / missing provenance).
+  if (!input.agentResourcesFetched || input.agentResourcesError) {
+    return opts?.assumeShowWhenAgentUnknown ?? true;
+  }
+  return input.agentTemplateIdCount > 0;
+}
+
+/**
  * Single source of truth for WHICH tabs exist for an agent (key + path),
  * independent of label/order. `buildTabs` adds the display label on top, and the
  * agent switcher uses this to know whether a target agent supports the current
  * tab — so the two can never drift on tab availability.
  */
-export function tabKeysFor(canEditConfig: boolean, isHuman: boolean): { key: string; path: string }[] {
+export function tabKeysFor(
+  canEditConfig: boolean,
+  isHuman: boolean,
+  showResponsibilities: boolean = !isHuman,
+): { key: string; path: string }[] {
   const tabs: { key: string; path: string }[] = [{ key: "profile", path: "profile" }];
-  if (!isHuman) {
+  if (showResponsibilities) {
     tabs.push({ key: "responsibilities", path: "responsibilities" });
   }
   if (canEditConfig) {
@@ -49,8 +97,15 @@ export function tabKeysFor(canEditConfig: boolean, isHuman: boolean): { key: str
   return tabs;
 }
 
-export function buildTabs(canEditConfig: boolean, isHuman: boolean): TabDef[] {
-  return tabKeysFor(canEditConfig, isHuman).map((t) => ({ ...t, label: TAB_LABELS[t.key] ?? t.key }));
+export function buildTabs(
+  canEditConfig: boolean,
+  isHuman: boolean,
+  showResponsibilities: boolean = !isHuman,
+): TabDef[] {
+  return tabKeysFor(canEditConfig, isHuman, showResponsibilities).map((t) => ({
+    ...t,
+    label: TAB_LABELS[t.key] ?? t.key,
+  }));
 }
 
 /** Mirror of the shell's `canEditConfig` derivation, for any agent (e.g. switcher targets). */
@@ -68,7 +123,10 @@ export function resolveTabPath(
   memberId: string | null,
   role: string | null,
   currentPath: string,
+  showResponsibilities: boolean = agent.type !== "human",
 ): string {
-  const paths = tabKeysFor(canEditConfigFor(agent, memberId, role), agent.type === "human").map((t) => t.path);
+  const paths = tabKeysFor(canEditConfigFor(agent, memberId, role), agent.type === "human", showResponsibilities).map(
+    (t) => t.path,
+  );
   return paths.includes(currentPath) ? currentPath : "profile";
 }


### PR DESCRIPTION
## Summary

- Hide Agent Detail **Responsibilities** only when both the public official Template catalog and the agent's `templateIds` are confirmed empty from settled successful queries.
- Preserve the entry for adopted Template responsibilities, including retired or missing official provenance. Loading, background refetches, initial errors, and retained-data refetch errors fail open; human agents remain unchanged.
- Apply the same gate to the Agent Detail shell, the Responsibilities route, and the agent switcher. A confirmed-empty deep link redirects to Profile; the switcher preserves Responsibilities while the target is uncertain and falls back only after confirmed empty state.

## Validation

- [x] Focused Agent Detail Vitest: 3 files / 56 tests passed
- [x] Full `@first-tree/web` Vitest: 243 files / 2181 tests passed
- [x] `pnpm --filter @first-tree/web typecheck`
- [x] Biome check on all 8 changed Web files
- [x] Independent `test-only` QA at exact head `79d8f37b860f02e561079241668d03ed65ca4662`, including the cached-empty background refetch regression
- [x] GitHub CI and CodeQL checks passed
