### PR TITLE
refactor(client): require DeliveryToken receipts + HandlerConfig.runtimeProvider

### DIFF
--- a/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
+++ b/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
@@ -60,6 +60,7 @@ import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import { IDENTITY_JSON_REL } from "../runtime/bootstrap.js";
 import type { SessionContext } from "../runtime/handler.js";
+import { noopDeliveryToken } from "../runtime/handler.js";
 import { INIT_COMPLETE_SENTINEL_REL } from "../runtime/workspace.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
@@ -158,11 +159,16 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
 
     const cache = buildCache([]);
     await cache.refresh(AGENT_ID);
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     try {
       await handler.start(
         makeMessage("chat-legacy-marker", "msg-legacy-marker"),
         buildSessionCtx("chat-legacy-marker"),
+        noopDeliveryToken(),
       );
 
       expect(lstatSync(join(workspaceRoot, ".first-tree-workspace")).isDirectory()).toBe(true);
@@ -182,8 +188,12 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     const cache = buildCache([{ url: fixtureBareRepo, localPath: "first-tree" }]);
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
-    await handler.start(makeMessage("chat-e2", "msg-1"), buildSessionCtx("chat-e2"));
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
+    await handler.start(makeMessage("chat-e2", "msg-1"), buildSessionCtx("chat-e2"), noopDeliveryToken());
 
     // `worktrees/` subdir is reserved for agent's on-demand worktrees only;
     // runtime must never pre-create it. Use both negation forms (the subdir
@@ -204,8 +214,12 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     await cache.refresh(AGENT_ID);
 
     // First chat — full bootstrap path.
-    const h1 = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
-    await h1.start(makeMessage("chat-A", "msg-A1"), buildSessionCtx("chat-A"));
+    const h1 = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
+    await h1.start(makeMessage("chat-A", "msg-A1"), buildSessionCtx("chat-A"), noopDeliveryToken());
 
     const sourceRepoPath = join(workspaceRoot, "repo-a");
     const sentinelPath = join(workspaceRoot, INIT_COMPLETE_SENTINEL_REL);
@@ -221,8 +235,12 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     await h1.shutdown();
 
     // Second chat — different chatId, same workspaceRoot.
-    const h2 = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
-    await h2.start(makeMessage("chat-B", "msg-B1"), buildSessionCtx("chat-B"));
+    const h2 = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
+    await h2.start(makeMessage("chat-B", "msg-B1"), buildSessionCtx("chat-B"), noopDeliveryToken());
 
     // The marker must survive, the repo must still not be materialised.
     expect(existsSync(reuseMarker)).toBe(true);
@@ -244,8 +262,12 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     const cache = buildCache([{ url: fixtureBareRepo, localPath: "lib" }]);
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
-    await handler.start(makeMessage("chat-e4", "msg-e4"), buildSessionCtx("chat-e4"));
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
+    await handler.start(makeMessage("chat-e4", "msg-e4"), buildSessionCtx("chat-e4"), noopDeliveryToken());
 
     // Stable agent identity / working-dir convention / source repos flow
     // through AGENTS.md (with CLAUDE.md symlinked to it). Per-chat context
@@ -303,8 +325,12 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     const cache = buildCache([]);
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
-    await handler.start(makeMessage("chat-e6", "msg-e6"), buildSessionCtx("chat-e6"));
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
+    await handler.start(makeMessage("chat-e6", "msg-e6"), buildSessionCtx("chat-e6"), noopDeliveryToken());
 
     const identityPath = join(workspaceRoot, IDENTITY_JSON_REL);
     expect(existsSync(identityPath)).toBe(true);
@@ -336,8 +362,12 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     const cache = buildCache([]);
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
-    await handler.start(makeMessage("chat-e7", "msg-e7"), buildSessionCtx("chat-e7"));
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
+    await handler.start(makeMessage("chat-e7", "msg-e7"), buildSessionCtx("chat-e7"), noopDeliveryToken());
 
     // Fresh session creates agent home + new layout.
     expect(existsSync(join(workspaceRoot, IDENTITY_JSON_REL))).toBe(true);
@@ -366,25 +396,30 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     const cache = buildCache([]);
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     // No transcript exists anywhere under `~/.claude/projects/<encoded-cwd>/`.
     const staleSessionId = "72a19485-ca9e-4bc3-9add-a57e8314e5c3";
     const returnedSessionId = await handler.resume(
       makeMessage("chat-e8", "msg-e8"),
       staleSessionId,
       buildSessionCtx("chat-e8"),
+      noopDeliveryToken(),
     );
 
     // Returned sessionId MUST differ from the stale input — that's how
     // SessionManager learns to update its registry.
-    expect(returnedSessionId).not.toBe(staleSessionId);
-    expect(returnedSessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(returnedSessionId.sessionId).not.toBe(staleSessionId);
+    expect(returnedSessionId.sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
 
     // The SDK was invoked WITHOUT a resume argument (fresh start semantics).
     expect(capturedSdkOptions.length).toBeGreaterThan(0);
     const lastOptions = capturedSdkOptions[capturedSdkOptions.length - 1]?.options;
     expect(lastOptions?.resume).toBeUndefined();
-    expect(lastOptions?.sessionId).toBe(returnedSessionId);
+    expect(lastOptions?.sessionId).toBe(returnedSessionId.sessionId);
 
     await handler.shutdown();
     rmSync(dataDir, { recursive: true, force: true });
@@ -421,15 +456,20 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
       const cache = buildCache([]);
       await cache.refresh(AGENT_ID);
 
-      const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+      const handler = createClaudeCodeHandler({
+        runtimeProvider: "claude-code",
+        workspaceRoot,
+        agentConfigCache: cache,
+      });
       const returnedSessionId = await handler.resume(
         makeMessage(chatId, "msg-e9"),
         legacySessionId,
         buildSessionCtx(chatId),
+        noopDeliveryToken(),
       );
 
       // The legacy sessionId MUST be preserved — no fresh-id rotation here.
-      expect(returnedSessionId).toBe(legacySessionId);
+      expect(returnedSessionId.sessionId).toBe(legacySessionId);
 
       // SDK was invoked with the legacy sessionId on the `resume` channel.
       expect(capturedSdkOptions.length).toBeGreaterThan(0);

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -384,8 +384,8 @@ async function makeSlot(options?: {
   const connection = new FakeClientConnection(sdk);
   const { AgentSlot } = await import("../runtime/agent-slot.js");
   const handlerFactory = vi.fn((config: HandlerConfig) => ({
-    start: vi.fn(async () => "session-1"),
-    resume: vi.fn(async () => "session-1"),
+    start: vi.fn(async () => ({ sessionId: "session-1", route: { kind: "owned" as const, mode: "queued" as const } })),
+    resume: vi.fn(async () => ({ sessionId: "session-1", route: { kind: "owned" as const, mode: "queued" as const } })),
     inject: vi.fn(),
     suspend: vi.fn(async () => {}),
     shutdown: vi.fn(async () => {}),

--- a/packages/client/src/__tests__/builtin-handlers.test.ts
+++ b/packages/client/src/__tests__/builtin-handlers.test.ts
@@ -33,7 +33,10 @@ describe("Built-in Handlers", () => {
     registerBuiltinHandlers();
 
     const factory = getHandlerFactory("claude-code");
-    const handler = factory({ workspaceRoot: "/tmp/test" });
+    const handler = factory({
+      runtimeProvider: "codex",
+      workspaceRoot: "/tmp/test",
+    });
     expect(handler).toBeDefined();
     expect(typeof handler.start).toBe("function");
     expect(typeof handler.resume).toBe("function");
@@ -54,7 +57,10 @@ describe("Built-in Handlers", () => {
     registerBuiltinHandlers();
 
     const factory = getHandlerFactory("claude-code-tui");
-    const handler = factory({ workspaceRoot: "/tmp/test" });
+    const handler = factory({
+      runtimeProvider: "codex",
+      workspaceRoot: "/tmp/test",
+    });
     expect(handler).toBeDefined();
     expect(typeof handler.start).toBe("function");
     expect(typeof handler.resume).toBe("function");
@@ -76,7 +82,10 @@ describe("Built-in Handlers", () => {
 
     const factory = getHandlerFactory("cursor");
     expect(typeof factory).toBe("function");
-    const handler = factory({ workspaceRoot: "/tmp/test" });
+    const handler = factory({
+      runtimeProvider: "codex",
+      workspaceRoot: "/tmp/test",
+    });
     expect(typeof handler.start).toBe("function");
     expect(typeof handler.resume).toBe("function");
     expect(typeof handler.inject).toBe("function");
@@ -102,7 +111,10 @@ describe("Built-in Handlers", () => {
 
     const factory = getHandlerFactory("kimi-code");
     expect(typeof factory).toBe("function");
-    const handler = factory({ workspaceRoot: "/tmp/test" });
+    const handler = factory({
+      runtimeProvider: "codex",
+      workspaceRoot: "/tmp/test",
+    });
     expect(typeof handler.start).toBe("function");
     expect(typeof handler.resume).toBe("function");
     expect(typeof handler.inject).toBe("function");
@@ -140,7 +152,10 @@ describe("Built-in Handlers", () => {
     registerBuiltinHandlers();
 
     const factory = getHandlerFactory("codex");
-    const handler = factory({ workspaceRoot: "/tmp/test" });
+    const handler = factory({
+      runtimeProvider: "codex",
+      workspaceRoot: "/tmp/test",
+    });
     expect(handler).toBeDefined();
     expect(typeof handler.start).toBe("function");
     expect(typeof handler.resume).toBe("function");

--- a/packages/client/src/__tests__/builtin-registry.test.ts
+++ b/packages/client/src/__tests__/builtin-registry.test.ts
@@ -1,11 +1,12 @@
 import { RUNTIME_PROVIDER_IDS } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ZodError } from "zod";
 import { registerBuiltinHandlers } from "../handlers/index.js";
 import { BUILTIN_PROVIDER_PROBES } from "../providers/builtin-probes.js";
 import { createBuiltinHandlerRegistry } from "../providers/builtin-registry.js";
 import { PROVIDER_SKILL_ROOTS } from "../providers/skill-roots.js";
 import { probeCapabilities } from "../runtime/capabilities/index.js";
-import { getHandlerFactory, hasHandler, registerHandler } from "../runtime/handler.js";
+import { getHandlerFactory, type HandlerConfig, hasHandler, registerHandler } from "../runtime/handler.js";
 import { providerSkillRoot } from "../runtime/managed-skills.js";
 
 const HANDLER_METHODS = ["start", "resume", "inject", "suspend", "shutdown"] as const;
@@ -120,4 +121,40 @@ describe("builtin handler registry", () => {
     );
     expect(runtimeSource).not.toContain("installHandlers");
   });
+});
+
+describe("builtin handler factories fail closed on runtimeProvider", () => {
+  function factories() {
+    return createBuiltinHandlerRegistry({
+      resolveExecutable: () => ({ path: undefined, source: "default" }),
+    });
+  }
+
+  function config(overrides: Record<string, unknown>): HandlerConfig {
+    return { workspaceRoot: "/tmp/registry-fail-closed", ...overrides } as HandlerConfig;
+  }
+
+  for (const id of RUNTIME_PROVIDER_IDS) {
+    it(`${id} rejects a missing runtimeProvider at construction`, () => {
+      expect(() => factories()[id](config({}))).toThrow(ZodError);
+    });
+
+    it(`${id} rejects an invalid runtimeProvider at construction`, () => {
+      expect(() => factories()[id](config({ runtimeProvider: "not-a-provider" }))).toThrow(ZodError);
+    });
+  }
+
+  // Codex selects between app-server and SDK implementations; every engine must
+  // reject the same bad config so validation is not path-dependent.
+  for (const codexHandlerEngine of ["app-server", "sdk", "auto"] as const) {
+    it(`codex ${codexHandlerEngine} engine rejects an invalid runtimeProvider`, () => {
+      expect(() => factories().codex(config({ runtimeProvider: "not-a-provider", codexHandlerEngine }))).toThrow(
+        ZodError,
+      );
+    });
+
+    it(`codex ${codexHandlerEngine} engine rejects a missing runtimeProvider`, () => {
+      expect(() => factories().codex(config({ codexHandlerEngine }))).toThrow(ZodError);
+    });
+  }
 });

--- a/packages/client/src/__tests__/claude-code-inject-materialize.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-materialize.test.ts
@@ -95,6 +95,7 @@ vi.mock("../runtime/source-repos.js", () => ({
 
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { writeAgentBriefing } from "../runtime/bootstrap.js";
+import { noopDeliveryToken } from "../runtime/handler.js";
 
 const AGENT_ID = "019e71d2-c9ec-7f11-86bf-5dfc9e873338";
 
@@ -206,11 +207,11 @@ afterEach(() => {
 describe("claude-code inject-time managed Skill reconciliation", () => {
   it("materializes a skill bound mid-session so the injected turn finds it on disk", async () => {
     cachedConfig = makeConfig(1, []);
-    const config = { workspaceRoot, agentConfigCache };
+    const config = { workspaceRoot, agentConfigCache, runtimeProvider: "claude-code" as const };
     const handler = createClaudeCodeHandler(config);
     const ctx = makeContext();
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, noopDeliveryToken());
     resolveChatContext();
     await startPromise;
     await waitFor(() => state.observedInputs.length === 1);
@@ -222,7 +223,7 @@ describe("claude-code inject-time managed Skill reconciliation", () => {
     // reflects the newer version. An injected message drives the drain →
     // maybeSwitchConfig → materialize.
     cachedConfig = makeConfig(2, [SCAN_SKILL]);
-    handler.inject(makeMessage("m2", "run the scan"));
+    handler.inject(makeMessage("m2", "run the scan"), noopDeliveryToken());
 
     // Wait for the body to actually land — existsSync alone can race the
     // create-then-write window and observe a still-empty file.
@@ -235,11 +236,11 @@ describe("claude-code inject-time managed Skill reconciliation", () => {
 
   it("does not prune a live skill when a refresh falls back to a lower-version empty config", async () => {
     cachedConfig = makeConfig(2, [SCAN_SKILL]);
-    const config = { workspaceRoot, agentConfigCache };
+    const config = { workspaceRoot, agentConfigCache, runtimeProvider: "claude-code" as const };
     const handler = createClaudeCodeHandler(config);
     const ctx = makeContext();
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, noopDeliveryToken());
     resolveChatContext();
     await startPromise;
     await waitFor(() => state.observedInputs.length === 1);
@@ -252,7 +253,7 @@ describe("claude-code inject-time managed Skill reconciliation", () => {
     // cannot prune the live skill.
     vi.mocked(writeAgentBriefing).mockClear();
     cachedConfig = makeConfig(0, []);
-    handler.inject(makeMessage("m2", "another message"));
+    handler.inject(makeMessage("m2", "another message"), noopDeliveryToken());
 
     await waitFor(() => vi.mocked(writeAgentBriefing).mock.calls.length >= 1);
     expect(existsSync(skillPath())).toBe(true);
@@ -296,16 +297,20 @@ describe("claude-code inject-time managed Skill reconciliation", () => {
       },
     };
     cachedConfig = makeConfig(1, []);
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache,
+    });
     const ctx = makeContext(fetchAttachment);
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, noopDeliveryToken());
     resolveChatContext();
     await startPromise;
     await waitFor(() => state.observedInputs.length === 1);
 
     cachedConfig = makeConfig(2, [bundledSkill]);
-    handler.inject(makeMessage("m2", "run the newly attached scan"));
+    handler.inject(makeMessage("m2", "run the newly attached scan"), noopDeliveryToken());
 
     await waitFor(() => state.observedInputs.length === 2);
     expect(fetchAttachment).toHaveBeenCalledTimes(1);
@@ -342,10 +347,14 @@ describe("claude-code inject-time managed Skill reconciliation", () => {
     });
     const logs: string[] = [];
     cachedConfig = makeConfig(1, [bundledSkill]);
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache,
+    });
     const ctx = makeContext(fetchAttachment, (message) => logs.push(message));
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, noopDeliveryToken());
     resolveChatContext();
     await startPromise;
     await waitFor(() => state.observedInputs.length === 1);
@@ -356,7 +365,7 @@ describe("claude-code inject-time managed Skill reconciliation", () => {
     chmodSync(discoveryRoot, 0o500);
     try {
       cachedConfig = makeConfig(2, [bundledSkill]);
-      handler.inject(makeMessage("m2", "must not reach provider"));
+      handler.inject(makeMessage("m2", "must not reach provider"), noopDeliveryToken());
       await waitFor(() => logs.some((message) => message.includes("cannot be verified or quarantined")));
       expect(state.observedInputs).toHaveLength(1);
       expect(readFileSync(join(scriptsRoot, "scan.sh"), "utf-8")).toContain("tampered");

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -112,6 +112,7 @@ vi.mock("../runtime/source-repos.js", () => ({
 }));
 
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 
 const AGENT_ID = "019e71d2-c9ec-7f11-86bf-5dfc9e873338";
 
@@ -206,7 +207,10 @@ afterEach(() => {
 describe("claude-code handler startup inject queue", () => {
   it("materializes legacy inline images and describes unavailable image batches", async () => {
     const completedCounts: Array<number | undefined> = [];
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(
       (count) => {
         completedCounts.push(count);
@@ -234,6 +238,7 @@ describe("claude-code handler startup inject queue", () => {
         "../unsafe/chat",
       ),
       ctx,
+      deliveryTokenFromSessionContext(ctx),
     );
 
     const batchMessage = makeFileMessage("batch-images", {
@@ -274,7 +279,7 @@ describe("claude-code handler startup inject queue", () => {
         createdAt: "2026-07-24T00:00:00.000Z",
       },
     ];
-    handler.inject(batchMessage);
+    handler.inject(batchMessage, deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => state.observedInputs.length === 2);
     expect(state.observedInputs[0]).toContain("Filename: legacy.png");
@@ -294,17 +299,20 @@ describe("claude-code handler startup inject queue", () => {
 
   it("queues injects received before the InputController exists so their inbox entries stay aligned with acks", async () => {
     const completedCounts: Array<number | undefined> = [];
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => {
       completedCounts.push(count);
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await Promise.resolve();
 
     // The handler has a session id, but startup is still waiting on chat
     // context; `spawnQuery` has not created the InputController yet.
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
 
     state.resolveChatContext?.({
       chatId: "chat-claude-startup-race",
@@ -331,7 +339,10 @@ describe("claude-code handler startup inject queue", () => {
     const secondGate = new Promise<void>((resolve) => {
       releaseSecond.current = resolve;
     });
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(
       (count) => {
         completedCounts.push(count);
@@ -345,9 +356,9 @@ describe("claude-code handler startup inject queue", () => {
       },
     );
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await Promise.resolve();
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
 
     state.resolveChatContext?.({
       chatId: "chat-claude-startup-race",
@@ -358,7 +369,7 @@ describe("claude-code handler startup inject queue", () => {
     });
 
     await startPromise;
-    handler.inject(makeMessage("m3", "third"));
+    handler.inject(makeMessage("m3", "third"), deliveryTokenFromSessionContext(ctx));
     await new Promise((resolve) => setImmediate(resolve));
     releaseSecond.current?.();
 
@@ -377,7 +388,10 @@ describe("claude-code handler startup inject queue", () => {
     state.coalesceFirstResultAfterInputs = 2;
     const finishedBatches: string[][] = [];
     const processingStarted: string[] = [];
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(() => {});
     ctx.markMessagesConsumed = (messages) => {
       const batch = Array.isArray(messages) ? messages : [messages];
@@ -396,8 +410,8 @@ describe("claude-code handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
-    handler.inject(makeMessage("m2", "second"));
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => state.observedInputs.length === 2);
     await waitFor(() => finishedBatches.length === 1);
@@ -413,7 +427,10 @@ describe("claude-code handler startup inject queue", () => {
   it("retries active injects whose SDK message conversion fails before provider custody", async () => {
     const completedCounts: Array<number | undefined> = [];
     const retryTurn = vi.fn();
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(
       (count) => {
         completedCounts.push(count);
@@ -436,8 +453,8 @@ describe("claude-code handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
-    handler.inject(makeMessage("m2", "bad"));
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
+    handler.inject(makeMessage("m2", "bad"), deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => retryTurn.mock.calls.length === 1);
 
@@ -473,7 +490,10 @@ describe("claude-code handler startup inject queue", () => {
         },
       },
     ];
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(() => {});
     ctx.log = (message) => {
       logs.push(message);
@@ -493,7 +513,7 @@ describe("claude-code handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "usage"), ctx);
+    await handler.start(makeMessage("m1", "usage"), ctx, deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => events.some((event) => event.kind === "turn_end"));
     expect(events.find((event) => event.kind === "token_usage")).toMatchObject({
@@ -556,7 +576,10 @@ describe("claude-code handler startup inject queue", () => {
               },
       },
     ];
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(() => {});
     ctx.emitEvent = (event) => {
       events.push(event);
@@ -569,9 +592,9 @@ describe("claude-code handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first usage turn"), ctx);
+    await handler.start(makeMessage("m1", "first usage turn"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 1);
-    handler.inject(makeMessage("m2", "second usage turn"));
+    handler.inject(makeMessage("m2", "second usage turn"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 2);
 
     expect(events.filter((event) => event.kind === "token_usage")).toEqual([
@@ -627,7 +650,10 @@ describe("claude-code handler startup inject queue", () => {
         },
       },
     ];
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(() => {});
     ctx.emitEvent = (event) => {
       events.push(event);
@@ -640,9 +666,9 @@ describe("claude-code handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "before counter rollback"), ctx);
+    await handler.start(makeMessage("m1", "before counter rollback"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 1);
-    handler.inject(makeMessage("m2", "after counter rollback"));
+    handler.inject(makeMessage("m2", "after counter rollback"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 2);
 
     expect(
@@ -671,7 +697,10 @@ describe("claude-code handler startup inject queue", () => {
         },
       },
     ];
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(() => {});
     ctx.emitEvent = (event) => {
       events.push(event);
@@ -684,11 +713,11 @@ describe("claude-code handler startup inject queue", () => {
       participants: [],
     });
 
-    const started = await handler.start(makeMessage("m1", "first Query"), ctx);
+    const started = await handler.start(makeMessage("m1", "first Query"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 1);
     await handler.suspend();
     const sessionId = typeof started === "string" ? started : started.sessionId;
-    await handler.resume(makeMessage("m2", "replacement Query"), sessionId, ctx);
+    await handler.resume(makeMessage("m2", "replacement Query"), sessionId, ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 2);
 
     expect(
@@ -704,7 +733,10 @@ describe("claude-code handler startup inject queue", () => {
     const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
     const logs: string[] = [];
     const outcomes: unknown[] = [];
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(() => {});
     ctx.forwardResult = vi.fn(async () => {
       throw new Error("completion sink down");
@@ -726,7 +758,7 @@ describe("claude-code handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "forward"), ctx);
+    await handler.start(makeMessage("m1", "forward"), ctx, deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => events.some((event) => event.kind === "turn_end"));
     expect(ctx.forwardResult).toHaveBeenCalledWith("reply 1");
@@ -755,7 +787,10 @@ describe("claude-code handler startup inject queue", () => {
     const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
     const outcomes: unknown[] = [];
     state.resultMessagesForInput = () => [{ type: "result", subtype: "success" }];
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(() => {});
     ctx.forwardResult = vi.fn(async () => {});
     ctx.emitEvent = (event) => {
@@ -772,7 +807,7 @@ describe("claude-code handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "empty result"), ctx);
+    await handler.start(makeMessage("m1", "empty result"), ctx, deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => events.some((event) => event.kind === "turn_end"));
     expect(ctx.forwardResult).not.toHaveBeenCalled();
@@ -786,7 +821,10 @@ describe("claude-code handler startup inject queue", () => {
     const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
     state.resultMessagesForInput = () => [{ type: "auth_status", error: "authentication_failed" }];
     state.closeAfterInput = true;
-    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+    });
     const ctx = makeContext(() => {});
     ctx.emitEvent = (event) => {
       events.push(event);
@@ -799,7 +837,7 @@ describe("claude-code handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "auth"), ctx);
+    await handler.start(makeMessage("m1", "auth"), ctx, deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => events.some((event) => event.kind === "error"));
     const errorEvent = events.find((event) => event.kind === "error");

--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -72,6 +72,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext, TurnOutcome } from "../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { formatProviderFailureRuntimeNotice } from "../runtime/runtime-notice.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
@@ -156,7 +157,11 @@ async function startSingleResultTurn() {
   const cache = buildCache();
   await cache.refresh(AGENT_ID);
 
-  const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+  const handler = createClaudeCodeHandler({
+    runtimeProvider: "claude-code",
+    workspaceRoot,
+    agentConfigCache: cache,
+  });
   const ctx: SessionContext = {
     agent: {
       agentId: AGENT_ID,
@@ -191,9 +196,21 @@ async function startSingleResultTurn() {
       metadata: null,
     },
     ctx,
+    deliveryTokenFromSessionContext(ctx),
   );
 
-  return { handler, cache, sendMessage, forwardResult, emitted, completed, logs, retryTurn, failSessionForRecovery };
+  return {
+    handler,
+    cache,
+    ctx,
+    sendMessage,
+    forwardResult,
+    emitted,
+    completed,
+    logs,
+    retryTurn,
+    failSessionForRecovery,
+  };
 }
 
 async function runSingleResultTurn() {
@@ -428,14 +445,17 @@ describe("claude-code handler — structured provider error result", () => {
       mockState.configVersion = 2;
       mockState.promptAppend = "updated prompt";
       await result.cache.refresh(AGENT_ID);
-      result.handler.inject({
-        id: "m2",
-        chatId: "chat-claude-provider-error",
-        senderId: "user-1",
-        format: "text",
-        content: "continue with the updated config",
-        metadata: null,
-      });
+      result.handler.inject(
+        {
+          id: "m2",
+          chatId: "chat-claude-provider-error",
+          senderId: "user-1",
+          format: "text",
+          content: "continue with the updated config",
+          metadata: null,
+        },
+        deliveryTokenFromSessionContext(result.ctx),
+      );
 
       await waitForCondition(() => mockState.queryCalls === 2, "config restart query");
       await waitForCondition(
@@ -483,14 +503,17 @@ describe("claude-code handler — structured provider error result", () => {
       mockState.configVersion = 2;
       mockState.configModel = "claude-opus-4-6";
       await result.cache.refresh(AGENT_ID);
-      result.handler.inject({
-        id: "m2",
-        chatId: "chat-claude-provider-error",
-        senderId: "user-1",
-        format: "text",
-        content: "continue with the new model",
-        metadata: null,
-      });
+      result.handler.inject(
+        {
+          id: "m2",
+          chatId: "chat-claude-provider-error",
+          senderId: "user-1",
+          format: "text",
+          content: "continue with the new model",
+          metadata: null,
+        },
+        deliveryTokenFromSessionContext(result.ctx),
+      );
 
       await waitForCondition(() => mockState.queryCalls === 2, "config restart query");
       await vi.advanceTimersByTimeAsync(500);

--- a/packages/client/src/__tests__/claude-code-sdk-options.test.ts
+++ b/packages/client/src/__tests__/claude-code-sdk-options.test.ts
@@ -53,6 +53,7 @@ import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext } from "../runtime/handler.js";
+import { noopDeliveryToken } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430d7";
@@ -114,11 +115,16 @@ describe("claude-code handler — SDK options", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx = buildSessionCtx("chat-settings");
     await handler.start(
       { id: "msg-1", chatId: "chat-settings", senderId: "user", format: "text", content: "hi", metadata: null },
       ctx,
+      noopDeliveryToken(),
     );
 
     expect(capturedCalls).toHaveLength(1);
@@ -134,11 +140,16 @@ describe("claude-code handler — SDK options", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx = buildSessionCtx("chat-perm");
     await handler.start(
       { id: "msg-2", chatId: "chat-perm", senderId: "user", format: "text", content: "hi", metadata: null },
       ctx,
+      noopDeliveryToken(),
     );
 
     const options = capturedCalls[0]?.options;
@@ -154,11 +165,16 @@ describe("claude-code handler — SDK options", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx = buildSessionCtx("chat-disallow");
     await handler.start(
       { id: "msg-3", chatId: "chat-disallow", senderId: "user", format: "text", content: "hi", metadata: null },
       ctx,
+      noopDeliveryToken(),
     );
 
     const options = capturedCalls[0]?.options;
@@ -190,7 +206,11 @@ describe("claude-code handler — SDK options", () => {
       const cache = buildCache([{ key: "PATH", value: payloadBin, sensitive: false }]);
       await cache.refresh(AGENT_ID);
 
-      const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+      const handler = createClaudeCodeHandler({
+        runtimeProvider: "claude-code",
+        workspaceRoot,
+        agentConfigCache: cache,
+      });
       const buildAgentEnv = vi.fn((env: NodeJS.ProcessEnv) => ({ ...env, PATH: finalProviderBin }));
       const ctx = buildSessionCtx("chat-provider-path", buildAgentEnv);
       await handler.start(
@@ -203,6 +223,7 @@ describe("claude-code handler — SDK options", () => {
           metadata: null,
         },
         ctx,
+        noopDeliveryToken(),
       );
 
       const childEnv = capturedCalls[0]?.options?.env;

--- a/packages/client/src/__tests__/claude-code-session-limit-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-session-limit-result.test.ts
@@ -37,6 +37,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext, TurnOutcome } from "../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { formatProviderFailureRuntimeNotice } from "../runtime/runtime-notice.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
@@ -89,7 +90,11 @@ describe("claude-code handler — session-limit success result", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -122,6 +127,7 @@ describe("claude-code handler — session-limit success result", () => {
         metadata: null,
       },
       ctx,
+      deliveryTokenFromSessionContext(ctx),
     );
     await handler.suspend();
     await new Promise((r) => setImmediate(r));

--- a/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
+++ b/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
@@ -132,6 +132,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext } from "../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 const AGENT_ID = "019dd905-1234-7777-8888-bef95070f001";
@@ -172,7 +173,11 @@ describe("claude-code handler — transient stream-error retry replays user mess
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -205,6 +210,7 @@ describe("claude-code handler — transient stream-error retry replays user mess
           metadata: null,
         },
         ctx,
+        deliveryTokenFromSessionContext(ctx),
       );
       await waitForCondition(
         () => logs.filter((line) => line.includes("Attempting auto-resume")).length === 1,
@@ -283,7 +289,11 @@ describe("claude-code handler — transient stream-error retry replays user mess
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -316,15 +326,19 @@ describe("claude-code handler — transient stream-error retry replays user mess
         metadata: null,
       },
       ctx,
+      deliveryTokenFromSessionContext(ctx),
     );
-    handler.inject({
-      id: "m2",
-      chatId: "chat-stream-retry",
-      senderId: "user-1",
-      format: "text",
-      content: SECOND_PROMPT,
-      metadata: null,
-    });
+    handler.inject(
+      {
+        id: "m2",
+        chatId: "chat-stream-retry",
+        senderId: "user-1",
+        format: "text",
+        content: SECOND_PROMPT,
+        metadata: null,
+      },
+      deliveryTokenFromSessionContext(ctx),
+    );
 
     await waitForObservedInputs(2, 2);
     await waitForObservedInputs(3, 2);
@@ -376,7 +390,11 @@ describe("claude-code handler — transient stream-error retry replays user mess
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const plumbing = mockCtxPlumbing({ sendMessage }, "chat-stream-retry");
     const ctx: SessionContext = {
       agent: {
@@ -415,16 +433,20 @@ describe("claude-code handler — transient stream-error retry replays user mess
         metadata: null,
       },
       ctx,
+      deliveryTokenFromSessionContext(ctx),
     );
     await waitForObservedInputs(1, 1);
-    handler.inject({
-      id: "m2",
-      chatId: "chat-stream-retry",
-      senderId: "user-1",
-      format: "text",
-      content: SECOND_PROMPT,
-      metadata: null,
-    });
+    handler.inject(
+      {
+        id: "m2",
+        chatId: "chat-stream-retry",
+        senderId: "user-1",
+        format: "text",
+        content: SECOND_PROMPT,
+        metadata: null,
+      },
+      deliveryTokenFromSessionContext(ctx),
+    );
     await m2Pushed;
     releaseAttempt1();
 

--- a/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
@@ -107,6 +107,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext } from "../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430db";
@@ -153,7 +154,11 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -179,6 +184,7 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       await handler.start(
         { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
         ctx,
+        deliveryTokenFromSessionContext(ctx),
       );
       await waitForCondition("scheduled retry", () => providerRetryPayloads(emitted).length === 1);
       await vi.advanceTimersByTimeAsync(5000);
@@ -245,7 +251,11 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -269,6 +279,7 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       await handler.start(
         { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
         ctx,
+        deliveryTokenFromSessionContext(ctx),
       );
       await waitForCondition("scheduled retry", () => providerRetryPayloads(emitted).length === 1);
       await vi.advanceTimersByTimeAsync(5000);
@@ -327,7 +338,11 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const plumbing = mockCtxPlumbing({ sendMessage }, "chat-resume-fail");
     const ctx: SessionContext = {
       agent: {
@@ -365,16 +380,20 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       await handler.start(
         { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
         ctx,
+        deliveryTokenFromSessionContext(ctx),
       );
       await waitForObservedInputs(1, 1);
-      handler.inject({
-        id: "m2",
-        chatId: "chat-resume-fail",
-        senderId: "u",
-        format: "text",
-        content: SECOND_PROMPT,
-        metadata: null,
-      });
+      handler.inject(
+        {
+          id: "m2",
+          chatId: "chat-resume-fail",
+          senderId: "u",
+          format: "text",
+          content: SECOND_PROMPT,
+          metadata: null,
+        },
+        deliveryTokenFromSessionContext(ctx),
+      );
       await m2Pushed;
       releaseAttempt1();
 

--- a/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
@@ -103,6 +103,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { DeliveryToken, SessionContext } from "../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430da";
@@ -142,7 +143,11 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -168,6 +173,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       await handler.start(
         { id: "m1", chatId: "chat-retry", senderId: "u", format: "text", content: "hi", metadata: null },
         ctx,
+        deliveryTokenFromSessionContext(ctx),
       );
       await waitForCondition("first scheduled retry", () => scheduledRetryCount(emitted) === 1);
       await vi.advanceTimersByTimeAsync(5000);
@@ -254,7 +260,11 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const plumbing = mockCtxPlumbing({ sendMessage }, "chat-retry");
     const ctx: SessionContext = {
       agent: {
@@ -291,6 +301,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       await handler.start(
         { id: "m1", chatId: "chat-retry", senderId: "u", format: "text", content: "hi", metadata: null },
         ctx,
+        deliveryTokenFromSessionContext(ctx),
       );
       await waitForObservedInputs(1, 1);
       handler.inject(
@@ -347,7 +358,11 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -371,6 +386,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     await handler.start(
       { id: "m1", chatId: "chat-retry-emit-throw", senderId: "u", format: "text", content: "hi", metadata: null },
       ctx,
+      deliveryTokenFromSessionContext(ctx),
     );
     await handler.suspend();
     await new Promise((r) => setImmediate(r));

--- a/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
@@ -44,6 +44,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext } from "../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { formatProviderFailureRuntimeNotice } from "../runtime/runtime-notice.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
@@ -80,7 +81,11 @@ describe("claude-code handler — turn_end on SDK-reported subtype error", () =>
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -102,6 +107,7 @@ describe("claude-code handler — turn_end on SDK-reported subtype error", () =>
     await handler.start(
       { id: "m1", chatId: "chat-1", senderId: "u", format: "text", content: "hi", metadata: null },
       ctx,
+      deliveryTokenFromSessionContext(ctx),
     );
     await handler.suspend();
     await new Promise((r) => setImmediate(r));

--- a/packages/client/src/__tests__/claude-code-turn-end-serialization.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-serialization.test.ts
@@ -68,6 +68,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext } from "../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430d9";
@@ -109,7 +110,11 @@ describe("claude-code handler — turn_end serialization (race guard)", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -134,6 +139,7 @@ describe("claude-code handler — turn_end serialization (race guard)", () => {
     const startPromise = handler.start(
       { id: "m1", chatId: "chat-1", senderId: "u", format: "text", content: "hi", metadata: null },
       ctx,
+      deliveryTokenFromSessionContext(ctx),
     );
 
     // Wait until the completion hook was invoked (turn 1 result arrived), then

--- a/packages/client/src/__tests__/claude-code-turn-end.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end.test.ts
@@ -41,6 +41,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext } from "../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430d7";
@@ -78,7 +79,11 @@ describe("claude-code handler — turn_end emission", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -100,6 +105,7 @@ describe("claude-code handler — turn_end emission", () => {
     await handler.start(
       { id: "m1", chatId: "chat-1", senderId: "u", format: "text", content: "hi", metadata: null },
       ctx,
+      deliveryTokenFromSessionContext(ctx),
     );
     await handler.suspend();
     await new Promise((r) => setImmediate(r));
@@ -116,7 +122,11 @@ describe("claude-code handler — turn_end emission", () => {
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
 
-    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentConfigCache: cache,
+    });
     const ctx: SessionContext = {
       agent: {
         agentId: AGENT_ID,
@@ -146,6 +156,7 @@ describe("claude-code handler — turn_end emission", () => {
     await handler.start(
       { id: "m1", chatId: "chat-1", senderId: "u", format: "text", content: "hi", metadata: null },
       ctx,
+      deliveryTokenFromSessionContext(ctx),
     );
 
     // Consumer loop is async; let microtasks settle.

--- a/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
@@ -23,6 +23,7 @@ import {
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { setCliBinding } from "../runtime/cli-binding.js";
 import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
+import { noopDeliveryToken } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 vi.mock("../runtime/bootstrap.js", () => ({
@@ -283,6 +284,7 @@ function makeContext(
 
 function makeHandler(fake: FakeAppServerClient, extraConfig: Record<string, unknown> = {}) {
   return createCodexAppServerHandler({
+    runtimeProvider: "codex",
     workspaceRoot,
     codexRuntimeBinaryResolver: async () => ({
       ok: true,
@@ -514,7 +516,9 @@ describe("codex app-server handler extra branches", () => {
         throw new Error("resolver exploded");
       },
     });
-    await expect(thrownResolve.start(makeMessage("m0", "first"), makeContext())).rejects.toMatchObject({
+    await expect(
+      thrownResolve.start(makeMessage("m0", "first"), makeContext(), noopDeliveryToken()),
+    ).rejects.toMatchObject({
       stage: "resolve-binary",
       message: expect.stringContaining("resolver exploded"),
     });
@@ -522,7 +526,9 @@ describe("codex app-server handler extra branches", () => {
     const resolveFailure = makeHandler(new FakeAppServerClient(), {
       codexRuntimeBinaryResolver: async () => ({ ok: false, error: "missing codex binary" }),
     });
-    await expect(resolveFailure.start(makeMessage("m1", "first"), makeContext())).rejects.toMatchObject({
+    await expect(
+      resolveFailure.start(makeMessage("m1", "first"), makeContext(), noopDeliveryToken()),
+    ).rejects.toMatchObject({
       stage: "resolve-binary",
       message: expect.stringContaining("missing codex binary"),
     });
@@ -532,7 +538,9 @@ describe("codex app-server handler extra branches", () => {
         throw new Error("initialize rpc failed");
       },
     });
-    await expect(initializeFailure.start(makeMessage("m2", "first"), makeContext())).rejects.toMatchObject({
+    await expect(
+      initializeFailure.start(makeMessage("m2", "first"), makeContext(), noopDeliveryToken()),
+    ).rejects.toMatchObject({
       stage: "initialize",
       message: expect.stringContaining("initialize rpc failed"),
     });
@@ -540,7 +548,9 @@ describe("codex app-server handler extra branches", () => {
     const malformedThread = new FakeAppServerClient();
     malformedThread.threadStartResult = { thread: {} };
     const malformedHandler = makeHandler(malformedThread);
-    await expect(malformedHandler.start(makeMessage("m3", "first"), makeContext())).rejects.toMatchObject({
+    await expect(
+      malformedHandler.start(makeMessage("m3", "first"), makeContext(), noopDeliveryToken()),
+    ).rejects.toMatchObject({
       stage: "thread-start",
       message: expect.stringContaining("missing thread id"),
     });
@@ -550,7 +560,7 @@ describe("codex app-server handler extra branches", () => {
     failedThread.errors.set("thread/start", new Error("thread start rpc failed"));
     const failedThreadHandler = makeHandler(failedThread);
     const failedThreadError = await failedThreadHandler
-      .start(makeMessage("m4", "first"), makeContext())
+      .start(makeMessage("m4", "first"), makeContext(), noopDeliveryToken())
       .catch((err) => err);
     expect(failedThreadError).toBeInstanceOf(CodexAppServerStartupError);
     expect(failedThreadError).toMatchObject({
@@ -587,6 +597,7 @@ describe("codex app-server handler extra branches", () => {
       get: vi.fn(() => cachedConfig),
     } as unknown as AgentConfigCache;
     const handler = createCodexAppServerHandler({
+      runtimeProvider: "codex",
       workspaceRoot,
       agentConfigCache,
       codexRuntimeBinaryResolver: async () => ({
@@ -608,7 +619,7 @@ describe("codex app-server handler extra branches", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), makeContext({ log }));
+    const startPromise = handler.start(makeMessage("m1", "first"), makeContext({ log }), noopDeliveryToken());
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "cached config turn/start");
     fake.emit("turn/completed", {
       threadId: "thread-app-server",
@@ -659,6 +670,7 @@ describe("codex app-server handler extra branches", () => {
       get: vi.fn(() => cachedConfig),
     } as unknown as AgentConfigCache;
     const handler = createCodexAppServerHandler({
+      runtimeProvider: "codex",
       workspaceRoot,
       agentConfigCache,
       codexRuntimeBinaryResolver: async () => ({
@@ -678,7 +690,7 @@ describe("codex app-server handler extra branches", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m-effort", "run"), makeContext());
+    const startPromise = handler.start(makeMessage("m-effort", "run"), makeContext(), noopDeliveryToken());
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "effort turn/start");
     const turnStart = fake.requests.find((request) => request.method === "turn/start");
     expect(asRecord(turnStart?.params)?.effort).toBe(reasoningEffort);
@@ -1335,7 +1347,7 @@ describe("codex app-server handler extra branches", () => {
     });
     expect(log.mock.calls.some(([entry]) => entry.includes("turn interrupt failed: interrupt rpc failed"))).toBe(true);
     expect(fake.shutdownCalls).toBe(1);
-    expect(handler.inject(makeMessage("m3", "late"))).toEqual({
+    expect(handler.inject(makeMessage("m3", "late"), noopDeliveryToken())).toEqual({
       kind: "rejected",
       reason: "no_active_context",
       retryable: true,

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -9,6 +9,7 @@ import { LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED } from "../handlers/codex/
 import { writeAgentBriefing } from "../runtime/bootstrap.js";
 import { setCliBinding } from "../runtime/cli-binding.js";
 import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 vi.mock("../runtime/agent-briefing.js", async (importOriginal) => {
@@ -274,6 +275,7 @@ function makeContext(
 
 function makeHandler(fake: FakeAppServerClient, extraConfig: Record<string, unknown> = {}) {
   return createCodexAppServerHandler({
+    runtimeProvider: "codex",
     workspaceRoot,
     codexRuntimeBinaryResolver: async () => ({
       ok: true,
@@ -541,7 +543,7 @@ describe("codex app-server handler", () => {
       agentMetadata: trialAgentMetadata,
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     expect(capturedSpawnProcess).toBeUndefined();
@@ -623,7 +625,7 @@ describe("codex app-server handler", () => {
     });
     const ctx = makeContext();
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     expect(capturedSpawnProcess).toBeUndefined();
@@ -643,7 +645,7 @@ describe("codex app-server handler", () => {
     const handler = makeHandler(fake, { agentConfigCache: mutable.cache });
     const ctx = makeContext();
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     const threadStart = fake.requests.find((request) => request.method === "thread/start");
@@ -675,7 +677,7 @@ describe("codex app-server handler", () => {
     const handler = makeHandler(fake, { agentConfigCache: cache });
     const ctx = makeContext();
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     const threadStart = fake.requests.find((request) => request.method === "thread/start");
@@ -694,7 +696,7 @@ describe("codex app-server handler", () => {
     const handler = makeHandler(fake, { agentConfigCache: mutable.cache });
     const ctx = makeContext();
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     const threadStart = fake.requests.find((request) => request.method === "thread/start");
@@ -769,10 +771,10 @@ describe("codex app-server handler", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
 
     const steer = fake.requests.find((request) => request.method === "turn/steer");
@@ -893,7 +895,7 @@ describe("codex app-server handler", () => {
     const handler = makeHandler(fake);
     const ctx = makeContext({ emitEvent });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     emitTokenUsage(fake, "turn-1", {
@@ -953,7 +955,12 @@ describe("codex app-server handler", () => {
       });
     };
 
-    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    const resumePromise = handler.resume(
+      makeMessage("m1", "first"),
+      "thread-app-server",
+      ctx,
+      deliveryTokenFromSessionContext(ctx),
+    );
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     emitTokenUsage(
@@ -1017,7 +1024,12 @@ describe("codex app-server handler", () => {
       });
     };
 
-    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    const resumePromise = handler.resume(
+      makeMessage("m1", "first"),
+      "thread-app-server",
+      ctx,
+      deliveryTokenFromSessionContext(ctx),
+    );
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     emitTokenUsage(
@@ -1102,7 +1114,12 @@ describe("codex app-server handler", () => {
     const handler = makeHandler(fake);
     const ctx = makeContext({ emitEvent });
 
-    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    const resumePromise = handler.resume(
+      makeMessage("m1", "first"),
+      "thread-app-server",
+      ctx,
+      deliveryTokenFromSessionContext(ctx),
+    );
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
     await flushAsync();
 
@@ -1191,7 +1208,12 @@ describe("codex app-server handler", () => {
       });
     };
 
-    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    const resumePromise = handler.resume(
+      makeMessage("m1", "first"),
+      "thread-app-server",
+      ctx,
+      deliveryTokenFromSessionContext(ctx),
+    );
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     emitTokenUsage(
@@ -1247,7 +1269,7 @@ describe("codex app-server handler", () => {
       },
     );
 
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === 2);
 
     emitTokenUsage(
@@ -1316,7 +1338,12 @@ describe("codex app-server handler", () => {
       });
     };
 
-    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    const resumePromise = handler.resume(
+      makeMessage("m1", "first"),
+      "thread-app-server",
+      ctx,
+      deliveryTokenFromSessionContext(ctx),
+    );
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     emitTokenUsage(
@@ -1348,7 +1375,7 @@ describe("codex app-server handler", () => {
     });
     await resumePromise;
 
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === 2);
     await flushAsync();
 
@@ -1418,7 +1445,7 @@ describe("codex app-server handler", () => {
       },
     );
 
-    handler.inject(makeMessage("m3", "third"));
+    handler.inject(makeMessage("m3", "third"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === 3);
 
     emitTokenUsage(
@@ -1484,10 +1511,10 @@ describe("codex app-server handler", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "thread/start"));
 
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await flushAsync();
 
     expect(retryTurn).not.toHaveBeenCalled();
@@ -1518,9 +1545,9 @@ describe("codex app-server handler", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
     await flushAsync();
 
@@ -1548,13 +1575,13 @@ describe("codex app-server handler", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
 
-    handler.inject(makeMessage("m3", "third"));
+    handler.inject(makeMessage("m3", "third"), deliveryTokenFromSessionContext(ctx));
     await flushAsync();
 
     expect(fake.requests.filter((request) => request.method === "turn/steer")).toHaveLength(1);
@@ -1587,15 +1614,15 @@ describe("codex app-server handler", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/steer").length === 1);
     await flushAsync();
 
     fake.steerError = null;
-    handler.inject(makeMessage("m3", "third"));
+    handler.inject(makeMessage("m3", "third"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/steer").length === 2);
 
     const retriedSteer = fake.requests.filter((request) => request.method === "turn/steer")[1];
@@ -1621,12 +1648,12 @@ describe("codex app-server handler", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/steer").length === 1);
-    handler.inject(makeMessage("m3", "third"));
+    handler.inject(makeMessage("m3", "third"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/steer").length === 2);
 
     completeTurn(fake, "turn-1", "first done");
@@ -1656,9 +1683,9 @@ describe("codex app-server handler", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
 
     completeTurn(fake, "turn-1", "final answer");
@@ -1685,9 +1712,9 @@ describe("codex app-server handler", () => {
       },
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
 
     completeTurn(fake, "turn-1", "first done");
@@ -1724,9 +1751,9 @@ describe("codex app-server handler", () => {
       failSessionForRecovery,
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
 
     failTurn(fake, "turn-1", { message: "provider failed" });
@@ -2358,9 +2385,9 @@ describe("codex app-server handler", () => {
     const handler = makeHandler(fake);
     const ctx = makeContext({ retryTurn, finishTurn });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
 
     fake.close();
@@ -2387,7 +2414,7 @@ describe("codex app-server handler", () => {
     const handler = makeHandler(fake);
     const ctx = makeContext({ retryTurn, finishTurn, failSessionForRecovery, sendMessage });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     expect(fake.isClosed).toBe(true);
     expect(retryTurn).toHaveBeenCalledWith(
@@ -2421,9 +2448,9 @@ describe("codex app-server handler", () => {
     const handler = makeHandler(fake);
     const ctx = makeContext({ retryTurn, finishTurn, failSessionForRecovery, sendMessage });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
     await startPromise;
 
@@ -2454,7 +2481,12 @@ describe("codex app-server briefing-update notice", () => {
     const handler = makeHandler(fake);
     const ctx = makeContext({ finishTurn: async () => {} });
 
-    const resumePromise = handler.resume(makeMessage("m1", "hello"), "thread-app-server", ctx);
+    const resumePromise = handler.resume(
+      makeMessage("m1", "hello"),
+      "thread-app-server",
+      ctx,
+      deliveryTokenFromSessionContext(ctx),
+    );
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     const start = fake.requests.find((request) => request.method === "turn/start");
@@ -2477,7 +2509,11 @@ describe("codex app-server briefing-update notice", () => {
     const handler = makeHandler(fake);
     const ctx = makeContext({ finishTurn: async () => {} });
 
-    const startPromise = handler.start(makeMessage("m1", "先讨论下，不动手"), ctx);
+    const startPromise = handler.start(
+      makeMessage("m1", "先讨论下，不动手"),
+      ctx,
+      deliveryTokenFromSessionContext(ctx),
+    );
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     const start = fake.requests.find((request) => request.method === "turn/start");
@@ -2496,7 +2532,11 @@ describe("codex app-server briefing-update notice", () => {
     const startFake = new FakeAppServerClient();
     const startHandler = makeHandler(startFake);
     const startCtx = makeContext({ finishTurn: async () => {} });
-    const startPromise = startHandler.start(makeMessage("m1", "first"), startCtx);
+    const startPromise = startHandler.start(
+      makeMessage("m1", "first"),
+      startCtx,
+      deliveryTokenFromSessionContext(startCtx),
+    );
     await waitFor(() => startFake.requests.some((request) => request.method === "turn/start"));
     completeTurn(startFake, "turn-1", "first answer");
     await startPromise;
@@ -2507,7 +2547,12 @@ describe("codex app-server briefing-update notice", () => {
     const resumeFake = new FakeAppServerClient();
     const resumeHandler = makeHandler(resumeFake);
     const resumeCtx = makeContext({ finishTurn: async () => {} });
-    const resumePromise = resumeHandler.resume(makeMessage("m2", "again"), "thread-app-server", resumeCtx);
+    const resumePromise = resumeHandler.resume(
+      makeMessage("m2", "again"),
+      "thread-app-server",
+      resumeCtx,
+      deliveryTokenFromSessionContext(resumeCtx),
+    );
     await waitFor(() => resumeFake.requests.some((request) => request.method === "turn/start"));
 
     const start = resumeFake.requests.find((request) => request.method === "turn/start");
@@ -2526,7 +2571,12 @@ describe("codex app-server briefing-update notice", () => {
     failFake.turnStartError = new CodexAppServerTransportError("codex app-server request timed out: turn/start");
     const failHandler = makeHandler(failFake);
     const failCtx = makeContext({ failSessionForRecovery: vi.fn(), finishTurn: async () => {} });
-    await failHandler.resume(makeMessage("m1", "hello"), "thread-app-server", failCtx);
+    await failHandler.resume(
+      makeMessage("m1", "hello"),
+      "thread-app-server",
+      failCtx,
+      deliveryTokenFromSessionContext(failCtx),
+    );
     expect(failFake.requests.some((request) => request.method === "turn/start")).toBe(true);
     await failHandler.shutdown();
 
@@ -2535,7 +2585,12 @@ describe("codex app-server briefing-update notice", () => {
     const okFake = new FakeAppServerClient();
     const okHandler = makeHandler(okFake);
     const okCtx = makeContext({ finishTurn: async () => {} });
-    const resumePromise = okHandler.resume(makeMessage("m2", "again"), "thread-app-server", okCtx);
+    const resumePromise = okHandler.resume(
+      makeMessage("m2", "again"),
+      "thread-app-server",
+      okCtx,
+      deliveryTokenFromSessionContext(okCtx),
+    );
     await waitFor(() => okFake.requests.some((request) => request.method === "turn/start"));
     const start = okFake.requests.find((request) => request.method === "turn/start");
     expect(JSON.stringify(start?.params ?? {})).toContain("<system-reminder>");
@@ -2553,7 +2608,7 @@ describe("codex app-server briefing-update notice", () => {
 
     // Start the session and finish its first turn (seeds the briefing baseline
     // for the BEFORE prompt). Session is now idle/active.
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
     completeTurn(fake, "turn-1", "first answer");
     await startPromise;
@@ -2563,7 +2618,7 @@ describe("codex app-server briefing-update notice", () => {
     // suspend/resume. The injected turn must pick up the new briefing and carry
     // the re-read notice.
     setAppend("AFTER_MARKER");
-    handler.inject(makeMessage("m2", "again"));
+    handler.inject(makeMessage("m2", "again"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === startTurns + 1);
 
     const injectedStart = fake.requests.filter((request) => request.method === "turn/start")[startTurns];
@@ -2579,7 +2634,7 @@ describe("codex app-server briefing-update notice", () => {
     const handler = makeHandler(fake, { agentConfigCache: cache });
     const ctx = makeContext({ finishTurn: async () => {} });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
     completeTurn(fake, "turn-1", "first answer");
     await startPromise;
@@ -2592,7 +2647,7 @@ describe("codex app-server briefing-update notice", () => {
     vi.mocked(writeAgentBriefing).mockImplementationOnce(() => {
       throw new Error("simulated disk failure");
     });
-    handler.inject(makeMessage("m2", "again"));
+    handler.inject(makeMessage("m2", "again"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === startTurns + 1);
 
     completeTurn(fake, "turn-2", "second answer");

--- a/packages/client/src/__tests__/codex-handler-engine-extra.test.ts
+++ b/packages/client/src/__tests__/codex-handler-engine-extra.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerConfig, SessionContext, SessionMessage } from "../runtime/handler.js";
+import { noopDeliveryToken } from "../runtime/handler.js";
 
 const trialMetadata = {
   landingCampaignTrial: true,
@@ -48,8 +49,8 @@ function context(metadata: Record<string, unknown> = {}): SessionContext {
 
 function makeMockHandler(overrides: Partial<MockHandler> = {}): MockHandler {
   return {
-    start: vi.fn(async () => ({ providerSessionId: "started" })),
-    resume: vi.fn(async () => ({ providerSessionId: "resumed" })),
+    start: vi.fn(async () => ({ sessionId: "started", route: { kind: "owned" as const, mode: "queued" as const } })),
+    resume: vi.fn(async () => ({ sessionId: "resumed", route: { kind: "owned" as const, mode: "queued" as const } })),
     inject: vi.fn(async () => undefined),
     suspend: vi.fn(async () => undefined),
     shutdown: vi.fn(async () => undefined),
@@ -60,6 +61,7 @@ function makeMockHandler(overrides: Partial<MockHandler> = {}): MockHandler {
 function handlerConfig(overrides: Partial<HandlerConfig> = {}): HandlerConfig {
   return {
     workspaceRoot: "/tmp/first-tree-codex-handler-test",
+    runtimeProvider: "codex",
     ...overrides,
   };
 }
@@ -117,15 +119,17 @@ describe("codex handler engine delegation branches", () => {
     const ctx = context();
     const handler = createCodexHandler(handlerConfig({ codexHandlerEngine: "sdk" }));
 
-    await expect(handler.start(message(), ctx)).resolves.toEqual({ providerSessionId: "started" });
-    await expect(handler.resume(message(), "session-1", ctx)).resolves.toEqual({ providerSessionId: "resumed" });
-    await handler.inject(message());
+    await expect(handler.start(message(), ctx, noopDeliveryToken())).resolves.toMatchObject({ sessionId: "started" });
+    await expect(handler.resume(message(), "session-1", ctx, noopDeliveryToken())).resolves.toMatchObject({
+      sessionId: "resumed",
+    });
+    await handler.inject(message(), noopDeliveryToken());
     await handler.suspend();
     await handler.shutdown("done");
 
-    expect(sdkHandler.start).toHaveBeenCalledWith(message(), ctx, undefined);
-    expect(sdkHandler.resume).toHaveBeenCalledWith(message(), "session-1", ctx, undefined);
-    expect(sdkHandler.inject).toHaveBeenCalledWith(message(), undefined);
+    expect(sdkHandler.start).toHaveBeenCalledWith(message(), ctx, expect.any(Object));
+    expect(sdkHandler.resume).toHaveBeenCalledWith(message(), "session-1", ctx, expect.any(Object));
+    expect(sdkHandler.inject).toHaveBeenCalledWith(message(), expect.any(Object));
     expect(sdkHandler.suspend).toHaveBeenCalledTimes(1);
     expect(sdkHandler.shutdown).toHaveBeenCalledWith("done");
   });
@@ -144,7 +148,7 @@ describe("codex handler engine delegation branches", () => {
     const ctx = context();
     const handler = createCodexHandler(handlerConfig({ codexHandlerEngine: "auto" }));
 
-    await expect(handler.start(message(), ctx)).resolves.toEqual({ providerSessionId: "started" });
+    await expect(handler.start(message(), ctx, noopDeliveryToken())).resolves.toMatchObject({ sessionId: "started" });
     await handler.suspend();
     await handler.shutdown("fallback done");
 
@@ -153,7 +157,7 @@ describe("codex handler engine delegation branches", () => {
       "codex app-server shutdown before fallback failed after launch: shutdown failed",
     );
     expect(ctx.log).toHaveBeenCalledWith("app server failed; falling back to @openai/codex-sdk handler");
-    expect(sdkHandler.start).toHaveBeenCalledWith(message(), ctx, undefined);
+    expect(sdkHandler.start).toHaveBeenCalledWith(message(), ctx, expect.any(Object));
     expect(sdkHandler.suspend).toHaveBeenCalledTimes(1);
     expect(sdkHandler.shutdown).toHaveBeenCalledWith("fallback done");
   });
@@ -168,11 +172,15 @@ describe("codex handler engine delegation branches", () => {
     });
 
     const handler = createCodexHandler(handlerConfig({ codexHandlerEngine: "auto" }));
-    await expect(handler.resume(message(), "session-1", context())).resolves.toEqual({ providerSessionId: "resumed" });
-    expect(sdkHandler.resume).toHaveBeenCalledWith(message(), "session-1", expect.any(Object), undefined);
+    await expect(handler.resume(message(), "session-1", context(), noopDeliveryToken())).resolves.toMatchObject({
+      sessionId: "resumed",
+    });
+    expect(sdkHandler.resume).toHaveBeenCalledWith(message(), "session-1", expect.any(Object), expect.any(Object));
 
     const trialHandler = createCodexHandler(handlerConfig({ codexHandlerEngine: "auto" }));
-    await expect(trialHandler.resume(message(), "session-2", context(trialMetadata))).rejects.toThrow("resume failed");
+    await expect(
+      trialHandler.resume(message(), "session-2", context(trialMetadata), noopDeliveryToken()),
+    ).rejects.toThrow("resume failed");
   });
 
   it("uses production auto mode when no explicit engine or test env fallback is present", async () => {
@@ -186,8 +194,8 @@ describe("codex handler engine delegation branches", () => {
 
     try {
       const handler = createCodexHandler(handlerConfig());
-      await handler.inject(message());
-      expect(appHandler.inject).toHaveBeenCalledWith(message(), undefined);
+      await handler.inject(message(), noopDeliveryToken());
+      expect(appHandler.inject).toHaveBeenCalledWith(message(), expect.any(Object));
     } finally {
       if (previousEngine === undefined) delete process.env.FIRST_TREE_CODEX_HANDLER_ENGINE;
       else process.env.FIRST_TREE_CODEX_HANDLER_ENGINE = previousEngine;

--- a/packages/client/src/__tests__/codex-handler-engine.test.ts
+++ b/packages/client/src/__tests__/codex-handler-engine.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createCodexHandler } from "../handlers/codex/index.js";
 import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import { noopDeliveryToken } from "../runtime/handler.js";
 
 const trialMetadata = {
   landingCampaignTrial: true,
@@ -46,7 +47,7 @@ describe("codex handler engine selection", () => {
       codexHandlerEngine: "sdk",
     });
 
-    expect(() => handler.start(message(), context(trialMetadata))).toThrow(
+    expect(() => handler.start(message(), context(trialMetadata), noopDeliveryToken())).toThrow(
       /require the app-server workspace-only runtime/,
     );
   });

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -108,6 +108,7 @@ vi.mock("../runtime/chat-context.js", () => ({
 }));
 
 import { createCodexHandler } from "../handlers/codex/index.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 
 const AGENT_ID = "019e71c9-88d2-70be-be67-fdb033b2ef0b";
 
@@ -204,6 +205,7 @@ function makeContext(
 
 function makeAutoHandler(fake: StartupFakeAppServerClient) {
   return createCodexHandler({
+    runtimeProvider: "codex",
     workspaceRoot,
     codexHandlerEngine: "auto",
     codexRuntimeBinaryResolver: async () => ({
@@ -324,7 +326,10 @@ describe("codex handler startup inject queue", () => {
       },
       { type: "unknown_future_item" },
     ]);
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext(
       (count) => {
         completedCounts.push(count);
@@ -340,7 +345,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const toolEvents = events.filter(
       (event): event is Extract<SessionEvent, { kind: "tool_call" }> => event.kind === "tool_call",
@@ -388,7 +393,10 @@ describe("codex handler startup inject queue", () => {
       { type: "error", message: warning },
       { type: "agent_message", text: "silently downgraded answer" },
     ]);
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext(
       (count) => {
         completedCounts.push(count);
@@ -403,7 +411,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     expect(events).toContainEqual({
       kind: "error",
@@ -431,17 +439,20 @@ describe("codex handler startup inject queue", () => {
 
   it("queues injects received before the Codex thread exists so their inbox entries stay aligned with acks", async () => {
     const completedCounts: Array<number | undefined> = [];
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => {
       completedCounts.push(count);
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await Promise.resolve();
 
     // The handler is active, but startup is still waiting on chat context;
     // `thread` and `currentTurnPromise` do not exist yet.
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
 
     state.resolveChatContext?.({
       chatId: "chat-startup-race",
@@ -475,7 +486,10 @@ describe("codex handler startup inject queue", () => {
     const firstFormatStartedPromise = new Promise<void>((resolve) => {
       firstFormatStarted = resolve;
     });
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext(
       (count) => {
         completedCounts.push(count);
@@ -503,10 +517,10 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await firstFormatStartedPromise;
 
-    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(state.runInputs).toHaveLength(0);
@@ -543,10 +557,13 @@ describe("codex handler startup inject queue", () => {
       },
     );
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
     await Promise.resolve();
 
-    expect(handler.inject(makeMessage("m2", "second"))).toMatchObject({ kind: "owned", mode: "queued" });
+    expect(handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx))).toMatchObject({
+      kind: "owned",
+      mode: "queued",
+    });
 
     state.resolveChatContext?.({
       chatId: "chat-startup-race",
@@ -587,7 +604,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     expect(fake.requests.some((request) => request.method === "turn/start")).toBe(true);
     expect(retried).toEqual([{ ids: ["m1"], reason: "codex_app_server_turn_start_unknown_custody_failed" }]);
@@ -599,7 +616,10 @@ describe("codex handler startup inject queue", () => {
 
   it("serializes ready-state injects through one drainer instead of starting parallel turns", async () => {
     const completedCounts: Array<number | undefined> = [];
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => {
       completedCounts.push(count);
     });
@@ -612,10 +632,10 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
-    handler.inject(makeMessage("m2", "second"));
-    handler.inject(makeMessage("m3", "third"));
+    handler.inject(makeMessage("m2", "second"), deliveryTokenFromSessionContext(ctx));
+    handler.inject(makeMessage("m3", "third"), deliveryTokenFromSessionContext(ctx));
 
     await new Promise((resolve) => setImmediate(resolve));
     await new Promise((resolve) => setImmediate(resolve));
@@ -633,7 +653,10 @@ describe("codex handler startup inject queue", () => {
 
   it("applies resume chat context to the next injected turn only when resume has no message", async () => {
     const completedCounts: Array<number | undefined> = [];
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => {
       completedCounts.push(count);
     });
@@ -646,16 +669,16 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.resume(undefined, "thread-test", ctx);
+    await handler.resume(undefined, "thread-test", ctx, deliveryTokenFromSessionContext(ctx));
 
-    handler.inject(makeMessage("m1", "first after resume"));
+    handler.inject(makeMessage("m1", "first after resume"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => state.runInputs.length === 1);
 
     expect(String(state.runInputs[0])).toContain("<first-tree-current-chat-context");
     expect(String(state.runInputs[0])).toContain('"chatId": "chat-startup-race"');
     expect(String(state.runInputs[0])).toContain("first after resume");
 
-    handler.inject(makeMessage("m2", "second after resume"));
+    handler.inject(makeMessage("m2", "second after resume"), deliveryTokenFromSessionContext(ctx));
     await waitFor(() => state.runInputs.length === 2);
 
     expect(String(state.runInputs[1])).not.toContain("<first-tree-current-chat-context");
@@ -670,7 +693,10 @@ describe("codex handler startup inject queue", () => {
       .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
       .mockResolvedValue(undefined);
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext(() => {}, { sendMessage, emitEvent });
 
     state.agentMessagesByTurn.set(1, ["working note", "final answer"]);
@@ -682,7 +708,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     // Final-text mirror retired: the result is captured as assistant_text
     // events, NOT delivered as a chat message.
@@ -702,7 +728,10 @@ describe("codex handler startup inject queue", () => {
       .mockResolvedValue(undefined);
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
     const completedCounts: Array<number | undefined> = [];
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent });
 
     state.agentMessagesByTurn.set(1, ["working note", "final answer"]);
@@ -715,7 +744,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const events = emitEvent.mock.calls.map(([event]) => event);
     // Final-text mirror retired: result captured as assistant_text, not sent.
@@ -743,7 +772,10 @@ describe("codex handler startup inject queue", () => {
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
     const completedCounts: Array<number | undefined> = [];
     const retryTurn = vi.fn<SessionContext["retryTurn"]>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), { emitEvent, retryTurn });
 
     state.agentMessagesByTurn.set(1, [
@@ -757,7 +789,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const events = emitEvent.mock.calls.map(([event]) => event);
     expect(
@@ -780,7 +812,10 @@ describe("codex handler startup inject queue", () => {
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
     const completedCounts: Array<number | undefined> = [];
     const retryTurn = vi.fn<SessionContext["retryTurn"]>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent, retryTurn });
 
     state.agentMessagesByTurn.set(1, ["working note"]);
@@ -793,7 +828,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const events = emitEvent.mock.calls.map(([event]) => event);
     expect(sendMessage).not.toHaveBeenCalled();
@@ -830,7 +865,10 @@ describe("codex handler startup inject queue", () => {
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
     const completedCounts: Array<number | undefined> = [];
     const retryTurn = vi.fn<SessionContext["retryTurn"]>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent, retryTurn });
 
     state.agentMessagesByTurn.set(1, []);
@@ -846,7 +884,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const events = emitEvent.mock.calls.map(([event]) => event);
     expect(state.runInputs).toHaveLength(1);
@@ -875,7 +913,10 @@ describe("codex handler startup inject queue", () => {
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
     const completedCounts: Array<number | undefined> = [];
     const retryTurn = vi.fn<SessionContext["retryTurn"]>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent, retryTurn });
 
     state.agentMessagesByTurn.set(1, ["working note"]);
@@ -888,7 +929,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const events = emitEvent.mock.calls.map(([event]) => event);
     expect(sendMessage).not.toHaveBeenCalled();
@@ -922,7 +963,10 @@ describe("codex handler startup inject queue", () => {
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
     const completedCounts: Array<number | undefined> = [];
     const retryTurn = vi.fn<SessionContext["retryTurn"]>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent, retryTurn });
 
     state.agentMessagesByTurn.set(1, ["working note"]);
@@ -935,7 +979,7 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const events = emitEvent.mock.calls.map(([event]) => event);
     expect(sendMessage).not.toHaveBeenCalled();
@@ -966,7 +1010,10 @@ describe("codex handler startup inject queue", () => {
   it("retries queued injects when all inbound formatting fails before provider custody", async () => {
     const completedCounts: Array<number | undefined> = [];
     const retryTurn = vi.fn();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext(
       (count) => {
         completedCounts.push(count);
@@ -989,8 +1036,8 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
-    handler.inject(makeMessage("m2", "bad"));
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
+    handler.inject(makeMessage("m2", "bad"), deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => retryTurn.mock.calls.length === 1);
 
@@ -1015,7 +1062,10 @@ describe("codex handler startup inject queue", () => {
   ])("retries the whole queued batch when mixed formatting occurs: $name", async ({ failingIds, messages }) => {
     const completedCounts: Array<number | undefined> = [];
     const retryTurn = vi.fn();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext(
       (count) => {
         completedCounts.push(count);
@@ -1038,8 +1088,8 @@ describe("codex handler startup inject queue", () => {
       participants: [],
     });
 
-    await handler.start(makeMessage("m1", "first"), ctx);
-    for (const message of messages) handler.inject(message);
+    await handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
+    for (const message of messages) handler.inject(message, deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => retryTurn.mock.calls.length === messages.length);
 

--- a/packages/client/src/__tests__/codex-retry-abort.test.ts
+++ b/packages/client/src/__tests__/codex-retry-abort.test.ts
@@ -111,6 +111,7 @@ vi.mock("../runtime/chat-context.js", () => ({
 }));
 
 import { createCodexHandler } from "../handlers/codex/index.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 
 const AGENT_ID = "019e71c9-88d2-70be-be67-fdb033b2ef0b";
 
@@ -192,14 +193,17 @@ describe("codex handler retry abort cleanup", () => {
       .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
       .mockResolvedValue(undefined);
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), {
       sendMessage,
       emitEvent,
       log: (message) => logs.push(message),
     });
 
-    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, deliveryTokenFromSessionContext(ctx));
 
     await waitForMicrotasks(
       () => state.streamClosedByAttempt[0] === true && logs.some((message) => message.includes("codex turn retry")),

--- a/packages/client/src/__tests__/codex-stale-rollout.test.ts
+++ b/packages/client/src/__tests__/codex-stale-rollout.test.ts
@@ -157,7 +157,10 @@ describe("codex stale rollout recovery", () => {
 
   it("fresh-starts the same resume turn and returns the replacement thread id", async () => {
     const replaceSessionId = vi.fn<NonNullable<SessionContext["replaceSessionId"]>>();
-    const handler = createCodexSdkHandler({ workspaceRoot });
+    const handler = createCodexSdkHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext({ replaceSessionId });
     const token = makeToken();
 

--- a/packages/client/src/__tests__/codex-usage-limit.test.ts
+++ b/packages/client/src/__tests__/codex-usage-limit.test.ts
@@ -101,6 +101,7 @@ vi.mock("../runtime/chat-context.js", () => ({
 
 import { createCodexHandler, createCodexSdkHandler } from "../handlers/codex/index.js";
 import { LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED } from "../handlers/codex/turn-completion.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 
 const AGENT_ID = "019e71c9-88d2-70be-be67-fdb033b2ef0b";
 
@@ -200,14 +201,17 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
       .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
       .mockResolvedValue(undefined);
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), {
       sendMessage,
       emitEvent,
       log: (message) => logs.push(message),
     });
 
-    await handler.start(makeMessage("m1", "hello"), ctx);
+    await handler.start(makeMessage("m1", "hello"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const events = emitEvent.mock.calls.map(([event]) => event);
 
@@ -258,14 +262,17 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
       .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
       .mockResolvedValue(undefined);
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), {
       sendMessage,
       emitEvent,
       log: (message) => logs.push(message),
     });
 
-    await handler.start(makeMessage("m1", "hello"), ctx);
+    await handler.start(makeMessage("m1", "hello"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const events = emitEvent.mock.calls.map(([event]) => event);
 
@@ -299,10 +306,13 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
       .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
       .mockResolvedValue(undefined);
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent });
 
-    await handler.start(makeMessage("m1", "hello"), ctx);
+    await handler.start(makeMessage("m1", "hello"), ctx, deliveryTokenFromSessionContext(ctx));
 
     const events = emitEvent.mock.calls.map(([event]) => event);
     // The final text is the agent's output stream, not a chat message — it is
@@ -333,10 +343,13 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
     const emitEventConfirmed = vi
       .fn<NonNullable<SessionContext["emitEventConfirmed"]>>()
       .mockRejectedValue(new Error("session event persist failed"));
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), { emitEvent, emitEventConfirmed });
 
-    await handler.start(makeMessage("m1", "hello"), ctx);
+    await handler.start(makeMessage("m1", "hello"), ctx, deliveryTokenFromSessionContext(ctx));
 
     expect(emitEventConfirmed).not.toHaveBeenCalled();
     expect(emitEvent).toHaveBeenCalledWith({
@@ -365,7 +378,10 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
     const emitEventConfirmed = vi
       .fn<NonNullable<SessionContext["emitEventConfirmed"]>>()
       .mockRejectedValue(new Error("session event persist failed"));
-    const handler = createCodexSdkHandler({ workspaceRoot });
+    const handler = createCodexSdkHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const message = makeMessage("m1", "hello", 101);
     const ctx = makeContext((count) => completedCounts.push(count), {
       emitEventConfirmed,
@@ -374,7 +390,7 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
       agentMetadata: trialAgentMetadata,
     });
 
-    await handler.start(message, ctx);
+    await handler.start(message, ctx, deliveryTokenFromSessionContext(ctx));
 
     expect(emitEventConfirmed).toHaveBeenCalledWith({
       kind: "turn_end",
@@ -396,13 +412,16 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
     const completed: Array<{ count?: number; reason?: string }> = [];
     const retryTurn = vi.fn<SessionContext["retryTurn"]>();
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count, outcome) => completed.push({ count, reason: outcome?.reason }), {
       emitEvent,
       retryTurn,
     });
 
-    await handler.start(makeMessage("m1", "hello"), ctx);
+    await handler.start(makeMessage("m1", "hello"), ctx, deliveryTokenFromSessionContext(ctx));
 
     expect(retryTurn).not.toHaveBeenCalled();
     expect(completed).toEqual([{ count: 1, reason: "capacity_wait_required" }]);
@@ -424,13 +443,16 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
     const completedCounts: Array<number | undefined> = [];
     const retryReasons: string[] = [];
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
-    const handler = createCodexHandler({ workspaceRoot });
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+    });
     const ctx = makeContext((count) => completedCounts.push(count), {
       emitEvent,
       retryTurn: (_messages, reason) => retryReasons.push(reason),
     });
 
-    await handler.start(makeMessage("m-pre-provider", "hello"), ctx);
+    await handler.start(makeMessage("m-pre-provider", "hello"), ctx, deliveryTokenFromSessionContext(ctx));
 
     expect(state.runInputs).toHaveLength(3);
     expect(completedCounts).toEqual([]);

--- a/packages/client/src/__tests__/delivery-token-receipt-characterization.test.ts
+++ b/packages/client/src/__tests__/delivery-token-receipt-characterization.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Characterization for Handler protocol dual-track (optional DeliveryToken +
+ * string|receipt Start/Resume results) and HandlerConfig.runtimeProvider optionality.
+ *
+ * Detects live source so the same file:
+ * - PASSes on PR base (documents dual-track + optional runtimeProvider)
+ * - PASSes on this branch after receipts/tokens are required and runtimeProvider is required
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const handlerSourcePath = join(here, "..", "runtime", "handler.ts");
+const claudeHandlerPath = join(here, "..", "handlers", "claude-code.ts");
+
+type ProtocolShape = {
+  startResultAllowsString: boolean;
+  resumeResultAllowsString: boolean;
+  startTokenOptional: boolean;
+  injectTokenOptional: boolean;
+  handlerConfigRuntimeProviderOptional: boolean;
+  claudeHasExplicitDeliveryTokenShim: boolean;
+};
+
+function detectProtocolShape(): ProtocolShape {
+  const handlerSrc = readFileSync(handlerSourcePath, "utf8");
+  const claudeSrc = readFileSync(claudeHandlerPath, "utf8");
+
+  const startResultAllowsString = /export type StartResult = StartReceipt\s*\|\s*string/.test(handlerSrc);
+  const resumeResultAllowsString = /export type ResumeResult = ResumeReceipt\s*\|\s*string/.test(handlerSrc);
+  const startTokenOptional = /start\(message: SessionMessage, ctx: SessionContext, token\?: DeliveryToken\)/.test(
+    handlerSrc,
+  );
+  const injectTokenOptional = /inject\(message: SessionMessage, token\?: DeliveryToken\)/.test(handlerSrc);
+  const handlerConfigRuntimeProviderOptional = /runtimeProvider\?: RuntimeProvider/.test(handlerSrc);
+  const claudeHasExplicitDeliveryTokenShim = /hasExplicitDeliveryToken/.test(claudeSrc);
+
+  return {
+    startResultAllowsString,
+    resumeResultAllowsString,
+    startTokenOptional,
+    injectTokenOptional,
+    handlerConfigRuntimeProviderOptional,
+    claudeHasExplicitDeliveryTokenShim,
+  };
+}
+
+describe("delivery-token / receipt protocol characterization", () => {
+  it("detects either legacy dual-track or tightened required receipts+token", () => {
+    const shape = detectProtocolShape();
+    const legacyDualTrack =
+      shape.startResultAllowsString &&
+      shape.resumeResultAllowsString &&
+      shape.startTokenOptional &&
+      shape.injectTokenOptional &&
+      shape.handlerConfigRuntimeProviderOptional &&
+      shape.claudeHasExplicitDeliveryTokenShim;
+
+    const tightened =
+      !shape.startResultAllowsString &&
+      !shape.resumeResultAllowsString &&
+      !shape.startTokenOptional &&
+      !shape.injectTokenOptional &&
+      !shape.handlerConfigRuntimeProviderOptional &&
+      !shape.claudeHasExplicitDeliveryTokenShim;
+
+    expect(legacyDualTrack || tightened).toBe(true);
+  });
+
+  it("StartResult / ResumeResult are either string|receipt (legacy) or receipt-only", () => {
+    const shape = detectProtocolShape();
+    if (shape.startResultAllowsString || shape.resumeResultAllowsString) {
+      expect(shape.startResultAllowsString).toBe(true);
+      expect(shape.resumeResultAllowsString).toBe(true);
+    } else {
+      const handlerSrc = readFileSync(handlerSourcePath, "utf8");
+      expect(handlerSrc).toMatch(/export type StartResult = StartReceipt;/);
+      expect(handlerSrc).toMatch(/export type ResumeResult = ResumeReceipt;/);
+    }
+  });
+
+  it("messageful DeliveryToken is either optional (legacy) or required on start/inject", () => {
+    const shape = detectProtocolShape();
+    if (shape.startTokenOptional || shape.injectTokenOptional) {
+      expect(shape.startTokenOptional).toBe(true);
+      expect(shape.injectTokenOptional).toBe(true);
+    } else {
+      const handlerSrc = readFileSync(handlerSourcePath, "utf8");
+      expect(handlerSrc).toMatch(/start\(message: SessionMessage, ctx: SessionContext, token: DeliveryToken\)/);
+      expect(handlerSrc).toMatch(/inject\(message: SessionMessage, token: DeliveryToken\)/);
+    }
+  });
+
+  it("HandlerConfig.runtimeProvider is either optional (legacy) or required", () => {
+    const shape = detectProtocolShape();
+    if (shape.handlerConfigRuntimeProviderOptional) {
+      expect(shape.handlerConfigRuntimeProviderOptional).toBe(true);
+    } else {
+      const handlerSrc = readFileSync(handlerSourcePath, "utf8");
+      expect(handlerSrc).toMatch(/runtimeProvider: RuntimeProvider;/);
+      expect(handlerSrc).not.toMatch(/runtimeProvider\?: RuntimeProvider/);
+    }
+  });
+
+  it("claude-code either keeps hasExplicitDeliveryToken shim or returns receipts only", () => {
+    const shape = detectProtocolShape();
+    const claudeSrc = readFileSync(claudeHandlerPath, "utf8");
+    if (shape.claudeHasExplicitDeliveryTokenShim) {
+      expect(claudeSrc).toContain("hasExplicitDeliveryToken");
+    } else {
+      expect(claudeSrc).not.toContain("hasExplicitDeliveryToken");
+      expect(claudeSrc).toMatch(/route:\s*\{\s*kind:\s*"owned"/);
+    }
+  });
+});

--- a/packages/client/src/__tests__/handler-registry.test.ts
+++ b/packages/client/src/__tests__/handler-registry.test.ts
@@ -47,7 +47,10 @@ describe("Handler Registry", () => {
   it("creates a handler with the factory", () => {
     registerHandler("test-handler", echoFactory);
     const factory = getHandlerFactory("test-handler");
-    const handler = factory({ workspaceRoot: "/tmp" });
+    const handler = factory({
+      runtimeProvider: "codex",
+      workspaceRoot: "/tmp",
+    });
     expect(handler).toBeDefined();
     expect(typeof handler.start).toBe("function");
     expect(typeof handler.resume).toBe("function");

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -13,6 +13,7 @@ import type { AgentRuntimeConfigPayload, SessionEvent } from "@first-tree/shared
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createKimiCodeHandler, formatKimiCodeError, kimiToolIsReadOnly } from "../handlers/kimi-code.js";
 import type { DeliveryToken, SessionContext, SessionMessage, TurnOutcome } from "../runtime/handler.js";
+import { noopDeliveryToken } from "../runtime/handler.js";
 import type { ReplayFenceEntry } from "../runtime/replay-fence.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
@@ -556,7 +557,7 @@ describe("Kimi Code handler", () => {
       }),
     });
 
-    await expect(handler.resume(undefined, fakeSession.id, makeContext([]))).rejects.toThrow(
+    await expect(handler.resume(undefined, fakeSession.id, makeContext([]), noopDeliveryToken())).rejects.toThrow(
       `${failurePoint} setup failed`,
     );
 

--- a/packages/client/src/__tests__/pi-handler.test.ts
+++ b/packages/client/src/__tests__/pi-handler.test.ts
@@ -17,6 +17,7 @@ import {
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { clearGitRepoIdentityCacheForTests } from "../runtime/git-repo-identity.js";
 import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
+import { noopDeliveryToken } from "../runtime/handler.js";
 import * as managedSkills from "../runtime/managed-skills.js";
 import type { ProviderProcessSpec, ProviderProcessSupervisor } from "../runtime/provider-process-supervisor.js";
 import { readSessionBriefingFingerprint } from "../runtime/session-briefing-fingerprint.js";
@@ -1383,7 +1384,12 @@ describe("Pi handler", () => {
       providerProcessSupervisor: createSyntheticSupervisor(specs),
     });
     const sessionCtx = makeContext([]);
-    await handler.resume(undefined, freshStartPiSessionId("agent-pi", "chat-pi", "m1"), sessionCtx);
+    await handler.resume(
+      undefined,
+      freshStartPiSessionId("agent-pi", "chat-pi", "m1"),
+      sessionCtx,
+      noopDeliveryToken(),
+    );
     const receipt = handler.inject(message("m-queue", "queued"), makeToken());
     expect(receipt).toEqual({ kind: "owned", mode: "queued" });
     await vi.waitFor(() => expect(specs.some((spec) => spec.args.includes("--mode"))).toBe(true));

--- a/packages/client/src/__tests__/reset-finalize-wire.test.ts
+++ b/packages/client/src/__tests__/reset-finalize-wire.test.ts
@@ -421,14 +421,14 @@ describe("Reset finalize handshake — wire level", () => {
         token?.processingStarted(message);
         await token?.complete(message, { status: "success", terminal: true });
         await ctx.finishTurn(message, { status: "success", terminal: true });
-        return `session-${message.id}`;
+        return { sessionId: `session-${message.id}`, route: { kind: "owned" as const, mode: "queued" as const } };
       },
       resume: async (message: SessionMessage | undefined, sessionId: string, ctx: SessionContext, token) => {
-        if (!message) return sessionId;
+        if (!message) return { sessionId: sessionId, route: { kind: "owned" as const, mode: "queued" as const } };
         token?.processingStarted(message);
         await token?.complete(message, { status: "success", terminal: true });
         await ctx.finishTurn(message, { status: "success", terminal: true });
-        return sessionId;
+        return { sessionId: sessionId, route: { kind: "owned" as const, mode: "queued" as const } };
       },
       inject: (messages) => {
         for (const message of Array.isArray(messages) ? messages : [messages]) injects.push(message.id);

--- a/packages/client/src/__tests__/runtime-provider-fail-closed-characterization.test.ts
+++ b/packages/client/src/__tests__/runtime-provider-fail-closed-characterization.test.ts
@@ -30,8 +30,8 @@ function internals(sm: SessionManager): SessionManagerInternals {
 
 function handler(): AgentHandler {
   return {
-    start: async () => "sess",
-    resume: async () => "sess",
+    start: async () => ({ sessionId: "sess", route: { kind: "owned" as const, mode: "queued" as const } }),
+    resume: async () => ({ sessionId: "sess", route: { kind: "owned" as const, mode: "queued" as const } }),
     inject: () => ({ kind: "owned", mode: "queued" }),
     suspend: async () => undefined,
     shutdown: async () => undefined,

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -135,8 +135,12 @@ function mockSdk(): FirstTreeHubSDK {
 
 function handler(overrides: Partial<AgentHandler> = {}): AgentHandler {
   return {
-    start: vi.fn().mockResolvedValue("session-id"),
-    resume: vi.fn().mockResolvedValue("session-id"),
+    start: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id", route: { kind: "owned" as const, mode: "queued" as const } }),
+    resume: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id", route: { kind: "owned" as const, mode: "queued" as const } }),
     inject: vi.fn().mockReturnValue({ kind: "owned", mode: "queued" }),
     suspend: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn().mockResolvedValue(undefined),
@@ -406,7 +410,7 @@ describe("SessionManager edge coverage", () => {
   it("handles suspend, terminate, pending-queue cleanup, ack failures, and quiet-gate snapshots", async () => {
     const first = handler({
       async start() {
-        return "idle-log-session";
+        return { sessionId: "idle-log-session", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const ackEntry = vi
@@ -493,7 +497,12 @@ describe("SessionManager edge coverage", () => {
     };
     writeFileSync(registryPath, JSON.stringify({ version: 1, entries }), "utf-8");
 
-    const resumed = handler({ resume: vi.fn().mockResolvedValue("resumed-from-registry") });
+    const resumed = handler({
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "resumed-from-registry",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const sm = makeManager({ handlers: [resumed], registryPath, maxSessions: 501 });
 
     expect(sm.getEvictedChatIds()).not.toContain("chat-0");
@@ -530,7 +539,7 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async () => {
         signalStartStarted?.();
         await startGate;
-        return "stale-session";
+        return { sessionId: "stale-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const first = makeManager({ handlers: [pendingHandler], registryPath });
@@ -559,7 +568,12 @@ describe("SessionManager edge coverage", () => {
     const persisted = JSON.parse(readFileSync(registryPath, "utf-8")) as { entries: Record<string, unknown> };
     expect(persisted.entries).toEqual({});
 
-    const replacement = handler({ start: vi.fn().mockResolvedValue("replacement-session") });
+    const replacement = handler({
+      start: vi.fn().mockResolvedValue({
+        sessionId: "replacement-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const second = makeManager({ handlers: [replacement], registryPath });
     await second.dispatch(entry);
 
@@ -644,7 +658,7 @@ describe("SessionManager edge coverage", () => {
         captured = ctx;
         ctx.log("started");
         ctx.recordProviderActivity();
-        return "session-context";
+        return { sessionId: "session-context", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sm = makeManager({
@@ -714,7 +728,7 @@ describe("SessionManager edge coverage", () => {
         handler({
           async start(_message, ctx) {
             captured = ctx;
-            return "session-empty-cache";
+            return { sessionId: "session-empty-cache", route: { kind: "owned" as const, mode: "queued" as const } };
           },
         }),
       ],
@@ -739,7 +753,7 @@ describe("SessionManager edge coverage", () => {
     const first = handler({
       async start(message) {
         seen = message;
-        return "session-no-entry-chat";
+        return { sessionId: "session-no-entry-chat", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sm = makeManager({ handlers: [first] });
@@ -832,7 +846,9 @@ describe("SessionManager edge coverage", () => {
   });
 
   it("routes same-chat delivery after manual suspend without explicit resume", async () => {
-    const resume = vi.fn().mockResolvedValue("resumed-paused");
+    const resume = vi
+      .fn()
+      .mockResolvedValue({ sessionId: "resumed-paused", route: { kind: "owned" as const, mode: "queued" as const } });
     const paused = makeSessionRecord("chat-paused", {
       status: "suspended",
       claudeSessionId: "old-paused-session",
@@ -861,7 +877,7 @@ describe("SessionManager edge coverage", () => {
     const working = handler({
       async start(message, ctx) {
         ctx.markMessagesConsumed(message);
-        return "working-session";
+        return { sessionId: "working-session", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const recovered = handler();
@@ -891,7 +907,7 @@ describe("SessionManager edge coverage", () => {
     const working = handler({
       async start(message, ctx) {
         ctx.markMessagesConsumed(message);
-        return "working-session";
+        return { sessionId: "working-session", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const recovered = handler();
@@ -925,11 +941,14 @@ describe("SessionManager edge coverage", () => {
         async start(message, ctx) {
           lifecycles.push({ chatId: message.chatId, phase: "start" });
           if (message.chatId === "chat-working") ctx.markMessagesConsumed(message);
-          return `session-${message.chatId}`;
+          return { sessionId: `session-${message.chatId}`, route: { kind: "owned" as const, mode: "queued" as const } };
         },
         async resume(message) {
           lifecycles.push({ chatId: message?.chatId ?? "", phase: "resume" });
-          return `session-${message?.chatId ?? "unknown"}`;
+          return {
+            sessionId: `session-${message?.chatId ?? "unknown"}`,
+            route: { kind: "owned" as const, mode: "queued" as const },
+          };
         },
       });
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
@@ -976,7 +995,7 @@ describe("SessionManager edge coverage", () => {
             firstMessage = message;
             firstContext = ctx;
             ctx.markMessagesConsumed(message);
-            return "session-chat-working";
+            return { sessionId: "session-chat-working", route: { kind: "owned" as const, mode: "queued" as const } };
           },
         });
       },
@@ -1001,8 +1020,18 @@ describe("SessionManager edge coverage", () => {
     const sm = makeManager({
       concurrency: 1,
       handlers: [
-        handler({ start: vi.fn().mockResolvedValue("retry-empty-start") }),
-        handler({ resume: vi.fn().mockResolvedValue("retry-from-evicted") }),
+        handler({
+          start: vi.fn().mockResolvedValue({
+            sessionId: "retry-empty-start",
+            route: { kind: "owned" as const, mode: "queued" as const },
+          }),
+        }),
+        handler({
+          resume: vi.fn().mockResolvedValue({
+            sessionId: "retry-from-evicted",
+            route: { kind: "owned" as const, mode: "queued" as const },
+          }),
+        }),
       ],
       onSessionEvent: (_chatId, event) => events.push(event),
     });
@@ -1056,7 +1085,12 @@ describe("SessionManager edge coverage", () => {
 
   it("does not let runRetry bypass existing recovery debt", async () => {
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
-    const recovered = handler({ start: vi.fn().mockResolvedValue("should-not-start") });
+    const recovered = handler({
+      start: vi.fn().mockResolvedValue({
+        sessionId: "should-not-start",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const sm = makeManager({ handlers: [recovered], recoverChat });
     const chatId = "chat-retry-debt";
     const inbox = internals(sm).inboxDelivery;
@@ -1083,7 +1117,11 @@ describe("SessionManager edge coverage", () => {
 
   it("keeps a message retry head out of the pending queue while a provider slot is busy", async () => {
     vi.useFakeTimers();
-    const recovered = handler({ resume: vi.fn().mockResolvedValue("resumed-once") });
+    const recovered = handler({
+      resume: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "resumed-once", route: { kind: "owned" as const, mode: "queued" as const } }),
+    });
     const sm = makeManager({ handlers: [recovered], concurrency: 1 });
     const i = internals(sm);
     const chatId = "chat-retry-slot-message";
@@ -1127,7 +1165,12 @@ describe("SessionManager edge coverage", () => {
 
   it("keeps a control resume retry out of the pending queue while a provider slot is busy", async () => {
     vi.useFakeTimers();
-    const recovered = handler({ resume: vi.fn().mockResolvedValue("control-resumed-once") });
+    const recovered = handler({
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "control-resumed-once",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const sm = makeManager({ handlers: [recovered], concurrency: 1 });
     const i = internals(sm);
     const chatId = "chat-retry-slot-control";
@@ -1341,7 +1384,7 @@ describe("SessionManager edge coverage", () => {
           await token?.complete(message, { status: "success", terminal: true });
           await ctx.finishTurn(message, { status: "success", terminal: true });
         }
-        return "stale-session";
+        return { sessionId: "stale-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     let freshCtx: SessionContext | undefined;
@@ -1350,7 +1393,7 @@ describe("SessionManager edge coverage", () => {
       resume: vi.fn().mockImplementation(async (message, _sessionId, ctx) => {
         freshCtx = ctx;
         freshHead = message;
-        return "fresh-session";
+        return { sessionId: "fresh-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
@@ -1440,7 +1483,7 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async () => {
         signalStartStarted?.();
         await pendingStart;
-        return "stale-start-session";
+        return { sessionId: "stale-start-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     let freshCtx: SessionContext | undefined;
@@ -1449,7 +1492,7 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async (message, ctx) => {
         freshCtx = ctx;
         freshHead = message;
-        return "fresh-start-session";
+        return { sessionId: "fresh-start-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
@@ -1534,10 +1577,15 @@ describe("SessionManager edge coverage", () => {
         token.processingStarted(message);
         signalStartStarted?.();
         await startGate;
-        return "stale-start-session";
+        return { sessionId: "stale-start-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
-    const replacement = handler({ start: vi.fn().mockResolvedValue("replacement-tail-session") });
+    const replacement = handler({
+      start: vi.fn().mockResolvedValue({
+        sessionId: "replacement-tail-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockImplementation(async () => {
       signalAckStarted?.();
       await ackGate;
@@ -1601,7 +1649,12 @@ describe("SessionManager edge coverage", () => {
   });
 
   it("does not create an empty resume mapping when LRU evicts a fresh-start retry window", async () => {
-    const replacement = handler({ start: vi.fn().mockResolvedValue("replacement-after-lru") });
+    const replacement = handler({
+      start: vi.fn().mockResolvedValue({
+        sessionId: "replacement-after-lru",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
     const sm = makeManager({
       handlers: [replacement],
@@ -1642,7 +1695,7 @@ describe("SessionManager edge coverage", () => {
   it("fences active inject tokens across suspend recovery and same-entry redelivery", async () => {
     let initialCtx: SessionContext | undefined;
     let initialHead: SessionMessage | undefined;
-    let staleToken: Parameters<AgentHandler["inject"]>[1];
+    let staleToken: Parameters<AgentHandler["inject"]>[1] | undefined;
     let signalWinningResumeStarted: (() => void) | undefined;
     let resolveWinningResume: (() => void) | undefined;
     const winningResumeStarted = new Promise<void>((resolve) => {
@@ -1657,7 +1710,7 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async (message, ctx) => {
         initialCtx = ctx;
         initialHead = message;
-        return "established-token-session";
+        return { sessionId: "established-token-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       inject: vi.fn().mockImplementation((_message, token) => {
         staleToken = token;
@@ -1668,7 +1721,7 @@ describe("SessionManager edge coverage", () => {
         winningHead = message;
         signalWinningResumeStarted?.();
         await winningResumeGate;
-        return "winning-token-session";
+        return { sessionId: "winning-token-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
@@ -1729,7 +1782,7 @@ describe("SessionManager edge coverage", () => {
   it("operator suspend does not sweep an unentered queued active-inject tail into the resolved prefix", async () => {
     let initialCtx: SessionContext | undefined;
     let initialHead: SessionMessage | undefined;
-    let enteredToken: Parameters<AgentHandler["inject"]>[1];
+    let enteredToken: Parameters<AgentHandler["inject"]>[1] | undefined;
     let enteredMessage: SessionMessage | undefined;
     let injectCount = 0;
     const sendMessage = vi.fn().mockResolvedValue({ id: "runtime-notice-inject-tail" });
@@ -1737,7 +1790,7 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async (message, ctx) => {
         initialCtx = ctx;
         initialHead = message;
-        return "active-inject-tail-session";
+        return { sessionId: "active-inject-tail-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       inject: vi.fn().mockImplementation((message, token) => {
         injectCount++;
@@ -1842,14 +1895,14 @@ describe("SessionManager edge coverage", () => {
   ] as const)("revokes a failed active inject token before %s recovery and same-entry redelivery", async (failureMode) => {
     let initialCtx: SessionContext | undefined;
     let initialHead: SessionMessage | undefined;
-    let staleToken: Parameters<AgentHandler["inject"]>[1];
-    let winningToken: Parameters<AgentHandler["inject"]>[1];
+    let staleToken: Parameters<AgentHandler["inject"]>[1] | undefined;
+    let winningToken: Parameters<AgentHandler["inject"]>[1] | undefined;
     let injectCount = 0;
     const activeHandler = handler({
       start: vi.fn().mockImplementation(async (message, ctx) => {
         initialCtx = ctx;
         initialHead = message;
-        return "active-attempt-session";
+        return { sessionId: "active-attempt-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       inject: vi.fn().mockImplementation((_message, token) => {
         injectCount++;
@@ -1927,9 +1980,12 @@ describe("SessionManager edge coverage", () => {
     const routedHandler = handler({
       start: vi.fn().mockImplementation(async (_message, ctx) => {
         oldCtx = ctx;
-        return "confirmed-event-session";
+        return { sessionId: "confirmed-event-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
-      resume: vi.fn().mockResolvedValue("confirmed-event-recovered-session"),
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "confirmed-event-recovered-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
     });
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
     const sm = makeManager({
@@ -2002,11 +2058,11 @@ describe("SessionManager edge coverage", () => {
     const routedHandler = handler({
       start: vi.fn().mockImplementation(async (_message, _ctx, token) => {
         oldToken = token;
-        return "notice-session";
+        return { sessionId: "notice-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       resume: vi.fn().mockImplementation(async (_message, _sessionId, _ctx, token) => {
         winningToken = token;
-        return "notice-recovered-session";
+        return { sessionId: "notice-recovered-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
@@ -2096,7 +2152,7 @@ describe("SessionManager edge coverage", () => {
         await resumeGate;
         providerMaterialized = true;
         providerClosed = false;
-        return "late-materialized-session";
+        return { sessionId: "late-materialized-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       shutdown: vi.fn().mockImplementation(async () => {
         if (providerMaterialized) providerClosed = true;
@@ -2146,11 +2202,16 @@ describe("SessionManager edge coverage", () => {
       resume: vi.fn().mockImplementation(async () => {
         signalOldResumeStarted?.();
         await oldResumeGate;
-        return "stale-preempted-session";
+        return { sessionId: "stale-preempted-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
 
-    const requesterHandler = handler({ start: vi.fn().mockResolvedValue("requester-session") });
+    const requesterHandler = handler({
+      start: vi.fn().mockResolvedValue({
+        sessionId: "requester-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     let signalFreshResumeStarted: (() => void) | undefined;
     let resolveFreshResume: (() => void) | undefined;
     const freshResumeStarted = new Promise<void>((resolve) => {
@@ -2167,7 +2228,7 @@ describe("SessionManager edge coverage", () => {
         freshHead = message;
         signalFreshResumeStarted?.();
         await freshResumeGate;
-        return "fresh-preemption-session";
+        return { sessionId: "fresh-preemption-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
@@ -2259,7 +2320,10 @@ describe("SessionManager edge coverage", () => {
     const existingHandler = handler({
       resume: vi.fn().mockImplementation(() => {
         signalResumeStarted?.();
-        return pendingResume;
+        return pendingResume.then((sessionId) => ({
+          sessionId,
+          route: { kind: "owned" as const, mode: "queued" as const },
+        }));
       }),
     });
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
@@ -2319,7 +2383,7 @@ describe("SessionManager edge coverage", () => {
       resume: vi.fn().mockImplementation(async () => {
         signalRetryStarted?.();
         await retryGate;
-        return "stale-retry-session";
+        return { sessionId: "stale-retry-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
@@ -3015,7 +3079,10 @@ describe("SessionManager edge coverage", () => {
     const boom = new Error("replacement shutdown failed");
     const retiredHandler = handler();
     const replacementHandler = handler({
-      resume: vi.fn().mockResolvedValue("replacement-session"),
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "replacement-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
       shutdown: vi.fn().mockRejectedValueOnce(boom).mockResolvedValue(undefined),
     });
     const sm = makeManager({ handlers: [replacementHandler] });
@@ -3219,7 +3286,11 @@ describe("SessionManager edge coverage", () => {
       suspend: vi.fn().mockRejectedValue(suspendBoom),
       shutdown: vi.fn().mockRejectedValueOnce(stopBoom).mockResolvedValue(undefined),
     });
-    const freshHandler = handler({ resume: vi.fn().mockResolvedValue("fresh-session") });
+    const freshHandler = handler({
+      resume: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "fresh-session", route: { kind: "owned" as const, mode: "queued" as const } }),
+    });
     const sm = makeManager({ handlers: [freshHandler] });
     const i = internals(sm);
     const chatId = "chat-resume-after-failed-suspend";
@@ -3618,7 +3689,7 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async () => {
         signalStartStarted?.();
         await startGate;
-        return "session-id";
+        return { sessionId: "session-id", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       shutdown: vi
         .fn()
@@ -3704,7 +3775,7 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async () => {
         signalStartStarted?.();
         await startGate;
-        return "session-id";
+        return { sessionId: "session-id", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       shutdown: vi
         .fn()
@@ -3771,7 +3842,7 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async () => {
         signalStartStarted?.();
         await startGate;
-        return "session-id";
+        return { sessionId: "session-id", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       shutdown: vi
         .fn()
@@ -3829,7 +3900,12 @@ describe("SessionManager edge coverage", () => {
         })
         .mockResolvedValue(undefined),
     });
-    const sessionHandler = handler({ resume: vi.fn().mockResolvedValue("resumed-session") });
+    const sessionHandler = handler({
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "resumed-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const sm = makeManager();
     const i = internals(sm);
     const chatId = "chat-route-waits-for-debt";
@@ -3859,7 +3935,12 @@ describe("SessionManager edge coverage", () => {
     const debtHandler = handler({
       shutdown: vi.fn().mockRejectedValueOnce(boom).mockResolvedValue(undefined),
     });
-    const sessionHandler = handler({ resume: vi.fn().mockResolvedValue("resumed-session") });
+    const sessionHandler = handler({
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "resumed-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
     const sm = makeManager({ recoverChat });
     const i = internals(sm);
@@ -3951,7 +4032,11 @@ describe("SessionManager edge coverage", () => {
 
   it("installs the retry route after the debt settles when no terminate intervenes", async () => {
     const debtHandler = handler();
-    const freshHandler = handler({ resume: vi.fn().mockResolvedValue("retry-session") });
+    const freshHandler = handler({
+      resume: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "retry-session", route: { kind: "owned" as const, mode: "queued" as const } }),
+    });
     const sm = makeManager({ handlers: [freshHandler] });
     const i = internals(sm);
     const chatId = "chat-retry-after-debt-settle";
@@ -4040,10 +4125,15 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async () => {
         signalStartStarted?.();
         await startGate;
-        return "stale-canceled-session";
+        return { sessionId: "stale-canceled-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
-    const freshHandler = handler({ start: vi.fn().mockResolvedValue("fresh-route-session") });
+    const freshHandler = handler({
+      start: vi.fn().mockResolvedValue({
+        sessionId: "fresh-route-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
     const sm = makeManager({ handlers: [canceledHandler, freshHandler], recoverChat });
     const i = internals(sm);
@@ -4102,7 +4192,12 @@ describe("SessionManager edge coverage", () => {
         })
         .mockResolvedValue(undefined),
     });
-    const sessionHandler = handler({ resume: vi.fn().mockResolvedValue("resumed-session") });
+    const sessionHandler = handler({
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "resumed-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const sm = makeManager();
     const i = internals(sm);
     const chatId = "chat-concurrent-resumes";
@@ -4148,7 +4243,12 @@ describe("SessionManager edge coverage", () => {
         })
         .mockResolvedValue(undefined),
     });
-    const freshHandler = handler({ start: vi.fn().mockResolvedValue("started-session") });
+    const freshHandler = handler({
+      start: vi.fn().mockResolvedValue({
+        sessionId: "started-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const sm = makeManager({ handlers: [freshHandler] });
     const i = internals(sm);
     const chatId = "chat-concurrent-starts";
@@ -4194,7 +4294,12 @@ describe("SessionManager edge coverage", () => {
         })
         .mockResolvedValue(undefined),
     });
-    const freshHandler = handler({ resume: vi.fn().mockResolvedValue("retry-route-session") });
+    const freshHandler = handler({
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "retry-route-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const sm = makeManager({ handlers: [freshHandler] });
     const i = internals(sm);
     const chatId = "chat-retry-replace-stop";
@@ -4369,7 +4474,12 @@ describe("SessionManager edge coverage", () => {
         })
         .mockResolvedValue(undefined),
     });
-    const freshHandler = handler({ resume: vi.fn().mockResolvedValue("retry-route-session") });
+    const freshHandler = handler({
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "retry-route-session",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const sm = makeManager({ handlers: [freshHandler] });
     const i = internals(sm);
     const chatId = "chat-overlapping-retries";
@@ -4689,8 +4799,16 @@ describe("SessionManager edge coverage", () => {
         await stopGateB;
       }),
     });
-    const freshA = handler({ resume: vi.fn().mockResolvedValue("session-a") });
-    const freshB = handler({ resume: vi.fn().mockResolvedValue("session-b") });
+    const freshA = handler({
+      resume: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "session-a", route: { kind: "owned" as const, mode: "queued" as const } }),
+    });
+    const freshB = handler({
+      resume: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "session-b", route: { kind: "owned" as const, mode: "queued" as const } }),
+    });
     const sm = makeManager({ handlers: [freshA, freshB], concurrency: 1 });
     const i = internals(sm);
     const entryA = makeSessionRecord("chat-cap-a", {
@@ -4758,7 +4876,11 @@ describe("SessionManager edge coverage", () => {
       }),
     });
     const freshA = handler();
-    const handlerC = handler({ start: vi.fn().mockResolvedValue("c-session") });
+    const handlerC = handler({
+      start: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "c-session", route: { kind: "owned" as const, mode: "queued" as const } }),
+    });
     const sm = makeManager({ handlers: [handlerC, freshA], concurrency: 1 });
     const i = internals(sm);
     const chatId = "chat-freed-slot-retry";
@@ -4843,7 +4965,7 @@ describe("SessionManager edge coverage", () => {
       start: vi.fn().mockImplementation(async () => {
         signalStartStarted?.();
         await startGate;
-        return "stale-session";
+        return { sessionId: "stale-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       shutdown: vi
         .fn()
@@ -4934,7 +5056,11 @@ describe("SessionManager edge coverage", () => {
 
     // A fresh manager over the same file reloads nothing, and the next real
     // dispatch starts a FRESH provider thread — no resume of the old one.
-    const freshHandler = handler({ start: vi.fn().mockResolvedValue("fresh-thread") });
+    const freshHandler = handler({
+      start: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "fresh-thread", route: { kind: "owned" as const, mode: "queued" as const } }),
+    });
     const reloaded = makeManager({ handlers: [freshHandler], registryPath });
     expect(reloaded.getEvictedChatIds()).toEqual([]);
     await reloaded.dispatch(mockEntry({ id: 151, chatId, messageId: "msg-after-reset" }));
@@ -6245,7 +6371,11 @@ describe("SessionManager edge coverage", () => {
     const terminalRetry = handler({
       resume: vi.fn().mockRejectedValue({ name: "ClientUserMismatchError", message: "wrong client" }),
     });
-    const replacement = handler({ start: vi.fn().mockResolvedValue("tail-session") });
+    const replacement = handler({
+      start: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "tail-session", route: { kind: "owned" as const, mode: "queued" as const } }),
+    });
     const sm = makeManager({
       handlers: [terminalRetry, replacement],
       confirmSessionEvent: vi.fn().mockImplementation(() => {
@@ -6392,7 +6522,11 @@ describe("SessionManager edge coverage", () => {
   it("uses retry-time config cache, clears existing retry timers, and catches retry-success emit failures", async () => {
     const cache = makeCache();
     const existingTimer = setTimeout(() => undefined, 60_000);
-    const successfulResume = handler({ resume: vi.fn().mockResolvedValue("retry-resumed") });
+    const successfulResume = handler({
+      resume: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "retry-resumed", route: { kind: "owned" as const, mode: "queued" as const } }),
+    });
     const transientResume = handler({
       resume: vi.fn().mockRejectedValue({ status: 429, message: "still limited" }),
     });
@@ -6597,7 +6731,7 @@ describe("SessionManager edge coverage", () => {
           async start(message, ctx) {
             captured = ctx;
             ctx.markMessagesConsumed(message);
-            return "runtime-session";
+            return { sessionId: "runtime-session", route: { kind: "owned" as const, mode: "queued" as const } };
           },
         }),
       ],
@@ -6656,7 +6790,7 @@ describe("SessionManager edge coverage", () => {
       async start(message, ctx) {
         capturedMessage = message;
         captured = ctx;
-        return "idle-log-session";
+        return { sessionId: "idle-log-session", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sm = new SessionManager({
@@ -6804,7 +6938,7 @@ describe("SessionManager edge coverage", () => {
       async start(message, _ctx, token) {
         capturedMessage = message;
         capturedToken = token;
-        return "runtime-notice-session";
+        return { sessionId: "runtime-notice-session", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sm = makeManager({
@@ -6916,14 +7050,24 @@ describe("SessionManager edge coverage", () => {
     const makeOwnedReceipt = (sessionId: string) => ({ sessionId, route: { kind: "owned", mode: "queued" } as const });
     const loseOwnership: SessionManagerInternals["markRouteOwned"] = () => "lost";
 
-    const startHandler = handler({ start: vi.fn().mockResolvedValue(makeOwnedReceipt("start-lost")) });
+    const startHandler = handler({
+      start: vi.fn().mockResolvedValue({
+        sessionId: makeOwnedReceipt("start-lost"),
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const startManager = makeManager({ handlers: [startHandler] });
     internals(startManager).markRouteOwned = loseOwnership;
     await internals(startManager).routeMessage("chat-start-lost", makeMessage("chat-start-lost"));
     expect(internals(startManager).sessions.has("chat-start-lost")).toBe(false);
     await startManager.shutdown();
 
-    const evictedHandler = handler({ resume: vi.fn().mockResolvedValue(makeOwnedReceipt("evicted-lost")) });
+    const evictedHandler = handler({
+      resume: vi.fn().mockResolvedValue({
+        sessionId: makeOwnedReceipt("evicted-lost"),
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const evictedManager = makeManager({ handlers: [evictedHandler] });
     internals(evictedManager).evictedMappings.set("chat-evicted-lost", {
       claudeSessionId: "old-evicted",
@@ -6936,7 +7080,12 @@ describe("SessionManager edge coverage", () => {
 
     const suspendedRecord = makeSessionRecord("chat-resume-lost", {
       status: "suspended",
-      handler: handler({ resume: vi.fn().mockResolvedValue(makeOwnedReceipt("resume-lost")) }),
+      handler: handler({
+        resume: vi.fn().mockResolvedValue({
+          sessionId: makeOwnedReceipt("resume-lost"),
+          route: { kind: "owned" as const, mode: "queued" as const },
+        }),
+      }),
     });
     const resumeManager = makeManager();
     internals(resumeManager).sessions.set("chat-resume-lost", suspendedRecord);
@@ -6945,7 +7094,12 @@ describe("SessionManager edge coverage", () => {
     expect(internals(resumeManager).sessions.has("chat-resume-lost")).toBe(false);
     await resumeManager.shutdown();
 
-    const retryResumeHandler = handler({ resume: vi.fn().mockResolvedValue(makeOwnedReceipt("retry-resume-lost")) });
+    const retryResumeHandler = handler({
+      resume: vi.fn().mockResolvedValue({
+        sessionId: makeOwnedReceipt("retry-resume-lost"),
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const retryResumeManager = makeManager({ handlers: [retryResumeHandler] });
     internals(retryResumeManager).sessions.set(
       "chat-retry-resume-lost",
@@ -6961,7 +7115,12 @@ describe("SessionManager edge coverage", () => {
     expect(internals(retryResumeManager).sessions.has("chat-retry-resume-lost")).toBe(false);
     await retryResumeManager.shutdown();
 
-    const retryStartHandler = handler({ start: vi.fn().mockResolvedValue(makeOwnedReceipt("retry-start-lost")) });
+    const retryStartHandler = handler({
+      start: vi.fn().mockResolvedValue({
+        sessionId: makeOwnedReceipt("retry-start-lost"),
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+    });
     const retryStartManager = makeManager({ handlers: [retryStartHandler] });
     internals(retryStartManager).sessions.set(
       "chat-retry-start-lost",
@@ -7053,7 +7212,7 @@ describe("SessionManager edge coverage", () => {
         if (!message || !token) throw new Error("retry head token was not provided");
         token.processingStarted(message);
         await token.complete(message, { status: "success", terminal: true });
-        return "retry-resumed";
+        return { sessionId: "retry-resumed", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       inject: vi.fn((message) => {
         if (message.id === "msg-deferred-first") {

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -64,8 +64,12 @@ function mockAckEntry(): (entryId: number) => Promise<void> {
 
 function createMockHandler(overrides: Partial<AgentHandler> = {}): AgentHandler {
   return {
-    start: vi.fn().mockResolvedValue("session-id-mock"),
-    resume: vi.fn().mockResolvedValue("session-id-mock"),
+    start: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } }),
+    resume: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } }),
     inject: vi.fn().mockReturnValue({ kind: "owned", mode: "queued" }),
     suspend: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn().mockResolvedValue(undefined),
@@ -560,7 +564,7 @@ describe("SessionManager additional delivery token and payload coverage", () => 
       const handler = createMockHandler({
         start: vi.fn(async (message) => {
           capturedMessage = message;
-          return "session-id-mock";
+          return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
       });
       const sm = createSessionManager({ handler, sdk });
@@ -606,7 +610,7 @@ describe("SessionManager additional delivery token and payload coverage", () => 
     const handler = createMockHandler({
       start: vi.fn(async (message) => {
         capturedMessage = message;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const sm = createSessionManager({ handler, sdk });
@@ -645,7 +649,7 @@ describe("SessionManager additional delivery token and payload coverage", () => 
         start: vi.fn(async (message, ctx) => {
           capturedMessage = message;
           renderedContent = await ctx.formatInboundContent(message);
-          return "session-id-mock";
+          return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
       });
       const sm = createSessionManager({ handler, sdk });
@@ -711,7 +715,7 @@ describe("SessionManager additional delivery token and payload coverage", () => 
       const handler = createMockHandler({
         start: vi.fn(async (message, ctx) => {
           renderedContent = await ctx.formatInboundContent(message);
-          return "session-id-mock";
+          return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
       });
       const sm = createSessionManager({ handler, sdk });
@@ -880,7 +884,10 @@ describe("SessionManager additional shutdown and finalization coverage", () => {
     const registryPath = join(dir, "sessions.json");
     const onStateChange = vi.fn<(chatId: string, state: SessionState) => void>();
     const handler = createMockHandler({
-      start: vi.fn(async () => "session-to-clear"),
+      start: vi.fn(async () => ({
+        sessionId: "session-to-clear",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      })),
       shutdown: vi.fn().mockRejectedValue(new Error("provider already closed")),
     });
     const sm = createSessionManager({ handler, registryPath, onStateChange });

--- a/packages/client/src/__tests__/session-manager-retry.test.ts
+++ b/packages/client/src/__tests__/session-manager-retry.test.ts
@@ -72,7 +72,10 @@ describe("SessionManager: transient session retry", () => {
   it("keeps the entry alive and schedules a retry on RateLimitError", async () => {
     const handler: AgentHandler = {
       start: vi.fn().mockRejectedValue(new FakeRateLimit("rate limited")),
-      resume: vi.fn().mockResolvedValue("session-after-retry"),
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "session-after-retry",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
       inject: vi.fn(),
       suspend: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn().mockResolvedValue(undefined),
@@ -225,8 +228,14 @@ describe("SessionManager: transient session retry", () => {
       shutdown: vi.fn().mockResolvedValue(undefined),
     };
     const recovered: AgentHandler = {
-      start: vi.fn().mockResolvedValue("session-after-retry"),
-      resume: vi.fn().mockResolvedValue("session-after-retry"),
+      start: vi.fn().mockResolvedValue({
+        sessionId: "session-after-retry",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "session-after-retry",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
       inject: vi.fn(),
       suspend: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn().mockResolvedValue(undefined),
@@ -264,7 +273,7 @@ describe("SessionManager: transient session retry", () => {
         start: vi.fn(async (message, ctx) => {
           initialMessage = message;
           initialCtx = ctx;
-          return "existing-opencode-session";
+          return { sessionId: "existing-opencode-session", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
         resume: vi.fn().mockRejectedValue(new ManagedSkillsUnsafeDiscoveryError("unsafe discovery on resume")),
         inject: vi.fn(),
@@ -286,7 +295,7 @@ describe("SessionManager: transient session retry", () => {
         resume: vi.fn(async (message, sessionId, ctx) => {
           recoveredHead = message;
           recoveredCtx = ctx;
-          return sessionId;
+          return { sessionId: sessionId, route: { kind: "owned" as const, mode: "queued" as const } };
         }),
         inject: vi.fn((message) => {
           recoveredTail.push(message);
@@ -447,8 +456,14 @@ describe("SessionManager: transient session retry", () => {
         shutdown: vi.fn().mockResolvedValue(undefined),
       };
       const recovered: AgentHandler = {
-        start: vi.fn().mockResolvedValue("session-after-retry"),
-        resume: vi.fn().mockResolvedValue("session-after-retry"),
+        start: vi.fn().mockResolvedValue({
+          sessionId: "session-after-retry",
+          route: { kind: "owned" as const, mode: "queued" as const },
+        }),
+        resume: vi.fn().mockResolvedValue({
+          sessionId: "session-after-retry",
+          route: { kind: "owned" as const, mode: "queued" as const },
+        }),
         inject: vi.fn(),
         suspend: vi.fn().mockResolvedValue(undefined),
         shutdown: vi.fn().mockResolvedValue(undefined),
@@ -490,9 +505,12 @@ describe("SessionManager: transient session retry", () => {
       start: vi.fn(async (message, ctx) => {
         startedMessages.push(message);
         capturedCtx.push(ctx);
-        return "session-after-retry";
+        return { sessionId: "session-after-retry", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
-      resume: vi.fn().mockResolvedValue("session-after-retry"),
+      resume: vi.fn().mockResolvedValue({
+        sessionId: "session-after-retry",
+        route: { kind: "owned" as const, mode: "queued" as const },
+      }),
       inject: vi.fn((message) => {
         injected.push(message);
         return { kind: "owned", mode: "queued" } as const;
@@ -531,7 +549,7 @@ describe("SessionManager: transient session retry", () => {
       start: vi.fn(async (message, ctx) => {
         initialMessage = message;
         initialCtx = ctx;
-        return "established-session";
+        return { sessionId: "established-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       resume: vi.fn().mockRejectedValue(new FakeRateLimit("resume transport failed")),
       inject: vi.fn(),
@@ -543,7 +561,7 @@ describe("SessionManager: transient session retry", () => {
       resume: vi.fn(async (message, _sessionId, ctx) => {
         retryMessage = message;
         retryCtx = ctx;
-        return "resumed-session";
+        return { sessionId: "resumed-session", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
       inject: vi.fn((message) => {
         injected.push(message);
@@ -602,11 +620,14 @@ describe("SessionManager: transient session retry", () => {
         start: vi.fn(async (message, ctx) => {
           initialMessage = message;
           initialCtx = ctx;
-          return "deferred-resume-session";
+          return { sessionId: "deferred-resume-session", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
         resume: vi.fn(() => {
           signalResumeStarted?.();
-          return pendingResume;
+          return pendingResume.then((sessionId) => ({
+            sessionId,
+            route: { kind: "owned" as const, mode: "queued" as const },
+          }));
         }),
         inject: vi.fn(),
         suspend: vi.fn().mockResolvedValue(undefined),
@@ -617,7 +638,7 @@ describe("SessionManager: transient session retry", () => {
         resume: vi.fn(async (message, _sessionId, ctx) => {
           retryMessage = message;
           retryCtx = ctx;
-          return "deferred-resume-recovered";
+          return { sessionId: "deferred-resume-recovered", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
         inject: vi.fn((message) => {
           injected.push(message);
@@ -669,7 +690,7 @@ describe("SessionManager: transient session retry", () => {
         start: vi.fn(async (message, ctx) => {
           initialMessage = message;
           initialCtx = ctx;
-          return "control-session";
+          return { sessionId: "control-session", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
         resume: vi.fn().mockRejectedValue(new FakeRateLimit("control resume transport failed")),
         inject: vi.fn(),
@@ -678,7 +699,10 @@ describe("SessionManager: transient session retry", () => {
       };
       const recovered: AgentHandler = {
         start: vi.fn(),
-        resume: vi.fn().mockResolvedValue("control-session-resumed"),
+        resume: vi.fn().mockResolvedValue({
+          sessionId: "control-session-resumed",
+          route: { kind: "owned" as const, mode: "queued" as const },
+        }),
         inject: vi.fn(),
         suspend: vi.fn().mockResolvedValue(undefined),
         shutdown: vi.fn().mockResolvedValue(undefined),

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -75,8 +75,12 @@ function deferred<T>() {
 /** Create a mock handler conforming to the new session-oriented interface. */
 function createMockHandler(overrides?: Partial<AgentHandler>): AgentHandler {
   return {
-    start: vi.fn().mockResolvedValue("session-id-mock"),
-    resume: vi.fn().mockResolvedValue("session-id-mock"),
+    start: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } }),
+    resume: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } }),
     inject: vi.fn().mockReturnValue({ kind: "owned", mode: "queued" }),
     suspend: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn().mockResolvedValue(undefined),
@@ -317,7 +321,7 @@ describe("SessionManager", () => {
     const handler = createMockHandler({
       async start(_msg, ctx) {
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sm = createSessionManager({ ackEntry, handler });
@@ -466,7 +470,10 @@ describe("SessionManager", () => {
     };
     const recoverChat = vi.fn().mockResolvedValue(undefined);
     const injectSpy = vi.fn().mockReturnValue({ kind: "owned", mode: "queued" });
-    const startSpy = vi.fn(async () => "session-id-mock");
+    const startSpy = vi.fn(async () => ({
+      sessionId: "session-id-mock",
+      route: { kind: "owned" as const, mode: "queued" as const },
+    }));
     const handler = createMockHandler({
       start: startSpy,
       inject: injectSpy,
@@ -544,7 +551,7 @@ describe("SessionManager", () => {
       const h = createMockHandler({
         start: vi.fn(async (message, ctx) => {
           ctx.markMessagesConsumed(message);
-          return `session-${message.chatId}`;
+          return { sessionId: `session-${message.chatId}`, route: { kind: "owned" as const, mode: "queued" as const } };
         }),
       });
       handlers.push(h);
@@ -583,7 +590,7 @@ describe("SessionManager", () => {
           messages.set(message.chatId, message);
           started.push(message.chatId);
           ctx.markMessagesConsumed(message);
-          return `session-${message.chatId}`;
+          return { sessionId: `session-${message.chatId}`, route: { kind: "owned" as const, mode: "queued" as const } };
         },
       });
     const sm = createSessionManager({
@@ -612,7 +619,7 @@ describe("SessionManager", () => {
     let capturedCtx: SessionContext | undefined;
     const startSpy = vi.fn(async (_msg: unknown, ctx: SessionContext) => {
       capturedCtx = ctx;
-      return "session-id-mock";
+      return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
     });
     const injectSpy = vi.fn();
     const handler = createMockHandler({ start: startSpy, inject: injectSpy });
@@ -841,7 +848,7 @@ describe("SessionManager", () => {
     const handler = createMockHandler({
       async start(_msg, ctx) {
         capturedCtx = ctx;
-        return "session-id";
+        return { sessionId: "session-id", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
 
@@ -885,7 +892,7 @@ describe("SessionManager", () => {
         async start(msg, ctx) {
           contexts.set(msg.chatId, ctx);
           messages.set(msg.chatId, msg);
-          return `session-${msg.chatId}`;
+          return { sessionId: `session-${msg.chatId}`, route: { kind: "owned" as const, mode: "queued" as const } };
         },
       });
       handlers.push(h);
@@ -938,7 +945,7 @@ describe("SessionManager", () => {
           contexts.set(msg.chatId, ctx);
           messages.set(msg.chatId, msg);
           lifecycleCalls.push({ type: "start", chatId: msg.chatId });
-          return sid;
+          return { sessionId: sid, route: { kind: "owned" as const, mode: "queued" as const } };
         },
         async resume(msg, sessionId, ctx) {
           if (msg) {
@@ -946,7 +953,7 @@ describe("SessionManager", () => {
             messages.set(msg.chatId, msg);
           }
           lifecycleCalls.push({ type: "resume", chatId: msg?.chatId ?? "", sessionId });
-          return sessionId;
+          return { sessionId: sessionId, route: { kind: "owned" as const, mode: "queued" as const } };
         },
       });
 
@@ -1024,7 +1031,7 @@ describe("SessionManager", () => {
       createMockHandler({
         async start(msg) {
           startCalls.push(msg.chatId);
-          return `session-${msg.chatId}`;
+          return { sessionId: `session-${msg.chatId}`, route: { kind: "owned" as const, mode: "queued" as const } };
         },
       });
 
@@ -1085,7 +1092,7 @@ describe("SessionManager dispatch integration", () => {
     const startSpy = handler.start as ReturnType<typeof vi.fn>;
     startSpy.mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
       capturedCtx = ctx;
-      return "session-id-mock";
+      return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
     });
     const ackEntry = mockAckEntry();
     const sm = createSessionManager({ handler, ackEntry });
@@ -1157,7 +1164,10 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
   it("starts a fresh chat without same-socket recovery even when recoverChat is configured", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);
-    const startSpy = vi.fn(async () => "session-id-mock");
+    const startSpy = vi.fn(async () => ({
+      sessionId: "session-id-mock",
+      route: { kind: "owned" as const, mode: "queued" as const },
+    }));
     const handler = createMockHandler({ start: startSpy });
     const { sm } = buildSm(ackEntry, handler, recoverChat);
 
@@ -1177,7 +1187,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const start = vi.fn(async (message: SessionMessage, ctx: SessionContext) => {
       capturedMessage = message;
       capturedCtx = ctx;
-      return "session-id-mock";
+      return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
     });
     const handler = createMockHandler({
       start,
@@ -1210,7 +1220,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const start = vi.fn(async (message: SessionMessage, ctx: SessionContext) => {
       capturedMessage = message;
       capturedCtx = ctx;
-      return "session-id-mock";
+      return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
     });
     const handler = createMockHandler({
       start,
@@ -1238,7 +1248,10 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
   it("requests chat recovery when concurrency preemption interrupts owed work", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);
-    const startSpy = vi.fn(async () => "session-id-mock");
+    const startSpy = vi.fn(async () => ({
+      sessionId: "session-id-mock",
+      route: { kind: "owned" as const, mode: "queued" as const },
+    }));
     const handler = createMockHandler({ start: startSpy });
     const sm = createSessionManager({
       ackEntry,
@@ -1274,7 +1287,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
           contexts.set(message.chatId, ctx);
           messages.set(message.chatId, message);
           ctx.markMessagesConsumed(message);
-          return `session-${message.chatId}`;
+          return { sessionId: `session-${message.chatId}`, route: { kind: "owned" as const, mode: "queued" as const } };
         },
       });
       return current;
@@ -1320,7 +1333,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const handler = createMockHandler({
       async start(_m, ctx) {
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const { sm } = buildSm(ackEntry, handler);
@@ -1344,7 +1357,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       inject: vi.fn((m) => {
         injected.push(m);
@@ -1380,7 +1393,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       inject: vi.fn((m) => {
         injected.push(m);
@@ -1415,7 +1428,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       async start(m, ctx) {
         capturedMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const { sm } = buildSm(ackEntry, handler);
@@ -1456,7 +1469,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
         routed.push(`start:${m.id}`);
         capturedCtx = ctx;
         startedMessage = m;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       inject: vi.fn((m) => {
         routed.push(`inject:${m.id}`);
@@ -1495,7 +1508,10 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
   it("requests chat recovery when routeMessage fails and lets later redelivery route", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);
-    const recoveryStart = vi.fn(async () => "session-id-recovery");
+    const recoveryStart = vi.fn(async () => ({
+      sessionId: "session-id-recovery",
+      route: { kind: "owned" as const, mode: "queued" as const },
+    }));
     let factoryCalls = 0;
     const factory = vi.fn<HandlerFactory>(() => {
       factoryCalls++;
@@ -1541,11 +1557,14 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const recoverChat = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
-    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const resumeSpy = vi.fn(async () => ({
+      sessionId: "session-id-mock",
+      route: { kind: "owned" as const, mode: "queued" as const },
+    }));
     const startSpy = vi.fn(async (m: Parameters<AgentHandler["start"]>[0], ctx: SessionContext) => {
       firstMessage = m;
       capturedCtx = ctx;
-      return "session-id-mock";
+      return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
     });
     const handler = createMockHandler({
       start: startSpy,
@@ -1578,12 +1597,15 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const recoverChat = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
-    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const resumeSpy = vi.fn(async () => ({
+      sessionId: "session-id-mock",
+      route: { kind: "owned" as const, mode: "queued" as const },
+    }));
     const handler = createMockHandler({
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       resume: resumeSpy,
     });
@@ -1615,12 +1637,15 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
     const injected: Parameters<AgentHandler["inject"]>[0][] = [];
-    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const resumeSpy = vi.fn(async () => ({
+      sessionId: "session-id-mock",
+      route: { kind: "owned" as const, mode: "queued" as const },
+    }));
     const handler = createMockHandler({
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       resume: resumeSpy,
       inject: vi.fn((m) => {
@@ -1659,12 +1684,15 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const recoverChat = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
-    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const resumeSpy = vi.fn(async () => ({
+      sessionId: "session-id-mock",
+      route: { kind: "owned" as const, mode: "queued" as const },
+    }));
     const handler = createMockHandler({
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       resume: resumeSpy,
       inject: vi.fn(() => ({ kind: "owned", mode: "queued" }) as const),
@@ -1695,12 +1723,15 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const recoverChat = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
-    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const resumeSpy = vi.fn(async () => ({
+      sessionId: "session-id-mock",
+      route: { kind: "owned" as const, mode: "queued" as const },
+    }));
     const handler = createMockHandler({
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       resume: resumeSpy,
       inject: vi.fn(() => ({ kind: "owned", mode: "queued" }) as const),
@@ -1739,7 +1770,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       inject: vi.fn((m) => {
         injected.push(m);
@@ -1770,7 +1801,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const startSpy = vi.fn(async (m: Parameters<AgentHandler["start"]>[0], ctx: SessionContext) => {
       firstMessage = m;
       capturedCtx = ctx;
-      return "session-id-mock";
+      return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
     });
     const handler = createMockHandler({
       start: startSpy,
@@ -1810,7 +1841,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       inject: injectSpy,
     });
@@ -1840,7 +1871,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       inject: injectSpy,
     });
@@ -1865,11 +1896,11 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const handler = createMockHandler({
       async start(_m, ctx) {
         capturedCtxs.push(ctx);
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
       async resume(_m, _sid, ctx) {
         capturedCtxs.push(ctx);
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sdk = mockSdk();
@@ -2650,7 +2681,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       start: vi.fn(async (message, ctx) => {
         capturedMessage = message;
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const { sm } = buildSm(ackEntry, handler, recoverChat);
@@ -2742,7 +2773,7 @@ describe("SessionManager lazy Context Tree binding", () => {
   };
 
   it("upgrades a tree-less handler config to tree-bound on a new session", async () => {
-    const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test" };
+    const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test", runtimeProvider: "codex" };
     let builtWith: HandlerConfig | undefined;
     const sm = createSessionManager({
       handlerConfig,
@@ -2767,7 +2798,11 @@ describe("SessionManager lazy Context Tree binding", () => {
 
   it("does not re-resolve when already bound (steady state pays nothing)", async () => {
     const resolve = vi.fn(async () => BINDING);
-    const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test", contextTreePath: "/already/bound" };
+    const handlerConfig: HandlerConfig = {
+      workspaceRoot: "/tmp/test",
+      runtimeProvider: "codex",
+      contextTreePath: "/already/bound",
+    };
     const sm = createSessionManager({ handlerConfig, resolveContextTreeBinding: resolve });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "c-bound", messageId: "m1" }));
@@ -2780,7 +2815,7 @@ describe("SessionManager lazy Context Tree binding", () => {
 
   it("re-resolves once for the new session, not again for a same-chat inject", async () => {
     const resolve = vi.fn(async () => null);
-    const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test" };
+    const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test", runtimeProvider: "codex" };
     const sm = createSessionManager({ handlerConfig, resolveContextTreeBinding: resolve });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "c-once", messageId: "m1" }));
@@ -2800,7 +2835,7 @@ describe("SessionManager subprocess-aware suspend/eviction", () => {
       const handler = createMockHandler({
         async start(_msg, c) {
           ctx = c;
-          return "sid";
+          return { sessionId: "sid", route: { kind: "owned" as const, mode: "queued" as const } };
         },
       });
       const hasLive = vi.fn().mockReturnValue(true);
@@ -2837,7 +2872,7 @@ describe("SessionManager subprocess-aware suspend/eviction", () => {
       const handler = createMockHandler({
         async start(_msg, c) {
           ctx = c;
-          return "sid";
+          return { sessionId: "sid", route: { kind: "owned" as const, mode: "queued" as const } };
         },
       });
       const probe: SubprocessProbe = { hasLiveSubprocess: vi.fn().mockReturnValue(true), stop: vi.fn() };
@@ -2867,7 +2902,10 @@ describe("SessionManager subprocess-aware suspend/eviction", () => {
       const h = createMockHandler({
         async start(msg, c) {
           ctxs[(msg as { chatId: string }).chatId] = c;
-          return `sid-${(msg as { chatId: string }).chatId}`;
+          return {
+            sessionId: `sid-${(msg as { chatId: string }).chatId}`,
+            route: { kind: "owned" as const, mode: "queued" as const },
+          };
         },
       });
       handlers.push(h);
@@ -3081,7 +3119,7 @@ describe("SessionManager completion disposition", () => {
     const handler = createMockHandler({
       async start(_msg, ctx) {
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sm = createSessionManager({ handler, ackEntry, recoverChat: async () => {} });
@@ -3105,7 +3143,7 @@ describe("SessionManager completion disposition", () => {
     const handler = createMockHandler({
       async start(_msg, ctx) {
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sm = createSessionManager({ handler, ackEntry, recoverChat });
@@ -3144,7 +3182,7 @@ describe("SessionManager completion disposition", () => {
     const handler = createMockHandler({
       async start(_msg, ctx) {
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sm = createSessionManager({ handler, ackEntry });
@@ -3178,7 +3216,7 @@ describe("SessionManager replay fence reconcile", () => {
       const handler = createMockHandler({
         start: vi.fn().mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
           capturedCtx = ctx;
-          return "session-id-mock";
+          return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
       });
       const sm = createSessionManager({
@@ -3444,7 +3482,7 @@ describe("SessionManager replay fence startup reconciliation", () => {
       const handler = createMockHandler({
         start: vi.fn().mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
           capturedCtx = ctx;
-          return "session-id-mock";
+          return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
       });
       const sm = createSessionManager({
@@ -3624,7 +3662,7 @@ describe("SessionManager replay fence convergence matrix", () => {
     const handler = createMockHandler({
       start: vi.fn().mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
         capturedCtx = ctx;
-        return "session-id-mock";
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
     const sm = createSessionManager({ handler, ackEntry, recoverChat });
@@ -3912,7 +3950,7 @@ describe("SessionManager confirmed-ACK fence settlement suppression", () => {
       const handler = createMockHandler({
         start: vi.fn().mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
           capturedCtx = ctx;
-          return "session-id-mock";
+          return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
         }),
       });
       const sm = createSessionManager({

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -16,8 +16,12 @@ function mockSdk(): FirstTreeHubSDK {
 
 function createMockHandler(overrides?: Partial<AgentHandler>): AgentHandler {
   return {
-    start: vi.fn().mockResolvedValue("session-id-mock"),
-    resume: vi.fn().mockResolvedValue("session-id-mock"),
+    start: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } }),
+    resume: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } }),
     inject: vi.fn().mockReturnValue({ kind: "owned", mode: "queued" }),
     suspend: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn().mockResolvedValue(undefined),
@@ -94,7 +98,7 @@ describe("SessionManager runtime projection from inbox coordinator work", () => 
       async start(msg, ctx) {
         capturedCtx = ctx;
         capturedMessage = msg;
-        return "session-1";
+        return { sessionId: "session-1", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const sm = createSessionManager({
@@ -135,7 +139,7 @@ describe("SessionManager runtime projection from inbox coordinator work", () => 
     handler.start = vi.fn(async (msg, ctx) => {
       capturedCtx = ctx;
       capturedMessage = msg;
-      return "session-1";
+      return { sessionId: "session-1", route: { kind: "owned" as const, mode: "queued" as const } };
     });
     const sm = createSessionManager({
       handler,
@@ -212,7 +216,7 @@ describe("SessionManager runtime projection from inbox coordinator work", () => 
         async start(msg, ctx) {
           capturedCtx = ctx;
           firstMessage = msg;
-          return "session-1";
+          return { sessionId: "session-1", route: { kind: "owned" as const, mode: "queued" as const } };
         },
       });
       const sm = createSessionManager({

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -113,8 +113,12 @@ function failingHandler(): AgentHandler {
 
 function workingHandler(sessionId = "session-after-recovery"): AgentHandler {
   return {
-    start: vi.fn().mockResolvedValue(sessionId),
-    resume: vi.fn().mockResolvedValue(sessionId),
+    start: vi
+      .fn()
+      .mockResolvedValue({ sessionId: sessionId, route: { kind: "owned" as const, mode: "queued" as const } }),
+    resume: vi
+      .fn()
+      .mockResolvedValue({ sessionId: sessionId, route: { kind: "owned" as const, mode: "queued" as const } }),
     inject: vi.fn().mockReturnValue({ kind: "owned", mode: "queued" }),
     suspend: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn().mockResolvedValue(undefined),
@@ -565,7 +569,9 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     let chatBContext: SessionContext | undefined;
     let chatBMessage: SessionMessage | undefined;
     const handlerA: AgentHandler = {
-      start: vi.fn().mockResolvedValue("session-A"),
+      start: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "session-A", route: { kind: "owned" as const, mode: "queued" as const } }),
       resume: vi.fn().mockRejectedValue(new FakeClientUserMismatchError("git mirror fetch failed: connection refused")),
       inject: vi.fn(),
       suspend: vi.fn().mockResolvedValue(undefined),
@@ -575,7 +581,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     handlerB.start = vi.fn(async (message, ctx) => {
       chatBMessage = message;
       chatBContext = ctx;
-      return "session-B";
+      return { sessionId: "session-B", route: { kind: "owned" as const, mode: "queued" as const } };
     });
     const sm = makeSerializedManager({
       handlerQueue: [handlerA, handlerB],
@@ -636,7 +642,9 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     let chatBContext: SessionContext | undefined;
     let chatBMessage: SessionMessage | undefined;
     const handlerA: AgentHandler = {
-      start: vi.fn().mockResolvedValue("session-A"),
+      start: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "session-A", route: { kind: "owned" as const, mode: "queued" as const } }),
       resume: vi.fn().mockRejectedValue(new FakeClientUserMismatchError("resume blew up")),
       inject: vi.fn(),
       suspend: vi.fn().mockResolvedValue(undefined),
@@ -646,7 +654,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     handlerB.start = vi.fn(async (message, ctx) => {
       chatBMessage = message;
       chatBContext = ctx;
-      return "session-B";
+      return { sessionId: "session-B", route: { kind: "owned" as const, mode: "queued" as const } };
     });
     const handlerARecovery = workingHandler("session-A-fresh");
     const sm = makeSerializedManager({

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -22,8 +22,12 @@ function mockSdk(): FirstTreeHubSDK {
 
 function createMockHandler(overrides?: Partial<AgentHandler>): AgentHandler {
   return {
-    start: vi.fn().mockResolvedValue("session-id-mock"),
-    resume: vi.fn().mockResolvedValue("session-id-mock"),
+    start: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } }),
+    resume: vi
+      .fn()
+      .mockResolvedValue({ sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } }),
     inject: vi.fn(),
     suspend: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn().mockResolvedValue(undefined),
@@ -39,14 +43,17 @@ function createCapturingFactory() {
       async start(message, ctx) {
         contexts.set(message.chatId, ctx);
         messages.set(message.chatId, message);
-        return `session-${message.chatId}`;
+        return { sessionId: `session-${message.chatId}`, route: { kind: "owned" as const, mode: "queued" as const } };
       },
       async resume(message, _sessionId, ctx) {
         if (message) {
           contexts.set(message.chatId, ctx);
           messages.set(message.chatId, message);
         }
-        return `session-${message?.chatId ?? "unknown"}`;
+        return {
+          sessionId: `session-${message?.chatId ?? "unknown"}`,
+          route: { kind: "owned" as const, mode: "queued" as const },
+        };
       },
     });
   };
@@ -177,14 +184,18 @@ describe("SessionManager: state notifications", () => {
     let chatBContext: SessionContext | undefined;
     let chatBMessage: SessionMessage | undefined;
     const handlerA = createMockHandler({
-      start: vi.fn().mockResolvedValue("session-chat-a"),
-      resume: vi.fn().mockResolvedValue("session-chat-a"),
+      start: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "session-chat-a", route: { kind: "owned" as const, mode: "queued" as const } }),
+      resume: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "session-chat-a", route: { kind: "owned" as const, mode: "queued" as const } }),
     });
     const handlerB = createMockHandler({
       async start(message, ctx) {
         chatBMessage = message;
         chatBContext = ctx;
-        return "session-chat-b";
+        return { sessionId: "session-chat-b", route: { kind: "owned" as const, mode: "queued" as const } };
       },
     });
     const handlers = [handlerA, handlerB];
@@ -241,8 +252,11 @@ describe("SessionManager: state-before-runtime ordering (codex review P2)", () =
         // Snapshot the state emissions seen so far — if the `active`
         // notification fired before invoking start, it must already be in
         // `emissions`.
-        observedActiveBeforeHandlerCompletion = emissions.some((e) => e.kind === "state" && e.value === "active");
-        return "session-id-mock";
+        observedActiveBeforeHandlerCompletion = emissions.some((e) => ({
+          sessionId: e.kind === "state" && e.value === "active",
+          route: { kind: "owned" as const, mode: "queued" as const },
+        }));
+        return { sessionId: "session-id-mock", route: { kind: "owned" as const, mode: "queued" as const } };
       }),
     });
 

--- a/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
+++ b/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
@@ -98,6 +98,7 @@ vi.mock("../handlers/claude-code-tui/transcript-tail.js", () => ({
 
 import { createClaudeCodeTuiHandler } from "../handlers/claude-code-tui/index.js";
 import { newSession } from "../handlers/claude-code-tui/tmux-session.js";
+import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
 
 const AGENT_ID = "019eca71-0000-7000-8000-000000000001";
 const CHAT_ID = "chat-tui-suspend-queued-recovery";
@@ -161,11 +162,15 @@ afterEach(() => {
 
 describe("claude-code-tui suspend queued recovery", () => {
   it("starts claude with the runtime output contract and Current Chat Context", async () => {
-    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const handler = createClaudeCodeTuiHandler({
+      runtimeProvider: "claude-code-tui",
+      workspaceRoot: state.workspaceRoot,
+      clientId: "client-test",
+    });
     const ctx = makeContext();
     const first = makeMessage("m1", "active turn");
 
-    const start = handler.start(first, ctx);
+    const start = handler.start(first, ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => vi.mocked(newSession).mock.calls.length > 0);
 
     const command = vi.mocked(newSession).mock.calls[0]?.[0].command ?? "";
@@ -190,20 +195,24 @@ describe("claude-code-tui suspend queued recovery", () => {
   });
 
   it("drops handler-local queued injects on suspend so recovered messages are not pasted twice", async () => {
-    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const handler = createClaudeCodeTuiHandler({
+      runtimeProvider: "claude-code-tui",
+      workspaceRoot: state.workspaceRoot,
+      clientId: "client-test",
+    });
     const ctx = makeContext();
     const first = makeMessage("m1", "active turn");
     const recovered = makeMessage("m2", "queued recovered turn");
 
-    const start = handler.start(first, ctx);
+    const start = handler.start(first, ctx, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => state.pasteTexts.some((text) => text.includes("active turn")));
 
-    handler.inject(recovered);
+    handler.inject(recovered, deliveryTokenFromSessionContext(ctx));
     await handler.suspend();
     const startResult = await start;
     const sessionId = typeof startResult === "string" ? startResult : startResult.sessionId;
 
-    await handler.resume(recovered, sessionId, ctx);
+    await handler.resume(recovered, sessionId, ctx, deliveryTokenFromSessionContext(ctx));
     await new Promise((resolve) => setImmediate(resolve));
 
     const recoveredPastes = state.pasteTexts.filter((text) => text.includes("queued recovered turn"));
@@ -220,7 +229,11 @@ describe("claude-code-tui suspend queued recovery", () => {
   });
 
   it("does not paste a drained queued batch when suspend arrives during formatting", async () => {
-    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const handler = createClaudeCodeTuiHandler({
+      runtimeProvider: "claude-code-tui",
+      workspaceRoot: state.workspaceRoot,
+      clientId: "client-test",
+    });
     const queued = makeMessage("m2", "format-held queued turn");
     let formattingStarted = false;
     let releaseFormat!: () => void;
@@ -238,9 +251,9 @@ describe("claude-code-tui suspend queued recovery", () => {
       },
     });
 
-    await handler.resume(undefined, "existing-session", ctx);
+    await handler.resume(undefined, "existing-session", ctx, deliveryTokenFromSessionContext(ctx));
 
-    handler.inject(queued);
+    handler.inject(queued, deliveryTokenFromSessionContext(ctx));
     await waitFor(() => formattingStarted);
 
     const suspend = handler.suspend();
@@ -257,7 +270,11 @@ describe("claude-code-tui suspend queued recovery", () => {
   });
 
   it("retries a queued batch when all inbound formatting fails before paste", async () => {
-    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const handler = createClaudeCodeTuiHandler({
+      runtimeProvider: "claude-code-tui",
+      workspaceRoot: state.workspaceRoot,
+      clientId: "client-test",
+    });
     const queued = makeMessage("m3", "format-fail queued turn");
     const ctx = makeContext({
       formatInboundContent: async (message) => {
@@ -267,8 +284,8 @@ describe("claude-code-tui suspend queued recovery", () => {
       },
     });
 
-    await handler.resume(undefined, "existing-session", ctx);
-    handler.inject(queued);
+    await handler.resume(undefined, "existing-session", ctx, deliveryTokenFromSessionContext(ctx));
+    handler.inject(queued, deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => vi.mocked(ctx.retryTurn).mock.calls.length > 0);
 
@@ -291,7 +308,11 @@ describe("claude-code-tui suspend queued recovery", () => {
       messages: [makeMessage("m4", "good first"), makeMessage("m5", "bad second")],
     },
   ])("retries the whole queued batch when mixed formatting occurs: $name", async ({ failingIds, messages }) => {
-    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const handler = createClaudeCodeTuiHandler({
+      runtimeProvider: "claude-code-tui",
+      workspaceRoot: state.workspaceRoot,
+      clientId: "client-test",
+    });
     const ctx = makeContext({
       formatInboundContent: async (message) => {
         if (failingIds.has(message.id)) throw new Error(`format failed for ${message.id}`);
@@ -300,8 +321,8 @@ describe("claude-code-tui suspend queued recovery", () => {
       },
     });
 
-    await handler.resume(undefined, "existing-session", ctx);
-    for (const message of messages) handler.inject(message);
+    await handler.resume(undefined, "existing-session", ctx, deliveryTokenFromSessionContext(ctx));
+    for (const message of messages) handler.inject(message, deliveryTokenFromSessionContext(ctx));
 
     await waitFor(() => vi.mocked(ctx.retryTurn).mock.calls.length >= messages.length);
 

--- a/packages/client/src/__tests__/turn-end-inbox-characterization.test.ts
+++ b/packages/client/src/__tests__/turn-end-inbox-characterization.test.ts
@@ -117,8 +117,12 @@ describe("characterization — SessionManager turn-end wiring", () => {
 
   function handler(overrides: Partial<AgentHandler> = {}): AgentHandler {
     return {
-      start: vi.fn().mockResolvedValue("session-id"),
-      resume: vi.fn().mockResolvedValue("session-id"),
+      start: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "session-id", route: { kind: "owned" as const, mode: "queued" as const } }),
+      resume: vi
+        .fn()
+        .mockResolvedValue({ sessionId: "session-id", route: { kind: "owned" as const, mode: "queued" as const } }),
       inject: vi.fn().mockReturnValue({ kind: "owned", mode: "queued" }),
       suspend: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn().mockResolvedValue(undefined),
@@ -200,7 +204,7 @@ describe("characterization — SessionManager turn-end wiring", () => {
         handler({
           async start(_message, ctx) {
             captured = ctx;
-            return "char-session";
+            return { sessionId: "char-session", route: { kind: "owned" as const, mode: "queued" as const } };
           },
         }),
       handlerConfig: { workspaceRoot, runtimeProvider: "codex" },

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -9,14 +9,15 @@ import type { PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
 import { renderChatContextPrompt, renderRuntimeOutputContract } from "../../runtime/chat-context-section.js";
 import { createContextTreeGitWriteTracker } from "../../runtime/context-tree-git-status.js";
-import {
-  type AgentHandler,
-  type DeliveryToken,
-  deliveryTokenFromSessionContext,
-  type HandlerFactory,
-  type SessionContext,
-  type SessionMessage,
+import type {
+  AgentHandler,
+  DeliveryToken,
+  HandlerFactory,
+  SessionContext,
+  SessionMessage,
 } from "../../runtime/handler.js";
+import { noopDeliveryToken, requireDeliveryToken } from "../../runtime/handler.js";
+
 import { type ReconciledTeamSkill, reconcileManagedSkillsForConfig } from "../../runtime/managed-skills.js";
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../../runtime/source-repos.js";
 import { teamSkillBundleResolverFromSdk } from "../../runtime/team-skill-bundle-resolver.js";
@@ -654,8 +655,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   return {
     async start(message, sessionCtx, token) {
       return lifecycleFence.run(async () => {
-        const hasExplicitDeliveryToken = token !== undefined;
-        const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+        const deliveryToken = token;
         // Hold turnRunning across the whole bootstrap so an inject arriving while
         // the session is still being prepared queues instead of racing pump()
         // into a second turn the instant startClaude sets tmuxSessionName.
@@ -704,13 +704,13 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           const sessionId = await startClaude({ sessionCtx, resumeSessionId: null, payload, providerEnv });
           if (lifecycleFence.stopRequested) {
             deliveryToken.retry(message, "tui_start_stopped_before_turn");
-            return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "queued" } } : sessionId;
+            return { sessionId, route: { kind: "owned", mode: "queued" } };
           }
 
           const inputText = await sessionCtx.formatInboundContent(message);
           if (lifecycleFence.stopRequested) {
             deliveryToken.retry(message, "tui_start_stopped_before_turn");
-            return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "queued" } } : sessionId;
+            return { sessionId, route: { kind: "owned", mode: "queued" } };
           }
           currentTurnPromise = runTurn(inputText, sessionCtx, [message], deliveryToken);
           try {
@@ -718,7 +718,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           } finally {
             currentTurnPromise = null;
           }
-          return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "processing" } } : sessionId;
+          return { sessionId, route: { kind: "owned", mode: "processing" } };
         } finally {
           turnRunning = false;
           // Drain any messages injected during bootstrap / the first turn.
@@ -729,8 +729,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
     async resume(message, sessionId, sessionCtx, token) {
       return lifecycleFence.run(async () => {
-        const hasExplicitDeliveryToken = token !== undefined;
-        const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+        const deliveryToken = message ? requireDeliveryToken(token, "messageful resume") : noopDeliveryToken();
         turnRunning = true;
         try {
           await orphanSweep(clientId);
@@ -774,16 +773,12 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           if (message) {
             if (lifecycleFence.stopRequested) {
               deliveryToken.retry(message, "tui_resume_stopped_before_turn");
-              return hasExplicitDeliveryToken
-                ? { sessionId: restartedId, route: { kind: "owned", mode: "queued" } }
-                : restartedId;
+              return { sessionId: restartedId, route: { kind: "owned", mode: "queued" } };
             }
             const inputText = await sessionCtx.formatInboundContent(message);
             if (lifecycleFence.stopRequested) {
               deliveryToken.retry(message, "tui_resume_stopped_before_turn");
-              return hasExplicitDeliveryToken
-                ? { sessionId: restartedId, route: { kind: "owned", mode: "queued" } }
-                : restartedId;
+              return { sessionId: restartedId, route: { kind: "owned", mode: "queued" } };
             }
             currentTurnPromise = runTurn(inputText, sessionCtx, [message], deliveryToken);
             try {
@@ -792,9 +787,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
               currentTurnPromise = null;
             }
           }
-          return hasExplicitDeliveryToken
-            ? { sessionId: restartedId, route: message ? { kind: "owned", mode: "processing" } : null }
-            : restartedId;
+          return { sessionId: restartedId, route: message ? { kind: "owned", mode: "processing" } : null };
         } finally {
           turnRunning = false;
           setImmediate(pump);
@@ -808,7 +801,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       // narrow window around turn completion / startup could either start a
       // second concurrent turn or be stranded with no drain scheduled.
       if (!ctx) return { kind: "rejected", reason: "tui_not_ready", retryable: true };
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(ctx);
+      const deliveryToken = token;
       queuedMessages.push({ message, token: deliveryToken });
       setImmediate(pump);
       return { kind: "owned", mode: "queued" };

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { type AgentRuntimeConfigPayload, DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD } from "@first-tree/shared";
+import {
+  type AgentRuntimeConfigPayload,
+  DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD,
+  runtimeProviderSchema,
+} from "@first-tree/shared";
 import { ensureAgentBootstrap } from "../../runtime/agent-bootstrap.js";
 import { buildAgentBriefing } from "../../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../../runtime/agent-config-cache.js";
@@ -135,7 +139,7 @@ async function orphanSweep(clientId: string): Promise<void> {
  */
 export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
-  const runtimeProvider = "claude-code-tui" as const;
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider);
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -26,14 +26,15 @@ import { renderDocumentAttachmentsForLLM } from "../runtime/agent-io.js";
 import { type PredeclaredSourceRepo, writeAgentBriefing } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
 import { createContextTreeGitWriteTracker } from "../runtime/context-tree-git-status.js";
-import {
-  type AgentHandler,
-  type DeliveryToken,
-  deliveryTokenFromSessionContext,
-  type HandlerFactory,
-  type SessionContext,
-  type SessionMessage,
+import type {
+  AgentHandler,
+  DeliveryToken,
+  HandlerFactory,
+  SessionContext,
+  SessionMessage,
 } from "../runtime/handler.js";
+import { noopDeliveryToken, requireDeliveryToken } from "../runtime/handler.js";
+
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
 import { type ReconciledTeamSkill, reconcileManagedSkillsForConfig } from "../runtime/managed-skills.js";
@@ -394,9 +395,7 @@ function emitTokenUsageFromResult(
  */
 export const createClaudeCodeHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
-  const runtimeProvider: RuntimeProvider = runtimeProviderSchema.safeParse(config.runtimeProvider).success
-    ? runtimeProviderSchema.parse(config.runtimeProvider)
-    : "claude-code";
+  const runtimeProvider: RuntimeProvider = runtimeProviderSchema.parse(config.runtimeProvider);
   const providerTurnMaxRetries = maxProviderTurnRetryAttempts();
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   // Pre-resolved by registerBuiltinHandlers at process start. Undefined =
@@ -1755,8 +1754,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
   const handler: AgentHandler = {
     async start(message, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = token;
       ctx = sessionCtx;
       claudeSessionId = randomUUID();
       // Per agent-session-cwd-redesign: cwd is per-agent, shared by every
@@ -1813,14 +1811,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       scheduleInjectedMessagesDrain(sessionCtx, claudeSessionId);
 
       sessionCtx.log(`Session started (${claudeSessionId})`);
-      return hasExplicitDeliveryToken
-        ? { sessionId: claudeSessionId, route: { kind: "owned", mode: "processing" } }
-        : claudeSessionId;
+      return { sessionId: claudeSessionId, route: { kind: "owned", mode: "processing" } };
     },
 
     async resume(message, sessionId, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = message ? requireDeliveryToken(token, "messageful resume") : noopDeliveryToken();
       ctx = sessionCtx;
       claudeSessionId = sessionId;
       retryCount = 0;
@@ -1891,9 +1886,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         }
         scheduleInjectedMessagesDrain(sessionCtx, sessionId);
         sessionCtx.log(`Session resumed at legacy cwd (${sessionId})`);
-        return hasExplicitDeliveryToken
-          ? { sessionId, route: message ? { kind: "owned", mode: "processing" } : null }
-          : sessionId;
+        return { sessionId, route: message ? { kind: "owned", mode: "processing" } : null };
       }
 
       // Normal new-design resume path: cwd is the agent home.
@@ -1951,9 +1944,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         }
         scheduleInjectedMessagesDrain(sessionCtx, freshSessionId);
         sessionCtx.log(`Session started (${freshSessionId}, replacing ${sessionId})`);
-        return hasExplicitDeliveryToken
-          ? { sessionId: freshSessionId, route: message ? { kind: "owned", mode: "processing" } : null }
-          : freshSessionId;
+        return { sessionId: freshSessionId, route: message ? { kind: "owned", mode: "processing" } : null };
       }
 
       sessionCtx.log(`Resuming session (${sessionId}), cwd=${cwd}`);
@@ -1979,9 +1970,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       scheduleInjectedMessagesDrain(sessionCtx, sessionId);
 
       sessionCtx.log(`Session resumed (${sessionId})`);
-      return hasExplicitDeliveryToken
-        ? { sessionId, route: message ? { kind: "owned", mode: "processing" } : null }
-        : sessionId;
+      return { sessionId, route: message ? { kind: "owned", mode: "processing" } : null };
     },
 
     inject(message, token) {
@@ -1990,7 +1979,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         return { kind: "rejected", reason: "no_active_session", retryable: true };
       }
       const sessionCtx = ctx;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = token;
       const sid = claudeSessionId;
       queuedInjectedMessages.push({ message, token: deliveryToken });
       scheduleInjectedMessagesDrain(sessionCtx, sid);

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -5,6 +5,7 @@ import {
   encodeProviderRetryEventMessage,
   isLandingCampaignTrialAgentMetadata,
   RUNTIME_NOTICE_METADATA_KEY,
+  runtimeProviderSchema,
   type SessionEvent,
   type ToolFileRef,
 } from "@first-tree/shared";
@@ -196,7 +197,7 @@ const CODEX_COMPACT_FAILURE_MESSAGE =
   "Codex failed to compact this thread before answering. Start a new thread or clear earlier history before retrying.";
 export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfig): AgentHandler => {
   const workspaceRoot = config.workspaceRoot as string;
-  const runtimeProvider = "codex" as const;
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider);
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -33,7 +33,8 @@ import type {
   SessionMessage,
   TurnConsumedErrorReason,
 } from "../../../runtime/handler.js";
-import { deliveryTokenFromSessionContext } from "../../../runtime/handler.js";
+import { noopDeliveryToken, requireDeliveryToken } from "../../../runtime/handler.js";
+
 import {
   isManagedSkillsUnsafeDiscoveryError,
   type ReconciledTeamSkill,
@@ -1862,8 +1863,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
 
   return {
     async start(message, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = token;
       shutdownRequested = false;
       providerRetryFence = false;
       startupTurnPending = true;
@@ -1881,13 +1881,13 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
           sessionCtx.log(
             `codex app-server initial formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`,
           );
-          return hasExplicitDeliveryToken ? { sessionId: id, route: { kind: "owned", mode: "queued" } } : id;
+          return { sessionId: id, route: { kind: "owned", mode: "queued" } };
         }
         const delivered = await runTurnFromText(input, [message], deliveryToken, sessionCtx);
         // Fresh thread: seed the briefing baseline once the turn actually
         // delivered, so a later resume only nudges on a real briefing change.
         if (cwd && delivered) writeSessionBriefingFingerprint(cwd, id, briefingFingerprint);
-        return hasExplicitDeliveryToken ? { sessionId: id, route: { kind: "owned", mode: "processing" } } : id;
+        return { sessionId: id, route: { kind: "owned", mode: "processing" } };
       } finally {
         startupTurnPending = false;
         schedulePendingDrain();
@@ -1895,8 +1895,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     },
 
     async resume(message, sessionId, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = message ? requireDeliveryToken(token, "messageful resume") : noopDeliveryToken();
       shutdownRequested = false;
       providerRetryFence = false;
       startupTurnPending = message !== undefined;
@@ -1937,9 +1936,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
             sessionCtx.log(
               `codex app-server resume formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`,
             );
-            return hasExplicitDeliveryToken
-              ? { sessionId: effectiveSessionId, route: { kind: "owned", mode: "queued" } }
-              : effectiveSessionId;
+            return { sessionId: effectiveSessionId, route: { kind: "owned", mode: "queued" } };
           }
           const delivered = await runTurnFromText(input, [message], deliveryToken, sessionCtx);
           effectiveSessionId = threadId ?? effectiveSessionId;
@@ -1947,9 +1944,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
           // delivered; a retried / pre-provider turn leaves it for redelivery.
           if (cwd && delivered) writeSessionBriefingFingerprint(cwd, effectiveSessionId, briefingFingerprint);
         }
-        return hasExplicitDeliveryToken
-          ? { sessionId: effectiveSessionId, route: message ? { kind: "owned", mode: "processing" } : null }
-          : effectiveSessionId;
+        return { sessionId: effectiveSessionId, route: message ? { kind: "owned", mode: "processing" } : null };
       } finally {
         startupTurnPending = false;
         schedulePendingDrain();
@@ -1958,7 +1953,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
 
     inject(message, token) {
       if (!ctx || shutdownRequested) return { kind: "rejected", reason: "no_active_context", retryable: true };
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(ctx);
+      const deliveryToken = token;
       pendingInputs.push({ message, token: deliveryToken });
       pendingInputGeneration++;
       schedulePendingDrain();

--- a/packages/client/src/handlers/codex/index.ts
+++ b/packages/client/src/handlers/codex/index.ts
@@ -1,5 +1,6 @@
 import { isLandingCampaignTrialAgentMetadata } from "@first-tree/shared";
 import type { AgentHandler, HandlerFactory, SessionContext } from "../../runtime/handler.js";
+
 import { CodexAppServerStartupError, createCodexAppServerHandler } from "./app-server/index.js";
 import { createCodexSdkHandler } from "./sdk.js";
 

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -53,7 +53,8 @@ import type {
   SessionMessage,
   TurnConsumedErrorReason,
 } from "../../runtime/handler.js";
-import { deliveryTokenFromSessionContext } from "../../runtime/handler.js";
+import { noopDeliveryToken, requireDeliveryToken } from "../../runtime/handler.js";
+
 import {
   isManagedSkillsUnsafeDiscoveryError,
   type ReconciledTeamSkill,
@@ -506,7 +507,7 @@ export function toolFileRefsForTerminalCodexTool(input: {
  */
 export const createCodexSdkHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
-  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider ?? "codex");
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider);
   const providerTurnMaxRetries = maxProviderTurnRetryAttempts();
   let activePayload: AgentRuntimeConfigPayload | null = null;
   let reconciledTeamSkills: readonly ReconciledTeamSkill[] = [];
@@ -1554,8 +1555,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
 
   return {
     async start(message, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = token;
       ctx = sessionCtx;
       // Per agent-session-cwd-redesign: cwd is the per-agent home, shared
       // by every chat session for this agent.
@@ -1642,14 +1642,11 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       // (only known after the first turn). A fresh thread starts in sync, so a
       // later resume only nudges on a real change.
       if (cwd) writeSessionBriefingFingerprint(cwd, threadId, computeBriefingFingerprint(briefing));
-      return hasExplicitDeliveryToken
-        ? { sessionId: threadId, route: { kind: "owned", mode: "processing" } }
-        : threadId;
+      return { sessionId: threadId, route: { kind: "owned", mode: "processing" } };
     },
 
     async resume(message, sessionId, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = message ? requireDeliveryToken(token, "messageful resume") : noopDeliveryToken();
       ctx = sessionCtx;
       cwd = acquireAgentHome(workspaceRoot);
 
@@ -1740,9 +1737,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
         // unchanged lets the redelivery's resume re-surface it.
         if (turnDelivered && threadId) writeSessionBriefingFingerprint(cwd, threadId, briefingFingerprint);
       }
-      return hasExplicitDeliveryToken
-        ? { sessionId: threadId ?? sessionId, route: message ? { kind: "owned", mode: "processing" } : null }
-        : (threadId ?? sessionId);
+      return { sessionId: threadId ?? sessionId, route: message ? { kind: "owned", mode: "processing" } : null };
     },
 
     inject(message, token) {
@@ -1752,7 +1747,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       // `runTurn()` sets `currentTurnPromise` cannot start parallel turns
       // and desynchronise completion from the messages actually consumed.
       if (!ctx) return { kind: "rejected", reason: "no_active_context", retryable: true };
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(ctx);
+      const deliveryToken = token;
       queuedMessages.push({ message, token: deliveryToken });
       scheduleQueuedMessagesDrain();
       return { kind: "owned", mode: "queued" };

--- a/packages/client/src/handlers/cursor/index.ts
+++ b/packages/client/src/handlers/cursor/index.ts
@@ -41,7 +41,8 @@ import type {
   SessionMessage,
   TurnConsumedErrorReason,
 } from "../../runtime/handler.js";
-import { deliveryTokenFromSessionContext } from "../../runtime/handler.js";
+import { noopDeliveryToken, requireDeliveryToken } from "../../runtime/handler.js";
+
 import {
   isManagedSkillsUnsafeDiscoveryError,
   type ReconciledTeamSkill,
@@ -522,7 +523,7 @@ function cursorToolEventName(tool: CursorToolCall): string {
 
 export const createCursorHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
-  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider ?? "cursor");
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider);
   const providerTurnMaxRetries = maxProviderTurnRetryAttempts();
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
@@ -1674,8 +1675,7 @@ export const createCursorHandler: HandlerFactory = (config) => {
 
   return {
     async start(message, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = token;
 
       // Guard the whole bring-up: an inject landing while prepareSession is
       // awaiting must queue, not race ahead of the session's first turn.
@@ -1704,12 +1704,11 @@ export const createCursorHandler: HandlerFactory = (config) => {
       const sessionId = providerSessionId ?? pendingSyntheticId;
       if (!sessionId) throw new Error("cursor session id unresolved after first turn");
       writeSessionBriefingFingerprint(workspaceCwd, sessionId, computeBriefingFingerprint(briefing));
-      return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "processing" } } : sessionId;
+      return { sessionId, route: { kind: "owned", mode: "processing" } };
     },
 
     async resume(message, sessionId, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = message ? requireDeliveryToken(token, "messageful resume") : noopDeliveryToken();
 
       // Guard the whole bring-up (see start()): a warm handler keeps
       // ctx/cwd/binary across suspend, so without this an inject arriving
@@ -1773,9 +1772,7 @@ export const createCursorHandler: HandlerFactory = (config) => {
       }
 
       const effectiveId = providerSessionId ?? pendingSyntheticId ?? sessionId;
-      return hasExplicitDeliveryToken
-        ? { sessionId: effectiveId, route: message ? { kind: "owned", mode: "processing" } : null }
-        : effectiveId;
+      return { sessionId: effectiveId, route: message ? { kind: "owned", mode: "processing" } : null };
     },
 
     inject(message, token) {
@@ -1783,7 +1780,7 @@ export const createCursorHandler: HandlerFactory = (config) => {
       // follow-up in v1. Every inject queues and drains as an ordered fused
       // batch after the active turn settles.
       if (!ctx) return { kind: "rejected", reason: "no_active_context", retryable: true };
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(ctx);
+      const deliveryToken = token;
       queuedMessages.push({ message, token: deliveryToken });
       scheduleQueuedMessagesDrain();
       return { kind: "owned", mode: "queued" };

--- a/packages/client/src/handlers/grok/index.ts
+++ b/packages/client/src/handlers/grok/index.ts
@@ -37,7 +37,8 @@ import type {
   SessionMessage,
   TurnConsumedErrorReason,
 } from "../../runtime/handler.js";
-import { deliveryTokenFromSessionContext } from "../../runtime/handler.js";
+import { noopDeliveryToken, requireDeliveryToken } from "../../runtime/handler.js";
+
 import {
   isManagedSkillsUnsafeDiscoveryError,
   type ReconciledTeamSkill,
@@ -179,7 +180,7 @@ type TurnAcpState = {
 
 export const createGrokHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
-  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider ?? "grok");
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider);
   const providerTurnMaxRetries = maxProviderTurnRetryAttempts();
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
@@ -1088,8 +1089,7 @@ export const createGrokHandler: HandlerFactory = (config) => {
 
   return {
     async start(message, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = token;
 
       // Guard the whole bring-up: an inject landing while prepareSession is
       // awaiting must queue, not race ahead of the session's first turn.
@@ -1118,12 +1118,11 @@ export const createGrokHandler: HandlerFactory = (config) => {
       const sessionId = providerSessionId ?? pendingSyntheticId;
       if (!sessionId) throw new Error("grok session id unresolved after first turn");
       writeSessionBriefingFingerprint(workspaceCwd, sessionId, computeBriefingFingerprint(briefing));
-      return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "processing" } } : sessionId;
+      return { sessionId, route: { kind: "owned", mode: "processing" } };
     },
 
     async resume(message, sessionId, sessionCtx, token) {
-      const hasExplicitDeliveryToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = message ? requireDeliveryToken(token, "messageful resume") : noopDeliveryToken();
 
       // Guard the whole bring-up (see start()).
       initialTurnPreparing = true;
@@ -1183,9 +1182,7 @@ export const createGrokHandler: HandlerFactory = (config) => {
       }
 
       const effectiveId = providerSessionId ?? pendingSyntheticId ?? sessionId;
-      return hasExplicitDeliveryToken
-        ? { sessionId: effectiveId, route: message ? { kind: "owned", mode: "processing" } : null }
-        : effectiveId;
+      return { sessionId: effectiveId, route: message ? { kind: "owned", mode: "processing" } : null };
     },
 
     inject(message, token) {
@@ -1193,7 +1190,7 @@ export const createGrokHandler: HandlerFactory = (config) => {
       // v1. Every inject queues and drains as an ordered fused batch after
       // the active turn settles.
       if (!ctx) return { kind: "rejected", reason: "no_active_context", retryable: true };
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(ctx);
+      const deliveryToken = token;
       queuedMessages.push({ message, token: deliveryToken });
       scheduleQueuedMessagesDrain();
       return { kind: "owned", mode: "queued" };

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -45,7 +45,8 @@ import type {
   SessionContext,
   SessionMessage,
 } from "../runtime/handler.js";
-import { deliveryTokenFromSessionContext } from "../runtime/handler.js";
+import { noopDeliveryToken, requireDeliveryToken } from "../runtime/handler.js";
+
 import { type ReconciledTeamSkill, reconcileManagedSkillsForConfig } from "../runtime/managed-skills.js";
 import { ProviderAttempt, type ProviderAttemptSettlement } from "../runtime/provider-attempt.js";
 import { maxProviderTurnRetryAttempts } from "../runtime/provider-retry-policy.js";
@@ -247,7 +248,7 @@ function additionalDirectories(workspaceCwd: string, contextTreePath: string | n
 /** Kimi Code handler backed by the direct Botiverse/Moonshot Node SDK. */
 export const createKimiCodeHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot;
-  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider ?? "kimi-code");
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider);
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
@@ -979,8 +980,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
 
   return {
     async start(message, sessionCtx, token) {
-      const explicitToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = token;
       const prepared = await prepareSession(sessionCtx);
       const mcpServers = mapKimiMcpServers(prepared.payload);
       // The pinned SDK runtime accepts caller-scoped MCP servers here even
@@ -1012,12 +1012,11 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         initialTurnPreparing = false;
         scheduleQueuedMessagesDrain();
       }
-      return explicitToken ? { sessionId, route: { kind: "owned", mode: "processing" } } : sessionId;
+      return { sessionId, route: { kind: "owned", mode: "processing" } };
     },
 
     async resume(message, id, sessionCtx, token) {
-      const explicitToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = message ? requireDeliveryToken(token, "messageful resume") : noopDeliveryToken();
       const prepared = await prepareSession(sessionCtx);
       const mcpServers = mapKimiMcpServers(prepared.payload);
       // ResumeSessionInput has the same declaration gap as create options.
@@ -1050,12 +1049,12 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         initialTurnPreparing = false;
         scheduleQueuedMessagesDrain();
       }
-      return explicitToken ? { sessionId, route: message ? { kind: "owned", mode: "processing" } : null } : sessionId;
+      return { sessionId, route: message ? { kind: "owned", mode: "processing" } : null };
     },
 
     inject(message, token) {
       if (!ctx || !sessionActive) return { kind: "rejected", reason: "no_active_context", retryable: true };
-      queuedMessages.push({ message, token: token ?? deliveryTokenFromSessionContext(ctx) });
+      queuedMessages.push({ message, token });
       scheduleQueuedMessagesDrain();
       return { kind: "owned", mode: "queued" };
     },

--- a/packages/client/src/handlers/opencode/index.ts
+++ b/packages/client/src/handlers/opencode/index.ts
@@ -22,7 +22,8 @@ import type {
   SessionMessage,
   TurnConsumedErrorReason,
 } from "../../runtime/handler.js";
-import { deliveryTokenFromSessionContext } from "../../runtime/handler.js";
+import { noopDeliveryToken, requireDeliveryToken } from "../../runtime/handler.js";
+
 import {
   isManagedSkillsUnsafeDiscoveryError,
   type ReconciledTeamSkill,
@@ -304,7 +305,7 @@ function queuedUnsafeDiscoveryRetryDelayMs(attempt: number): number {
 
 export const createOpenCodeHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
-  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider ?? "opencode");
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider);
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
@@ -1317,8 +1318,7 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
 
   return {
     async start(message, sessionCtx, token) {
-      const explicit = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = token;
       initialTurnPreparing = true;
       let completed = false;
       let delivered = false;
@@ -1339,12 +1339,11 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       if (delivered) {
         writeSessionBriefingFingerprint(workspaceCwd, sessionId, computeBriefingFingerprint(briefing));
       }
-      return explicit ? { sessionId, route: { kind: "owned", mode: "processing" } } : sessionId;
+      return { sessionId, route: { kind: "owned", mode: "processing" } };
     },
 
     async resume(message, sessionId, sessionCtx, token) {
-      const explicit = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = message ? requireDeliveryToken(token, "messageful resume") : noopDeliveryToken();
       initialTurnPreparing = true;
       let briefing: string;
       let workspaceCwd: string;
@@ -1381,14 +1380,12 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
         scheduleDrain();
       }
       const effectiveId = providerSessionId ?? pendingSyntheticId ?? sessionId;
-      return explicit
-        ? { sessionId: effectiveId, route: message ? { kind: "owned", mode: "processing" } : null }
-        : effectiveId;
+      return { sessionId: effectiveId, route: message ? { kind: "owned", mode: "processing" } : null };
     },
 
     inject(message, token) {
       if (!ctx) return { kind: "rejected", reason: "no_active_context", retryable: true };
-      queue.push({ message, token: token ?? deliveryTokenFromSessionContext(ctx) });
+      queue.push({ message, token });
       scheduleDrain();
       return { kind: "owned", mode: "queued" };
     },

--- a/packages/client/src/handlers/pi/index.ts
+++ b/packages/client/src/handlers/pi/index.ts
@@ -33,7 +33,8 @@ import type {
   SessionContext,
   SessionMessage,
 } from "../../runtime/handler.js";
-import { deliveryTokenFromSessionContext } from "../../runtime/handler.js";
+import { noopDeliveryToken, requireDeliveryToken } from "../../runtime/handler.js";
+
 import { type ReconciledTeamSkill, reconcileManagedSkillsForConfig } from "../../runtime/managed-skills.js";
 import {
   isSupportedPiVersion,
@@ -448,7 +449,7 @@ export async function defaultPiRetrySleep(delayMs: number, signal: AbortSignal):
 
 export const createPiHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
-  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider ?? "pi");
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider);
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
@@ -1938,8 +1939,7 @@ export const createPiHandler: HandlerFactory = (config) => {
 
   const handler = {
     async start(message, sessionCtx, token) {
-      const explicitToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = token;
       // Mint the fresh-start identity from the first inbound message plus any
       // durable Reset tombstone (see freshStartPiSessionId). Mapping deletion
       // alone is not enough: same-row redelivery after restart must still mint
@@ -1956,34 +1956,26 @@ export const createPiHandler: HandlerFactory = (config) => {
       } catch (error) {
         if (error instanceof PiLifecycleCancelledError) {
           deliveryToken.retry([message], "pi_turn_cancelled");
-          return explicitToken
-            ? { sessionId: startSessionId, route: { kind: "owned", mode: "processing" } }
-            : startSessionId;
+          return { sessionId: startSessionId, route: { kind: "owned", mode: "processing" } };
         }
         await cleanupFailedInitialization();
         throw error;
       }
       if (!sessionActive) {
         deliveryToken.retry([message], "pi_turn_cancelled");
-        return explicitToken
-          ? { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } }
-          : prepared.sessionId;
+        return { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } };
       }
       initialTurnPreparing = true;
       try {
         const client = await ensureRpcClient(prepared, sessionCtx);
         if (!sessionActive) {
           deliveryToken.retry([message], "pi_turn_cancelled");
-          return explicitToken
-            ? { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } }
-            : prepared.sessionId;
+          return { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } };
         }
         const basePrompt = await sessionCtx.formatInboundContent(message);
         if (!sessionActive) {
           deliveryToken.retry([message], "pi_turn_cancelled");
-          return explicitToken
-            ? { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } }
-            : prepared.sessionId;
+          return { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } };
         }
         const prompt = await buildTurnPrompt(sessionCtx, basePrompt, prepared);
         await runTurn(prompt, sessionCtx, [{ messages: [message], token: deliveryToken }], client);
@@ -1994,9 +1986,7 @@ export const createPiHandler: HandlerFactory = (config) => {
         }
         if (error instanceof PiLifecycleCancelledError) {
           deliveryToken.retry([message], "pi_turn_cancelled");
-          return explicitToken
-            ? { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } }
-            : prepared.sessionId;
+          return { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } };
         }
         await cleanupFailedInitialization();
         throw error;
@@ -2004,14 +1994,11 @@ export const createPiHandler: HandlerFactory = (config) => {
         initialTurnPreparing = false;
         scheduleQueuedMessagesDrain();
       }
-      return explicitToken
-        ? { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } }
-        : prepared.sessionId;
+      return { sessionId: prepared.sessionId, route: { kind: "owned", mode: "processing" } };
     },
 
     async resume(message, id, sessionCtx, token) {
-      const explicitToken = token !== undefined;
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
+      const deliveryToken = message ? requireDeliveryToken(token, "messageful resume") : noopDeliveryToken();
       let prepared: PreparedSession;
       try {
         // Resume adopts the persisted mapping id verbatim: First Tree's
@@ -2021,7 +2008,7 @@ export const createPiHandler: HandlerFactory = (config) => {
       } catch (error) {
         if (error instanceof PiLifecycleCancelledError) {
           if (message) deliveryToken.retry([message], "pi_turn_cancelled");
-          return explicitToken ? { sessionId: id, route: message ? { kind: "owned", mode: "processing" } : null } : id;
+          return { sessionId: id, route: message ? { kind: "owned", mode: "processing" } : null };
         }
         await cleanupFailedInitialization();
         throw error;
@@ -2029,34 +2016,28 @@ export const createPiHandler: HandlerFactory = (config) => {
       if (message) {
         if (!sessionActive) {
           deliveryToken.retry([message], "pi_turn_cancelled");
-          return explicitToken
-            ? {
-                sessionId: prepared.sessionId,
-                route: { kind: "owned", mode: "processing" },
-              }
-            : prepared.sessionId;
+          return {
+            sessionId: prepared.sessionId,
+            route: { kind: "owned", mode: "processing" },
+          };
         }
         initialTurnPreparing = true;
         try {
           const client = await ensureRpcClient(prepared, sessionCtx);
           if (!sessionActive) {
             deliveryToken.retry([message], "pi_turn_cancelled");
-            return explicitToken
-              ? {
-                  sessionId: prepared.sessionId,
-                  route: { kind: "owned", mode: "processing" },
-                }
-              : prepared.sessionId;
+            return {
+              sessionId: prepared.sessionId,
+              route: { kind: "owned", mode: "processing" },
+            };
           }
           const basePrompt = await sessionCtx.formatInboundContent(message);
           if (!sessionActive) {
             deliveryToken.retry([message], "pi_turn_cancelled");
-            return explicitToken
-              ? {
-                  sessionId: prepared.sessionId,
-                  route: { kind: "owned", mode: "processing" },
-                }
-              : prepared.sessionId;
+            return {
+              sessionId: prepared.sessionId,
+              route: { kind: "owned", mode: "processing" },
+            };
           }
           const prompt = await buildTurnPrompt(sessionCtx, basePrompt, prepared);
           await runTurn(prompt, sessionCtx, [{ messages: [message], token: deliveryToken }], client);
@@ -2067,12 +2048,10 @@ export const createPiHandler: HandlerFactory = (config) => {
           }
           if (error instanceof PiLifecycleCancelledError) {
             deliveryToken.retry([message], "pi_turn_cancelled");
-            return explicitToken
-              ? {
-                  sessionId: prepared.sessionId,
-                  route: { kind: "owned", mode: "processing" },
-                }
-              : prepared.sessionId;
+            return {
+              sessionId: prepared.sessionId,
+              route: { kind: "owned", mode: "processing" },
+            };
           }
           await cleanupFailedInitialization();
           throw error;
@@ -2083,17 +2062,15 @@ export const createPiHandler: HandlerFactory = (config) => {
       } else {
         scheduleQueuedMessagesDrain();
       }
-      return explicitToken
-        ? {
-            sessionId: prepared.sessionId,
-            route: message ? { kind: "owned", mode: "processing" } : null,
-          }
-        : prepared.sessionId;
+      return {
+        sessionId: prepared.sessionId,
+        route: message ? { kind: "owned", mode: "processing" } : null,
+      };
     },
 
     inject(message, token) {
       if (!ctx || !sessionActive) return { kind: "rejected", reason: "no_active_context", retryable: true };
-      const deliveryToken = token ?? deliveryTokenFromSessionContext(ctx);
+      const deliveryToken = token;
       // Steer once the active turn has crossed the provider write/accept
       // boundary — do not wait for the first stream event. Once the current
       // observation is settled, close the steer window: post-agent_settled

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -95,14 +95,14 @@ export type StartReceipt = {
   route: Extract<HandlerRouteReceipt, { kind: "owned" }>;
 };
 
-export type StartResult = StartReceipt | string;
+export type StartResult = StartReceipt;
 
 export type ResumeReceipt = {
   sessionId: string;
   route: Extract<HandlerRouteReceipt, { kind: "owned" }> | null;
 };
 
-export type ResumeResult = ResumeReceipt | string;
+export type ResumeResult = ResumeReceipt;
 
 export type DeliveryToken = {
   processingStarted(messages: SessionMessage | readonly SessionMessage[]): void;
@@ -130,6 +130,14 @@ export type DeliveryToken = {
 export type DeliveryCompletionDisposition = "settled" | "retry";
 // biome-ignore lint/suspicious/noConfusingVoidType: legacy/test tokens intentionally resolve void.
 export type DeliveryCompletionResult = DeliveryCompletionDisposition | void;
+
+/** Fail closed when a messageful handler path is missing its DeliveryToken. */
+export function requireDeliveryToken(token: DeliveryToken | undefined, label: string): DeliveryToken {
+  if (token === undefined) {
+    throw new Error(`DeliveryToken required for ${label}`);
+  }
+  return token;
+}
 
 export function noopDeliveryToken(): DeliveryToken {
   return {
@@ -334,10 +342,11 @@ export type PrecedingMessage = {
  */
 export type AgentHandler = {
   /** First message in a new chat. Spawn query, start consumer loop. */
-  start(message: SessionMessage, ctx: SessionContext, token?: DeliveryToken): Promise<StartResult>;
+  start(message: SessionMessage, ctx: SessionContext, token: DeliveryToken): Promise<StartResult>;
 
   /** Message arrives for a suspended/evicted chat. Resume query from disk.
-   *  `message` is undefined for admin-triggered resume (no new user input). */
+   *  `message` is undefined for admin-triggered resume (no new user input).
+   *  Messageful resume requires a DeliveryToken; admin reclaim may omit it. */
   resume(
     message: SessionMessage | undefined,
     sessionId: string,
@@ -346,7 +355,7 @@ export type AgentHandler = {
   ): Promise<ResumeResult>;
 
   /** Message arrives while session is active. Push into provider-owned queue or reject. */
-  inject(message: SessionMessage, token?: DeliveryToken): HandlerRouteReceipt | undefined;
+  inject(message: SessionMessage, token: DeliveryToken): HandlerRouteReceipt | undefined;
 
   /**
    * Idle timeout / operator pause. Close query, preserve state for resume.
@@ -385,7 +394,7 @@ export type HandlerConfig = {
   /** Root directory for per-chat workspaces (`<dataDir>/workspaces/<agentName>`). */
   workspaceRoot: string;
   /** Runtime provider for this handler slot, used for structured status payloads. */
-  runtimeProvider?: RuntimeProvider;
+  runtimeProvider: RuntimeProvider;
   /** Additional handler-specific config. */
   [key: string]: unknown;
 };

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -536,9 +536,6 @@ function normalizeStartReceipt(result: StartResult): {
   sessionId: string;
   route: Extract<HandlerRouteReceipt, { kind: "owned" }>;
 } {
-  if (typeof result === "string") {
-    return { sessionId: result, route: { kind: "owned", mode: "queued" } };
-  }
   return result;
 }
 
@@ -546,9 +543,6 @@ function normalizeResumeReceipt(result: ResumeResult): {
   sessionId: string;
   route: Extract<HandlerRouteReceipt, { kind: "owned" }> | null;
 } {
-  if (typeof result === "string") {
-    return { sessionId: result, route: { kind: "owned", mode: "queued" } };
-  }
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Close Handler protocol dual-track: `start`/`inject` require `DeliveryToken`; `start`/`resume` return receipts only (no bare `string` session id)
- Make `HandlerConfig.runtimeProvider` required at the type/constructor boundary; factories parse fail-closed (no per-handler default fallback)
- Drop `hasExplicitDeliveryToken` / string-return shims across built-in handlers; SessionManager no longer coerces string results
- Every built-in factory validates `config.runtimeProvider` at construction — Claude TUI and Codex app-server no longer hard-code a provider constant, so Codex `app-server` / `sdk` / `auto` fail closed identically
- Add dual-detect characterization for the protocol tightening, plus a registry regression over every provider × {missing, invalid}

## Context
Follows #2186 (runtimeProvider fail-closed + SessionManager guard). Slice chosen by yuezengwu: **2b + 类型必填**.

## Test plan
- [x] `pnpm typecheck` in `packages/client`
- [x] Characterization: `delivery-token-receipt-characterization` + prior runtime-provider characterization
- [x] Full `packages/client` vitest: 2410 passed / 7 skipped
- [x] Independent QA (`yzw-codex`, `test-only`): **PASS** on exact head `152d47ffe`, including an independent dual-detect (new tests give 22 passed / 6 failed on the pre-fix head, 28/28 on this head)

## Notes
- Admin (message-less) `resume` still omits token; messageful resume fail-closes without one
- Non-blocking follow-up from #2186 review is addressed by required `HandlerConfig.runtimeProvider`

Made with [Cursor](https://cursor.com)
