### PR TITLE
Unify computer and runtime selection for new agents

### DIFF
--- a/e2e/agent-creation-runtime.test.yaml
+++ b/e2e/agent-creation-runtime.test.yaml
@@ -1,0 +1,16 @@
+fileType: momentic/test/v2
+id: agent-creation-runtime
+description: A user explicitly chooses the computer and runtime for a new agent when more than one computer is online
+defaultEnv: local
+url: http://127.0.0.1:5173/preview/onboarding?role=admin&view=states&scenario=admin-ca-multiple-computers
+steps:
+  - assert: the Create your first agent card has one This agent will run section;
+      it shows a Choose a computer control, does not yet show runtime choices,
+      and the Create agent button is disabled
+  - click: the Choose a computer control
+  - assert: the open computer menu shows gandys-macbook with macOS · online and
+      gandys-studio with Linux · online as compact two-line choices
+  - click: the gandys-studio computer choice
+  - assert: the This agent will run section now shows gandys-studio with
+      Linux · online, followed directly by Codex and Claude Code choices; there
+      are no On, Using, Run on, or Powered by labels, and Create agent is enabled

--- a/packages/web/src/components/__tests__/new-agent-dialog-extra.test.tsx
+++ b/packages/web/src/components/__tests__/new-agent-dialog-extra.test.tsx
@@ -262,7 +262,18 @@ describe("NewAgentDialog extra branches", () => {
     const onCreated = vi.fn();
     const container = await renderDom(<NewAgentDialog open onOpenChange={() => undefined} onCreated={onCreated} />);
 
-    await waitForText(container, "gandy-macbook");
+    await waitForText(container, "Choose a computer");
+    expect(document.body.textContent).toContain("This agent will run");
+    expect(document.body.textContent).toContain("Who can use it?");
+    expect(document.body.textContent).not.toContain("Where it runs");
+    expect(document.body.textContent).not.toContain("Powered by");
+    expect(buttonByText(document.body, "Create").disabled).toBe(true);
+    await click(document.body.querySelector("#new-agent-computer"));
+    await click(buttonByText(document.body, "alice-linux"));
+    await waitForCondition(
+      () => activityMocks.getClientCapabilities.mock.calls.some((call) => call[0] === "client-2"),
+      "Expected second client capability fetch",
+    );
     expect(document.body.textContent).toContain("Claude Code");
     const initialRuntimeInputs = [...document.body.querySelectorAll<HTMLInputElement>('input[name="runtime"]')];
     expect(initialRuntimeInputs.map((input) => input.closest("label")?.textContent)).toEqual([
@@ -279,15 +290,6 @@ describe("NewAgentDialog extra branches", () => {
       (input) => input.closest("label")?.textContent?.includes("Visible to your team"),
     );
     await click(sharedRadio ?? null);
-    await click(
-      [...document.body.querySelectorAll<HTMLInputElement>('input[name="picked-client"]')].find((input) =>
-        input.closest("label")?.textContent?.includes("alice-linux"),
-      ) ?? null,
-    );
-    await waitForCondition(
-      () => activityMocks.getClientCapabilities.mock.calls.some((call) => call[0] === "client-2"),
-      "Expected second client capability fetch",
-    );
     await click(
       [...document.body.querySelectorAll<HTMLInputElement>('input[name="runtime"]')].find((input) =>
         input.closest("label")?.textContent?.includes("Codex"),
@@ -308,6 +310,54 @@ describe("NewAgentDialog extra branches", () => {
     );
     expect(authMock.value.refreshMe).toHaveBeenCalled();
     expect(onCreated).toHaveBeenCalledWith(expect.objectContaining({ uuid: "agent-created" }), "codex", 0);
+  });
+
+  it("reapplies runtime priority after an automatic choice but preserves a manual choice", async () => {
+    const { NewAgentDialog } = await import("../new-agent-dialog.js");
+    activityMocks.getClientCapabilities.mockImplementation(async (clientId: string) =>
+      clientId === "client-1"
+        ? client({ capabilities: { "claude-code": capability("ok") } })
+        : client({ id: "client-2", hostname: "alice-linux" }),
+    );
+    await renderDom(<NewAgentDialog open onOpenChange={() => undefined} onCreated={() => undefined} />);
+
+    await waitForText(document.body, "Choose a computer");
+    await click(document.body.querySelector("#new-agent-computer"));
+    await click(buttonByText(document.body, "gandy-macbook"));
+    await waitForCondition(
+      () =>
+        [...document.body.querySelectorAll<HTMLInputElement>('input[name="runtime"]')].some(
+          (input) => input.checked && input.closest("label")?.textContent?.includes("Claude Code"),
+        ),
+      "Expected the sole ready runtime to be selected",
+    );
+
+    await click(document.body.querySelector("#new-agent-computer"));
+    await click(buttonByText(document.body, "alice-linux"));
+    await waitForCondition(
+      () =>
+        [...document.body.querySelectorAll<HTMLInputElement>('input[name="runtime"]')].some(
+          (input) => input.checked && input.closest("label")?.textContent?.includes("Codex"),
+        ),
+      "Expected the preferred runtime after switching computers",
+    );
+
+    const claude = [...document.body.querySelectorAll<HTMLInputElement>('input[name="runtime"]')].find((input) =>
+      input.closest("label")?.textContent?.includes("Claude Code"),
+    );
+    await click(claude ?? null);
+    await click(document.body.querySelector("#new-agent-computer"));
+    await click(buttonByText(document.body, "gandy-macbook"));
+    await waitForText(document.body, "Claude Code");
+    await click(document.body.querySelector("#new-agent-computer"));
+    await click(buttonByText(document.body, "alice-linux"));
+    await waitForCondition(
+      () =>
+        [...document.body.querySelectorAll<HTMLInputElement>('input[name="runtime"]')].some(
+          (input) => input.checked && input.closest("label")?.textContent?.includes("Claude Code"),
+        ),
+      "Expected the explicit runtime choice to be preserved",
+    );
   });
 
   // Dropped "offers in-product Connect when the picked computer has an
@@ -419,6 +469,7 @@ describe("NewAgentDialog extra branches", () => {
 
   it("keeps creation disabled while a name probe fails without blocking submission", async () => {
     const { NewAgentDialog } = await import("../new-agent-dialog.js");
+    activityMocks.listClients.mockResolvedValue([client()]);
     agentMocks.checkAgentNameAvailability.mockRejectedValueOnce(new Error("network"));
     const container = await renderDom(
       <NewAgentDialog open onOpenChange={() => undefined} onCreated={() => undefined} />,

--- a/packages/web/src/components/connected-computer-select.tsx
+++ b/packages/web/src/components/connected-computer-select.tsx
@@ -1,0 +1,67 @@
+import type { ReactElement } from "react";
+import type { HubClient } from "../api/activity.js";
+import { Select } from "./ui/select.js";
+
+type ConnectedComputerSelectProps = {
+  clients: HubClient[];
+  value: string | null;
+  onChange: (clientId: string) => void;
+  id?: string;
+};
+
+function clientLabel(client: HubClient): string {
+  return client.hostname ?? client.id;
+}
+
+function operatingSystemLabel(os: string | null): string {
+  switch (os?.toLowerCase()) {
+    case "darwin":
+    case "macos":
+      return "macOS";
+    case "linux":
+      return "Linux";
+    case "win32":
+    case "windows":
+      return "Windows";
+    default:
+      return os ?? "Unknown OS";
+  }
+}
+
+function clientHint(client: HubClient): string {
+  return `${operatingSystemLabel(client.os)} · online`;
+}
+
+/**
+ * Compact multi-computer picker shared by both agent-creation surfaces.
+ * The hostname and connection context stay visible in the collapsed trigger;
+ * no extra "On" label is needed inside the surrounding execution field.
+ */
+export function ConnectedComputerSelect({ clients, value, onChange, id }: ConnectedComputerSelectProps): ReactElement {
+  return (
+    <Select
+      id={id}
+      value={value ?? ""}
+      onChange={onChange}
+      options={clients.map((client) => ({
+        value: client.id,
+        label: clientLabel(client),
+        hint: clientHint(client),
+      }))}
+      placeholder="Choose a computer"
+      aria-label="Choose a computer"
+      hintLayout="stacked"
+      triggerClassName="h-auto min-h-9 py-2"
+    />
+  );
+}
+
+/** Read-only counterpart for the common single-computer path. */
+export function ConnectedComputerSummary({ client }: { client: HubClient }): ReactElement {
+  return (
+    <div className="min-w-0">
+      <div className="truncate text-body font-medium">{clientLabel(client)}</div>
+      <div className="text-caption text-muted-foreground">{clientHint(client)}</div>
+    </div>
+  );
+}

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -10,7 +10,6 @@ import {
   isReservedAgentName,
   MAX_AGENT_TEMPLATE_IDS,
   PREFERRED_RUNTIME_PROVIDER,
-  pickPreferredRuntimeProvider,
   type RuntimeProvider,
   runtimeProviderLabel,
 } from "@first-tree/shared";
@@ -22,9 +21,11 @@ import { listAgentTemplates } from "../api/agent-templates.js";
 import { checkAgentNameAvailability, createAgent } from "../api/agents.js";
 import { ApiError, api, type ValidationIssue } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
+import { resolveComputerSelection, resolveRuntimeSelection } from "../features/agent-setup/computer-selection.js";
 import { useCopyFeedback } from "../lib/use-copy-feedback.js";
 import { runVisibilityAwareInterval } from "../lib/visibility-interval.js";
 import { slugify } from "../utils/agent-naming.js";
+import { ConnectedComputerSelect, ConnectedComputerSummary } from "./connected-computer-select.js";
 import { activeTemplateResponsibilityLabel, TemplateResponsibilityLabel } from "./template-responsibility-label.js";
 import { Button } from "./ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog.js";
@@ -144,15 +145,6 @@ async function resolveAvailableHandle(base: string, isStale: () => boolean): Pro
   return null;
 }
 
-/**
- * Pick the preferred runtime among the ones in `ok` state on a given client.
- * Uses the catalog-owned Codex/Claude preference prefix, then preserves the
- * selected Client's reported order (which may differ from display order).
- */
-function pickPreferredRuntime(caps: ClientCapabilities): RuntimeProvider | null {
-  return pickPreferredRuntimeProvider(caps);
-}
-
 function availabilityReasonMessage(reason: "invalid" | "reserved" | "taken"): string {
   switch (reason) {
     case "taken":
@@ -201,6 +193,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
   // personal until explicitly shared.
   const [visibility, setVisibility] = useState<AgentVisibility>("private");
   const [runtime, setRuntime] = useState<RuntimeProvider>(PREFERRED_RUNTIME_PROVIDER);
+  const runtimeSelectionIsManualRef = useRef(false);
 
   // Handle resolution. The slug follows the display name (auto-deduped on
   // collision); `resolvedHandle` is the winner. `manualHandle` is only used
@@ -215,7 +208,10 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
   // installed there) before clicking Create. Mirrors onboarding step 2.
   const [connectedClients, setConnectedClients] = useState<HubClient[]>([]);
   const [clientsLoaded, setClientsLoaded] = useState(false);
-  const [pickedClientId, setPickedClientId] = useState<string | null>(null);
+  const [pickedClientIdState, setPickedClientIdState] = useState<string | null>(null);
+  const explicitlyPickedClientIdRef = useRef<string | null>(null);
+  const clientsRequestSeqRef = useRef(0);
+  const capabilitiesRequestSeqRef = useRef(0);
   const [capabilities, setCapabilities] = useState<ClientCapabilities | null>(null);
   const [capabilitiesClientId, setCapabilitiesClientId] = useState<string | null>(null);
   // Connect-token state for the zero-computer recovery affordance. We only
@@ -298,13 +294,15 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
       setDisplayName("");
       setVisibility("private");
       setRuntime(PREFERRED_RUNTIME_PROVIDER);
+      runtimeSelectionIsManualRef.current = false;
       setResolvedHandle("");
       setHandleState({ status: "idle" });
       setManualHandle("");
       setManualAvailability({ status: "idle" });
       setConnectedClients([]);
       setClientsLoaded(false);
-      setPickedClientId(null);
+      setPickedClientIdState(null);
+      explicitlyPickedClientIdRef.current = null;
       setCapabilities(null);
       setCapabilitiesClientId(null);
       setConnectToken(null);
@@ -435,6 +433,20 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
     return () => window.clearTimeout(timer);
   }, [open, handleState.status, manualHandle]);
 
+  const connectedClientIds = useMemo(() => connectedClients.map((client) => client.id), [connectedClients]);
+  const pickedClientId = resolveComputerSelection({
+    clientIds: connectedClientIds,
+    currentClientId: pickedClientIdState,
+    explicitlySelectedClientId: explicitlyPickedClientIdRef.current,
+    requireExplicitWhenMultiple: true,
+  });
+  const currentPickedClientIdRef = useRef<string | null>(null);
+  currentPickedClientIdRef.current = pickedClientId;
+  const pickClient = useCallback((next: string): void => {
+    explicitlyPickedClientIdRef.current = next;
+    setPickedClientIdState(next);
+  }, []);
+
   // Poll `listClients` to keep the connected-computer list fresh while the
   // dialog is open. 5s cadence so a computer coming online (or going
   // offline) reflects without the user closing and reopening the dialog.
@@ -445,9 +457,10 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
     if (!open) return;
     let cancelled = false;
     const tick = async (): Promise<void> => {
+      const seq = ++clientsRequestSeqRef.current;
       try {
         const list = await listClients();
-        if (cancelled) return;
+        if (cancelled || seq !== clientsRequestSeqRef.current) return;
         const connected = list
           .filter((c) => c.status === "connected")
           .sort((a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt));
@@ -457,28 +470,27 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
         // Best-effort. Mark as loaded so the empty-state UI shows instead of
         // a forever spinner — the user can still see *something* and the
         // next tick will recover.
-        if (!cancelled) setClientsLoaded(true);
+        if (!cancelled && seq === clientsRequestSeqRef.current) setClientsLoaded(true);
       }
     };
     const dispose = runVisibilityAwareInterval(tick, 5_000);
     return () => {
       cancelled = true;
+      clientsRequestSeqRef.current += 1;
       dispose();
     };
   }, [open]);
 
-  // Auto-pick the most-recently-seen connected client, but stay on the
-  // user's manual choice as long as it's still in the list.
+  // Synchronise storage with the effective selection. The effective value is
+  // derived during render, so an automatic one-computer choice never flashes
+  // as selected after a second computer appears.
   useEffect(() => {
-    if (connectedClients.length === 0) {
-      setPickedClientId(null);
-      return;
+    const explicitClientId = explicitlyPickedClientIdRef.current;
+    if (explicitClientId && !connectedClientIds.includes(explicitClientId)) {
+      explicitlyPickedClientIdRef.current = null;
     }
-    setPickedClientId((prev) => {
-      if (prev && connectedClients.some((c) => c.id === prev)) return prev;
-      return connectedClients[0]?.id ?? null;
-    });
-  }, [connectedClients]);
+    setPickedClientIdState((prev) => (prev === pickedClientId ? prev : pickedClientId));
+  }, [connectedClientIds, pickedClientId]);
 
   // Capability fetch — exposed as a callback so an in-dialog Connect can force
   // an immediate refresh (otherwise the just-signed-in runtime only flips to ok
@@ -486,13 +498,17 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
   // late write from a previous client is ignored by `activeCapabilities`.
   const refreshCapabilities = useCallback(async (): Promise<void> => {
     if (!pickedClientId) return;
+    const clientId = pickedClientId;
+    const seq = ++capabilitiesRequestSeqRef.current;
     try {
-      const res = await getClientCapabilities(pickedClientId);
+      const res = await getClientCapabilities(clientId);
+      if (seq !== capabilitiesRequestSeqRef.current || currentPickedClientIdRef.current !== clientId) return;
       setCapabilities(res.capabilities);
-      setCapabilitiesClientId(pickedClientId);
+      setCapabilitiesClientId(clientId);
     } catch {
       // Transient — keep whatever we have (initial null shows "detecting…",
       // prior success keeps the chips). The next tick will retry.
+      return;
     }
   }, [pickedClientId]);
 
@@ -502,12 +518,16 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
   // reopens the dialog. Visibility-aware (see `runVisibilityAwareInterval`).
   useEffect(() => {
     if (!pickedClientId) {
+      capabilitiesRequestSeqRef.current += 1;
       setCapabilities(null);
       setCapabilitiesClientId(null);
       return;
     }
     const dispose = runVisibilityAwareInterval(refreshCapabilities, 5_000);
-    return () => dispose();
+    return () => {
+      capabilitiesRequestSeqRef.current += 1;
+      dispose();
+    };
   }, [pickedClientId, refreshCapabilities]);
 
   // Connect-token generation. Only fires when the dialog is open AND the
@@ -568,8 +588,13 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
   useEffect(() => {
     if (!activeCapabilities) return;
     setRuntime((prev) => {
-      if (okRuntimes.includes(prev)) return prev;
-      return pickPreferredRuntime(activeCapabilities) ?? prev;
+      const next = resolveRuntimeSelection({
+        currentRuntime: prev,
+        selectionIsManual: runtimeSelectionIsManualRef.current,
+        readyRuntimes: okRuntimes,
+      });
+      runtimeSelectionIsManualRef.current = next.selectionIsManual;
+      return next.runtime ?? prev;
     });
   }, [activeCapabilities, okRuntimes]);
 
@@ -839,35 +864,6 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
             )}
           </div>
 
-          <div className="space-y-2">
-            <Label>Visibility</Label>
-            <div className="space-y-2">
-              <OptionCard
-                name="visibility"
-                checked={visibility === "organization"}
-                onSelect={() => setVisibility("organization")}
-              >
-                <div>
-                  <div className="text-body font-medium">Visible to your team</div>
-                  <div className="text-caption text-muted-foreground">
-                    Anyone on your team can @mention it and start work with it — it runs on your computer and uses your
-                    plan.
-                  </div>
-                </div>
-              </OptionCard>
-              <OptionCard
-                name="visibility"
-                checked={visibility === "private"}
-                onSelect={() => setVisibility("private")}
-              >
-                <div>
-                  <div className="text-body font-medium">Private to you</div>
-                  <div className="text-caption text-muted-foreground">Only you can see and chat with it.</div>
-                </div>
-              </OptionCard>
-            </div>
-          </div>
-
           {/* Optional official Template responsibilities. Hidden entirely when
               the catalog is empty or failed to load — the plain create path
               stays byte-identical in those cases. */}
@@ -950,20 +946,16 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
             </div>
           )}
 
-          {/*
-            "Where it runs" block. The computer card and runtime row each render
-            a dimension-matched skeleton while their async data loads
-            (`ComputerCardSkeleton` / `RuntimeChipsSkeleton`), so the block
-            holds a stable height through the detect → loaded transition without
-            a hand-tuned `minHeight`. The 0-computer and N-radio states may grow
-            taller — that's expected; the jump we cared about was the initial
-            detection swap, which the skeletons absorb.
-          */}
+          {/* One execution field: computer identity first, then the runtime
+              options it supports. Control shape and order distinguish the two
+              choices without adding "Run on", "On", "Using", or "Powered by"
+              labels. */}
           <div className="space-y-3">
-            <Label>Where it runs</Label>
+            <Label>This agent will run</Label>
 
-            {/* Computer picker. 0 / 1 / N branches keep the most common
-                case (1 connected computer) free of radio-button noise. */}
+            {/* The common one-computer case is plain read-only information.
+                Multiple computers use one compact dropdown and deliberately
+                start without a selection. */}
             {!clientsLoaded ? (
               <ComputerCardSkeleton label="Detecting connected computers…" />
             ) : connectedClients.length === 0 ? (
@@ -975,35 +967,22 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
                   void copyToken(connectCommand);
                 }}
               />
-            ) : connectedClients.length === 1 ? (
-              <SingleComputerCard client={connectedClients[0]} />
+            ) : connectedClients.length === 1 && connectedClients[0] ? (
+              <ConnectedComputerSummary client={connectedClients[0]} />
             ) : (
-              <div className="space-y-2">
-                {connectedClients.map((client) => (
-                  <OptionCard
-                    key={client.id}
-                    name="picked-client"
-                    checked={pickedClientId === client.id}
-                    onSelect={() => setPickedClientId(client.id)}
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="text-body font-medium truncate">{client.hostname ?? client.id}</div>
-                      <div className="text-caption text-muted-foreground">{client.os ?? "unknown OS"} · online</div>
-                    </div>
-                  </OptionCard>
-                ))}
-              </div>
+              <ConnectedComputerSelect
+                clients={connectedClients}
+                value={pickedClientId}
+                onChange={pickClient}
+                id="new-agent-computer"
+              />
             )}
 
-            {/* Runtime row. Renders *whenever* a computer is picked OR while
-                we're still detecting computers — keeping a stable "Powered
-                by" slot below the computer card prevents the second jump
-                (skeleton paragraph being replaced by the runtime chip row).
-                Only the inner content swaps; the section header and a
-                skeleton chip row hold the space. */}
+            {/* Runtime options belong to the selected computer. In the
+                multi-computer path they appear only after the user chooses,
+                so stale capabilities can never look actionable. */}
             {(pickedClientId || !clientsLoaded) && (
               <div className="space-y-1.5">
-                <div className="text-caption text-muted-foreground">Powered by</div>
                 {!pickedClientId || activeCapabilities === null ? (
                   <RuntimeChipsSkeleton />
                 ) : okRuntimes.length === 0 ? (
@@ -1016,7 +995,10 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
                         name="runtime"
                         layout="pill"
                         checked={runtime === provider}
-                        onSelect={() => setRuntime(provider)}
+                        onSelect={() => {
+                          runtimeSelectionIsManualRef.current = true;
+                          setRuntime(provider);
+                        }}
                       >
                         <span className="text-body">{runtimeProviderLabel(provider)}</span>
                       </OptionCard>
@@ -1027,6 +1009,35 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
             )}
 
             {fieldErrors.clientId && <p className="text-caption text-destructive">{fieldErrors.clientId}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Who can use it?</Label>
+            <div className="space-y-2">
+              <OptionCard
+                name="visibility"
+                checked={visibility === "organization"}
+                onSelect={() => setVisibility("organization")}
+              >
+                <div>
+                  <div className="text-body font-medium">Visible to your team</div>
+                  <div className="text-caption text-muted-foreground">
+                    Anyone on your team can @mention it and start work with it — it runs on your computer and uses your
+                    plan.
+                  </div>
+                </div>
+              </OptionCard>
+              <OptionCard
+                name="visibility"
+                checked={visibility === "private"}
+                onSelect={() => setVisibility("private")}
+              >
+                <div>
+                  <div className="text-body font-medium">Private to you</div>
+                  <div className="text-caption text-muted-foreground">Only you can see and chat with it.</div>
+                </div>
+              </OptionCard>
+            </div>
           </div>
 
           {fieldErrors._root && (
@@ -1080,7 +1091,7 @@ function ZeroComputerBlock({
   return (
     <div className="space-y-2">
       {/* Regular weight + a slightly lighter tone (`--fg-2`) so the section
-          label "Where it runs" stays the heading and this reads as status,
+          label "This agent will run" stays the heading and this reads as status,
           not a competing second title. */}
       <div className="text-body text-fg-2">No computer connected yet.</div>
       <div className="text-caption text-muted-foreground">
@@ -1103,27 +1114,7 @@ function ZeroComputerBlock({
 }
 
 /**
- * Single-computer confirmation. Used in the common case where the user only
- * has one computer connected — non-interactive, so it's just a plain two-line
- * readout of where the agent will live (no card / border / fill; the framed
- * box was over-packaging for read-only content).
- *
- * Layout note: mirrors `ComputerCardSkeleton`'s two-line shape so the
- * "Where it runs" block holds a stable height across the detect → loaded
- * swap. If you change this readout's line count, mirror it in the skeleton.
- */
-function SingleComputerCard({ client }: { client: HubClient | undefined }) {
-  if (!client) return null;
-  return (
-    <div>
-      <div className="text-body font-medium truncate">{client.hostname ?? client.id}</div>
-      <div className="text-caption text-muted-foreground">{client.os ?? "unknown OS"} · online</div>
-    </div>
-  );
-}
-
-/**
- * Loading placeholder that mirrors `SingleComputerCard`'s two-line readout
+ * Loading placeholder that mirrors `ConnectedComputerSummary`'s two-line readout
  * (same plain, borderless shape) so the surrounding form keeps a stable
  * height while `listClients` is in flight. The previous placeholder was a
  * single-line paragraph, which is what made the dialog visibly jump when the
@@ -1143,7 +1134,7 @@ function ComputerCardSkeleton({ label }: { label: string }) {
 /**
  * Loading placeholder for the runtime chip row. A single greyed chip-shaped
  * box reserves the height the real chips will occupy. Pairs with
- * `ComputerCardSkeleton` so the whole "Where it runs" block reaches its
+ * `ComputerCardSkeleton` so the whole execution block reaches its
  * steady-state height on first paint — no second jump when capabilities
  * resolve.
  */

--- a/packages/web/src/components/ui/select.tsx
+++ b/packages/web/src/components/ui/select.tsx
@@ -34,6 +34,12 @@ export type SelectProps = {
   searchable?: boolean;
   /** Monospace the trigger + options (model ids, transports, ...). */
   mono?: boolean;
+  /**
+   * Places an option hint beneath its label in both the trigger and list.
+   * Keep the default inline layout for compact metadata such as context size;
+   * use stacked for two-line identities such as connected computers.
+   */
+  hintLayout?: "inline" | "stacked";
   id?: string;
   "aria-label"?: string;
   className?: string;
@@ -48,6 +54,7 @@ export function Select({
   placeholder,
   searchable,
   mono,
+  hintLayout = "inline",
   id,
   "aria-label": ariaLabel,
   className,
@@ -298,9 +305,20 @@ export function Select({
         aria-controls={open ? listboxId : undefined}
         aria-label={ariaLabel}
       >
-        <span className="truncate" style={{ color: selected ? undefined : "var(--fg-3)" }}>
-          {selected?.label ?? placeholder ?? value}
-        </span>
+        {hintLayout === "stacked" && selected ? (
+          <span className="min-w-0 flex-1 text-left">
+            <span className="block truncate">{selected.label}</span>
+            {selected.hint && (
+              <span className="block truncate text-caption" style={{ color: "var(--fg-4)" }}>
+                {selected.hint}
+              </span>
+            )}
+          </span>
+        ) : (
+          <span className="truncate" style={{ color: selected ? undefined : "var(--fg-3)" }}>
+            {selected?.label ?? placeholder ?? value}
+          </span>
+        )}
         <ChevronDown
           className="ml-2 h-3.5 w-3.5 transition-transform"
           style={{ color: "var(--fg-3)", transform: open ? "rotate(180deg)" : undefined }}
@@ -378,7 +396,8 @@ export function Select({
                     onClick={() => commit(o)}
                     onMouseEnter={() => !o.disabled && setActiveIndex(i)}
                     className={cn(
-                      "flex w-full cursor-pointer items-center gap-2 bg-transparent px-3 py-1.5 text-body text-left transition-colors focus-visible:outline-none",
+                      "flex w-full cursor-pointer gap-2 bg-transparent px-3 py-1.5 text-body text-left transition-colors focus-visible:outline-none",
+                      hintLayout === "stacked" ? "items-start" : "items-center",
                       mono && "mono",
                       isActive && "bg-accent text-accent-foreground",
                       o.disabled && "cursor-not-allowed opacity-50",
@@ -386,14 +405,27 @@ export function Select({
                     style={{ color: o.value === "" ? "var(--fg-3)" : undefined }}
                   >
                     <Check
-                      className="h-3.5 w-3.5 flex-shrink-0"
+                      className={cn("h-3.5 w-3.5 flex-shrink-0", hintLayout === "stacked" && "mt-0.5")}
                       style={{ visibility: isSelected ? "visible" : "hidden", color: "var(--success)" }}
                     />
-                    <span className="flex-1 truncate">{o.label}</span>
-                    {o.hint && (
-                      <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-                        {o.hint}
+                    {hintLayout === "stacked" ? (
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate">{o.label}</span>
+                        {o.hint && (
+                          <span className="block truncate text-caption" style={{ color: "var(--fg-4)" }}>
+                            {o.hint}
+                          </span>
+                        )}
                       </span>
+                    ) : (
+                      <>
+                        <span className="flex-1 truncate">{o.label}</span>
+                        {o.hint && (
+                          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+                            {o.hint}
+                          </span>
+                        )}
+                      </>
                     )}
                   </button>
                 );

--- a/packages/web/src/features/agent-setup/__tests__/computer-selection.test.ts
+++ b/packages/web/src/features/agent-setup/__tests__/computer-selection.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { resolveComputerSelection, resolveRuntimeSelection } from "../computer-selection.js";
+
+describe("resolveComputerSelection", () => {
+  it("uses the only connected computer without asking", () => {
+    expect(
+      resolveComputerSelection({
+        clientIds: ["client-1"],
+        currentClientId: null,
+        explicitlySelectedClientId: null,
+        requireExplicitWhenMultiple: true,
+      }),
+    ).toBe("client-1");
+  });
+
+  it("requires a still-connected explicit choice when several computers are online", () => {
+    const input = {
+      clientIds: ["client-1", "client-2"],
+      currentClientId: "client-1",
+      requireExplicitWhenMultiple: true,
+    };
+
+    expect(resolveComputerSelection({ ...input, explicitlySelectedClientId: null })).toBeNull();
+    expect(resolveComputerSelection({ ...input, explicitlySelectedClientId: "client-2" })).toBe("client-2");
+    expect(resolveComputerSelection({ ...input, explicitlySelectedClientId: "disconnected" })).toBeNull();
+  });
+
+  it("preserves or supplies a selection for non-creation monitoring surfaces", () => {
+    const input = {
+      clientIds: ["newest", "older"],
+      explicitlySelectedClientId: null,
+      requireExplicitWhenMultiple: false,
+    };
+
+    expect(resolveComputerSelection({ ...input, currentClientId: "older" })).toBe("older");
+    expect(resolveComputerSelection({ ...input, currentClientId: "disconnected" })).toBe("newest");
+  });
+});
+
+describe("resolveRuntimeSelection", () => {
+  it("preserves a still-ready manual choice", () => {
+    expect(
+      resolveRuntimeSelection({
+        currentRuntime: "claude-code",
+        selectionIsManual: true,
+        readyRuntimes: ["codex", "claude-code"],
+      }),
+    ).toEqual({ runtime: "claude-code", selectionIsManual: true });
+  });
+
+  it("reapplies catalog order when the previous choice was automatic", () => {
+    expect(
+      resolveRuntimeSelection({
+        currentRuntime: "claude-code",
+        selectionIsManual: false,
+        readyRuntimes: ["codex", "claude-code"],
+      }),
+    ).toEqual({ runtime: "codex", selectionIsManual: false });
+  });
+
+  it("falls back when a manual choice is unavailable on the selected computer", () => {
+    expect(
+      resolveRuntimeSelection({
+        currentRuntime: "claude-code",
+        selectionIsManual: true,
+        readyRuntimes: ["codex", "opencode"],
+      }),
+    ).toEqual({ runtime: "codex", selectionIsManual: false });
+  });
+
+  it("keeps the current value while no runtime is ready", () => {
+    expect(
+      resolveRuntimeSelection({
+        currentRuntime: "codex",
+        selectionIsManual: true,
+        readyRuntimes: [],
+      }),
+    ).toEqual({ runtime: "codex", selectionIsManual: false });
+  });
+});

--- a/packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx
+++ b/packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx
@@ -54,6 +54,12 @@ function expectHookValue<T>(value: T): NonNullable<T> {
   return value;
 }
 
+function latestVisibilityTick(): () => void | Promise<void> {
+  const tick = visibilityMocks.runVisibilityAwareInterval.mock.calls.at(-1)?.[0];
+  if (!tick) throw new Error("visibility-aware interval was not registered");
+  return tick;
+}
+
 function createStorage(): Storage {
   const data = new Map<string, string>();
   return {
@@ -181,6 +187,94 @@ describe("shared setup hooks", () => {
     expect(eventMocks.reportOnboardingEvent).not.toHaveBeenCalled();
   });
 
+  it("requires an explicit computer choice when multiple computers are connected", async () => {
+    const latest: { current: ComputerConnection | null } = { current: null };
+    const older = {
+      id: "client-old",
+      userId: "user-self",
+      status: "connected",
+      authState: "ok",
+      binName: "first-tree-dev",
+      sdkVersion: "0.5.0",
+      hostname: "studio-mac",
+      os: "darwin",
+      agentCount: 1,
+      connectedAt: "2026-05-28T00:00:00.000Z",
+      lastSeenAt: "2026-05-28T11:00:00.000Z",
+      capabilities: {},
+    };
+    const newer = {
+      ...older,
+      id: "client-new",
+      hostname: "travel-mac",
+      lastSeenAt: "2026-05-28T12:00:00.000Z",
+    };
+    activityMocks.listClients.mockResolvedValue([older, newer]);
+    activityMocks.getClientCapabilities.mockImplementation(async (clientId: string) => ({
+      ...(clientId === older.id ? older : newer),
+      capabilities:
+        clientId === older.id
+          ? {
+              "claude-code": {
+                state: "ok",
+                available: true,
+                detectedAt: "2026-05-28T12:00:00.000Z",
+              },
+            }
+          : {
+              codex: {
+                state: "ok",
+                available: true,
+                detectedAt: "2026-05-28T12:00:00.000Z",
+              },
+              "claude-code": {
+                state: "ok",
+                available: true,
+                detectedAt: "2026-05-28T12:00:00.000Z",
+              },
+            },
+    }));
+
+    function Probe() {
+      latest.current = useComputerConnection(true, { requireExplicitSelectionWhenMultiple: true });
+      return <div>{latest.current.selectedClientId ?? "choose"}</div>;
+    }
+
+    await renderProbe(<Probe />);
+    await flush();
+    await flush();
+
+    expect(expectHookValue(latest.current).connectedClients.map((client) => client.id)).toEqual([
+      "client-new",
+      "client-old",
+    ]);
+    expect(expectHookValue(latest.current).selectedClientId).toBeNull();
+    expect(expectHookValue(latest.current).connectedClient).toBeNull();
+    expect(activityMocks.getClientCapabilities).not.toHaveBeenCalled();
+
+    await act(async () => expectHookValue(latest.current).setSelectedClientId("client-old"));
+    await flush();
+    await flush();
+
+    expect(expectHookValue(latest.current).connectedClient?.id).toBe("client-old");
+    expect(activityMocks.getClientCapabilities).toHaveBeenCalledWith("client-old");
+    expect(expectHookValue(latest.current).selectedRuntime).toBe("claude-code");
+
+    await act(async () => expectHookValue(latest.current).setSelectedClientId("client-new"));
+    await flush();
+    await flush();
+    expect(expectHookValue(latest.current).selectedRuntime).toBe("codex");
+
+    await act(async () => expectHookValue(latest.current).setSelectedRuntime("claude-code"));
+    await act(async () => expectHookValue(latest.current).setSelectedClientId("client-old"));
+    await flush();
+    await flush();
+    await act(async () => expectHookValue(latest.current).setSelectedClientId("client-new"));
+    await flush();
+    await flush();
+    expect(expectHookValue(latest.current).selectedRuntime).toBe("claude-code");
+  });
+
   it("keeps an empty capability snapshot in detecting state until a provider report arrives", async () => {
     const latest = { current: null as ComputerConnection | null };
     const client = {
@@ -198,18 +292,7 @@ describe("shared setup hooks", () => {
       capabilities: {},
     };
     activityMocks.listClients.mockResolvedValue([client]);
-    activityMocks.getClientCapabilities.mockResolvedValueOnce({ ...client, capabilities: {} }).mockResolvedValueOnce({
-      ...client,
-      capabilities: {
-        codex: {
-          state: "ok",
-          available: true,
-          authenticated: true,
-          authMethod: "none",
-          detectedAt: "2026-05-28T12:00:05.000Z",
-        },
-      },
-    });
+    activityMocks.getClientCapabilities.mockResolvedValue({ ...client, capabilities: {} });
 
     function Probe() {
       latest.current = useComputerConnection(true);
@@ -225,8 +308,19 @@ describe("shared setup hooks", () => {
     expect(expectHookValue(latest.current).okRuntimes).toEqual([]);
     expect(expectHookValue(latest.current).selectedRuntime).toBeNull();
 
-    const tick = visibilityMocks.runVisibilityAwareInterval.mock.calls[0]?.[0];
-    if (!tick) throw new Error("visibility-aware interval was not registered");
+    activityMocks.getClientCapabilities.mockResolvedValue({
+      ...client,
+      capabilities: {
+        codex: {
+          state: "ok",
+          available: true,
+          authenticated: true,
+          authMethod: "none",
+          detectedAt: "2026-05-28T12:00:05.000Z",
+        },
+      },
+    });
+    const tick = latestVisibilityTick();
     await act(async () => {
       await tick();
     });
@@ -259,14 +353,7 @@ describe("shared setup hooks", () => {
       detectedAt: "2026-05-28T12:00:00.000Z",
     };
     activityMocks.listClients.mockResolvedValue([client]);
-    activityMocks.getClientCapabilities.mockRejectedValueOnce(new Error("capabilities offline")).mockResolvedValue({
-      ...client,
-      capabilities: {
-        // Disabled known provider + unknown wire id — neither is selectable.
-        "claude-code-tui": ok,
-        "future-provider": ok,
-      },
-    });
+    activityMocks.getClientCapabilities.mockRejectedValue(new Error("capabilities offline"));
 
     function Probe() {
       latest.current = useComputerConnection(true);
@@ -279,8 +366,15 @@ describe("shared setup hooks", () => {
 
     expect(expectHookValue(latest.current).capabilitiesLoaded).toBe(false);
 
-    const tick = visibilityMocks.runVisibilityAwareInterval.mock.calls[0]?.[0];
-    if (!tick) throw new Error("visibility-aware interval was not registered");
+    activityMocks.getClientCapabilities.mockResolvedValue({
+      ...client,
+      capabilities: {
+        // Disabled known provider + unknown wire id — neither is selectable.
+        "claude-code-tui": ok,
+        "future-provider": ok,
+      },
+    });
+    const tick = latestVisibilityTick();
     await act(async () => {
       await tick();
     });

--- a/packages/web/src/features/agent-setup/computer-selection.ts
+++ b/packages/web/src/features/agent-setup/computer-selection.ts
@@ -1,0 +1,65 @@
+import type { RuntimeProvider } from "@first-tree/shared";
+
+export type ComputerSelectionInput = {
+  clientIds: readonly string[];
+  currentClientId: string | null;
+  explicitlySelectedClientId: string | null;
+  requireExplicitWhenMultiple: boolean;
+};
+
+/**
+ * Resolves the computer shown by an agent-creation surface.
+ *
+ * A sole connected computer is unambiguous. With several computers, creation
+ * surfaces accept only a still-connected explicit choice; monitoring surfaces
+ * may preserve their current client or fall back to the freshest roster entry.
+ */
+export function resolveComputerSelection({
+  clientIds,
+  currentClientId,
+  explicitlySelectedClientId,
+  requireExplicitWhenMultiple,
+}: ComputerSelectionInput): string | null {
+  const onlyClientId = clientIds.length === 1 ? clientIds[0] : undefined;
+  if (onlyClientId) return onlyClientId;
+  if (clientIds.length === 0) return null;
+
+  if (requireExplicitWhenMultiple) {
+    return explicitlySelectedClientId && clientIds.includes(explicitlySelectedClientId)
+      ? explicitlySelectedClientId
+      : null;
+  }
+
+  return currentClientId && clientIds.includes(currentClientId) ? currentClientId : (clientIds[0] ?? null);
+}
+
+export type RuntimeSelectionInput = {
+  currentRuntime: RuntimeProvider | null;
+  selectionIsManual: boolean;
+  readyRuntimes: readonly RuntimeProvider[];
+};
+
+export type RuntimeSelection = {
+  runtime: RuntimeProvider | null;
+  selectionIsManual: boolean;
+};
+
+/**
+ * Keeps an explicit runtime choice while it remains available on the selected
+ * computer. Automatic choices are recalculated from the catalog-ordered ready
+ * list whenever the computer changes.
+ */
+export function resolveRuntimeSelection({
+  currentRuntime,
+  selectionIsManual,
+  readyRuntimes,
+}: RuntimeSelectionInput): RuntimeSelection {
+  if (selectionIsManual && currentRuntime && readyRuntimes.includes(currentRuntime)) {
+    return { runtime: currentRuntime, selectionIsManual: true };
+  }
+
+  return {
+    runtime: readyRuntimes[0] ?? currentRuntime,
+    selectionIsManual: false,
+  };
+}

--- a/packages/web/src/features/agent-setup/use-computer-connection.ts
+++ b/packages/web/src/features/agent-setup/use-computer-connection.ts
@@ -1,13 +1,9 @@
-import {
-  type ClientCapabilities,
-  enabledOkRuntimeProviders,
-  pickPreferredRuntimeProvider,
-  type RuntimeProvider,
-} from "@first-tree/shared";
+import { type ClientCapabilities, enabledOkRuntimeProviders, type RuntimeProvider } from "@first-tree/shared";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type ConnectTokenResponse, getClientCapabilities, type HubClient, listClients } from "../../api/activity.js";
 import { api } from "../../api/client.js";
 import { runVisibilityAwareInterval } from "../../lib/visibility-interval.js";
+import { resolveComputerSelection, resolveRuntimeSelection } from "./computer-selection.js";
 
 const CLIENT_DETECT_POLL_MS = 5_000;
 
@@ -18,16 +14,20 @@ const CLIENT_DETECT_POLL_MS = 5_000;
  * Lifecycle (mirrors the proven logic from the legacy Step2Body):
  *   1. Mint a short-lived connect token + bootstrap command (the command block
  *      the user pastes into their terminal).
- *   2. Poll `listClients()`; the most-recently-seen connected client wins.
- *   3. Once a client is connected, fetch its capabilities to learn which AI
- *      runtimes are ready, and auto-pick via the shared Codex-first catalog
- *      selection priority.
+ *   2. Poll `listClients()` and keep the connected-computer roster current.
+ *      A sole computer is automatic; multi-computer creation can require an
+ *      explicit choice instead of using heartbeat order.
+ *   3. Fetch capabilities for the selected computer to learn which runtimes
+ *      are ready, and auto-pick via the shared Codex-first catalog priority.
  *
  * Pure presentation state is returned; the React step renders it. Polling
  * pauses while the tab is hidden (`runVisibilityAwareInterval`) and stops
  * entirely when `enabled` is false.
  */
 export type ComputerConnection = {
+  connectedClients: HubClient[];
+  selectedClientId: string | null;
+  setSelectedClientId: (next: string | null) => void;
   connectedClient: HubClient | null;
   capabilitiesLoaded: boolean;
   /** Enabled `ok` providers in catalog display order. */
@@ -57,6 +57,12 @@ export type UseComputerConnectionOptions = {
    * running on the same computer represented by the Web's global signal.
    */
   prepareBootstrapWhenConnected?: boolean;
+  /**
+   * Do not silently choose between multiple connected computers. The one-
+   * computer path remains automatic; callers render a picker when this leaves
+   * `selectedClientId` null.
+   */
+  requireExplicitSelectionWhenMultiple?: boolean;
 };
 
 /** Silent auto-retries before surfacing a token-mint failure to the user. */
@@ -71,10 +77,11 @@ export function useComputerConnection(
   enabled: boolean,
   options: UseComputerConnectionOptions = {},
 ): ComputerConnection {
-  const [connectedClient, setConnectedClient] = useState<HubClient | null>(null);
+  const [connectedClients, setConnectedClients] = useState<HubClient[]>([]);
+  const [selectedClientIdState, setSelectedClientIdState] = useState<string | null>(null);
   const [capabilities, setCapabilities] = useState<ClientCapabilities | null>(null);
   const [capabilitiesClientId, setCapabilitiesClientId] = useState<string | null>(null);
-  const [selectedRuntime, setSelectedRuntime] = useState<RuntimeProvider | null>(null);
+  const [selectedRuntimeState, setSelectedRuntimeState] = useState<RuntimeProvider | null>(null);
   const [connectToken, setConnectToken] = useState<string | null>(null);
   const [connectTokenExpiresAt, setConnectTokenExpiresAt] = useState<number | null>(null);
   const [bootstrapCommand, setBootstrapCommand] = useState<string | null>(null);
@@ -82,45 +89,28 @@ export function useComputerConnection(
   // Bumped by retry() to force a fresh mint attempt from the effect below.
   const [retryNonce, setRetryNonce] = useState(0);
 
-  const capabilitiesClientIdRef = useRef<string | null>(null);
-  const detectSeqRef = useRef(0);
+  const clientDetectSeqRef = useRef(0);
+  const capabilitiesDetectSeqRef = useRef(0);
+  const explicitlySelectedClientIdRef = useRef<string | null>(null);
+  const runtimeSelectionIsManualRef = useRef(false);
   const onTokenMintFailedRef = useRef(options.onTokenMintFailed);
   onTokenMintFailedRef.current = options.onTokenMintFailed;
 
-  // Detect the connected computer + its capabilities.
+  // Detect all connected computers. Selection and capability polling are
+  // separate so a multi-computer create step can pause for an explicit choice
+  // instead of fetching from the most-recent heartbeat implicitly.
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
     const detect = async (): Promise<void> => {
-      const seq = ++detectSeqRef.current;
+      const seq = ++clientDetectSeqRef.current;
       try {
         const clients = await listClients();
-        if (cancelled || seq !== detectSeqRef.current) return;
+        if (cancelled || seq !== clientDetectSeqRef.current) return;
         const connected = clients
           .filter((c) => c.status === "connected")
           .sort((a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt));
-        const latest = connected[0] ?? null;
-        setConnectedClient((prev) => (prev?.id === latest?.id ? prev : latest));
-        if (latest) {
-          if (capabilitiesClientIdRef.current !== latest.id) {
-            capabilitiesClientIdRef.current = null;
-            setCapabilitiesClientId(null);
-            setCapabilities(null);
-          }
-          try {
-            const withCaps = await getClientCapabilities(latest.id);
-            if (cancelled || seq !== detectSeqRef.current) return;
-            capabilitiesClientIdRef.current = latest.id;
-            setCapabilitiesClientId(latest.id);
-            setCapabilities(withCaps.capabilities);
-          } catch {
-            // transient — try again next tick
-          }
-        } else {
-          capabilitiesClientIdRef.current = null;
-          setCapabilitiesClientId(null);
-          setCapabilities(null);
-        }
+        setConnectedClients(connected);
       } catch {
         // best-effort
       }
@@ -132,6 +122,67 @@ export function useComputerConnection(
     };
   }, [enabled]);
 
+  const clientIds = useMemo(() => connectedClients.map((client) => client.id), [connectedClients]);
+  const selectedClientId = resolveComputerSelection({
+    clientIds,
+    currentClientId: selectedClientIdState,
+    explicitlySelectedClientId: explicitlySelectedClientIdRef.current,
+    requireExplicitWhenMultiple: options.requireExplicitSelectionWhenMultiple === true,
+  });
+
+  const setSelectedClientId = useCallback((next: string | null): void => {
+    explicitlySelectedClientIdRef.current = next;
+    setSelectedClientIdState(next);
+  }, []);
+
+  // Keep storage aligned with the synchronously-derived effective choice. The
+  // render never exposes a stale automatic choice while this effect catches up.
+  useEffect(() => {
+    const explicitClientId = explicitlySelectedClientIdRef.current;
+    if (explicitClientId && !clientIds.includes(explicitClientId)) {
+      explicitlySelectedClientIdRef.current = null;
+    }
+    setSelectedClientIdState((prev) => (prev === selectedClientId ? prev : selectedClientId));
+  }, [clientIds, selectedClientId]);
+
+  const connectedClient = useMemo(
+    () => connectedClients.find((client) => client.id === selectedClientId) ?? null,
+    [connectedClients, selectedClientId],
+  );
+
+  // Poll capabilities only for the chosen computer. A stale response from a
+  // previous choice cannot become active because both sequence and client id
+  // are checked before committing it.
+  useEffect(() => {
+    if (!enabled || !selectedClientId) {
+      capabilitiesDetectSeqRef.current += 1;
+      setCapabilitiesClientId(null);
+      setCapabilities(null);
+      return;
+    }
+    let cancelled = false;
+    setCapabilitiesClientId(null);
+    setCapabilities(null);
+    const detectCapabilities = async (): Promise<void> => {
+      const seq = ++capabilitiesDetectSeqRef.current;
+      try {
+        const withCaps = await getClientCapabilities(selectedClientId);
+        if (cancelled || seq !== capabilitiesDetectSeqRef.current) return;
+        setCapabilitiesClientId(selectedClientId);
+        setCapabilities(withCaps.capabilities);
+      } catch {
+        // The interval owns retry timing; an explicit return keeps the last
+        // successful snapshot inactive only when the selected client changed.
+        return;
+      }
+    };
+    const dispose = runVisibilityAwareInterval(detectCapabilities, CLIENT_DETECT_POLL_MS);
+    return () => {
+      cancelled = true;
+      dispose();
+    };
+  }, [enabled, selectedClientId]);
+
   // Mint / refresh the connect token while no computer is connected yet.
   // retryNonce in the deps is an intentional re-run trigger (bumped by retry()
   // after a failure); it isn't read inside, hence the suppression.
@@ -139,7 +190,7 @@ export function useComputerConnection(
   useEffect(() => {
     if (!enabled) return;
     if (options.allowBootstrapMint === false) return;
-    if (connectedClient && !options.prepareBootstrapWhenConnected) return;
+    if (connectedClients.length > 0 && !options.prepareBootstrapWhenConnected) return;
     if (connectToken && connectTokenExpiresAt && connectTokenExpiresAt > Date.now()) {
       const refreshAt = Math.max(connectTokenExpiresAt - Date.now(), 0);
       const handle = window.setTimeout(() => {
@@ -187,7 +238,7 @@ export function useComputerConnection(
     };
   }, [
     enabled,
-    connectedClient,
+    connectedClients.length,
     connectToken,
     connectTokenExpiresAt,
     options.allowBootstrapMint,
@@ -216,20 +267,33 @@ export function useComputerConnection(
   // Auto-pick via the catalog preference prefix while preserving Client order;
   // keep a still-valid prior choice.
   useEffect(() => {
-    setSelectedRuntime((prev) => {
+    setSelectedRuntimeState((prev) => {
       if (!activeCapabilities) return prev;
-      if (prev && okRuntimes.includes(prev)) return prev;
-      return pickPreferredRuntimeProvider(activeCapabilities);
+      const next = resolveRuntimeSelection({
+        currentRuntime: prev,
+        selectionIsManual: runtimeSelectionIsManualRef.current,
+        readyRuntimes: okRuntimes,
+      });
+      runtimeSelectionIsManualRef.current = next.selectionIsManual;
+      return next.runtime;
     });
   }, [activeCapabilities, okRuntimes]);
+
+  const setSelectedRuntime = useCallback((next: RuntimeProvider | null): void => {
+    runtimeSelectionIsManualRef.current = next !== null;
+    setSelectedRuntimeState(next);
+  }, []);
 
   const cliCommand = bootstrapCommand;
 
   return {
+    connectedClients,
+    selectedClientId,
+    setSelectedClientId,
     connectedClient,
     capabilitiesLoaded: activeCapabilities !== null,
     okRuntimes,
-    selectedRuntime,
+    selectedRuntime: selectedRuntimeState,
     setSelectedRuntime,
     cliCommand,
     tokenError,

--- a/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
@@ -399,6 +399,43 @@ describe("onboarding preview review surface", () => {
     await act(async () => live.root.unmount());
   });
 
+  it("previews the explicit multi-computer choice before runtime options", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/preview/onboarding?role=admin&view=states&scenario=admin-ca-multiple-computers",
+    );
+    const { OnboardingPreviewPage } = await import("../onboarding-preview.js");
+    const view = await renderDom(
+      <MemoryRouter>
+        <OnboardingPreviewPage />
+      </MemoryRouter>,
+    );
+
+    await waitForText(view.container, "Choose a computer");
+    expect(view.container.textContent).not.toContain("Codex");
+    expect(view.container.textContent).not.toContain("isn't connected");
+    const create = [...view.container.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent?.trim() === "Create agent",
+    );
+    expect(create?.disabled).toBe(true);
+
+    await clickByText(view.container, "Choose a computer");
+    const studio = [...document.body.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+      button.textContent?.includes("gandys-studio"),
+    );
+    if (!studio) throw new Error("Missing gandys-studio option");
+    await act(async () => {
+      studio.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+
+    expect(view.container.textContent).toContain("gandys-studioLinux · online");
+    expect(view.container.textContent).toContain("Codex");
+    expect(view.container.textContent).not.toContain("Powered by");
+    await act(async () => view.root.unmount());
+  });
+
   it("does not repeat the BYO choice after the member selected a First Tree agent", async () => {
     authMock.memberships = [{}];
     window.history.replaceState(null, "", "/preview/onboarding?role=invitee&view=flow&scenario=inv-ko-ready");

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -759,6 +759,9 @@ function createFlowValue(overrides: FlowOverrides = {}): OnboardingFlowValue {
     teamDisplayName: "Acme",
     orgHasOtherMembers: true,
     computer: {
+      connectedClients: CLIENTS[0] ? [CLIENTS[0]] : [],
+      selectedClientId: CLIENTS[0]?.id ?? null,
+      setSelectedClientId: () => undefined,
       connectedClient: CLIENTS[0] ?? null,
       capabilitiesLoaded: true,
       okRuntimes: ["claude-code", "codex"],

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -2134,6 +2134,48 @@ describe("web DOM interaction coverage", () => {
     await unmountRoot(root);
   });
 
+  it("explains how to recover when the selected computer has no ready runtime", async () => {
+    authMock.value = { ...authMock.value, currentOrgHasPersonalAgent: false };
+    const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
+    const firstClient = CLIENTS[0];
+    const secondClientBase = CLIENTS[1];
+    if (!firstClient || !secondClientBase) throw new Error("Expected two connected client fixtures");
+    const secondClient: HubClient = {
+      ...secondClientBase,
+      status: "connected",
+      authState: "ok",
+    };
+    const { container, root } = await renderOnboardingDom(<StepCreateAgent />, {
+      activeStep: "create-agent",
+      computer: {
+        connectedClients: [firstClient, secondClient],
+        selectedClientId: secondClient.id,
+        setSelectedClientId: vi.fn(),
+        connectedClient: secondClient,
+        capabilitiesLoaded: true,
+        okRuntimes: [],
+        selectedRuntime: null,
+        setSelectedRuntime: vi.fn(),
+        cliCommand: "first-tree-dev login token",
+        tokenError: null,
+        retry: vi.fn(),
+      },
+    });
+
+    await waitForText("Nothing is ready to run on this computer", container);
+    expect(container.textContent).not.toContain("Not ready");
+    expect(container.querySelectorAll('input[name="onboarding-coding-agent"]')).toHaveLength(0);
+    const recoveryLink = container.querySelector<HTMLAnchorElement>('a[href="/settings/computers"]');
+    expect(recoveryLink?.textContent).toContain("Finish setup in Settings → Computers");
+    expect(recoveryLink?.target).toBe("_blank");
+    expect(recoveryLink?.rel).toContain("noopener");
+    const create = [...container.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+      button.textContent?.includes("Create agent"),
+    );
+    expect(create?.disabled).toBe(true);
+    await unmountRoot(root);
+  });
+
   it("handles create-agent timeout actions", async () => {
     const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
     const retryAgent = vi.fn(async () => undefined);

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -487,6 +487,9 @@ function createFlowValue(overrides: FlowOverrides = {}): OnboardingFlowValue {
     teamDisplayName: "Acme",
     orgHasOtherMembers: true,
     computer: {
+      connectedClients: CLIENTS[0] ? [CLIENTS[0]] : [],
+      selectedClientId: CLIENTS[0]?.id ?? null,
+      setSelectedClientId: vi.fn(),
       connectedClient: CLIENTS[0] ?? null,
       capabilitiesLoaded: true,
       okRuntimes: ["claude-code", "codex"],
@@ -2037,6 +2040,9 @@ describe("web DOM interaction coverage", () => {
       setVisibility,
       createAgent,
       computer: {
+        connectedClients: CLIENTS[0] ? [CLIENTS[0]] : [],
+        selectedClientId: CLIENTS[0]?.id ?? null,
+        setSelectedClientId: vi.fn(),
         connectedClient: CLIENTS[0] ?? null,
         capabilitiesLoaded: true,
         okRuntimes: ["claude-code", "codex"],
@@ -2080,6 +2086,54 @@ describe("web DOM interaction coverage", () => {
     await unmountRoot(root);
   });
 
+  it("requires a computer choice before showing runtime options when several are online", async () => {
+    authMock.value = { ...authMock.value, currentOrgHasPersonalAgent: false };
+    const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
+    const setSelectedClientId = vi.fn();
+    const firstClient = CLIENTS[0];
+    const secondClientBase = CLIENTS[1];
+    if (!firstClient || !secondClientBase) throw new Error("Expected two connected client fixtures");
+    const secondClient: HubClient = {
+      ...secondClientBase,
+      status: "connected",
+      authState: "ok",
+    };
+    const { container, root } = await renderOnboardingDom(<StepCreateAgent />, {
+      activeStep: "create-agent",
+      computer: {
+        connectedClients: [firstClient, secondClient],
+        selectedClientId: null,
+        setSelectedClientId,
+        connectedClient: null,
+        capabilitiesLoaded: false,
+        okRuntimes: [],
+        selectedRuntime: null,
+        setSelectedRuntime: vi.fn(),
+        cliCommand: "first-tree-dev login token",
+        tokenError: null,
+        retry: vi.fn(),
+      },
+    });
+
+    await waitForText("Choose a computer", container);
+    expect(container.textContent).not.toContain("Not ready");
+    expect(container.textContent).not.toContain("isn't connected");
+    expect(container.querySelectorAll('input[name="onboarding-coding-agent"]')).toHaveLength(0);
+    const create = [...container.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+      button.textContent?.includes("Create agent"),
+    );
+    expect(create?.disabled).toBe(true);
+
+    await click(container.querySelector("#onboarding-agent-computer"));
+    await click(
+      [...document.body.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+        button.textContent?.includes("alice-linux"),
+      ) ?? null,
+    );
+    expect(setSelectedClientId).toHaveBeenCalledWith("client-2");
+    await unmountRoot(root);
+  });
+
   it("handles create-agent timeout actions", async () => {
     const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
     const retryAgent = vi.fn(async () => undefined);
@@ -2114,6 +2168,9 @@ describe("web DOM interaction coverage", () => {
       activeStep: "create-agent",
       goTo,
       computer: {
+        connectedClients: [],
+        selectedClientId: null,
+        setSelectedClientId: vi.fn(),
         connectedClient: null,
         capabilitiesLoaded: true,
         okRuntimes: [],

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -814,6 +814,42 @@ describe("Select", () => {
     getRect.mockRestore();
   });
 
+  it("keeps stacked option context visible in both the trigger and list", async () => {
+    const { Select } = await import("../../../components/ui/select.js");
+    const getRect = vi.spyOn(HTMLButtonElement.prototype, "getBoundingClientRect");
+    getRect.mockReturnValue({
+      x: 10,
+      y: 20,
+      top: 20,
+      right: 210,
+      bottom: 68,
+      left: 10,
+      width: 200,
+      height: 48,
+      toJSON: () => ({}),
+    });
+    const { container, root } = await renderDom(
+      <Select
+        value="alpha"
+        onChange={vi.fn()}
+        hintLayout="stacked"
+        options={[
+          { value: "alpha", label: "Studio Mac", hint: "darwin · online" },
+          { value: "beta", label: "Travel Mac", hint: "linux · online" },
+        ]}
+      />,
+    );
+
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-haspopup="listbox"]');
+    expect(trigger?.textContent).toContain("Studio Macdarwin · online");
+    await click(trigger);
+    const travel = buttonByText(document.body, "Travel Mac");
+    expect(travel?.textContent).toContain("Travel Maclinux · online");
+
+    await act(async () => root.unmount());
+    getRect.mockRestore();
+  });
+
   it("stays closed when disabled and falls back to the raw value for unknown selections", async () => {
     const { Select } = await import("../../../components/ui/select.js");
     const onChange = vi.fn();

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -73,6 +73,13 @@ const HOST: HubClient = {
   lastSeenAt: NOW_ISO,
   capabilities: {},
 };
+const SECOND_HOST: HubClient = {
+  ...HOST,
+  id: "client-2c8b40",
+  hostname: "gandys-studio",
+  os: "linux",
+  lastSeenAt: new Date(Date.now() - 60_000).toISOString(),
+};
 
 const REPO_WEB = "https://github.com/acme/web.git";
 
@@ -182,11 +189,15 @@ const COMPUTER: Record<
   | "ready"
   | "readyCodex"
   | "readyMulti"
+  | "readyMultipleComputers"
   | "unsupportedByo"
   | "lostWhileReady",
   ComputerConnection
 > = {
   waiting: {
+    connectedClients: [],
+    selectedClientId: null,
+    setSelectedClientId: NOOP,
     connectedClient: null,
     capabilitiesLoaded: false,
     okRuntimes: [],
@@ -197,6 +208,9 @@ const COMPUTER: Record<
     retry: NOOP,
   },
   tokenError: {
+    connectedClients: [],
+    selectedClientId: null,
+    setSelectedClientId: NOOP,
     connectedClient: null,
     capabilitiesLoaded: false,
     okRuntimes: [],
@@ -207,6 +221,9 @@ const COMPUTER: Record<
     retry: NOOP,
   },
   detecting: {
+    connectedClients: [HOST],
+    selectedClientId: HOST.id,
+    setSelectedClientId: NOOP,
     connectedClient: HOST,
     capabilitiesLoaded: false,
     okRuntimes: [],
@@ -217,6 +234,9 @@ const COMPUTER: Record<
     retry: NOOP,
   },
   noRuntime: {
+    connectedClients: [HOST],
+    selectedClientId: HOST.id,
+    setSelectedClientId: NOOP,
     connectedClient: HOST,
     capabilitiesLoaded: true,
     okRuntimes: [],
@@ -228,6 +248,9 @@ const COMPUTER: Record<
   },
   // Exactly one runtime → the step renders a confirmation line (no picker).
   ready: {
+    connectedClients: [HOST],
+    selectedClientId: HOST.id,
+    setSelectedClientId: NOOP,
     connectedClient: HOST,
     capabilitiesLoaded: true,
     okRuntimes: ["claude-code"],
@@ -239,6 +262,9 @@ const COMPUTER: Record<
   },
   // BYO provider projection with Codex as the only supported local surface.
   readyCodex: {
+    connectedClients: [HOST],
+    selectedClientId: HOST.id,
+    setSelectedClientId: NOOP,
     connectedClient: HOST,
     capabilitiesLoaded: true,
     okRuntimes: ["codex"],
@@ -250,9 +276,27 @@ const COMPUTER: Record<
   },
   // Multiple runtimes → the step renders the single-select runtime list.
   readyMulti: {
+    connectedClients: [HOST],
+    selectedClientId: HOST.id,
+    setSelectedClientId: NOOP,
     connectedClient: HOST,
     capabilitiesLoaded: true,
     okRuntimes: ["claude-code", "codex", "opencode", "pi"],
+    selectedRuntime: "codex",
+    setSelectedRuntime: NOOP,
+    cliCommand: SAMPLE_CLI,
+    tokenError: null,
+    retry: NOOP,
+  },
+  // Multiple online computers require an explicit choice before runtime
+  // options become actionable.
+  readyMultipleComputers: {
+    connectedClients: [HOST, SECOND_HOST],
+    selectedClientId: null,
+    setSelectedClientId: NOOP,
+    connectedClient: null,
+    capabilitiesLoaded: true,
+    okRuntimes: ["codex", "claude-code", "opencode", "pi"],
     selectedRuntime: "codex",
     setSelectedRuntime: NOOP,
     cliCommand: SAMPLE_CLI,
@@ -264,6 +308,9 @@ const COMPUTER: Record<
   // narrower handoff capability without implying the tools themselves are
   // unsupported by First Tree.
   unsupportedByo: {
+    connectedClients: [HOST],
+    selectedClientId: HOST.id,
+    setSelectedClientId: NOOP,
     connectedClient: HOST,
     capabilitiesLoaded: true,
     okRuntimes: ["cursor", "kimi-code"],
@@ -277,6 +324,9 @@ const COMPUTER: Record<
   // are gone (okRuntimes empties) but the last pick is remembered, so create-agent
   // shows that coding agent DISABLED rather than letting the field vanish.
   lostWhileReady: {
+    connectedClients: [],
+    selectedClientId: null,
+    setSelectedClientId: NOOP,
     connectedClient: null,
     capabilitiesLoaded: false,
     okRuntimes: [],
@@ -712,6 +762,13 @@ export const ONBOARDING_PREVIEW_SCENARIOS: Scenario[] = [
     role: "admin",
     view: "flow",
     wizard: { step: "create-agent", flow: { computer: COMPUTER.ready, agentPhase: "idle" } },
+  },
+  {
+    id: "admin-ca-multiple-computers",
+    label: "Create agent · choose computer",
+    group: "Create-agent states",
+    role: "admin",
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.readyMultipleComputers, agentPhase: "idle" } },
   },
   {
     id: "admin-ca-creating",
@@ -1615,6 +1672,7 @@ function WizardScenarioView({ spec, role }: { spec: WizardSpec; role: Role }) {
   const [selectedRuntime, setSelectedRuntime] = useState<RuntimeProvider | null>(
     init.computer?.selectedRuntime ?? null,
   );
+  const [selectedClientId, setSelectedClientId] = useState<string | null>(init.computer?.selectedClientId ?? null);
 
   const queryClient = useMemo(
     () => new QueryClient({ defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } } }),
@@ -1622,6 +1680,8 @@ function WizardScenarioView({ spec, role }: { spec: WizardSpec; role: Role }) {
   );
 
   const base = baseFlow(path);
+  const selectedConnectedClient =
+    init.computer?.connectedClients.find((client) => client.id === selectedClientId) ?? null;
   const flow: OnboardingFlowValue = {
     ...base,
     ...init,
@@ -1641,9 +1701,21 @@ function WizardScenarioView({ spec, role }: { spec: WizardSpec; role: Role }) {
     setTreeUrl,
     treeAutoDetectDone,
     markTreeAutoDetectDone: () => setTreeAutoDetectDone(true),
-    // Override the injected computer's runtime selection with the stateful
-    // pair so clicking a runtime pill re-renders with the new choice.
-    computer: init.computer ? { ...init.computer, selectedRuntime, setSelectedRuntime } : base.computer,
+    // Keep both choices stateful. Deriving the active computer from the id
+    // lets the multi-computer preview move from placeholder → selected host →
+    // runtime pills exactly like production.
+    computer: init.computer
+      ? {
+          ...init.computer,
+          selectedClientId,
+          setSelectedClientId,
+          connectedClient: selectedConnectedClient,
+          capabilitiesLoaded: selectedConnectedClient ? init.computer.capabilitiesLoaded : false,
+          okRuntimes: selectedConnectedClient ? init.computer.okRuntimes : [],
+          selectedRuntime,
+          setSelectedRuntime,
+        }
+      : base.computer,
   };
 
   const Shell = OnboardingShell;

--- a/packages/web/src/pages/onboarding/__tests__/onboarding-flow-template-intent.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/onboarding-flow-template-intent.test.tsx
@@ -55,6 +55,9 @@ vi.mock("../../../features/agent-setup/use-agent-creation.js", async (importOrig
 });
 vi.mock("../../../features/agent-setup/use-computer-connection.js", () => ({
   useComputerConnection: () => ({
+    connectedClients: [],
+    selectedClientId: null,
+    setSelectedClientId: vi.fn(),
     connectedClient: null,
     capabilitiesLoaded: false,
     okRuntimes: [],

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -213,6 +213,15 @@ export const COPY = {
     // disabled picker reads AS unavailable (action needed: reconnect) at a glance,
     // not just a quietly greyed pill.
     codingAgentNotReady: "Not ready",
+    /** A selected computer can be online without any ready runtime. Keep the
+        reason and recovery action inside the execution field so a disabled
+        Create button never becomes an unexplained dead end. Settings opens in
+        another tab, preserving this onboarding draft while setup is finished. */
+    noRuntime: {
+      pre: "Nothing is ready to run on this computer. ",
+      link: "Finish setup in Settings → Computers",
+      post: ", then come back.",
+    },
     nameLabel: "Name your agent",
     // "Bringing your agent online…" (not "Setting up…"): the step registers the
     // agent then polls until it comes online. Pairs with timeout's "isn't online

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -300,6 +300,7 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
     onTokenMintFailed: () => reportStepFailure("connect_token_mint_failed", { step: "connect-computer" }),
     allowBootstrapMint: activeStep !== "get-started" || byoBootstrapRequested,
     prepareBootstrapWhenConnected: activeStep === "get-started" && byoBootstrapRequested,
+    requireExplicitSelectionWhenMultiple: activeStep === "create-agent",
   });
 
   // A connected computer with a completed capability report but no usable

--- a/packages/web/src/pages/onboarding/steps/__tests__/step-connect-computer-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-connect-computer-dom.test.tsx
@@ -17,6 +17,9 @@ const BOOTSTRAP_COMMAND =
 
 function computer(overrides: Partial<ComputerConnection> = {}): ComputerConnection {
   return {
+    connectedClients: [],
+    selectedClientId: null,
+    setSelectedClientId: vi.fn(),
     connectedClient: null,
     capabilitiesLoaded: false,
     okRuntimes: [],

--- a/packages/web/src/pages/onboarding/steps/__tests__/step-create-agent-template.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-create-agent-template.test.tsx
@@ -16,28 +16,38 @@ const templateMocks = vi.hoisted(() => ({
   updateAgentTemplates: vi.fn(),
 }));
 
-const flowMock = vi.hoisted(() => ({
-  path: "admin" as const,
-  organizationId: "org-1" as string | null,
-  agentDisplayName: "My assistant",
-  setAgentDisplayName: vi.fn(),
-  visibility: "organization" as const,
-  setVisibility: vi.fn(),
-  computer: {
-    connectedClient: { id: "client-1" } as { id: string } | null,
-    selectedRuntime: "claude-code" as string | null,
-    setSelectedRuntime: vi.fn(),
-    okRuntimes: ["claude-code"],
-  },
-  createAgent: vi.fn(async (_args: Record<string, unknown>) => undefined),
-  retryAgent: vi.fn(async () => undefined),
-  finishLater: vi.fn(async () => undefined),
-  agentPhase: "idle" as const,
-  agentError: null as string | null,
-  goNext: vi.fn(),
-  goTo: vi.fn(),
-  sequence: ["create-team", "connect-computer", "create-agent", "start-chat"] as const,
-}));
+const flowMock = vi.hoisted(() => {
+  function nullable<T>(value: T): T | null {
+    return value;
+  }
+
+  return {
+    path: "admin" as const,
+    organizationId: "org-1" as string | null,
+    agentDisplayName: "My assistant",
+    setAgentDisplayName: vi.fn(),
+    visibility: "organization" as const,
+    setVisibility: vi.fn(),
+    computer: {
+      connectedClients: [{ id: "client-1", hostname: "gandy-macbook", os: "darwin" }],
+      selectedClientId: nullable("client-1"),
+      setSelectedClientId: vi.fn(),
+      connectedClient: nullable({ id: "client-1", hostname: "gandy-macbook", os: "darwin" }),
+      capabilitiesLoaded: true,
+      selectedRuntime: nullable("claude-code"),
+      setSelectedRuntime: vi.fn(),
+      okRuntimes: ["claude-code"],
+    },
+    createAgent: vi.fn(async (_args: Record<string, unknown>) => undefined),
+    retryAgent: vi.fn(async () => undefined),
+    finishLater: vi.fn(async () => undefined),
+    agentPhase: "idle" as const,
+    agentError: null as string | null,
+    goNext: vi.fn(),
+    goTo: vi.fn(),
+    sequence: ["create-team", "connect-computer", "create-agent", "start-chat"] as const,
+  };
+});
 
 const authMock = vi.hoisted(() => ({
   value: { currentOrgHasPersonalAgent: false },
@@ -185,7 +195,7 @@ describe("StepCreateAgent template intent", () => {
     flowMock.agentPhase = "idle";
     flowMock.agentError = null;
     flowMock.organizationId = "org-1";
-    flowMock.computer.connectedClient = { id: "client-1" };
+    flowMock.computer.connectedClient = { id: "client-1", hostname: "gandy-macbook", os: "darwin" };
     flowMock.computer.selectedRuntime = "claude-code";
     authMock.value.currentOrgHasPersonalAgent = false;
     windowProbeEnabled = false;

--- a/packages/web/src/pages/onboarding/steps/__tests__/step-get-started-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-get-started-dom.test.tsx
@@ -51,6 +51,9 @@ function flow(overrides: Partial<OnboardingFlowValue> = {}): OnboardingFlowValue
     teamDisplayName: "Acme",
     orgHasOtherMembers: true,
     computer: {
+      connectedClients: [],
+      selectedClientId: null,
+      setSelectedClientId: vi.fn(),
       connectedClient: null,
       capabilitiesLoaded: false,
       okRuntimes: [],
@@ -204,6 +207,9 @@ describe("StepGetStarted", () => {
   it("skips the computer step when a supported coding tool is already ready", async () => {
     const value = flow({
       computer: {
+        connectedClients: [],
+        selectedClientId: "client-1",
+        setSelectedClientId: vi.fn(),
         connectedClient: {
           id: "client-1",
           hostname: "caseys-mac",
@@ -334,6 +340,9 @@ describe("StepGetStarted", () => {
     const value = flow({
       offerTeamAgentStart: false,
       computer: {
+        connectedClients: [],
+        selectedClientId: "client-1",
+        setSelectedClientId: vi.fn(),
         connectedClient: {
           id: "client-1",
           hostname: "caseys-mac",
@@ -364,6 +373,9 @@ describe("StepGetStarted", () => {
   it("does not infer BYO provider readiness from the globally connected Computer", async () => {
     const value = flow({
       computer: {
+        connectedClients: [],
+        selectedClientId: "client-1",
+        setSelectedClientId: vi.fn(),
         connectedClient: {
           id: "client-1",
           hostname: "caseys-mac",
@@ -391,6 +403,9 @@ describe("StepGetStarted", () => {
   it("allows BYO from a Browser whose connected Computer reports only another runtime", async () => {
     const value = flow({
       computer: {
+        connectedClients: [],
+        selectedClientId: "client-1",
+        setSelectedClientId: vi.fn(),
         connectedClient: {
           id: "client-1",
           hostname: "caseys-mac",

--- a/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
@@ -166,6 +166,7 @@ export function StepCreateAgent() {
   // jump. A disabled pill + the reconnect hint reads as "your agent's here, just
   // temporarily unreachable", not "it's gone".
   const connected = !!computer.connectedClient;
+  const noRuntime = connected && computer.capabilitiesLoaded && orderedOkRuntimes.length === 0;
   const displayProviders = connected
     ? orderedOkRuntimes
     : computer.connectedClients.length === 0 && selectedRuntime
@@ -273,6 +274,20 @@ export function StepCreateAgent() {
         <p className="text-caption text-muted-foreground" role="status" style={{ margin: 0 }}>
           Detecting what this computer can run…
         </p>
+      ) : noRuntime ? (
+        <FlowHint role="status">
+          {COPY.createAgent.noRuntime.pre}
+          <a
+            href="/settings/computers"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-2"
+            style={{ color: "var(--primary)" }}
+          >
+            {COPY.createAgent.noRuntime.link}
+          </a>
+          {COPY.createAgent.noRuntime.post}
+        </FlowHint>
       ) : displayProviders.length > 0 ? (
         <div className="flex flex-wrap" style={{ gap: "var(--sp-2)" }}>
           {displayProviders.map((provider) => (

--- a/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
@@ -8,6 +8,7 @@ import { ArrowRight } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { getAgentTemplate } from "../../../api/agent-templates.js";
 import { useAuth } from "../../../auth/auth-context.js";
+import { ConnectedComputerSelect, ConnectedComputerSummary } from "../../../components/connected-computer-select.js";
 import { Button } from "../../../components/ui/button.js";
 import { Input } from "../../../components/ui/input.js";
 import { OptionCard } from "../../../components/ui/option-card.js";
@@ -158,11 +159,6 @@ export function StepCreateAgent() {
   // Codex-first catalog preference in `useComputerConnection`.
   const { okRuntimes, selectedRuntime, setSelectedRuntime } = computer;
   const orderedOkRuntimes = useMemo(() => orderRuntimeProvidersByPreference(okRuntimes), [okRuntimes]);
-  useEffect(() => {
-    if (selectedRuntime && orderedOkRuntimes.includes(selectedRuntime)) return;
-    const next = orderedOkRuntimes[0];
-    if (next) setSelectedRuntime(next);
-  }, [orderedOkRuntimes, selectedRuntime, setSelectedRuntime]);
 
   // Coding-agent pills to render. When the computer drops mid-form, okRuntimes
   // empties but `selectedRuntime` keeps the last pick — so we still show THAT
@@ -170,7 +166,11 @@ export function StepCreateAgent() {
   // jump. A disabled pill + the reconnect hint reads as "your agent's here, just
   // temporarily unreachable", not "it's gone".
   const connected = !!computer.connectedClient;
-  const displayProviders = orderedOkRuntimes.length > 0 ? orderedOkRuntimes : selectedRuntime ? [selectedRuntime] : [];
+  const displayProviders = connected
+    ? orderedOkRuntimes
+    : computer.connectedClients.length === 0 && selectedRuntime
+      ? [selectedRuntime]
+      : [];
 
   if (agentPhase === "creating") {
     return <WorkingState label={COPY.createAgent.creating} hint={COPY.createAgent.creatingHint} />;
@@ -217,47 +217,63 @@ export function StepCreateAgent() {
     });
   };
 
-  const toolPicker =
-    displayProviders.length > 0 ? (
-      <fieldset className="flex flex-col" style={{ gap: "var(--sp-2)", margin: 0, padding: 0, border: 0 }}>
-        <legend
-          className="text-label font-medium"
-          style={{
-            color: "var(--fg-2)",
-            marginBottom: "var(--sp-1)",
-            display: "inline-flex",
-            alignItems: "center",
-            gap: "var(--sp-2)",
-          }}
-        >
-          {COPY.createAgent.codingAgentLabel}
-          {/* Prominent amber "Not ready" badge when the computer dropped — makes
-              the disabled pill read as unavailable (reconnect needed), not just
-              quietly greyed. */}
-          {!connected && (
+  const executionPicker = (
+    <fieldset className="flex flex-col" style={{ gap: "var(--sp-2)", margin: 0, padding: 0, border: 0 }}>
+      <legend
+        className="text-label font-medium"
+        style={{
+          color: "var(--fg-2)",
+          marginBottom: "var(--sp-1)",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "var(--sp-2)",
+        }}
+      >
+        {COPY.createAgent.codingAgentLabel}
+        {/* Only a genuinely disconnected state is "Not ready". With several
+            online computers and no selection, the dropdown itself is the
+            required next action. */}
+        {computer.connectedClients.length === 0 && (
+          <span
+            className="inline-flex items-center text-caption font-medium"
+            style={{
+              gap: "var(--sp-1)",
+              padding: "var(--sp-0_5) var(--sp-1_5)",
+              borderRadius: "var(--radius-chip)",
+              background: "var(--state-needs-you-soft)",
+              color: "var(--fg-needs-you-strong)",
+            }}
+          >
             <span
-              className="inline-flex items-center text-caption font-medium"
+              aria-hidden="true"
               style={{
-                gap: "var(--sp-1)",
-                padding: "var(--sp-0_5) var(--sp-1_5)",
-                borderRadius: "var(--radius-chip)",
-                background: "var(--state-needs-you-soft)",
-                color: "var(--fg-needs-you-strong)",
+                width: "var(--sp-1_5)",
+                height: "var(--sp-1_5)",
+                borderRadius: "var(--radius-full)",
+                background: "var(--state-needs-you)",
               }}
-            >
-              <span
-                aria-hidden="true"
-                style={{
-                  width: "var(--sp-1_5)",
-                  height: "var(--sp-1_5)",
-                  borderRadius: "var(--radius-full)",
-                  background: "var(--state-needs-you)",
-                }}
-              />
-              {COPY.createAgent.codingAgentNotReady}
-            </span>
-          )}
-        </legend>
+            />
+            {COPY.createAgent.codingAgentNotReady}
+          </span>
+        )}
+      </legend>
+
+      {computer.connectedClients.length > 1 ? (
+        <ConnectedComputerSelect
+          clients={computer.connectedClients}
+          value={computer.selectedClientId}
+          onChange={computer.setSelectedClientId}
+          id="onboarding-agent-computer"
+        />
+      ) : computer.connectedClients.length === 1 && computer.connectedClients[0] ? (
+        <ConnectedComputerSummary client={computer.connectedClients[0]} />
+      ) : null}
+
+      {connected && !computer.capabilitiesLoaded ? (
+        <p className="text-caption text-muted-foreground" role="status" style={{ margin: 0 }}>
+          Detecting what this computer can run…
+        </p>
+      ) : displayProviders.length > 0 ? (
         <div className="flex flex-wrap" style={{ gap: "var(--sp-2)" }}>
           {displayProviders.map((provider) => (
             <OptionCard
@@ -272,8 +288,9 @@ export function StepCreateAgent() {
             </OptionCard>
           ))}
         </div>
-      </fieldset>
-    ) : null;
+      ) : null}
+    </fieldset>
+  );
 
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
@@ -330,7 +347,7 @@ export function StepCreateAgent() {
         />
       </div>
 
-      {toolPicker}
+      {executionPicker}
 
       <fieldset className="flex flex-col" style={{ gap: "var(--sp-2)", margin: 0, padding: 0, border: 0 }}>
         <legend className="text-label font-medium" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-1)" }}>
@@ -361,7 +378,7 @@ export function StepCreateAgent() {
         </FlowHint>
       )}
 
-      {!computer.connectedClient && (
+      {computer.connectedClients.length === 0 && (
         // Computer dropped (slept / offline) or resumed here with it not
         // connected — Create is gated on a live client. One line with the
         // "reconnect it" action inline (→ connect-computer), not a separate


### PR DESCRIPTION
## Summary

- unify Team → New Agent and onboarding around one `This agent will run` section
- keep the one-computer path read-only, require an explicit compact dropdown choice when several computers are online, and reveal runtime options only for the chosen computer
- preserve a still-valid manual runtime choice while reapplying the shared Codex → Claude Code → remaining-provider preference after automatic selections or computer changes
- rename and move the access section to `Who can use it?`, without changing visibility behavior
- add a production-component preview state and a versioned Momentic test for the multi-computer path

## Validation

- `pnpm --filter @first-tree/web test` — 245 files / 2,211 tests passed
- `pnpm --filter @first-tree/web typecheck`
- design-token guardrails
- `pnpm --filter @first-tree/web build`
- `npx momentic@3.42.0 lint`
- uploaded Momentic E2E run: https://app.momentic.ai/run-groups/11c7f6cd-2867-4ccf-8c37-c027b3a4e103
- exact-head browser verification at desktop and narrow product width; no horizontal overflow
- two independent reviews completed with no remaining blocking or judgement-call findings

## Risk

No data model, permission, provider-auth, runtime-switch, or onboarding step-sequence changes. The existing zero- and one-computer paths remain intact; the behavior change is limited to making multi-computer agent creation explicit.
