### PR TITLE
feat(web): add own-agent entry to team switcher

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -92,7 +92,7 @@ the local stack and the local tests do not touch staging.
 | Test | Env | Covers |
 | --- | --- | --- |
 | `registration-new-user.test.yaml` | local | A brand-new account is created and lands on onboarding step 1 |
-| `onboarding-complete-setup.test.yaml` | local | The whole first-run journey: sign up → create team → connect a computer → create the first agent → start the kickoff chat → land in the workspace |
+| `onboarding-complete-setup.test.yaml` | local | The whole first-run journey: sign up → create team → connect a computer → create the first agent → start the kickoff chat → land in the workspace → open the Team-scoped own-agent setup path |
 | `dev-cloud-sign-in-available.test.yaml` | first-tree-dev-cloud | Staging serves the landing page and offers Google + GitHub sign-in |
 
 `modules/sign-up-fresh-user.module.yaml` holds the shared sign-up flow. Each run

--- a/e2e/onboarding-complete-setup.test.yaml
+++ b/e2e/onboarding-complete-setup.test.yaml
@@ -43,6 +43,17 @@ steps:
       whose first message asks the user's new assistant agent for help getting
       started, and a message composer addressed to that agent is available
 
+  # ── Team switcher — external-agent entry stays Team-scoped ────────────────
+  - click: current team selector in the header
+  - assert: the open team menu shows Use your own agent in the Current team
+      section, keeps Create team under Add team, and has no Join with invite
+      link action
+  - click: Use your own agent menu item
+  - waitForUrl: /settings/context#coding-agent-access
+  - assert: the Context Tree settings page is open at the Coding-agent access
+      section, where the new Team cannot configure personal coding-agent access
+      until it has a valid Context Tree binding
+
   # ── Settings — the permanent readiness overview keeps its stable route ────
   - click: Settings link in the top navigation
   - waitForUrl: /settings/account

--- a/packages/qa/cases/cross-surface/registration-first-run-onboarding.md
+++ b/packages/qa/cases/cross-surface/registration-first-run-onboarding.md
@@ -20,7 +20,10 @@ the admin first-run journey to a usable workspace:
 - the create-agent step binds the agent to that client and waits for it to come
   online before offering to start;
 - the kickoff chat is created once and the user lands in the workspace with
-  onboarding stamped complete.
+  onboarding stamped complete;
+- from that workspace, the current Team menu exposes the Team-scoped path for
+  using an external agent without taking configuration ownership away from
+  Settings.
 
 Deterministic tests own copy, field rendering, per-step readiness logic, and the
 kickoff contract itself. This case owns what those tests cannot prove: that the
@@ -76,11 +79,19 @@ first user, who becomes an admin and creates the team.
    the kickoff chat exists exactly once, its first message addresses the new
    agent, and the membership carries `onboarding_completed_at` with
    `onboarding_suppressed_reason='completed'`.
+8. Open the current Team menu. Verify **Use your own agent** appears in the
+   **Current team** section, **Create team** remains under **Add team**, and no
+   manual **Join with invite link** action is offered there. Activate the new
+   action and verify it lands on
+   `/settings/context#coding-agent-access`, where the Context Tree settings page
+   owns the coding-agent access state. This menu check does not replace the
+   separate `/invite/:token` join-path contract.
 
 ## Evidence
 
 A credible result names the identity used, shows the workspace landing with the
-kickoff chat, and quotes the membership row's onboarding stamps. For any gate
+kickoff chat, quotes the membership row's onboarding stamps, and shows the
+current Team menu plus the resulting coding-agent access URL. For any gate
 claimed to have blocked, show the disabled state, not only the later success.
 
 ## Limitations
@@ -96,7 +107,7 @@ claimed to have blocked, show the disabled state, not only the later success.
 
 ## Optional executable aid
 
-`e2e/` holds a Momentic browser suite that walks steps 1–7 unattended and is
+`e2e/` holds a Momentic browser suite that walks steps 1–8 unattended and is
 useful for a quick regression pass. It is optional tooling, not a replacement for
 this case: it needs an external Momentic account, resolves steps through a hosted
 model, and covers only the happy path plus the connect-computer gate. Judgement

--- a/packages/web/src/components/__tests__/layout-ask-agent-lock-dom.test.tsx
+++ b/packages/web/src/components/__tests__/layout-ask-agent-lock-dom.test.tsx
@@ -357,12 +357,12 @@ describe("Layout Ask agent navigation lock", () => {
     expect(trigger()?.disabled).toBe(true);
 
     // Every surface-leaving row is VISIBLY inert — not only handler-guarded:
-    // the other-team switch row, Leave, Create, Join, Invite.
+    // the other-team switch row, Leave, Create, own-agent setup, and Invite.
     const teamTwoRow = menuItemByText(container, "Team Two");
     expect(teamTwoRow?.disabled).toBe(true);
     const createRow = menuItemByText(container, "Create team");
     expect(createRow?.disabled).toBe(true);
-    expect(menuItemByText(container, "Join with invite link")?.disabled).toBe(true);
+    expect(menuItemByText(container, "Use your own agent")?.disabled).toBe(true);
     expect(menuItemByText(container, "Leave team")?.disabled).toBe(true);
     expect(menuItemByText(container, "Invite teammates")?.disabled).toBe(true);
 
@@ -373,11 +373,12 @@ describe("Layout Ask agent navigation lock", () => {
     expect(locationText(container)).toBe("/?review=need-you");
     expect(container.querySelector('[data-testid="workspace-surface"]')).not.toBeNull();
 
-    // Create/Join cannot reach the setup modal (whose success path calls
-    // selectOrganization and navigates to /onboarding).
+    // Create cannot reach the setup modal (whose success path calls
+    // selectOrganization and navigates to /onboarding), and own-agent setup
+    // cannot leave the current work surface.
     await click(createRow);
     expect(document.body.textContent).not.toContain("Create a new team");
-    expect(document.body.textContent).not.toContain("Join a team");
+    await click(menuItemByText(container, "Use your own agent"));
     expect(authMock.value.selectOrganization).not.toHaveBeenCalled();
     expect(locationText(container)).toBe("/?review=need-you");
 

--- a/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
+++ b/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
@@ -202,7 +202,12 @@ function Harness({
 
 function LocationProbe() {
   const location = useLocation();
-  return <span data-testid="location">{location.pathname}</span>;
+  return (
+    <>
+      <span data-testid="location">{location.pathname}</span>
+      <span data-testid="location-hash">{location.hash}</span>
+    </>
+  );
 }
 
 async function renderHarness(
@@ -245,19 +250,22 @@ describe("TeamSwitcher", () => {
     expect(container.textContent).not.toContain("· current team");
     expect(container.textContent).toContain("Admin");
     const inviteAction = buttonByText(container, "Invite teammates");
+    const ownAgentAction = buttonByText(container, "Use your own agent");
     const leaveAction = buttonByText(container, "Leave team");
     expect(inviteAction).not.toBeNull();
+    expect(ownAgentAction).not.toBeNull();
     expect(leaveAction).not.toBeNull();
-    if (!inviteAction || !leaveAction) throw new Error("Current-team actions missing");
-    expect(inviteAction.compareDocumentPosition(leaveAction) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    if (!inviteAction || !ownAgentAction || !leaveAction) throw new Error("Current-team actions missing");
+    expect(inviteAction.compareDocumentPosition(ownAgentAction) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(ownAgentAction.compareDocumentPosition(leaveAction) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(container.textContent).toContain("Switch team");
     expect(buttonByText(container, "Globex")).not.toBeNull();
     expect(buttonByText(container, "Initech")).not.toBeNull();
     // The current team is in the header, not the switch list.
     expect(buttonByText(container, "Globex")?.getAttribute("role")).toBe("menuitem");
-    expect(container.textContent).toContain("Add or join");
+    expect(container.textContent).toContain("Add team");
     expect(buttonByText(container, "Create team")).not.toBeNull();
-    expect(buttonByText(container, "Join with invite link")).not.toBeNull();
+    expect(buttonByText(container, "Join with invite link")).toBeNull();
     const roleBadges = [...container.querySelectorAll<HTMLElement>(".mono")];
     expect(roleBadges).toHaveLength(2);
     expect(roleBadges.every((badge) => badge.style.background === "var(--bg-sunken)")).toBe(true);
@@ -273,14 +281,14 @@ describe("TeamSwitcher", () => {
 
     const rows = [
       buttonByText(container, "Invite teammates"),
+      buttonByText(container, "Use your own agent"),
       buttonByText(container, "Leave team"),
       buttonByText(container, "Globex"),
       buttonByText(container, "Create team"),
-      buttonByText(container, "Join with invite link"),
     ];
     if (rows.some((row) => !row)) throw new Error("menu action rows missing");
 
-    // One shared row grid across Current team / Switch team / Add or join:
+    // One shared row grid across Current team / Switch team / Add team:
     // same gutter, icon column, and full-bleed hover hit area — no
     // Current-team-only inset, rounding, or extra row spacing.
     const rowClasses = new Set(rows.flatMap((row) => (row ? [row.className] : [])));
@@ -294,7 +302,7 @@ describe("TeamSwitcher", () => {
 
     // All three section eyebrows share the same section padding.
     const eyebrows = [...container.querySelectorAll<HTMLElement>(".text-eyebrow")];
-    expect(eyebrows.map((eyebrow) => eyebrow.textContent)).toEqual(["Current team", "Switch team", "Add or join"]);
+    expect(eyebrows.map((eyebrow) => eyebrow.textContent)).toEqual(["Current team", "Switch team", "Add team"]);
     expect(new Set(eyebrows.map((eyebrow) => eyebrow.style.padding)).size).toBe(1);
 
     await act(async () => root.unmount());
@@ -411,7 +419,7 @@ describe("TeamSwitcher", () => {
     expect(document.activeElement).toBe(buttonByText(container, "Invite teammates"));
 
     await keyDown(menu, "End");
-    expect(document.activeElement).toBe(buttonByText(container, "Join with invite link"));
+    expect(document.activeElement).toBe(buttonByText(container, "Create team"));
 
     await keyDown(menu, "Home");
     expect(document.activeElement).toBe(buttonByLabel(container, "Rename team"));
@@ -510,7 +518,7 @@ describe("TeamSwitcher", () => {
     await act(async () => root.unmount());
   });
 
-  it("opens team management actions and invite affordances from the menu", async () => {
+  it("opens team creation, own-agent settings, and invite affordances from the menu", async () => {
     const { container, root } = await renderHarness(vi.fn(async () => {}));
 
     await click(anchorOf(container));
@@ -518,8 +526,10 @@ describe("TeamSwitcher", () => {
     expect(anchorOf(container).getAttribute("aria-expanded")).toBe("false");
 
     await click(anchorOf(container));
-    await click(buttonByText(container, "Join with invite link"));
+    await click(buttonByText(container, "Use your own agent"));
     expect(anchorOf(container).getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/settings/context");
+    expect(container.querySelector('[data-testid="location-hash"]')?.textContent).toBe("#coding-agent-access");
 
     await click(anchorOf(container));
     await click(buttonByText(container, "Invite teammates"));

--- a/packages/web/src/components/team-switcher.tsx
+++ b/packages/web/src/components/team-switcher.tsx
@@ -1,6 +1,6 @@
 import type { Organization, OrgBrief } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, Link2, Loader2, LogOut, Pencil, Plus, UserPlus } from "lucide-react";
+import { Bot, ChevronDown, Loader2, LogOut, Pencil, Plus, UserPlus } from "lucide-react";
 import { type FormEvent, type KeyboardEvent as ReactKeyboardEvent, useEffect, useId, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { api } from "../api/client.js";
@@ -21,10 +21,10 @@ import { Input } from "./ui/input.js";
 // frame. Tunable by feel during QA.
 const MIN_SHOW_MS = 300;
 
-// One row grid for every menu action (Invite / Leave / Switch / Create /
-// Join): same gutter, same icon column, same full-bleed hover hit area,
-// so the groups can't drift apart again. Per-row color and disabled opacity
-// stay on the row's own `style`.
+// One row grid for every menu action (Invite / own agent / Leave / Switch /
+// Create): same gutter, same icon column, same full-bleed hover hit area, so
+// the groups can't drift apart again. Per-row color and disabled opacity stay
+// on the row's own `style`.
 const MENU_ROW_CLASS =
   "flex w-full items-center gap-2 px-3.5 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]";
 
@@ -32,8 +32,9 @@ const MENU_ROW_CLASS =
  * Header-left team anchor: the always-present "which team am I in" marker and
  * the entry point for switching teams + team management. Consolidates the
  * team half of the old right-side user menu — the org list, `selectOrganization`,
- * Create / Join / Invite entries, and the `TeamSetupModal` / `InviteDialog`
- * mounts all live here now; the avatar menu is account-only.
+ * Create / Invite entries, the external-agent setup shortcut, and the
+ * `TeamSetupModal` / `InviteDialog` mounts all live here now; the avatar menu
+ * is account-only.
  *
  * One state drives the whole switch (`switchingOrg`, from `auth-context`): the
  * picked row spins + the rest of the list disables, the anchor optimistically
@@ -64,14 +65,14 @@ export function TeamSwitcher({
   } = useAuth();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  // While an Ask agent attempt is pending, team switching/leaving clears
-  // org-scoped caches and navigates — destroying the attempt's owning
-  // surface. The trigger goes inert and the switch/leave actions re-check
-  // the lock imperatively (a menu opened before the attempt started).
+  // While an Ask agent attempt is pending, surface-leaving actions either
+  // navigate or clear org-scoped caches — destroying the attempt's owning
+  // surface. The trigger goes inert and every such action re-checks the lock
+  // imperatively (a menu opened before the attempt started).
   const askAgentNavLocked = useAskAgentNavLocked();
   const [open, setOpen] = useState(false);
   const [inviteOpen, setInviteOpen] = useState(false);
-  const [setupAction, setSetupAction] = useState<"create" | "join" | null>(null);
+  const [setupAction, setSetupAction] = useState<"create" | null>(null);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [leaveConfirmOpen, setLeaveConfirmOpen] = useState(false);
   const [renameDraft, setRenameDraft] = useState("");
@@ -373,7 +374,7 @@ export function TeamSwitcher({
             className="absolute left-0 z-[46] mt-2 overflow-hidden rounded-[var(--radius-panel)] border bg-popover shadow-[var(--shadow-md)]"
             style={{ width: "var(--sp-70)", borderColor: "var(--border)" }}
           >
-            {/* ① Current team identity and membership actions — always shown. */}
+            {/* ① Current team identity and actions — always shown. */}
             <div role="presentation" className="border-b pb-1" style={{ borderColor: "var(--border)" }}>
               <div
                 aria-hidden="true"
@@ -430,6 +431,24 @@ export function TeamSwitcher({
               >
                 <UserPlus className="h-3.5 w-3.5" />
                 <span>Invite teammates</span>
+              </button>
+              {/* TeamSwitcher preserves the active-Team context; Settings owns
+                  the actual external-agent Context Tree configuration. */}
+              <button
+                type="button"
+                role="menuitem"
+                tabIndex={-1}
+                disabled={askAgentNavLocked}
+                onClick={() => {
+                  if (isAskAgentNavLocked()) return;
+                  setOpen(false);
+                  navigate("/settings/context#coding-agent-access");
+                }}
+                className={MENU_ROW_CLASS}
+                style={{ color: "var(--fg)", opacity: askAgentNavLocked ? 0.5 : undefined }}
+              >
+                <Bot className="h-3.5 w-3.5" />
+                <span>Use your own agent</span>
               </button>
               <button
                 type="button"
@@ -506,18 +525,19 @@ export function TeamSwitcher({
               </div>
             )}
 
-            {/* ③ Add or join — always shown. Create/Join complete via
-                `TeamSetupModal`'s `selectOrganization` + `/onboarding` navigation,
-                so they are guarded exactly like the switch rows: inert while a
-                pending Ask agent attempt owns the surface, plus an imperative
-                re-check at the action boundary. */}
+            {/* ③ Add team — always shown. Create completes via `TeamSetupModal`'s
+                `selectOrganization` + `/onboarding` navigation, so it is guarded
+                exactly like the switch rows: inert while a pending Ask agent
+                attempt owns the surface, plus an imperative re-check at the
+                action boundary. Invite recipients join through the shared
+                `/invite/:token` URL instead of pasting that URL back into Web. */}
             <div role="presentation" className="py-1">
               <div
                 aria-hidden="true"
                 className="text-eyebrow"
                 style={{ color: "var(--fg-3)", padding: "var(--sp-1_25) var(--sp-3_5) var(--sp-0_75)" }}
               >
-                Add or join
+                Add team
               </div>
               <button
                 type="button"
@@ -534,22 +554,6 @@ export function TeamSwitcher({
               >
                 <Plus className="h-3.5 w-3.5" />
                 <span>Create team</span>
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                tabIndex={-1}
-                disabled={askAgentNavLocked}
-                onClick={() => {
-                  if (isAskAgentNavLocked()) return;
-                  setOpen(false);
-                  setSetupAction("join");
-                }}
-                className={MENU_ROW_CLASS}
-                style={{ color: "var(--fg)", opacity: askAgentNavLocked ? 0.5 : undefined }}
-              >
-                <Link2 className="h-3.5 w-3.5" />
-                <span>Join with invite link</span>
               </button>
             </div>
           </div>

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -17,9 +17,9 @@ const PARENT_URL = "https://first-tree.ai";
  * Right-side account menu. Avatar trigger; dropdown shows the signed-in user
  * and account actions.
  *
- * Team switching and team management (the org list, Create / Join / Invite)
- * moved to the header-left `TeamSwitcher` — team and account are now separate
- * surfaces (team on the left, account on the right).
+ * Team switching and team management (the org list, Create / Invite, and the
+ * own-agent setup shortcut) moved to the header-left `TeamSwitcher` — team and
+ * account are now separate surfaces (team on the left, account on the right).
  */
 export function UserMenu() {
   const { user, logout } = useAuth();

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1540,7 +1540,7 @@ describe("web DOM interaction coverage", () => {
     await unmountRoot(plain.root);
   });
 
-  it("switches orgs and opens setup actions from the TeamSwitcher, and signs out from the UserMenu", async () => {
+  it("switches orgs and exposes focused setup actions from the TeamSwitcher, and signs out from the UserMenu", async () => {
     clientApiMocks.post.mockResolvedValue({});
     const { TeamSwitcher } = await import("../../components/team-switcher.js");
     const { UserMenu } = await import("../../components/user-menu.js");
@@ -1580,12 +1580,8 @@ describe("web DOM interaction coverage", () => {
     await waitForText("Create", document.body);
 
     await click(switcher.container.querySelector('button[aria-haspopup="menu"]'));
-    await click(
-      [...switcher.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Join with invite link"),
-      ) ?? null,
-    );
-    await waitForText("Join", document.body);
+    expect(switcher.container.textContent).toContain("Use your own agent");
+    expect(switcher.container.textContent).not.toContain("Join with invite link");
 
     // The avatar menu is account-only: no team rows, with a permanent mobile
     // handoff alongside account settings and sign-out.


### PR DESCRIPTION
## Summary

- add a Team-scoped **Use your own agent** shortcut to Context Tree settings
- remove the manual invite-link paste action from the Team Switcher while preserving direct invite URLs and no-team recovery
- simplify the lower menu section to **Add team** with **Create team**
- cover the menu, navigation-lock, deep-link, and onboarding behavior in deterministic tests and the committed cross-surface QA case

## Validation

- eight focused Web Vitest files — 158/158 passed
- `pnpm --filter @first-tree/web test` — 2161 passed
- `pnpm --filter @first-tree/web typecheck` — passed
- `pnpm --filter @first-tree/web build` — passed
- `pnpm check` — passed (existing non-blocking warnings only)
- Momentic lint for both committed E2E tests — passed
- exact merge-head Momentic local E2E — 2/2 passed and uploaded: https://app.momentic.ai/run-groups/2561b7de-11cb-42c0-9a75-2b7f0c14f9f1

## Review

- independent code review: passed after aligning the QA case and stale comments
- independent product/UX review: passed with no findings
- merged current `main` without rebasing, preserved both E2E entries introduced across the branches, and aligned the onboarding contract with the canonical **Coding agent setup** heading
