### PR TITLE
docs(qa): clarify TeamSwitcher Momentic scope

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -25,9 +25,10 @@ Two limits follow from that and are deliberate:
 - It is **not a CI gate** and is not wired into any workflow. Steps resolve from
   natural-language descriptions through a hosted model and some assertions are
   model-evaluated, so a red run is a signal to investigate, not a merge blocker.
-- It covers the registration happy path, the connect-computer gate, and the Web
-  setup-prompt dialog — not the negative branches, provider handoff execution,
-  degraded states, or evidence judgement the cases ask for.
+- It covers the registration happy path, the connect-computer gate, the Team
+  switcher's handoff to the unbound Coding agent setup state, and the Web
+  setup-prompt dialog — not the other negative branches, provider handoff
+  execution, degraded states, or evidence judgement the cases ask for.
 
 A stable invariant that Vitest could assert still belongs in Vitest. Do not move
 a check here to escape a flaky product test.

--- a/packages/qa/cases/cross-surface/registration-first-run-onboarding.md
+++ b/packages/qa/cases/cross-surface/registration-first-run-onboarding.md
@@ -111,5 +111,7 @@ claimed to have blocked, show the disabled state, not only the later success.
 `e2e/` holds a Momentic browser suite that walks steps 1–8 unattended and is
 useful for a quick regression pass. It is optional tooling, not a replacement for
 this case: it needs an external Momentic account, resolves steps through a hosted
-model, and covers only the happy path plus the connect-computer gate. Judgement
-about whether the journey is genuinely healthy still lives here.
+model, and covers the happy path, the connect-computer gate, and the Team
+switcher's handoff to the unbound **Coding agent setup** state. Other negative
+branches and judgement about whether the journey is genuinely healthy still
+live here.


### PR DESCRIPTION
## Summary

- state that the onboarding Momentic journey covers the TeamSwitcher handoff to the unbound Coding agent setup state
- keep the remaining negative, provider-handoff, degraded-state, and evidence-judgement boundaries explicit in both the E2E README and authoritative QA case

Follow-up to #2182 after an independent Standards review found that the executable-aid scope description understated the already-committed journey.

## Validation

- `npx momentic@3.42.0 lint` — passed
- `git diff --check` — passed
- independent Standards review — no findings
- independent Spec review — no findings

This PR changes documentation only; it does not change product code or Momentic YAML. The product behavior merged in #2182 was validated on that PR's exact head by [Momentic run group 2561b7de-11cb-42c0-9a75-2b7f0c14f9f1](https://app.momentic.ai/run-groups/2561b7de-11cb-42c0-9a75-2b7f0c14f9f1) (2/2 passed). That result is not attributed to this docs-only commit. The dashboard contents were not independently opened or read from this environment.
