### PR TITLE
fix(context): correct portable Core policy path

### DIFF
--- a/apps/cli/src/__tests__/context-bundle-manifest.test.ts
+++ b/apps/cli/src/__tests__/context-bundle-manifest.test.ts
@@ -176,6 +176,32 @@ describe("context integration bundle", () => {
     );
   });
 
+  it("emits the flattened Core Policy path used by portable app artifacts", () => {
+    const root = mkdtempSync(join(tmpdir(), "first-tree-portable-context-bundle-"));
+    roots.push(root);
+    const repoRoot = resolve(import.meta.dirname, "../../../..");
+    execFileSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-context-integration-bundle.mjs"),
+        "--out-dir",
+        root,
+        "--version",
+        "1.2.3",
+        "--channel",
+        "staging",
+        "--core-policy-path",
+        "runtime-assets/context-tree-policy.md",
+      ],
+      { stdio: "pipe" },
+    );
+
+    const manifest = contextIntegrationReleaseManifestSchema.parse(
+      JSON.parse(readFileSync(join(root, "release-manifest.json"), "utf8")),
+    );
+    expect(manifest.core.policy.path).toBe("runtime-assets/context-tree-policy.md");
+  });
+
   it("keeps adapter identity and bytes stable across a Core-only CLI release", () => {
     const firstRoot = mkdtempSync(join(tmpdir(), "first-tree-context-bundle-first-"));
     const secondRoot = mkdtempSync(join(tmpdir(), "first-tree-context-bundle-second-"));

--- a/scripts/build-context-integration-bundle.mjs
+++ b/scripts/build-context-integration-bundle.mjs
@@ -2,7 +2,7 @@
 
 import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -24,7 +24,7 @@ function parseArgs(argv) {
     const value = argv[index + 1];
     if (!key?.startsWith("--") || value === undefined) {
       throw new Error(
-        "Usage: build-context-integration-bundle.mjs [--out-dir <path>] [--version <semver>] [--channel <prod|staging|dev>] [--core-root <path>]",
+        "Usage: build-context-integration-bundle.mjs [--out-dir <path>] [--version <semver>] [--channel <prod|staging|dev>] [--core-root <path>] [--core-policy-path <release-relative-path>]",
       );
     }
     args.set(key, value);
@@ -38,6 +38,7 @@ function parseArgs(argv) {
     version: args.get("--version") ?? packageJson.version,
     channel: args.get("--channel") ?? sourceChannel,
     coreRoot: resolve(args.get("--core-root") ?? REPO_ROOT),
+    corePolicyPath: args.get("--core-policy-path") ?? "dist/runtime-assets/context-tree-policy.md",
   };
 }
 
@@ -276,12 +277,16 @@ export function buildContextIntegrationBundle(rawOptions) {
     ...rawOptions,
     outDir: resolve(rawOptions.outDir),
     coreRoot: resolve(rawOptions.coreRoot ?? REPO_ROOT),
+    corePolicyPath: rawOptions.corePolicyPath ?? "dist/runtime-assets/context-tree-policy.md",
   };
   if (!["prod", "staging", "dev"].includes(options.channel)) {
     throw new Error(`Unsupported context integration channel: ${options.channel}`);
   }
   if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(options.version)) {
     throw new Error(`Context integration version must be SemVer: ${options.version}`);
+  }
+  if (isAbsolute(options.corePolicyPath) || options.corePolicyPath.split(/[\\/]/u).includes("..")) {
+    throw new Error(`Context integration Core Policy path must be release-relative: ${options.corePolicyPath}`);
   }
 
   rmSync(options.outDir, { recursive: true, force: true });
@@ -336,7 +341,7 @@ export function buildContextIntegrationBundle(rawOptions) {
     policyDigest,
     core: {
       digest: coreDigest,
-      policy: { path: "dist/runtime-assets/context-tree-policy.md", digest: policyDigest },
+      policy: { path: options.corePolicyPath, digest: policyDigest },
       skills: coreSkills,
     },
     providers,

--- a/scripts/portable/build-portable.mjs
+++ b/scripts/portable/build-portable.mjs
@@ -674,6 +674,7 @@ async function prepareAppTemplate({ channel, channelConfig, version }) {
     outDir: join(appDir, "context-integration"),
     version,
     channel,
+    corePolicyPath: "runtime-assets/context-tree-policy.md",
   });
   await rewriteBundleChannel(appDir, channel);
   cpSync(join(REPO_ROOT, "skills"), join(appDir, "skills"), { recursive: true });

--- a/scripts/portable/verify-portable-artifact.mjs
+++ b/scripts/portable/verify-portable-artifact.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -75,7 +75,9 @@ function verify(options) {
 
   const root = mkdtempSync(join(tmpdir(), "first-tree-portable-verify-"));
   try {
-    run("tar", tarExtractArgs(options.tarball, root));
+    const versionRoot = join(root, "versions", manifest.version);
+    mkdirSync(versionRoot, { recursive: true });
+    run("tar", tarExtractArgs(options.tarball, versionRoot));
     for (const path of [
       "VERSION",
       "INSTALL.json",
@@ -85,20 +87,20 @@ function verify(options) {
       `bin/${manifest.binName}`,
       `bin/${manifest.aliasName}`,
     ]) {
-      if (!existsSync(join(root, path))) fail(`extracted artifact missing ${path}`);
+      if (!existsSync(join(versionRoot, path))) fail(`extracted artifact missing ${path}`);
     }
-    const install = readJson(join(root, "INSTALL.json"));
+    const install = readJson(join(versionRoot, "INSTALL.json"));
     if (install.version !== manifest.version) fail("INSTALL.json version mismatch");
     if (install.platform !== options.platform) fail("INSTALL.json platform mismatch");
     if (install.appEntry !== "app/cli/index.mjs") fail("INSTALL.json appEntry mismatch");
-    const packageJson = readJson(join(root, "app", "package.json"));
+    const packageJson = readJson(join(versionRoot, "app", "package.json"));
     if (packageJson.name !== manifest.packageName) fail("app/package.json package name mismatch");
     if (packageJson.version !== manifest.version) fail("app/package.json version mismatch");
     if (!packageJson.dependencies?.["fs-native-extensions"]) {
       fail("app/package.json is missing the external native workspace-lock dependency");
     }
     const nativeLockPrebuild = join(
-      root,
+      versionRoot,
       "app",
       "node_modules",
       "fs-native-extensions",
@@ -109,11 +111,25 @@ function verify(options) {
     if (!existsSync(nativeLockPrebuild)) {
       fail(`portable artifact is missing native workspace-lock prebuild for ${options.platform}`);
     }
-    const versionRes = run(join(root, "bin", manifest.binName), ["--version"], {
+    const versionRes = run(join(versionRoot, "bin", manifest.binName), ["--version"], {
       env: { ...process.env, FIRST_TREE_HOME: join(root, "home") },
     });
     if (!versionRes.stdout.includes(manifest.version)) {
       fail(`expected --version output to include ${manifest.version}, got ${versionRes.stdout}`);
+    }
+    const loaderRes = run(
+      join(versionRoot, "bin", manifest.binName),
+      ["--json", "context", "skill", "load", "--protocol", "1", "--provider", "codex", "--name", "first-tree-read"],
+      { env: { ...process.env, FIRST_TREE_HOME: join(root, "home") } },
+    );
+    const loader = JSON.parse(loaderRes.stdout);
+    const appRoot = join(versionRoot, "app");
+    if (
+      loader?.ok !== true ||
+      loader.data?.skillPath !== join(appRoot, "skills", "first-tree-read", "SKILL.md") ||
+      loader.data?.policyPath !== join(appRoot, "runtime-assets", "context-tree-policy.md")
+    ) {
+      fail("portable Context loader did not resolve Core files from the immutable installed app root");
     }
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Emit the Context Policy path that matches the flattened portable app layout (`app/runtime-assets`) while preserving the npm package layout (`dist/runtime-assets`).
- Verify portable artifacts after extraction into the real immutable `versions/<version>` layout and execute the Core Skill loader from the installed shim.
- Add a regression test for the portable release manifest path.

## Root cause

PR #2191 made the loader consume a manifest-declared exact-release Policy path. The portable builder flattens `apps/cli/dist` into `app`, but the generated manifest still declared `dist/runtime-assets/context-tree-policy.md`, so SessionStart failed with `ENOENT` even though the Policy existed at `app/runtime-assets/context-tree-policy.md`.

## Validation

- Context bundle manifest + portable builder suites: 54/54 passed.
- CLI typecheck passed.
- Workspace build passed.
- A real linux-x64 portable artifact was built and verified; the verifier now executes `context skill load` from an extracted `versions/0.0.0/app` layout and asserts both Skill and Policy paths.
- Changed-file Biome and `git diff --check` passed.
