### PR TITLE
feat(web): refine first-chat Orientation handoff

### DIFF
--- a/docs/development/onboarding-kickoff-contract.md
+++ b/docs/development/onboarding-kickoff-contract.md
@@ -6,12 +6,17 @@ chats and the adjacent campaign quickstart handoff.
 ## Current Contract
 
 - `POST /api/v1/me/onboarding/kickoff` starts the user's first onboarding chat.
-- The first message is visible task text sent through task `createChat`; the
-  agent sees the same message the user sees.
+- The first message is task text sent through task `createChat`. Without the
+  Orientation capability it remains an ordinary visible message and the agent
+  sees the same text as the user. With Orientation enabled, Web replaces that
+  marked row with the senderless Orientation surface while the stored text
+  remains the agent's replayable conversational context.
 - An ordinary onboarding client may send `orientation: 1` to opt into the
-  current soft Orientation flow. The server then stores the visible bootstrap
-  as silent, replayable context and adds the server-owned
-  `firstChatOrientation` marker for Web rendering. The next ordinary visible
+  current soft Orientation flow. The server then stores the bootstrap as
+  silent, replayable context and adds the server-owned
+  `firstChatOrientation` marker for Web rendering. Web must not expose the
+  bootstrap body or attribute it to its human sender; it renders a senderless
+  Orientation row instead. The next ordinary visible
   human message addressed to the original bootstrap target wakes that agent
   and carries the bootstrap as preceding context. A message addressed only to
   a participant added later remains an ordinary turn and does not consume the
@@ -35,9 +40,10 @@ chats and the adjacent campaign quickstart handoff.
   If the bootstrap was already claimed, the continuation is a normal next turn
   and wakes independently. Campaign actions and dedicated tree-setup kickoffs
   do not accept or render this Orientation marker.
-- Skill activation comes from the visible message, bound resources, and skill
-  descriptions. The client must not append hidden onboarding directives from
-  message metadata.
+- Skill activation comes from conversational message text delivered to the
+  agent, bound resources, and skill descriptions. Orientation changes only the
+  Web presentation of its stored bootstrap; the client must not append hidden
+  onboarding directives from message metadata.
 - Campaign quickstart starts through `POST /api/v1/me/landing-campaigns/start`.
   That server-owned path creates the trial chat, binds the managed trial prompt
   guardrail, and wakes the agent from visible task text. The campaign skill is

--- a/e2e/onboarding-complete-setup.test.yaml
+++ b/e2e/onboarding-complete-setup.test.yaml
@@ -40,8 +40,13 @@ steps:
   # ── Landing — onboarding is done and the user is in the workspace ───────────
   - waitForUrl: /?c=
   - assert: the workspace is open on a chat named Get started with First Tree,
-      whose first message asks the user's new assistant agent for help getting
-      started, and a message composer addressed to that agent is available
+      where a senderless Get to know First Tree Orientation appears instead of
+      a user-attributed bootstrap message; Skip intro, Start with the new agent,
+      and a message composer addressed to that agent are all available
+  - click: the Start with the new agent button in the Orientation
+  - assert: the Orientation is now a compact First Tree introduction entry and
+      the first attributed timeline message belongs to the user and says I'm
+      ready — let's get started
 
   # ── Settings — the permanent readiness overview keeps its stable route ────
   - click: Settings link in the top navigation

--- a/packages/qa/cases/cross-surface/onboarding-first-chat-orientation.md
+++ b/packages/qa/cases/cross-surface/onboarding-first-chat-orientation.md
@@ -9,30 +9,32 @@ surfaces: [web, server, client, runtime]
 
 ## Goal
 
-Confirm that an ordinary onboarding chat presents one immediately skippable Orientation before any agent task guidance,
-then produces exactly one normal agent wake with the original visible bootstrap as context. This case owns the live
+Confirm that an ordinary onboarding chat presents one immediately skippable, senderless Orientation before any agent
+task guidance, then produces exactly one normal agent wake with the stored bootstrap as preceding context. This case owns the live
 Web → kickoff API → Inbox → runtime boundary that deterministic component and service tests cannot prove.
 
 ## Preconditions
 
-- Use isolated fresh admin and invited-member accounts plus active target agents. Include a Team agent whose connected
-  computer belongs to another member so the security copy can be judged without assuming the viewer owns that runtime.
+- Use isolated fresh admin and invited-member accounts plus active target agents.
 - Keep the target runtime connected and observable, but do not let it receive unrelated work during the run.
 - Have a current Web bundle and a legacy-capability request fixture that omits `orientation`; do not use campaign-action
   or dedicated Context Tree setup kickoffs as the positive path.
 
 ## Operate and observe
 
-1. Start an ordinary onboarding chat. The one visible bootstrap renders one inline Orientation with four choices:
-   multi-agent collaboration, Context Tree, GitHub automation, and data/security. The runtime receives no initial wake.
-2. Without choosing a chapter, use the one global skip action. It sends one visible human continuation and only then
+1. Start an ordinary onboarding chat. The timeline renders one senderless, full-width Orientation rather than the
+   bootstrap body, sender avatar, name, timestamp, or read receipt. It offers three persistent chapters: multi-agent
+   collaboration, Context Tree, and GitHub automation. The runtime receives no initial wake.
+2. Without choosing a chapter, use the header **Skip intro** action. It sends one visible human continuation and only then
    wakes the target agent. Verify the runtime receives that continuation with the bootstrap as preceding context and
    follows the existing `first-tree-welcome` task-guidance lane rather than treating the turn as an ordinary task.
-3. Repeat with a fresh account, choose any chapter, inspect the placeholder transcript, and start. The chapter view
-   replaces the choice list rather than creating a tall stacked tutorial. The same single continuation and wake occur.
+3. Repeat with a fresh account, choose any chapter, and use **Start with <agent>**. The chapter list stays available while
+   one selected video is shown. No transcript control is permanently visible; force a video load failure and verify its
+   transcript appears directly in the error state with a retry action. The same single continuation and wake occur.
 4. Repeat with a fresh account and ignore the card. Send a normal composer message. It implicitly closes Orientation,
    preserves the typed content, wakes the agent once, and leaves a compact history entry that can be watched again
-   without another wake.
+   without another wake. A concrete task may proceed directly instead of forcing the `first-tree-welcome` menu; an
+   ambiguous get-started message should still carry enough bootstrap context for the welcome lane.
 5. Reload before and after continuation, retry the kickoff, and exercise concurrent kickoff requests. One chat and one
    bootstrap remain; pending Orientation never duplicates or traps the user, and completed history does not reopen as a
    blocking step.
@@ -52,18 +54,20 @@ Web → kickoff API → Inbox → runtime boundary that deterministic component 
    the server lifecycle and cannot enqueue another first wake.
 9. Start a fresh kickoff with the capability omitted. It retains the legacy immediate wake. Verify campaign action,
    dedicated tree setup, and ordinary chat messages never render or accept the trusted Orientation marker.
-10. At a narrow phone viewport, the initial chapter choice plus global skip are visible without traversing an empty video
-   well, the selected chapter remains usable without horizontal overflow, and every action is keyboard and touch
-   reachable. Verify the Team-agent security chapter uses team/agent-neutral ownership language.
+10. At a narrow phone viewport, **Skip intro** is visible in the card header without scrolling, the selected video poster
+   and persistent chapter list remain usable without horizontal overflow, and every action is keyboard and touch
+   reachable. Confirm the pending one-on-one composer explains that the member may message the target agent directly or
+   use the optional tour, then returns to the ordinary composer prompt after continuation.
 
 ## Expected result and evidence
 
-`PASS` requires one bootstrap, no pre-continue runtime turn, one visible continuation, one agent wake, correct preceding
-context and `first-tree-welcome` behavior, working skip/chapter/direct-message branches, durable reload/retry behavior,
-original-target-bound continuation and replay, bounded replay after completion, legacy reconciliation, and
-campaign/tree/ordinary-chat exclusion. `FAIL` includes an early or duplicate wake, lost or stale bootstrap context, a
-handoff consumed by or replayed to the wrong participant, a reopened completed Orientation, inaccessible skip,
-ownership-misleading security copy, or a marker accepted from an untrusted send.
+`PASS` requires one hidden bootstrap, one senderless Orientation row, no pre-continue runtime turn, one visible
+continuation, one agent wake, correct preceding context and skip/start `first-tree-welcome` behavior, working
+skip/chapter/direct-message branches, durable reload/retry behavior, original-target-bound continuation and replay,
+bounded replay after completion, legacy reconciliation, and campaign/tree/ordinary-chat exclusion. `FAIL` includes an
+early or duplicate wake, exposed or user-attributed bootstrap, lost or stale bootstrap context, a handoff consumed by or
+replayed to the wrong participant, a reopened completed Orientation, inaccessible skip/start, or a marker accepted from
+an untrusted send.
 
 Keep the exact tested commit/build, redacted network request shapes, message and Inbox ordering, runtime turn evidence,
 and desktop/narrow screenshots. Do not retain tokens, message bodies from real repositories, or private identifiers.

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -71,11 +71,12 @@ export function readAskAgentMessageMetadata(
 }
 
 /**
- * Server-owned marker on the visible bootstrap message of an ordinary first
- * chat. Web uses it to mount the optional Orientation surface in that message
- * row. It is presentation metadata only and never becomes agent prompt text;
- * the visible bootstrap and the user's next visible turn remain the complete
- * conversational context.
+ * Server-owned marker on the stored bootstrap message of an ordinary first
+ * chat. Web uses it to replace that row with the senderless Orientation
+ * surface: the member does not see the bootstrap body or its persisted human
+ * sender attribution. It is presentation metadata only and never becomes
+ * agent prompt text; the stored bootstrap and the user's next visible turn
+ * remain the complete conversational context replayed to the original target.
  */
 export const FIRST_CHAT_ORIENTATION_METADATA_KEY = "firstChatOrientation";
 export const firstChatOrientationMessageMetadataSchema = z.object({

--- a/packages/web/src/components/chat/__tests__/onboarding-orientation.test.tsx
+++ b/packages/web/src/components/chat/__tests__/onboarding-orientation.test.tsx
@@ -40,7 +40,7 @@ afterEach(() => {
 });
 
 describe("OnboardingOrientation", () => {
-  it("shows the selected video, persistent chapter list, and header skip plus continue actions", async () => {
+  it("shows the selected video, persistent chapter list, and header skip plus start actions", async () => {
     const onContinue = vi.fn();
     const { container } = await renderOrientation({ onContinue });
 
@@ -54,36 +54,39 @@ describe("OnboardingOrientation", () => {
     expect(container.querySelector("video")?.autoplay).toBe(false);
 
     const skipButton = [...container.querySelectorAll("button")].find(
-      (button) => button.textContent?.trim() === "Skip",
+      (button) => button.textContent?.trim() === "Skip intro",
     );
     await click(skipButton ?? null);
     expect(onContinue).toHaveBeenCalledTimes(1);
 
-    const continueButton = [...container.querySelectorAll("button")].find(
-      (button) => button.textContent?.trim() === "Continue with Nova",
+    const startButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Start with Nova",
     );
-    await click(continueButton ?? null);
+    await click(startButton ?? null);
     expect(onContinue).toHaveBeenCalledTimes(2);
   });
 
   it("shows the transcript inside the failed-video overlay", async () => {
     vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => undefined);
     const { container } = await renderOrientation();
-    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector("[data-onboarding-orientation-video-error]")).toBeNull();
 
     const video = container.querySelector("video");
     await act(async () => {
       video?.dispatchEvent(new Event("error"));
     });
-    const alert = container.querySelector('[role="alert"]');
-    expect(alert?.textContent).toContain("This video couldn’t load");
-    expect(alert?.textContent).toContain("Give one lead agent a clear software task");
+    const errorState = container.querySelector("[data-onboarding-orientation-video-error]");
+    expect(errorState?.textContent).toContain("This video couldn’t load");
+    expect(errorState?.textContent).toContain("Give one lead agent a clear software task");
+    const status = errorState?.querySelector('[role="status"]');
+    expect(status?.textContent).not.toContain("Give one lead agent a clear software task");
+    expect(errorState?.querySelector('[aria-label="Multi-agent collaboration transcript"]')).not.toBeNull();
 
     const tryAgain = [...container.querySelectorAll("button")].find(
       (button) => button.textContent?.trim() === "Try again",
     );
     await click(tryAgain ?? null);
-    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector("[data-onboarding-orientation-video-error]")).toBeNull();
   });
 
   it("plays a chapter when its persistent playlist item is clicked and marks it watched on completion", async () => {
@@ -110,11 +113,39 @@ describe("OnboardingOrientation", () => {
     });
     expect(multiAgent?.dataset.orientationChapterStatus).toBe("watched");
 
-    const continueButton = [...container.querySelectorAll("button")].find(
-      (button) => button.textContent?.trim() === "Continue with Nova",
+    const startButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Start with Nova",
     );
-    await click(continueButton ?? null);
+    await click(startButton ?? null);
     expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("acknowledges completion after all three chapters finish", async () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: scrollIntoView });
+    const { container } = await renderOrientation();
+    const chapterButtons = [...container.querySelectorAll<HTMLButtonElement>("[data-orientation-chapter]")];
+
+    for (const chapterButton of chapterButtons) {
+      await click(chapterButton);
+      await act(async () => {
+        container.querySelector("video")?.dispatchEvent(new Event("ended"));
+      });
+    }
+
+    expect(container.textContent).toContain("Tour complete. Start whenever you’re ready.");
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "nearest" });
+  });
+
+  it("wraps an unbroken long agent name inside the start action", async () => {
+    const { container } = await renderOrientation({ targetAgentName: "A".repeat(231) });
+    const startButton = [...container.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+      button.textContent?.startsWith("Start with A"),
+    );
+
+    expect(startButton?.style.overflowWrap).toBe("anywhere");
+    expect(startButton?.className).toContain("h-auto");
+    expect(startButton?.className).toContain("whitespace-normal");
   });
 
   it("connects the Context Tree chapter to its silent media, captions, and transcript", async () => {
@@ -155,13 +186,20 @@ describe("OnboardingOrientation", () => {
 
     expect(container.querySelector('[data-onboarding-orientation="completed"]')).not.toBeNull();
     expect(container.querySelectorAll("[data-orientation-chapter]")).toHaveLength(0);
-    expect(container.textContent).not.toContain("Continue with Nova");
+    expect(container.textContent).not.toContain("Start with Nova");
 
     const review = [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === "Watch");
     await click(review ?? null);
     expect(container.querySelectorAll("[data-orientation-chapter]")).toHaveLength(3);
     expect(onContinue).not.toHaveBeenCalled();
-    expect(container.textContent).not.toContain("Continue with Nova");
-    expect(container.textContent).not.toContain("Skip");
+    expect(container.textContent).not.toContain("Start with Nova");
+    expect(container.textContent).not.toContain("Skip intro");
+    expect(container.textContent).toContain("Replay any chapter");
+
+    const close = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Close tour",
+    );
+    await click(close ?? null);
+    expect(container.querySelector('[data-onboarding-orientation="completed"]')).not.toBeNull();
   });
 });

--- a/packages/web/src/components/chat/__tests__/onboarding-orientation.test.tsx
+++ b/packages/web/src/components/chat/__tests__/onboarding-orientation.test.tsx
@@ -40,7 +40,7 @@ afterEach(() => {
 });
 
 describe("OnboardingOrientation", () => {
-  it("shows the selected video, persistent chapter list, and one continue action", async () => {
+  it("shows the selected video, persistent chapter list, and header skip plus continue actions", async () => {
     const onContinue = vi.fn();
     const { container } = await renderOrientation({ onContinue });
 
@@ -50,14 +50,40 @@ describe("OnboardingOrientation", () => {
     expect(container.textContent).toContain("Context Tree");
     expect(container.textContent).toContain("GitHub automation");
     expect(container.textContent).not.toContain("Video placeholder");
-    expect(container.textContent).toContain("Transcript");
+    expect(container.textContent).not.toContain("Transcript");
     expect(container.querySelector("video")?.autoplay).toBe(false);
+
+    const skipButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Skip",
+    );
+    await click(skipButton ?? null);
+    expect(onContinue).toHaveBeenCalledTimes(1);
 
     const continueButton = [...container.querySelectorAll("button")].find(
       (button) => button.textContent?.trim() === "Continue with Nova",
     );
     await click(continueButton ?? null);
-    expect(onContinue).toHaveBeenCalledTimes(1);
+    expect(onContinue).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows the transcript inside the failed-video overlay", async () => {
+    vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => undefined);
+    const { container } = await renderOrientation();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+
+    const video = container.querySelector("video");
+    await act(async () => {
+      video?.dispatchEvent(new Event("error"));
+    });
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain("This video couldn’t load");
+    expect(alert?.textContent).toContain("Give one lead agent a clear software task");
+
+    const tryAgain = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Try again",
+    );
+    await click(tryAgain ?? null);
+    expect(container.querySelector('[role="alert"]')).toBeNull();
   });
 
   it("plays a chapter when its persistent playlist item is clicked and marks it watched on completion", async () => {
@@ -76,7 +102,7 @@ describe("OnboardingOrientation", () => {
     expect(video?.getAttribute("poster")).toBe("/onboarding/orientation/stills/multi-agent-poster.png");
     expect(video?.querySelector("source")?.getAttribute("src")).toBe("/onboarding/orientation/multi-agent.mp4");
     expect(video?.querySelector("track")?.getAttribute("src")).toBe("/onboarding/orientation/multi-agent.vtt");
-    expect(container.textContent).toContain("Transcript");
+    expect(container.textContent).not.toContain("Transcript");
     expect(container.textContent).not.toContain("Choose another chapter");
 
     await act(async () => {
@@ -136,5 +162,6 @@ describe("OnboardingOrientation", () => {
     expect(container.querySelectorAll("[data-orientation-chapter]")).toHaveLength(3);
     expect(onContinue).not.toHaveBeenCalled();
     expect(container.textContent).not.toContain("Continue with Nova");
+    expect(container.textContent).not.toContain("Skip");
   });
 });

--- a/packages/web/src/components/chat/onboarding-orientation.tsx
+++ b/packages/web/src/components/chat/onboarding-orientation.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, Play, RotateCcw } from "lucide-react";
+import { Check, Play, RotateCcw } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { cn } from "../../lib/utils.js";
 import { Button } from "../ui/button.js";
@@ -155,13 +155,20 @@ export function OnboardingOrientation({
       style={{ borderRadius: "var(--radius-panel)" }}
     >
       <header className="flex flex-col" style={{ gap: "var(--sp-1)", padding: "var(--sp-4)" }}>
-        <div className="flex flex-wrap items-baseline justify-between" style={{ gap: "var(--sp-2)" }}>
+        <div className="flex flex-wrap items-center justify-between" style={{ gap: "var(--sp-2)" }}>
           <p id={titleId} className="text-title font-semibold text-balance">
             Get to know First Tree
           </p>
-          <p className="mono text-caption shrink-0 text-muted-foreground">
-            Optional · {formatTotalDuration(TOTAL_DURATION_IN_SECONDS)}
-          </p>
+          <div className="flex shrink-0 items-center" style={{ gap: "var(--sp-2)" }}>
+            <p className="mono text-caption text-muted-foreground">
+              Optional · {formatTotalDuration(TOTAL_DURATION_IN_SECONDS)}
+            </p>
+            {!completed ? (
+              <Button type="button" variant="ghost" size="sm" disabled={continuing} onClick={() => void onContinue()}>
+                Skip
+              </Button>
+            ) : null}
+          </div>
         </div>
         <p className="text-body max-w-[65ch] text-muted-foreground text-pretty">
           Watch the short tours, or continue when you’re ready.
@@ -204,27 +211,25 @@ export function OnboardingOrientation({
           </video>
           {videoError ? (
             <div
-              className="absolute inset-0 flex flex-col items-center justify-center bg-background/95 p-6 text-center"
+              className="absolute inset-0 flex flex-col overflow-auto bg-background/95 text-left"
               role="alert"
-              style={{ gap: "var(--sp-3)" }}
+              style={{ gap: "var(--sp-3)", padding: "var(--sp-4)" }}
             >
-              <div>
-                <p className="text-label font-medium">This video couldn’t load</p>
-                <p className="text-body mt-1 text-muted-foreground">
-                  Read the transcript below or try loading it again.
-                </p>
+              <div className="flex flex-wrap items-center justify-between" style={{ gap: "var(--sp-2)" }}>
+                <p className="text-label font-medium">This video couldn’t load — here’s the transcript</p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setVideoError(false);
+                    videoRef.current?.load();
+                  }}
+                >
+                  Try again
+                </Button>
               </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setVideoError(false);
-                  videoRef.current?.load();
-                }}
-              >
-                Try again
-              </Button>
+              <p className="text-body max-w-[65ch] text-muted-foreground text-pretty">{selected.transcript}</p>
             </div>
           ) : null}
         </div>
@@ -294,14 +299,6 @@ export function OnboardingOrientation({
             </Button>
           </div>
         ) : null}
-
-        <details className="group mt-3 border-t border-border pt-3">
-          <summary className="text-label inline-flex min-h-11 cursor-pointer items-center font-medium">
-            Transcript
-            <ChevronDown className="ml-2 size-4 transition-transform group-open:rotate-180" aria-hidden="true" />
-          </summary>
-          <p className="text-body mt-2 max-w-[65ch] text-muted-foreground text-pretty">{selected.transcript}</p>
-        </details>
       </div>
     </section>
   );

--- a/packages/web/src/components/chat/onboarding-orientation.tsx
+++ b/packages/web/src/components/chat/onboarding-orientation.tsx
@@ -3,7 +3,11 @@ import { useEffect, useId, useRef, useState } from "react";
 import { cn } from "../../lib/utils.js";
 import { Button } from "../ui/button.js";
 
-export const ONBOARDING_ORIENTATION_CONTINUE_MESSAGE = "I'm ready. Please help me get started with First Tree.";
+export const ONBOARDING_ORIENTATION_CONTINUE_MESSAGE = "I'm ready — let's get started.";
+
+export function onboardingOrientationComposerPlaceholder(targetAgentName: string): string {
+  return `Message ${targetAgentName} anything — or start with the tour above`;
+}
 
 export const ONBOARDING_ORIENTATION_CHAPTERS = {
   "multi-agent": {
@@ -76,6 +80,7 @@ export function OnboardingOrientation({
 }: OnboardingOrientationProps) {
   const titleId = useId();
   const videoRef = useRef<HTMLVideoElement>(null);
+  const startFooterRef = useRef<HTMLDivElement>(null);
   const [expanded, setExpanded] = useState(!completed);
   const [selectedId, setSelectedId] = useState<OnboardingOrientationChapterId>(
     ONBOARDING_ORIENTATION_DEFAULT_CHAPTER_ID,
@@ -84,10 +89,20 @@ export function OnboardingOrientation({
   const [watchedIds, setWatchedIds] = useState<Set<OnboardingOrientationChapterId>>(() => new Set());
   const [videoError, setVideoError] = useState(false);
   const normalizedTargetAgentName = targetAgentName?.trim() || null;
+  const tourComplete = watchedIds.size === CHAPTERS.length;
 
   useEffect(() => {
     if (completed) setExpanded(false);
   }, [completed]);
+
+  useEffect(() => {
+    if (!tourComplete || completed) return;
+    const prefersReducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    startFooterRef.current?.scrollIntoView?.({
+      behavior: prefersReducedMotion ? "auto" : "smooth",
+      block: "nearest",
+    });
+  }, [completed, tourComplete]);
 
   const selected = ONBOARDING_ORIENTATION_CHAPTERS[selectedId];
 
@@ -165,13 +180,19 @@ export function OnboardingOrientation({
             </p>
             {!completed ? (
               <Button type="button" variant="ghost" size="sm" disabled={continuing} onClick={() => void onContinue()}>
-                Skip
+                Skip intro
               </Button>
-            ) : null}
+            ) : (
+              <Button type="button" variant="ghost" size="sm" onClick={() => setExpanded(false)}>
+                Close tour
+              </Button>
+            )}
           </div>
         </div>
         <p className="text-body max-w-[65ch] text-muted-foreground text-pretty">
-          Watch the short tours, or continue when you’re ready.
+          {completed
+            ? "Replay any chapter, then close the tour when you’re done."
+            : "Watch the short tours, or start whenever you’re ready."}
         </p>
       </header>
 
@@ -187,14 +208,14 @@ export function OnboardingOrientation({
         </div>
 
         <div
-          className="relative aspect-video overflow-hidden border border-border bg-muted/40"
+          className={cn("overflow-hidden border border-border bg-muted/40", videoError ? "" : "relative aspect-video")}
           style={{ borderRadius: "var(--radius-input)" }}
         >
           <video
             key={selected.id}
             ref={videoRef}
             data-onboarding-orientation-video={selected.id}
-            className="size-full"
+            className={cn("size-full", videoError && "hidden")}
             controls
             playsInline
             preload="metadata"
@@ -211,12 +232,14 @@ export function OnboardingOrientation({
           </video>
           {videoError ? (
             <div
-              className="absolute inset-0 flex flex-col overflow-auto bg-background/95 text-left"
-              role="alert"
+              data-onboarding-orientation-video-error
+              className="flex flex-col bg-background text-left"
               style={{ gap: "var(--sp-3)", padding: "var(--sp-4)" }}
             >
               <div className="flex flex-wrap items-center justify-between" style={{ gap: "var(--sp-2)" }}>
-                <p className="text-label font-medium">This video couldn’t load — here’s the transcript</p>
+                <p className="text-label font-medium" role="status">
+                  This video couldn’t load. You can read the transcript instead.
+                </p>
                 <Button
                   type="button"
                   variant="outline"
@@ -229,7 +252,10 @@ export function OnboardingOrientation({
                   Try again
                 </Button>
               </div>
-              <p className="text-body max-w-[65ch] text-muted-foreground text-pretty">{selected.transcript}</p>
+              <section aria-label={`${selected.title} transcript`}>
+                <p className="mono text-caption text-muted-foreground">Transcript</p>
+                <p className="text-body mt-1 max-w-[65ch] text-muted-foreground text-pretty">{selected.transcript}</p>
+              </section>
             </div>
           ) : null}
         </div>
@@ -280,22 +306,26 @@ export function OnboardingOrientation({
 
         {!completed ? (
           <div
+            ref={startFooterRef}
             className="mt-4 flex flex-col border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between"
             style={{ gap: "var(--sp-3)" }}
           >
-            <p className="text-caption text-muted-foreground">You can return to these videos anytime.</p>
+            <p className="text-caption text-muted-foreground" aria-live="polite">
+              {tourComplete ? "Tour complete. Start whenever you’re ready." : "You can return to these videos anytime."}
+            </p>
             <Button
               type="button"
               variant="cta"
-              className="min-h-11 w-full shrink-0 sm:w-auto"
+              className="h-auto min-h-11 w-full max-w-full shrink-0 whitespace-normal break-words text-center sm:w-auto"
+              style={{ overflowWrap: "anywhere" }}
               disabled={continuing}
               onClick={() => void onContinue()}
             >
               {continuing
-                ? "Continuing…"
+                ? "Starting…"
                 : normalizedTargetAgentName
-                  ? `Continue with ${normalizedTargetAgentName}`
-                  : "Continue"}
+                  ? `Start with ${normalizedTargetAgentName}`
+                  : "Start"}
             </Button>
           </div>
         ) : null}

--- a/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
@@ -432,7 +432,9 @@ describe("onboarding preview review surface", () => {
     );
 
     expect(container.textContent).toContain("Personal agent setup remains available");
-    expect(container.textContent).toContain("Starting your first Team-agent conversation");
+    expect(container.textContent).toContain("Get to know First Tree");
+    expect(container.textContent).toContain("Start with Dev Assistant");
+    expect(container.textContent).not.toContain("welcome aboard");
     expect(container.textContent).not.toContain("Reading the team's shared context");
     expect(container.textContent).not.toContain("Onboarding complete");
 

--- a/packages/web/src/pages/onboarding-orientation-preview.tsx
+++ b/packages/web/src/pages/onboarding-orientation-preview.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import {
   ONBOARDING_ORIENTATION_CONTINUE_MESSAGE,
   OnboardingOrientation,
@@ -6,7 +6,89 @@ import {
 import { Button } from "../components/ui/button.js";
 
 /** DEV-only visual review surface for the real inline first-chat Orientation. */
+
+type Variant = "current" | "proposed";
+
+function MessageRow({ name, initial, children }: { name: string; initial: string; children: ReactNode }) {
+  return (
+    <div className="grid" style={{ gridTemplateColumns: "var(--sp-5) 1fr", gap: "var(--sp-2)" }}>
+      <span
+        aria-hidden="true"
+        className="flex size-5 items-center justify-center rounded-full bg-secondary text-caption font-semibold"
+      >
+        {initial}
+      </span>
+      <div className="min-w-0">
+        <p className="mono text-body font-semibold">{name}</p>
+        <div className="text-body mt-1">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function ContinuationRows() {
+  return (
+    <>
+      <MessageRow name="Gandy" initial="G">
+        <p>{ONBOARDING_ORIENTATION_CONTINUE_MESSAGE}</p>
+      </MessageRow>
+      <MessageRow name="Nova" initial="N">
+        <p className="text-muted-foreground">
+          The existing first-task guidance begins here after the visible continue message wakes the agent.
+        </p>
+      </MessageRow>
+    </>
+  );
+}
+
+/** Today's rendering: the bootstrap is an ordinary user-attributed message with the card below its body. */
+function CurrentVariant({ completed, onContinue }: { completed: boolean; onContinue: () => void }) {
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <MessageRow name="Gandy" initial="G">
+        <p>
+          Nova, welcome aboard.
+          <br />
+          <br />
+          Please help me get started with First Tree.
+        </p>
+        <OnboardingOrientation
+          key={completed ? "completed" : "pending"}
+          completed={completed}
+          continuing={false}
+          targetAgentName="Nova"
+          onContinue={onContinue}
+        />
+      </MessageRow>
+      {completed ? <ContinuationRows /> : null}
+    </div>
+  );
+}
+
+/**
+ * Proposed rendering: the bootstrap body and sender attribution are not shown.
+ * The Orientation is a sender-less full-width card; the member's continuation
+ * is the first attributed message in the timeline.
+ */
+function ProposedVariant({ completed, onContinue }: { completed: boolean; onContinue: () => void }) {
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <div className="[&>section]:mt-0">
+        <OnboardingOrientation
+          key={completed ? "completed" : "pending"}
+          completed={completed}
+          continuing={false}
+          targetAgentName="Nova"
+          onContinue={onContinue}
+        />
+      </div>
+      {completed ? <ContinuationRows /> : null}
+    </div>
+  );
+}
+
 export function OnboardingOrientationPreviewPage() {
+  const [variant, setVariant] = useState<Variant>("proposed");
   const [completed, setCompleted] = useState(false);
 
   return (
@@ -20,55 +102,40 @@ export function OnboardingOrientationPreviewPage() {
               Resize to a narrow phone width to review the mobile layout.
             </p>
           </div>
-          <div className="flex" style={{ gap: "var(--sp-2)" }}>
-            <Button type="button" variant={!completed ? "default" : "outline"} onClick={() => setCompleted(false)}>
-              Pending
-            </Button>
-            <Button type="button" variant={completed ? "default" : "outline"} onClick={() => setCompleted(true)}>
-              Completed
-            </Button>
+          <div className="flex flex-wrap" style={{ gap: "var(--sp-2)" }}>
+            <div className="flex" style={{ gap: "var(--sp-2)" }}>
+              <Button
+                type="button"
+                variant={variant === "current" ? "default" : "outline"}
+                onClick={() => setVariant("current")}
+              >
+                Current
+              </Button>
+              <Button
+                type="button"
+                variant={variant === "proposed" ? "default" : "outline"}
+                onClick={() => setVariant("proposed")}
+              >
+                Proposed
+              </Button>
+            </div>
+            <div className="flex" style={{ gap: "var(--sp-2)" }}>
+              <Button type="button" variant={!completed ? "default" : "outline"} onClick={() => setCompleted(false)}>
+                Pending
+              </Button>
+              <Button type="button" variant={completed ? "default" : "outline"} onClick={() => setCompleted(true)}>
+                Completed
+              </Button>
+            </div>
           </div>
         </header>
 
         <section aria-label="First chat message preview" className="border-y border-border py-4">
-          <div className="grid" style={{ gridTemplateColumns: "var(--sp-5) 1fr", gap: "var(--sp-2)" }}>
-            <span
-              aria-hidden="true"
-              className="flex size-5 items-center justify-center rounded-full bg-secondary text-caption font-semibold"
-            >
-              G
-            </span>
-            <div className="min-w-0">
-              <p className="mono text-body font-semibold">Gandy</p>
-              <p className="text-body mt-1">
-                Nova, welcome aboard.
-                <br />
-                <br />
-                Please help me get started with First Tree.
-              </p>
-              <OnboardingOrientation
-                key={completed ? "completed" : "pending"}
-                completed={completed}
-                continuing={false}
-                targetAgentName="Nova"
-                onContinue={() => setCompleted(true)}
-              />
-            </div>
-          </div>
-          {completed ? (
-            <div className="mt-4 flex flex-col border-t border-border pt-4" style={{ gap: "var(--sp-4)" }}>
-              <div>
-                <p className="mono text-body font-semibold">Gandy</p>
-                <p className="text-body mt-1">{ONBOARDING_ORIENTATION_CONTINUE_MESSAGE}</p>
-              </div>
-              <div>
-                <p className="mono text-body font-semibold">Nova</p>
-                <p className="text-body mt-1 text-muted-foreground">
-                  The existing first-task guidance begins here after the visible continue message wakes the agent.
-                </p>
-              </div>
-            </div>
-          ) : null}
+          {variant === "current" ? (
+            <CurrentVariant completed={completed} onContinue={() => setCompleted(true)} />
+          ) : (
+            <ProposedVariant completed={completed} onContinue={() => setCompleted(true)} />
+          )}
         </section>
       </div>
     </main>

--- a/packages/web/src/pages/onboarding-orientation-preview.tsx
+++ b/packages/web/src/pages/onboarding-orientation-preview.tsx
@@ -1,13 +1,14 @@
-import { type ReactNode, useState } from "react";
+import { type FormEvent, type KeyboardEvent, type ReactNode, useState } from "react";
 import {
   ONBOARDING_ORIENTATION_CONTINUE_MESSAGE,
   OnboardingOrientation,
+  onboardingOrientationComposerPlaceholder,
 } from "../components/chat/onboarding-orientation.js";
 import { Button } from "../components/ui/button.js";
 
 /** DEV-only visual review surface for the real inline first-chat Orientation. */
 
-type Variant = "current" | "proposed";
+type Variant = "attributed" | "senderless";
 
 function MessageRow({ name, initial, children }: { name: string; initial: string; children: ReactNode }) {
   return (
@@ -26,23 +27,31 @@ function MessageRow({ name, initial, children }: { name: string; initial: string
   );
 }
 
-function ContinuationRows() {
+function ContinuationRows({ humanMessage }: { humanMessage: string }) {
   return (
     <>
       <MessageRow name="Gandy" initial="G">
-        <p>{ONBOARDING_ORIENTATION_CONTINUE_MESSAGE}</p>
+        <p>{humanMessage}</p>
       </MessageRow>
       <MessageRow name="Nova" initial="N">
         <p className="text-muted-foreground">
-          The existing first-task guidance begins here after the visible continue message wakes the agent.
+          The agent wakes from this first visible message, with the stored bootstrap as preceding context.
         </p>
       </MessageRow>
     </>
   );
 }
 
-/** Today's rendering: the bootstrap is an ordinary user-attributed message with the card below its body. */
-function CurrentVariant({ completed, onContinue }: { completed: boolean; onContinue: () => void }) {
+/** Comparison baseline: the bootstrap is a user-attributed message row. */
+function AttributedVariant({
+  completed,
+  humanMessage,
+  onContinue,
+}: {
+  completed: boolean;
+  humanMessage: string;
+  onContinue: () => void;
+}) {
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
       <MessageRow name="Gandy" initial="G">
@@ -60,7 +69,7 @@ function CurrentVariant({ completed, onContinue }: { completed: boolean; onConti
           onContinue={onContinue}
         />
       </MessageRow>
-      {completed ? <ContinuationRows /> : null}
+      {completed ? <ContinuationRows humanMessage={humanMessage} /> : null}
     </div>
   );
 }
@@ -70,7 +79,15 @@ function CurrentVariant({ completed, onContinue }: { completed: boolean; onConti
  * The Orientation is a sender-less full-width card; the member's continuation
  * is the first attributed message in the timeline.
  */
-function ProposedVariant({ completed, onContinue }: { completed: boolean; onContinue: () => void }) {
+function SenderlessVariant({
+  completed,
+  humanMessage,
+  onContinue,
+}: {
+  completed: boolean;
+  humanMessage: string;
+  onContinue: () => void;
+}) {
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
       <div className="[&>section]:mt-0">
@@ -82,60 +99,145 @@ function ProposedVariant({ completed, onContinue }: { completed: boolean; onCont
           onContinue={onContinue}
         />
       </div>
-      {completed ? <ContinuationRows /> : null}
+      {completed ? <ContinuationRows humanMessage={humanMessage} /> : null}
     </div>
   );
 }
 
-export function OnboardingOrientationPreviewPage() {
-  const [variant, setVariant] = useState<Variant>("proposed");
-  const [completed, setCompleted] = useState(false);
+function ComposerPreview({
+  orientationPending,
+  draft,
+  onDraftChange,
+  onSend,
+}: {
+  orientationPending: boolean;
+  draft: string;
+  onDraftChange: (draft: string) => void;
+  onSend: () => void;
+}) {
+  const submit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    onSend();
+  };
+
+  const sendOnEnter = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+    if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) return;
+    event.preventDefault();
+    onSend();
+  };
 
   return (
-    <main className="min-h-screen bg-background p-4 sm:p-8">
-      <div className="mx-auto max-w-3xl">
-        <header className="mb-6 flex flex-wrap items-end justify-between" style={{ gap: "var(--sp-3)" }}>
+    <form className="shrink-0 border-t border-border bg-background" onSubmit={submit}>
+      <div
+        className="composer-card m-3 flex items-end border border-border bg-background sm:m-4"
+        style={{ gap: "var(--sp-2)" }}
+      >
+        <textarea
+          aria-label="Message composer preview"
+          className="text-subtitle min-h-14 min-w-0 flex-1 resize-none border-0 bg-transparent p-3 font-normal text-foreground outline-none"
+          placeholder={
+            orientationPending
+              ? onboardingOrientationComposerPlaceholder("Nova")
+              : "Message @Nova  ·  / for commands  ·  @ to mention"
+          }
+          value={draft}
+          onChange={(event) => onDraftChange(event.target.value)}
+          onKeyDown={sendOnEnter}
+          rows={2}
+        />
+        <Button type="submit" className="m-2 shrink-0" disabled={!draft.trim()}>
+          Send
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export function OnboardingOrientationPreviewPage() {
+  const [variant, setVariant] = useState<Variant>("senderless");
+  const [completed, setCompleted] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [humanMessage, setHumanMessage] = useState(ONBOARDING_ORIENTATION_CONTINUE_MESSAGE);
+
+  const completeWith = (message: string): void => {
+    setHumanMessage(message);
+    setCompleted(true);
+  };
+
+  const sendDraft = (): void => {
+    const message = draft.trim();
+    if (!message) return;
+    completeWith(message);
+    setDraft("");
+  };
+
+  return (
+    <main className="h-dvh-screen overflow-hidden bg-background p-4 sm:p-8">
+      <div className="mx-auto flex h-full min-h-0 max-w-3xl flex-col">
+        <header className="mb-6 flex shrink-0 flex-wrap items-end justify-between" style={{ gap: "var(--sp-3)" }}>
           <div>
             <p className="mono text-caption text-muted-foreground">DEV PREVIEW · REAL COMPONENT</p>
             <h1 className="text-title font-semibold">First-chat Orientation</h1>
             <p className="text-body text-muted-foreground">
-              Resize to a narrow phone width to review the mobile layout.
+              Compare row ownership, then type in the live composer to exercise the direct-message path.
             </p>
           </div>
           <div className="flex flex-wrap" style={{ gap: "var(--sp-2)" }}>
             <div className="flex" style={{ gap: "var(--sp-2)" }}>
               <Button
                 type="button"
-                variant={variant === "current" ? "default" : "outline"}
-                onClick={() => setVariant("current")}
+                variant={variant === "attributed" ? "default" : "outline"}
+                onClick={() => setVariant("attributed")}
               >
-                Current
+                Attributed row
               </Button>
               <Button
                 type="button"
-                variant={variant === "proposed" ? "default" : "outline"}
-                onClick={() => setVariant("proposed")}
+                variant={variant === "senderless" ? "default" : "outline"}
+                onClick={() => setVariant("senderless")}
               >
-                Proposed
+                Senderless row
               </Button>
             </div>
             <div className="flex" style={{ gap: "var(--sp-2)" }}>
               <Button type="button" variant={!completed ? "default" : "outline"} onClick={() => setCompleted(false)}>
                 Pending
               </Button>
-              <Button type="button" variant={completed ? "default" : "outline"} onClick={() => setCompleted(true)}>
+              <Button
+                type="button"
+                variant={completed ? "default" : "outline"}
+                onClick={() => completeWith(ONBOARDING_ORIENTATION_CONTINUE_MESSAGE)}
+              >
                 Completed
               </Button>
             </div>
           </div>
         </header>
 
-        <section aria-label="First chat message preview" className="border-y border-border py-4">
-          {variant === "current" ? (
-            <CurrentVariant completed={completed} onContinue={() => setCompleted(true)} />
-          ) : (
-            <ProposedVariant completed={completed} onContinue={() => setCompleted(true)} />
-          )}
+        <section
+          aria-label="First chat preview"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden border-y border-border"
+        >
+          <div
+            className="min-h-0 flex-1 overflow-y-auto py-4"
+            data-onboarding-orientation-preview-timeline
+            style={{ paddingInline: "var(--sp-1)" }}
+          >
+            {variant === "attributed" ? (
+              <AttributedVariant
+                completed={completed}
+                humanMessage={humanMessage}
+                onContinue={() => completeWith(ONBOARDING_ORIENTATION_CONTINUE_MESSAGE)}
+              />
+            ) : (
+              <SenderlessVariant
+                completed={completed}
+                humanMessage={humanMessage}
+                onContinue={() => completeWith(ONBOARDING_ORIENTATION_CONTINUE_MESSAGE)}
+              />
+            )}
+          </div>
+          <ComposerPreview orientationPending={!completed} draft={draft} onDraftChange={setDraft} onSend={sendDraft} />
         </section>
       </div>
     </main>

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -1,11 +1,12 @@
 import type { AgentVisibility, GithubAppInstallationOutput, RuntimeProvider } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Bot, CircleCheck, MessageSquare, Plus, SendHorizontal } from "lucide-react";
+import { CircleCheck, MessageSquare, Plus, SendHorizontal } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import type { HubClient } from "../api/activity.js";
 import { getApiSelectedOrganizationId, setApiSelectedOrganizationId } from "../api/client.js";
 import type { GithubRepo } from "../api/github.js";
 import { Avatar } from "../components/avatar.js";
+import { OnboardingOrientation } from "../components/chat/onboarding-orientation.js";
 import type { ComputerConnection } from "../features/agent-setup/use-computer-connection.js";
 import { InviteAcceptCard, InviteAcceptError, InviteAcceptShell, InviteAcceptSkeleton } from "./invite-accept.js";
 import { COPY } from "./onboarding/copy.js";
@@ -19,10 +20,6 @@ import { StepGetStarted } from "./onboarding/steps/step-get-started.js";
 import { StepStartChat } from "./onboarding/steps/step-start-chat.js";
 import { StepTeam } from "./onboarding/steps/step-team.js";
 import { getStepSequence, type OnboardingPath, type StepId } from "./onboarding/steps.js";
-import {
-  buildInviteeReadyBootstrap,
-  buildTeamAgentStartBootstrap,
-} from "./workspace/center/onboarding/bootstrap-prose.js";
 
 /**
  * DEV-only gallery of every onboarding screen + state, mounted at
@@ -1326,15 +1323,14 @@ export const ONBOARDING_PREVIEW_SCENARIOS: Scenario[] = [
 /**
  * The onboarding step components redirect into the normal chat route after
  * kickoff, so the gallery needs an explicit destination frame to make the
- * member journey reviewable end to end. This deliberately shows the stable
- * first-chat contract (selected chat, visible bootstrap, agent working state,
- * composer) without pretending to be a second interactive Chat implementation.
+ * member journey reviewable end to end. It uses the real senderless Orientation
+ * component plus a static composer without pretending to be a second
+ * interactive Chat implementation.
  */
 function MemberChatDestination({ mode }: { mode: "team-agent" | "personal-agent" }) {
   const teamAgent = mode === "team-agent";
   const agentName = teamAgent ? "Dev Assistant" : "Gandy's assistant";
   const agentHandle = teamAgent ? "@dev-assistant" : "@gandy-assistant";
-  const bootstrap = teamAgent ? buildTeamAgentStartBootstrap(agentName) : buildInviteeReadyBootstrap(agentName);
 
   return (
     <div className="flex h-full" style={{ background: "var(--bg)" }}>
@@ -1433,34 +1429,13 @@ function MemberChatDestination({ mode }: { mode: "team-agent" | "personal-agent"
           style={{ width: "min(48rem, 100%)", margin: "0 auto", padding: "var(--sp-7) var(--sp-6)" }}
         >
           <div className="flex-1 overflow-y-auto">
-            <div className="flex justify-end">
-              <div
-                className="text-label"
-                style={{
-                  maxWidth: "78%",
-                  whiteSpace: "pre-wrap",
-                  padding: "var(--sp-3) var(--sp-4)",
-                  borderRadius: "var(--radius-panel)",
-                  background: "var(--fg)",
-                  color: "var(--bg)",
-                }}
-              >
-                {bootstrap}
-              </div>
-            </div>
-
-            <div className="flex items-start" style={{ gap: "var(--sp-3)", marginTop: "var(--sp-6)" }}>
-              <Avatar name={agentName} seed={agentHandle} size={30} />
-              <div className="min-w-0">
-                <div className="text-label font-medium">{agentName}</div>
-                <div
-                  className="text-label inline-flex items-center"
-                  style={{ gap: "var(--sp-2)", marginTop: "var(--sp-2)", color: "var(--fg-3)" }}
-                >
-                  <Bot className="h-4 w-4" aria-hidden />
-                  {teamAgent ? "Starting your first Team-agent conversation…" : "Getting your first Agent Chat ready…"}
-                </div>
-              </div>
+            <div className="[&>section]:mt-0">
+              <OnboardingOrientation
+                completed={false}
+                continuing={false}
+                targetAgentName={agentName}
+                onContinue={NOOP}
+              />
             </div>
           </div>
 

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -834,16 +834,29 @@ describe("ChatView", () => {
       source: "api",
       createdAt: "2026-05-28T11:55:00.000Z",
     });
+    const orientationChat = chatDetail({
+      participants: [
+        participant({ agentId: "human-agent-self", type: "human", name: "gandy", displayName: "Gandy" }),
+        participant({ agentId: "agent-2", name: "design", displayName: "Design Critique" }),
+      ],
+    });
     chatMocks.listChatMessages.mockResolvedValue(messages([bootstrap]));
     const { container, root } = await renderDom(
-      <ChatView agentId="agent-1" chatId="chat-1" initialChatDetail={chatDetail()} />,
-      (queryClient) => seedChat(queryClient, chatDetail(), messages([bootstrap])),
+      <ChatView agentId="agent-2" chatId="chat-1" initialChatDetail={orientationChat} />,
+      (queryClient) => seedChat(queryClient, orientationChat, messages([bootstrap])),
       "/",
     );
 
-    await waitForText(container, "Continue with Design Critique");
+    await waitForText(container, "Start with Design Critique");
+    const orientationRow = container.querySelector(
+      '[data-onboarding-orientation-row][data-message-id="orientation-bootstrap"]',
+    );
+    expect(orientationRow).not.toBeNull();
+    expect(orientationRow?.textContent).not.toContain("welcome aboard");
+    expect(container.textContent).not.toContain("Design Critique, welcome aboard.");
     const composer = container.querySelector<HTMLTextAreaElement>("textarea");
     if (!composer) throw new Error("Composer textarea missing");
+    expect(composer.placeholder).toBe("Message Design Critique anything — or start with the tour above");
     await setValue(composer, "A draft I still want to send");
     chatMocks.listChatMessages.mockResolvedValue(
       messages([
@@ -851,21 +864,108 @@ describe("ChatView", () => {
         message({
           id: "orientation-ready-message",
           senderId: "human-agent-self",
-          content: "I'm ready. Please help me get started with First Tree.",
+          content: "I'm ready — let's get started.",
           metadata: { mentions: ["agent-2"] },
           createdAt: "2026-05-28T11:56:00.000Z",
         }),
       ]),
     );
-    await click(buttonByText(container, "Continue with Design Critique"));
-    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith(
-      "chat-1",
-      "I'm ready. Please help me get started with First Tree.",
-      ["agent-2"],
-    );
+    const skipButton = buttonByText(container, "Skip intro");
+    const startButton = buttonByText(container, "Start with Design Critique");
+    if (!skipButton || !startButton) throw new Error("Orientation actions missing");
+    // Both controls are visible at once. A fast double activation must still
+    // produce only one continuation before React has time to disable them.
+    await act(async () => {
+      skipButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      startButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected Orientation continuation");
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "I'm ready — let's get started.", ["agent-2"]);
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledTimes(1);
     expect(composer.value).toBe("A draft I still want to send");
     await waitForText(container, "Watch");
     expect(container.querySelectorAll('[data-onboarding-orientation="pending"]')).toHaveLength(0);
+    expect(composer.placeholder).not.toContain("tour above");
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps the trusted Orientation bootstrap senderless for a later human viewer", async () => {
+    authMock.value = {
+      agentId: "human-agent-alice",
+      memberId: "member-alice",
+      organizationId: "org-1",
+      role: "member",
+    };
+    const { ChatView } = await import("../chat-view.js");
+    const bootstrap = message({
+      id: "orientation-bootstrap-shared-view",
+      senderId: "human-agent-self",
+      content: "Design Critique, welcome aboard. Please help me get started with First Tree.",
+      metadata: {
+        mentions: ["agent-2"],
+        [FIRST_CHAT_ORIENTATION_METADATA_KEY]: { version: 1 },
+      },
+      source: "api",
+      createdAt: "2026-05-28T11:55:00.000Z",
+    });
+    const sharedChat = chatDetail({
+      participants: [
+        participant({ agentId: "human-agent-self", type: "human", name: "gandy", displayName: "Gandy" }),
+        participant({ agentId: "human-agent-alice", type: "human", name: "alice", displayName: "Alice" }),
+        participant({ agentId: "agent-2", name: "design", displayName: "Design Critique" }),
+      ],
+    });
+    const page = messages([bootstrap]);
+    chatMocks.listChatMessages.mockResolvedValue(page);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-2" chatId="chat-1" initialChatDetail={sharedChat} />,
+      (queryClient) => seedChat(queryClient, sharedChat, page),
+      "/",
+    );
+
+    await waitForText(container, "First Tree introduction");
+    expect(
+      container.querySelector('[data-onboarding-orientation-row][data-message-id="orientation-bootstrap-shared-view"]'),
+    ).not.toBeNull();
+    expect(container.textContent).not.toContain("welcome aboard");
+    expect(container.textContent).not.toContain("Start with Design Critique");
+    expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not advertise a removed Orientation target in the composer", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const bootstrap = message({
+      id: "orientation-bootstrap-removed-target",
+      senderId: "human-agent-self",
+      content: "Nova, welcome aboard.",
+      metadata: {
+        mentions: ["agent-1"],
+        [FIRST_CHAT_ORIENTATION_METADATA_KEY]: { version: 1 },
+      },
+      source: "api",
+      createdAt: "2026-05-28T11:55:00.000Z",
+    });
+    const targetRemovedChat = chatDetail({
+      participants: [
+        participant({ agentId: "human-agent-self", type: "human", name: "gandy", displayName: "Gandy" }),
+        participant({ agentId: "agent-2", name: "design", displayName: "Design Critique" }),
+      ],
+    });
+    const page = messages([bootstrap]);
+    chatMocks.listChatMessages.mockResolvedValue(page);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" initialChatDetail={targetRemovedChat} />,
+      (queryClient) => seedChat(queryClient, targetRemovedChat, page),
+      "/",
+    );
+
+    await waitForText(container, "Start with Nova");
+    const composer = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!composer) throw new Error("Composer textarea missing");
+    expect(composer.placeholder).not.toContain("tour above");
 
     await act(async () => root.unmount());
   });
@@ -900,7 +1000,7 @@ describe("ChatView", () => {
 
     await waitForText(container, "Watch");
     expect(container.textContent).toContain("Start by reading /projects/acme.");
-    expect(container.textContent).not.toContain("Continue with Nova");
+    expect(container.textContent).not.toContain("Start with Nova");
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
@@ -934,7 +1034,7 @@ describe("ChatView", () => {
       "/",
     );
 
-    await waitForText(container, "Continue with Nova");
+    await waitForText(container, "Start with Nova");
     expect(container.querySelectorAll('[data-onboarding-orientation="pending"]')).toHaveLength(1);
     expect(container.textContent).not.toContain("First Tree introduction");
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
@@ -967,7 +1067,7 @@ describe("ChatView", () => {
     );
 
     await waitForText(container, "Watch");
-    expect(container.textContent).not.toContain("Continue with Nova");
+    expect(container.textContent).not.toContain("Start with Nova");
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -113,6 +113,7 @@ import { ImageRefGallery } from "../../../components/chat/image-ref-gallery.js";
 import {
   ONBOARDING_ORIENTATION_CONTINUE_MESSAGE,
   OnboardingOrientation,
+  onboardingOrientationComposerPlaceholder,
 } from "../../../components/chat/onboarding-orientation.js";
 import {
   historyContainsThirdParty,
@@ -595,11 +596,6 @@ type MessageBodyProps = {
   requestTagAgentId: string | null;
   myAgentId: string | null;
   mentionParticipants: RenderedMentionParticipant[];
-  orientationTargetName: string | null;
-  orientationCompleted: boolean;
-  orientationHidden: boolean;
-  orientationContinuing: boolean;
-  onOrientationContinue: (bootstrap: MessageWithDelivery) => void;
 };
 
 type MessageMarkdownProps = {
@@ -666,11 +662,6 @@ const MessageBody = memo(function MessageBody({
   requestTagAgentId,
   myAgentId,
   mentionParticipants,
-  orientationTargetName,
-  orientationCompleted,
-  orientationHidden,
-  orientationContinuing,
-  onOrientationContinue,
 }: MessageBodyProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -937,14 +928,6 @@ const MessageBody = memo(function MessageBody({
           {JSON.stringify(msg.content, null, 2)}
         </pre>
       )}
-      {!orientationHidden && isFirstChatOrientationMessage(msg, myAgentId) ? (
-        <OnboardingOrientation
-          completed={orientationCompleted}
-          continuing={orientationContinuing}
-          targetAgentName={orientationTargetName}
-          onContinue={() => onOrientationContinue(msg)}
-        />
-      ) : null}
       <ImageRefGallery
         images={metadataImages}
         hasLeadingContent={typeof msg.content === "string" && msg.content.trim().length > 0}
@@ -1004,6 +987,31 @@ const MessageRow = memo(function MessageRow({
   const isSelf = !isSystem && myAgentId === msg.senderId;
   const orientationTargetAgentId = firstChatOrientationTargetAgentId(msg);
   const orientationTargetName = orientationTargetAgentId ? agentNameFn(orientationTargetAgentId) : null;
+  const isOrientationPresentation = !orientationHidden && isFirstChatOrientationMessage(msg);
+  const ownsOrientation = myAgentId !== null && msg.senderId === myAgentId;
+
+  if (isOrientationPresentation) {
+    return (
+      <div
+        className="[&>section]:mt-0"
+        data-message-id={msg.id}
+        data-onboarding-orientation-row
+        style={{ padding: "var(--sp-1_5) 0" }}
+      >
+        <OnboardingOrientation
+          // The member who started onboarding owns the pending handoff. Other
+          // members may encounter the trusted bootstrap later in shared
+          // history; keep its body/sender hidden for them too, but present it
+          // as a passive replay entry so they cannot consume someone else's
+          // first-chat transition.
+          completed={orientationCompleted || !ownsOrientation}
+          continuing={orientationContinuing}
+          targetAgentName={orientationTargetName}
+          onContinue={() => onOrientationContinue(msg)}
+        />
+      </div>
+    );
+  }
 
   return (
     <div
@@ -1081,11 +1089,6 @@ const MessageRow = memo(function MessageRow({
           requestTagAgentId={requestTagAgentId}
           myAgentId={myAgentId}
           mentionParticipants={mentionParticipants}
-          orientationTargetName={orientationTargetName}
-          orientationCompleted={orientationCompleted}
-          orientationHidden={orientationHidden}
-          orientationContinuing={orientationContinuing}
-          onOrientationContinue={onOrientationContinue}
         />
       </div>
     </div>
@@ -1114,23 +1117,45 @@ function areMessageBodyPropsEqual(prev: MessageBodyProps, next: MessageBodyProps
     messageBodyFieldsEqual(prev.msg, next.msg) &&
     prev.requestTagAgentId === next.requestTagAgentId &&
     prev.myAgentId === next.myAgentId &&
-    prev.orientationTargetName === next.orientationTargetName &&
-    prev.orientationCompleted === next.orientationCompleted &&
-    prev.orientationHidden === next.orientationHidden &&
-    prev.orientationContinuing === next.orientationContinuing &&
-    prev.onOrientationContinue === next.onOrientationContinue &&
     mentionParticipantsEqual(prev.mentionParticipants, next.mentionParticipants)
   );
 }
 
-function isFirstChatOrientationMessage(msg: MessageWithDelivery, myAgentId: string | null): boolean {
+function isFirstChatOrientationMessage(msg: MessageWithDelivery): boolean {
   return (
-    myAgentId !== null &&
-    msg.senderId === myAgentId &&
-    msg.source === "api" &&
-    msg.format === "text" &&
-    readFirstChatOrientationMessageMetadata(msg.metadata) !== null
+    msg.source === "api" && msg.format === "text" && readFirstChatOrientationMessageMetadata(msg.metadata) !== null
   );
+}
+
+function isOwnedFirstChatOrientationMessage(msg: MessageWithDelivery, myAgentId: string | null): boolean {
+  return myAgentId !== null && msg.senderId === myAgentId && isFirstChatOrientationMessage(msg);
+}
+
+function completedFirstChatOrientationMessageIds(
+  messages: readonly MessageWithDelivery[],
+  lifecycleCompleted: boolean,
+): Set<string> {
+  const completed = new Set<string>();
+  if (lifecycleCompleted) {
+    for (const message of messages) {
+      if (isFirstChatOrientationMessage(message)) completed.add(message.id);
+    }
+    return completed;
+  }
+  for (let bootstrapIndex = 0; bootstrapIndex < messages.length; bootstrapIndex += 1) {
+    const bootstrap = messages[bootstrapIndex];
+    if (!bootstrap || !isFirstChatOrientationMessage(bootstrap)) continue;
+    const targetAgentId = firstChatOrientationTargetAgentId(bootstrap);
+    if (!targetAgentId) continue;
+    for (let messageIndex = bootstrapIndex + 1; messageIndex < messages.length; messageIndex += 1) {
+      const candidate = messages[messageIndex];
+      if (candidate?.senderId === bootstrap.senderId && messageRoutesToAgent(candidate, targetAgentId)) {
+        completed.add(bootstrap.id);
+        break;
+      }
+    }
+  }
+  return completed;
 }
 
 function firstChatOrientationTargetAgentId(msg: MessageWithDelivery): string | null {
@@ -1470,32 +1495,14 @@ const ChatTimeline = memo(function ChatTimeline({
     return map;
   }, [visibleItems]);
   const completedOrientationMessageIds = useMemo(() => {
-    const completed = new Set<string>();
-    if (!myAgentId) return completed;
     const messageItems = visibleItems.filter(
       (item): item is Extract<TimelineItem, { kind: "message" }> => item.kind === "message",
     );
-    if (orientationLifecycleCompleted) {
-      for (const item of messageItems) {
-        if (isFirstChatOrientationMessage(item.data, myAgentId)) completed.add(item.data.id);
-      }
-      return completed;
-    }
-    for (let bootstrapIndex = 0; bootstrapIndex < messageItems.length; bootstrapIndex += 1) {
-      const bootstrap = messageItems[bootstrapIndex]?.data;
-      if (!bootstrap || !isFirstChatOrientationMessage(bootstrap, myAgentId)) continue;
-      const targetAgentId = firstChatOrientationTargetAgentId(bootstrap);
-      if (!targetAgentId) continue;
-      for (let messageIndex = bootstrapIndex + 1; messageIndex < messageItems.length; messageIndex += 1) {
-        const candidate = messageItems[messageIndex]?.data;
-        if (candidate?.senderId === myAgentId && messageRoutesToAgent(candidate, targetAgentId)) {
-          completed.add(bootstrap.id);
-          break;
-        }
-      }
-    }
-    return completed;
-  }, [myAgentId, orientationLifecycleCompleted, visibleItems]);
+    return completedFirstChatOrientationMessageIds(
+      messageItems.map((item) => item.data),
+      orientationLifecycleCompleted,
+    );
+  }, [orientationLifecycleCompleted, visibleItems]);
   // Which non-human agents this turn awaits a reply from — routing-derived from
   // the latest message's persisted recipients (metadata.addressedAgentIds, which
   // includes the system addressedToAgentIds routing the onboarding bootstrap uses
@@ -2358,21 +2365,38 @@ export function ChatView({
     },
   });
   const sendChatMutation = sendMut.mutate;
+  const orientationContinueInFlightRef = useRef({ chatId, pending: false });
 
   const continueOnboardingOrientation = useCallback(
     (bootstrap: MessageWithDelivery) => {
+      if (orientationContinueInFlightRef.current.chatId !== chatId) {
+        orientationContinueInFlightRef.current = { chatId, pending: false };
+      }
+      if (bootstrap.senderId !== myAgentId || orientationContinueInFlightRef.current.pending) return;
       const mentions = readMentions(bootstrap.metadata).filter((id) => id !== myAgentId);
       if (mentions.length === 0) {
         setUploadError("This introduction can no longer reach its agent. Send a message from the composer instead.");
         return;
       }
-      sendChatMutation({
-        content: ONBOARDING_ORIENTATION_CONTINUE_MESSAGE,
-        mentions,
-        preserveDraft: true,
-      });
+      orientationContinueInFlightRef.current = { chatId, pending: true };
+      sendChatMutation(
+        {
+          content: ONBOARDING_ORIENTATION_CONTINUE_MESSAGE,
+          mentions,
+          preserveDraft: true,
+        },
+        {
+          onError: () => {
+            // A failed send did not consume the handoff, so let the member
+            // retry either action after the shared mutation error is shown.
+            if (orientationContinueInFlightRef.current.chatId === chatId) {
+              orientationContinueInFlightRef.current.pending = false;
+            }
+          },
+        },
+      );
     },
-    [myAgentId, sendChatMutation],
+    [chatId, myAgentId, sendChatMutation],
   );
 
   const handleSend = async () => {
@@ -3930,6 +3954,18 @@ export function ChatView({
   );
 
   const displayName = chatScopedAgentName(agentId);
+  const orientationChatState = readFirstChatOrientationChatState(chatDetail?.metadata);
+  const orientationLifecycleCompleted = orientationChatState === FIRST_CHAT_ORIENTATION_CHAT_STATES.CONTINUED;
+  const orientationHidden = orientationChatState === FIRST_CHAT_ORIENTATION_CHAT_STATES.LEGACY_STARTED;
+  const pendingOrientationTargetAgentId = useMemo(() => {
+    if (orientationHidden) return null;
+    const completedIds = completedFirstChatOrientationMessageIds(mergedMessages, orientationLifecycleCompleted);
+    for (const message of mergedMessages) {
+      if (!isOwnedFirstChatOrientationMessage(message, myAgentId) || completedIds.has(message.id)) continue;
+      return firstChatOrientationTargetAgentId(message);
+    }
+    return null;
+  }, [mergedMessages, myAgentId, orientationHidden, orientationLifecycleCompleted]);
 
   // `managedByMe` is `managerId === myMemberId`, derived client-side
   // from the `listAgents` response (the row carries `managerId`). Drives
@@ -4131,6 +4167,10 @@ export function ChatView({
     }
     return null;
   }, [chatDetail, myAgentId]);
+  const orientationComposerTargetName =
+    pendingOrientationTargetAgentId && pendingOrientationTargetAgentId === peerAgentId
+      ? chatScopedAgentName(pendingOrientationTargetAgentId)
+      : null;
   const effectiveSendMentions = useMemo(
     () => (peerAgentId ? [...new Set([...draftMentions, peerAgentId])] : draftMentions),
     [draftMentions, peerAgentId],
@@ -4862,13 +4902,8 @@ export function ChatView({
             pillCount={pillCount}
             onPillClick={onPillClick}
             orientationContinuing={sendMut.isPending}
-            orientationLifecycleCompleted={
-              readFirstChatOrientationChatState(chatDetail?.metadata) === FIRST_CHAT_ORIENTATION_CHAT_STATES.CONTINUED
-            }
-            orientationHidden={
-              readFirstChatOrientationChatState(chatDetail?.metadata) ===
-              FIRST_CHAT_ORIENTATION_CHAT_STATES.LEGACY_STARTED
-            }
+            orientationLifecycleCompleted={orientationLifecycleCompleted}
+            orientationHidden={orientationHidden}
             onOrientationContinue={continueOnboardingOrientation}
           />
 
@@ -5308,19 +5343,21 @@ export function ChatView({
                                   // slash commands or @mention (one agent), so the
                                   // placeholder is just the plain message prompt.
                                   `Message @${displayName}`
-                                : requiresMention
-                                  ? // Group chat: the placeholder carries the rule (this
-                                    // is the calm, always-there teaching surface). It
-                                    // shows only while empty; once the user types it's
-                                    // gone, and the tip bubble covers a blocked send.
-                                    "In a group, @mention who this is for"
-                                  : composerMobile
-                                    ? // Mobile: drop the desktop keyboard-shortcut
-                                      // teaching text — `/` and `@` live in the
-                                      // toolbar and there's no keyboard hint to give
-                                      // on a touch surface. Keep it to the bare prompt.
-                                      `Message @${displayName}`
-                                    : `Message @${displayName}  ·  / for commands  ·  @ to mention`
+                                : orientationComposerTargetName && !requiresMention
+                                  ? onboardingOrientationComposerPlaceholder(orientationComposerTargetName)
+                                  : requiresMention
+                                    ? // Group chat: the placeholder carries the rule (this
+                                      // is the calm, always-there teaching surface). It
+                                      // shows only while empty; once the user types it's
+                                      // gone, and the tip bubble covers a blocked send.
+                                      "In a group, @mention who this is for"
+                                    : composerMobile
+                                      ? // Mobile: drop the desktop keyboard-shortcut
+                                        // teaching text — `/` and `@` live in the
+                                        // toolbar and there's no keyboard hint to give
+                                        // on a touch surface. Keep it to the bare prompt.
+                                        `Message @${displayName}`
+                                      : `Message @${displayName}  ·  / for commands  ·  @ to mention`
                           }
                           // The auto-resize hook measures `scrollHeight` after
                           // `height:auto`, which reverts the box to this `rows` count —


### PR DESCRIPTION
## Summary

- replace the trusted first-chat bootstrap row with a full-width, senderless Orientation while preserving its message id and deferred agent context
- make the handoff user-readable: `Skip intro`, `Start with <agent>`, a direct-message composer hint, a same-client rapid-action guard, and a compact replay state
- keep transcripts out of the normal path, expand them accessibly on video failure, surface tour completion on mobile, and let completed replays close again
- turn the development preview into a bounded chat shell whose composer can exercise the direct-message transition
- align the kickoff contract, shared schema documentation, cross-surface QA case, and Momentic onboarding test with the three-chapter senderless flow

The server-owned one-time handoff contract is unchanged: the first visible human message addressed to the original target wakes that agent with the stored bootstrap as preceding context.

## Approved decision dependency

[first-tree-context#890](https://github.com/agent-team-foundation/first-tree-context/pull/890) was independently reviewed and merged at `8936882`. The locked onboarding decision now authorizes the senderless Orientation, the first visible human continuation, the value-first direct-task branch, and the no-hidden-client-prompt boundary implemented here.

## Verification

- original implementation head: `pnpm check`, `pnpm typecheck`, and `pnpm --filter @first-tree/web test` — 243 files / 2,165 tests passed
- post-`origin/main` merge head `4a113c4c0`: `pnpm check`, Web typecheck/design-token guardrails, and `npx momentic lint`
- post-merge targeted Orientation, ChatView, and onboarding preview Vitest — 115 tests passed
- isolated reruns of the two unrelated failures from the concurrent monorepo test run:
  - server admin session suite — 49 tests passed
  - CLI runtime layout suite — 5 tests passed with a 60s hook timeout
- `npx momentic lint`
- exact-head Playwright review at 1440px and 390px: pending senderless row, fixed composer, direct typed continuation, compact replay, and replay close

## Validation gap

The full local onboarding Momentic journey was not run or uploaded: this machine does not have `MOMENTIC_API_KEY`, and the disposable full local server/database fixture stack was not available. The committed v2 test definition was updated and linted; the cross-surface QA case remains the live runtime handoff authority.
