### PR TITLE
refactor(client): fail closed on runtimeProvider and guard SessionManager

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -458,6 +458,18 @@ describe("AgentSlot", () => {
     expect(state.logger.info).toHaveBeenCalledWith("server reports type=human — message processing disabled");
   });
 
+  it("refuses to construct SessionManager when runtimeType is not a known RuntimeProvider", async () => {
+    const { slot, connection, state } = await makeSlot({ runtimeType: "not-a-provider" });
+
+    await expect(slot.start()).rejects.toThrow(/Unsupported agent runtime type "not-a-provider"/);
+
+    expect(connection.bindAgent).toHaveBeenCalledWith("agent-1", "not-a-provider", "1.2.3");
+    expect(connection.unbindAgent).toHaveBeenCalledWith("agent-1");
+    expect(state.sessions).toHaveLength(0);
+    expect(state.sessionConfigs).toHaveLength(0);
+    expect(Reflect.get(slot, "sessionManager")).toBeNull();
+  });
+
   it("aborts the bind immediately on a permanent (4xx) config rejection — no retry", async () => {
     const { slot, connection, sdk, state } = await makeSlot({ configError: new SdkError(403, "forbidden") });
 

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -46,6 +46,7 @@ const GUARDED_CLIENT_FILES = [
   "runtime/runtime.ts",
   "runtime/handler.ts",
   "runtime/runtime-notice.ts",
+  "runtime/session-manager.ts",
   "handlers/auth-error-hint.ts",
 ] as const;
 
@@ -138,6 +139,17 @@ describe("runtime provider architecture guard", () => {
         expect(source).toContain("runtimeProviderLabel");
         expect(source).not.toMatch(/function providerLabel/);
         expect(source).not.toMatch(/case ["']codex["']:\s*return ["']Codex["']/);
+        continue;
+      }
+
+      if (relPosix === "runtime/session-manager.ts") {
+        // Session lifecycle owns provider-typed payloads but must not hard-code
+        // a concrete runtime id (including the retired silent Claude-era default).
+        const hit = containsAnyProviderLiteral(source);
+        expect(hit, `${rel} must not hard-code provider literal ${hit}`).toBeNull();
+        expect(source).not.toMatch(/from ["'].*handlers\/(claude-code|codex|cursor|grok|kimi-code|opencode|pi)/);
+        expect(source).toContain("runtimeProviderSchema");
+        expect(source).toMatch(/runtimeProvider is required/);
         continue;
       }
 

--- a/packages/client/src/__tests__/runtime-provider-fail-closed-characterization.test.ts
+++ b/packages/client/src/__tests__/runtime-provider-fail-closed-characterization.test.ts
@@ -133,16 +133,7 @@ describe("characterization — provider-boundary guard covers SessionManager", (
     const failClosed = detectFailClosed();
     if (!failClosed) return;
     const source = readFileSync(sessionManagerSourcePath, "utf8");
-    for (const id of [
-      "claude-code",
-      "claude-code-tui",
-      "codex",
-      "cursor",
-      "grok",
-      "kimi-code",
-      "opencode",
-      "pi",
-    ]) {
+    for (const id of ["claude-code", "claude-code-tui", "codex", "cursor", "grok", "kimi-code", "opencode", "pi"]) {
       expect(source.includes(`"${id}"`) || source.includes(`'${id}'`), `literal ${id}`).toBe(false);
     }
   });

--- a/packages/client/src/__tests__/runtime-provider-fail-closed-characterization.test.ts
+++ b/packages/client/src/__tests__/runtime-provider-fail-closed-characterization.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Characterization for SessionManager.runtimeProvider resolution and the
+ * provider-boundary guard's coverage of session-manager.ts.
+ *
+ * Detects live implementation via `detectFailClosed()` so the same file:
+ * - PASSes on PR base (documents silent Claude-era fallback + guard gap)
+ * - PASSes on this branch after fail-closed + guard inclusion land
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { RuntimeProvider } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentHandler } from "../runtime/handler.js";
+import { SessionManager } from "../runtime/session-manager.js";
+import type { FirstTreeHubSDK } from "../sdk.js";
+import { silentLogger } from "./_logger-helpers.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const sessionManagerSourcePath = join(here, "..", "runtime", "session-manager.ts");
+const guardSourcePath = join(here, "provider-boundary-guard.test.ts");
+
+type SessionManagerInternals = {
+  runtimeProvider(): RuntimeProvider;
+};
+
+function internals(sm: SessionManager): SessionManagerInternals {
+  return sm as unknown as SessionManagerInternals;
+}
+
+function handler(): AgentHandler {
+  return {
+    start: async () => "sess",
+    resume: async () => "sess",
+    inject: () => ({ kind: "owned", mode: "queued" }),
+    suspend: async () => undefined,
+    shutdown: async () => undefined,
+  };
+}
+
+function mockSdk(): FirstTreeHubSDK {
+  return {
+    serverUrl: "https://first-tree.example.test",
+    register: vi.fn(),
+    sendMessage: vi.fn().mockResolvedValue({ id: "m" }),
+    sendToAgent: vi.fn().mockResolvedValue({ id: "m" }),
+    listChatParticipants: vi.fn().mockResolvedValue([]),
+  } as unknown as FirstTreeHubSDK;
+}
+
+function makeManager(opts: { runtimeProvider?: unknown } = {}): SessionManager {
+  const handlerConfig: Record<string, unknown> = {
+    workspaceRoot: "/tmp/runtime-provider-char",
+  };
+  if ("runtimeProvider" in opts) {
+    handlerConfig.runtimeProvider = opts.runtimeProvider;
+  }
+  return new SessionManager({
+    session: {
+      idle_timeout: 300,
+      max_sessions: 10,
+      working_grace_seconds: 3600,
+      reconcile_interval_seconds: 300,
+    },
+    concurrency: 5,
+    handlerFactory: () => handler(),
+    handlerConfig: handlerConfig as ConstructorParameters<typeof SessionManager>[0]["handlerConfig"],
+    agentIdentity: {
+      agentId: "agent-1",
+      inboxId: "inbox-1",
+      displayName: "Agent",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: mockSdk(),
+    log: silentLogger(),
+    ackEntry: async () => undefined,
+  });
+}
+
+/** True once SessionManager no longer silently defaults a missing provider. */
+function detectFailClosed(): boolean {
+  const source = readFileSync(sessionManagerSourcePath, "utf8");
+  return !source.includes('return parsed.success ? parsed.data : "claude-code"');
+}
+
+describe("characterization — SessionManager.runtimeProvider", () => {
+  it("returns the configured provider when it is a valid RuntimeProvider", async () => {
+    const sm = makeManager({ runtimeProvider: "codex" });
+    expect(internals(sm).runtimeProvider()).toBe("codex");
+    await sm.shutdown();
+  });
+
+  it("handles missing runtimeProvider according to the fail-closed contract", async () => {
+    const sm = makeManager({});
+    const failClosed = detectFailClosed();
+    if (failClosed) {
+      expect(() => internals(sm).runtimeProvider()).toThrow(/runtimeProvider/i);
+    } else {
+      // PRE-REFACTOR: silent Claude-era fallback (the debt this slice removes).
+      expect(internals(sm).runtimeProvider()).toBe("claude-code");
+    }
+    await sm.shutdown();
+  });
+
+  it("handles invalid runtimeProvider according to the fail-closed contract", async () => {
+    const sm = makeManager({ runtimeProvider: "not-a-provider" });
+    const failClosed = detectFailClosed();
+    if (failClosed) {
+      expect(() => internals(sm).runtimeProvider()).toThrow(/runtimeProvider/i);
+    } else {
+      expect(internals(sm).runtimeProvider()).toBe("claude-code");
+    }
+    await sm.shutdown();
+  });
+});
+
+describe("characterization — provider-boundary guard covers SessionManager", () => {
+  it("lists runtime/session-manager.ts among guarded client files once fail-closed lands", () => {
+    const guardSource = readFileSync(guardSourcePath, "utf8");
+    const failClosed = detectFailClosed();
+    if (failClosed) {
+      expect(guardSource).toContain('"runtime/session-manager.ts"');
+    } else {
+      // PRE-REFACTOR: SessionManager is still outside the guard (known gap).
+      expect(guardSource).not.toContain('"runtime/session-manager.ts"');
+    }
+  });
+
+  it("after fail-closed, session-manager.ts has no concrete provider string literals", () => {
+    const failClosed = detectFailClosed();
+    if (!failClosed) return;
+    const source = readFileSync(sessionManagerSourcePath, "utf8");
+    for (const id of [
+      "claude-code",
+      "claude-code-tui",
+      "codex",
+      "cursor",
+      "grok",
+      "kimi-code",
+      "opencode",
+      "pi",
+    ]) {
+      expect(source.includes(`"${id}"`) || source.includes(`'${id}'`), `literal ${id}`).toBe(false);
+    }
+  });
+});

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -224,7 +224,7 @@ function makeManager(
     concurrency: opts.concurrency ?? 5,
     subprocessProbe: opts.subprocessProbe,
     handlerFactory,
-    handlerConfig: { workspaceRoot: opts.workspaceRoot ?? "/tmp/test-edge/agent-a" },
+    handlerConfig: { workspaceRoot: opts.workspaceRoot ?? "/tmp/test-edge/agent-a", runtimeProvider: "codex" },
     agentIdentity: {
       agentId: "agent-1",
       inboxId: "inbox-agent-1",
@@ -6663,7 +6663,7 @@ describe("SessionManager edge coverage", () => {
       session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 1, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: () => first,
-      handlerConfig: { workspaceRoot: "/tmp/test-edge/idle-log" },
+      handlerConfig: { workspaceRoot: "/tmp/test-edge/idle-log", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -99,7 +99,7 @@ function createSessionManager(opts: {
     concurrency: 5,
     subprocessProbe: opts.subprocessProbe,
     handlerFactory: opts.handlerFactory ?? (() => handler),
-    handlerConfig: opts.handlerConfig ?? { workspaceRoot: "/tmp/test" },
+    handlerConfig: opts.handlerConfig ?? { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
     resolveContextTreeBinding: opts.resolveContextTreeBinding ?? (async () => null),
     agentIdentity: {
       agentId: "agent-1",

--- a/packages/client/src/__tests__/session-manager-retry.test.ts
+++ b/packages/client/src/__tests__/session-manager-retry.test.ts
@@ -44,7 +44,7 @@ function makeManager(opts: {
     session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
     concurrency: 5,
     handlerFactory: factory,
-    handlerConfig: { workspaceRoot: "/tmp/test-retry" },
+    handlerConfig: { workspaceRoot: "/tmp/test-retry", runtimeProvider: "codex" },
     agentIdentity: {
       agentId: "agent-1",
       inboxId: "inbox-agent-1",

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -252,7 +252,7 @@ function createSessionManager(opts: {
     concurrency: opts.concurrency ?? 5,
     subprocessProbe: opts.subprocessProbe,
     handlerFactory: factory,
-    handlerConfig: opts.handlerConfig ?? { workspaceRoot: "/tmp/test" },
+    handlerConfig: opts.handlerConfig ?? { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
     // Tests never want the live git-backed resolver — default to a no-op so a
     // tree-less handlerConfig stays tree-less unless a test opts in.
     resolveContextTreeBinding: opts.resolveContextTreeBinding ?? (async () => null),
@@ -389,7 +389,7 @@ describe("SessionManager", () => {
       session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
-      handlerConfig: { workspaceRoot: "/tmp/test" },
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
@@ -801,7 +801,7 @@ describe("SessionManager", () => {
       session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
-      handlerConfig: { workspaceRoot: "/tmp/test" },
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
@@ -897,7 +897,7 @@ describe("SessionManager", () => {
       session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
-      handlerConfig: { workspaceRoot: "/tmp/test" },
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
@@ -955,7 +955,7 @@ describe("SessionManager", () => {
       session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
-      handlerConfig: { workspaceRoot: "/tmp/test" },
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
@@ -1033,7 +1033,7 @@ describe("SessionManager", () => {
       session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 2,
       handlerFactory: factory,
-      handlerConfig: { workspaceRoot: "/tmp/test" },
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
@@ -1129,7 +1129,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: () => h,
-      handlerConfig: { workspaceRoot: "/tmp/test" },
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
@@ -1506,7 +1506,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
-      handlerConfig: { workspaceRoot: "/tmp/test" },
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
@@ -1877,7 +1877,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       session: { idle_timeout: 300, max_sessions: 1, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 1,
       handlerFactory: () => handler,
-      handlerConfig: { workspaceRoot: "/tmp/test" },
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -55,7 +55,7 @@ function createSessionManager(opts: {
     },
     concurrency: opts.concurrency ?? 5,
     handlerFactory: factory,
-    handlerConfig: { workspaceRoot: "/tmp/test" },
+    handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
     agentIdentity: {
       agentId: "agent-1",
       inboxId: "inbox-agent-1",

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -72,7 +72,7 @@ function makeSessionManager(opts: {
     session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
     concurrency: 5,
     handlerFactory: factory,
-    handlerConfig: { workspaceRoot: "/tmp/test" },
+    handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
     agentIdentity: {
       agentId: "agent-1",
       inboxId: "inbox-agent-1",
@@ -536,7 +536,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
       session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 1,
       handlerFactory: () => queue.shift() ?? workingHandler(),
-      handlerConfig: { workspaceRoot: "/tmp/test" },
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -88,7 +88,7 @@ function createSessionManager(opts: {
     },
     concurrency: opts.concurrency ?? 5,
     handlerFactory: factory,
-    handlerConfig: { workspaceRoot: "/tmp/test" },
+    handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
     agentIdentity: {
       agentId: "agent-1",
       inboxId: "inbox-agent-1",

--- a/packages/client/src/__tests__/turn-end-inbox-characterization.test.ts
+++ b/packages/client/src/__tests__/turn-end-inbox-characterization.test.ts
@@ -203,7 +203,7 @@ describe("characterization — SessionManager turn-end wiring", () => {
             return "char-session";
           },
         }),
-      handlerConfig: { workspaceRoot },
+      handlerConfig: { workspaceRoot, runtimeProvider: "codex" },
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -346,6 +346,11 @@ export class AgentSlot {
         await this.clientConnection.sendInboxRecover(agent.agentId, chatId);
       };
       const runtimeProvider = runtimeProviderSchema.safeParse(runtimeType);
+      if (!runtimeProvider.success) {
+        throw new Error(
+          `Unsupported agent runtime type "${runtimeType}" — refusing to start SessionManager without a known RuntimeProvider`,
+        );
+      }
 
       // Defer idle-suspend while a provider has a live background subprocess
       // (default on; opt out via `session.defer_suspend_on_subprocess: false`).
@@ -365,7 +370,7 @@ export class AgentSlot {
           contextTreePath: contextTreeBinding?.path,
           contextTreeRepoUrl: contextTreeBinding?.repoUrl,
           contextTreeBranch: contextTreeBinding?.branch,
-          ...(runtimeProvider.success ? { runtimeProvider: runtimeProvider.data } : {}),
+          runtimeProvider: runtimeProvider.data,
           // Identifies the owning client process. The claude-code-tui handler
           // uses it to scope tmux session ownership (orphan sweep / names) so
           // it never touches another live client's sessions. Other handlers

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -2313,7 +2313,12 @@ export class SessionManager {
 
   private runtimeProvider(): RuntimeProvider {
     const parsed = runtimeProviderSchema.safeParse(this.config.handlerConfig.runtimeProvider);
-    return parsed.success ? parsed.data : "claude-code";
+    if (!parsed.success) {
+      throw new Error(
+        `handlerConfig.runtimeProvider is required and must be a known RuntimeProvider (got ${JSON.stringify(this.config.handlerConfig.runtimeProvider)})`,
+      );
+    }
+    return parsed.data;
   }
 
   private captureRuntimeFailureNotice(


### PR DESCRIPTION
## Summary
- `SessionManager.runtimeProvider()` no longer silently falls back to a Claude-era default when `handlerConfig.runtimeProvider` is missing/invalid — it throws.
- `AgentSlot` refuses to construct SessionManager unless bind `runtimeType` parses as a known `RuntimeProvider`.
- Provider-boundary guard now includes `runtime/session-manager.ts` (no concrete provider literals; requires the fail-closed error text).
- Characterization tests document pre-refactor fallback on base and post-refactor fail-closed on this head (dual-detect).

## Test plan
- [x] Base `75a2c238b` + characterization overlay only: 5/5 PASS
- [x] Head characterization + provider-boundary-guard
- [x] Targeted SessionManager / AgentSlot / Reset wire (359 passed)
- [x] `pnpm --filter @first-tree/client typecheck`
- [x] `pnpm --filter @first-tree/client test` (2382 passed)
- [ ] yzw-codex independent QA on exact head
- [ ] CI green

## Gate
Kept **Draft** until independent QA PASS on exact head. Out of scope: DeliveryToken / receipt dual-track (2b).


Made with [Cursor](https://cursor.com)