### PR TITLE
feat(web): reveal exact agent in onboarding

### DIFF
--- a/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
@@ -357,11 +357,13 @@ describe("onboarding preview review surface", () => {
         <OnboardingPreviewPage />
       </MemoryRouter>,
     );
-    expect(start.container.textContent).toContain("Meet your agent");
+    expect(start.container.textContent).toContain("YOUR FIRST TREE AGENT");
+    expect(start.container.textContent).toContain("Meet Gandy's assistant");
     expect(start.container.textContent).toContain(
-      "Explore First Tree together, then choose what you’d like to try first.",
+      "Gandy's assistant is ready to explore First Tree with you. Bring a question, a project, or a task you want to move forward.",
     );
-    expect(start.container.textContent).toContain("Start exploring");
+    expect(start.container.textContent).toContain("Meet your agent");
+    expect(start.container.textContent).toContain("You’ll open your first Chat and can start typing right away.");
     expect(start.container.textContent).not.toContain("Stay connected");
     expect(start.container.textContent).not.toContain("WeChat group");
     expect(start.container.textContent).not.toContain("Discord");
@@ -373,11 +375,11 @@ describe("onboarding preview review surface", () => {
         <OnboardingPreviewPage />
       </MemoryRouter>,
     );
-    expect(liveStart.container.textContent).toContain("Meet your agent");
+    expect(liveStart.container.textContent).toContain("Meet Gandy's assistant");
     expect(liveStart.container.textContent).toContain(
-      "Explore First Tree together, then choose what you’d like to try first.",
+      "Gandy's assistant is ready to explore First Tree with you. Bring a question, a project, or a task you want to move forward.",
     );
-    expect(liveStart.container.textContent).toContain("Start exploring");
+    expect(liveStart.container.textContent).toContain("Meet your agent");
     expect(liveStart.container.textContent).not.toContain("Stay connected");
     await act(async () => liveStart.root.unmount());
 

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1276,7 +1276,7 @@ describe("page SSR smoke coverage", () => {
     const { StepConnectCode } = await import("../onboarding/steps/step-connect-code.js");
     const { StepConnectComputer } = await import("../onboarding/steps/step-connect-computer.js");
     const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
-    const { StepStartChat } = await import("../onboarding/steps/step-start-chat.js");
+    const { AgentArrival, StepStartChat } = await import("../onboarding/steps/step-start-chat.js");
     const { StepTeam } = await import("../onboarding/steps/step-team.js");
 
     const html = renderPage(
@@ -1336,7 +1336,29 @@ describe("page SSR smoke coverage", () => {
     expect(await renderOnboardingStep(<StepConnectCode />, { activeStep: "connect-code" })).toContain(
       "Loading your repos",
     );
-    expect(await renderOnboardingStep(<StepStartChat />, { activeStep: "start-chat" })).toContain("Meet your agent");
+    const arrivalHtml = renderPage(
+      <AgentArrival
+        agent={{
+          uuid: "agent-1",
+          name: "nova",
+          displayName: "Nova",
+          type: "agent",
+          organizationId: "org-1",
+          inboxId: "inbox-1",
+          visibility: "organization",
+          runtimeProvider: "claude-code",
+          clientId: "client-1",
+          status: "active",
+          avatarImageUrl: null,
+        }}
+        error={null}
+        onStart={() => undefined}
+        phase="idle"
+      />,
+    );
+    expect(arrivalHtml).toContain("Meet Nova");
+    expect(arrivalHtml).toContain("Meet your agent");
+    expect(await renderOnboardingStep(<StepStartChat />, { activeStep: "start-chat" })).toContain("Finding your agent");
     expect(
       await renderOnboardingStep(<StepStartChat />, {
         activeStep: "start-chat",
@@ -1344,14 +1366,14 @@ describe("page SSR smoke coverage", () => {
         treeBindingPlan: "createBinding",
         treeUrl: "",
       }),
-    ).toContain("Meet your agent");
+    ).toContain("Finding your agent");
     expect(
       await renderOnboardingStep(<StepStartChat />, {
         path: "invitee",
         activeStep: "start-chat",
         selectedRepoUrls: [],
       }),
-    ).toContain("Meet your agent");
+    ).toContain("Finding your agent");
   });
 
   it("renders invite, GitHub App, settings, and layout surfaces", async () => {

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -2171,8 +2171,11 @@ describe("web DOM interaction coverage", () => {
       setTreeUrl,
       markTreeAutoDetectDone,
     });
-    await waitForText("Meet your agent", adminAutoDetect.container);
-    expect(markTreeAutoDetectDone).toHaveBeenCalled();
+    await waitForText("Meet Nova", adminAutoDetect.container);
+    await waitForCondition(
+      () => markTreeAutoDetectDone.mock.calls.length > 0,
+      "Expected the bound-tree probe to settle",
+    );
     expect(setTreeBindingPlan).toHaveBeenCalledWith("useBoundTree");
     expect(setTreeUrl).toHaveBeenCalledWith("https://github.com/acme/context-tree");
     await unmountRoot(adminAutoDetect.root);
@@ -2186,8 +2189,8 @@ describe("web DOM interaction coverage", () => {
       treeBindingPlan: "useBoundTree",
       treeUrl: "https://github.com/acme/context-tree",
     });
-    await waitForText("Meet your agent", adminExisting.container);
-    await click(findButton(adminExisting.container, "Start exploring"));
+    await waitForText("You’ll open your first Chat and can start typing right away.", adminExisting.container);
+    await click(findButton(adminExisting.container, "Meet your agent"));
     await waitForText("Opening your first Chat", adminExisting.container);
     expect(agentApiMocks.listManagedAgents).toHaveBeenCalled();
     expect(onboardingEventMocks.startOnboardingChat).toHaveBeenCalledWith(
@@ -2215,15 +2218,15 @@ describe("web DOM interaction coverage", () => {
       treeBindingPlan: "createBinding",
       treeUrl: "",
     });
-    await waitForText("Meet your agent", adminNoProject.container);
+    await waitForText("Meet Nova", adminNoProject.container);
     expect(adminNoProject.container.textContent).toContain(
-      "Explore First Tree together, then choose what you’d like to try first.",
+      "Nova is ready to explore First Tree with you. Bring a question, a project, or a task you want to move forward.",
     );
     expect(adminNoProject.container.textContent).not.toContain("Stay connected");
     expect(adminNoProject.container.textContent).not.toContain("Mobile app");
     expect(adminNoProject.container.textContent).not.toContain("WeChat group");
     expect(adminNoProject.container.textContent).not.toContain("Discord");
-    await click(findButton(adminNoProject.container, "Start exploring"));
+    await click(findButton(adminNoProject.container, "Meet your agent"));
     expect(onboardingEventMocks.startOnboardingChat).toHaveBeenLastCalledWith(
       expect.objectContaining({ agentUuid: "agent-1", topic: "Get started with First Tree", orientation: 1 }),
     );
@@ -2236,11 +2239,11 @@ describe("web DOM interaction coverage", () => {
     contextEnablementMocks.getContextEnablementHandoff.mockClear();
     orgSettingsMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: "", branch: null });
     const inviteeNoTree = await renderOnboardingDom(<StepStartChat />, { path: "invitee", activeStep: "start-chat" });
-    await waitForText("Meet your agent", inviteeNoTree.container);
+    await waitForText("You’ll open your first Chat and can start typing right away.", inviteeNoTree.container);
     expect(inviteeNoTree.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(inviteeNoTree.container.textContent).not.toContain("Needs Admin");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
-    await click(findButton(inviteeNoTree.container, "Start exploring"));
+    await click(findButton(inviteeNoTree.container, "Meet your agent"));
     await waitForText("Opening your first Chat", inviteeNoTree.container);
     expect(inviteeNoTree.flow.completeAndEnterChat).toHaveBeenCalled();
     await unmountRoot(inviteeNoTree.root);
@@ -2259,7 +2262,7 @@ describe("web DOM interaction coverage", () => {
       path: "invitee",
       activeStep: "start-chat",
     });
-    await waitForText("Meet your agent", inviteeNoRepo.container);
+    await waitForText("You’ll open your first Chat and can start typing right away.", inviteeNoRepo.container);
     expect(inviteeNoRepo.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(inviteeNoRepo.container.textContent).not.toContain("Needs Admin");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
@@ -2279,11 +2282,11 @@ describe("web DOM interaction coverage", () => {
       path: "invitee",
       activeStep: "start-chat",
     });
-    await waitForText("Meet your agent", inviteeNoInstall.container);
+    await waitForText("You’ll open your first Chat and can start typing right away.", inviteeNoInstall.container);
     expect(inviteeNoInstall.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     expect(findButton(inviteeNoInstall.container, "Start chat")).toBeNull();
-    await click(findButton(inviteeNoInstall.container, "Start exploring"));
+    await click(findButton(inviteeNoInstall.container, "Meet your agent"));
     expect(inviteeNoInstall.flow.completeAndEnterChat).toHaveBeenCalled();
     await unmountRoot(inviteeNoInstall.root);
 
@@ -2297,7 +2300,7 @@ describe("web DOM interaction coverage", () => {
       path: "invitee",
       activeStep: "start-chat",
     });
-    await waitForText("Meet your agent", inviteeProbeFail.container);
+    await waitForText("You’ll open your first Chat and can start typing right away.", inviteeProbeFail.container);
     expect(inviteeProbeFail.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
     expect(findButton(inviteeProbeFail.container, "Start chat")).toBeNull();
@@ -2307,10 +2310,10 @@ describe("web DOM interaction coverage", () => {
     // agent already inherits the team's recommended repos.
     contextEnablementMocks.getContextEnablementHandoff.mockClear();
     const inviteeReady = await renderOnboardingDom(<StepStartChat />, { path: "invitee", activeStep: "start-chat" });
-    await waitForText("Meet your agent", inviteeReady.container);
+    await waitForText("You’ll open your first Chat and can start typing right away.", inviteeReady.container);
     expect(inviteeReady.container.textContent).not.toContain("Use with Claude Code or Codex");
     expect(contextEnablementMocks.getContextEnablementHandoff).not.toHaveBeenCalled();
-    await click(findButton(inviteeReady.container, "Start exploring"));
+    await click(findButton(inviteeReady.container, "Meet your agent"));
     // Ready invitee also lands in a value-first work chat, not the tree setup
     // chat. The inherited team tree is context for orientation.
     expect(onboardingEventMocks.startOnboardingChat).toHaveBeenCalledWith(
@@ -2339,9 +2342,9 @@ describe("web DOM interaction coverage", () => {
       treeBindingPlan: "createBinding",
       treeUrl: "",
     });
-    await waitForText("Meet your agent", view.container);
+    await waitForText("You’ll open your first Chat and can start typing right away.", view.container);
     await click(
-      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Start")) ??
+      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Meet your agent")) ??
         null) as HTMLButtonElement | null,
     );
     await waitForText("Opening your first Chat", view.container);
@@ -2406,9 +2409,9 @@ describe("web DOM interaction coverage", () => {
       treeBindingPlan: "useBoundTree",
       treeUrl: "https://github.com/acme/context-tree",
     });
-    await waitForText("Meet your agent", view.container);
+    await waitForText("You’ll open your first Chat and can start typing right away.", view.container);
     await click(
-      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Start")) ??
+      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Meet your agent")) ??
         null) as HTMLButtonElement | null,
     );
     await waitForText("Opening your first Chat", view.container);
@@ -2435,9 +2438,9 @@ describe("web DOM interaction coverage", () => {
       treeBindingPlan: "useBoundTree",
       treeUrl: "https://github.com/acme/context-tree",
     });
-    await waitForText("Meet your agent", view.container);
+    await waitForText("You’ll open your first Chat and can start typing right away.", view.container);
     await click(
-      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Start")) ??
+      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Meet your agent")) ??
         null) as HTMLButtonElement | null,
     );
     await waitForText("Couldn't check your repositories", view.container);
@@ -2491,9 +2494,9 @@ describe("web DOM interaction coverage", () => {
         );
       },
     );
-    await waitForText("Meet your agent", view.container);
+    await waitForText("You’ll open your first Chat and can start typing right away.", view.container);
     await click(
-      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Start")) ??
+      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Meet your agent")) ??
         null) as HTMLButtonElement | null,
     );
     await waitForText("Opening your first Chat", view.container);

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -8,15 +8,14 @@ import type { GithubRepo } from "../api/github.js";
 import { Avatar } from "../components/avatar.js";
 import type { ComputerConnection } from "../features/agent-setup/use-computer-connection.js";
 import { InviteAcceptCard, InviteAcceptError, InviteAcceptShell, InviteAcceptSkeleton } from "./invite-accept.js";
-import { COPY } from "./onboarding/copy.js";
-import { FlowHint, StepHeading, WorkingState } from "./onboarding/flow-ui.js";
+import { FlowHint, StepHeading } from "./onboarding/flow-ui.js";
 import { OnboardingFlowContext, type OnboardingFlowValue, type TreeBindingPlan } from "./onboarding/onboarding-flow.js";
 import { OnboardingShell } from "./onboarding/onboarding-shell.js";
 import { StepConnectCode } from "./onboarding/steps/step-connect-code.js";
 import { StepConnectComputer } from "./onboarding/steps/step-connect-computer.js";
 import { StepCreateAgent } from "./onboarding/steps/step-create-agent.js";
 import { StepGetStarted } from "./onboarding/steps/step-get-started.js";
-import { StepStartChat } from "./onboarding/steps/step-start-chat.js";
+import { AgentArrival, StepStartChat } from "./onboarding/steps/step-start-chat.js";
 import { StepTeam } from "./onboarding/steps/step-team.js";
 import { getStepSequence, type OnboardingPath, type StepId } from "./onboarding/steps.js";
 import {
@@ -155,6 +154,25 @@ const INSTALLATION_USER: GithubAppInstallationOutput = {
 
 const NOOP = (): void => {};
 const ASYNC_NOOP = async (): Promise<void> => {};
+const PREVIEW_ARRIVAL_AGENT = {
+  uuid: "01920000-0000-7000-8000-00000000000b",
+  name: "gandy-assistant",
+  displayName: "Gandy's assistant",
+  type: "agent",
+  organizationId: ORG_ID,
+  inboxId: "inbox-1",
+  visibility: "organization",
+  runtimeProvider: "claude-code",
+  status: "active",
+  clientId: HOST.id,
+  avatarImageUrl: null,
+};
+const PREVIEW_LONG_NAME_AGENT = {
+  ...PREVIEW_ARRIVAL_AGENT,
+  uuid: "01920000-0000-7000-8000-00000000000c",
+  name: "customer-platform-reliability-assistant",
+  displayName: "Customer Platform Reliability and Release Coordination Assistant",
+};
 
 // ── Computer-connection fixtures (drive the connect-computer + create-agent steps) ──
 // `selectedRuntime` / `setSelectedRuntime` are made interactive per-scenario in
@@ -837,7 +855,17 @@ export const ONBOARDING_PREVIEW_SCENARIOS: Scenario[] = [
     wizard: {
       step: "start-chat",
       flow: { selectedRepoUrls: [REPO_WEB] },
-      body: <WorkingState label={COPY.startChat.starting} />,
+      body: <AgentArrival agent={PREVIEW_ARRIVAL_AGENT} error={null} onStart={NOOP} phase="starting" />,
+    },
+  },
+  {
+    id: "admin-ko-long-name",
+    label: "Long agent name",
+    group: "Meet-your-agent states",
+    role: "admin",
+    wizard: {
+      step: "start-chat",
+      body: <AgentArrival agent={PREVIEW_LONG_NAME_AGENT} error={null} onStart={NOOP} phase="idle" />,
     },
   },
 
@@ -1319,7 +1347,10 @@ export const ONBOARDING_PREVIEW_SCENARIOS: Scenario[] = [
     label: "Starting…",
     group: "Meet-your-agent states",
     role: "invitee",
-    wizard: { step: "start-chat", body: <WorkingState label={COPY.startChat.starting} /> },
+    wizard: {
+      step: "start-chat",
+      body: <AgentArrival agent={PREVIEW_ARRIVAL_AGENT} error={null} onStart={NOOP} phase="starting" />,
+    },
   },
 ];
 

--- a/packages/web/src/pages/onboarding/__tests__/copy.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/copy.test.ts
@@ -106,49 +106,24 @@ describe("onboarding vocabulary (connect-agent reframe)", () => {
     expect(COPY.createAgent.codingAgentLabel).toBe("This agent will run");
   });
 
-  it("keeps the meet-your-agent finale action-oriented and consistent", () => {
-    expect(COPY.startChat.newTitle).toBe("Meet your agent");
-    expect(COPY.startChat.existingTitle).toBe("Meet your agent");
-    expect(COPY.startChat.noProjectTitle).toBe("Meet your agent");
-    expect(COPY.startChat.inviteeReadyTitle).toBe("Meet your agent");
-    expect(COPY.invitee.notReadyTitle).toBe("Meet your agent");
-
-    expect(COPY.startChat.startBuilding).toBe("Start exploring");
-    expect(COPY.startChat.startExisting).toBe("Start exploring");
-    expect(COPY.startChat.startChatting).toBe("Start exploring");
-    expect(COPY.startChat.startWorking).toBe("Start exploring");
-    expect(COPY.invitee.startAnyway).toBe("Start exploring");
+  it("anchors the finale on the exact agent and explains the next action", () => {
+    expect(COPY.startChat.eyebrow).toBe("YOUR FIRST TREE AGENT");
+    expect(COPY.startChat.title("Nova")).toBe("Meet Nova");
+    expect(COPY.startChat.body("Nova")).toBe(
+      "Nova is ready to explore First Tree with you. Bring a question, a project, or a task you want to move forward.",
+    );
+    expect(COPY.startChat.meetAgent).toBe("Meet your agent");
+    expect(COPY.startChat.nextStepHint).toBe("You’ll open your first Chat and can start typing right away.");
+    expect(COPY.startChat.starting).toBe("Opening your first Chat…");
   });
 
-  it("shows one plain launch subtitle across every start-chat state", () => {
-    // The finale intentionally reads the same regardless of role or team/tree
-    // state: that state is invisible to the user (Context Tree is introduced
-    // later, in chat), so the subtitle stays a single plain launch line.
-    const launch = "Explore First Tree together, then choose what you’d like to try first.";
-    expect(COPY.startChat.noProjectBody).toBe(launch);
-    expect(COPY.startChat.inviteeReadyBody).toBe(launch);
-    expect(COPY.invitee.notReadyBody).toBe(launch);
-    expect(COPY.startChat.newWhy(1)).toBe(launch);
-    expect(COPY.startChat.existingWhy(3)).toBe(launch);
-  });
-
-  it("keeps the launch subtitle free of the Context Tree concept", () => {
+  it("keeps the arrival body free of the Context Tree concept", () => {
     // Requirement: don't name "context" on this screen — it's taught later in chat.
-    for (const s of [COPY.startChat.noProjectBody, COPY.startChat.inviteeReadyBody, COPY.invitee.notReadyBody]) {
-      expect(s.toLowerCase()).not.toContain("context");
-    }
+    expect(COPY.startChat.body("Nova").toLowerCase()).not.toContain("context");
   });
 
   it("does not overpromise repo access on start-chat screens", () => {
-    const strings = [
-      COPY.startChat.newWhy(1),
-      COPY.startChat.newWhy(3),
-      COPY.startChat.existingWhy(1),
-      COPY.startChat.existingWhy(3),
-      COPY.startChat.noProjectBody,
-      COPY.startChat.inviteeReadyBody,
-      COPY.invitee.notReadyBody,
-    ];
+    const strings = [COPY.startChat.body("Nova")];
 
     for (const s of strings) {
       expect(s).not.toContain("It'll read your");

--- a/packages/web/src/pages/onboarding/__tests__/resolve-agent.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/resolve-agent.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedAgent } from "../../../api/agents.js";
+import { writeOnboardingAgentUuid } from "../../../utils/onboarding-flags.js";
+import { resolveOnboardingAgent } from "../resolve-agent.js";
+
+const agentApiMocks = vi.hoisted(() => ({
+  listManagedAgents: vi.fn(),
+}));
+
+vi.mock("../../../api/agents.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/agents.js")>()),
+  listManagedAgents: agentApiMocks.listManagedAgents,
+}));
+
+function managedAgent(overrides: Partial<ManagedAgent> = {}): ManagedAgent {
+  return {
+    uuid: overrides.uuid ?? "01920000-0000-7000-8000-000000000001",
+    name: overrides.name ?? "nova",
+    displayName: overrides.displayName ?? "Nova",
+    type: overrides.type ?? "agent",
+    organizationId: overrides.organizationId ?? "org-1",
+    inboxId: overrides.inboxId ?? "inbox-1",
+    visibility: overrides.visibility ?? "organization",
+    runtimeProvider: overrides.runtimeProvider ?? "codex",
+    clientId: overrides.clientId ?? "client-1",
+    status: overrides.status ?? "active",
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.sessionStorage.clear();
+});
+
+describe("resolveOnboardingAgent", () => {
+  it("restores the exact agent created earlier instead of trusting list order or the flow's default name", async () => {
+    const resumed = managedAgent({
+      uuid: "01920000-0000-7000-8000-000000000001",
+      displayName: "Resumed Agent",
+    });
+    const newer = managedAgent({
+      uuid: "01930000-0000-7000-8000-000000000001",
+      displayName: "Newer Unrelated Agent",
+    });
+    agentApiMocks.listManagedAgents.mockResolvedValue([newer, resumed]);
+    writeOnboardingAgentUuid(resumed.uuid);
+
+    await expect(resolveOnboardingAgent("org-1")).resolves.toEqual(resumed);
+  });
+
+  it("ignores a stashed agent from another team and stays inside the selected organization", async () => {
+    const otherTeam = managedAgent({
+      uuid: "01940000-0000-7000-8000-000000000001",
+      organizationId: "org-2",
+      displayName: "Other Team Agent",
+    });
+    const selectedTeam = managedAgent({
+      uuid: "01930000-0000-7000-8000-000000000001",
+      organizationId: "org-1",
+      displayName: "Selected Team Agent",
+    });
+    agentApiMocks.listManagedAgents.mockResolvedValue([otherTeam, selectedTeam]);
+    writeOnboardingAgentUuid(otherTeam.uuid);
+
+    await expect(resolveOnboardingAgent("org-1")).resolves.toEqual(selectedTeam);
+  });
+});

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -70,12 +70,6 @@ export const STEP_COPY: Record<StepId, StepCopy> = {
   },
 };
 
-/** One plain exploration line for every first-chat finale — admin or invitee,
- *  team ready or not. The page introduces the managed First Tree agent without
- *  exposing repo / Context Tree readiness or turning Chat into the concept the
- *  member has to understand first. */
-const START_CHAT_LAUNCH_WHY = "Explore First Tree together, then choose what you’d like to try first.";
-
 /** Shared phrases reused across steps so wording stays consistent. */
 export const COPY = {
   /** Title shown across the flow's top chrome. */
@@ -251,52 +245,20 @@ export const COPY = {
     templateIntentUnavailable:
       "The template you started from is no longer available — you can still create your agent from scratch.",
   },
-  /** start-chat — one unified "launch" finale across every path. Titles/bodies are
-      rendered per-state by the step; the shell leaves STEP_COPY["start-chat"] empty
-      for this finale. */
+  /** One exact-agent arrival for every personal-agent start-chat path. */
   startChat: {
-    // Every finale below shares one title + one subtitle + one button. The
-    // per-state keys are kept because the step still selects them by path/state,
-    // but they resolve to the same strings on purpose (see START_CHAT_LAUNCH_WHY):
-    // the team/tree difference behind them is invisible to the user, so a
-    // differentiated subtitle only leaked backend readiness they can't act on.
-
-    // admin · new tree (the default — the team has none yet). `newWhy`/`existingWhy`
-    // are only read by the dormant repo-aware branch (StepConnectCode is out of the
-    // live sequence); kept as functions so that call site's shape is unchanged.
-    newTitle: "Meet your agent",
-    newWhy: (_repoCount: number): string => START_CHAT_LAUNCH_WHY,
-    startBuilding: "Start exploring",
-
-    // admin · the team already has a Context Tree (re-run / second admin /
-    // CLI-bound). Detected silently; also part of the dormant repo-aware branch.
-    existingTitle: "Meet your agent",
-    existingWhy: (_repoCount: number): string => START_CHAT_LAUNCH_WHY,
-    startExisting: "Start exploring",
-
-    // admin · no repo connected (the live default path).
-    noProjectTitle: "Meet your agent",
-    noProjectBody: START_CHAT_LAUNCH_WHY,
-    startChatting: "Start exploring",
-
-    // invitee · ready (team has a tree + a GitHub connection). The agent inherits
-    // the team's recommended repos automatically, so there is nothing to select.
-    inviteeReadyTitle: "Meet your agent",
-    inviteeReadyBody: START_CHAT_LAUNCH_WHY,
-    startWorking: "Start exploring",
-
+    eyebrow: "YOUR FIRST TREE AGENT",
+    title: (agentDisplayName: string): string => `Meet ${agentDisplayName}`,
+    body: (agentDisplayName: string): string =>
+      `${agentDisplayName} is ready to explore First Tree with you. Bring a question, a project, or a task you want to move forward.`,
+    meetAgent: "Meet your agent",
+    nextStepHint: "You’ll open your first Chat and can start typing right away.",
+    resolvingAgent: "Finding your agent…",
+    resolveAgentFailed: "We couldn't load your agent just now.",
+    resolveAgentRetry: "Try again",
+    preparing: "Preparing your first Chat…",
     // shared launch transition
     starting: "Opening your first Chat…",
-  },
-  /** Invitee not-ready (blocked-on-admin) state. The not-ready screen covers
-   *  both "no Context Tree" and "no GitHub connection" — the invitee can't act
-   *  on either, and it advances on its own once the admin finishes. */
-  invitee: {
-    notReadyTitle: "Meet your agent",
-    notReadyBody: START_CHAT_LAUNCH_WHY,
-    // The primary action on the not-ready screen — start a simple first chat now
-    // instead of waiting on the team.
-    startAnyway: "Start exploring",
   },
   /** Progressive Member entry: one recommended personal-agent path first,
    *  then Team-agent and external Context access after explicit continuation. */

--- a/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { onlineManager, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeScanFixHandoffFlag } from "../../../../utils/onboarding-flags.js";
+import type { StartChatAgent } from "../../tree-setup-chat.js";
 import { StepStartChat } from "../step-start-chat.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -15,7 +16,7 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 // These tests exercise the `!hasRepos` branch only, matching that live shape.
 
 const flowMock = vi.hoisted(() => ({
-  path: "admin" as const,
+  path: "admin" as "admin" | "invitee",
   organizationId: "org-1" as string | null,
   selectedRepoUrls: [] as string[],
   treeBindingPlan: "createBinding",
@@ -27,20 +28,28 @@ const flowMock = vi.hoisted(() => ({
   reportStepFailure: vi.fn(),
 }));
 
+const inviteeReadinessMocks = vi.hoisted(() => ({
+  getContextTreeSetting: vi.fn(),
+  getGithubAppInstallationExists: vi.fn(),
+  listTeamResourcesForOrg: vi.fn(),
+}));
+
 const resolveAgentMock = vi.hoisted(() => ({
-  resolveOnboardingAgent: vi.fn(async () => ({
-    uuid: "agent-1",
-    name: "agent",
-    displayName: "Cedar",
-    type: "cedar",
-    organizationId: "org-1",
-    inboxId: "inbox-1",
-    visibility: "org",
-    runtimeProvider: "claude",
-    clientId: "client-1",
-    status: "active",
-    avatarImageUrl: null,
-  })),
+  resolveOnboardingAgent: vi.fn(
+    async (): Promise<StartChatAgent> => ({
+      uuid: "agent-1",
+      name: "agent",
+      displayName: "Cedar",
+      type: "cedar",
+      organizationId: "org-1",
+      inboxId: "inbox-1",
+      visibility: "org",
+      runtimeProvider: "claude",
+      clientId: "client-1",
+      status: "active",
+      avatarImageUrl: null,
+    }),
+  ),
 }));
 
 const treeSetupChatMock = vi.hoisted(() => ({
@@ -51,12 +60,37 @@ const treeSetupChatMock = vi.hoisted(() => ({
   ),
 }));
 
+function startChatAgent(overrides: Partial<StartChatAgent> = {}): StartChatAgent {
+  return {
+    uuid: overrides.uuid ?? "agent-1",
+    name: overrides.name ?? "agent",
+    displayName: overrides.displayName ?? "Cedar",
+    type: overrides.type ?? "agent",
+    organizationId: overrides.organizationId ?? "org-1",
+    inboxId: overrides.inboxId ?? "inbox-1",
+    visibility: overrides.visibility ?? "organization",
+    runtimeProvider: overrides.runtimeProvider ?? "claude",
+    clientId: overrides.clientId ?? "client-1",
+    status: overrides.status ?? "active",
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+  };
+}
+
 vi.mock("../../onboarding-flow.js", async () => {
   const actual = await vi.importActual<typeof import("../../onboarding-flow.js")>("../../onboarding-flow.js");
   return { ...actual, useOnboardingFlow: () => flowMock };
 });
 vi.mock("../../resolve-agent.js", () => resolveAgentMock);
 vi.mock("../../tree-setup-chat.js", () => treeSetupChatMock);
+vi.mock("../../../../api/org-settings.js", () => ({
+  getContextTreeSetting: inviteeReadinessMocks.getContextTreeSetting,
+}));
+vi.mock("../../../../api/github-app.js", () => ({
+  getGithubAppInstallationExists: inviteeReadinessMocks.getGithubAppInstallationExists,
+}));
+vi.mock("../../../../api/resources.js", () => ({
+  listTeamResourcesForOrg: inviteeReadinessMocks.listTeamResourcesForOrg,
+}));
 
 function createStorage(): Storage {
   const data = new Map<string, string>();
@@ -80,14 +114,21 @@ let root: Root | null = null;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resolveAgentMock.resolveOnboardingAgent.mockReset();
   document.body.innerHTML = "";
   Object.defineProperty(window, "sessionStorage", { configurable: true, value: createStorage() });
   Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: window.sessionStorage });
   flowMock.organizationId = "org-1";
+  flowMock.path = "admin";
   flowMock.selectedRepoUrls = [];
   flowMock.treeBindingPlan = "createBinding";
   flowMock.treeAutoDetectDone = true;
   flowMock.completeAndEnterChat = vi.fn(async () => undefined);
+  onlineManager.setOnline(true);
+  resolveAgentMock.resolveOnboardingAgent.mockResolvedValue(startChatAgent());
+  inviteeReadinessMocks.getContextTreeSetting.mockResolvedValue({ repo: "https://github.com/acme/context-tree" });
+  inviteeReadinessMocks.getGithubAppInstallationExists.mockResolvedValue(true);
+  inviteeReadinessMocks.listTeamResourcesForOrg.mockResolvedValue([{ type: "repo", scope: "team", status: "active" }]);
   treeSetupChatMock.startOnboardingChat.mockResolvedValue("chat-1");
 });
 
@@ -95,13 +136,15 @@ afterEach(async () => {
   if (root) await act(async () => root?.unmount());
   root = null;
   document.body.innerHTML = "";
+  onlineManager.setOnline(true);
 });
 
-async function renderStep(): Promise<HTMLElement> {
+async function renderStep(
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+): Promise<HTMLElement> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   await act(async () => {
     root?.render(
       <QueryClientProvider client={queryClient}>
@@ -109,12 +152,14 @@ async function renderStep(): Promise<HTMLElement> {
       </QueryClientProvider>,
     );
   });
+  await flush();
   return container;
 }
 
 async function flush(): Promise<void> {
   await act(async () => {
     for (let i = 0; i < 8; i++) await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 }
 
@@ -131,7 +176,158 @@ function expectCall<T>(value: T | undefined): T {
   return value;
 }
 
-describe("AdminStartChat — production-scan fix handoff", () => {
+describe("StepStartChat", () => {
+  it("reveals the exact resolved agent and reuses it for kickoff", async () => {
+    resolveAgentMock.resolveOnboardingAgent.mockResolvedValueOnce(
+      startChatAgent({
+        uuid: "agent-resumed",
+        name: "resumed-agent",
+        displayName: "Resumed Agent",
+        inboxId: "inbox-resumed",
+        runtimeProvider: "codex",
+        avatarImageUrl: "https://avatars.example.test/resumed-agent.png",
+      }),
+    );
+
+    const container = await renderStep();
+    await flush();
+
+    expect(container.textContent).toContain("YOUR FIRST TREE AGENT");
+    expect(container.textContent).toContain("Meet Resumed Agent");
+    expect(container.textContent).toContain(
+      "Resumed Agent is ready to explore First Tree with you. Bring a question, a project, or a task you want to move forward.",
+    );
+    expect(container.textContent).toContain("You’ll open your first Chat and can start typing right away.");
+    expect(container.querySelector('img[alt="Resumed Agent"]')?.getAttribute("src")).toBe(
+      "https://avatars.example.test/resumed-agent.png",
+    );
+
+    clickStart(container);
+    await flush();
+
+    expect(resolveAgentMock.resolveOnboardingAgent).toHaveBeenCalledTimes(1);
+    expect(treeSetupChatMock.startOnboardingChat).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: expect.objectContaining({ uuid: "agent-resumed" }) }),
+    );
+    expect(container.textContent).toContain("Meet Resumed Agent");
+    expect(container.textContent).toContain("Opening your first Chat…");
+  });
+
+  it("shows the same exact-agent arrival for an invitee and preserves its ready kickoff plan", async () => {
+    flowMock.path = "invitee";
+
+    const container = await renderStep();
+    await flush();
+
+    expect(container.textContent).toContain("Meet Cedar");
+    expect(container.textContent).not.toContain("Context Tree");
+    expect(container.textContent).not.toContain("GitHub");
+
+    clickStart(container);
+    await flush();
+
+    expect(resolveAgentMock.resolveOnboardingAgent).toHaveBeenCalledTimes(1);
+    expect(treeSetupChatMock.startOnboardingChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({ uuid: "agent-1" }),
+        joinPath: "invite",
+        treeBindingPlan: "useBoundTree",
+      }),
+    );
+  });
+
+  it("resolves again when the same team re-enters the payoff screen", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    resolveAgentMock.resolveOnboardingAgent
+      .mockResolvedValueOnce(
+        startChatAgent({
+          uuid: "agent-earlier-run",
+          name: "earlier-run",
+          displayName: "Earlier Agent",
+          inboxId: "inbox-earlier-run",
+          runtimeProvider: "codex",
+        }),
+      )
+      .mockResolvedValueOnce(
+        startChatAgent({
+          uuid: "agent-resumed-run",
+          name: "resumed-run",
+          displayName: "Resumed Agent",
+          inboxId: "inbox-resumed-run",
+          runtimeProvider: "codex",
+        }),
+      );
+
+    const first = await renderStep(queryClient);
+    expect(first.textContent).toContain("Meet Earlier Agent");
+
+    await act(async () => root?.unmount());
+    root = null;
+    const resumed = await renderStep(queryClient);
+
+    expect(resolveAgentMock.resolveOnboardingAgent).toHaveBeenCalledTimes(2);
+    expect(resumed.textContent).toContain("Meet Resumed Agent");
+    expect(resumed.textContent).not.toContain("Meet Earlier Agent");
+  });
+
+  it("keeps the revealed target frozen across a network reconnect", async () => {
+    const exactAgent = startChatAgent({ uuid: "agent-frozen", displayName: "Frozen Agent" });
+    resolveAgentMock.resolveOnboardingAgent
+      .mockResolvedValueOnce(exactAgent)
+      .mockResolvedValueOnce(startChatAgent({ uuid: "agent-wrong", displayName: "Wrong Agent" }));
+
+    const container = await renderStep();
+    expect(container.textContent).toContain("Meet Frozen Agent");
+
+    await act(async () => {
+      onlineManager.setOnline(false);
+      onlineManager.setOnline(true);
+    });
+    await flush();
+
+    expect(resolveAgentMock.resolveOnboardingAgent).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("Meet Frozen Agent");
+    expect(container.textContent).not.toContain("Meet Wrong Agent");
+  });
+
+  it("uses the deterministic identicon and keeps a long exact name readable", async () => {
+    const displayName = "A very long agent name that still has to remain fully visible on a narrow onboarding screen";
+    resolveAgentMock.resolveOnboardingAgent.mockResolvedValueOnce(
+      startChatAgent({
+        uuid: "agent-long-name",
+        name: "agent-long-name",
+        displayName,
+        inboxId: "inbox-long-name",
+        runtimeProvider: "codex",
+      }),
+    );
+
+    const container = await renderStep();
+
+    expect(container.textContent).toContain(`Meet ${displayName}`);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector(`[role="img"][aria-label="${displayName}"]`)).not.toBeNull();
+    expect(container.querySelector("h1")?.style.overflowWrap).toBe("anywhere");
+  });
+
+  it("uses neutral, retryable identity resolution states without a working pulse", async () => {
+    resolveAgentMock.resolveOnboardingAgent.mockImplementationOnce(() => new Promise(() => {}));
+    const loading = await renderStep();
+
+    expect(loading.textContent).toContain("Finding your agent…");
+    expect(loading.querySelector(".onboarding-working-dot")).toBeNull();
+
+    await act(async () => root?.unmount());
+    root = null;
+    resolveAgentMock.resolveOnboardingAgent.mockRejectedValueOnce(new Error("offline"));
+    const failed = await renderStep();
+
+    expect(failed.textContent).toContain("We couldn't load your agent just now.");
+    clickStart(failed);
+    await flush();
+    expect(failed.textContent).toContain("Meet Cedar");
+  });
+
   it("sends the scan-fix bootstrap and topic, threads the repo slug, and clears the flag once the chat exists", async () => {
     writeScanFixHandoffFlag({
       repoUrl: "https://github.com/acme/backend",

--- a/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
@@ -1,12 +1,13 @@
 import type { LandingCampaignActionContext } from "@first-tree/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
-import { useEffect, useState } from "react";
+import { type ReactNode, useEffect, useId, useState } from "react";
 import { listOrgGithubRepos } from "../../../api/github.js";
 import { getGithubAppInstallationExists } from "../../../api/github-app.js";
 import type { OnboardingFailureReason } from "../../../api/onboarding-events.js";
 import { getContextTreeSetting } from "../../../api/org-settings.js";
 import { listTeamResourcesForOrg } from "../../../api/resources.js";
+import { Avatar } from "../../../components/avatar.js";
 import { Button } from "../../../components/ui/button.js";
 import { readCampaignActionHandoffFlag, writeCampaignActionHandoffFlag } from "../../../utils/onboarding-flags.js";
 import { getCampaign } from "../../quickstart/campaigns.js";
@@ -17,7 +18,7 @@ import {
   buildValueFirstBootstrap,
 } from "../../workspace/center/onboarding/bootstrap-prose.js";
 import { COPY } from "../copy.js";
-import { FlowHint, StatusRow, StepHeading, WorkingState } from "../flow-ui.js";
+import { FlowHint } from "../flow-ui.js";
 import { type TreeBindingPlan, useOnboardingFlow } from "../onboarding-flow.js";
 import { startChatErrorMessage } from "../provision-tree.js";
 import { resolveOnboardingAgent } from "../resolve-agent.js";
@@ -26,9 +27,8 @@ import { ensureStartChatRepos, type StartChatAgent, startOnboardingChat } from "
 
 /** Shared "create chat + send start-chat bootstrap + finish" sequence for single-chat paths. */
 async function runStartChat(args: {
+  agent: StartChatAgent;
   bootstrap: string | ((agent: StartChatAgent) => string);
-  /** The selected org — scopes agent resolution so the seed never lands on an
-   *  agent from a different org. */
   organizationId: string | null;
   /** Display title for the created chat. */
   topic: string;
@@ -38,10 +38,9 @@ async function runStartChat(args: {
   campaignAction?: LandingCampaignActionContext;
   complete: (chatId: string) => Promise<void>;
 }): Promise<void> {
-  const agent = await resolveOnboardingAgent(args.organizationId);
-  const bootstrap = typeof args.bootstrap === "function" ? args.bootstrap(agent) : args.bootstrap;
+  const bootstrap = typeof args.bootstrap === "function" ? args.bootstrap(args.agent) : args.bootstrap;
   const chatId = await startOnboardingChat({
-    agent,
+    agent: args.agent,
     bootstrap,
     organizationId: args.organizationId,
     topic: args.topic,
@@ -53,13 +52,111 @@ async function runStartChat(args: {
 }
 
 export function StepStartChat() {
-  const { path } = useOnboardingFlow();
-  return path === "admin" ? <AdminStartChat /> : <InviteeStartChat />;
+  const { organizationId, path } = useOnboardingFlow();
+  const resolutionInstance = useId();
+  const agentQuery = useQuery({
+    // Scope the cache to this mounted payoff screen. A later same-org resume
+    // must resolve again instead of rendering an agent cached by an older run.
+    queryKey: ["onboarding", "start-chat-agent", organizationId, resolutionInstance],
+    queryFn: () => resolveOnboardingAgent(organizationId),
+    retry: false,
+    // The reveal and kickoff must stay bound to one exact object for the life
+    // of this screen. A later mount gets a new useId-scoped key and resolves
+    // again, but focus/reconnect cannot silently swap the visible target.
+    staleTime: Number.POSITIVE_INFINITY,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+  });
+
+  if (agentQuery.isPending) {
+    return (
+      <p className="text-label" role="status" style={{ margin: 0, color: "var(--fg-3)" }}>
+        {COPY.startChat.resolvingAgent}
+      </p>
+    );
+  }
+
+  if (agentQuery.isError) {
+    return (
+      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+        <FlowHint tone="error" role="alert">
+          {COPY.startChat.resolveAgentFailed}
+        </FlowHint>
+        <div className="flex">
+          <Button type="button" variant="outline" onClick={() => void agentQuery.refetch()}>
+            {COPY.startChat.resolveAgentRetry}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return path === "admin" ? <AdminStartChat agent={agentQuery.data} /> : <InviteeStartChat agent={agentQuery.data} />;
+}
+
+type AgentArrivalProps = {
+  agent: StartChatAgent;
+  error: string | null;
+  onStart: () => void;
+  phase: "idle" | "starting";
+  preparing?: boolean;
+};
+
+export function AgentArrival({ agent, error, onStart, phase, preparing = false }: AgentArrivalProps): ReactNode {
+  const displayName = agent.displayName.trim() || agent.name || "Your agent";
+  const starting = phase === "starting";
+
+  return (
+    <div
+      className="flex min-w-0 flex-col"
+      data-agent-arrival
+      aria-busy={starting || preparing}
+      style={{ gap: "var(--sp-6)" }}
+    >
+      <div className="flex min-w-0 flex-col" style={{ gap: "var(--sp-4)" }}>
+        <Avatar src={agent.avatarImageUrl} name={displayName} seed={agent.uuid} size={64} className="shrink-0" />
+        <div className="flex min-w-0 flex-col" style={{ gap: "var(--sp-2_5)" }}>
+          <p className="text-eyebrow" style={{ margin: 0, color: "var(--fg-3)" }}>
+            {COPY.startChat.eyebrow}
+          </p>
+          <h1 className="text-title font-semibold" style={{ margin: 0, color: "var(--fg)", overflowWrap: "anywhere" }}>
+            {COPY.startChat.title(displayName)}
+          </h1>
+          <p className="text-body" style={{ margin: 0, color: "var(--fg-3)", overflowWrap: "anywhere" }}>
+            {COPY.startChat.body(displayName)}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-col" style={{ gap: "var(--sp-3)" }}>
+        {error && (
+          <FlowHint tone="error" role="alert">
+            {error}
+          </FlowHint>
+        )}
+        <div className="flex">
+          <Button type="button" variant="cta" onClick={onStart} disabled={starting || preparing}>
+            <span>{COPY.startChat.meetAgent}</span>
+            <ArrowRight className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </div>
+        <p
+          className="text-label"
+          role={starting || preparing ? "status" : undefined}
+          aria-live={starting || preparing ? "polite" : undefined}
+          style={{ margin: 0, color: "var(--fg-4)" }}
+        >
+          {starting ? COPY.startChat.starting : preparing ? COPY.startChat.preparing : COPY.startChat.nextStepHint}
+        </p>
+      </div>
+    </div>
+  );
 }
 
 // ── Admin ───────────────────────────────────────────────────────────────
 
-function AdminStartChat() {
+function AdminStartChat({ agent }: { agent: StartChatAgent }) {
   const {
     organizationId,
     selectedRepoUrls,
@@ -87,7 +184,6 @@ function AdminStartChat() {
   // branches below stay dormant — kept intact for when/if a GitHub connect step
   // is re-added to onboarding.
   const hasRepos = selectedRepoUrls.length > 0;
-  const repoCount = selectedRepoUrls.length;
 
   // Silently detect a bound team Context Tree (a re-run / second admin /
   // CLI-bound tree). There is no "paste your tree URL" path anymore. Detection
@@ -110,8 +206,6 @@ function AdminStartChat() {
     setTreeBindingPlan("useBoundTree");
   }, [detectedTreeUrl, setTreeUrl, setTreeBindingPlan, treeAutoDetectDone, markTreeAutoDetectDone]);
 
-  const canStart = phase === "form";
-
   const handleStart = async (): Promise<void> => {
     setError(null);
     setPhase("starting");
@@ -119,6 +213,7 @@ function AdminStartChat() {
     try {
       if (!hasRepos) {
         await runStartChat({
+          agent,
           bootstrap: (agent) =>
             campaignActionHandoff && campaignActionConfig
               ? buildCampaignActionBootstrap(
@@ -188,6 +283,7 @@ function AdminStartChat() {
       // provisioning a tree from repos the app can no longer access.
       if (repos.length === 0) {
         await runStartChat({
+          agent,
           bootstrap: (agent) => buildNoRepoBootstrap(agent.displayName || "your agent"),
           organizationId,
           topic: "Get started with First Tree",
@@ -205,7 +301,6 @@ function AdminStartChat() {
 
       const useBoundTree = treeBindingPlan === "useBoundTree";
       const resolvedTreeBindingPlan = useBoundTree ? "useBoundTree" : "none";
-      const agent = await resolveOnboardingAgent(organizationId);
       failureReason = "repo_resource_sync_failed";
       await ensureStartChatRepos(organizationId, repos);
 
@@ -230,66 +325,23 @@ function AdminStartChat() {
     }
   };
 
-  if (phase === "starting") return <StartingState />;
-
-  // No repo connected is now a normal value-first path. The user can start
-  // chatting and share a project path or GitHub URL in the agent chat; GitHub
-  // access is no longer a required onboarding chore.
-  if (!hasRepos) {
-    return (
-      <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-        <StepHeading title={COPY.startChat.noProjectTitle} why={COPY.startChat.noProjectBody} />
-        <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-          {error && (
-            <FlowHint tone="error" role="alert">
-              {error}
-            </FlowHint>
-          )}
-          <div className="flex">
-            <Button type="button" variant="cta" onClick={() => void handleStart()} disabled={!canStart}>
-              <span>{COPY.startChat.startChatting}</span>
-              <ArrowRight className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Wait for the bound-tree probe so we don't flash "create" then flip to
-  // "bound".
-  if (treeSettingQuery.isLoading) {
-    return <StatusRow state="waiting" label="Checking your team's setup…" />;
-  }
-
-  const usesBoundTree = treeBindingPlan === "useBoundTree";
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      <StepHeading
-        title={usesBoundTree ? COPY.startChat.existingTitle : COPY.startChat.newTitle}
-        why={usesBoundTree ? COPY.startChat.existingWhy(repoCount) : COPY.startChat.newWhy(repoCount)}
-      />
-      <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
-        {error && (
-          <FlowHint tone="error" role="alert">
-            {error}
-          </FlowHint>
-        )}
-        <div className="flex">
-          <Button type="button" variant="cta" onClick={() => void handleStart()} disabled={!canStart}>
-            <span>{usesBoundTree ? COPY.startChat.startExisting : COPY.startChat.startBuilding}</span>
-            <ArrowRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-    </div>
+    <AgentArrival
+      agent={agent}
+      error={error}
+      onStart={() => void handleStart()}
+      phase={phase === "starting" ? "starting" : "idle"}
+      preparing={hasRepos && treeSettingQuery.isLoading}
+    />
   );
 }
 
 // ── Invitee ─────────────────────────────────────────────────────────────
 
-function InviteeStartChat() {
-  const { organizationId } = useOnboardingFlow();
+function InviteeStartChat({ agent }: { agent: StartChatAgent }) {
+  const { organizationId, completeAndEnterChat, reportStepFailure } = useOnboardingFlow();
+  const [phase, setPhase] = useState<"idle" | "starting">("idle");
+  const [error, setError] = useState<string | null>(null);
   // This is the member's already-selected managed-agent path. Readiness here
   // controls only the first First Tree chat; optional external Context access
   // is not part of this managed-agent path.
@@ -336,42 +388,21 @@ function InviteeStartChat() {
     },
   });
 
-  if (teamQuery.isLoading) {
-    return <StatusRow state="waiting" label="Checking what your team has set up…" />;
-  }
-
-  // Read failure → not-ready; the query keeps polling so a transient blip
-  // resolves on its own.
-  if (teamQuery.isError || !teamQuery.data) {
-    return <InviteeNotReady />;
-  }
-
-  const { treeUrl, hasInstallation, installationKnown, hasCodeRepository } = teamQuery.data;
+  const { treeUrl, hasInstallation, installationKnown, hasCodeRepository } = teamQuery.data ?? {
+    treeUrl: "",
+    hasInstallation: false,
+    installationKnown: false,
+    hasCodeRepository: false,
+  };
   // "ready" requires an AUTHORITATIVE install=true. `hasInstallation` is optimistic
   // on a failed probe (null → true) so the query keeps polling instead of flapping
   // — but we must NOT render the ready launch (which reads the tree and would 403
-  // without an installation) until the probe actually confirms one. Until then,
-  // not-ready holds: it offers a simple first chat (no git op, no 403) and keeps
-  // polling, so it advances to ready on its own once install is confirmed.
+  // without an installation) until the probe actually confirms one. Until then
+  // the shared arrival keeps the launch in its no-repo mode and the
+  // query keeps polling, so the exact same surface advances quietly once the
+  // provider capability is confirmed.
   const installed = installationKnown && hasInstallation;
-  return resolveInviteeStartChatState({ treeUrl, hasInstallation: installed }) === "ready" && hasCodeRepository ? (
-    <InviteeReady />
-  ) : (
-    <InviteeNotReady />
-  );
-}
-
-/**
- * Invitee · ready to launch. The team has a Context Tree and the provider
- * capability needed by the managed first chat, so the agent already inherits
- * the team's `recommended` repo resources automatically (they're enabled for
- * every org agent). This is the member's selected First Tree path; optional
- * external Context access is not replayed here.
- */
-function InviteeReady() {
-  const { organizationId, completeAndEnterChat, reportStepFailure } = useOnboardingFlow();
-  const [phase, setPhase] = useState<"idle" | "starting">("idle");
-  const [error, setError] = useState<string | null>(null);
+  const ready = resolveInviteeStartChatState({ treeUrl, hasInstallation: installed }) === "ready" && hasCodeRepository;
 
   const handleStart = async (): Promise<void> => {
     setError(null);
@@ -381,10 +412,11 @@ function InviteeReady() {
       // chat is value-first: read the team's tree/recommended repos, show
       // concrete understanding, then ask which useful first task to do.
       await runStartChat({
+        agent,
         bootstrap: (agent) => buildInviteeReadyBootstrap(agent.displayName || "your agent"),
         organizationId,
         topic: "Get settled on First Tree",
-        treeBindingPlan: "useBoundTree",
+        treeBindingPlan: ready ? "useBoundTree" : "none",
         joinPath: "invite",
         complete: async (chatId) => {
           // Scan-fix handoffs are consumed by the admin fix path only — drop
@@ -401,97 +433,13 @@ function InviteeReady() {
     }
   };
 
-  if (phase === "starting") return <StartingState />;
-
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      <StepHeading title={COPY.startChat.inviteeReadyTitle} why={COPY.startChat.inviteeReadyBody} />
-      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        {error && (
-          <FlowHint tone="error" role="alert">
-            {error}
-          </FlowHint>
-        )}
-        <div className="flex">
-          <Button type="button" variant="cta" onClick={() => void handleStart()}>
-            <span>{COPY.startChat.startWorking}</span>
-            <ArrowRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-    </div>
+    <AgentArrival
+      agent={agent}
+      error={error}
+      onStart={() => void handleStart()}
+      phase={phase}
+      preparing={teamQuery.isLoading}
+    />
   );
-}
-
-/**
- * Invitee · the managed first chat isn't ready yet. This can be an Admin-owned
- * Context/Team-repository gap or only the legacy GitHub capability gap.
- * Missing Team setup stays out of the finale because a member cannot fix it
- * here, and optional external Context access is not replayed after this First
- * Tree path was selected.
- *
- * The primary action starts a real first chat with the agent. Routing it through
- * `completeAndEnterChat` — not `finishLater` — means the button lands the user
- * in a real chat WITH the agent, instead of dropping them into an empty workspace.
- */
-function InviteeNotReady() {
-  const { organizationId, completeAndEnterChat, reportStepFailure } = useOnboardingFlow();
-  const [phase, setPhase] = useState<"idle" | "starting">("idle");
-  const [error, setError] = useState<string | null>(null);
-
-  const handleMeet = async (): Promise<void> => {
-    setError(null);
-    setPhase("starting");
-    try {
-      await runStartChat({
-        bootstrap: (agent) => buildInviteeReadyBootstrap(agent.displayName || "your agent"),
-        organizationId,
-        topic: "Get settled on First Tree",
-        treeBindingPlan: "none",
-        joinPath: "invite",
-        complete: async (chatId) => {
-          // Scan-fix handoffs are consumed by the admin fix path only — drop
-          // any stale flag once a non-fix first chat exists, so a later
-          // onboarding run in this tab cannot consume someone else's scan.
-          writeCampaignActionHandoffFlag(null);
-          await completeAndEnterChat(chatId);
-        },
-      });
-    } catch (err) {
-      setError(startChatErrorMessage(err, COPY.errors.chatFailed));
-      setPhase("idle");
-      reportStepFailure("start_chat_failed", { step: "start-chat" });
-    }
-  };
-
-  if (phase === "starting") return <StartingState />;
-
-  return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      <StepHeading title={COPY.invitee.notReadyTitle} why={COPY.invitee.notReadyBody} />
-      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        {error && (
-          <FlowHint tone="error" role="alert">
-            {error}
-          </FlowHint>
-        )}
-        {/* The primary action is not an escape hatch: the common not-ready case
-            (admin finished without a tree) never resolves, so the real path
-            forward is to start now. If the team does finish, the page still
-            advances on its own — quietly, no longer announced. */}
-        <div className="flex">
-          <Button type="button" variant="cta" onClick={() => void handleMeet()}>
-            <span>{COPY.invitee.startAnyway}</span>
-            <ArrowRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── shared ──────────────────────────────────────────────────────────────
-
-function StartingState() {
-  return <WorkingState label={COPY.startChat.starting} />;
 }


### PR DESCRIPTION
## Summary

- replace the generic onboarding finale with a shared exact-agent arrival for Admin and Invitee personal-agent paths
- reveal the resolved agent's avatar or identicon, display name, invitation, single CTA, and first-Chat expectation
- resolve the target once per mounted payoff screen and reuse that exact object for kickoff without reconnect/focus refetch swaps
- keep readiness differences behind the shared surface while preserving existing tree-binding, scan-fix, orientation, and completion behavior
- add production-backed preview states for starting and long-name review

## Validation

- `pnpm check`
- `pnpm typecheck` (includes the Web production build)
- `pnpm test`
- focused onboarding regression suite: 83 tests passed
- exact-agent and reconnect/remount coverage: 11 tests passed
- exact-head Playwright preview checks for Admin and Invitee, desktop and 320px, light and dark themes, long names, starting identity, keyboard focus, and reduced motion

## Product boundary

This remains the value-first start-chat payoff. It does not change Team-agent quick start, External BYO Context, kickoff kinds or idempotency, first-Chat orientation, onboarding completion/resume semantics, or capability ownership. Repo, Context Tree, and provider readiness remain outside the arrival copy.

The implementation follows the durable onboarding constraints in [`system/cloud/onboarding.md`](https://github.com/agent-team-foundation/first-tree-context/blob/7c113cfa5f54181e93a80344bb62d4af2f23e4d5/system/cloud/onboarding.md).

## Review

- Standards: no blockers on final staged diff
- Spec: no blockers on final staged diff
