### PR TITLE
fix: consolidate coding agent prompt actions

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,20 +10,24 @@ unchanged: deterministic behaviour belongs in per-package Vitest suites,
 agent-skill regression in `@first-tree/skill-evals`, and judgment / live /
 cross-surface validation in committed `@first-tree/qa` cases.
 
-The journey these tests walk is owned by the case
-[`registration-first-run-onboarding`](../packages/qa/cases/cross-surface/registration-first-run-onboarding.md).
-That case remains the contract and the place judgement lives. This directory is
-one way to execute part of it unattended, in the same spirit as the fixtures and
-environment recipes under `packages/qa` — useful for a quick regression pass, not
-a substitute for the case and not a new authority over what "validated" means.
+The journeys these tests walk are owned by the cases
+[`registration-first-run-onboarding`](../packages/qa/cases/cross-surface/registration-first-run-onboarding.md)
+and
+[`external-context-current-session-handoff`](../packages/qa/cases/cross-surface/external-context-current-session-handoff.md).
+Those cases remain the contracts and the place judgement lives. This directory
+is one way to execute parts of them unattended, in the same spirit as the
+fixtures and environment recipes under `packages/qa` — useful for a quick
+regression pass, not a substitute for the cases and not a new authority over
+what "validated" means.
 
 Two limits follow from that and are deliberate:
 
 - It is **not a CI gate** and is not wired into any workflow. Steps resolve from
   natural-language descriptions through a hosted model and some assertions are
   model-evaluated, so a red run is a signal to investigate, not a merge blocker.
-- It covers the happy path plus the connect-computer gate — not the negative
-  branches, degraded states and evidence judgement the case asks for.
+- It covers the registration happy path, the connect-computer gate, and the Web
+  setup-prompt dialog — not the negative branches, provider handoff execution,
+  degraded states, or evidence judgement the cases ask for.
 
 A stable invariant that Vitest could assert still belongs in Vitest. Do not move
 a check here to escape a flaky product test.
@@ -93,6 +97,7 @@ the local stack and the local tests do not touch staging.
 | --- | --- | --- |
 | `registration-new-user.test.yaml` | local | A brand-new account is created and lands on onboarding step 1 |
 | `onboarding-complete-setup.test.yaml` | local | The whole first-run journey: sign up → create team → connect a computer → create the first agent → start the kickoff chat → land in the workspace |
+| `settings-coding-agent-prompt-dialog.test.yaml` | local | A signed-in Team with a bound Context Tree opens the real setup prompt, reviews the provider-neutral handoff, and copies it from the dialog |
 | `dev-cloud-sign-in-available.test.yaml` | first-tree-dev-cloud | Staging serves the landing page and offers Google + GitHub sign-in |
 
 `modules/sign-up-fresh-user.module.yaml` holds the shared sign-up flow. Each run
@@ -137,7 +142,10 @@ the github.com round trip removed, and it 404s unless explicitly opted in
 Two steps of onboarding wait on a *second machine* that a browser test does not
 have: the First Tree client daemon, plus an installed coding-agent runtime.
 `scripts/seed-connected-computer.js` and `scripts/seed-agent-online.js` seed the
-rows that daemon would otherwise write.
+rows that daemon would otherwise write. The setup-prompt test also uses
+`scripts/seed-context-tree-binding.js` to supply the bound-tree prerequisite;
+provider repository creation and authorization are separate from the prompt
+dialog journey under test.
 
 The fixtures replace the machine, not the behaviour under test — every screen,
 transition, API call and assertion around them is exercised for real. What they

--- a/e2e/modules/complete-first-run-onboarding.module.yaml
+++ b/e2e/modules/complete-first-run-onboarding.module.yaml
@@ -1,0 +1,35 @@
+fileType: momentic/module/v2
+description: Register a new user, complete the real first-run onboarding flow, and land in the workspace
+id: complete-first-run-onboarding
+steps:
+  # ── Sign up ─────────────────────────────────────────────────────────────────
+  - module:
+      path: ./sign-up-fresh-user.module.yaml
+
+  # ── Step 1 of 3 — confirm the team ─────────────────────────────────────────
+  - click: Continue button
+
+  # ── Step 2 of 3 — connect a computer ────────────────────────────────────────
+  # The product waits for a client daemon. This fixture replaces that second
+  # machine while the browser continues through the real product flow.
+  - javascript:
+      code: ../scripts/seed-connected-computer.js
+      environment: node
+      saveAs: FIXTURE_CLIENT_ID
+  - assert: the connect-computer step reports a connected computer and lists
+      Claude Code as a ready coding agent on it
+  - click: Continue button
+
+  # ── Step 3 of 3 — create the first agent ────────────────────────────────────
+  - click: Create agent button
+  - javascript:
+      code: ../scripts/seed-agent-online.js
+      environment: node
+      saveAs: FIXTURE_AGENT_ID
+  - click: Start chat button
+
+  # ── Landing — onboarding is done and the user is in the workspace ───────────
+  - waitForUrl: /?c=
+  - assert: the workspace is open on a chat named Get started with First Tree,
+      whose first message asks the user's new assistant agent for help getting
+      started, and a message composer addressed to that agent is available

--- a/e2e/onboarding-complete-setup.test.yaml
+++ b/e2e/onboarding-complete-setup.test.yaml
@@ -3,45 +3,9 @@ id: early-firm-harbor-dreams-poorly
 description: A new user completes onboarding end to end and lands in the workspace
 defaultEnv: local
 steps:
-  # ── Sign up ─────────────────────────────────────────────────────────────────
+  # The reusable module drives the real registration and onboarding journey.
   - module:
-      path: ./modules/sign-up-fresh-user.module.yaml
-
-  # ── Step 1 of 3 — confirm the team ─────────────────────────────────────────
-  # The org already exists from sign-in; this screen loads it with the name
-  # prefilled and only PATCHes when the name is edited. Accepting it as-is
-  # writes nothing, so there is no creation to assert here.
-  - click: Continue button
-
-  # ── Step 2 of 3 — connect a computer ────────────────────────────────────────
-  # The product waits here for a client daemon to report in. See
-  # seed-connected-computer.js for why that machine is a fixture in this test.
-  - javascript:
-      code: ./scripts/seed-connected-computer.js
-      environment: node
-      saveAs: FIXTURE_CLIENT_ID
-  # Gate on the UI actually observing the computer (it polls every 5s) so the
-  # click below lands on an enabled button rather than racing the poll.
-  - assert: the connect-computer step reports a connected computer and lists
-      Claude Code as a ready coding agent on it
-  - click: Continue button
-
-  # ── Step 3 of 3 — create the first agent ────────────────────────────────────
-  - click: Create agent button
-  # Without a real daemon the new agent never binds, so presence is seeded to
-  # let the run reach the end of onboarding instead of the "taking longer than
-  # usual" fallback. The script polls until the agent row exists.
-  - javascript:
-      code: ./scripts/seed-agent-online.js
-      environment: node
-      saveAs: FIXTURE_AGENT_ID
-  - click: Start chat button
-
-  # ── Landing — onboarding is done and the user is in the workspace ───────────
-  - waitForUrl: /?c=
-  - assert: the workspace is open on a chat named Get started with First Tree,
-      whose first message asks the user's new assistant agent for help getting
-      started, and a message composer addressed to that agent is available
+      path: ./modules/complete-first-run-onboarding.module.yaml
 
   # ── Settings — the permanent readiness overview keeps its stable route ────
   - click: Settings link in the top navigation

--- a/e2e/scripts/seed-context-tree-binding.js
+++ b/e2e/scripts/seed-context-tree-binding.js
@@ -1,0 +1,44 @@
+/**
+ * Fixture: give the newly created Team a valid Context Tree binding.
+ *
+ * The browser journey under test starts after a Team already has a Context
+ * Tree. Creating and authorizing a provider repository is a separate admin
+ * journey, so this fixture writes only that prerequisite. The Settings page,
+ * setup-prompt APIs, token generation, dialog, and clipboard interaction all
+ * continue through the real app and server.
+ *
+ * Requires GH_LOGIN from new-test-identity.js and DATABASE_URL from the
+ * environment.
+ */
+const binding = {
+  provider: "github",
+  repo: "https://github.com/agent-team-foundation/first-tree-context",
+  branch: "main",
+};
+
+const db = new pg.Client({ connectionString: env.DATABASE_URL });
+await db.connect();
+try {
+  const { rows } = await db.query(
+    `INSERT INTO organization_settings (organization_id, namespace, value, version, updated_by, updated_at)
+     SELECT m.organization_id, 'context_tree', $1::jsonb, 0, u.id, NOW()
+       FROM users u
+       JOIN members m ON m.user_id = u.id
+      WHERE u.username = $2
+      ORDER BY m.created_at ASC
+      LIMIT 1
+     ON CONFLICT (organization_id, namespace) DO UPDATE
+        SET value = EXCLUDED.value,
+            version = organization_settings.version + 1,
+            updated_by = EXCLUDED.updated_by,
+            updated_at = EXCLUDED.updated_at
+     RETURNING organization_id`,
+    [JSON.stringify(binding), env.GH_LOGIN],
+  );
+  if (rows.length === 0) {
+    throw new Error(`No org membership for ${env.GH_LOGIN} — did onboarding complete?`);
+  }
+  return rows[0].organization_id;
+} finally {
+  await db.end();
+}

--- a/e2e/settings-coding-agent-prompt-dialog.test.yaml
+++ b/e2e/settings-coding-agent-prompt-dialog.test.yaml
@@ -19,5 +19,8 @@ steps:
   - assert: a Setup prompt dialog shows a complete provider-neutral setup prompt with a
       temporary sign-in code, instructions for both Claude Code and Codex, and a Copy prompt action
   - click: Copy prompt button in the Setup prompt dialog
-  - assert: the Setup prompt dialog is closed and the Coding agent setup section still has
-      exactly one setup-prompt action
+  - assert: the Setup prompt dialog remains open with the complete prompt visible and its copy
+      action reports Copied
+  - click: Close button in the Setup prompt dialog
+  - assert: the Setup prompt dialog is closed and the Coding agent setup section still has exactly
+      one setup-prompt action

--- a/e2e/settings-coding-agent-prompt-dialog.test.yaml
+++ b/e2e/settings-coding-agent-prompt-dialog.test.yaml
@@ -1,0 +1,23 @@
+fileType: momentic/test/v2
+id: settings-coding-agent-prompt-dialog
+description: A Team member reviews the complete coding-agent setup prompt before copying it
+defaultEnv: local
+steps:
+  # Establish a real signed-in Team through the product's registration and
+  # onboarding flow, then seed only the Context Tree binding prerequisite.
+  - module:
+      path: ./modules/complete-first-run-onboarding.module.yaml
+  - javascript:
+      code: ./scripts/seed-context-tree-binding.js
+      environment: node
+      saveAs: FIXTURE_CONTEXT_TREE_ORG_ID
+  - navigate: /settings/context
+  - waitForUrl: /settings/context
+  - assert: the Coding agent setup section has exactly one action named View setup prompt,
+      with no separate Copy setup prompt or Preview prompt actions
+  - click: View setup prompt button in the Coding agent setup section
+  - assert: a Setup prompt dialog shows a complete provider-neutral setup prompt with a
+      temporary sign-in code, instructions for both Claude Code and Codex, and a Copy prompt action
+  - click: Copy prompt button in the Setup prompt dialog
+  - assert: the Setup prompt dialog is closed and the Coding agent setup section still has
+      exactly one setup-prompt action

--- a/packages/web/src/components/byo-setup-prompt-actions.tsx
+++ b/packages/web/src/components/byo-setup-prompt-actions.tsx
@@ -11,15 +11,13 @@ type ByoSetupPromptActionsProps = {
   resetKey: string;
 };
 
-type PendingAction = "copy" | "preview" | null;
-
 export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey }: ByoSetupPromptActionsProps) {
   const copyFeedback = useCopyFeedback();
-  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [preparing, setPreparing] = useState(false);
   const [prepareFailed, setPrepareFailed] = useState(false);
   const [prompt, setPrompt] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
-  const [copyingPreview, setCopyingPreview] = useState(false);
+  const [copyingPrompt, setCopyingPrompt] = useState(false);
   const prepareAttempt = useRef(0);
   const copyAttempt = useRef(0);
   const activeResetKey = useRef(resetKey);
@@ -31,11 +29,11 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
     const renderedResetKey = resetKey;
     prepareAttempt.current += 1;
     copyAttempt.current += 1;
-    setPendingAction(null);
+    setPreparing(false);
     setPrepareFailed(false);
     setPrompt(null);
     setOpen(false);
-    setCopyingPreview(false);
+    setCopyingPrompt(false);
     copyFeedback.reset();
     return () => {
       if (activeResetKey.current === renderedResetKey) {
@@ -49,40 +47,26 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
     copyAttempt.current += 1;
     setOpen(false);
     setPrompt(null);
-    setCopyingPreview(false);
+    setCopyingPrompt(false);
     copyFeedback.reset();
   };
 
-  const prepare = (action: Exclude<PendingAction, null>): void => {
+  const prepare = (): void => {
     const attempt = ++prepareAttempt.current;
     const renderedResetKey = resetKey;
-    setPendingAction(action);
+    setPreparing(true);
     setPrepareFailed(false);
     copyFeedback.reset();
     void (async () => {
       try {
         const nextPrompt = await preparePromptRef.current();
         if (prepareAttempt.current !== attempt || activeResetKey.current !== renderedResetKey) return;
-        if (action === "preview") {
-          setPendingAction(null);
-          setPrompt(nextPrompt);
-          setOpen(true);
-          return;
-        }
-
-        const copy = ++copyAttempt.current;
-        await copyFeedback.copy(nextPrompt);
-        if (
-          prepareAttempt.current !== attempt ||
-          copyAttempt.current !== copy ||
-          activeResetKey.current !== renderedResetKey
-        ) {
-          return;
-        }
-        setPendingAction(null);
+        setPreparing(false);
+        setPrompt(nextPrompt);
+        setOpen(true);
       } catch {
         if (prepareAttempt.current !== attempt || activeResetKey.current !== renderedResetKey) return;
-        setPendingAction(null);
+        setPreparing(false);
         setPrepareFailed(true);
       }
     })();
@@ -93,11 +77,11 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
     const copy = ++copyAttempt.current;
     const renderedPrompt = prompt;
     const renderedResetKey = resetKey;
-    setCopyingPreview(true);
+    setCopyingPrompt(true);
     void (async () => {
       const result = await copyFeedback.copy(renderedPrompt);
       if (copyAttempt.current !== copy || activeResetKey.current !== renderedResetKey) return;
-      setCopyingPreview(false);
+      setCopyingPrompt(false);
       if (result === "copied") {
         setOpen(false);
         setPrompt(null);
@@ -115,23 +99,13 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
         className={`flex flex-wrap items-center ${align === "end" ? "justify-end" : "justify-start"}`}
         style={{ gap: "var(--sp-1)" }}
       >
-        <Button type="button" size="sm" disabled={pendingAction !== null} onClick={() => prepare("copy")}>
+        <Button type="button" size="sm" disabled={preparing} onClick={prepare}>
           {copyFeedback.status === "copied" ? (
             <Check className="h-3.5 w-3.5" aria-hidden />
           ) : (
-            <Clipboard className="h-3.5 w-3.5" aria-hidden />
+            <Eye className="h-3.5 w-3.5" aria-hidden />
           )}
-          {pendingAction === "copy" ? "Preparing…" : "Copy setup prompt"}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          disabled={pendingAction !== null}
-          onClick={() => prepare("preview")}
-        >
-          <Eye className="h-3.5 w-3.5" aria-hidden />
-          {pendingAction === "preview" ? "Preparing…" : "Preview prompt"}
+          {preparing ? "Preparing…" : "View setup prompt"}
         </Button>
         <span aria-live="polite" className="sr-only">
           {copyFeedback.status === "copied" ? "Setup prompt copied." : ""}
@@ -156,9 +130,9 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
       >
         <DialogContent data-clarity-mask="true" className="max-h-[calc(100vh-var(--sp-8))] max-w-3xl overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Review setup prompt</DialogTitle>
+            <DialogTitle>Setup prompt</DialogTitle>
             <DialogDescription style={{ color: "var(--fg-2)" }}>
-              Check the exact instructions before copying. Nothing runs until you paste them into Claude Code or Codex.
+              Review the complete prompt, then copy and paste it into Claude Code or Codex.
             </DialogDescription>
           </DialogHeader>
 
@@ -188,9 +162,9 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
             <Button type="button" variant="ghost" onClick={closePrompt}>
               Cancel
             </Button>
-            <Button type="button" disabled={copyingPreview} onClick={copyPrompt}>
+            <Button type="button" disabled={copyingPrompt} onClick={copyPrompt}>
               <Clipboard className="h-4 w-4" aria-hidden />
-              {copyingPreview ? "Copying…" : "Copy prompt"}
+              {copyingPrompt ? "Copying…" : "Copy prompt"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/packages/web/src/components/byo-setup-prompt-actions.tsx
+++ b/packages/web/src/components/byo-setup-prompt-actions.tsx
@@ -79,13 +79,9 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
     const renderedResetKey = resetKey;
     setCopyingPrompt(true);
     void (async () => {
-      const result = await copyFeedback.copy(renderedPrompt);
+      await copyFeedback.copy(renderedPrompt);
       if (copyAttempt.current !== copy || activeResetKey.current !== renderedResetKey) return;
       setCopyingPrompt(false);
-      if (result === "copied") {
-        setOpen(false);
-        setPrompt(null);
-      }
     })();
   };
 
@@ -100,16 +96,9 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
         style={{ gap: "var(--sp-1)" }}
       >
         <Button type="button" size="sm" disabled={preparing} onClick={prepare}>
-          {copyFeedback.status === "copied" ? (
-            <Check className="h-3.5 w-3.5" aria-hidden />
-          ) : (
-            <Eye className="h-3.5 w-3.5" aria-hidden />
-          )}
+          <Eye className="h-3.5 w-3.5" aria-hidden />
           {preparing ? "Preparing…" : "View setup prompt"}
         </Button>
-        <span aria-live="polite" className="sr-only">
-          {copyFeedback.status === "copied" ? "Setup prompt copied." : ""}
-        </span>
       </div>
 
       {prepareFailed ? (
@@ -159,12 +148,24 @@ export function ByoSetupPromptActions({ align = "start", preparePrompt, resetKey
           </div>
 
           <DialogFooter>
+            <span aria-live="polite" className="sr-only">
+              {copyFeedback.status === "copied" ? "Setup prompt copied." : ""}
+            </span>
             <Button type="button" variant="ghost" onClick={closePrompt}>
-              Cancel
+              Close
             </Button>
-            <Button type="button" disabled={copyingPrompt} onClick={copyPrompt}>
-              <Clipboard className="h-4 w-4" aria-hidden />
-              {copyingPrompt ? "Copying…" : "Copy prompt"}
+            <Button
+              type="button"
+              aria-label={!copyingPrompt && copyFeedback.status === "copied" ? "Copied. Copy prompt again" : undefined}
+              disabled={copyingPrompt}
+              onClick={copyPrompt}
+            >
+              {!copyingPrompt && copyFeedback.status === "copied" ? (
+                <Check className="h-4 w-4" aria-hidden />
+              ) : (
+                <Clipboard className="h-4 w-4" aria-hidden />
+              )}
+              {copyingPrompt ? "Copying…" : copyFeedback.status === "copied" ? "Copied" : "Copy prompt"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/packages/web/src/pages/__tests__/context-enablement.test.tsx
+++ b/packages/web/src/pages/__tests__/context-enablement.test.tsx
@@ -113,8 +113,9 @@ describe("personal Context access", () => {
     expect(copiedPrompt).toContain("context enable --provider 'claude-code' --team 'org-1'");
     expect(copiedPrompt).toContain("First Tree Web owns onboarding completion separately.");
     expect(copiedPrompt).not.toContain("onboarding completion has been recorded");
-    expect(promptPreview()).toBeNull();
-    expect(host.textContent).toContain("Setup prompt copied.");
+    expect(promptPreview()?.value).toContain("'first-tree-staging' login 'short-lived-code'");
+    expect(document.body.textContent).toContain("Copied");
+    expect(document.body.querySelector('span[aria-live="polite"]')?.textContent).toBe("Setup prompt copied.");
     expect(host.textContent).not.toContain("Copied — paste it into");
   });
 
@@ -190,6 +191,7 @@ describe("personal Context access", () => {
 
   it("surfaces an onboarding clipboard failure", async () => {
     vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error("clipboard denied"));
+    vi.mocked(navigator.clipboard.writeText).mockResolvedValueOnce();
     await render(true);
 
     await clickAndFlush(buttonByText(host, "View setup prompt"));
@@ -197,15 +199,22 @@ describe("personal Context access", () => {
 
     expect(document.body.textContent).toContain("Could not copy the setup prompt.");
     expect(promptPreview()).not.toBeNull();
+
+    await clickAndFlush(buttonByText(document.body, "Copy prompt"));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(2);
+    expect(document.body.textContent).toContain("Copied");
+    expect(document.body.textContent).not.toContain("Could not copy the setup prompt.");
+    expect(promptPreview()).not.toBeNull();
   });
 
-  it("lets the member cancel without copying or retaining the temporary prompt", async () => {
+  it("lets the member close without copying or retaining the temporary prompt", async () => {
     await render(true);
 
     await clickAndFlush(buttonByText(host, "View setup prompt"));
     expect(promptPreview()).not.toBeNull();
 
-    await clickAndFlush(buttonByText(document.body, "Cancel"));
+    await clickAndFlush(buttonByText(document.body, "Close"));
 
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
     expect(promptPreview()).toBeNull();
@@ -291,7 +300,8 @@ describe("personal Context access", () => {
     expect(copiedPrompt).not.toContain("Complete result with a missing or invalid handoff");
     expect(copiedPrompt).not.toContain("Determine whether this session has an attached local project");
     expect(copiedPrompt).toContain("Do not mark onboarding complete.");
-    expect(host.textContent).toContain("Setup prompt copied.");
+    expect(promptPreview()).not.toBeNull();
+    expect(document.body.textContent).toContain("Copied");
     expect(host.textContent).not.toContain("Copied — paste it into");
     expect(activityMocks.generateConnectToken).toHaveBeenCalledTimes(1);
     expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledTimes(2);
@@ -404,14 +414,14 @@ describe("personal Context access", () => {
     expect(promptPreview()?.value).toBe("ready-prompt");
     await clickAndFlush(buttonByText(document.body, "Copy prompt"));
 
-    expect(promptPreview()).toBeNull();
-    expect(host.textContent).toContain("Setup prompt copied.");
+    expect(promptPreview()?.value).toBe("ready-prompt");
+    expect(document.body.textContent).toContain("Copied");
     expect(host.textContent).not.toContain("Copied — paste it into");
     expect(preparePrompt).toHaveBeenCalledTimes(2);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ready-prompt");
   });
 
-  it("keeps successful copy feedback transient without adding a visible helper row", async () => {
+  it("keeps successful copy feedback transient and lets the member copy again", async () => {
     vi.useFakeTimers();
     try {
       const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -440,19 +450,53 @@ describe("personal Context access", () => {
         await Promise.resolve();
       });
 
-      expect(host.querySelector("svg.lucide-check")).not.toBeNull();
-      expect(host.textContent).toContain("Setup prompt copied.");
+      const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]');
+      expect(dialog?.querySelector("svg.lucide-check")).not.toBeNull();
+      expect(dialog?.textContent).toContain("Copied");
+      expect(promptPreview()?.value).toBe("ready-prompt");
       expect(actions?.childElementCount).toBe(actionChildCount);
-      expect(actions?.querySelector('span.sr-only[aria-live="polite"]')?.textContent).toBe("Setup prompt copied.");
+      expect(dialog?.querySelector('span.sr-only[aria-live="polite"]')?.textContent).toBe("Setup prompt copied.");
       expect(actions?.querySelector('p[aria-live="polite"]')).toBeNull();
+      expect(buttonByText(dialog ?? document.body, "Copied")?.getAttribute("aria-label")).toBe(
+        "Copied. Copy prompt again",
+      );
+
+      let resolveRepeatedCopy: (() => void) | undefined;
+      vi.mocked(navigator.clipboard.writeText).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRepeatedCopy = resolve;
+          }),
+      );
+      await act(async () => {
+        buttonByText(dialog ?? document.body, "Copied")?.click();
+        await Promise.resolve();
+      });
+
+      const copyingAgain = buttonByText(dialog ?? document.body, "Copying…");
+      expect(copyingAgain?.getAttribute("aria-label")).toBeNull();
+      expect(copyingAgain?.disabled).toBe(true);
+      expect(dialog?.querySelector("svg.lucide-check")).toBeNull();
+      expect(dialog?.querySelector("svg.lucide-clipboard")).not.toBeNull();
+
+      await act(async () => {
+        resolveRepeatedCopy?.();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(2);
+      expect(navigator.clipboard.writeText).toHaveBeenLastCalledWith("ready-prompt");
+      expect(promptPreview()?.value).toBe("ready-prompt");
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(COPY_FEEDBACK_MS);
       });
 
-      expect(host.querySelector("svg.lucide-check")).toBeNull();
+      expect(dialog?.querySelector("svg.lucide-check")).toBeNull();
       expect(host.querySelector("svg.lucide-eye")).not.toBeNull();
-      expect(host.textContent).not.toContain("Setup prompt copied.");
+      expect(dialog?.textContent).toContain("Copy prompt");
+      expect(dialog?.textContent).not.toContain("Copied");
     } finally {
       vi.useRealTimers();
     }
@@ -479,7 +523,7 @@ describe("personal Context access", () => {
     });
     await clickAndFlush(buttonByText(host, "View setup prompt"));
     await clickAndFlush(buttonByText(document.body, "Copy prompt"));
-    await clickAndFlush(buttonByText(document.body, "Cancel"));
+    await clickAndFlush(buttonByText(document.body, "Close"));
     await clickAndFlush(buttonByText(host, "View setup prompt"));
 
     expect(promptPreview()?.value).toBe("second-prompt");

--- a/packages/web/src/pages/__tests__/context-enablement.test.tsx
+++ b/packages/web/src/pages/__tests__/context-enablement.test.tsx
@@ -85,12 +85,13 @@ describe("personal Context access", () => {
   it("offers an optional onboarding preview without gating on this browser's Computer", async () => {
     await render(true);
     expect(host.textContent).toContain("Use Team Context in your coding agent");
-    expect(host.textContent).toContain("Copy setup prompt");
-    expect(host.textContent).toContain("Preview prompt");
+    expect(host.textContent).toContain("View setup prompt");
+    expect(host.textContent).not.toContain("Copy setup prompt");
+    expect(host.textContent).not.toContain("Preview prompt");
     expect(host.textContent).not.toContain("context enable --provider");
     expect(apiMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
 
-    await clickAndFlush(buttonByText(host, "Preview prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
 
     expect(activityMocks.generateConnectToken).toHaveBeenCalledTimes(1);
     expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledWith("org-1", "claude-code", "onboarding");
@@ -101,7 +102,9 @@ describe("personal Context access", () => {
     expect(preview?.value).toContain("context enable --provider 'claude-code' --team 'org-1'");
     expect(preview?.value).toContain("context enable --provider 'codex' --team 'org-1'");
     expect(preview?.closest('[data-clarity-mask="true"]')).not.toBeNull();
-    expect(document.body.textContent).toContain("Nothing runs until you paste them into Claude Code or Codex.");
+    expect(document.body.textContent).toContain(
+      "Review the complete prompt, then copy and paste it into Claude Code or Codex.",
+    );
     expect(document.body.textContent).toContain("Contains a temporary sign-in code. Don't share it.");
 
     await clickAndFlush(buttonByText(document.body, "Copy prompt"));
@@ -121,7 +124,7 @@ describe("personal Context access", () => {
     expect(apiMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
   });
 
-  it("copies one provider-neutral onboarding prompt without a provider picker", async () => {
+  it("copies one provider-neutral onboarding prompt from the dialog without a provider picker", async () => {
     apiMocks.getContextEnablementHandoff.mockImplementation(
       async (_organizationId: string, provider: "claude-code" | "codex") => ({
         organizationId: "org-1",
@@ -134,7 +137,9 @@ describe("personal Context access", () => {
     );
     await render(true);
 
-    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    await clickAndFlush(buttonByText(document.body, "Copy prompt"));
 
     expect(apiMocks.getContextEnablementHandoff).toHaveBeenCalledTimes(2);
     const copiedPrompt = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0];
@@ -164,8 +169,8 @@ describe("personal Context access", () => {
     );
     await render(true);
 
-    const copy = buttonByText(host, "Copy setup prompt");
-    await act(async () => copy?.click());
+    const viewPrompt = buttonByText(host, "View setup prompt");
+    await act(async () => viewPrompt?.click());
     await render(false);
     await act(async () => {
       resolveHandoff?.({
@@ -187,16 +192,17 @@ describe("personal Context access", () => {
     vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error("clipboard denied"));
     await render(true);
 
-    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
+    await clickAndFlush(buttonByText(document.body, "Copy prompt"));
 
     expect(document.body.textContent).toContain("Could not copy the setup prompt.");
-    expect(promptPreview()).toBeNull();
+    expect(promptPreview()).not.toBeNull();
   });
 
   it("lets the member cancel without copying or retaining the temporary prompt", async () => {
     await render(true);
 
-    await clickAndFlush(buttonByText(host, "Preview prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
     expect(promptPreview()).not.toBeNull();
 
     await clickAndFlush(buttonByText(document.body, "Cancel"));
@@ -219,7 +225,7 @@ describe("personal Context access", () => {
     );
     await render(true);
 
-    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
     for (let attempt = 0; attempt < 5 && !host.textContent?.includes("Could not prepare"); attempt += 1) {
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
@@ -255,12 +261,12 @@ describe("personal Context access", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(host.textContent).toContain("Use with Claude Code or Codex");
+    expect(host.textContent).toContain("Setup prompt");
     expect(host.textContent).toContain(
-      "Open your project in Claude Code or Codex, then copy and paste the setup prompt.",
+      "Open your project in Claude Code or Codex, then paste this prompt into the conversation.",
     );
     expect(host.textContent).not.toContain("context enable --provider");
-    await clickAndFlush(buttonByText(host, "Preview prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
     expect(promptPreview()?.value).toContain("If you are Claude Code:");
     expect(promptPreview()?.value).toContain("If you are Codex:");
@@ -391,10 +397,12 @@ describe("personal Context access", () => {
       );
       await Promise.resolve();
     });
-    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
 
     expect(host.textContent).toContain("Could not prepare the setup prompt.");
-    await clickAndFlush(buttonByText(host, "Copy setup prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
+    expect(promptPreview()?.value).toBe("ready-prompt");
+    await clickAndFlush(buttonByText(document.body, "Copy prompt"));
 
     expect(promptPreview()).toBeNull();
     expect(host.textContent).toContain("Setup prompt copied.");
@@ -421,8 +429,13 @@ describe("personal Context access", () => {
       const actions = host.querySelector<HTMLElement>("[data-byo-prompt-actions]");
       const actionChildCount = actions?.childElementCount;
       await act(async () => {
-        buttonByText(host, "Copy setup prompt")?.click();
+        buttonByText(host, "View setup prompt")?.click();
         await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        buttonByText(document.body, "Copy prompt")?.click();
         await Promise.resolve();
         await Promise.resolve();
       });
@@ -438,7 +451,7 @@ describe("personal Context access", () => {
       });
 
       expect(host.querySelector("svg.lucide-check")).toBeNull();
-      expect(host.querySelector("svg.lucide-clipboard")).not.toBeNull();
+      expect(host.querySelector("svg.lucide-eye")).not.toBeNull();
       expect(host.textContent).not.toContain("Setup prompt copied.");
     } finally {
       vi.useRealTimers();
@@ -464,10 +477,10 @@ describe("personal Context access", () => {
       );
       await Promise.resolve();
     });
-    await clickAndFlush(buttonByText(host, "Preview prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
     await clickAndFlush(buttonByText(document.body, "Copy prompt"));
     await clickAndFlush(buttonByText(document.body, "Cancel"));
-    await clickAndFlush(buttonByText(host, "Preview prompt"));
+    await clickAndFlush(buttonByText(host, "View setup prompt"));
 
     expect(promptPreview()?.value).toBe("second-prompt");
     await act(async () => {
@@ -496,7 +509,7 @@ describe("personal Context access", () => {
         </QueryClientProvider>,
       );
     });
-    await act(async () => buttonByText(host, "Copy setup prompt")?.click());
+    await act(async () => buttonByText(host, "View setup prompt")?.click());
 
     await act(async () => {
       root.render(
@@ -511,7 +524,7 @@ describe("personal Context access", () => {
     });
 
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
-    expect(host.textContent).toContain("Copy setup prompt");
+    expect(host.textContent).toContain("View setup prompt");
     expect(promptPreview()).toBeNull();
   });
 
@@ -532,7 +545,7 @@ describe("personal Context access", () => {
         </QueryClientProvider>,
       );
     });
-    await act(async () => buttonByText(host, "Copy setup prompt")?.click());
+    await act(async () => buttonByText(host, "View setup prompt")?.click());
     await act(async () => root.render(null));
     await act(async () => {
       resolvePrompt?.("unmounted-prompt");

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -266,7 +266,18 @@ describe("extra preview pages", () => {
     expect(admin.container.querySelector('[data-settings-context-tree-preview="admin"]')).not.toBeNull();
     expect(text(admin.container)).toContain("Binding");
     expect(text(admin.container)).toContain("Automatic review");
-    expect(text(admin.container)).toContain("Coding-agent access");
+    expect(text(admin.container)).toContain("Coding agent setup");
+    const promptActions = admin.container.querySelector<HTMLElement>("[data-byo-prompt-actions]");
+    const viewPrompt = [...(promptActions?.querySelectorAll<HTMLButtonElement>("button") ?? [])].find(
+      (button) => button.textContent === "View setup prompt",
+    );
+    expect(promptActions?.querySelectorAll("button")).toHaveLength(1);
+    await act(async () => viewPrompt?.click());
+    await flush();
+    expect(document.body.querySelector<HTMLTextAreaElement>("[data-byo-setup-prompt-preview]")?.value).toContain(
+      "Connect this coding agent to Gandy's team Context Tree.",
+    );
+    expect(text(document.body)).toContain("Copy prompt");
     expect(admin.container.querySelector('[data-setup-owner-controls="context-tree"]')).not.toBeNull();
     expect(admin.container.querySelector('[role="switch"]')).not.toBeNull();
     expect(globalThis.fetch).not.toHaveBeenCalled();

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -2237,7 +2237,7 @@ describe("web DOM interaction coverage", () => {
     orgSettingsMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: "", branch: null });
     const inviteeNoTree = await renderOnboardingDom(<StepStartChat />, { path: "invitee", activeStep: "start-chat" });
     await waitForText("Meet your agent", inviteeNoTree.container);
-    expect(inviteeNoTree.container.textContent).not.toContain("Use with Claude Code or Codex");
+    expect(inviteeNoTree.container.textContent).not.toContain("View setup prompt");
     expect(inviteeNoTree.container.textContent).not.toContain("Needs Admin");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     await click(findButton(inviteeNoTree.container, "Start exploring"));
@@ -2260,7 +2260,7 @@ describe("web DOM interaction coverage", () => {
       activeStep: "start-chat",
     });
     await waitForText("Meet your agent", inviteeNoRepo.container);
-    expect(inviteeNoRepo.container.textContent).not.toContain("Use with Claude Code or Codex");
+    expect(inviteeNoRepo.container.textContent).not.toContain("View setup prompt");
     expect(inviteeNoRepo.container.textContent).not.toContain("Needs Admin");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     await unmountRoot(inviteeNoRepo.root);
@@ -2280,7 +2280,7 @@ describe("web DOM interaction coverage", () => {
       activeStep: "start-chat",
     });
     await waitForText("Meet your agent", inviteeNoInstall.container);
-    expect(inviteeNoInstall.container.textContent).not.toContain("Use with Claude Code or Codex");
+    expect(inviteeNoInstall.container.textContent).not.toContain("View setup prompt");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     expect(findButton(inviteeNoInstall.container, "Start chat")).toBeNull();
     await click(findButton(inviteeNoInstall.container, "Start exploring"));
@@ -2298,7 +2298,7 @@ describe("web DOM interaction coverage", () => {
       activeStep: "start-chat",
     });
     await waitForText("Meet your agent", inviteeProbeFail.container);
-    expect(inviteeProbeFail.container.textContent).not.toContain("Use with Claude Code or Codex");
+    expect(inviteeProbeFail.container.textContent).not.toContain("View setup prompt");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     expect(findButton(inviteeProbeFail.container, "Start chat")).toBeNull();
     await unmountRoot(inviteeProbeFail.root);
@@ -2308,7 +2308,7 @@ describe("web DOM interaction coverage", () => {
     contextEnablementMocks.getContextEnablementHandoff.mockClear();
     const inviteeReady = await renderOnboardingDom(<StepStartChat />, { path: "invitee", activeStep: "start-chat" });
     await waitForText("Meet your agent", inviteeReady.container);
-    expect(inviteeReady.container.textContent).not.toContain("Use with Claude Code or Codex");
+    expect(inviteeReady.container.textContent).not.toContain("View setup prompt");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     await click(findButton(inviteeReady.container, "Start exploring"));
     // Ready invitee also lands in a value-first work chat, not the tree setup

--- a/packages/web/src/pages/settings-context-tree-preview.tsx
+++ b/packages/web/src/pages/settings-context-tree-preview.tsx
@@ -11,6 +11,9 @@ import { PREVIEW_CAPABILITIES } from "./setup-preview.js";
 type PreviewRole = "admin" | "member";
 
 const ORGANIZATION_ID = "org-preview";
+const PREVIEW_SETUP_PROMPT = `Connect this coding agent to Gandy's team Context Tree.
+
+Use First Tree to read the applicable Team context before acting, then continue the current task.`;
 
 export function SettingsContextTreePreviewPage() {
   const [searchParams] = useSearchParams();
@@ -33,7 +36,7 @@ export function SettingsContextTreePreviewPage() {
       <AuthContext.Provider value={auth}>
         <div data-settings-context-tree-preview={role} style={{ minHeight: "100vh", background: "var(--bg)" }}>
           <SettingsLayout activePathname="/settings/context">
-            <SettingsContextTreePage />
+            <SettingsContextTreePage preparePrompt={async () => PREVIEW_SETUP_PROMPT} />
           </SettingsLayout>
           <nav
             aria-label="Context Tree settings preview controls"

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -52,7 +52,7 @@ const REPOSITORIES_ITEM: Item = {
 const CONTEXT_TREE_ITEM: Item = {
   to: "/settings/context",
   label: "Context Tree",
-  description: "Manage shared context, automatic review, and coding-agent access for this Team.",
+  description: "Manage shared context, automatic review, and coding agent setup for this Team.",
 };
 const RESOURCES_ITEM: Item = {
   to: "/settings/resources",

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -995,17 +995,18 @@ describe("Settings Setup overview", () => {
     const { page } = await openContextTreeControls(view);
     const personalAccess = await waitForSelector<HTMLElement>(page, "[data-setup-personal-access]");
 
-    expect(personalAccess.textContent).toContain("Use with Claude Code or Codex");
+    expect(personalAccess.textContent).toContain("Setup prompt");
     expect(personalAccess.textContent).toContain(
-      "Open your project in Claude Code or Codex, then copy and paste the setup prompt.",
+      "Open your project in Claude Code or Codex, then paste this prompt into the conversation.",
     );
-    expect(personalAccess.textContent).toContain("Copy setup prompt");
-    expect(personalAccess.textContent).toContain("Preview prompt");
+    expect(personalAccess.textContent).toContain("View setup prompt");
+    expect(personalAccess.textContent).not.toContain("Copy setup prompt");
+    expect(personalAccess.textContent).not.toContain("Preview prompt");
     expect(personalAccess.textContent).not.toContain("context enable --provider");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
 
     const preview = [...personalAccess.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Preview prompt",
+      (button) => button.textContent === "View setup prompt",
     );
     await act(async () => preview?.click());
     await flush();
@@ -1048,17 +1049,23 @@ describe("Settings Setup overview", () => {
     const view = await renderSettingsSetupPage("/settings/context");
     const page = await waitForSelector<HTMLElement>(view.host, '[data-context-tree-settings="member"]');
     const personalAccess = await waitForSelector<HTMLElement>(page, "[data-setup-personal-access]");
-    expect(personalAccess.textContent).toContain("Use with Claude Code or Codex");
-    expect(personalAccess.textContent).toContain("Copy setup prompt");
-    expect(personalAccess.textContent).toContain("Preview prompt");
+    expect(personalAccess.textContent).toContain("Setup prompt");
+    expect(personalAccess.textContent).toContain("View setup prompt");
+    expect(personalAccess.textContent).not.toContain("Copy setup prompt");
+    expect(personalAccess.textContent).not.toContain("Preview prompt");
     expect(page.querySelector<HTMLAnchorElement>('a[href="/context"]')?.textContent).toContain("Open Context");
     expect(page.querySelector("[data-setup-owner-controls]")).toBeNull();
     expect(page.querySelector('[role="switch"]')).toBeNull();
     expect(reviewerMocks.getContextReviewerCandidates).not.toHaveBeenCalled();
     expect(orgSettingsMocks.getRawContextTreeSetting).not.toHaveBeenCalled();
 
-    const copy = [...personalAccess.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Copy setup prompt",
+    const viewPrompt = [...personalAccess.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "View setup prompt",
+    );
+    await act(async () => viewPrompt?.click());
+    await flush();
+    const copy = [...document.body.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Copy prompt",
     );
     await act(async () => copy?.click());
     await flush();

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -1028,6 +1028,8 @@ describe("Settings Setup overview", () => {
       expect.stringContaining("first-tree-dev login short-lived-code"),
     );
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining("exact `applyCommand`"));
+    expect(document.body.querySelector("[data-byo-setup-prompt-preview]")).not.toBeNull();
+    expect(document.body.textContent).toContain("Copied");
 
     await act(async () => view.root.unmount());
   });
@@ -1075,6 +1077,8 @@ describe("Settings Setup overview", () => {
       expect.stringContaining("first-tree-dev login short-lived-code"),
     );
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining("exact `applyCommand`"));
+    expect(document.body.querySelector("[data-byo-setup-prompt-preview]")).not.toBeNull();
+    expect(document.body.textContent).toContain("Copied");
 
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/settings/context-enablement.tsx
+++ b/packages/web/src/pages/settings/context-enablement.tsx
@@ -83,10 +83,10 @@ export function ContextPersonalAccess({
     >
       <div className="min-w-0" style={{ flex: "1 1 28rem" }}>
         <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
-          Use with Claude Code or Codex
+          Setup prompt
         </div>
         <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
-          Open your project in Claude Code or Codex, then copy and paste the setup prompt.
+          Open your project in Claude Code or Codex, then paste this prompt into the conversation.
         </div>
       </div>
       <ByoSetupPromptActions

--- a/packages/web/src/pages/settings/context-tree.tsx
+++ b/packages/web/src/pages/settings/context-tree.tsx
@@ -27,7 +27,11 @@ type ContextTreeAvailability = "active" | "stale" | "unavailable" | "checking" |
  * assignment, and personal coding-agent handoff. Members see the same Team
  * facts without receiving admin mutation controls.
  */
-export function SettingsContextTreePage() {
+export function SettingsContextTreePage({
+  preparePrompt,
+}: {
+  preparePrompt?: (organizationId: string) => Promise<string>;
+} = {}) {
   const { organizationId, role } = useAuth();
   const location = useLocation();
   const bindingRef = useRef<HTMLElement>(null);
@@ -156,13 +160,13 @@ export function SettingsContextTreePage() {
         ref={codingAgentAccessRef}
         id={CODING_AGENT_ACCESS_HASH.slice(1)}
         tabIndex={-1}
-        aria-label="Coding-agent access"
+        aria-label="Coding agent setup"
         style={{ scrollMarginTop: "var(--sp-4)" }}
       >
-        <Section title="Coding-agent access" description="Use this Team's Context Tree from Claude Code or Codex.">
+        <Section title="Coding agent setup" description="Use this Team's Context Tree in Claude Code or Codex.">
           <div style={{ padding: "var(--sp-3) 0" }}>
             {contextBound ? (
-              <ContextPersonalAccess organizationId={organizationId} />
+              <ContextPersonalAccess organizationId={organizationId} preparePrompt={preparePrompt} />
             ) : (
               <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
                 Available once this Team has a valid Context Tree binding.


### PR DESCRIPTION
## Summary

- replace the separate Copy and Preview actions with one `View setup prompt` entry
- show the complete prompt in a dialog and keep `Copy prompt` inside that dialog
- keep the dialog and complete prompt visible after copy, show transient `Copied` feedback, and let the user close explicitly
- rename the section from access-oriented language to `Coding agent setup` and align the supporting copy
- add deterministic Web coverage and a real-app Momentic journey mapped to the existing external-context QA case

## Validation

- `pnpm check`
- `pnpm typecheck`
- targeted Web tests for the final increment (3 files, 90 tests)
- `npx momentic@3.42.0 lint`
- local Playwright walkthrough of view, full prompt retention, and explicit close
- two independent reviews covering repository standards and the requested behavior

## Validation gaps

- Momentic's hosted API was unreachable from this environment, so the committed journey was linted but could not produce an uploaded dashboard run URL/ID.
- The final full Web run passed 2,160 of 2,161 tests and hit one unrelated ComposeStatusBar focus-timing failure; that exact test passed when rerun in isolation. The previous head's complete Web suite and CI were green.
- The root `pnpm test` run hit unrelated existing failures: a Pi version-gate timeout remained reproducible in 1 of 47 isolated client tests, while the isolated CLI timeout test passed. All changed Web tests are green.
