### PR TITLE
Show agent-reported Context Tree influence in Chat and Need you

### DIFF
--- a/packages/server/src/__tests__/message-context-decision-trust.test.ts
+++ b/packages/server/src/__tests__/message-context-decision-trust.test.ts
@@ -64,6 +64,23 @@ describe("contextDecision receipt trust boundary", () => {
     expect(() => preflight(AGENT, "constrained")).toThrow(/metadata.contextDecision/);
   });
 
+  // Validation is not normalization: the schema strips unknown keys and trims
+  // `summary`, so persisting the caller's object would durably keep an extra
+  // credential-bearing field and an over-long summary that no reader surfaces.
+  it("persists the parsed receipt, not the caller's raw object", () => {
+    const stored = preflight(AGENT, {
+      ...RECEIPT,
+      summary: `  ${"x".repeat(398)}   `,
+      secretToken: "top-level-extra",
+      evidence: [{ ...RECEIPT.evidence[0], accessToken: "nested-extra-secret" }],
+    }).metadata[CONTEXT_DECISION_METADATA_KEY] as Record<string, unknown>;
+
+    expect(Object.keys(stored).sort()).toEqual(["effect", "evidence", "summary", "version"]);
+    expect(stored.summary).toBe("x".repeat(398));
+    const rows = stored.evidence as Array<Record<string, unknown>>;
+    expect(Object.keys(rows[0] ?? {}).sort()).toEqual(["commit", "heading", "nodePath", "repoUrl"]);
+  });
+
   it("leaves an ordinary send untouched", () => {
     const result = preflightMessageSendIntent({
       chatId: "chat-1",

--- a/packages/server/src/__tests__/message-context-decision-trust.test.ts
+++ b/packages/server/src/__tests__/message-context-decision-trust.test.ts
@@ -1,0 +1,77 @@
+import { CONTEXT_DECISION_METADATA_KEY } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import { preflightMessageSendIntent, type SendIntentParticipant } from "../services/message.js";
+
+const HUMAN: SendIntentParticipant = {
+  agentId: "human-1",
+  name: "gandy",
+  displayName: "Gandy",
+  status: "active",
+  type: "human",
+};
+const AGENT: SendIntentParticipant = {
+  agentId: "agent-1",
+  name: "assistant",
+  displayName: "Assistant",
+  status: "active",
+  type: "agent",
+};
+
+const RECEIPT = {
+  version: 1,
+  effect: "constrained",
+  summary: "The organization-isolation constraint ruled out a global shared index.",
+  evidence: [
+    {
+      repoUrl: "https://github.com/example/context-tree",
+      commit: "0123456789abcdef0123456789abcdef01234567",
+      nodePath: "system/cloud/team/tenancy-and-identity.md",
+      heading: "Organization isolation",
+    },
+  ],
+};
+
+function preflight(sender: SendIntentParticipant, receipt: unknown) {
+  return preflightMessageSendIntent({
+    chatId: "chat-1",
+    senderId: sender.agentId,
+    senderType: sender.type,
+    data: {
+      format: "markdown",
+      content: "Keeping the index per organization.",
+      source: "cli",
+      metadata: {
+        [CONTEXT_DECISION_METADATA_KEY]: receipt,
+        mentions: [sender.agentId === HUMAN.agentId ? AGENT.agentId : HUMAN.agentId],
+      },
+    },
+    participants: [HUMAN, AGENT],
+  });
+}
+
+describe("contextDecision receipt trust boundary", () => {
+  it("keeps a well-formed receipt from an agent sender", () => {
+    expect(preflight(AGENT, RECEIPT).metadata[CONTEXT_DECISION_METADATA_KEY]).toEqual(RECEIPT);
+  });
+
+  it("strips the receipt from a human sender so it cannot be spoofed", () => {
+    expect(preflight(HUMAN, RECEIPT).metadata[CONTEXT_DECISION_METADATA_KEY]).toBeUndefined();
+  });
+
+  it("rejects a malformed receipt from an agent sender instead of storing it", () => {
+    expect(() => preflight(AGENT, { ...RECEIPT, effect: "none" })).toThrow(/metadata.contextDecision/);
+    expect(() => preflight(AGENT, { ...RECEIPT, evidence: [] })).toThrow(/metadata.contextDecision/);
+    expect(() => preflight(AGENT, "constrained")).toThrow(/metadata.contextDecision/);
+  });
+
+  it("leaves an ordinary send untouched", () => {
+    const result = preflightMessageSendIntent({
+      chatId: "chat-1",
+      senderId: AGENT.agentId,
+      senderType: AGENT.type,
+      data: { format: "text", content: "No receipt here.", source: "cli", metadata: { mentions: [HUMAN.agentId] } },
+      participants: [HUMAN, AGENT],
+    });
+    expect(result.metadata[CONTEXT_DECISION_METADATA_KEY]).toBeUndefined();
+  });
+});

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -141,7 +141,13 @@ function applyContextDecisionTrustBoundary(meta: Record<string, unknown>, sender
         "evidence: [{repoUrl, commit, nodePath, heading?}] with 1-3 rows}.",
     );
   }
-  return meta;
+  // Persist the PARSED receipt, not the caller's object. Validation is not the
+  // same as normalization: the schema strips unknown keys and trims `summary`,
+  // so storing the raw value would durably keep an extra (possibly
+  // credential-bearing) field and a summary longer than the declared bound —
+  // invisibly, because every reader re-parses and drops them. The row must hold
+  // exactly the shape the contract promises.
+  return { ...meta, [CONTEXT_DECISION_METADATA_KEY]: parsed.data };
 }
 
 /**

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -4,7 +4,9 @@ import {
   attachmentRefsFromMetadata,
   CLI_BODY_ORIGIN_METADATA_KEY,
   CLI_BODY_ORIGINS,
+  CONTEXT_DECISION_METADATA_KEY,
   CRON_TRIGGER_METADATA_KEY,
+  contextDecisionSchema,
   extractCaption,
   FIRST_CHAT_ORIENTATION_CHAT_METADATA_KEY,
   FIRST_CHAT_ORIENTATION_CHAT_STATES,
@@ -110,6 +112,36 @@ function stripUntrustedMetadataKeys(
         (options.allowSystemSender || key !== "systemSender"),
     ),
   );
+}
+
+/**
+ * Trust boundary for `metadata.contextDecision` — the agent-reported record
+ * that Context Tree content shaped the choice carried by this message.
+ *
+ * Two rules, both fail-closed:
+ *   1. A HUMAN sender never carries one. The key is stripped rather than
+ *      rejected (a human's message body is fine; only the agent-attribution
+ *      claim is not theirs to make), so a browser/API write cannot dress a
+ *      human message as agent-reported Context Tree influence.
+ *   2. An AGENT sender's receipt must parse. Rejecting the write surfaces the
+ *      mistake to the agent, which fixes and resends; storing it silently would
+ *      leave an unrenderable receipt that no consumer can show and no author
+ *      knows is broken.
+ */
+function applyContextDecisionTrustBoundary(meta: Record<string, unknown>, senderType: string): Record<string, unknown> {
+  if (!(CONTEXT_DECISION_METADATA_KEY in meta)) return meta;
+  if (senderType === "human") {
+    return Object.fromEntries(Object.entries(meta).filter(([key]) => key !== CONTEXT_DECISION_METADATA_KEY));
+  }
+  const parsed = contextDecisionSchema.safeParse(meta[CONTEXT_DECISION_METADATA_KEY]);
+  if (!parsed.success) {
+    throw new BadRequestError(
+      'Malformed "metadata.contextDecision": expected {version: 1, effect: ' +
+        '"conflicted"|"redirected"|"constrained"|"confirmed", summary: <one sentence>, ' +
+        "evidence: [{repoUrl, commit, nodePath, heading?}] with 1-3 rows}.",
+    );
+  }
+  return meta;
 }
 
 /**
@@ -517,7 +549,10 @@ export function preflightMessageSendIntent(input: {
   // normalization can salvage an empty body into a bare "@name".
   validateMessageContent({ format: data.format, content: effectiveContent }, { hasAttachmentRefs });
 
-  const incomingMeta = stripUntrustedMetadataKeys(rawIncomingMeta, options);
+  const incomingMeta = applyContextDecisionTrustBoundary(
+    stripUntrustedMetadataKeys(rawIncomingMeta, options),
+    senderType,
+  );
   validateDocumentContext(incomingMeta);
   const parsedResolution = requestResolutionSchema.safeParse(incomingMeta.resolves);
   if (incomingMeta.resolves !== undefined && !parsedResolution.success) {

--- a/packages/shared/src/__tests__/context-decision-schema.test.ts
+++ b/packages/shared/src/__tests__/context-decision-schema.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTEXT_DECISION_METADATA_KEY,
+  type ContextDecision,
+  contextDecisionSchema,
+  readContextDecisionMetadata,
+} from "../schemas/context-decision.js";
+
+const COMMIT = "0123456789abcdef0123456789abcdef01234567";
+
+function receipt(overrides: Partial<ContextDecision> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    effect: "constrained",
+    summary: "The organization-isolation constraint ruled out a global shared index.",
+    evidence: [
+      {
+        repoUrl: "https://github.com/example/context-tree",
+        commit: COMMIT,
+        nodePath: "system/cloud/team/tenancy-and-identity.md",
+        heading: "Organization isolation",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("contextDecisionSchema", () => {
+  it("accepts the skill's documented receipt shape", () => {
+    const parsed = contextDecisionSchema.safeParse(receipt());
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts an omitted heading and up to three evidence rows", () => {
+    const rows = [
+      { repoUrl: "https://github.com/example/tree", commit: COMMIT, nodePath: "a.md" },
+      { repoUrl: "https://github.com/example/tree", commit: COMMIT, nodePath: "b/c.md" },
+      { repoUrl: "git@gitlab.example.com:group/sub/tree.git", commit: "abc1234", nodePath: "d.md" },
+    ];
+    expect(contextDecisionSchema.safeParse(receipt({ evidence: rows })).success).toBe(true);
+  });
+
+  it("rejects an effect outside the four observable categories", () => {
+    expect(contextDecisionSchema.safeParse(receipt({ effect: "none" as never })).success).toBe(false);
+  });
+
+  it("rejects a receipt with nothing to inspect", () => {
+    expect(contextDecisionSchema.safeParse(receipt({ evidence: [] })).success).toBe(false);
+  });
+
+  it("rejects more evidence than the skill's three-node cap", () => {
+    const row = { repoUrl: "https://github.com/example/tree", commit: COMMIT, nodePath: "a.md" };
+    expect(contextDecisionSchema.safeParse(receipt({ evidence: [row, row, row, row] })).success).toBe(false);
+  });
+
+  it("rejects an empty summary", () => {
+    expect(contextDecisionSchema.safeParse(receipt({ summary: "   " })).success).toBe(false);
+  });
+
+  it("rejects a credential-bearing repository URL", () => {
+    const evidence = [{ repoUrl: "https://user:token@github.com/example/tree", commit: COMMIT, nodePath: "a.md" }];
+    expect(contextDecisionSchema.safeParse(receipt({ evidence })).success).toBe(false);
+  });
+
+  it("rejects a repository value that is not a resolvable git URL", () => {
+    const evidence = [{ repoUrl: "context-tree", commit: COMMIT, nodePath: "a.md" }];
+    expect(contextDecisionSchema.safeParse(receipt({ evidence })).success).toBe(false);
+  });
+
+  it("rejects a commit that is not a hex object id", () => {
+    const evidence = [{ repoUrl: "https://github.com/example/tree", commit: "main", nodePath: "a.md" }];
+    expect(contextDecisionSchema.safeParse(receipt({ evidence })).success).toBe(false);
+  });
+
+  it("rejects an escaping node path", () => {
+    const absolute = [{ repoUrl: "https://github.com/example/tree", commit: COMMIT, nodePath: "/etc/passwd" }];
+    const traversal = [{ repoUrl: "https://github.com/example/tree", commit: COMMIT, nodePath: "a/../../b.md" }];
+    expect(contextDecisionSchema.safeParse(receipt({ evidence: absolute })).success).toBe(false);
+    expect(contextDecisionSchema.safeParse(receipt({ evidence: traversal })).success).toBe(false);
+  });
+});
+
+describe("readContextDecisionMetadata", () => {
+  it("returns the receipt when the stored payload parses", () => {
+    expect(readContextDecisionMetadata({ [CONTEXT_DECISION_METADATA_KEY]: receipt() })?.effect).toBe("constrained");
+  });
+
+  it("fails closed on absent, unknown-version, and malformed payloads", () => {
+    expect(readContextDecisionMetadata(undefined)).toBeNull();
+    expect(readContextDecisionMetadata(null)).toBeNull();
+    expect(readContextDecisionMetadata({})).toBeNull();
+    expect(
+      readContextDecisionMetadata({ [CONTEXT_DECISION_METADATA_KEY]: receipt({ version: 2 as never }) }),
+    ).toBeNull();
+    expect(readContextDecisionMetadata({ [CONTEXT_DECISION_METADATA_KEY]: "constrained" })).toBeNull();
+    expect(readContextDecisionMetadata({ [CONTEXT_DECISION_METADATA_KEY]: { effect: "constrained" } })).toBeNull();
+  });
+});

--- a/packages/shared/src/__tests__/context-decision-schema.test.ts
+++ b/packages/shared/src/__tests__/context-decision-schema.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../schemas/context-decision.js";
 
 const COMMIT = "0123456789abcdef0123456789abcdef01234567";
+const SHA256_COMMIT = "0123456789abcdef".repeat(4);
 
 function receipt(overrides: Partial<ContextDecision> = {}): Record<string, unknown> {
   return {
@@ -35,9 +36,28 @@ describe("contextDecisionSchema", () => {
     const rows = [
       { repoUrl: "https://github.com/example/tree", commit: COMMIT, nodePath: "a.md" },
       { repoUrl: "https://github.com/example/tree", commit: COMMIT, nodePath: "b/c.md" },
-      { repoUrl: "git@gitlab.example.com:group/sub/tree.git", commit: "abc1234", nodePath: "d.md" },
+      { repoUrl: "git@gitlab.example.com:group/sub/tree.git", commit: SHA256_COMMIT, nodePath: "d.md" },
     ];
     expect(contextDecisionSchema.safeParse(receipt({ evidence: rows })).success).toBe(true);
+  });
+
+  // The producer copies the declared binding repository verbatim, so every
+  // transport the binding accepts must survive the receipt too — an SSH-backed
+  // team otherwise cannot send a valid final message at all.
+  it("accepts every credential-free binding transport the Context Tree binding allows", () => {
+    const transports = [
+      "https://github.com/example/context-tree",
+      "https://github.com/example/context-tree.git",
+      "ssh://git@github.com/example/context-tree.git",
+      "git@github.com:example/context-tree.git",
+      "ssh://git@gitlab.example.com:2222/group/sub/context-tree.git",
+    ];
+    for (const repoUrl of transports) {
+      const parsed = contextDecisionSchema.safeParse(
+        receipt({ evidence: [{ repoUrl, commit: COMMIT, nodePath: "a.md" }] }),
+      );
+      expect(parsed.success, repoUrl).toBe(true);
+    }
   });
 
   it("rejects an effect outside the four observable categories", () => {
@@ -57,9 +77,32 @@ describe("contextDecisionSchema", () => {
     expect(contextDecisionSchema.safeParse(receipt({ summary: "   " })).success).toBe(false);
   });
 
-  it("rejects a credential-bearing repository URL", () => {
-    const evidence = [{ repoUrl: "https://user:token@github.com/example/tree", commit: COMMIT, nodePath: "a.md" }];
-    expect(contextDecisionSchema.safeParse(receipt({ evidence })).success).toBe(false);
+  // A secret rides a repository URL as userinfo, a query parameter, or a
+  // fragment. All three would be persisted verbatim in an immutable row.
+  it("rejects every credential-bearing repository URL form", () => {
+    const leaky = [
+      "https://user:token@github.com/example/tree",
+      "https://token@github.com/example/tree",
+      "https://github.com/example/tree?access_token=secret",
+      "https://github.com/example/tree#access_token=secret",
+      "ssh://git:token@github.com/example/tree.git",
+    ];
+    for (const repoUrl of leaky) {
+      const parsed = contextDecisionSchema.safeParse(
+        receipt({ evidence: [{ repoUrl, commit: COMMIT, nodePath: "a.md" }] }),
+      );
+      expect(parsed.success, repoUrl).toBe(false);
+    }
+  });
+
+  it("rejects transports the Context Tree binding refuses", () => {
+    const rejected = ["http://github.com/example/tree", "git://github.com/example/tree", "file:///tmp/tree"];
+    for (const repoUrl of rejected) {
+      const parsed = contextDecisionSchema.safeParse(
+        receipt({ evidence: [{ repoUrl, commit: COMMIT, nodePath: "a.md" }] }),
+      );
+      expect(parsed.success, repoUrl).toBe(false);
+    }
   });
 
   it("rejects a repository value that is not a resolvable git URL", () => {
@@ -67,9 +110,20 @@ describe("contextDecisionSchema", () => {
     expect(contextDecisionSchema.safeParse(receipt({ evidence })).success).toBe(false);
   });
 
-  it("rejects a commit that is not a hex object id", () => {
-    const evidence = [{ repoUrl: "https://github.com/example/tree", commit: "main", nodePath: "a.md" }];
-    expect(contextDecisionSchema.safeParse(receipt({ evidence })).success).toBe(false);
+  // An abbreviation resolves against one repository at one moment; only a full
+  // object id keeps naming the same version for the life of the stored receipt.
+  it("requires a full object id and rejects abbreviations", () => {
+    expect(
+      contextDecisionSchema.safeParse(
+        receipt({
+          evidence: [{ repoUrl: "https://github.com/example/tree", commit: SHA256_COMMIT, nodePath: "a.md" }],
+        }),
+      ).success,
+    ).toBe(true);
+    for (const commit of ["main", "abc1234", COMMIT.slice(0, 12), COMMIT.slice(0, 39), `${COMMIT}ab`]) {
+      const evidence = [{ repoUrl: "https://github.com/example/tree", commit, nodePath: "a.md" }];
+      expect(contextDecisionSchema.safeParse(receipt({ evidence })).success, commit).toBe(false);
+    }
   });
 
   it("rejects an escaping node path", () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -464,6 +464,18 @@ export {
   legacyContextActivationResponseSchema,
 } from "./schemas/context-activation.js";
 export {
+  CONTEXT_DECISION_METADATA_KEY,
+  type ContextDecision,
+  type ContextDecisionEffect,
+  type ContextDecisionEvidence,
+  contextDecisionEffectSchema,
+  contextDecisionEvidenceSchema,
+  contextDecisionSchema,
+  MAX_CONTEXT_DECISION_EVIDENCE,
+  MAX_CONTEXT_DECISION_SUMMARY_LENGTH,
+  readContextDecisionMetadata,
+} from "./schemas/context-decision.js";
+export {
   CONTEXT_ACTIVATION_SCOPE_KINDS,
   CONTEXT_INTEGRATION_PROVIDERS,
   CONTEXT_SKILL_LOADER_NAMES,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -472,6 +472,7 @@ export {
   contextDecisionEvidenceSchema,
   contextDecisionSchema,
   MAX_CONTEXT_DECISION_EVIDENCE,
+  MAX_CONTEXT_DECISION_REPO_URL_LENGTH,
   MAX_CONTEXT_DECISION_SUMMARY_LENGTH,
   readContextDecisionMetadata,
 } from "./schemas/context-decision.js";

--- a/packages/shared/src/schemas/context-decision.ts
+++ b/packages/shared/src/schemas/context-decision.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import { canonicalGitRepoIdentity } from "../canonical-git-repo-url.js";
+
+/**
+ * `metadata.contextDecision` — an agent's self-attributed record that Context
+ * Tree content materially shaped the choice carried by THIS message.
+ *
+ * Written by the `first-tree-read` skill on the same final `chat send` (or
+ * blocking `chat ask`) that contains the affected choice, never as a separate
+ * message and never as prose. The receipt is the agent's own report: First Tree
+ * preserves the cited repository/commit/path so a reader can inspect the exact
+ * source, but it does NOT independently verify that the passage caused the
+ * choice. Every consumer must present it as agent-reported, never as a
+ * system-verified causal claim.
+ *
+ * Trust boundary: the server strips the key from human senders and rejects a
+ * malformed receipt from an agent sender, so a stored receipt is always an
+ * agent's and always parses. Readers still parse defensively (`safeParse` via
+ * `readContextDecisionMetadata`) because message rows are immutable — history
+ * written before that guard is not re-validated.
+ */
+export const CONTEXT_DECISION_METADATA_KEY = "contextDecision";
+
+/**
+ * How Tree content acted on the choice. Exactly one applies; the skill picks
+ * the first matching category in this precedence order so reports stay
+ * comparable:
+ *
+ *   - `conflicted`  — exposed a conflict that still needs resolution/escalation
+ *   - `redirected`  — changed the intended approach
+ *   - `constrained` — ruled out an option or narrowed the solution boundary
+ *   - `confirmed`   — removed material uncertainty and justified keeping the
+ *                     choice without changing its boundary
+ */
+export const contextDecisionEffectSchema = z.enum(["conflicted", "redirected", "constrained", "confirmed"]);
+export type ContextDecisionEffect = z.infer<typeof contextDecisionEffectSchema>;
+
+/** At most three node paths may jointly influence one choice (skill contract). */
+export const MAX_CONTEXT_DECISION_EVIDENCE = 3;
+export const MAX_CONTEXT_DECISION_SUMMARY_LENGTH = 400;
+
+/**
+ * One cited passage: the exact repository + commit + Tree-root-relative node
+ * path that supplied it. `repoUrl` is the credential-free binding repository as
+ * the activation receipt / workspace briefing declares it — never a local
+ * transport URL and never a credential-bearing remote, so a stored receipt can
+ * be shown and linked without leaking a secret.
+ */
+export const contextDecisionEvidenceSchema = z.object({
+  repoUrl: z
+    .string()
+    .min(1)
+    .max(2_000)
+    .refine((value) => canonicalGitRepoIdentity(value) !== null, {
+      message: "repoUrl must be a resolvable git repository URL",
+    })
+    .refine((value) => !hasEmbeddedCredentials(value), {
+      message: "repoUrl must not embed credentials",
+    }),
+  /**
+   * The exact commit the passage was read at. Full 40-char SHA-1 is what the
+   * skill specifies; shorter unambiguous prefixes are accepted rather than
+   * failing an otherwise valid final message, and 64 covers SHA-256 repos.
+   */
+  commit: z.string().regex(/^[0-9a-fA-F]{7,64}$/, "commit must be a hex git object id (7-64 chars)"),
+  /** Tree-root-relative path, e.g. `system/cloud/team/tenancy-and-identity.md`. */
+  nodePath: z
+    .string()
+    .min(1)
+    .max(1_000)
+    .refine((value) => !value.startsWith("/") && !value.split("/").includes(".."), {
+      message: "nodePath must be a tree-root-relative path without `..` segments",
+    }),
+  /** Optional heading inside the node; omitted when it cannot be named reliably. */
+  heading: z.string().min(1).max(200).optional(),
+});
+export type ContextDecisionEvidence = z.infer<typeof contextDecisionEvidenceSchema>;
+
+export const contextDecisionSchema = z.object({
+  version: z.literal(1),
+  effect: contextDecisionEffectSchema,
+  /** One concrete sentence naming what the Tree content actually did here. */
+  summary: z.string().trim().min(1).max(MAX_CONTEXT_DECISION_SUMMARY_LENGTH),
+  /**
+   * Required: a receipt with nothing to inspect is a claim, not a receipt —
+   * the inspectable source is the only part First Tree can vouch for.
+   */
+  evidence: z.array(contextDecisionEvidenceSchema).min(1).max(MAX_CONTEXT_DECISION_EVIDENCE),
+});
+export type ContextDecision = z.infer<typeof contextDecisionSchema>;
+
+/**
+ * Strict reader for a stored message's receipt. Returns `null` for absent,
+ * unknown-version, or malformed payloads so a renderer fails closed (shows
+ * nothing) instead of rendering a partial, misleading influence claim.
+ */
+export function readContextDecisionMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): ContextDecision | null {
+  if (metadata?.[CONTEXT_DECISION_METADATA_KEY] === undefined) return null;
+  const parsed = contextDecisionSchema.safeParse(metadata[CONTEXT_DECISION_METADATA_KEY]);
+  return parsed.success ? parsed.data : null;
+}
+
+/**
+ * A URL that carries `user:token@host` would be persisted, rendered, and linked
+ * verbatim. Reject it at the write boundary instead.
+ */
+function hasEmbeddedCredentials(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed.includes("://")) return false;
+  try {
+    const url = new URL(trimmed);
+    return url.username !== "" || url.password !== "";
+  } catch {
+    return false;
+  }
+}

--- a/packages/shared/src/schemas/context-decision.ts
+++ b/packages/shared/src/schemas/context-decision.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { canonicalGitRepoIdentity } from "../canonical-git-repo-url.js";
+import { contextTreeRepoSchema } from "./org-settings.js";
 
 /**
  * `metadata.contextDecision` — an agent's self-attributed record that Context
@@ -38,6 +38,7 @@ export type ContextDecisionEffect = z.infer<typeof contextDecisionEffectSchema>;
 /** At most three node paths may jointly influence one choice (skill contract). */
 export const MAX_CONTEXT_DECISION_EVIDENCE = 3;
 export const MAX_CONTEXT_DECISION_SUMMARY_LENGTH = 400;
+export const MAX_CONTEXT_DECISION_REPO_URL_LENGTH = 2_000;
 
 /**
  * One cited passage: the exact repository + commit + Tree-root-relative node
@@ -47,22 +48,30 @@ export const MAX_CONTEXT_DECISION_SUMMARY_LENGTH = 400;
  * be shown and linked without leaking a secret.
  */
 export const contextDecisionEvidenceSchema = z.object({
-  repoUrl: z
-    .string()
-    .min(1)
-    .max(2_000)
-    .refine((value) => canonicalGitRepoIdentity(value) !== null, {
-      message: "repoUrl must be a resolvable git repository URL",
-    })
-    .refine((value) => !hasEmbeddedCredentials(value), {
-      message: "repoUrl must not embed credentials",
-    }),
   /**
-   * The exact commit the passage was read at. Full 40-char SHA-1 is what the
-   * skill specifies; shorter unambiguous prefixes are accepted rather than
-   * failing an otherwise valid final message, and 64 covers SHA-256 repos.
+   * The SAME contract the Context Tree binding itself is validated against.
+   * The producer copies the declared binding repository verbatim, so a second
+   * URL rule here could only drift from it: a stricter one rejects a valid
+   * binding (`ssh://git@host/path` carries a username by design) and a looser
+   * one admits shapes the binding would refuse. `contextTreeRepoSchema` already
+   * requires https / ssh / scp-like transport with a host and repository path,
+   * and rejects embedded passwords, HTTPS usernames, query and fragment
+   * components, control characters, and line separators — so a credential
+   * cannot ride any of the three forms into an immutable message row.
    */
-  commit: z.string().regex(/^[0-9a-fA-F]{7,64}$/, "commit must be a hex git object id (7-64 chars)"),
+  repoUrl: contextTreeRepoSchema.refine((value) => value.length <= MAX_CONTEXT_DECISION_REPO_URL_LENGTH, {
+    message: `repoUrl must be at most ${MAX_CONTEXT_DECISION_REPO_URL_LENGTH} characters`,
+  }),
+  /**
+   * The exact commit the passage was read at. A clone identity resolves an
+   * abbreviation against one repository at one moment, so only a full object id
+   * keeps naming the same immutable version for the life of the stored receipt.
+   * SHA-1 (40) and SHA-256 (64) are the two legal lengths; every producer path
+   * emits one because the receipt is built from `git rev-parse HEAD`.
+   */
+  commit: z
+    .string()
+    .regex(/^([0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/, "commit must be a full SHA-1 (40) or SHA-256 (64) object id"),
   /** Tree-root-relative path, e.g. `system/cloud/team/tenancy-and-identity.md`. */
   nodePath: z
     .string()
@@ -100,19 +109,4 @@ export function readContextDecisionMetadata(
   if (metadata?.[CONTEXT_DECISION_METADATA_KEY] === undefined) return null;
   const parsed = contextDecisionSchema.safeParse(metadata[CONTEXT_DECISION_METADATA_KEY]);
   return parsed.success ? parsed.data : null;
-}
-
-/**
- * A URL that carries `user:token@host` would be persisted, rendered, and linked
- * verbatim. Reject it at the write boundary instead.
- */
-function hasEmbeddedCredentials(value: string): boolean {
-  const trimmed = value.trim();
-  if (!trimmed.includes("://")) return false;
-  try {
-    const url = new URL(trimmed);
-    return url.username !== "" || url.password !== "";
-  } catch {
-    return false;
-  }
 }

--- a/packages/web/src/components/chat/__tests__/context-decision-receipt.test.tsx
+++ b/packages/web/src/components/chat/__tests__/context-decision-receipt.test.tsx
@@ -124,6 +124,15 @@ describe("contextDecisionSourceHref", () => {
     expect(contextDecisionSourceHref(evidence(repo), null)).toBeNull();
   });
 
+  // SSH bindings are valid receipt sources, so their links must resolve too.
+  it("links an SSH-form GitHub source to the same web blob URL", () => {
+    for (const repoUrl of ["git@github.com:example/tree.git", "ssh://git@github.com/example/tree.git"]) {
+      expect(contextDecisionSourceHref(evidence(repoUrl), null), repoUrl).toBe(
+        `https://github.com/example/tree/blob/${COMMIT}/a/b.md`,
+      );
+    }
+  });
+
   it("escapes path segments so a source link cannot be broken by the path", () => {
     const href = contextDecisionSourceHref(evidence("https://github.com/example/tree", "a b/c?d.md"), null);
     expect(href).toBe(`https://github.com/example/tree/blob/${COMMIT}/a%20b/c%3Fd.md`);

--- a/packages/web/src/components/chat/__tests__/context-decision-receipt.test.tsx
+++ b/packages/web/src/components/chat/__tests__/context-decision-receipt.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+
+import type { ContextDecision } from "@first-tree/shared";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { ContextDecisionReceipt, contextDecisionSourceHref } from "../context-decision-receipt.js";
+
+const COMMIT = "0123456789abcdef0123456789abcdef01234567";
+
+function receipt(overrides: Partial<ContextDecision> = {}): ContextDecision {
+  return {
+    version: 1,
+    effect: "constrained",
+    summary: "Team rollout policy caps Web at 20%; CLI stays at 5% until the migration guard clears.",
+    evidence: [
+      {
+        repoUrl: "https://github.com/example/context-tree",
+        commit: COMMIT,
+        nodePath: "product/release/rollout-policy.md",
+        heading: "Expansion gates",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+let h: DomHarness;
+
+beforeEach(() => {
+  h = createDomHarness();
+});
+afterEach(() => h.cleanup());
+
+const text = (): string => h.container.textContent ?? "";
+const toggle = (): HTMLButtonElement => {
+  const button = h.container.querySelector("button");
+  if (!button) throw new Error("sources toggle not rendered");
+  return button as HTMLButtonElement;
+};
+
+describe("ContextDecisionReceipt", () => {
+  it("leads with the Context Tree effect and the agent's concrete summary", () => {
+    h.render(<ContextDecisionReceipt receipt={receipt()} />);
+    expect(text()).toContain("Context Tree in action");
+    expect(text()).toContain("Options narrowed");
+    expect(text()).toContain("Team rollout policy caps Web at 20%");
+    expect(text()).toContain("1 team decision");
+  });
+
+  it("names each effect in user language, never the raw enum", () => {
+    const labels: Array<[ContextDecision["effect"], string]> = [
+      ["conflicted", "Conflict surfaced"],
+      ["redirected", "Approach changed"],
+      ["constrained", "Options narrowed"],
+      ["confirmed", "Direction supported"],
+    ];
+    for (const [effect, label] of labels) {
+      h.render(<ContextDecisionReceipt receipt={receipt({ effect })} />);
+      expect(text()).toContain(label);
+      expect(text()).not.toContain(effect);
+    }
+  });
+
+  it("keeps sources collapsed until asked, then shows the exact cited source", () => {
+    h.render(<ContextDecisionReceipt receipt={receipt()} />);
+    expect(toggle().getAttribute("aria-expanded")).toBe("false");
+    expect(text()).not.toContain("product/release/rollout-policy.md");
+
+    act(() => toggle().click());
+
+    expect(toggle().getAttribute("aria-expanded")).toBe("true");
+    expect(text()).toContain("Expansion gates");
+    expect(text()).toContain("product/release/rollout-policy.md");
+    expect(text()).toContain("example/context-tree · 0123456");
+    expect(text()).not.toContain(COMMIT);
+  });
+
+  it("discloses agent attribution only inside the expanded sources", () => {
+    h.render(<ContextDecisionReceipt receipt={receipt()} />);
+    expect(text()).not.toContain("Added by the agent");
+
+    act(() => toggle().click());
+
+    expect(text()).toContain("Added by the agent");
+    expect(text()).toContain("does not independently verify causality");
+  });
+
+  it("makes no verification claim about the confirmed effect", () => {
+    h.render(<ContextDecisionReceipt receipt={receipt({ effect: "confirmed" })} />);
+    act(() => toggle().click());
+    expect(text().toLowerCase()).not.toContain("verified");
+  });
+
+  it("links a GitHub source to the exact commit", () => {
+    h.render(<ContextDecisionReceipt receipt={receipt()} />);
+    act(() => toggle().click());
+    const link = h.container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe(
+      `https://github.com/example/context-tree/blob/${COMMIT}/product/release/rollout-policy.md`,
+    );
+    expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("shows an unidentifiable forge as plain text rather than a guessed link", () => {
+    const evidence = [{ repoUrl: "https://git.example.com/team/tree", commit: COMMIT, nodePath: "a.md" }];
+    h.render(<ContextDecisionReceipt receipt={receipt({ evidence })} />);
+    act(() => toggle().click());
+    expect(h.container.querySelector("a")).toBeNull();
+    expect(text()).toContain("a.md");
+    expect(text()).toContain("team/tree · 0123456");
+  });
+});
+
+describe("contextDecisionSourceHref", () => {
+  const evidence = (repoUrl: string, nodePath = "a/b.md") => ({ repoUrl, commit: COMMIT, nodePath });
+
+  it("builds a GitLab blob link only when the repo matches the connected instance", () => {
+    const repo = "https://gitlab.example.com/group/sub/tree";
+    expect(contextDecisionSourceHref(evidence(repo), "https://gitlab.example.com")).toBe(
+      `https://gitlab.example.com/group/sub/tree/-/blob/${COMMIT}/a/b.md`,
+    );
+    expect(contextDecisionSourceHref(evidence(repo), "https://gitlab.other.com")).toBeNull();
+    expect(contextDecisionSourceHref(evidence(repo), null)).toBeNull();
+  });
+
+  it("escapes path segments so a source link cannot be broken by the path", () => {
+    const href = contextDecisionSourceHref(evidence("https://github.com/example/tree", "a b/c?d.md"), null);
+    expect(href).toBe(`https://github.com/example/tree/blob/${COMMIT}/a%20b/c%3Fd.md`);
+  });
+});

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -30,7 +30,7 @@
  * the ONLY way to resolve a question: the target human answers here, in the web
  * UI; an agent can only ask, never answer or close.
  */
-import type { AskOption, AskRequest, AttachmentKind, MentionParticipant } from "@first-tree/shared";
+import type { AskOption, AskRequest, AttachmentKind, ContextDecision, MentionParticipant } from "@first-tree/shared";
 import { COMPOSER_ACCEPT_ATTRIBUTE, extractMentions } from "@first-tree/shared";
 import { AtSign, History, Paperclip, X } from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -47,6 +47,7 @@ import { FileChip } from "../ui/file-chip.js";
 import { Markdown, type MarkdownProps } from "../ui/markdown.js";
 import { useMentionComposer } from "../use-mention-composer.js";
 import type { AskAgentExchange } from "./ask-agent-state.js";
+import { ContextDecisionReceipt } from "./context-decision-receipt.js";
 import { ImageRefGallery, type ReferencedImage } from "./image-ref-gallery.js";
 import { allRequiredAnswered, buildResolveAnswer } from "./request-state.js";
 
@@ -139,6 +140,8 @@ export function AskTakeover({
   requestId,
   body,
   images = [],
+  contextDecision = null,
+  gitlabInstanceOrigin = null,
   payload,
   askerName,
   sending = false,
@@ -165,6 +168,15 @@ export function AskTakeover({
   body: string;
   /** Images attached to the ask, shown beneath the body in the same scroller. */
   images?: readonly ReferencedImage[];
+  /**
+   * The asking agent's Context Tree receipt for THIS question, when it reported
+   * one. Rendered after the question body and before the answer controls: it is
+   * context for the decision the human is about to make, never a second thing
+   * to answer. It adds no request state, notification, or blocking condition.
+   */
+  contextDecision?: ContextDecision | null;
+  /** Team GitLab web origin, forwarded to the receipt's source links. */
+  gitlabInstanceOrigin?: string | null;
   payload: AskRequest;
   askerName?: string;
   sending?: boolean;
@@ -807,6 +819,9 @@ export function AskTakeover({
           >
             <Markdown components={markdownComponents}>{body}</Markdown>
             <ImageRefGallery images={images} hasLeadingContent={body.trim().length > 0} />
+            {contextDecision ? (
+              <ContextDecisionReceipt receipt={contextDecision} gitlabInstanceOrigin={gitlabInstanceOrigin} />
+            ) : null}
           </div>
 
           {askAgent && askAgent.exchanges.length > 0 ? (

--- a/packages/web/src/components/chat/context-decision-receipt.tsx
+++ b/packages/web/src/components/chat/context-decision-receipt.tsx
@@ -1,0 +1,235 @@
+import {
+  type ContextDecision,
+  type ContextDecisionEffect,
+  type ContextDecisionEvidence,
+  canonicalGitRepoIdentity,
+  resolveGitLabRepositoryWebIdentity,
+} from "@first-tree/shared";
+import { ChevronDown, ChevronUp, ExternalLink } from "lucide-react";
+import { useId, useState } from "react";
+import { FirstTreeLogo } from "../first-tree-logo.js";
+
+/**
+ * How the four receipt effects read to a person. The label answers "what did
+ * shared team context DO here" in the user's language; the raw enum never
+ * reaches the screen. `confirmed` deliberately avoids "verified"/"correct" and
+ * carries no success check — Tree content supported the direction, it did not
+ * prove the result right.
+ */
+const EFFECT_LABELS: Record<ContextDecisionEffect, string> = {
+  conflicted: "Conflict surfaced",
+  redirected: "Approach changed",
+  constrained: "Options narrowed",
+  confirmed: "Direction supported",
+};
+
+/**
+ * Agent-reported proof that the team's Context Tree shaped THIS answer.
+ *
+ * Placement is the whole point: it sits directly under the result being judged
+ * (an agent's chat reply, or an ask's question body above the answer controls),
+ * so the reader sees what team context changed at the moment they decide
+ * whether to trust the result.
+ *
+ * Trust contract — the module states the outcome objectively ("Options
+ * narrowed") because that is what the agent reports, but it is NOT a First Tree
+ * verification:
+ *   - the visual is a scoped Context Tree panel, never system/verified card
+ *     chrome, and carries no success check or "verified" copy;
+ *   - the collapsed state stays on user value; the agent-attribution sentence
+ *     lives at the bottom of the expanded sources, where a reader who is
+ *     inspecting provenance actually needs it. That weakening is only valid
+ *     while the receipt is still attached to its authoring agent's message —
+ *     any future cross-message digest must re-state attribution up front.
+ *
+ * Rendering is gated on a strict parse upstream (`readContextDecisionMetadata`),
+ * so a partial or unknown-version payload shows nothing at all rather than a
+ * half-claim.
+ */
+export function ContextDecisionReceipt({
+  receipt,
+  gitlabInstanceOrigin = null,
+}: {
+  receipt: ContextDecision;
+  /**
+   * The Team's GitLab web origin, when connected. Used only to turn a GitLab
+   * source into an exact-commit link; without a confident match the source
+   * stays plain text rather than becoming a guessed (possibly dead) URL.
+   */
+  gitlabInstanceOrigin?: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const detailsId = useId();
+  const conflict = receipt.effect === "conflicted";
+
+  return (
+    <aside
+      aria-label="Context Tree influence reported by the agent"
+      className="text-body"
+      style={{
+        marginTop: "var(--sp-3)",
+        padding: "var(--sp-3)",
+        borderRadius: "var(--radius-panel)",
+        background: "var(--brand-bg)",
+      }}
+    >
+      <div className="flex items-start" style={{ gap: "var(--sp-2_5)" }}>
+        <FirstTreeLogo
+          width={14}
+          height={16}
+          style={{ marginTop: "var(--sp-1)", flexShrink: 0, color: "var(--brand)" }}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="text-eyebrow uppercase" style={{ color: "var(--brand-dim)" }}>
+            Context Tree in action
+          </div>
+          <div
+            className="font-semibold"
+            style={{
+              marginTop: "var(--sp-0_5)",
+              color: conflict ? "var(--warning)" : "var(--fg)",
+            }}
+          >
+            {EFFECT_LABELS[receipt.effect]}
+          </div>
+          <p className="leading-relaxed" style={{ marginTop: "var(--sp-1)", color: "var(--fg-2)" }}>
+            {receipt.summary}
+          </p>
+          <button
+            type="button"
+            aria-expanded={open}
+            aria-controls={detailsId}
+            onClick={() => setOpen((value) => !value)}
+            className="text-caption font-medium flex w-full items-center text-left"
+            style={{
+              marginTop: "var(--sp-1_5)",
+              minHeight: "var(--sp-11)",
+              gap: "var(--sp-2)",
+              color: "var(--fg-3)",
+            }}
+          >
+            <span className="min-w-0 flex-1">
+              {receipt.evidence.length === 1 ? "1 team decision" : `${receipt.evidence.length} team decisions`}
+            </span>
+            {open ? (
+              <ChevronUp aria-hidden className="size-3.5 shrink-0" />
+            ) : (
+              <ChevronDown aria-hidden className="size-3.5 shrink-0" />
+            )}
+          </button>
+          {open ? (
+            <div id={detailsId}>
+              <div className="text-label font-semibold" style={{ color: "var(--fg)" }}>
+                Team decisions applied to this result
+              </div>
+              <ul
+                className="flex flex-col"
+                style={{ listStyle: "none", margin: "var(--sp-2) 0 0", padding: 0, gap: "var(--sp-2)" }}
+              >
+                {receipt.evidence.map((evidence) => (
+                  <li key={`${evidence.repoUrl}@${evidence.commit}:${evidence.nodePath}`}>
+                    <EvidenceRow evidence={evidence} gitlabInstanceOrigin={gitlabInstanceOrigin} />
+                  </li>
+                ))}
+              </ul>
+              <p
+                className="text-caption leading-relaxed"
+                style={{
+                  marginTop: "var(--sp-3)",
+                  paddingTop: "var(--sp-2_5)",
+                  borderTop: "var(--hairline) solid var(--border-faint)",
+                  color: "var(--fg-3)",
+                }}
+              >
+                Added by the agent. First Tree preserves the cited version for inspection, but does not independently
+                verify causality.
+              </p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+/**
+ * One cited node: the human-readable heading first, then the exact source it
+ * came from. The repository shows as its `namespace/repo` identity and the
+ * commit as a short prefix — a full URL or 40-char SHA is noise at this size,
+ * and the link (when the forge is unambiguous) already carries the exact one.
+ */
+function EvidenceRow({
+  evidence,
+  gitlabInstanceOrigin,
+}: {
+  evidence: ContextDecisionEvidence;
+  gitlabInstanceOrigin: string | null;
+}) {
+  const identity = canonicalGitRepoIdentity(evidence.repoUrl);
+  const href = contextDecisionSourceHref(evidence, gitlabInstanceOrigin);
+  const title = evidence.heading ?? nodeFileName(evidence.nodePath);
+  const provenance = `${identity?.path ?? evidence.repoUrl} · ${evidence.commit.slice(0, 7)}`;
+
+  const body = (
+    <>
+      <span className="text-label font-medium block truncate" style={{ color: "var(--fg)" }}>
+        {title}
+      </span>
+      <span className="mono text-caption block truncate" style={{ color: "var(--fg-2)" }}>
+        {evidence.nodePath}
+      </span>
+      <span className="text-caption block truncate" style={{ color: "var(--fg-3)" }}>
+        {provenance}
+      </span>
+    </>
+  );
+
+  if (!href) {
+    return (
+      <div className="min-w-0" style={{ minHeight: "var(--sp-11)" }} title={evidence.nodePath}>
+        {body}
+      </div>
+    );
+  }
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex min-w-0 items-start no-underline"
+      style={{ minHeight: "var(--sp-11)", gap: "var(--sp-2)", color: "inherit" }}
+      title={`${evidence.nodePath} at ${evidence.commit.slice(0, 7)}`}
+    >
+      <span className="min-w-0 flex-1">{body}</span>
+      <ExternalLink aria-hidden className="size-3.5 shrink-0" style={{ color: "var(--fg-3)" }} />
+    </a>
+  );
+}
+
+/**
+ * Exact-commit file link, or `null` when the forge cannot be identified with
+ * confidence. GitHub is recognized by host; a non-GitHub host only links when
+ * it matches the Team's connected GitLab origin. Everything else stays plain
+ * text — a broken link would undermine the one thing this module can promise:
+ * the cited source is inspectable.
+ */
+export function contextDecisionSourceHref(
+  evidence: ContextDecisionEvidence,
+  gitlabInstanceOrigin: string | null,
+): string | null {
+  const identity = canonicalGitRepoIdentity(evidence.repoUrl);
+  if (!identity) return null;
+  const path = evidence.nodePath.split("/").map(encodeURIComponent).join("/");
+  if (identity.host === "github.com") {
+    return `https://github.com/${identity.path}/blob/${evidence.commit}/${path}`;
+  }
+  const gitlab = resolveGitLabRepositoryWebIdentity(evidence.repoUrl, gitlabInstanceOrigin);
+  if (gitlab?.originMatchesConnection) {
+    return `${gitlab.origin}/${gitlab.path}/-/blob/${evidence.commit}/${path}`;
+  }
+  return null;
+}
+
+function nodeFileName(nodePath: string): string {
+  return nodePath.split("/").filter(Boolean).at(-1) ?? nodePath;
+}

--- a/packages/web/src/pages/request-dock-preview.tsx
+++ b/packages/web/src/pages/request-dock-preview.tsx
@@ -1,6 +1,7 @@
-import type { AskRequest, GithubEventCard } from "@first-tree/shared";
+import type { AskRequest, ContextDecision, GithubEventCard } from "@first-tree/shared";
 import { useState } from "react";
 import { AskTakeover } from "../components/chat/ask-takeover.js";
+import { ContextDecisionReceipt } from "../components/chat/context-decision-receipt.js";
 import { GithubEventCardMessage } from "../components/chat/github-event-card.js";
 
 /**
@@ -70,6 +71,77 @@ const COMMIT_CARD: GithubEventCard = {
   },
 };
 
+/**
+ * Agent-reported Context Tree receipts, one per observable effect. Same shape
+ * the `first-tree-read` skill attaches to a real final send, so this preview
+ * exercises the production component rather than a look-alike.
+ */
+const RECEIPTS: ContextDecision[] = [
+  {
+    version: 1,
+    effect: "conflicted",
+    summary: "The error budget supports expansion, but the weekend freeze blocks rollout changes after 18:00.",
+    evidence: [
+      {
+        repoUrl: "https://github.com/agent-team-foundation/first-tree-context",
+        commit: COMMIT_SHA,
+        nodePath: "product/release/rollout-policy.md",
+        heading: "Weekend change freeze",
+      },
+      {
+        repoUrl: "https://github.com/agent-team-foundation/first-tree-context",
+        commit: COMMIT_SHA,
+        nodePath: "product/reliability/error-budget.md",
+        heading: "Expansion threshold",
+      },
+    ],
+  },
+  {
+    version: 1,
+    effect: "redirected",
+    summary: "The approved migration sequence requires Web adoption before CLI expansion, so the order was reversed.",
+    evidence: [
+      {
+        repoUrl: "https://github.com/agent-team-foundation/first-tree-context",
+        commit: COMMIT_SHA,
+        nodePath: "product/billing/migration-sequence.md",
+        heading: "Web adoption first",
+      },
+    ],
+  },
+  {
+    version: 1,
+    effect: "constrained",
+    summary: "Team rollout policy caps Web at 20%; CLI remains at 5% until the migration guard is cleared.",
+    evidence: [
+      {
+        repoUrl: "https://github.com/agent-team-foundation/first-tree-context",
+        commit: COMMIT_SHA,
+        nodePath: "product/release/rollout-policy.md",
+        heading: "Expansion gates",
+      },
+      {
+        repoUrl: "https://gitlab.example.com/team/context-tree",
+        commit: COMMIT_SHA,
+        nodePath: "product/release/very/deeply/nested/surface-rollout-order-and-gates.md",
+      },
+    ],
+  },
+  {
+    version: 1,
+    effect: "confirmed",
+    summary: "Current expansion gates and the latest error-budget decision both support moving Web from 5% to 20%.",
+    evidence: [
+      {
+        repoUrl: "https://github.com/agent-team-foundation/first-tree-context",
+        commit: COMMIT_SHA,
+        nodePath: "product/reliability/error-budget.md",
+        heading: "Expansion threshold",
+      },
+    ],
+  },
+];
+
 const MODES: { label: string; payload: AskRequest }[] = [
   { label: "options · single", payload: SINGLE_PAYLOAD },
   { label: "options · multi", payload: MULTI_PAYLOAD },
@@ -81,11 +153,13 @@ function ModeBlock({
   payload,
   height = 560,
   mobile = false,
+  contextDecision = null,
 }: {
   label: string;
   payload: AskRequest;
   height?: number;
   mobile?: boolean;
+  contextDecision?: ContextDecision | null;
 }) {
   const [status, setStatus] = useState<string | null>(null);
   return (
@@ -106,6 +180,7 @@ function ModeBlock({
       >
         <AskTakeover
           body={BODY}
+          contextDecision={contextDecision}
           payload={payload}
           askerName="deploy-agent"
           mobile={mobile}
@@ -139,8 +214,36 @@ export function RequestDockPreviewPage() {
         stays pinned, so Submit is reachable at any height. Both resolve the question: Submit sends the composed answer,
         Skip sends a skipped answer (there is no keep-it-open path).
       </p>
-      {MODES.map((m) => (
-        <ModeBlock key={m.label} label={m.label} payload={m.payload} />
+      {MODES.map((m, index) => (
+        <ModeBlock
+          key={m.label}
+          label={m.label}
+          payload={m.payload}
+          contextDecision={index === 0 ? RECEIPTS[0] : null}
+        />
+      ))}
+
+      <h2 className="mono text-caption font-semibold" style={{ color: "var(--fg-3)", textTransform: "uppercase" }}>
+        Context Tree decision receipt — the four observable effects
+      </h2>
+      <p className="text-body" style={{ color: "var(--fg-3)", margin: "var(--sp-1) 0 var(--sp-4)" }}>
+        Rendered where it ships: under the agent result it explains. Collapsed shows what team context did and what
+        changed; expanding reveals the exact cited nodes, repository and commit, plus the agent-attribution note.
+      </p>
+      {RECEIPTS.map((receipt) => (
+        <div
+          key={receipt.effect}
+          style={{
+            marginBottom: "var(--sp-4)",
+            padding: "var(--sp-3)",
+            border: "var(--hairline) solid var(--border)",
+            borderRadius: "var(--radius-panel)",
+            background: "var(--bg-raised)",
+          }}
+        >
+          <div className="text-body">Recommendation: expand Web to 20%, keep CLI at 5%.</div>
+          <ContextDecisionReceipt receipt={receipt} gitlabInstanceOrigin="https://gitlab.example.com" />
+        </div>
       ))}
 
       <h2 className="mono text-caption font-semibold" style={{ color: "var(--fg-3)", textTransform: "uppercase" }}>

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -5175,6 +5175,60 @@ describe("ChatView Context Tree decision receipt", () => {
     await act(async () => root.unmount());
   });
 
+  // The participant list holds CURRENT speakers only, so a removed human's
+  // historical row would read as "not a known human" under a negative gate and
+  // surface a receipt forged before the server-side guard existed.
+  it("hides a receipt from a sender who is no longer a chat participant", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const history = messages([
+      withReceipt({
+        id: "msg-departed-human",
+        senderId: "human-agent-removed",
+        content: "Message from a human who has since been removed.",
+      }),
+    ]);
+    chatMocks.listChatMessages.mockResolvedValue(history);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), history),
+      "/",
+    );
+
+    await waitForText(container, "Message from a human who has since been removed.");
+    expect(container.textContent).not.toContain("Context Tree in action");
+
+    await act(async () => root.unmount());
+  });
+
+  // Cached messages paint before `chatDetail` resolves; an unresolved sender is
+  // not evidence of an agent sender.
+  it("hides a receipt while the participant list is still loading", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const history = messages([
+      withReceipt({
+        id: "msg-loading",
+        senderId: "agent-1",
+        content: "Agent reply rendered before chat detail resolves.",
+        source: "cli",
+      }),
+    ]);
+    chatMocks.listChatMessages.mockResolvedValue(history);
+    chatMocks.getChat.mockReturnValue(new Promise(() => {}));
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => {
+        seedChat(client, chatDetail(), history);
+        client.removeQueries({ queryKey: ["chat-detail", "chat-1"] });
+      },
+      "/",
+    );
+
+    await waitForText(container, "Agent reply rendered before chat detail resolves.");
+    expect(container.textContent).not.toContain("Context Tree in action");
+
+    await act(async () => root.unmount());
+  });
+
   it("shows the asking agent's receipt inside the blocking ask, above the answer controls", async () => {
     const { ChatView } = await import("../chat-view.js");
     const ask = withReceipt({

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -4,6 +4,7 @@ import {
   type Agent,
   type ChatDetail,
   type ChatParticipantDetail,
+  CONTEXT_DECISION_METADATA_KEY,
   encodeProviderRetryEventMessage,
   FIRST_CHAT_ORIENTATION_CHAT_STATES,
   FIRST_CHAT_ORIENTATION_METADATA_KEY,
@@ -5091,6 +5092,118 @@ describe("need-you queue session", () => {
     await answerOpenAsk(container);
     expect(locText(container)).toBe("/");
     expect(meChatMocks.listNeedYouRequests).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+});
+
+describe("ChatView Context Tree decision receipt", () => {
+  const RECEIPT = {
+    version: 1,
+    effect: "constrained",
+    summary: "Team rollout policy caps Web at 20%; CLI stays at 5% until the migration guard clears.",
+    evidence: [
+      {
+        repoUrl: "https://github.com/example/context-tree",
+        commit: "0123456789abcdef0123456789abcdef01234567",
+        nodePath: "product/release/rollout-policy.md",
+        heading: "Expansion gates",
+      },
+    ],
+  };
+
+  function withReceipt(
+    overrides: Partial<MessageWithDelivery> & { id: string; senderId: string },
+    receipt: unknown = RECEIPT,
+  ): MessageWithDelivery {
+    return message({
+      ...overrides,
+      metadata: { ...(overrides.metadata ?? {}), [CONTEXT_DECISION_METADATA_KEY]: receipt },
+    });
+  }
+
+  it("shows the receipt under an agent reply", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const history = messages([
+      withReceipt({
+        id: "msg-receipt",
+        senderId: "agent-1",
+        content: "Expanding Web to 20% and holding CLI at 5%.",
+        source: "cli",
+      }),
+    ]);
+    chatMocks.listChatMessages.mockResolvedValue(history);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), history),
+      "/",
+    );
+
+    await waitForText(container, "Context Tree in action");
+    expect(container.textContent).toContain("Options narrowed");
+    expect(container.textContent).toContain("Team rollout policy caps Web at 20%");
+    // Collapsed by default: the exact source is one click away, not in the way.
+    expect(container.textContent).not.toContain("product/release/rollout-policy.md");
+
+    await act(async () => root.unmount());
+  });
+
+  it("ignores a receipt on a human message and a malformed receipt from an agent", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const history = messages([
+      withReceipt({
+        id: "msg-human",
+        senderId: "human-agent-self",
+        content: "Human message claiming context influence.",
+        metadata: { mentions: ["agent-1"] },
+      }),
+      withReceipt(
+        { id: "msg-broken", senderId: "agent-1", content: "Agent reply with a broken receipt.", source: "cli" },
+        { ...RECEIPT, effect: "none" },
+      ),
+    ]);
+    chatMocks.listChatMessages.mockResolvedValue(history);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), history),
+      "/",
+    );
+
+    await waitForText(container, "Agent reply with a broken receipt.");
+    expect(container.textContent).not.toContain("Context Tree in action");
+
+    await act(async () => root.unmount());
+  });
+
+  it("shows the asking agent's receipt inside the blocking ask, above the answer controls", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const ask = withReceipt({
+      id: "ask-receipt",
+      senderId: "agent-1",
+      format: "request",
+      content: "Expand Web to 20% now, or hold for 24 hours?",
+      metadata: { mentions: ["human-agent-self"], request: { multiSelect: false } },
+      createdAt: "2026-05-28T11:59:00.000Z",
+    });
+    chatMocks.listChatOpenRequests.mockResolvedValue({ items: [ask] });
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => {
+        seedChat(client, chatDetail(), messages([ask]));
+        client.setQueryData(["chat-open-requests", "chat-1"], { items: [ask] });
+      },
+      "/",
+    );
+
+    await waitForText(container, "Expand Web to 20% now, or hold for 24 hours?");
+    await waitForText(container, "Context Tree in action");
+    const takeover = container.querySelector<HTMLElement>('[aria-label^="Question from"]');
+    if (!takeover) throw new Error("ask takeover missing");
+    const receipt = takeover.querySelector<HTMLElement>('[aria-label="Context Tree influence reported by the agent"]');
+    const answerBox = takeover.querySelector<HTMLTextAreaElement>('textarea[placeholder^="Type your answer"]');
+    if (!receipt || !answerBox) throw new Error("receipt or answer input missing from the takeover");
+    // The receipt is context for the decision, so it must precede the controls.
+    expect(receipt.compareDocumentPosition(answerBox) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -5229,6 +5229,52 @@ describe("ChatView Context Tree decision receipt", () => {
     await act(async () => root.unmount());
   });
 
+  // `chatParticipantDetailSchema.type` is a loose wire string so legacy and
+  // unrecognised values flow through. Under version skew a `!== "human"` set
+  // would readmit exactly the forged human row the gate exists to stop.
+  it("hides a receipt from a sender whose participant type is unknown, in both timeline and ask", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const skewedChat = chatDetail({
+      participants: [
+        ...PARTICIPANTS,
+        participant({ agentId: "agent-legacy", type: "autonomous_agent", name: "legacy", displayName: "Legacy" }),
+        participant({ agentId: "agent-untyped", type: "", name: "untyped", displayName: "Untyped" }),
+      ],
+    });
+    const ask = withReceipt({
+      id: "ask-unknown-type",
+      senderId: "agent-untyped",
+      format: "request",
+      content: "Question from a sender with no resolved type?",
+      metadata: { mentions: ["human-agent-self"], request: { multiSelect: false } },
+      createdAt: "2026-05-28T11:59:00.000Z",
+    });
+    const history = messages([
+      withReceipt({
+        id: "msg-legacy-type",
+        senderId: "agent-legacy",
+        content: "Reply from a legacy participant type.",
+        source: "cli",
+      }),
+      ask,
+    ]);
+    chatMocks.listChatMessages.mockResolvedValue(history);
+    chatMocks.listChatOpenRequests.mockResolvedValue({ items: [ask] });
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" initialChatDetail={skewedChat} />,
+      (client) => {
+        seedChat(client, skewedChat, history);
+        client.setQueryData(["chat-open-requests", "chat-1"], { items: [ask] });
+      },
+      "/",
+    );
+
+    await waitForText(container, "Question from a sender with no resolved type?");
+    expect(container.textContent).not.toContain("Context Tree in action");
+
+    await act(async () => root.unmount());
+  });
+
   it("shows the asking agent's receipt inside the blocking ask, above the answer controls", async () => {
     const { ChatView } = await import("../chat-view.js");
     const ask = withReceipt({

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,4 +1,5 @@
 import {
+  AGENT_TYPES,
   type AttachmentRef,
   attachmentRefsFromMetadata,
   type CapabilityEntry,
@@ -602,14 +603,16 @@ type MessageBodyProps = {
   myAgentId: string | null;
   mentionParticipants: RenderedMentionParticipant[];
   /**
-   * True only when this row's sender is a KNOWN non-human speaker of this chat.
-   * Gates the agent-attributed Context Tree receipt, and is deliberately a
-   * positive test rather than "not a known human": the participant list holds
-   * current speakers only, so a removed human's historical row and every row
-   * rendered from cache before `chatDetail` resolves both look non-human under
-   * a negative test, and a receipt forged before the server-side guard would
-   * surface. Failing closed hides the receipt on those unknown rows instead —
-   * a departed agent's receipt is lost, a forged one never renders.
+   * True only when this row's sender is a speaker of this chat POSITIVELY typed
+   * as an agent. Gates the agent-attributed Context Tree receipt, and is
+   * deliberately a positive test rather than "not a known human": the
+   * participant list holds current speakers only and its `type` is a loose wire
+   * string, so a removed human's historical row, a row painted from cache before
+   * `chatDetail` resolves, and a legacy or unrecognised type all read as
+   * non-human under a negative test — and a receipt forged before the
+   * server-side guard would surface. Failing closed hides the receipt on every
+   * unresolved sender instead: a departed agent's receipt is lost, a forged one
+   * never renders.
    */
   senderIsAgent: boolean;
 };
@@ -2913,12 +2916,15 @@ export function ChatView({
     () => new Set((chatDetail?.participants ?? []).filter((p) => p.type === "human").map((p) => p.agentId)),
     [chatDetail?.participants],
   );
-  // Non-human speakers of THIS chat, resolved from the loaded participant list.
-  // Empty while `chatDetail` is still loading, which is the point: a sender this
-  // set does not name is not treated as an agent (see
-  // `MessageBodyProps.senderIsAgent`).
+  // Speakers of THIS chat that are POSITIVELY typed as agents. The wire schema
+  // keeps `type` a loose string so legacy and unrecognised DB values flow
+  // through, so `!== "human"` would quietly admit a missing, legacy, or
+  // future-unknown type — and under version skew a cached human row could pass
+  // the receipt gate again. Matching the known agent value instead keeps every
+  // unresolved type out, and the set is empty while `chatDetail` loads, which is
+  // the same fail-closed direction (see `MessageBodyProps.senderIsAgent`).
   const agentParticipantIds = useMemo(
-    () => new Set((chatDetail?.participants ?? []).filter((p) => p.type !== "human").map((p) => p.agentId)),
+    () => new Set((chatDetail?.participants ?? []).filter((p) => p.type === AGENT_TYPES.AGENT).map((p) => p.agentId)),
     [chatDetail?.participants],
   );
   // The exact condition under which filtering on `agentId` keeps EVERY

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -20,6 +20,7 @@ import {
   type RequestResolution,
   type RuntimeAuthProvider,
   readAskAgentMessageMetadata,
+  readContextDecisionMetadata,
   readFirstChatOrientationChatState,
   readFirstChatOrientationMessageMetadata,
   statusReasonFromProviderRetryEvent,
@@ -95,6 +96,7 @@ import { sendAskAnswer } from "../../../components/chat/ask-answer-transport.js"
 import { type AskAnswer, AskTakeover, clearAskTakeoverDraft } from "../../../components/chat/ask-takeover.js";
 import { awaitedAgentsFromMessage, ChatOfflineNotice } from "../../../components/chat/chat-offline-notice.js";
 import { ComposeStatusBar } from "../../../components/chat/compose-status-bar.js";
+import { ContextDecisionReceipt } from "../../../components/chat/context-decision-receipt.js";
 import {
   GITHUB_SYSTEM_SENDER_NAME,
   GithubEventCardMessage,
@@ -580,6 +582,8 @@ type MessageRowProps = {
   agentAvatarFn: (id: string) => string | null;
   agentColorTokenFn: (id: string) => string | null;
   mentionParticipants: RenderedMentionParticipant[];
+  /** See `MessageBodyProps.senderIsHuman`. */
+  senderIsHuman: boolean;
   /** Trial surface: render sender avatar/name as plain identity, without the
    *  AgentHovercard whose actions ("View profile" → /agents/:id, "New chat" →
    *  /?c=draft) would navigate out of the controlled trial conversation. */
@@ -597,6 +601,13 @@ type MessageBodyProps = {
   requestTagAgentId: string | null;
   myAgentId: string | null;
   mentionParticipants: RenderedMentionParticipant[];
+  /**
+   * True when this row's sender is a human speaker in THIS chat. Only used to
+   * suppress an agent-attributed Context Tree receipt on a human's message: the
+   * server strips the key from human sends, but message rows are immutable, so
+   * history written before that guard is still checked here.
+   */
+  senderIsHuman: boolean;
 };
 
 type MessageMarkdownProps = {
@@ -663,6 +674,7 @@ const MessageBody = memo(function MessageBody({
   requestTagAgentId,
   myAgentId,
   mentionParticipants,
+  senderIsHuman,
 }: MessageBodyProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -706,6 +718,13 @@ const MessageBody = memo(function MessageBody({
     );
   }, [msg.metadata, msg.content]);
   const failedDocMentions = useMemo(() => failedDocMentionsFromMetadata(msg.metadata), [msg.metadata]);
+  // The agent's own record of how team context shaped THIS reply. Strictly
+  // parsed (unknown version / malformed payload -> null -> nothing renders),
+  // and never shown for a human speaker's row.
+  const contextDecision = useMemo(
+    () => (senderIsHuman ? null : readContextDecisionMetadata(msg.metadata)),
+    [msg.metadata, senderIsHuman],
+  );
   // Resolve a visible label only when this token's persisted mention ID still
   // identifies the current owner of the canonical handle. System-level
   // addressedAgentIds can include recipients unrelated to a particular token
@@ -950,6 +969,9 @@ const MessageBody = memo(function MessageBody({
           ))}
         </div>
       )}
+      {contextDecision ? (
+        <ContextDecisionReceipt receipt={contextDecision} gitlabInstanceOrigin={gitlabInstanceOrigin} />
+      ) : null}
     </div>
   );
 }, areMessageBodyPropsEqual);
@@ -962,6 +984,7 @@ const MessageRow = memo(function MessageRow({
   agentAvatarFn,
   agentColorTokenFn,
   mentionParticipants,
+  senderIsHuman,
   isTrial,
   orientationCompleted,
   orientationHidden,
@@ -1090,6 +1113,7 @@ const MessageRow = memo(function MessageRow({
           requestTagAgentId={requestTagAgentId}
           myAgentId={myAgentId}
           mentionParticipants={mentionParticipants}
+          senderIsHuman={senderIsHuman}
         />
       </div>
     </div>
@@ -1104,6 +1128,7 @@ function areMessageRowPropsEqual(prev: MessageRowProps, next: MessageRowProps): 
     prev.agentNameFn === next.agentNameFn &&
     prev.agentAvatarFn === next.agentAvatarFn &&
     prev.agentColorTokenFn === next.agentColorTokenFn &&
+    prev.senderIsHuman === next.senderIsHuman &&
     prev.isTrial === next.isTrial &&
     prev.orientationCompleted === next.orientationCompleted &&
     prev.orientationHidden === next.orientationHidden &&
@@ -1118,6 +1143,7 @@ function areMessageBodyPropsEqual(prev: MessageBodyProps, next: MessageBodyProps
     messageBodyFieldsEqual(prev.msg, next.msg) &&
     prev.requestTagAgentId === next.requestTagAgentId &&
     prev.myAgentId === next.myAgentId &&
+    prev.senderIsHuman === next.senderIsHuman &&
     mentionParticipantsEqual(prev.mentionParticipants, next.mentionParticipants)
   );
 }
@@ -1444,6 +1470,8 @@ type ChatTimelineProps = {
   /** Non-human agent participants — drives the inline offline notice. */
   agents: ChatParticipantDetail[];
   mentionParticipants: RenderedMentionParticipant[];
+  /** Human speakers in this chat — see `MessageBodyProps.senderIsHuman`. */
+  humanParticipantIds: ReadonlySet<string>;
   dockRequestId: string | undefined;
   gapAfterMessageId: string | null;
   firstNewItemIdx: number;
@@ -1477,6 +1505,7 @@ const ChatTimeline = memo(function ChatTimeline({
   chatId,
   agents,
   mentionParticipants,
+  humanParticipantIds,
   dockRequestId,
   gapAfterMessageId,
   firstNewItemIdx,
@@ -1583,6 +1612,7 @@ const ChatTimeline = memo(function ChatTimeline({
                     agentAvatarFn={agentAvatarFn}
                     agentColorTokenFn={agentColorTokenFn}
                     mentionParticipants={mentionParticipants}
+                    senderIsHuman={humanParticipantIds.has(msg.senderId)}
                     isTrial={isTrial}
                     orientationCompleted={completedOrientationMessageIds.has(msg.id)}
                     orientationHidden={orientationHidden}
@@ -4411,6 +4441,12 @@ export function ChatView({
                   imageId: ref.attachmentId,
                   filename: ref.filename,
                 }))}
+                contextDecision={
+                  humanParticipantIds.has(dockRequest.senderId)
+                    ? null
+                    : readContextDecisionMetadata(dockRequest.metadata)
+                }
+                gitlabInstanceOrigin={gitlabInstanceOrigin}
                 payload={dockPayload}
                 askerName={chatScopedAgentName(dockRequest.senderId)}
                 sending={askBusy}
@@ -4952,6 +4988,7 @@ export function ChatView({
             chatId={chatId}
             agents={(chatDetail?.participants ?? []).filter((p) => p.type !== "human")}
             mentionParticipants={renderMentionParticipants}
+            humanParticipantIds={humanParticipantIds}
             dockRequestId={dockRequestId}
             gapAfterMessageId={gapAfterMessageId}
             firstNewItemIdx={firstNewItemIdx}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -582,8 +582,8 @@ type MessageRowProps = {
   agentAvatarFn: (id: string) => string | null;
   agentColorTokenFn: (id: string) => string | null;
   mentionParticipants: RenderedMentionParticipant[];
-  /** See `MessageBodyProps.senderIsHuman`. */
-  senderIsHuman: boolean;
+  /** See `MessageBodyProps.senderIsAgent`. */
+  senderIsAgent: boolean;
   /** Trial surface: render sender avatar/name as plain identity, without the
    *  AgentHovercard whose actions ("View profile" → /agents/:id, "New chat" →
    *  /?c=draft) would navigate out of the controlled trial conversation. */
@@ -602,12 +602,16 @@ type MessageBodyProps = {
   myAgentId: string | null;
   mentionParticipants: RenderedMentionParticipant[];
   /**
-   * True when this row's sender is a human speaker in THIS chat. Only used to
-   * suppress an agent-attributed Context Tree receipt on a human's message: the
-   * server strips the key from human sends, but message rows are immutable, so
-   * history written before that guard is still checked here.
+   * True only when this row's sender is a KNOWN non-human speaker of this chat.
+   * Gates the agent-attributed Context Tree receipt, and is deliberately a
+   * positive test rather than "not a known human": the participant list holds
+   * current speakers only, so a removed human's historical row and every row
+   * rendered from cache before `chatDetail` resolves both look non-human under
+   * a negative test, and a receipt forged before the server-side guard would
+   * surface. Failing closed hides the receipt on those unknown rows instead —
+   * a departed agent's receipt is lost, a forged one never renders.
    */
-  senderIsHuman: boolean;
+  senderIsAgent: boolean;
 };
 
 type MessageMarkdownProps = {
@@ -674,7 +678,7 @@ const MessageBody = memo(function MessageBody({
   requestTagAgentId,
   myAgentId,
   mentionParticipants,
-  senderIsHuman,
+  senderIsAgent,
 }: MessageBodyProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -720,10 +724,10 @@ const MessageBody = memo(function MessageBody({
   const failedDocMentions = useMemo(() => failedDocMentionsFromMetadata(msg.metadata), [msg.metadata]);
   // The agent's own record of how team context shaped THIS reply. Strictly
   // parsed (unknown version / malformed payload -> null -> nothing renders),
-  // and never shown for a human speaker's row.
+  // and shown only for a positively identified agent sender.
   const contextDecision = useMemo(
-    () => (senderIsHuman ? null : readContextDecisionMetadata(msg.metadata)),
-    [msg.metadata, senderIsHuman],
+    () => (senderIsAgent ? readContextDecisionMetadata(msg.metadata) : null),
+    [msg.metadata, senderIsAgent],
   );
   // Resolve a visible label only when this token's persisted mention ID still
   // identifies the current owner of the canonical handle. System-level
@@ -984,7 +988,7 @@ const MessageRow = memo(function MessageRow({
   agentAvatarFn,
   agentColorTokenFn,
   mentionParticipants,
-  senderIsHuman,
+  senderIsAgent,
   isTrial,
   orientationCompleted,
   orientationHidden,
@@ -1113,7 +1117,7 @@ const MessageRow = memo(function MessageRow({
           requestTagAgentId={requestTagAgentId}
           myAgentId={myAgentId}
           mentionParticipants={mentionParticipants}
-          senderIsHuman={senderIsHuman}
+          senderIsAgent={senderIsAgent}
         />
       </div>
     </div>
@@ -1128,7 +1132,7 @@ function areMessageRowPropsEqual(prev: MessageRowProps, next: MessageRowProps): 
     prev.agentNameFn === next.agentNameFn &&
     prev.agentAvatarFn === next.agentAvatarFn &&
     prev.agentColorTokenFn === next.agentColorTokenFn &&
-    prev.senderIsHuman === next.senderIsHuman &&
+    prev.senderIsAgent === next.senderIsAgent &&
     prev.isTrial === next.isTrial &&
     prev.orientationCompleted === next.orientationCompleted &&
     prev.orientationHidden === next.orientationHidden &&
@@ -1143,7 +1147,7 @@ function areMessageBodyPropsEqual(prev: MessageBodyProps, next: MessageBodyProps
     messageBodyFieldsEqual(prev.msg, next.msg) &&
     prev.requestTagAgentId === next.requestTagAgentId &&
     prev.myAgentId === next.myAgentId &&
-    prev.senderIsHuman === next.senderIsHuman &&
+    prev.senderIsAgent === next.senderIsAgent &&
     mentionParticipantsEqual(prev.mentionParticipants, next.mentionParticipants)
   );
 }
@@ -1470,8 +1474,8 @@ type ChatTimelineProps = {
   /** Non-human agent participants — drives the inline offline notice. */
   agents: ChatParticipantDetail[];
   mentionParticipants: RenderedMentionParticipant[];
-  /** Human speakers in this chat — see `MessageBodyProps.senderIsHuman`. */
-  humanParticipantIds: ReadonlySet<string>;
+  /** Non-human speakers in this chat — see `MessageBodyProps.senderIsAgent`. */
+  agentParticipantIds: ReadonlySet<string>;
   dockRequestId: string | undefined;
   gapAfterMessageId: string | null;
   firstNewItemIdx: number;
@@ -1505,7 +1509,7 @@ const ChatTimeline = memo(function ChatTimeline({
   chatId,
   agents,
   mentionParticipants,
-  humanParticipantIds,
+  agentParticipantIds,
   dockRequestId,
   gapAfterMessageId,
   firstNewItemIdx,
@@ -1612,7 +1616,7 @@ const ChatTimeline = memo(function ChatTimeline({
                     agentAvatarFn={agentAvatarFn}
                     agentColorTokenFn={agentColorTokenFn}
                     mentionParticipants={mentionParticipants}
-                    senderIsHuman={humanParticipantIds.has(msg.senderId)}
+                    senderIsAgent={agentParticipantIds.has(msg.senderId)}
                     isTrial={isTrial}
                     orientationCompleted={completedOrientationMessageIds.has(msg.id)}
                     orientationHidden={orientationHidden}
@@ -2907,6 +2911,14 @@ export function ChatView({
   // agent I am talking to", and the viewer is the human side of the pair.
   const humanParticipantIds = useMemo(
     () => new Set((chatDetail?.participants ?? []).filter((p) => p.type === "human").map((p) => p.agentId)),
+    [chatDetail?.participants],
+  );
+  // Non-human speakers of THIS chat, resolved from the loaded participant list.
+  // Empty while `chatDetail` is still loading, which is the point: a sender this
+  // set does not name is not treated as an agent (see
+  // `MessageBodyProps.senderIsAgent`).
+  const agentParticipantIds = useMemo(
+    () => new Set((chatDetail?.participants ?? []).filter((p) => p.type !== "human").map((p) => p.agentId)),
     [chatDetail?.participants],
   );
   // The exact condition under which filtering on `agentId` keeps EVERY
@@ -4442,9 +4454,9 @@ export function ChatView({
                   filename: ref.filename,
                 }))}
                 contextDecision={
-                  humanParticipantIds.has(dockRequest.senderId)
-                    ? null
-                    : readContextDecisionMetadata(dockRequest.metadata)
+                  agentParticipantIds.has(dockRequest.senderId)
+                    ? readContextDecisionMetadata(dockRequest.metadata)
+                    : null
                 }
                 gitlabInstanceOrigin={gitlabInstanceOrigin}
                 payload={dockPayload}
@@ -4988,7 +5000,7 @@ export function ChatView({
             chatId={chatId}
             agents={(chatDetail?.participants ?? []).filter((p) => p.type !== "human")}
             mentionParticipants={renderMentionParticipants}
-            humanParticipantIds={humanParticipantIds}
+            agentParticipantIds={agentParticipantIds}
             dockRequestId={dockRequestId}
             gapAfterMessageId={gapAfterMessageId}
             firstNewItemIdx={firstNewItemIdx}


### PR DESCRIPTION
## Why

`first-tree-read` (#1978) already instructs an agent to attach a `contextDecision` receipt to the same final `chat send` / blocking `chat ask` that carries the affected choice. Nothing consumed it: the receipt sat in free-form message metadata with no shared schema, no trust boundary, and no renderer — so the one place a user could see Context Tree paying off was invisible.

This lands the first consumer: the receipt is shown where the result is judged.

## What

**shared** — versioned `contextDecision` schema + strict `readContextDecisionMetadata`. Each evidence row must name a credential-free repository, a hex commit, and a tree-root-relative node path (1–3 rows, matching the skill's cap). A receipt with nothing to inspect is rejected; unknown-version / malformed payloads read back as `null`.

**server** — trust boundary in `preflightMessageSendIntent`:
- a human sender's `contextDecision` is stripped (the agent-attribution claim is not theirs to make, and a browser/API write must not be able to forge one);
- an agent sender's malformed receipt fails the write with a shape hint, so the author fixes and resends instead of silently storing something no consumer can render.

**web** — `ContextDecisionReceipt`, rendered in two places:
- under an agent's chat reply, after its body, images and attachments;
- inside the blocking ask, after the question body and before the answer controls (adds no request state, notification, or blocking condition).

Collapsed it shows the Context Tree mark, what team context did (`Conflict surfaced` / `Approach changed` / `Options narrowed` / `Direction supported`), the agent's one-sentence summary, and an `N team decisions` disclosure. Expanding reveals the cited nodes with repository and short commit, an exact-commit link when the forge is unambiguous (GitHub by host; GitLab only when it matches the connected instance), and the attribution note at the bottom.

## Trust framing

The module states the outcome objectively because that is what the agent reports, but it is not a First Tree verification: no success check, no "verified" copy, no system-card chrome. Attribution is weakened to a footnote *only* because the receipt is still attached to its authoring agent's message — a future cross-message digest (e.g. a Context page rollup) must re-state it up front. This is recorded in the component's contract comment.

Rendering is gated on a strict parse and never runs for a human speaker's row, so pre-guard history cannot surface a forged receipt.

## Verification

- `pnpm typecheck` (all packages) and `pnpm check` clean; `pnpm --filter @first-tree/web lint:tokens` clean.
- New tests: shared schema (12), server trust boundary (4), receipt component (9), and three ChatView DOM cases — agent reply renders it, human sender / malformed receipt render nothing, and the ask shows it before the answer input.
- `@first-tree/shared`, `@first-tree/server`, `@first-tree/web` suites pass. `@first-tree/client` passes standalone; two of its timeout-driven tests (`pi-handler`, `opencode-handler`) flake under a fully parallel `pnpm test` on this machine and are untouched by this change.
- Real browser at 1440px and 390px on `/preview/request-dock`: collapsed and expanded, all four effects, `scrollWidth === clientWidth` at both widths, 44px disclosure target.

## Follow-ups (not in scope)

- #2004 — an agent can still emit the receipt as visible body text; that is an agent-side transport regression, not a rendering one.
- Context page 7-day rollup of receipts, which needs its own server read model and permission story.
