### PR TITLE
refactor(client): S1a provider binary failure classifier seam

### DIFF
--- a/packages/client/src/__tests__/error-taxonomy.test.ts
+++ b/packages/client/src/__tests__/error-taxonomy.test.ts
@@ -167,6 +167,47 @@ describe("error-taxonomy.classify", () => {
       expect(c.strategy.kind).toBe("exponentialBackoff");
     });
 
+    it("same-provider verify-transient still wins over that provider's missing patterns", () => {
+      // Cursor verify name + Cursor missing text: verify is checked first for
+      // Cursor, so the busy-host flake stays transient (not permanent missing).
+      const err = new Error("Cursor Agent CLI is missing on this machine");
+      err.name = "CursorBinaryVerifyTransientError";
+      const c = classify(err, { source: "session" });
+      expect(c.kind).toBe(ERROR_KINDS.TRANSIENT);
+      expect(c.reasonCode).toBe("cursor_verify_transient");
+      expect(c.strategy.kind).toBe("exponentialBackoff");
+    });
+
+    it("cross-provider ambiguity keeps the historical interleaved order (earlier provider missing beats later verify)", () => {
+      // Cursor verify name + Codex missing text: old taxonomy checked Codex
+      // missing before Cursor verify, so the outcome is permanent Codex missing.
+      const cursorOverCodex = new Error("Unable to locate Codex CLI binaries for x86_64-apple-darwin");
+      cursorOverCodex.name = "CursorBinaryVerifyTransientError";
+      expect(classify(cursorOverCodex, { source: "session" })).toMatchObject({
+        kind: ERROR_KINDS.PERMANENT,
+        reasonCode: "codex_binary_missing",
+        strategy: { kind: "none" },
+      });
+
+      // Grok verify name + Cursor missing text: Cursor missing precedes Grok verify.
+      const grokOverCursor = new Error("Cursor Agent CLI is missing on this machine");
+      grokOverCursor.name = "GrokBinaryVerifyTransientError";
+      expect(classify(grokOverCursor, { source: "session" })).toMatchObject({
+        kind: ERROR_KINDS.PERMANENT,
+        reasonCode: "cursor_binary_missing",
+        strategy: { kind: "none" },
+      });
+
+      // Pi verify name + Grok missing text: Grok missing precedes Pi verify.
+      const piOverGrok = new Error("Grok Build CLI is missing on this machine");
+      piOverGrok.name = "PiBinaryVerifyTransientError";
+      expect(classify(piOverGrok, { source: "session" })).toMatchObject({
+        kind: ERROR_KINDS.PERMANENT,
+        reasonCode: "grok_binary_missing",
+        strategy: { kind: "none" },
+      });
+    });
+
     it("AbortSignal.timeout TimeoutError is transient (recognised by name and by message)", () => {
       const byName = classify(new DOMException("The operation was aborted due to timeout", "TimeoutError"), {
         source: "session",

--- a/packages/client/src/__tests__/pi-binary.test.ts
+++ b/packages/client/src/__tests__/pi-binary.test.ts
@@ -92,8 +92,13 @@ describe("Pi binary resolution", () => {
     expect(isPiBinaryMissingError("pi: command not found")).toBe(true);
     expect(isPiBinaryMissingError("pi is not installed")).toBe(true);
     expect(isPiBinaryMissingError(new Error("ENOENT: pi binary not found"))).toBe(true);
+    expect(isPiBinaryMissingError("no pi binary resolved")).toBe(true);
     expect(isPiBinaryMissingError("python: command not found")).toBe(false);
     expect(isPiBinaryMissingError("network timeout")).toBe(false);
+    // Generic absence phrases without a Pi subject stay unmatched — the old
+    // Pi sanitizer regex could falsely claim ownership of bare "not found".
+    expect(isPiBinaryMissingError("file not found")).toBe(false);
+    expect(isPiBinaryMissingError("package not installed")).toBe(false);
   });
 
   it("rejects adversarial repeated-pi strings in linear time (no catastrophic backtracking)", () => {

--- a/packages/client/src/__tests__/pi-binary.test.ts
+++ b/packages/client/src/__tests__/pi-binary.test.ts
@@ -95,8 +95,8 @@ describe("Pi binary resolution", () => {
     expect(isPiBinaryMissingError("no pi binary resolved")).toBe(true);
     expect(isPiBinaryMissingError("python: command not found")).toBe(false);
     expect(isPiBinaryMissingError("network timeout")).toBe(false);
-    // Generic absence phrases without a Pi subject stay unmatched — the old
-    // Pi sanitizer regex could falsely claim ownership of bare "not found".
+    // Generic taxonomy matcher requires a Pi subject — bare absence phrases
+    // stay unmatched (Pi-scoped sanitizer uses a broader seam entry instead).
     expect(isPiBinaryMissingError("file not found")).toBe(false);
     expect(isPiBinaryMissingError("package not installed")).toBe(false);
   });

--- a/packages/client/src/__tests__/pi-handler.test.ts
+++ b/packages/client/src/__tests__/pi-handler.test.ts
@@ -651,11 +651,12 @@ describe("sanitizePiProviderDetail", () => {
   });
 
   it("delegates binary-missing recognition to the provider-support seam", () => {
+    // Pi-scoped sanitizer keeps the historical broad mapping.
     expect(sanitizePiProviderDetail("Pi CLI is missing on this machine")).toBe("pi_binary_missing");
     expect(sanitizePiProviderDetail("no pi binary resolved")).toBe("pi_binary_missing");
     expect(sanitizePiProviderDetail("pi: command not found")).toBe("pi_binary_missing");
-    // Bare non-Pi absence text must not become the binary-missing token.
-    expect(sanitizePiProviderDetail("file not found")).toBe("pi_provider_error");
+    expect(sanitizePiProviderDetail("file not found")).toBe("pi_binary_missing");
+    expect(sanitizePiProviderDetail("package not installed")).toBe("pi_binary_missing");
   });
 });
 

--- a/packages/client/src/__tests__/pi-handler.test.ts
+++ b/packages/client/src/__tests__/pi-handler.test.ts
@@ -649,6 +649,14 @@ describe("sanitizePiProviderDetail", () => {
     expect(sanitizePiProviderDetail("Please ignore prior text: PRIVATE_USER_PROMPT_XYZ")).toBe("pi_provider_error");
     expect(sanitizePiProviderDetail("Please ignore prior text: PRIVATE_USER_PROMPT_XYZ")).not.toContain("PRIVATE");
   });
+
+  it("delegates binary-missing recognition to the provider-support seam", () => {
+    expect(sanitizePiProviderDetail("Pi CLI is missing on this machine")).toBe("pi_binary_missing");
+    expect(sanitizePiProviderDetail("no pi binary resolved")).toBe("pi_binary_missing");
+    expect(sanitizePiProviderDetail("pi: command not found")).toBe("pi_binary_missing");
+    // Bare non-Pi absence text must not become the binary-missing token.
+    expect(sanitizePiProviderDetail("file not found")).toBe("pi_provider_error");
+  });
 });
 
 describe("resolvePiNativeToolRefs", () => {

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -192,6 +192,15 @@ describe("runtime provider architecture guard", () => {
     expect(source).toContain("isGrokBinaryMissingError");
     expect(source).toContain("isPiBinaryMissingError");
     expect(source).toContain("piProviderDetailBinaryMissingReasonCode");
+    // Contextual Pi-detail entry must compose the strict matcher, not copy its phrases.
+    expect(source).toMatch(
+      /export function piProviderDetailBinaryMissingReasonCode\([\s\S]*?isPiBinaryMissingError\(detail\)/,
+    );
+    const contextualFn = source.slice(source.indexOf("export function piProviderDetailBinaryMissingReasonCode"));
+    expect(contextualFn).not.toContain("pi cli is missing");
+    expect(contextualFn).not.toContain("no pi binary");
+    expect(contextualFn).toContain('includes("not found")');
+    expect(contextualFn).toContain('includes("not installed")');
   });
 
   it("keeps binary modules as re-export delegates for missing-error matchers (single owner)", () => {

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -191,6 +191,7 @@ describe("runtime provider architecture guard", () => {
     expect(source).toContain("isCursorBinaryMissingError");
     expect(source).toContain("isGrokBinaryMissingError");
     expect(source).toContain("isPiBinaryMissingError");
+    expect(source).toContain("piProviderDetailBinaryMissingReasonCode");
   });
 
   it("keeps binary modules as re-export delegates for missing-error matchers (single owner)", () => {
@@ -249,12 +250,12 @@ describe("runtime provider architecture guard", () => {
       }
     }
 
-    // Pi sanitizer must consume the seam matcher + stable constant.
+    // Pi sanitizer must consume the Pi-detail seam entry (not a local table).
     const piHandler = readFileSync(join(clientSrc, "handlers/pi/index.ts"), "utf8");
-    expect(piHandler).toContain("isPiBinaryMissingError");
-    expect(piHandler).toContain("PROVIDER_BINARY_FAILURE_REASON_CODES");
+    expect(piHandler).toContain("piProviderDetailBinaryMissingReasonCode");
     expect(piHandler).toContain("provider-support/binary-failure");
-    expect(piHandler).toContain("PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING");
+    expect(piHandler).not.toContain("isPiBinaryMissingError");
+    expect(piHandler).not.toContain("PROVIDER_BINARY_FAILURE_REASON_CODES");
   });
 
   it("names only the concrete composition files as registration roots", () => {

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -47,8 +47,13 @@ const GUARDED_CLIENT_FILES = [
   "runtime/handler.ts",
   "runtime/runtime-notice.ts",
   "runtime/session-manager.ts",
+  "runtime/error-taxonomy.ts",
   "handlers/auth-error-hint.ts",
 ] as const;
+
+/** Concrete provider binary / handler implementation modules (not support seams). */
+const CONCRETE_PROVIDER_BINARY_IMPORT = /from ["']\.\/(?:codex|cursor|grok|pi|kimi|opencode)-binary\.js["']/;
+const CONCRETE_PROVIDER_HANDLER_IMPORT = /from ["'].*handlers\/(claude-code|codex|cursor|grok|kimi-code|opencode|pi)/;
 
 /** Live presentation consumers that must derive catalog-owned copy. */
 const CATALOG_CONSUMER_FILES = [
@@ -147,18 +152,62 @@ describe("runtime provider architecture guard", () => {
         // a concrete runtime id (including the retired silent Claude-era default).
         const hit = containsAnyProviderLiteral(source);
         expect(hit, `${rel} must not hard-code provider literal ${hit}`).toBeNull();
-        expect(source).not.toMatch(/from ["'].*handlers\/(claude-code|codex|cursor|grok|kimi-code|opencode|pi)/);
+        expect(source).not.toMatch(CONCRETE_PROVIDER_HANDLER_IMPORT);
         expect(source).toContain("runtimeProviderSchema");
         expect(source).toMatch(/runtimeProvider is required/);
         continue;
       }
 
-      expect(source).not.toMatch(/from ["'].*handlers\/(claude-code|codex|cursor|grok|kimi-code|opencode|pi)/);
+      if (relPosix === "runtime/error-taxonomy.ts") {
+        // Generic taxonomy consumes normalized binary-failure signals only.
+        expect(source).toContain("recognizeProviderBinaryFailure");
+        expect(source).toContain("provider-support/binary-failure");
+        expect(source).not.toMatch(CONCRETE_PROVIDER_BINARY_IMPORT);
+        expect(source).not.toMatch(CONCRETE_PROVIDER_HANDLER_IMPORT);
+        expect(source).not.toMatch(/from ["']\.\/(?:codex|cursor|grok|pi)-binary/);
+        continue;
+      }
+
+      expect(source).not.toMatch(CONCRETE_PROVIDER_HANDLER_IMPORT);
       if (relPosix === "runtime/handler.ts" || relPosix === "runtime/runtime.ts") {
         const hit = containsAnyProviderLiteral(source);
         expect(hit, `${rel} must not contain ${hit}`).toBeNull();
         expect(source).not.toContain("installHandlers");
       }
+    }
+  });
+
+  it("keeps the provider-support binary-failure seam free of concrete provider implementations", () => {
+    const rel = "runtime/provider-support/binary-failure.ts";
+    const source = readFileSync(join(clientSrc, rel), "utf8");
+    expect(source).toContain("recognizeProviderBinaryFailure");
+    expect(source).toContain("PROVIDER_BINARY_FAILURE_REASON_CODES");
+    expect(source).not.toMatch(CONCRETE_PROVIDER_BINARY_IMPORT);
+    expect(source).not.toMatch(CONCRETE_PROVIDER_HANDLER_IMPORT);
+    expect(source).not.toMatch(/from ["']\.\.\/(?:codex|cursor|grok|pi|kimi|opencode)-binary/);
+    expect(source).not.toMatch(/from ["'].*handlers\//);
+    // Match rules are owned here — binary modules must re-export, not duplicate.
+    expect(source).toContain("isCodexBinaryMissingError");
+    expect(source).toContain("isCursorBinaryMissingError");
+    expect(source).toContain("isGrokBinaryMissingError");
+    expect(source).toContain("isPiBinaryMissingError");
+  });
+
+  it("keeps binary modules as re-export delegates for missing-error matchers (single owner)", () => {
+    for (const [file, symbol] of [
+      ["runtime/codex-binary.ts", "isCodexBinaryMissingError"],
+      ["runtime/cursor-binary.ts", "isCursorBinaryMissingError"],
+      ["runtime/grok-binary.ts", "isGrokBinaryMissingError"],
+      ["runtime/pi-binary.ts", "isPiBinaryMissingError"],
+    ] as const) {
+      const source = readFileSync(join(clientSrc, file), "utf8");
+      expect(source, `${file} must re-export ${symbol} from provider-support`).toContain(
+        'from "./provider-support/binary-failure.js"',
+      );
+      expect(source).toContain(symbol);
+      // No second owner of the match tables / regexes.
+      expect(source).not.toMatch(/BINARY_MISSING_PATTERNS/);
+      expect(source).not.toMatch(/function is(?:Codex|Cursor|Grok|Pi)BinaryMissingError/);
     }
   });
 

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -211,6 +211,52 @@ describe("runtime provider architecture guard", () => {
     }
   });
 
+  it("keeps production handlers from owning a second binary-missing matcher or reason-code table", () => {
+    const handlersRoot = join(clientSrc, "handlers");
+    const productionFiles = listFilesRecursive(handlersRoot, (p) => p.endsWith(".ts"));
+    // Local regex / phrase tables that re-recognize provider binary absence.
+    const secondOwnerMatchers = [
+      /pi cli is missing/i,
+      /no pi binary/i,
+      /BINARY_MISSING_PATTERNS/,
+      /codex runtime binary is missing/i,
+      /unable to locate codex cli binaries/i,
+      /cursor agent cli is missing/i,
+      /grok build cli is missing/i,
+    ] as const;
+    const reasonLiterals = [
+      '"codex_binary_missing"',
+      '"cursor_binary_missing"',
+      '"grok_binary_missing"',
+      '"pi_binary_missing"',
+      "'codex_binary_missing'",
+      "'cursor_binary_missing'",
+      "'grok_binary_missing'",
+      "'pi_binary_missing'",
+    ] as const;
+
+    for (const file of productionFiles) {
+      const source = readFileSync(file, "utf8");
+      const rel = relative(clientSrc, file).replaceAll("\\", "/");
+      for (const matcher of secondOwnerMatchers) {
+        expect(source, `${rel} must not re-own binary-missing recognition (${matcher})`).not.toMatch(matcher);
+      }
+      for (const literal of reasonLiterals) {
+        expect(
+          source,
+          `${rel} must not hard-code ${literal}; import PROVIDER_BINARY_FAILURE_REASON_CODES`,
+        ).not.toContain(literal);
+      }
+    }
+
+    // Pi sanitizer must consume the seam matcher + stable constant.
+    const piHandler = readFileSync(join(clientSrc, "handlers/pi/index.ts"), "utf8");
+    expect(piHandler).toContain("isPiBinaryMissingError");
+    expect(piHandler).toContain("PROVIDER_BINARY_FAILURE_REASON_CODES");
+    expect(piHandler).toContain("provider-support/binary-failure");
+    expect(piHandler).toContain("PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING");
+  });
+
   it("names only the concrete composition files as registration roots", () => {
     for (const rel of ["handlers/index.ts", "providers/builtin-registry.ts"] as const) {
       const source = readFileSync(join(clientSrc, rel), "utf8");

--- a/packages/client/src/handlers/pi/index.ts
+++ b/packages/client/src/handlers/pi/index.ts
@@ -50,6 +50,10 @@ import {
 } from "../../runtime/provider-process-supervisor.js";
 import { isExhaustedCapacityPhrasing, maxProviderTurnRetryAttempts } from "../../runtime/provider-retry-policy.js";
 import {
+  isPiBinaryMissingError,
+  PROVIDER_BINARY_FAILURE_REASON_CODES,
+} from "../../runtime/provider-support/binary-failure.js";
+import {
   buildBriefingUpdateNotice,
   computeBriefingFingerprint,
   readSessionBriefingFingerprint,
@@ -94,7 +98,8 @@ export function sanitizePiProviderDetail(raw: string): string {
   if (/timed out|timeout|etimedout/.test(lower)) return "pi_timeout";
   if (/unsupported version|not a supported pi|requires >=/.test(lower)) return "pi_unsupported_version";
   if (/not supported on windows/.test(lower)) return "pi_platform_unsupported";
-  if (/pi cli is missing|no pi binary|not (?:found|installed)/.test(lower)) return "pi_binary_missing";
+  // Single owner: match rules + stable token live in provider-support.
+  if (isPiBinaryMissingError(raw)) return PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING;
   if (/managed mcp|mcp servers are not supported/.test(lower)) return "pi_mcp_unsupported";
   if (/model mismatch|thinkinglevel mismatch|model selector is invalid/.test(lower)) return "pi_model_mismatch";
   if (/session identity mismatch|get_state response missing|pi get_state failed/.test(lower)) {

--- a/packages/client/src/handlers/pi/index.ts
+++ b/packages/client/src/handlers/pi/index.ts
@@ -49,10 +49,7 @@ import {
   supportsDefaultProviderProcessSupervision,
 } from "../../runtime/provider-process-supervisor.js";
 import { isExhaustedCapacityPhrasing, maxProviderTurnRetryAttempts } from "../../runtime/provider-retry-policy.js";
-import {
-  isPiBinaryMissingError,
-  PROVIDER_BINARY_FAILURE_REASON_CODES,
-} from "../../runtime/provider-support/binary-failure.js";
+import { piProviderDetailBinaryMissingReasonCode } from "../../runtime/provider-support/binary-failure.js";
 import {
   buildBriefingUpdateNotice,
   computeBriefingFingerprint,
@@ -98,8 +95,10 @@ export function sanitizePiProviderDetail(raw: string): string {
   if (/timed out|timeout|etimedout/.test(lower)) return "pi_timeout";
   if (/unsupported version|not a supported pi|requires >=/.test(lower)) return "pi_unsupported_version";
   if (/not supported on windows/.test(lower)) return "pi_platform_unsupported";
-  // Single owner: match rules + stable token live in provider-support.
-  if (isPiBinaryMissingError(raw)) return PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING;
+  // Single owner: Pi-detail binary-missing mapping lives in provider-support
+  // (broader than the generic taxonomy matcher; input is already Pi-scoped).
+  const binaryMissing = piProviderDetailBinaryMissingReasonCode(raw);
+  if (binaryMissing !== null) return binaryMissing;
   if (/managed mcp|mcp servers are not supported/.test(lower)) return "pi_mcp_unsupported";
   if (/model mismatch|thinkinglevel mismatch|model selector is invalid/.test(lower)) return "pi_model_mismatch";
   if (/session identity mismatch|get_state response missing|pi get_state failed/.test(lower)) {

--- a/packages/client/src/runtime/codex-binary.ts
+++ b/packages/client/src/runtime/codex-binary.ts
@@ -90,17 +90,10 @@ export class CodexBinaryVerifyTransientError extends Error {
   }
 }
 
-const CODEX_BINARY_MISSING_PATTERNS: readonly RegExp[] = [
-  /codex runtime binary is missing/i,
-  /unable to locate codex cli binaries/i,
-  /findCodexPath/,
-  /missing optional dependency\s+@openai\/codex[-\w]*/i,
-];
+import { isCodexBinaryMissingError } from "./provider-support/binary-failure.js";
 
-export function isCodexBinaryMissingError(input: unknown): boolean {
-  const text = errorSearchText(input);
-  return CODEX_BINARY_MISSING_PATTERNS.some((pattern) => pattern.test(text));
-}
+/** Single-owner match rules live in provider-support; re-export for call sites. */
+export { isCodexBinaryMissingError };
 
 export function formatCodexBinaryMissingMessage(input: unknown): string {
   const original = errorText(input).trim();
@@ -267,11 +260,6 @@ function errorText(input: unknown): string {
     if (typeof maybe.message === "string") return maybe.message;
   }
   return String(input);
-}
-
-function errorSearchText(input: unknown): string {
-  if (input instanceof Error) return [input.message, input.stack].filter(Boolean).join("\n");
-  return errorText(input);
 }
 
 function readPathValue(env: Record<string, string | undefined>, platform = process.platform): string | undefined {

--- a/packages/client/src/runtime/cursor-binary.ts
+++ b/packages/client/src/runtime/cursor-binary.ts
@@ -68,15 +68,8 @@ export class CursorBinaryVerifyTransientError extends Error {
   }
 }
 
-const CURSOR_BINARY_MISSING_PATTERNS: readonly RegExp[] = [
-  /cursor agent cli is missing/i,
-  /cursor-agent.*not (?:found|installed)/i,
-];
-
-export function isCursorBinaryMissingError(input: unknown): boolean {
-  const text = errorSearchText(input);
-  return CURSOR_BINARY_MISSING_PATTERNS.some((pattern) => pattern.test(text));
-}
+/** Single-owner match rules live in provider-support; re-export for call sites. */
+export { isCursorBinaryMissingError } from "./provider-support/binary-failure.js";
 
 export function formatCursorBinaryMissingMessage(input: unknown): string {
   const original = errorText(input).trim();
@@ -285,9 +278,4 @@ function errorText(input: unknown): string {
     if (typeof maybe.message === "string") return maybe.message;
   }
   return String(input);
-}
-
-function errorSearchText(input: unknown): string {
-  if (input instanceof Error) return `${input.name} ${input.message}`;
-  return errorText(input);
 }

--- a/packages/client/src/runtime/error-taxonomy.ts
+++ b/packages/client/src/runtime/error-taxonomy.ts
@@ -19,10 +19,7 @@
  * a conservative cap — see {@link UNKNOWN_FALLBACK} for the rationale.
  */
 
-import { isCodexBinaryMissingError } from "./codex-binary.js";
-import { isCursorBinaryMissingError } from "./cursor-binary.js";
-import { isGrokBinaryMissingError } from "./grok-binary.js";
-import { isPiBinaryMissingError } from "./pi-binary.js";
+import { recognizeProviderBinaryFailure } from "./provider-support/binary-failure.js";
 
 export const ERROR_KINDS = {
   TRANSIENT: "transient",
@@ -274,79 +271,26 @@ export function classify(err: unknown, context?: { source?: ErrorSource }): Clas
       message: shape.message ?? "Claude Code CLI requires re-authentication (run /login)",
     };
   }
-  // A *present* codex binary whose `--version` smoke check flaked (spawn
-  // timeout / host pressure) is transient — retry the bring-up. This MUST win
-  // over the missing-binary check below so a busy host never masquerades as an
-  // uninstalled codex (which would terminate the session with no retry).
-  if (shape.name === "CodexBinaryVerifyTransientError") {
-    return {
-      kind: ERROR_KINDS.TRANSIENT,
-      strategy: TRANSIENT_FAST,
-      reasonCode: "codex_verify_transient",
-      message: shape.message ?? "codex --version smoke check did not complete (transient)",
-    };
-  }
-  if (isCodexBinaryMissingError(err)) {
-    return {
-      kind: ERROR_KINDS.PERMANENT,
-      strategy: NONE,
-      reasonCode: "codex_binary_missing",
-      message: shape.message ?? "Codex runtime binary missing",
-    };
-  }
-  // Same present-but-flaky vs genuinely-missing split for the external Cursor
-  // Agent CLI: a smoke-check flake retries, a resolved-nothing / clean-broken
-  // binary is a permanent capability failure.
-  if (shape.name === "CursorBinaryVerifyTransientError") {
-    return {
-      kind: ERROR_KINDS.TRANSIENT,
-      strategy: TRANSIENT_FAST,
-      reasonCode: "cursor_verify_transient",
-      message: shape.message ?? "cursor-agent --version smoke check did not complete (transient)",
-    };
-  }
-  if (isCursorBinaryMissingError(err)) {
+  // Provider binary missing / verify-transient: consume the normalized signal
+  // from provider-support. That seam owns the match rules and reason codes so
+  // this generic taxonomy never imports concrete *-binary modules. Verify-
+  // transient wins over missing so a busy-host smoke flake never masquerades
+  // as an uninstalled provider.
+  const binaryFailure = recognizeProviderBinaryFailure(err);
+  if (binaryFailure) {
+    if (binaryFailure.outcome === "verify_transient") {
+      return {
+        kind: ERROR_KINDS.TRANSIENT,
+        strategy: TRANSIENT_FAST,
+        reasonCode: binaryFailure.reasonCode,
+        message: shape.message ?? binaryFailure.defaultMessage,
+      };
+    }
     return {
       kind: ERROR_KINDS.PERMANENT,
       strategy: NONE,
-      reasonCode: "cursor_binary_missing",
-      message: shape.message ?? "Cursor Agent CLI binary missing",
-    };
-  }
-  // Same present-but-flaky vs genuinely-missing split for the external Grok
-  // Build CLI: a smoke-check flake retries, a resolved-nothing / clean-broken
-  // / unsupported-version binary is a permanent capability failure.
-  if (shape.name === "GrokBinaryVerifyTransientError") {
-    return {
-      kind: ERROR_KINDS.TRANSIENT,
-      strategy: TRANSIENT_FAST,
-      reasonCode: "grok_verify_transient",
-      message: shape.message ?? "grok --version smoke check did not complete (transient)",
-    };
-  }
-  if (isGrokBinaryMissingError(err)) {
-    return {
-      kind: ERROR_KINDS.PERMANENT,
-      strategy: NONE,
-      reasonCode: "grok_binary_missing",
-      message: shape.message ?? "Grok Build CLI binary missing",
-    };
-  }
-  // Same present-but-flaky vs genuinely-missing split for the external Pi CLI.
-  if (shape.name === "PiBinaryVerifyTransientError") {
-    return {
-      kind: ERROR_KINDS.TRANSIENT,
-      strategy: TRANSIENT_FAST,
-      reasonCode: "pi_verify_transient",
-      message: shape.message ?? "pi --version smoke check did not complete (transient)",
-    };
-  }
-  if (isPiBinaryMissingError(err)) {
-    return {
-      kind: ERROR_KINDS.PERMANENT,
-      strategy: NONE,
-      reasonCode: "pi_binary_missing",
-      message: shape.message ?? "Pi CLI binary missing",
+      reasonCode: binaryFailure.reasonCode,
+      message: shape.message ?? binaryFailure.defaultMessage,
     };
   }
   // `AbortSignal.timeout()` aborts with a `DOMException` whose `name` is

--- a/packages/client/src/runtime/error-taxonomy.ts
+++ b/packages/client/src/runtime/error-taxonomy.ts
@@ -272,10 +272,10 @@ export function classify(err: unknown, context?: { source?: ErrorSource }): Clas
     };
   }
   // Provider binary missing / verify-transient: consume the normalized signal
-  // from provider-support. That seam owns the match rules and reason codes so
-  // this generic taxonomy never imports concrete *-binary modules. Verify-
-  // transient wins over missing so a busy-host smoke flake never masquerades
-  // as an uninstalled provider.
+  // from provider-support. That seam owns the match rules, reason codes, and
+  // the historical interleaved order (Codex→Cursor→Grok→Pi, verify-then-missing
+  // within each provider) so this generic taxonomy never imports concrete
+  // *-binary modules. Cross-provider ambiguity keeps the earlier provider.
   const binaryFailure = recognizeProviderBinaryFailure(err);
   if (binaryFailure) {
     if (binaryFailure.outcome === "verify_transient") {

--- a/packages/client/src/runtime/grok-binary.ts
+++ b/packages/client/src/runtime/grok-binary.ts
@@ -73,15 +73,8 @@ export class GrokBinaryVerifyTransientError extends Error {
   }
 }
 
-const GROK_BINARY_MISSING_PATTERNS: readonly RegExp[] = [
-  /grok build cli is missing/i,
-  /grok.*not (?:found|installed)/i,
-];
-
-export function isGrokBinaryMissingError(input: unknown): boolean {
-  const text = errorSearchText(input);
-  return GROK_BINARY_MISSING_PATTERNS.some((pattern) => pattern.test(text));
-}
+/** Single-owner match rules live in provider-support; re-export for call sites. */
+export { isGrokBinaryMissingError } from "./provider-support/binary-failure.js";
 
 export function formatGrokBinaryMissingMessage(input: unknown): string {
   const original = errorText(input).trim();
@@ -341,9 +334,4 @@ function errorText(input: unknown): string {
     if (typeof maybe.message === "string") return maybe.message;
   }
   return String(input);
-}
-
-function errorSearchText(input: unknown): string {
-  if (input instanceof Error) return `${input.name} ${input.message}`;
-  return errorText(input);
 }

--- a/packages/client/src/runtime/pi-binary.ts
+++ b/packages/client/src/runtime/pi-binary.ts
@@ -29,17 +29,8 @@ export function formatPiBinaryMissingMessage(input: unknown): string {
   );
 }
 
-export function isPiBinaryMissingError(input: unknown): boolean {
-  const text = errorText(input).toLowerCase();
-  if (text.includes("pi cli is missing")) return true;
-  // Linear-time classification: any "pi" followed later by "not found" /
-  // "not installed". Avoid `pi.*not ...` regex backtracking on adversarial
-  // strings that repeat "pi" many times without a terminal phrase.
-  const piIdx = text.indexOf("pi");
-  if (piIdx < 0) return false;
-  const afterPi = text.slice(piIdx + 2);
-  return afterPi.includes("not found") || afterPi.includes("not installed");
-}
+/** Single-owner match rules live in provider-support; re-export for call sites. */
+export { isPiBinaryMissingError } from "./provider-support/binary-failure.js";
 
 export type FindPiExecutableDeps = {
   loginShellPathDirs?: () => string[];

--- a/packages/client/src/runtime/provider-support/binary-failure.ts
+++ b/packages/client/src/runtime/provider-support/binary-failure.ts
@@ -130,6 +130,33 @@ export function isPiBinaryMissingError(input: unknown): boolean {
   return afterPi.includes("not found") || afterPi.includes("not installed");
 }
 
+/**
+ * Pi-provider-detail context only. Callers must already have scoped `detail`
+ * to Pi provider diagnostics (e.g. {@link sanitizePiProviderDetail}).
+ *
+ * Preserves the historical sanitizer mapping, which is intentionally broader
+ * than {@link isPiBinaryMissingError}: once the subject is known to be Pi,
+ * bare `not found` / `not installed` still map to {@link PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING}.
+ * Generic taxonomy must keep using {@link isPiBinaryMissingError} so unscoped
+ * text cannot be misclassified as a missing binary.
+ */
+export function piProviderDetailBinaryMissingReasonCode(
+  detail: string,
+): (typeof PROVIDER_BINARY_FAILURE_REASON_CODES)["PI_BINARY_MISSING"] | null {
+  const lower = detail.trim().toLowerCase();
+  if (!lower) return null;
+  // Historical sanitizer: /pi cli is missing|no pi binary|not (?:found|installed)/
+  if (
+    lower.includes("pi cli is missing") ||
+    lower.includes("no pi binary") ||
+    lower.includes("not found") ||
+    lower.includes("not installed")
+  ) {
+    return PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING;
+  }
+  return null;
+}
+
 function readErrorName(err: unknown): string | undefined {
   if (err instanceof Error) return err.name;
   if (err && typeof err === "object") {

--- a/packages/client/src/runtime/provider-support/binary-failure.ts
+++ b/packages/client/src/runtime/provider-support/binary-failure.ts
@@ -1,0 +1,189 @@
+/**
+ * Provider-support binary failure seam.
+ *
+ * Owns the recognition rules and stable machine reason codes for provider
+ * binary missing / verify-transient failures. Generic runtime code (notably
+ * error-taxonomy) consumes the normalized signal only — it must not import
+ * concrete provider binary modules. Provider binary modules may re-export the
+ * `is*BinaryMissingError` helpers so existing call sites keep a single owner
+ * for the match rules (no duplicated regex / string tables).
+ */
+
+export const PROVIDER_BINARY_FAILURE_REASON_CODES = {
+  CODEX_VERIFY_TRANSIENT: "codex_verify_transient",
+  CODEX_BINARY_MISSING: "codex_binary_missing",
+  CURSOR_VERIFY_TRANSIENT: "cursor_verify_transient",
+  CURSOR_BINARY_MISSING: "cursor_binary_missing",
+  GROK_VERIFY_TRANSIENT: "grok_verify_transient",
+  GROK_BINARY_MISSING: "grok_binary_missing",
+  PI_VERIFY_TRANSIENT: "pi_verify_transient",
+  PI_BINARY_MISSING: "pi_binary_missing",
+} as const;
+
+export type ProviderBinaryFailureReasonCode =
+  (typeof PROVIDER_BINARY_FAILURE_REASON_CODES)[keyof typeof PROVIDER_BINARY_FAILURE_REASON_CODES];
+
+export type ProviderBinaryFailureSignal = {
+  /** Present-but-flaky smoke check vs genuinely-missing / unresolved binary. */
+  outcome: "verify_transient" | "binary_missing";
+  reasonCode: ProviderBinaryFailureReasonCode;
+  /** Fallback human summary when the thrown value carries no message. */
+  defaultMessage: string;
+};
+
+const VERIFY_TRANSIENT_BY_NAME = {
+  CodexBinaryVerifyTransientError: {
+    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.CODEX_VERIFY_TRANSIENT,
+    defaultMessage: "codex --version smoke check did not complete (transient)",
+  },
+  CursorBinaryVerifyTransientError: {
+    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.CURSOR_VERIFY_TRANSIENT,
+    defaultMessage: "cursor-agent --version smoke check did not complete (transient)",
+  },
+  GrokBinaryVerifyTransientError: {
+    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.GROK_VERIFY_TRANSIENT,
+    defaultMessage: "grok --version smoke check did not complete (transient)",
+  },
+  PiBinaryVerifyTransientError: {
+    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.PI_VERIFY_TRANSIENT,
+    defaultMessage: "pi --version smoke check did not complete (transient)",
+  },
+} as const satisfies Record<string, { reasonCode: ProviderBinaryFailureReasonCode; defaultMessage: string }>;
+
+const CODEX_BINARY_MISSING_PATTERNS: readonly RegExp[] = [
+  /codex runtime binary is missing/i,
+  /unable to locate codex cli binaries/i,
+  /findCodexPath/,
+  /missing optional dependency\s+@openai\/codex[-\w]*/i,
+];
+
+const CURSOR_BINARY_MISSING_PATTERNS: readonly RegExp[] = [
+  /cursor agent cli is missing/i,
+  /cursor-agent.*not (?:found|installed)/i,
+];
+
+const GROK_BINARY_MISSING_PATTERNS: readonly RegExp[] = [
+  /grok build cli is missing/i,
+  /grok.*not (?:found|installed)/i,
+];
+
+function errorText(input: unknown): string {
+  if (input instanceof Error) return input.message;
+  if (typeof input === "string") return input;
+  if (input && typeof input === "object") {
+    const maybe = input as { message?: unknown };
+    if (typeof maybe.message === "string") return maybe.message;
+  }
+  return String(input);
+}
+
+/** Codex: message + stack so stack-only `findCodexPath` frames still match. */
+function codexErrorSearchText(input: unknown): string {
+  if (input instanceof Error) return [input.message, input.stack].filter(Boolean).join("\n");
+  return errorText(input);
+}
+
+/** Cursor / Grok: name + message (no stack). */
+function namedErrorSearchText(input: unknown): string {
+  if (input instanceof Error) return `${input.name} ${input.message}`;
+  return errorText(input);
+}
+
+/** Pi: name + message, then linear substring scan (no catastrophic regex). */
+function piErrorText(input: unknown): string {
+  if (input instanceof Error) return `${input.name} ${input.message}`;
+  if (typeof input === "string") return input;
+  if (input && typeof input === "object" && "message" in input) {
+    const message = (input as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return String(input);
+}
+
+export function isCodexBinaryMissingError(input: unknown): boolean {
+  const text = codexErrorSearchText(input);
+  return CODEX_BINARY_MISSING_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function isCursorBinaryMissingError(input: unknown): boolean {
+  const text = namedErrorSearchText(input);
+  return CURSOR_BINARY_MISSING_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function isGrokBinaryMissingError(input: unknown): boolean {
+  const text = namedErrorSearchText(input);
+  return GROK_BINARY_MISSING_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function isPiBinaryMissingError(input: unknown): boolean {
+  const text = piErrorText(input).toLowerCase();
+  if (text.includes("pi cli is missing")) return true;
+  // Linear-time classification: any "pi" followed later by "not found" /
+  // "not installed". Avoid `pi.*not ...` regex backtracking on adversarial
+  // strings that repeat "pi" many times without a terminal phrase.
+  const piIdx = text.indexOf("pi");
+  if (piIdx < 0) return false;
+  const afterPi = text.slice(piIdx + 2);
+  return afterPi.includes("not found") || afterPi.includes("not installed");
+}
+
+const BINARY_MISSING_CHECKS = [
+  {
+    match: isCodexBinaryMissingError,
+    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.CODEX_BINARY_MISSING,
+    defaultMessage: "Codex runtime binary missing",
+  },
+  {
+    match: isCursorBinaryMissingError,
+    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.CURSOR_BINARY_MISSING,
+    defaultMessage: "Cursor Agent CLI binary missing",
+  },
+  {
+    match: isGrokBinaryMissingError,
+    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.GROK_BINARY_MISSING,
+    defaultMessage: "Grok Build CLI binary missing",
+  },
+  {
+    match: isPiBinaryMissingError,
+    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING,
+    defaultMessage: "Pi CLI binary missing",
+  },
+] as const;
+
+function readErrorName(err: unknown): string | undefined {
+  if (err instanceof Error) return err.name;
+  if (err && typeof err === "object") {
+    const name = (err as { name?: unknown }).name;
+    if (typeof name === "string") return name;
+  }
+  return undefined;
+}
+
+/**
+ * Normalize a thrown value into a binary-failure signal, or `null` when the
+ * error is unrelated. Verify-transient names win over missing-binary patterns
+ * so a busy-host smoke flake never masquerades as an uninstalled provider.
+ */
+export function recognizeProviderBinaryFailure(err: unknown): ProviderBinaryFailureSignal | null {
+  const name = readErrorName(err);
+  if (name && Object.hasOwn(VERIFY_TRANSIENT_BY_NAME, name)) {
+    const entry = VERIFY_TRANSIENT_BY_NAME[name as keyof typeof VERIFY_TRANSIENT_BY_NAME];
+    return {
+      outcome: "verify_transient",
+      reasonCode: entry.reasonCode,
+      defaultMessage: entry.defaultMessage,
+    };
+  }
+
+  for (const check of BINARY_MISSING_CHECKS) {
+    if (check.match(err)) {
+      return {
+        outcome: "binary_missing",
+        reasonCode: check.reasonCode,
+        defaultMessage: check.defaultMessage,
+      };
+    }
+  }
+
+  return null;
+}

--- a/packages/client/src/runtime/provider-support/binary-failure.ts
+++ b/packages/client/src/runtime/provider-support/binary-failure.ts
@@ -118,6 +118,9 @@ export function isGrokBinaryMissingError(input: unknown): boolean {
 export function isPiBinaryMissingError(input: unknown): boolean {
   const text = piErrorText(input).toLowerCase();
   if (text.includes("pi cli is missing")) return true;
+  // Production resolution errors use this phrase before formatting the
+  // user-facing "Pi CLI is missing…" copy (e.g. "no pi binary resolved").
+  if (text.includes("no pi binary")) return true;
   // Linear-time classification: any "pi" followed later by "not found" /
   // "not installed". Avoid `pi.*not ...` regex backtracking on adversarial
   // strings that repeat "pi" many times without a terminal phrase.

--- a/packages/client/src/runtime/provider-support/binary-failure.ts
+++ b/packages/client/src/runtime/provider-support/binary-failure.ts
@@ -134,24 +134,22 @@ export function isPiBinaryMissingError(input: unknown): boolean {
  * Pi-provider-detail context only. Callers must already have scoped `detail`
  * to Pi provider diagnostics (e.g. {@link sanitizePiProviderDetail}).
  *
- * Preserves the historical sanitizer mapping, which is intentionally broader
- * than {@link isPiBinaryMissingError}: once the subject is known to be Pi,
- * bare `not found` / `not installed` still map to {@link PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING}.
- * Generic taxonomy must keep using {@link isPiBinaryMissingError} so unscoped
- * text cannot be misclassified as a missing binary.
+ * Composes {@link isPiBinaryMissingError} for the shared Pi-specific phrases,
+ * then adds only the historical sanitizer extras that are safe once the
+ * subject is known to be Pi: bare `not found` / `not installed`. Generic
+ * taxonomy must keep using {@link isPiBinaryMissingError} so unscoped text
+ * cannot inherit that breadth.
  */
 export function piProviderDetailBinaryMissingReasonCode(
   detail: string,
 ): (typeof PROVIDER_BINARY_FAILURE_REASON_CODES)["PI_BINARY_MISSING"] | null {
+  if (isPiBinaryMissingError(detail)) {
+    return PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING;
+  }
   const lower = detail.trim().toLowerCase();
   if (!lower) return null;
-  // Historical sanitizer: /pi cli is missing|no pi binary|not (?:found|installed)/
-  if (
-    lower.includes("pi cli is missing") ||
-    lower.includes("no pi binary") ||
-    lower.includes("not found") ||
-    lower.includes("not installed")
-  ) {
+  // Pi-scoped sanitizer extras only — do not duplicate the strict matcher phrases.
+  if (lower.includes("not found") || lower.includes("not installed")) {
     return PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING;
   }
   return null;

--- a/packages/client/src/runtime/provider-support/binary-failure.ts
+++ b/packages/client/src/runtime/provider-support/binary-failure.ts
@@ -127,29 +127,6 @@ export function isPiBinaryMissingError(input: unknown): boolean {
   return afterPi.includes("not found") || afterPi.includes("not installed");
 }
 
-const BINARY_MISSING_CHECKS = [
-  {
-    match: isCodexBinaryMissingError,
-    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.CODEX_BINARY_MISSING,
-    defaultMessage: "Codex runtime binary missing",
-  },
-  {
-    match: isCursorBinaryMissingError,
-    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.CURSOR_BINARY_MISSING,
-    defaultMessage: "Cursor Agent CLI binary missing",
-  },
-  {
-    match: isGrokBinaryMissingError,
-    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.GROK_BINARY_MISSING,
-    defaultMessage: "Grok Build CLI binary missing",
-  },
-  {
-    match: isPiBinaryMissingError,
-    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING,
-    defaultMessage: "Pi CLI binary missing",
-  },
-] as const;
-
 function readErrorName(err: unknown): string | undefined {
   if (err instanceof Error) return err.name;
   if (err && typeof err === "object") {
@@ -159,31 +136,68 @@ function readErrorName(err: unknown): string | undefined {
   return undefined;
 }
 
+function verifyTransientSignal(
+  err: unknown,
+  errorName: keyof typeof VERIFY_TRANSIENT_BY_NAME,
+): ProviderBinaryFailureSignal | null {
+  if (readErrorName(err) !== errorName) return null;
+  const entry = VERIFY_TRANSIENT_BY_NAME[errorName];
+  return {
+    outcome: "verify_transient",
+    reasonCode: entry.reasonCode,
+    defaultMessage: entry.defaultMessage,
+  };
+}
+
+function missingSignal(
+  match: (input: unknown) => boolean,
+  reasonCode: ProviderBinaryFailureReasonCode,
+  defaultMessage: string,
+  err: unknown,
+): ProviderBinaryFailureSignal | null {
+  if (!match(err)) return null;
+  return { outcome: "binary_missing", reasonCode, defaultMessage };
+}
+
 /**
  * Normalize a thrown value into a binary-failure signal, or `null` when the
- * error is unrelated. Verify-transient names win over missing-binary patterns
- * so a busy-host smoke flake never masquerades as an uninstalled provider.
+ * error is unrelated.
+ *
+ * Order matches the historical `error-taxonomy` classifier exactly — per
+ * provider interleaved as verify-transient then missing, walking Codex →
+ * Cursor → Grok → Pi. "Verify beats missing" is only within the same provider;
+ * a later provider's verify name must not preempt an earlier provider's missing
+ * match (cross-provider ambiguity keeps the earlier provider's outcome).
  */
 export function recognizeProviderBinaryFailure(err: unknown): ProviderBinaryFailureSignal | null {
-  const name = readErrorName(err);
-  if (name && Object.hasOwn(VERIFY_TRANSIENT_BY_NAME, name)) {
-    const entry = VERIFY_TRANSIENT_BY_NAME[name as keyof typeof VERIFY_TRANSIENT_BY_NAME];
-    return {
-      outcome: "verify_transient",
-      reasonCode: entry.reasonCode,
-      defaultMessage: entry.defaultMessage,
-    };
-  }
-
-  for (const check of BINARY_MISSING_CHECKS) {
-    if (check.match(err)) {
-      return {
-        outcome: "binary_missing",
-        reasonCode: check.reasonCode,
-        defaultMessage: check.defaultMessage,
-      };
-    }
-  }
-
-  return null;
+  return (
+    verifyTransientSignal(err, "CodexBinaryVerifyTransientError") ??
+    missingSignal(
+      isCodexBinaryMissingError,
+      PROVIDER_BINARY_FAILURE_REASON_CODES.CODEX_BINARY_MISSING,
+      "Codex runtime binary missing",
+      err,
+    ) ??
+    verifyTransientSignal(err, "CursorBinaryVerifyTransientError") ??
+    missingSignal(
+      isCursorBinaryMissingError,
+      PROVIDER_BINARY_FAILURE_REASON_CODES.CURSOR_BINARY_MISSING,
+      "Cursor Agent CLI binary missing",
+      err,
+    ) ??
+    verifyTransientSignal(err, "GrokBinaryVerifyTransientError") ??
+    missingSignal(
+      isGrokBinaryMissingError,
+      PROVIDER_BINARY_FAILURE_REASON_CODES.GROK_BINARY_MISSING,
+      "Grok Build CLI binary missing",
+      err,
+    ) ??
+    verifyTransientSignal(err, "PiBinaryVerifyTransientError") ??
+    missingSignal(
+      isPiBinaryMissingError,
+      PROVIDER_BINARY_FAILURE_REASON_CODES.PI_BINARY_MISSING,
+      "Pi CLI binary missing",
+      err,
+    )
+  );
 }


### PR DESCRIPTION
## Summary
- Extract a minimal in-package `provider-support/binary-failure` seam that uniquely owns provider binary missing / verify-transient recognition and stable reason codes.
- Make `error-taxonomy` consume only the normalized signal (no imports of concrete `*-binary` modules), while `is*BinaryMissingError` on binary modules re-export the same owner (no duplicated match tables).
- Route Pi provider-detail sanitization through the same support owner using an explicitly context-scoped matcher, preserving its historical broader mapping without widening generic taxonomy classification.
- Compose the contextual Pi-detail entry through the strict Pi matcher and add only its context-specific bare-absence cases, so shared phrases have one match table.
- Strengthen `provider-boundary-guard` so taxonomy, support, and production handlers cannot recreate a concrete-provider dependency or second binary-missing owner.

This is slice **S1a** of the Client multi-package refactor (cloud-client → client-runtime → client-providers). Existing classifier and Pi sanitizer outcomes remain unchanged.

## Test plan
- [x] Author focused run on exact head `fae881514dc83938c00346122ebef7976223a8db`: 8 files / 217 tests passed
- [x] Author Client typecheck
- [ ] Reviewer re-review on exact head
- [ ] Independent Client full suite, typecheck, and build on exact head
- [ ] Root `pnpm check` on exact head
- [ ] Independent QA verdict on exact head

Previous QA/review evidence on `f871589b3`, `664808690`, and `e24422619` was invalidated by follow-up commits and is not evidence for the current head.

## Out of scope
Provider file moves, contracts/provider-support two-entry convergence, handler registry removal, SessionManager teardown, new workspace packages.

Made with [Cursor](https://cursor.com)
