### PR TITLE
Polish section border ownership

### DIFF
--- a/e2e/agent-detail-configuration.test.yaml
+++ b/e2e/agent-detail-configuration.test.yaml
@@ -22,11 +22,13 @@ steps:
       than a second page-level Instructions title
   - click: Tools & skills in the Agent sections navigation
   - assert: Tools & skills is the current section and the content separately shows Skills and Integrations;
-      because neither is configured, each empty state explains the impact and offers a clear setup action
+      because neither is configured, each empty state explains the impact and offers a clear setup action; each section
+      uses one clean divider below its heading, and the empty content is plain rather than enclosed by a second outlined card
   - click: Repositories in the Agent sections navigation
   - assert: Repositories is the current section and the content does not add a visible page title above its actual
       Repositories and Context tree sections
   - click: Tools & skills in the Agent sections navigation
   - click: Set up integration button in the Integrations empty state
   - waitForUrl: /settings/resources
-  - assert: Team Settings opens on Resources, where MCP integrations are managed alongside Instructions and Skills
+  - assert: Team Settings opens on Resources, where MCP integrations are managed alongside Instructions and Skills;
+      resource sections use the same single-divider and flat-content treatment without doubled or clipped border edges

--- a/packages/qa/cases/cross-surface/agent-detail-availability-and-capabilities.md
+++ b/packages/qa/cases/cross-surface/agent-detail-availability-and-capabilities.md
@@ -49,6 +49,11 @@ axes as a health score.
   Each configured row must expose its purpose, neutral Enabled/Disabled state,
   effective rule, and origin without implying that an enabled resource makes an
   offline or suspended agent runnable.
+- Confirm Agent Detail and the matching Settings resource sections use one
+  structural divider below each heading. Empty informational content remains
+  flat rather than gaining a nested outline; selectable lists keep one complete
+  outer frame with separators only between rows. No edge is doubled, clipped,
+  or missing at 100% and 200% zoom.
 - As the admin, toggle or add an Agent-level capability and observe
   **Saving… → Saved**. Force a save failure, verify the attempted state remains
   understandable, then reload the latest settings and repeat the narrow control

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -2490,11 +2490,15 @@ tr[data-interactive]:hover {
   border-top: var(--hairline) solid var(--border-faint);
 }
 
-/* Agent-detail: drop the bottom hairline on a section's last row/block so it
-   doesn't double up with the gap before the next section. Inter-row lines stay;
-   only the trailing one goes. Beats the rows' inline border-bottom (!important). */
-.ad-tail-trim > :last-child {
-  border-bottom: 0 !important;
+/* Agent-detail resource stacks: the row primitive owns its separator, while
+   the stack trims only its final row. An empty state or future framed child
+   therefore cannot lose its own bottom edge merely by being last. */
+.ad-resource-row {
+  border-bottom: var(--hairline) solid var(--border-faint);
+}
+
+.ad-tail-trim > [data-resource-row]:last-child {
+  border-bottom: 0;
 }
 
 .usage-turn-table th {

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -891,10 +891,10 @@ function BindClientList({
         listStyle: "none",
       }}
     >
-      {bindable.map((c) => {
+      {bindable.map((c, index) => {
         const picked = c.id === selected;
         return (
-          <li key={c.id} style={{ borderTop: "var(--hairline) solid var(--border-faint)" }}>
+          <li key={c.id} style={index > 0 ? { borderTop: "var(--hairline) solid var(--border-faint)" } : undefined}>
             <button
               type="button"
               onClick={() => onSelect(c.id)}
@@ -1061,12 +1061,15 @@ function RuntimeSwitchControls({
             listStyle: "none",
           }}
         >
-          {clients.map((client) => {
+          {clients.map((client, index) => {
             const picked = client.id === selectedClientId;
             const blocker = runtimeSwitchClientBlocker(client);
             const disabled = blocker !== null;
             return (
-              <li key={client.id} style={{ borderTop: "var(--hairline) solid var(--border-faint)" }}>
+              <li
+                key={client.id}
+                style={index > 0 ? { borderTop: "var(--hairline) solid var(--border-faint)" } : undefined}
+              >
                 <button
                   type="button"
                   onClick={() => {

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -936,6 +936,14 @@ describe("Resources and runtime extra sections", () => {
     expect(recovery.textContent).toContain("Claim unknown is in phase unknown");
     expect(recovery.textContent).toContain("recovery failed");
     expect(buttonByText(recovery, "Recovering")?.disabled).toBe(true);
+    const recoverySection = [...recovery.querySelectorAll<HTMLElement>("section")].find(
+      (section) => section.querySelector("h3")?.textContent?.trim() === "Runtime switch recovery",
+    );
+    const recoveryContent = recoverySection?.children.item(1) as HTMLElement | null;
+    const recoveryRow = recoveryContent?.firstElementChild as HTMLElement | null;
+    expect(recoveryContent?.style.cssText).toContain("border-top");
+    expect(recoveryRow?.style.border).toBe("");
+    expect(recoveryRow?.style.borderRadius).toBe("");
   });
 });
 

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -1452,6 +1452,10 @@ describe("AgentDetailPage", () => {
     await click(buttonByText(first.container, "Choose computer"));
     await waitForText(document.body, "gandy-macbook");
     expect(document.body.textContent).toContain("Choose a computer");
+    const bindList = buttonByText(document.body, "gandy-macbook")?.closest("ul");
+    const bindRows = bindList?.querySelectorAll<HTMLElement>(":scope > li");
+    expect(bindRows?.item(0).style.cssText).not.toContain("border-top");
+    expect(bindRows?.item(1).style.cssText).toContain("border-top");
     await click(buttonByText(document.body, "gandy-macbook"));
     await click(exactButtonByText(document.body, "Assign"));
     await waitForCondition(() => agentMocks.updateAgent.mock.calls.length > 0, "Expected bind mutation");
@@ -1473,6 +1477,10 @@ describe("AgentDetailPage", () => {
 
     await click(buttonByText(view.container, "Switch runtime"));
     await waitForText(document.body, "Switch runtime");
+    const runtimeList = buttonByText(document.body, "gandy-macbook")?.closest("ul");
+    const runtimeRows = runtimeList?.querySelectorAll<HTMLElement>(":scope > li");
+    expect(runtimeRows?.item(0).style.cssText).not.toContain("border-top");
+    expect(runtimeRows?.item(1).style.cssText).toContain("border-top");
     await click(buttonByText(document.body, "Codex"));
     await click(exactButtonByText(document.body, "Review impact"));
     await waitForText(document.body, "Existing runtime sessions stop");

--- a/packages/web/src/pages/agent-detail/__tests__/repositories-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/repositories-tab-dom.test.tsx
@@ -185,6 +185,13 @@ describe("RepositoriesTab", () => {
     expect(container.querySelector('[data-testid="resource-section"]')?.textContent).toContain("resources editable");
     await waitForText(container, "context-tree");
     expect(container.textContent).toContain("acme/context-tree");
+    const contextTreeSection = [...container.querySelectorAll<HTMLElement>("section")].find(
+      (section) => section.querySelector("h3")?.textContent?.trim() === "Context tree",
+    );
+    expect(contextTreeSection?.querySelector<HTMLElement>(":scope > div:last-child")?.style.borderTop).toContain(
+      "var(--border)",
+    );
+    expect(contextTreeSection?.querySelector(".ad-tail-trim > [data-resource-row]")).not.toBeNull();
 
     await click(container.querySelector("button"));
     expect(navigateAway).toHaveBeenCalledWith("/settings/resources");

--- a/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
@@ -206,6 +206,14 @@ function buttonByText(container: ParentNode, text: string): HTMLButtonElement | 
   return [...container.querySelectorAll("button")].find((button) => button.textContent?.includes(text)) ?? null;
 }
 
+function sectionByHeading(container: ParentNode, heading: string): HTMLElement | null {
+  return (
+    [...container.querySelectorAll<HTMLElement>("section")].find(
+      (section) => section.querySelector("h3")?.textContent?.trim() === heading,
+    ) ?? null
+  );
+}
+
 async function setInputValue(element: HTMLInputElement, value: string): Promise<void> {
   await act(async () => {
     const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
@@ -428,6 +436,12 @@ describe("ResourcesTab", () => {
 
     expect(container.textContent).toContain("Repositories");
     expect(container.textContent).toContain("Team repo");
+    const section = sectionByHeading(container, "Repositories · 1");
+    const sectionContent = section?.children.item(1) as HTMLElement | null;
+    const resourceList = sectionContent?.firstElementChild as HTMLElement | null;
+    expect(sectionContent?.style.cssText).toContain("border-top");
+    expect(resourceList?.style.border).toBe("");
+    expect(resourceList?.style.borderRadius).toBe("");
     // Repo peek is the compact `owner/repo` coordinate (default branch + derived
     // path are omitted), not the full clone URL.
     expect(container.textContent).toContain("acme/web");
@@ -458,6 +472,13 @@ describe("ResourcesTab", () => {
     const container = await renderRouted(
       <ResourceTypeSection type="repo" data={data} canEdit pending={false} onMutate={onMutate} />,
     );
+    const section = sectionByHeading(container, "Repositories · 0");
+    const sectionContent = section?.children.item(1) as HTMLElement | null;
+    const resourceList = sectionContent?.firstElementChild as HTMLElement | null;
+    const emptyState = resourceList?.firstElementChild as HTMLElement | null;
+    expect(sectionContent?.style.cssText).toContain("border-top");
+    expect(emptyState?.style.border).toBe("");
+    expect(emptyState?.style.borderRadius).toBe("");
     await click(container.querySelector('button[aria-label="Add repository"]'));
     await click(buttonByText(document.body, "Add agent repo"));
     // Two fields only — URL + Default branch — no Name (matches Settings → Resources).

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -205,20 +205,7 @@ export function ResourceTypeSection(props: {
       description={type === "mcp" ? "Services this agent can access through MCP." : undefined}
       action={rows.length > 0 ? addControl : null}
     >
-      <div
-        className="ad-tail-trim"
-        style={
-          rows.length > 0
-            ? {
-                border: "var(--hairline) solid var(--border)",
-                borderRadius: "var(--radius-panel)",
-                paddingLeft: "var(--sp-3)",
-                paddingRight: "var(--sp-3)",
-                overflow: "hidden",
-              }
-            : undefined
-        }
-      >
+      <div className="ad-tail-trim">
         {rows.length === 0 ? (
           <CapabilityEmptyState
             type={type}
@@ -312,16 +299,7 @@ function CapabilityEmptyState(props: {
     <div
       className={props.canEdit ? "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between" : undefined}
       style={{
-        paddingTop: "var(--sp-4)",
-        paddingBottom: "var(--sp-4)",
-        paddingLeft: props.canEdit ? "var(--sp-4)" : 0,
-        paddingRight: props.canEdit ? "var(--sp-4)" : 0,
-        ...(props.canEdit
-          ? {
-              border: "var(--hairline) solid var(--border)",
-              borderRadius: "var(--radius-panel)",
-            }
-          : null),
+        padding: "var(--sp-4) 0",
       }}
     >
       <div className="min-w-0">

--- a/packages/web/src/pages/agent-detail/repositories-tab.tsx
+++ b/packages/web/src/pages/agent-detail/repositories-tab.tsx
@@ -141,7 +141,7 @@ function ContextTreeRow(): ReactNode {
 
   return (
     <Section headingLevel={3} title="Context tree">
-      {row}
+      <div className="ad-tail-trim">{row}</div>
     </Section>
   );
 }

--- a/packages/web/src/pages/agent-detail/resource-row.tsx
+++ b/packages/web/src/pages/agent-detail/resource-row.tsx
@@ -81,10 +81,11 @@ export function ResourceRowView(props: {
   const expandNoun = typeof props.name === "string" && props.name ? props.name : (props.expandLabel ?? "");
   return (
     <div
+      data-resource-row
       data-dimmed={props.dimmed ? "true" : undefined}
+      className="ad-resource-row"
       style={{
         padding: "var(--sp-3) 0",
-        borderBottom: "var(--hairline) solid var(--border-faint)",
       }}
     >
       {/* Title + action cluster. On mobile they stack (title, then the controls

--- a/packages/web/src/pages/agent-detail/runtime-section.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-section.tsx
@@ -63,9 +63,7 @@ export function RuntimeSwitchRecoveryNotice({
       <div
         className="flex items-start gap-3"
         style={{
-          padding: "var(--sp-3)",
-          border: "var(--hairline) solid var(--state-blocked)",
-          borderRadius: "var(--radius-panel)",
+          padding: "var(--sp-3) 0",
         }}
       >
         <AlertTriangle className="h-4 w-4 shrink-0" style={{ color: "var(--state-blocked)", marginTop: 2 }} />

--- a/packages/web/src/pages/settings-github-preview.tsx
+++ b/packages/web/src/pages/settings-github-preview.tsx
@@ -153,10 +153,7 @@ function TaskRoutingPreview() {
       className="flex flex-col"
       style={{
         gap: "var(--sp-3)",
-        padding: "var(--sp-4)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-panel)",
-        background: "var(--bg-sunken)",
+        padding: "var(--sp-3) 0",
       }}
     >
       <div>

--- a/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
@@ -191,6 +191,12 @@ describe("SettingsGithubPage — task routing", () => {
     expect(connection.compareDocumentPosition(taskRouting) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
     expect(taskRouting.textContent).toContain("GitHub Task Agent");
 
+    const controls = await waitForSelector<HTMLElement>(taskRouting, '[data-github-task-agent-controls="admin"]');
+    expect(controls.parentElement?.style.cssText).toContain("border-top");
+    expect(controls.style.border).toBe("");
+    expect(controls.style.borderRadius).toBe("");
+    expect(controls.style.background).toBe("");
+
     const select = await waitForSelector<HTMLButtonElement>(taskRouting, '[aria-label="GitHub Task Agent"]');
     await act(async () => select.click());
     const option = [...document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')].find((candidate) =>

--- a/packages/web/src/pages/settings/github-task-agent-controls.tsx
+++ b/packages/web/src/pages/settings/github-task-agent-controls.tsx
@@ -117,10 +117,7 @@ export function GithubTaskAgentControls({
       className="flex flex-col"
       style={{
         gap: "var(--sp-3)",
-        padding: "var(--sp-4)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-panel)",
-        background: "var(--bg-sunken)",
+        padding: "var(--sp-3) 0",
       }}
     >
       <div>


### PR DESCRIPTION
## Summary

- make shared section dividers the single structural boundary across Agent Detail and the matching Settings controls
- remove nested decorative outlines from capability empty states, capability rows, runtime recovery, and GitHub task routing
- keep complete outer frames only for selectable computer/runtime lists, with separators strictly between rows
- scope Agent Detail trailing-divider trimming to actual resource rows so an arbitrary final child cannot lose its bottom edge
- apply the same scoped trailing-row trim to the standalone read-only Context tree row
- add deterministic DOM coverage plus visual E2E assertions for doubled, clipped, and missing borders

## UX decision

This does not remove every line. A line remains when it communicates structure or selection:

- one divider below a section heading;
- one complete frame around an interactive selection list;
- separators between repeated rows.

Informational empty states and read-only configuration stay flat. This follows the dashboard design-system rule that an outlined card should imply an interactive or optional object, not merely decorate content.

## Root causes fixed

- The shared `Section` divider and a nested empty-state/card top border occupied the same coordinate, producing a doubled horizontal rule.
- `.ad-tail-trim > :last-child` removed the bottom border from any final child, which clipped the bottom edge of the empty-state card.
- Selection lists drew both an outer top edge and a first-row top separator.

## Validation

- `pnpm --filter @first-tree/web test` — 244 files / 2,201 tests passed
- focused border regressions — 5 files / 66 tests passed
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/web lint:tokens`
- `pnpm check`
- `pnpm build`
- changed-file Biome check and `git diff --check`
- `npx momentic@3.42.0 lint e2e/agent-detail-configuration.test.yaml --config momentic.config.yaml`
- independent exact-head QA on `40657388fba663dbf5239d14f569348165371f7e` — focused DOM 7 files / 75 tests passed; light/dark and 100%/effective-200% browser checks passed; Momentic 1/1 test and 17/17 steps passed with zero console errors: https://app.momentic.ai/run-groups/14bee71b-9ffb-454d-895e-587252f46fe4

## Context Tree

No durable product-contract change. The implementation stays within the existing boundary: Settings manages shared setup and Agent Detail presents one agent's effective configuration.
