### PR TITLE
Polish Agent Detail navigation and tab transitions

### DIFF
--- a/e2e/agent-detail-configuration.test.yaml
+++ b/e2e/agent-detail-configuration.test.yaml
@@ -14,9 +14,19 @@ steps:
   - click: the agent teammate row in the Public section
   - assert: the Agent detail page has a Team breadcrumb, a compact identity header with one Online status
       and connected-computer explanation, and a local section navigation instead of a horizontal tab bar
+  - assert: the active item in the Agent sections navigation uses the same quiet neutral filled treatment as the
+      Settings sidebar, with no separate accent rail; the content starts with a short explanation rather than a
+      visible page title that repeats the active navigation label
+  - click: Instructions in the Agent sections navigation
+  - assert: Instructions is the current section and its content has one visible Instructions section heading rather
+      than a second page-level Instructions title
   - click: Tools & skills in the Agent sections navigation
   - assert: Tools & skills is the current section and the content separately shows Skills and Integrations;
       because neither is configured, each empty state explains the impact and offers a clear setup action
+  - click: Repositories in the Agent sections navigation
+  - assert: Repositories is the current section and the content does not add a visible page title above its actual
+      Repositories and Context tree sections
+  - click: Tools & skills in the Agent sections navigation
   - click: Set up integration button in the Integrations empty state
   - waitForUrl: /settings/resources
   - assert: Team Settings opens on Resources, where MCP integrations are managed alongside Instructions and Skills

--- a/packages/web/src/components/ui/local-nav-link.tsx
+++ b/packages/web/src/components/ui/local-nav-link.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { cn } from "../../lib/utils.js";
+
+/**
+ * Shared local-navigation item for entity detail and Settings sidebars.
+ *
+ * The active destination uses one quiet neutral fill and medium label weight;
+ * section-specific rails and accent bars would create competing navigation
+ * grammars inside the same dashboard.
+ */
+export function LocalNavLink({
+  to,
+  label,
+  active,
+  replace,
+  ariaLabel,
+  trailing,
+}: {
+  to: string;
+  label: string;
+  active: boolean;
+  replace?: boolean;
+  ariaLabel?: string;
+  trailing?: ReactNode;
+}) {
+  return (
+    <Link
+      to={to}
+      replace={replace}
+      aria-current={active ? "page" : undefined}
+      aria-label={ariaLabel}
+      className={cn(
+        "block w-full text-body transition-colors",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
+      )}
+    >
+      <span
+        className={cn("flex min-h-11 items-center justify-between", active ? "font-medium" : "font-normal")}
+        style={{
+          padding: "var(--sp-2) var(--sp-3)",
+          borderRadius: "var(--radius-input)",
+          color: active ? "var(--fg)" : "var(--fg-3)",
+          background: active ? "var(--bg-hover)" : "transparent",
+        }}
+      >
+        <span>{label}</span>
+        {trailing}
+      </span>
+    </Link>
+  );
+}

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -29,6 +29,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "./../components/ui/dialog.js";
+import { LocalNavLink } from "./../components/ui/local-nav-link.js";
 import { Select } from "./../components/ui/select.js";
 import { useWorkspaceViewport } from "./../hooks/use-viewport.js";
 import { deriveAgentAvailability } from "./../lib/agent-availability.js";
@@ -578,10 +579,10 @@ function AgentDetailPageView() {
         >
           {currentTab ? (
             <div style={{ marginBottom: "var(--sp-5)" }}>
-              <h2 id="agent-detail-section-title" className="m-0 text-title" style={{ color: "var(--fg)" }}>
+              <h2 id="agent-detail-section-title" className="sr-only">
                 {currentTab.label}
               </h2>
-              <p className="m-0 text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
+              <p className="m-0 text-body" style={{ color: "var(--fg-3)" }}>
                 {currentTab.description}
               </p>
             </div>
@@ -819,32 +820,12 @@ function AgentSectionNavigation({
   return (
     <aside style={{ position: "sticky", top: "var(--sp-4)", alignSelf: "start" }}>
       <nav aria-label="Agent sections">
-        <ul className="m-0 flex list-none flex-col gap-1 p-0">
+        <ul className="m-0 flex list-none flex-col p-0" style={{ gap: "var(--sp-0_5)" }}>
           {tabs.map((tab) => {
             const active = currentTabKey === tab.key;
             return (
               <li key={tab.key}>
-                <button
-                  type="button"
-                  aria-current={active ? "page" : undefined}
-                  onClick={() => navigate(`/agents/${agentUuid}/${tab.path}`, { replace: true })}
-                  className={cn(
-                    "text-body w-full text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
-                    active ? "font-semibold" : "font-normal",
-                  )}
-                  style={{
-                    minHeight: "var(--sp-11)",
-                    padding: "var(--sp-2) var(--sp-3)",
-                    border: 0,
-                    borderLeft: `var(--hairline-bold) solid ${active ? "var(--fg)" : "transparent"}`,
-                    borderRadius: "var(--radius-input)",
-                    background: active ? "var(--bg-active)" : "transparent",
-                    color: active ? "var(--fg)" : "var(--fg-3)",
-                    cursor: "pointer",
-                  }}
-                >
-                  {tab.label}
-                </button>
+                <LocalNavLink to={`/agents/${agentUuid}/${tab.path}`} label={tab.label} active={active} replace />
               </li>
             );
           })}

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -341,7 +341,11 @@ async function renderDom(
   route: string,
   child: ReactElement,
   setup?: (queryClient: QueryClient) => void | Promise<void>,
-  routeChildren?: { prompt?: ReactElement },
+  routeChildren?: {
+    prompt?: ReactElement;
+    capabilities?: ReactElement;
+    repositories?: ReactElement;
+  },
 ): Promise<{ container: HTMLElement; root: Root; queryClient: QueryClient }> {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -364,7 +368,8 @@ async function renderDom(
                 <Route path="profile" element={child} />
                 <Route path="responsibilities" element={<ResponsibilitiesTab />} />
                 <Route path="prompt" element={routeChildren?.prompt ?? child} />
-                <Route path="capabilities" element={child} />
+                <Route path="capabilities" element={routeChildren?.capabilities ?? child} />
+                <Route path="repositories" element={routeChildren?.repositories ?? child} />
                 <Route path="resources" element={<div>Resources route</div>} />
                 <Route path="runtime" element={child} />
                 <Route path="usage" element={<UsageTab />} />
@@ -881,13 +886,19 @@ describe("AgentDetailPage", () => {
     await act(async () => view.root.unmount());
   });
 
-  it("does not flash Responsibilities when opening a resource-backed tab", async () => {
-    const { PromptTab } = await import("../prompt-tab.js");
+  it("does not flash Responsibilities when opening resource-backed tabs", async () => {
+    const [{ PromptTab }, { RepositoriesTab }, { ResourcesTab }] = await Promise.all([
+      import("../prompt-tab.js"),
+      import("../repositories-tab.js"),
+      import("../resources-tab.js"),
+    ]);
     templateMocks.listAgentTemplates.mockResolvedValue({ templates: [] });
     agentResourceMocks.getAgentResources.mockResolvedValue(agentResources({ templateIds: [], adoptedTemplates: [] }));
 
     const view = await renderDom("/agents/agent-1/profile", <div>Profile route</div>, undefined, {
       prompt: <PromptTab />,
+      capabilities: <ResourcesTab />,
+      repositories: <RepositoriesTab />,
     });
     await waitForText(view.container, "Profile route");
     await waitForCondition(
@@ -898,10 +909,13 @@ describe("AgentDetailPage", () => {
     const requestsBeforeNavigation = agentResourceMocks.getAgentResources.mock.calls.length;
     agentResourceMocks.getAgentResources.mockImplementation(() => new Promise(() => undefined));
 
-    await click(agentSectionLink(view.container, "Instructions"));
-    await flush();
-    expect(agentResourceMocks.getAgentResources).toHaveBeenCalledTimes(requestsBeforeNavigation);
-    expect(agentSectionLabels(view.container)).not.toContain("Responsibilities");
+    for (const label of ["Instructions", "Tools & skills", "Repositories"]) {
+      await click(agentSectionLink(view.container, label));
+      await flush();
+      expect(agentSectionLink(view.container, label)?.getAttribute("aria-current")).toBe("page");
+      expect(agentResourceMocks.getAgentResources).toHaveBeenCalledTimes(requestsBeforeNavigation);
+      expect(agentSectionLabels(view.container)).not.toContain("Responsibilities");
+    }
 
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -341,6 +341,7 @@ async function renderDom(
   route: string,
   child: ReactElement,
   setup?: (queryClient: QueryClient) => void | Promise<void>,
+  routeChildren?: { prompt?: ReactElement },
 ): Promise<{ container: HTMLElement; root: Root; queryClient: QueryClient }> {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -362,7 +363,7 @@ async function renderDom(
               <Route path="/agents/:uuid" element={<AgentDetailPage />}>
                 <Route path="profile" element={child} />
                 <Route path="responsibilities" element={<ResponsibilitiesTab />} />
-                <Route path="prompt" element={child} />
+                <Route path="prompt" element={routeChildren?.prompt ?? child} />
                 <Route path="capabilities" element={child} />
                 <Route path="resources" element={<div>Resources route</div>} />
                 <Route path="runtime" element={child} />
@@ -415,7 +416,12 @@ function exactButtonByText(container: ParentNode, text: string): HTMLButtonEleme
 
 function agentSectionLabels(container: ParentNode): Array<string | undefined> {
   const nav = container.querySelector('nav[aria-label="Agent sections"]');
-  return nav ? [...nav.querySelectorAll("button")].map((button) => button.textContent?.trim()) : [];
+  return nav ? [...nav.querySelectorAll("a")].map((link) => link.textContent?.trim()) : [];
+}
+
+function agentSectionLink(container: ParentNode, label: string): HTMLAnchorElement | null {
+  const nav = container.querySelector('nav[aria-label="Agent sections"]');
+  return [...(nav?.querySelectorAll("a") ?? [])].find((link) => link.textContent?.trim() === label) ?? null;
 }
 
 function menuItemByText(container: ParentNode, text: string): HTMLButtonElement | null {
@@ -577,6 +583,27 @@ describe("AgentDetailPage", () => {
     await act(async () => view.root.unmount());
   });
 
+  it("uses the shared local-navigation treatment without a repeated visible tab title", async () => {
+    const { ProfileTab } = await import("../profile-tab.js");
+    const view = await renderDom("/agents/agent-1/profile", <ProfileTab />);
+    await waitForText(view.container, "Identity");
+
+    const activeLink = view.container.querySelector<HTMLAnchorElement>(
+      'nav[aria-label="Agent sections"] a[aria-current="page"]',
+    );
+    const activeSurface = activeLink?.querySelector<HTMLElement>(":scope > span");
+    expect(activeLink?.textContent?.trim()).toBe("Profile");
+    expect(activeSurface?.classList.contains("font-medium")).toBe(true);
+    expect(activeSurface?.style.background).toBe("var(--bg-hover)");
+    expect(activeSurface?.style.borderLeft).toBe("");
+
+    const sectionTitle = view.container.querySelector<HTMLHeadingElement>("#agent-detail-section-title");
+    expect(sectionTitle?.textContent?.trim()).toBe("Profile");
+    expect(sectionTitle?.classList.contains("sr-only")).toBe(true);
+    expect(view.container.textContent).toContain("Identity, ownership, and lifecycle for this agent.");
+    await act(async () => view.root.unmount());
+  });
+
   it("keeps reactivation failures and retry beside the shared header action", async () => {
     const { ResourcesTab } = await import("../resources-tab.js");
     agentMocks.getAgent.mockResolvedValueOnce(agent({ status: "suspended", runtimeState: null }));
@@ -637,7 +664,7 @@ describe("AgentDetailPage", () => {
     );
     const profileNav = profile.container.querySelector('nav[aria-label="Agent sections"]');
     if (!profileNav) throw new Error("Expected Agent navigation");
-    expect([...profileNav.querySelectorAll("button")].map((tab) => tab.textContent?.trim())).toEqual([
+    expect([...profileNav.querySelectorAll("a")].map((tab) => tab.textContent?.trim())).toEqual([
       "Profile",
       "Responsibilities",
       "Runtime",
@@ -654,6 +681,11 @@ describe("AgentDetailPage", () => {
     expect(
       [...responsibilities.container.querySelectorAll("h2")].map((heading) => heading.textContent?.trim()),
     ).toContain("Responsibilities");
+    expect(
+      [...responsibilities.container.querySelectorAll("h2")]
+        .find((heading) => heading.textContent?.trim() === "Responsibilities")
+        ?.classList.contains("sr-only"),
+    ).toBe(true);
     expect(
       [...responsibilities.container.querySelectorAll("h3")].map((heading) => heading.textContent?.trim()),
     ).not.toContain("Responsibilities");
@@ -675,7 +707,7 @@ describe("AgentDetailPage", () => {
     await waitForText(view.container, "PR Engineer");
     const viewerNav = view.container.querySelector('nav[aria-label="Agent sections"]');
     if (!viewerNav) throw new Error("Expected Agent navigation");
-    expect([...viewerNav.querySelectorAll("button")].map((tab) => tab.textContent?.trim())).toEqual([
+    expect([...viewerNav.querySelectorAll("a")].map((tab) => tab.textContent?.trim())).toEqual([
       "Profile",
       "Responsibilities",
       "Tools & skills",
@@ -849,6 +881,31 @@ describe("AgentDetailPage", () => {
     await act(async () => view.root.unmount());
   });
 
+  it("does not flash Responsibilities when opening a resource-backed tab", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    templateMocks.listAgentTemplates.mockResolvedValue({ templates: [] });
+    agentResourceMocks.getAgentResources.mockResolvedValue(agentResources({ templateIds: [], adoptedTemplates: [] }));
+
+    const view = await renderDom("/agents/agent-1/profile", <div>Profile route</div>, undefined, {
+      prompt: <PromptTab />,
+    });
+    await waitForText(view.container, "Profile route");
+    await waitForCondition(
+      () => !agentSectionLabels(view.container).includes("Responsibilities"),
+      "Expected Responsibilities to close after confirmed empty",
+    );
+
+    const requestsBeforeNavigation = agentResourceMocks.getAgentResources.mock.calls.length;
+    agentResourceMocks.getAgentResources.mockImplementation(() => new Promise(() => undefined));
+
+    await click(agentSectionLink(view.container, "Instructions"));
+    await flush();
+    expect(agentResourceMocks.getAgentResources).toHaveBeenCalledTimes(requestsBeforeNavigation);
+    expect(agentSectionLabels(view.container)).not.toContain("Responsibilities");
+
+    await act(async () => view.root.unmount());
+  });
+
   it("renders prompt resource blocks and edits the custom prompt inline", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
     agentResourceMocks.getAgentResources.mockResolvedValue(
@@ -884,7 +941,7 @@ describe("AgentDetailPage", () => {
     expect(container.textContent).toContain("Start chat");
     const nav = container.querySelector('nav[aria-label="Agent sections"]');
     if (!nav) throw new Error("Expected Agent navigation");
-    expect([...nav.querySelectorAll("button")].map((tab) => tab.textContent?.trim())).toEqual([
+    expect([...nav.querySelectorAll("a")].map((tab) => tab.textContent?.trim())).toEqual([
       "Profile",
       "Responsibilities",
       "Runtime",

--- a/packages/web/src/pages/agent-detail/__tests__/repositories-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/repositories-tab-dom.test.tsx
@@ -172,7 +172,10 @@ describe("RepositoriesTab", () => {
     const { container } = await renderTab({ context });
 
     expect(container.textContent).toContain("Profile tab");
-    expect(resourceMocks.useAgentResources).toHaveBeenCalledWith("agent-1", { enabled: false });
+    expect(resourceMocks.useAgentResources).toHaveBeenCalledWith("agent-1", {
+      enabled: false,
+      refetchOnMount: false,
+    });
   });
 
   it("renders the repository section and configured context tree row", async () => {

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -97,7 +97,10 @@ export function agentResourcesMutationHandlers(
   };
 }
 
-export function useAgentResources(uuid: string, opts: { enabled: boolean }): AgentResourcesController {
+export function useAgentResources(
+  uuid: string,
+  opts: { enabled: boolean; refetchOnMount?: boolean },
+): AgentResourcesController {
   const queryClient = useQueryClient();
   const { justSaved, markSaved } = useJustSaved();
   const [reloading, setReloading] = useState(false);
@@ -106,6 +109,7 @@ export function useAgentResources(uuid: string, opts: { enabled: boolean }): Age
     queryKey: ["agent-resources", uuid],
     queryFn: () => getAgentResources(uuid),
     enabled: opts.enabled,
+    refetchOnMount: opts.refetchOnMount,
   });
   const updateMut = useMutation({
     mutationFn: (bindings: AgentResourceBindingInput[]) => {

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -38,6 +38,7 @@ export function PromptTab() {
     queryKey: ["agent-resources", ctx.uuid],
     queryFn: () => getAgentResources(ctx.uuid),
     enabled: !!ctx.uuid && ctx.canManageAgent && !ctx.isHuman,
+    refetchOnMount: false,
   });
   const savePromptMut = useMutation({
     mutationFn: (body: string) => {

--- a/packages/web/src/pages/agent-detail/repositories-tab.tsx
+++ b/packages/web/src/pages/agent-detail/repositories-tab.tsx
@@ -23,7 +23,7 @@ export function RepositoriesTab() {
   const ctx = useAgentDetailContext();
   // Gate on canEditConfig (not just !isHuman): non-editors hit the redirect
   // below, so there's no point firing an agent-resources GET for them.
-  const repos = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && ctx.canEditConfig });
+  const repos = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && ctx.canEditConfig, refetchOnMount: false });
   const canEditResources = ctx.canManageAgent && ctx.agent.status === "active";
   const readOnlyReason =
     ctx.canManageAgent && ctx.agent.status === "suspended"

--- a/packages/web/src/pages/agent-detail/resources-tab.tsx
+++ b/packages/web/src/pages/agent-detail/resources-tab.tsx
@@ -11,7 +11,7 @@ const RESOURCE_TYPES: ResourceType[] = ["skill", "mcp"];
 
 export function ResourcesTab() {
   const ctx = useAgentDetailContext();
-  const resources = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && !ctx.isHuman });
+  const resources = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && !ctx.isHuman, refetchOnMount: false });
   // Skill and MCP share one resource mutation/justSaved flag, so flash "Saved"
   // only on the section that was actually edited (tracked at click time).
   const [lastSavedType, setLastSavedType] = useState<ResourceType | null>(null);

--- a/packages/web/src/pages/agent-detail/responsibilities-tab.tsx
+++ b/packages/web/src/pages/agent-detail/responsibilities-tab.tsx
@@ -8,7 +8,7 @@ import { responsibilitiesSideFromQuery, shouldShowResponsibilitiesTab } from "./
 
 export function ResponsibilitiesTab() {
   const ctx = useAgentDetailContext();
-  const resources = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && !ctx.isHuman });
+  const resources = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && !ctx.isHuman, refetchOnMount: false });
   // Same catalog key as the Agent Detail shell / edit dialog — hide this route
   // when the public catalog and this agent's adopted templateIds are both empty.
   const catalogQuery = useQuery({
@@ -16,6 +16,7 @@ export function ResponsibilitiesTab() {
     queryFn: listAgentTemplates,
     enabled: !!ctx.uuid && !ctx.isHuman,
     retry: 1,
+    refetchOnMount: false,
   });
 
   const showResponsibilities = shouldShowResponsibilitiesTab(ctx.isHuman, {

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -4,6 +4,7 @@ import { NavLink, Outlet, useLocation } from "react-router";
 import { getContextTreeSnapshot } from "../api/context-tree.js";
 import { getTeamSetupCapabilitiesAt, setupCapabilitiesQueryKey } from "../api/setup-capabilities.js";
 import { useAuth } from "../auth/auth-context.js";
+import { LocalNavLink } from "../components/ui/local-nav-link.js";
 import { useWorkspaceViewport } from "../hooks/use-viewport.js";
 import { cn } from "../lib/utils.js";
 import {
@@ -270,46 +271,31 @@ function SidebarLink({
   attention?: boolean;
   activeOverride?: boolean;
 }) {
+  const { pathname } = useLocation();
+  const active = activeOverride ?? pathname.startsWith(to);
   return (
-    <NavLink
+    <LocalNavLink
       to={to}
-      aria-label={attention ? `${label} — Needs you` : undefined}
-      className={cn(
-        "block text-body transition-colors",
-        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-      )}
-    >
-      {({ isActive }) => {
-        const active = activeOverride ?? isActive;
-        return (
+      label={label}
+      active={active}
+      ariaLabel={attention ? `${label} — Needs you` : undefined}
+      trailing={
+        attention ? (
           <span
-            className={cn("flex items-center justify-between", active && "font-medium")}
+            aria-hidden
+            data-setup-attention
+            title="Needs you"
             style={{
-              padding: "var(--sp-2) var(--sp-3)",
-              borderRadius: "var(--radius-input)",
-              color: active ? "var(--fg)" : "var(--fg-3)",
-              background: active ? "var(--bg-hover)" : "transparent",
+              width: "var(--sp-2)",
+              height: "var(--sp-2)",
+              flexShrink: 0,
+              borderRadius: "var(--radius-full)",
+              background: "var(--state-needs-you)",
             }}
-          >
-            <span>{label}</span>
-            {attention ? (
-              <span
-                aria-hidden
-                data-setup-attention
-                title="Needs you"
-                style={{
-                  width: "var(--sp-2)",
-                  height: "var(--sp-2)",
-                  flexShrink: 0,
-                  borderRadius: "var(--radius-full)",
-                  background: "var(--state-needs-you)",
-                }}
-              />
-            ) : null}
-          </span>
-        );
-      }}
-    </NavLink>
+          />
+        ) : null
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

- give Agent Detail and Settings one shared desktop local-navigation component and active-state treatment
- remove the redundant visible Agent Detail page heading while preserving the document outline for assistive technology
- prevent resource-backed tabs from triggering mount-only refetches that temporarily reopened Responsibilities from the shell's fail-open state
- extend deterministic DOM coverage and the existing Agent Detail Momentic journey for all three behaviors

## Why the Responsibilities flash happened

The Agent Detail shell is the authority for whether Responsibilities is visible. Instructions, Tools & skills, Repositories, and Responsibilities mounted additional observers on the same cached resource data. Their default mount refetch changed the shell's observation to fetching, which correctly fails open under uncertainty but produced a visible transient Responsibilities entry during ordinary tab navigation.

Nested tab observers now reuse the shell-owned result without refetching on mount. Genuine invalidation, mutation, error, and explicit reload behavior remains unchanged.

## Validation

- `pnpm --filter @first-tree/web test -- --run` — 244 files / 2,201 tests passed
- deterministic Agent Detail DOM regression — 34/34 passed, including real Instructions → Tools & skills → Repositories transitions
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/web lint:tokens`
- `pnpm check`
- `pnpm build`
- `git diff --check`
- `npx momentic@3.42.0 lint e2e/agent-detail-configuration.test.yaml`
- exact-head `09bec60017ae280e47231f714ca7df775dc97e78` focused-local Momentic E2E passed, 17/17 steps, and uploaded: https://app.momentic.ai/run-groups/9468c179-2d5c-4f5b-9712-6abe140aa33c
- independent QA rebuilt an isolated exact-head stack and passed the same 17/17-step journey with zero console errors: https://app.momentic.ai/run-groups/c10a4e5c-b04e-4ba0-afc1-6d46bf20a96f
- exact-head screenshots confirmed the shared neutral navigation treatment and non-duplicated visible heading hierarchy; the captured browser console had no error-level messages
- two independent code/spec reviewers approved the exact head with no remaining findings

## Context Tree

No durable product contract changes. This follows the existing Agent Detail seven-area contract and the established Settings pattern that keeps the page heading available to assistive technology without repeating it visually.
