### PR TITLE
fix: pin CapRover deploy CLI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,13 +86,17 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment: production
     steps:
-      - name: Deploy to CapRover
-        uses: caprover/deploy-from-github@d76580d79952f6841c453bb3ed37ef452b19752c
+      - uses: actions/setup-node@v4
         with:
-          server: ${{ secrets.CAPROVER_HOST }}
-          app: ${{ vars.CAPROVER_APP }}
-          token: ${{ secrets.CAPROVER_APP_TOKEN }}
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          node-version: "22.13"
+
+      - name: Deploy to CapRover
+        env:
+          CAPROVER_URL: ${{ secrets.CAPROVER_HOST }}
+          CAPROVER_APP: ${{ vars.CAPROVER_APP }}
+          CAPROVER_APP_TOKEN: ${{ secrets.CAPROVER_APP_TOKEN }}
+          CAPROVER_IMAGE_NAME: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+        run: npx --yes caprover@2.3.1 deploy
 
       - name: Send feishu message
         env:


### PR DESCRIPTION
## Summary

- replace the upstream CapRover Docker action, which installs a floating CLI version at runtime
- run the repository-compatible Node 22.13 toolchain and pin the deploy command to `caprover@2.3.1`
- preserve the existing main-push gate, production environment, exact-SHA image, CapRover secrets/variables, and success notification

## Root cause

`caprover@2.4.0` was published shortly before the failed deployment. The upstream action uses Node 16 and runs an unpinned `npm i -g caprover`, so it picked up 2.4.0 and crashed with `ERR_REQUIRE_ESM` before contacting the CapRover service. A minimal container reproduction confirmed that 2.4.0 fails while 2.3.1 starts successfully.

## Validation

- `docker run --rm node:22.13-alpine npx --yes caprover@2.3.1 deploy --help`
- `docker run --rm -w /repo -v "$PWD:/repo" rhysd/actionlint:1.7.12 -color .github/workflows/docker.yml`
- `git diff --check`
- `pnpm check` (passes with existing unrelated warnings)
- `pnpm typecheck`
- two independent reviews: repository/Actions standards and requested deployment semantics

## Test note

The full `pnpm test` run reached unrelated existing timeout limits in one Context Tree audit fixture and one CLI runtime-layout build hook under concurrent load. Both exact failures passed when rerun in isolation. This workflow-only change does not alter product or test code.
