### PR TITLE
refactor(client): clear retired result-sink deps and inbox ACK docs

### DIFF
--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -907,3 +907,67 @@ describe("ClientConnection — additional branch coverage", () => {
     priv(connection).clearTimers();
   });
 });
+
+describe("characterization — inbox:deliver identity and deferred ACK", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("ws");
+    vi.resetModules();
+  });
+
+  it("emits frame.inboxId as the first listener arg and does not ACK merely on deliver", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+    await bindAgent(connection, socket);
+
+    const received: Array<{ firstArg: string; inboxId: string; entryId: number }> = [];
+    connection.on("inbox:deliver", (firstArg, frame) => {
+      received.push({ firstArg, inboxId: frame.inboxId, entryId: frame.entryId });
+    });
+
+    const sentBefore = socket.sent.length;
+    const deliveredFrame = {
+      type: "inbox:deliver",
+      entryId: 777,
+      inboxId: "inbox-agent-1",
+      chatId: "chat-char",
+      message: {
+        id: "message-char",
+        chatId: "chat-char",
+        senderId: "agent-sender",
+        format: "text",
+        content: "hello",
+        metadata: {},
+        inReplyTo: null,
+        source: null,
+        createdAt: "2026-07-10T00:00:00.000Z",
+        configVersion: 1,
+        recipientMode: "full",
+        precedingMessages: [],
+      },
+    };
+    socket.emitMessage(deliveredFrame);
+    await flushMicrotasks();
+
+    expect(received).toEqual([{ firstArg: "inbox-agent-1", inboxId: "inbox-agent-1", entryId: 777 }]);
+    // Receiving a deliver frame must not emit inbox:ack — ACK is owned by the
+    // handler turn completion path (SessionManager → ackEntry → sendInboxAck).
+    const newFrames = socket.sent.slice(sentBefore).map((raw) => JSON.parse(raw) as { type?: string });
+    expect(newFrames.every((frame) => frame.type !== "inbox:ack")).toBe(true);
+
+    // Explicit ACK path remains available and is the only ClientConnection ACK surface.
+    const ackPromise = connection.sendInboxAck(777, "agent-1");
+    const ackFrame = parseSent(socket, socket.sent.length - 1);
+    expect(ackFrame.type).toBe("inbox:ack");
+    expect(ackFrame.entryId).toBe(777);
+    socket.emitMessage({
+      type: "inbox:ack:accepted",
+      entryId: 777,
+      ref: ackFrame.ref,
+      disposition: "acked",
+    });
+    await expect(ackPromise).resolves.toBeUndefined();
+
+    priv(connection).clearTimers();
+  });
+});

--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -196,7 +196,7 @@ describe("ClientConnection — additional branch coverage", () => {
     const commands: unknown[] = [];
     const pins: unknown[] = [];
     const runtimeAuthStarts: unknown[] = [];
-    connection.on("inbox:deliver", (agentId, frame) => delivered.push({ agentId, frame }));
+    connection.on("inbox:deliver", (inboxId, frame) => delivered.push({ inboxId, frame }));
     connection.on("session:command", (command) => commands.push(command));
     connection.on("agent:pinned", (message) => pins.push(message));
     connection.on("runtime-auth:start", (command) => runtimeAuthStarts.push(command));
@@ -270,7 +270,7 @@ describe("ClientConnection — additional branch coverage", () => {
       },
     };
     socket.emitMessage(deliveredFrame);
-    expect(delivered).toEqual([{ agentId: "inbox-agent-1", frame: deliveredFrame }]);
+    expect(delivered).toEqual([{ inboxId: "inbox-agent-1", frame: deliveredFrame }]);
 
     socket.emitMessage({
       type: "session:event:accepted",

--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import { createResultSink, type Trigger } from "../runtime/result-sink.js";
-import type { FirstTreeHubSDK } from "../sdk.js";
+import { describe, expect, it } from "vitest";
+import { createResultSink } from "../runtime/result-sink.js";
 
 /**
  * Contract tests for the turn-completion sink.
@@ -11,52 +10,36 @@ import type { FirstTreeHubSDK } from "../sdk.js";
  * turn trigger so the next inject() starts clean.
  */
 
-const ME = "agent-me";
-
-function buildSink(initialTrigger: Trigger | null) {
-  const sendMessage = vi.fn().mockResolvedValue(undefined);
+function buildSink(initialTrigger: { messageId: string; senderId: string } | null) {
   const logs: string[] = [];
   let trigger = initialTrigger;
 
-  const sdk = { serverUrl: "http://test", sendMessage } as unknown as FirstTreeHubSDK;
-
   const sink = createResultSink({
-    sdk,
-    agent: {
-      agentId: ME,
-      inboxId: "inbox-me",
-      displayName: "test-agent",
-      type: "agent",
-      visibility: "organization",
-      delegateMention: null,
-      metadata: {},
-    },
-    chatId: "chat-1",
-    getTrigger: () => trigger,
     clearTrigger: () => {
       trigger = null;
     },
     log: (msg) => logs.push(msg),
   });
 
-  return { sink, sendMessage, logs, readTrigger: () => trigger };
+  return { sink, logs, readTrigger: () => trigger };
 }
 
 describe("createResultSink — final-text delivery retired", () => {
-  it("does NOT deliver a non-empty final text to chat", async () => {
-    const { sink, sendMessage } = buildSink({ messageId: "m1", senderId: "agent-peer" });
+  it("clears trigger and logs retired delivery for a non-empty turn", async () => {
+    const { sink, logs, readTrigger } = buildSink({ messageId: "m1", senderId: "agent-peer" });
 
     await sink("final answer");
 
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(readTrigger()).toBeNull();
+    expect(logs.some((m) => /retired/.test(m))).toBe(true);
   });
 
-  it("does NOT deliver an empty / whitespace-only (silent) turn either", async () => {
-    const { sink, sendMessage } = buildSink(null);
+  it("logs a silent turn for empty / whitespace-only output", async () => {
+    const { sink, logs } = buildSink(null);
 
     await sink("   ");
 
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(logs.some((m) => /silent turn/.test(m))).toBe(true);
   });
 
   it("clears the turn trigger so a concurrent inject() starts clean", async () => {
@@ -66,13 +49,5 @@ describe("createResultSink — final-text delivery retired", () => {
     await sink("final answer");
 
     expect(readTrigger()).toBeNull();
-  });
-
-  it("logs that final-text delivery is retired on a non-empty turn", async () => {
-    const { sink, logs } = buildSink(null);
-
-    await sink("did the thing");
-
-    expect(logs.some((m) => /retired/.test(m))).toBe(true);
   });
 });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -107,11 +107,6 @@ type SessionManagerInternals = {
   recomputeRuntimeState(): void;
   buildSessionContext(chatId: string): SessionContext;
   confirmSessionEventOrThrow(chatId: string, event: SessionEvent): Promise<void>;
-  resolveSelfFence(
-    log: (msg: string) => void,
-    chatId: string,
-  ): Promise<{ agentHome: string; singleRepoLocalPath?: string }>;
-  resolveChatOrgId(log: (msg: string) => void, chatId: string): Promise<string | null>;
   reaffirmRuntimeStates(): void;
   persistRegistry(): void;
 };
@@ -6650,62 +6645,6 @@ describe("SessionManager edge coverage", () => {
     await confirmedCtx.emitEventConfirmed(event);
     expect(confirmSessionEvent).toHaveBeenCalledWith("chat-confirmed", event);
     await confirmed.shutdown();
-  });
-
-  it("resolves document self fences from runtime config and falls back on refresh failure", async () => {
-    const workspaceRoot = "/tmp/test-edge/fence-agent";
-    const config = runtimeConfig({
-      payload: {
-        ...runtimeConfig().payload,
-        gitRepos: [{ url: "https://github.com/acme/repo.git", localPath: "repo" }],
-      },
-    });
-    const sm = makeManager({ workspaceRoot, agentConfigCache: makeCache({ config }) });
-    const logs: string[] = [];
-
-    await expect(internals(sm).resolveSelfFence((msg) => logs.push(msg), "chat-fence")).resolves.toEqual({
-      agentHome: workspaceRoot,
-      singleRepoLocalPath: "source-repos/repo",
-    });
-    expect(logs).toEqual([]);
-    await sm.shutdown();
-
-    const failing = makeManager({
-      workspaceRoot,
-      agentConfigCache: makeCache({
-        refreshIfNewer: async () => {
-          throw new Error("config unavailable");
-        },
-      }),
-    });
-    await expect(internals(failing).resolveSelfFence((msg) => logs.push(msg), "chat-fence-fallback")).resolves.toEqual({
-      agentHome: workspaceRoot,
-    });
-    expect(logs.some((msg) => msg.includes("config unavailable"))).toBe(true);
-    await failing.shutdown();
-  });
-
-  it("resolves chat org ids with caching and degrades lookup failures to null", async () => {
-    const getChatDetail = vi.fn(async (chatId: string) => {
-      if (chatId === "chat-org") return { organizationId: "org-1" };
-      if (chatId === "chat-empty-org") return { organizationId: "" };
-      throw new Error("lookup failed");
-    });
-    const sdk = { ...mockSdk(), getChatDetail } as unknown as FirstTreeHubSDK;
-    const sm = makeManager({ sdk });
-    const logs: string[] = [];
-    const log = (msg: string): void => {
-      logs.push(msg);
-    };
-
-    await expect(internals(sm).resolveChatOrgId(log, "chat-org")).resolves.toBe("org-1");
-    await expect(internals(sm).resolveChatOrgId(log, "chat-org")).resolves.toBe("org-1");
-    expect(getChatDetail).toHaveBeenCalledTimes(1);
-
-    await expect(internals(sm).resolveChatOrgId(log, "chat-empty-org")).resolves.toBeNull();
-    await expect(internals(sm).resolveChatOrgId(log, "chat-fail")).resolves.toBeNull();
-    expect(logs.some((msg) => msg.includes("lookup failed"))).toBe(true);
-    await sm.shutdown();
   });
 
   it("uses idle fallback in evictIdle logging when no runtime state was recorded", async () => {

--- a/packages/client/src/__tests__/turn-end-inbox-characterization.test.ts
+++ b/packages/client/src/__tests__/turn-end-inbox-characterization.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Characterization: turn-end sink + SessionManager wiring contracts that must
+ * stay identical across the inert ResultSinkDeps cleanup.
+ *
+ * This file is intentionally dual-compatible with:
+ * - PR base (ResultSinkDeps still requires sdk/agent/chatId/getTrigger)
+ * - PR head (ResultSinkDeps only clearTrigger + log)
+ * via a casted deps bag. Do not tighten the cast until both eras are gone.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentRuntimeConfig, SessionState } from "@first-tree/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentHandler, SessionContext } from "../runtime/handler.js";
+import { createResultSink } from "../runtime/result-sink.js";
+import { SessionManager } from "../runtime/session-manager.js";
+import type { FirstTreeHubSDK } from "../sdk.js";
+import { silentLogger } from "./_logger-helpers.js";
+import { mockEntry } from "./test-helpers.js";
+
+type Trigger = { messageId: string; senderId: string };
+
+type SessionManagerInternals = {
+  currentTrigger: Map<string, Trigger>;
+};
+
+function internals(sm: SessionManager): SessionManagerInternals {
+  return sm as unknown as SessionManagerInternals;
+}
+
+function dualCompatSinkDeps(opts: {
+  clearTrigger: () => void;
+  log: (msg: string) => void;
+  getTrigger?: () => Trigger | null;
+  sendMessage?: ReturnType<typeof vi.fn>;
+}): Parameters<typeof createResultSink>[0] {
+  const sendMessage = opts.sendMessage ?? vi.fn().mockResolvedValue(undefined);
+  // Cast: base requires the retired enrichment fields; head ignores extras.
+  return {
+    clearTrigger: opts.clearTrigger,
+    log: opts.log,
+    getTrigger: opts.getTrigger ?? (() => null),
+    sdk: { sendMessage } as unknown as FirstTreeHubSDK,
+    agent: {
+      agentId: "agent-me",
+      inboxId: "inbox-me",
+      displayName: "test-agent",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    chatId: "chat-1",
+  } as Parameters<typeof createResultSink>[0];
+}
+
+describe("characterization — ResultSink turn-end contract", () => {
+  it("clears currentTrigger exactly once for a non-empty turn, never sendMessage, logs retired", async () => {
+    let trigger: Trigger | null = { messageId: "m1", senderId: "peer" };
+    const clearTrigger = vi.fn(() => {
+      trigger = null;
+    });
+    const logs: string[] = [];
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const sink = createResultSink(
+      dualCompatSinkDeps({
+        clearTrigger,
+        log: (msg) => logs.push(msg),
+        getTrigger: () => trigger,
+        sendMessage,
+      }),
+    );
+
+    await sink("final answer");
+
+    expect(clearTrigger).toHaveBeenCalledTimes(1);
+    expect(trigger).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(logs.some((m) => /retired/.test(m))).toBe(true);
+    expect(logs.some((m) => /silent turn/.test(m))).toBe(false);
+  });
+
+  it("clears currentTrigger exactly once for whitespace-only turn, never sendMessage, logs silent", async () => {
+    let trigger: Trigger | null = { messageId: "m2", senderId: "peer" };
+    const clearTrigger = vi.fn(() => {
+      trigger = null;
+    });
+    const logs: string[] = [];
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const sink = createResultSink(
+      dualCompatSinkDeps({
+        clearTrigger,
+        log: (msg) => logs.push(msg),
+        getTrigger: () => trigger,
+        sendMessage,
+      }),
+    );
+
+    await sink("   \n\t  ");
+
+    expect(clearTrigger).toHaveBeenCalledTimes(1);
+    expect(trigger).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(logs.some((m) => /silent turn/.test(m))).toBe(true);
+    expect(logs.some((m) => /retired/.test(m))).toBe(false);
+  });
+});
+
+describe("characterization — SessionManager turn-end wiring", () => {
+  const sessionConfig = {
+    idle_timeout: 300,
+    max_sessions: 10,
+    working_grace_seconds: 3600,
+    reconcile_interval_seconds: 300,
+  };
+
+  function handler(overrides: Partial<AgentHandler> = {}): AgentHandler {
+    return {
+      start: vi.fn().mockResolvedValue("session-id"),
+      resume: vi.fn().mockResolvedValue("session-id"),
+      inject: vi.fn().mockReturnValue({ kind: "owned", mode: "queued" }),
+      suspend: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  }
+
+  function runtimeConfig(overrides: Partial<AgentRuntimeConfig> = {}): AgentRuntimeConfig {
+    return {
+      agentId: "agent-1",
+      version: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      updatedBy: "tester",
+      payload: {
+        kind: "claude-code",
+        prompt: { append: "" },
+        model: "opus",
+        mcpServers: [],
+        env: [],
+        gitRepos: [{ url: "https://github.com/acme/project.git", localPath: "project" }],
+        resourceSkills: [],
+        reasoningEffort: "",
+      },
+      ...overrides,
+    };
+  }
+
+  function makeCache(config: AgentRuntimeConfig) {
+    return {
+      get: vi.fn((agentId: string) => (agentId === "agent-1" ? config : undefined)),
+      refreshIfNewer: vi.fn(async () => config),
+      refresh: vi.fn(),
+      updateSdk: vi.fn(),
+      updateUrls: vi.fn(),
+      allReferencedUrls: vi.fn(() => new Set<string>()),
+      forget: vi.fn(),
+    };
+  }
+
+  function mockSdk(): FirstTreeHubSDK {
+    return {
+      serverUrl: "https://first-tree.example.test",
+      register: vi.fn(),
+      sendMessage: vi.fn().mockResolvedValue({ id: "msg-reply" }),
+      sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+      getChatDetail: vi.fn().mockResolvedValue({ organizationId: "org-should-not-be-fetched-on-turn-end" }),
+      listChatParticipants: vi.fn().mockResolvedValue([
+        { agentId: "sender-1", role: "member", mode: "full", name: "alice", displayName: "Alice", type: "human" },
+        { agentId: "agent-1", role: "member", mode: "full", name: "helper", displayName: "Helper", type: "agent" },
+      ]),
+    } as unknown as FirstTreeHubSDK;
+  }
+
+  const managers: SessionManager[] = [];
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    while (managers.length > 0) {
+      const sm = managers.pop();
+      if (sm) await sm.shutdown();
+    }
+    while (roots.length > 0) {
+      const root = roots.pop();
+      if (root) rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("sets trigger on dispatch, clears it via forwardResult without retired lookup paths, keeps FIRST_TREE_DOC_*", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "ft-turn-end-char-"));
+    roots.push(workspaceRoot);
+    const sdk = mockSdk();
+    const config = runtimeConfig();
+    const cache = makeCache(config);
+    let captured: SessionContext | undefined;
+    const sm = new SessionManager({
+      session: sessionConfig,
+      concurrency: 5,
+      handlerFactory: () =>
+        handler({
+          async start(_message, ctx) {
+            captured = ctx;
+            return "char-session";
+          },
+        }),
+      handlerConfig: { workspaceRoot },
+      agentIdentity: {
+        agentId: "agent-1",
+        inboxId: "inbox-agent-1",
+        displayName: "Agent",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk,
+      log: silentLogger(),
+      agentConfigCache: cache,
+      ackEntry: vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
+      onStateChange: (_chatId: string, _state: SessionState) => undefined,
+    });
+    managers.push(sm);
+
+    const entry = mockEntry({ id: 42, chatId: "chat-char", messageId: "msg-char-1", senderId: "sender-1" });
+    await sm.dispatch(entry);
+
+    expect(captured).toBeDefined();
+    const ctx = captured;
+    if (!ctx) throw new Error("missing session context");
+
+    expect(internals(sm).currentTrigger.get("chat-char")).toEqual({
+      messageId: "msg-char-1",
+      senderId: "sender-1",
+    });
+
+    // Reset call counts after dispatch/start so turn-end assertions are clean.
+    vi.mocked(sdk.getChatDetail).mockClear();
+    vi.mocked(sdk.sendMessage).mockClear();
+    vi.mocked(cache.refreshIfNewer).mockClear();
+
+    await ctx.forwardResult("characterization final text");
+
+    expect(internals(sm).currentTrigger.has("chat-char")).toBe(false);
+    expect(sdk.sendMessage).not.toHaveBeenCalled();
+    expect(sdk.getChatDetail).not.toHaveBeenCalled();
+    expect(cache.refreshIfNewer).not.toHaveBeenCalled();
+
+    const env = ctx.buildAgentEnv({ PATH: "/usr/bin" });
+    expect(env.FIRST_TREE_DOC_BASE).toBe(join(workspaceRoot, "source-repos", "project"));
+    expect(env.FIRST_TREE_DOC_AGENT_HOME).toBe(workspaceRoot);
+    expect(env.FIRST_TREE_DOC_REPO_LOCAL_PATH).toBe("source-repos/project");
+  });
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -245,10 +245,11 @@ type ClientConnectionEvents = {
   "agent:unbound": [agentId: string, reason?: string];
   /**
    * Server pushed a fully-assembled inbox entry over the WS data plane.
-   * Listeners must call `connection.sendInboxAck(frame.entryId)` once the
-   * entry has been durably handed to the session manager.
+   * First arg is `frame.inboxId` (not agentId). ACK is deferred until the
+   * handler turn closes inside SessionManager — do not ACK from this listener
+   * merely because the frame reached the session manager / early buffer.
    */
-  "inbox:deliver": [agentId: string, frame: InboxDeliverFrame];
+  "inbox:deliver": [inboxId: string, frame: InboxDeliverFrame];
   "agent:bind:rejected": [reason: AgentBindRejectReason, agentId: string];
   /**
    * Server announced that an agent has been pinned to this client (either

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -1,7 +1,3 @@
-import type { FirstTreeHubSDK } from "../sdk.js";
-import type { SelfFence } from "./doc-snapshots.js";
-import type { AgentIdentity } from "./handler.js";
-
 /**
  * Turn-completion sink the runtime calls when a handler finishes a turn.
  *
@@ -13,39 +9,20 @@ import type { AgentIdentity } from "./handler.js";
  * is always an explicit `chat send` (agent or human) or `chat ask` (a human
  * decision); there is no implicit final-text delivery to fall back on.
  *
- * The sink is kept as the single hook every handler (Claude Code today,
- * Gemini / Cursor / custom tomorrow) calls at turn end; it now only clears the
- * turn trigger and never writes to chat. The enrichment deps in
- * `ResultSinkDeps` (sdk / self-fence / org / doc-snapshot inputs) are inert
- * now — they are retained to keep the wiring stable and are cleaned up
- * together with the turn-trigger machinery in a follow-up.
+ * The sink remains the single hook every built-in handler calls at turn end; it
+ * only clears the turn trigger and never writes to chat. Replacing this hook
+ * with a dedicated turn-end API (and retiring `currentTrigger` with it) is a
+ * follow-up — not this cleanup.
  */
 
 export type Trigger = { messageId: string; senderId: string };
 
 export type ResultSinkDeps = {
-  sdk: FirstTreeHubSDK;
-  agent: AgentIdentity;
-  chatId: string;
-  /** Reads the current trigger (managed by session-manager). Returning
-   *  `null` means the handler's reply is unprompted — typically on resume
-   *  with no new message, or post-shutdown. */
-  getTrigger: () => Trigger | null;
-  /** Called by the sink to clear the trigger before awaiting the transport,
-   *  so a concurrently-arriving inject() can set a fresh trigger without this
+  /** Called by the sink to clear the trigger before returning, so a
+   *  concurrently-arriving inject() can set a fresh trigger without this
    *  reply consuming it. */
   clearTrigger: () => void;
   log: (msg: string) => void;
-  /**
-   * INERT (see the module note): these fed the retired doc-capture/snapshot
-   * enrichment that ran when the sink delivered the final-text mirror. The sink
-   * no longer writes to chat, so they are never read; they are retained only to
-   * keep the wiring stable and are cleaned up with the turn-trigger machinery.
-   */
-  getSelfFence?: () => Promise<SelfFence | null>;
-  getOrgId?: () => Promise<string | null>;
-  workspacesRoot?: string;
-  selfSlug?: string;
 };
 
 export type ResultSink = (text: string) => Promise<void>;

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -692,7 +692,6 @@ export class SessionManager {
   /** Cache of chatId → organizationId, resolved via `getChatDetail`. A chat's
    *  org is immutable, so this is a cheap permanent memo that keeps doc-capture
    *  uploads off the hot path after the first lookup. */
-  private readonly chatOrgIds = new Map<string, string>();
   private lastReportedRuntimeState: RuntimeState | null = null;
   private idleTimer: ReturnType<typeof setInterval> | null = null;
   private runtimeReaffirmTimer: ReturnType<typeof setTimeout> | null = null;
@@ -4616,18 +4615,10 @@ export class SessionManager {
       : sessionRoot;
 
     const forwardResult = createResultSink({
-      sdk: this.config.sdk,
-      agent: this.config.agentIdentity,
-      chatId,
-      getTrigger: () => this.currentTrigger.get(chatId) ?? null,
       clearTrigger: () => {
         this.currentTrigger.delete(chatId);
       },
       log,
-      getSelfFence: () => this.resolveSelfFence(log, chatId),
-      getOrgId: () => this.resolveChatOrgId(log, chatId),
-      workspacesRoot,
-      selfSlug,
     });
 
     const envCtx = {
@@ -4763,50 +4754,6 @@ export class SessionManager {
       throw new Error("route transition invalidated");
     }
     this.captureRuntimeFailureNotice(chatId, event, mutationLeaseValid);
-  }
-
-  private async resolveSelfFence(log: (msg: string) => void, chatId: string): Promise<SelfFence> {
-    // Session doc root: the dir the handler actually hands the agent as cwd —
-    // the per-agent home for new chats, the legacy `<workspaceRoot>/<chatId>/`
-    // dir for pre-#506 chats. See `resolveSessionDocRoot` (read-only existsSync;
-    // no acquire* side effects on every outbound message).
-    const workspaceRoot = this.config.handlerConfig.workspaceRoot;
-    const sessionRoot = resolveSessionDocRoot(workspaceRoot, chatId);
-    if (!this.config.agentConfigCache) return { agentHome: sessionRoot };
-    try {
-      const { payload } = await this.config.agentConfigCache.refreshIfNewer(this.config.agentIdentity.agentId, 0);
-      return selfFenceFromRuntimeConfig(payload, sessionRoot, workspaceRoot);
-    } catch (err) {
-      log(
-        `document preview self-fence: config unavailable, using agent home only: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return { agentHome: sessionRoot };
-    }
-  }
-
-  /**
-   * Resolve the organization id a chat belongs to, for doc-capture uploads
-   * (`POST /orgs/:orgId/attachments`). Cached permanently (a chat's org never
-   * changes). Returns `null` when the lookup fails so the sink degrades doc
-   * mentions to plain text instead of blocking the message.
-   */
-  private async resolveChatOrgId(log: (msg: string) => void, chatId: string): Promise<string | null> {
-    const cached = this.chatOrgIds.get(chatId);
-    if (cached) return cached;
-    try {
-      const detail = await this.config.sdk.getChatDetail(chatId);
-      const orgId = detail.organizationId;
-      if (typeof orgId === "string" && orgId.length > 0) {
-        this.chatOrgIds.set(chatId, orgId);
-        return orgId;
-      }
-      return null;
-    } catch (err) {
-      log(
-        `doc capture: org lookup failed, doc mentions stay plain text: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return null;
-    }
   }
 
   private projectSessionRuntime(chatId: string, opts: { drainPendingOnIdle?: boolean } = {}): void {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -689,9 +689,6 @@ export class SessionManager {
    * shutdown that a lenient caller started still sees the failure.
    */
   private readonly handlerShutdowns = new WeakMap<AgentHandler, { raw: Promise<void>; observed: Promise<void> }>();
-  /** Cache of chatId → organizationId, resolved via `getChatDetail`. A chat's
-   *  org is immutable, so this is a cheap permanent memo that keeps doc-capture
-   *  uploads off the hot path after the first lookup. */
   private lastReportedRuntimeState: RuntimeState | null = null;
   private idleTimer: ReturnType<typeof setInterval> | null = null;
   private runtimeReaffirmTimer: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
## Summary
- Strip inert `ResultSinkDeps` (sdk / agent / getTrigger / doc-fence / org lookup) left after the agent-final-text mirror was retired; delete the SessionManager-only resolvers that existed solely to feed them.
- Keep `forwardResult` as the shared turn-end hook that clears `currentTrigger` (full turn-end API + trigger retirement is a follow-up).
- Rename `inbox:deliver` event tuple `agentId` → `inboxId` and correct the ACK comment to match deferred ACK until handler turn close.
- Drop the orphaned `chatOrgIds` comment that incorrectly sat on `lastReportedRuntimeState` after the cache was removed (review finding on #2176).

## Notes
- Replaces #2176: previous head branch `cleanup/handler-inert-debt` failed the branch-name convention (`feat|fix|refactor|…`).
- Kept as **draft** per refactor gate: expand/confirm unit coverage before marking ready.
- Prior CI on #2176: client suite had 1 unrelated failure (`pi-handler` version-gate timeout flake); `result-sink` tests passed. Re-run expected on this branch.

## Test plan
- [x] Local: `result-sink` + `client-connection-more-coverage` + `packages/client` typecheck
- [ ] CI green on this PR (branch-name + client tests)
- [ ] yzw-codex: confirm pre-refactor coverage of touched sink/inbox paths; post-change focused + suite re-run before ready-for-review


Made with [Cursor](https://cursor.com)