### PR TITLE
Require verified GitHub identity before App install

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,6 +16,8 @@ and
 [`external-context-current-session-handoff`](../packages/qa/cases/cross-surface/external-context-current-session-handoff.md).
 The Agent Detail journey is owned by
 [`agent-detail-availability-and-capabilities`](../packages/qa/cases/cross-surface/agent-detail-availability-and-capabilities.md).
+The GitHub install identity-gate journey is owned by
+[`github-settings-connection-panel`](../packages/qa/cases/cross-surface/github-settings-connection-panel.md).
 Those cases remain the contracts and the place judgement lives. This directory
 is one way to execute parts of them unattended, in the same spirit as the
 fixtures and environment recipes under `packages/qa` — useful for a quick
@@ -27,9 +29,11 @@ Two limits follow from that and are deliberate:
 - It is **not a CI gate** and is not wired into any workflow. Steps resolve from
   natural-language descriptions through a hosted model and some assertions are
   model-evaluated, so a red run is a signal to investigate, not a merge blocker.
-- It covers the registration happy path, the connect-computer gate, and the Web
-  setup-prompt dialog — not the negative branches, provider handoff execution,
-  degraded states, or evidence judgement the cases ask for.
+- It covers selected visible journeys: registration, the connect-computer gate,
+  the Web setup-prompt dialog, and the GitHub install identity gate before and
+  after account linking. It does not drive real provider OAuth, GitHub App
+  installation or owner approval, degraded provider states, or the evidence
+  judgement the cases ask for.
 
 A stable invariant that Vitest could assert still belongs in Vitest. Do not move
 a check here to escape a flaky product test.
@@ -101,6 +105,7 @@ the local stack and the local tests do not touch staging.
 | `onboarding-complete-setup.test.yaml` | local | The whole first-run journey: sign up → create team → connect a computer → create the first agent → start the kickoff chat → land in the workspace → open the Team-scoped own-agent setup path |
 | `settings-coding-agent-prompt-dialog.test.yaml` | local | A signed-in Team with a bound Context Tree opens the real setup prompt, reviews the provider-neutral handoff, and copies it from the dialog |
 | `agent-detail-configuration.test.yaml` | local | A Team admin follows one agent from the directory through its availability and effective tools into shared resource Settings |
+| `github-install-identity-gate.test.yaml` | local | A Google/OIDC-style admin is gated from install until GitHub is linked, then returns to the same Team with Install as a separate action |
 | `dev-cloud-sign-in-available.test.yaml` | first-tree-dev-cloud | Staging serves the landing page and offers Google + GitHub sign-in |
 
 `modules/sign-up-fresh-user.module.yaml` holds the shared sign-up flow. Each run
@@ -167,6 +172,15 @@ connected clients and agents whose heartbeat is older than
 `packages/server/src/services/client.ts`). Without a heartbeat loop a plain
 `NOW()` would decay mid-run and the flow would regress to "Your computer isn't
 connected".
+
+`set-test-user-provider-mode.js` substitutes only the external provider callback
+for the GitHub install identity-gate journey. It keeps the existing First Tree
+user, Team, membership, and browser tokens intact while changing that user's
+provider rows from Google-only to Google+GitHub. The visible Settings flow and
+all capability queries still run through the real web and server. It does not
+claim to validate github.com's login, consent, installation picker, or owner
+approval UI; deterministic server integration tests own those state and
+authorization boundaries.
 
 If onboarding ever stops depending on a connected daemon, delete the fixtures
 rather than working around them.

--- a/e2e/github-install-identity-gate.test.yaml
+++ b/e2e/github-install-identity-gate.test.yaml
@@ -1,0 +1,43 @@
+fileType: momentic/test/v2
+id: github-install-identity-gate
+description: A Google-authenticated Team admin links GitHub before starting a GitHub App install
+defaultEnv: local
+steps:
+  # Establish a real signed-in Team. The fixture below changes only the
+  # provider rows; the First Tree user, Team, membership, and browser session
+  # remain the ones created by the product onboarding flow.
+  - module:
+      path: ./modules/complete-first-run-onboarding.module.yaml
+  - javascript:
+      code: return "google-only";
+      environment: node
+      saveAs: PROVIDER_MODE
+  - javascript:
+      code: ./scripts/set-test-user-provider-mode.js
+      environment: node
+      saveAs: GOOGLE_ONLY_FIXTURE
+
+  - navigate: /settings/integrations/github
+  - waitForUrl: /settings/integrations/github
+  - assert: the GitHub Connection section says this Team is not connected and offers one Connect GitHub action
+  - click: Connect GitHub button in the Connection section
+  - assert: the existing Connection panel shows Connect your GitHub account,
+      explains that it is required before installing the First Tree GitHub App,
+      and offers one Continue with GitHub action; no Install on GitHub action is present
+
+  # A real provider callback is outside the disposable local environment. Add
+  # the same user's GitHub identity, then exercise the exact post-link return
+  # URL and visible state produced by that callback.
+  - javascript:
+      code: return "github-linked";
+      environment: node
+      saveAs: PROVIDER_MODE
+  - javascript:
+      code: ./scripts/set-test-user-provider-mode.js
+      environment: node
+      saveAs: GITHUB_LINKED_FIXTURE
+  - navigate: /settings/github?connection=github-linked
+  - waitForUrl: /settings/integrations/github?connection=github-linked
+  - assert: the browser returned to the same Team's GitHub Connection panel,
+      shows GitHub connected as @{{env.GH_LOGIN}}, and offers Install on GitHub
+      as a separate explicit action; Continue with GitHub is no longer present

--- a/e2e/scripts/set-test-user-provider-mode.js
+++ b/e2e/scripts/set-test-user-provider-mode.js
@@ -1,0 +1,64 @@
+/**
+ * Fixture: switch the fresh E2E user's provider shape without changing the
+ * First Tree user, Team, membership, or browser session.
+ *
+ * The external GitHub OAuth UI cannot be driven with disposable credentials.
+ * This fixture substitutes only that provider callback so the browser can
+ * verify the Settings capability gate and its post-link return state against
+ * the real server and web app.
+ *
+ * Requires GH_ID, GH_LOGIN, PROVIDER_MODE, and DATABASE_URL.
+ */
+const mode = env.PROVIDER_MODE;
+if (mode !== "google-only" && mode !== "github-linked") {
+  throw new Error(`Unsupported PROVIDER_MODE: ${mode}`);
+}
+
+const db = new pg.Client({ connectionString: env.DATABASE_URL });
+await db.connect();
+try {
+  await db.query("BEGIN");
+  const { rows: users } = await db.query(`SELECT id FROM users WHERE username = $1 LIMIT 1`, [env.GH_LOGIN]);
+  const userId = users[0]?.id;
+  if (!userId) throw new Error(`No E2E user found for ${env.GH_LOGIN}`);
+
+  if (mode === "google-only") {
+    await db.query(`DELETE FROM auth_identities WHERE user_id = $1 AND provider = 'github'`, [userId]);
+    await db.query(
+      `INSERT INTO auth_identities
+         (id, user_id, provider, identifier, verified_at, metadata, created_at, updated_at)
+       VALUES ($1, $2, 'google', $3, NOW(), $4::jsonb, NOW(), NOW())
+       ON CONFLICT (user_id, provider) DO UPDATE
+          SET identifier = EXCLUDED.identifier,
+              verified_at = EXCLUDED.verified_at,
+              metadata = EXCLUDED.metadata,
+              updated_at = NOW()`,
+      [
+        `e2e-google-${env.GH_ID}`,
+        userId,
+        `e2e-google-subject-${env.GH_ID}`,
+        JSON.stringify({ accountName: `e2e-google-${env.GH_ID}` }),
+      ],
+    );
+  } else {
+    await db.query(
+      `INSERT INTO auth_identities
+         (id, user_id, provider, identifier, verified_at, metadata, created_at, updated_at)
+       VALUES ($1, $2, 'github', $3, NOW(), $4::jsonb, NOW(), NOW())
+       ON CONFLICT (user_id, provider) DO UPDATE
+          SET identifier = EXCLUDED.identifier,
+              verified_at = EXCLUDED.verified_at,
+              metadata = EXCLUDED.metadata,
+              updated_at = NOW()`,
+      [`e2e-github-${env.GH_ID}`, userId, env.GH_ID, JSON.stringify({ accountName: env.GH_LOGIN })],
+    );
+  }
+
+  await db.query("COMMIT");
+  return { userId, mode };
+} catch (error) {
+  await db.query("ROLLBACK");
+  throw error;
+} finally {
+  await db.end();
+}

--- a/packages/qa/cases/cross-surface/github-settings-connection-panel.md
+++ b/packages/qa/cases/cross-surface/github-settings-connection-panel.md
@@ -1,6 +1,6 @@
 ---
 id: github-settings-connection-panel
-description: Verify the Settings→GitHub connection panel — member-vs-admin permission split, GitHub App install/connect/disconnect lifecycle, and the installation catalog — across the server API and web UI.
+description: Verify the Settings→GitHub connection panel — provider identity preflight, permission split, and GitHub App install/connect/disconnect lifecycle — across the server API and web UI.
 areas: [cross-surface]
 surfaces: [server, web, github]
 ---
@@ -11,7 +11,8 @@ surfaces: [server, web, github]
 
 Verify the team-facing GitHub settings surface and its App-connection lifecycle across its real boundaries: the
 member-readable-but-admin-mutable permission split, the connect → disconnect → reconnect lifecycle with its
-installer/requester ownership gate, the admin-only install-URL and repository catalog, and the Settings → GitHub UI states.
+installer/requester ownership gate, the linked-identity and current-github.com-account preflight before installation, the
+admin-only install-URL and repository catalog, and the Settings → GitHub UI states.
 Product tests own deterministic per-endpoint checks; this case verifies the assembled deployment still wires the panel,
 the org-scope helpers, and the installation lifecycle together.
 
@@ -34,6 +35,10 @@ only touches the webhook where an `installation.created` delivery records the ro
 - To exercise the member (non-admin) path, either invite a second member or flip an existing member's `role` in the
   isolated QA DB. Roles are re-read per request, so an in-DB role flip on one user isolates the permission gate cleanly
   (the same token flips 200 ↔ 403 as the role bit changes).
+- For the capability-gate browser path, prepare an active Team admin authenticated through Google/OIDC with no GitHub
+  identity, then link a known GitHub identity to that same First Tree user. A local database fixture may stand in for the
+  external provider callback only when the report marks the OAuth-provider segment as substituted; it must not create a
+  second First Tree user or alter Team membership.
 
 ## Operate and Observe
 
@@ -64,13 +69,32 @@ only touches the webhook where an `installation.created` delivery records the ro
 - `disconnect` needs only org-admin — the binding is the team's own resource. It does not uninstall on GitHub, so the row
   survives and is reconnectable from any panel.
 
-### install-url and repositories (need App config or mock)
+### GitHub identity gate and installation preflight (need App config or mock)
 
-- `install-url` (admin, slug configured): 200 with an `installations/new` URL carrying a signed `state` JWT, plus a
-  `Set-Cookie` for the `oauth_state_nonce` cookie (the CSRF double-submit nonce paired with the signed state; the server
-  exports this exact name as `OAUTH_STATE_COOKIE`). Without a slug: 503 with an operator hint. A caller-supplied `next`
-  must never be reflected verbatim (open-redirect guard — only an allowlisted path or the Settings default rides the signed
-  state).
+- An active Team admin with no linked GitHub identity sees `Connect your GitHub account` and one `Continue with GitHub`
+  action in the existing panel; Install is absent. `install-url` fails 409 `github_identity_required` before signing state
+  or setting a nonce cookie. A member sees neither capability action.
+- Account-link success returns to the same Team's `/settings/github` Connection section, shows `GitHub connected as
+  @<login>`, and exposes Install as a second explicit action. Cancel, conflict, and expired-state returns preserve the
+  First Tree session and one clear retry path. An external, protocol-relative, unrelated, or malformed `next` falls back
+  to the supported Account settings route instead of becoming a redirect.
+- `install-url` (linked admin, slug configured): 200 with a GitHub OAuth authorize URL carrying a signed identity-phase
+  `state`, plus a protected `oauth_state_nonce` cookie. The callback must re-read the kickoff user's active Team-admin
+  membership and linked numeric GitHub ID. A matching github.com account receives a fresh installation-phase state/cookie
+  and redirects to `installations/new`; a mismatch, role loss, missing identity, missing code, or expired/replayed state
+  fails before the picker. A code-bearing callback after the picker rechecks numeric identity before persisting any
+  foreign identity. The mismatch surface names the expected linked login and returns to Settings → GitHub.
+- A completed non-owner installation request returns without a code only during the installation phase, lands on the
+  kickoff surface only after rechecking that the kickoff user is still an active Team admin with a linked GitHub identity,
+  then waits for the signed webhook row; delayed owner approval makes the installation appear through polling without
+  refresh or a duplicate request. GitHub supplies no OAuth code on this landing, so First Tree cannot prove the current
+  github.com session. A deliberate cross-tab account switch after the picker opened can therefore create an unbound row,
+  but it cannot bind the installation or cross Team authority boundaries. Without a slug: 503 with an operator hint. A
+  caller-supplied `next` must never be reflected verbatim (open-redirect guard — only an allowlisted path or the Settings
+  default rides signed state).
+
+### repositories (need App config or mock)
+
 - `repositories` (admin, App key + reachable GitHub API/mock): 200 with the installation's repository catalog. Failure
   shapes carry distinct codes: no installation → 503 `no_installation`, suspended → 503 `suspended`, App unconfigured →
   503 `not_configured`, upstream blip → 502 `upstream`.
@@ -81,20 +105,28 @@ only touches the webhook where an `installation.created` delivery records the ro
   "Manage connection" / "Manage on GitHub" / "Connection details" controls; the connect panel exposes Reinstall (step 1,
   when installed) and Disconnect (step 2).
 - Admin, not connected: a "Connect GitHub" call-to-action.
+- Google/OIDC admin without GitHub identity: after opening Connect, only the inline link-account state appears. After the
+  identity is linked and the same Team is restored, the panel shows the linked login and Install remains a separate click.
+- Install preflight mismatch: the current First Tree session and selected Team remain unchanged; the recovery message
+  names the expected GitHub login and offers a retry rather than opening the picker.
 - Member: the connection state stays readable, but every admin control (Manage / Disconnect / Connect / Reinstall /
   Install / Add source repo) is absent.
 - No browser console errors on any state.
 
 ## Expected Result
 
-`PASS`: the permission split holds (member reads, admin mutates), the connect/disconnect/reconnect cycle and its
-installer/requester ownership gate behave as described, install-url/repositories succeed with an App/mock or degrade
-gracefully without one, and the UI renders connected / not-connected / read-only states with no console errors.
+`PASS`: the identity gate and two-phase install preflight fail closed before the picker on identity mismatch and never
+persist a foreign First Tree identity; no-code request landings recheck live Team admin and linked-identity authority;
+the permission split holds (member reads, admin mutates), the connect/disconnect/reconnect cycle and its installer/requester
+ownership gate behave as described, install-url/repositories succeed with an App/mock or degrade gracefully without one,
+and the UI renders connected / not-connected / read-only states with no console errors.
 
 `FAIL`: a reproducible defect — a member can mutate, an admin is denied a member-readable read, an admin-only route denies
-purely on org-role grounds once its own preconditions are met, `connect` ignores the installer/requester gate, `disconnect`
-leaves a stale binding, `install-url` reflects an arbitrary `next`, a distinct failure code is wrong, or the panel throws a
-console error.
+purely on org-role grounds once its own preconditions are met, an admin without GitHub identity can mint install state, a
+github.com account that mismatches during preflight reaches the picker, a code-bearing mismatch creates a First Tree
+identity, account linking returns to the wrong
+Team, `connect` ignores the installer/requester gate, `disconnect` leaves a stale binding, `install-url` reflects an
+arbitrary `next`, a distinct failure code is wrong, or the panel throws a console error.
 
 `BLOCKED`: the run cell cannot bootstrap login / web, or an App-dependent sub-path (real github.com install dialog, real
 webhook secret) can be neither provisioned nor mocked.
@@ -103,14 +135,19 @@ webhook secret) can be neither provisioned nor mocked.
 
 ## Evidence
 
-Keep the admin/member status matrix, the connect/disconnect/reconnect responses plus the DB installation row
-(bound org, installer id), the `install-url` URL (redact the state JWT) and the `oauth_state_nonce` cookie presence, the
-`repositories` payload, and UI snapshots or DOM text for the connected / not-connected / read-only states. Redact bearer
-tokens, connect codes, the App private key, and the webhook secret.
+Keep the admin/member status matrix, before/after provider summaries (provider and display login only), the side-effect-free
+409 response, identity-match/mismatch callback outcomes, the connect/disconnect/reconnect responses plus the DB
+installation row (bound org, installer id), the `install-url` URL (redact the state JWT) and protected
+`oauth_state_nonce` cookie presence, the `repositories` payload, and UI snapshots or DOM text for the identity-required,
+connected / not-connected / read-only states. Redact provider numeric IDs, bearer tokens, OAuth codes, connect codes, the
+App private key, and the webhook secret.
 
 ## Limitations
 
-The real github.com install dialog is a GitHub-hosted page and cannot be mocked; only the server-side install-url
-construction and the post-install callback state are reachable in an isolated cell. Full webhook card delivery into a
-followed chat belongs to `github-webhook-routing-regression.md`; a mock GitHub REST API proves First Tree's
-request/parse/verify logic, not github.com's live responses.
+The real github.com sign-in/install dialog and owner approval are GitHub-hosted and cannot be faithfully mocked. Browser
+evidence can cover First Tree's inline capability states and return behavior; deterministic integration tests cover state
+rotation, numeric-ID match/mismatch, role loss, no-code request landing, polling, and side-effect boundaries. Full webhook
+card delivery into a followed chat belongs to `github-webhook-routing-regression.md`; a mock GitHub REST API proves First
+Tree's request/parse/verify logic, not github.com's live responses. In particular, GitHub's no-code owner-approval landing
+cannot attest which github.com account submitted the request after the picker opened; this case may leave an unbound row but
+cannot authorize a binding.

--- a/packages/server/src/__tests__/github-app-callback-target-org.test.ts
+++ b/packages/server/src/__tests__/github-app-callback-target-org.test.ts
@@ -1,11 +1,13 @@
 import { generateKeyPairSync } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import { readOAuthStateNonce } from "../api/auth/oauth-cookie.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
+import { users } from "../db/schema/users.js";
+import { decryptValue } from "../services/crypto.js";
 import { findInstallationByGithubId, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
 import { ensureMembership } from "../services/membership.js";
 import { STATE_NONCE_COOKIE_NAME, signOAuthState, verifyOAuthState } from "../services/oauth-state.js";
@@ -129,6 +131,47 @@ async function seedGithubIdentity(
   });
 }
 
+function installSelectAfterReadHook(
+  app: FastifyInstance,
+  matches: (fields: object) => boolean,
+  afterRead: () => Promise<void>,
+): { wasTriggered: () => boolean; restore: () => void } {
+  const realSelect = app.db.select.bind(app.db);
+  let triggered = false;
+  const selectSpy = vi.spyOn(app.db, "select").mockImplementation(((fields?: unknown) => {
+    const builder = realSelect(fields as never);
+    if (!triggered && fields !== null && typeof fields === "object" && matches(fields)) {
+      const wrapQueryStep = (step: object): object =>
+        new Proxy(step, {
+          get(target, property, receiver) {
+            const member = Reflect.get(target, property, receiver);
+            if (typeof member !== "function") return member;
+            if (property === "then") return member.bind(target);
+            return (...args: unknown[]) => {
+              const next = Reflect.apply(member, target, args) as unknown;
+              if (property === "limit") {
+                return Promise.resolve(next).then(async (rows) => {
+                  if (!triggered) {
+                    triggered = true;
+                    await afterRead();
+                  }
+                  return rows;
+                });
+              }
+              return next !== null && typeof next === "object" ? wrapQueryStep(next) : next;
+            };
+          },
+        });
+      return wrapQueryStep(builder) as typeof builder;
+    }
+    return builder;
+  }) as typeof app.db.select);
+  return {
+    wasTriggered: () => triggered,
+    restore: () => selectSpy.mockRestore(),
+  };
+}
+
 describe("/auth/github/callback honors targetOrganizationId in the state (codex P1-3)", () => {
   const getApp = useTestApp({ githubAppPrivateKeyPem: TEST_APP_PRIVATE_KEY_PEM });
 
@@ -171,6 +214,17 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
         targetOrganizationId: admin.organizationId,
         kickoffUserId: admin.userId,
       });
+      const [identity] = await app.db
+        .select({ metadata: authIdentities.metadata })
+        .from(authIdentities)
+        .where(and(eq(authIdentities.userId, admin.userId), eq(authIdentities.provider, "github")))
+        .limit(1);
+      expect(decryptValue(String(identity?.metadata.accessToken), app.config.secrets.encryptionKey)).toBe(
+        "gho_stub_access",
+      );
+      expect(decryptValue(String(identity?.metadata.refreshToken), app.config.secrets.encryptionKey)).toBe(
+        "ghr_stub_refresh",
+      );
     } finally {
       restore();
     }
@@ -389,7 +443,11 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     });
 
     const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "installation",
+      provider: "github",
       targetOrganizationId: orgBId,
+      kickoffUserId: admin.userId,
     });
     const restore = stubGithub({ githubId, login, installationIds: [installationId] });
     try {
@@ -473,6 +531,9 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     await seedGithubIdentity(app, admin.userId, kickoffGithubId, login);
 
     const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/onboarding/connected", {
+      intent: "install",
+      installPhase: "installation",
+      provider: "github",
       targetOrganizationId: admin.organizationId,
       kickoffUserId: admin.userId,
     });
@@ -538,6 +599,9 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     });
 
     const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "installation",
+      provider: "github",
       targetOrganizationId: admin.organizationId,
       kickoffUserId: admin.userId,
     });
@@ -567,6 +631,118 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     expect(row?.hubOrganizationId).toBeNull();
   });
 
+  it("fails without claiming the verified subject when the kickoff identity changes before persistence", async () => {
+    const app = getApp();
+    const githubId = 770_023;
+    const replacementGithubId = 770_024;
+    const login = `targetorg-race-${uuidv7().slice(0, 6)}`;
+    const installationId = 8_822_023;
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, githubId, login);
+    const usersBefore = await app.db.select({ id: users.id }).from(users);
+    const identitiesBefore = await app.db
+      .select({ id: authIdentities.id })
+      .from(authIdentities)
+      .where(eq(authIdentities.provider, "github"));
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "installation",
+      provider: "github",
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+
+    const identityRace = installSelectAfterReadHook(
+      app,
+      (fields) => Reflect.has(fields, "identifier") && Reflect.has(fields, "metadata"),
+      async () => {
+        await app.db
+          .update(authIdentities)
+          .set({ identifier: String(replacementGithubId) })
+          .where(and(eq(authIdentities.userId, admin.userId), eq(authIdentities.provider, "github")));
+      },
+    );
+    const restore = stubGithub({ githubId, login, installationIds: [installationId] });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
+        headers: { cookie: `${STATE_NONCE_COOKIE_NAME}=${nonce}` },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("error=install-not-verified");
+      expect(res.headers.location).not.toContain("access=");
+    } finally {
+      restore();
+      identityRace.restore();
+    }
+
+    expect(identityRace.wasTriggered()).toBe(true);
+    const usersAfter = await app.db.select({ id: users.id }).from(users);
+    expect(usersAfter).toHaveLength(usersBefore.length);
+    const identities = await app.db
+      .select({ id: authIdentities.id, userId: authIdentities.userId, identifier: authIdentities.identifier })
+      .from(authIdentities)
+      .where(eq(authIdentities.provider, "github"));
+    expect(identities).toHaveLength(identitiesBefore.length);
+    expect(identities).toContainEqual({
+      id: expect.any(String),
+      userId: admin.userId,
+      identifier: String(replacementGithubId),
+    });
+    expect(identities.some((identity) => identity.identifier === String(githubId))).toBe(false);
+    expect(await findInstallationByGithubId(app.db, installationId)).toBeNull();
+  });
+
+  it("fails without refreshing credentials when Team admin authority changes before persistence", async () => {
+    const app = getApp();
+    const githubId = 770_025;
+    const login = `targetorg-role-race-${uuidv7().slice(0, 6)}`;
+    const installationId = 8_822_025;
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, githubId, login);
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "installation",
+      provider: "github",
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    const roleRace = installSelectAfterReadHook(
+      app,
+      (fields) => Reflect.has(fields, "memberId") && Reflect.has(fields, "role"),
+      async () => {
+        await app.db.update(members).set({ role: "member" }).where(eq(members.userId, admin.userId));
+      },
+    );
+    const restore = stubGithub({ githubId, login, installationIds: [installationId] });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
+        headers: { cookie: `${STATE_NONCE_COOKIE_NAME}=${nonce}` },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("error=install-not-admin");
+      expect(res.headers.location).not.toContain("access=");
+    } finally {
+      restore();
+      roleRace.restore();
+    }
+
+    expect(roleRace.wasTriggered()).toBe(true);
+    const [identity] = await app.db
+      .select({ metadata: authIdentities.metadata })
+      .from(authIdentities)
+      .where(and(eq(authIdentities.userId, admin.userId), eq(authIdentities.provider, "github")))
+      .limit(1);
+    expect(identity?.metadata.accessToken).toBeUndefined();
+    expect(identity?.metadata.refreshToken).toBeUndefined();
+    expect(await findInstallationByGithubId(app.db, installationId)).toBeNull();
+  });
+
   it("surfaces an error (not success) when the identities mismatch, regardless of installation_id", async () => {
     // Review finding (yuezengwu + codex): the mismatch branch must NOT
     // bounce to the success `next` — in onboarding that page auto-closes as
@@ -581,6 +757,9 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     await seedGithubIdentity(app, admin.userId, kickoffGithubId, login);
 
     const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/onboarding/connected", {
+      intent: "install",
+      installPhase: "installation",
+      provider: "github",
       targetOrganizationId: admin.organizationId,
       kickoffUserId: admin.userId,
     });
@@ -615,6 +794,9 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     await seedGithubIdentity(app, admin.userId, githubId, login);
 
     const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "installation",
+      provider: "github",
       targetOrganizationId: admin.organizationId,
       kickoffUserId: admin.userId,
     });
@@ -735,16 +917,15 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     expect(res.headers.location).toContain("callbackIntent=install");
   });
 
-  it("ignores a targetOrganizationId naming an org the user isn't a member of", async () => {
+  it("rejects an incomplete legacy install state before creating an account", async () => {
     const app = getApp();
     const githubId = 770_003;
     const login = `targetorg-stranger-${uuidv7().slice(0, 6)}`;
     const installationId = 8_822_003;
 
-    // Brand-new GitHub user; the callback mints them with no membership in
-    // the default org → `findActiveMembership` returns null → refusal via
-    // the SPA error surface (no kickoffUserId in this legacy-shape state,
-    // so the OAuth identity is the bind authority).
+    // A target Team alone used to imply an install callback. That legacy
+    // shape has no verified kickoff user, so it must fail before the generic
+    // account bootstrap can create a user and claim the GitHub subject.
     const defaultOrgId = await resolveDefaultOrgId(app.db);
     await upsertInstallationFromMetadata(app.db, {
       installation: {
@@ -760,6 +941,8 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
       targetOrganizationId: defaultOrgId,
     });
+    const usersBefore = await app.db.select({ id: users.id }).from(users);
+    const identitiesBefore = await app.db.select({ id: authIdentities.id }).from(authIdentities);
     const restore = stubGithub({ githubId, login, installationIds: [installationId] });
     try {
       const res = await app.inject({
@@ -769,9 +952,13 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
       });
       expect(res.statusCode).toBe(302);
       expect(res.headers.location).toContain("/auth/github/complete#");
-      expect(res.headers.location).toContain("error=install-not-admin");
+      expect(res.headers.location).toContain("error=state-expired");
+      expect(res.headers.location).toContain("callbackIntent=install");
     } finally {
       restore();
     }
+    expect(await app.db.select({ id: users.id }).from(users)).toHaveLength(usersBefore.length);
+    expect(await app.db.select({ id: authIdentities.id }).from(authIdentities)).toHaveLength(identitiesBefore.length);
+    expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBeNull();
   });
 });

--- a/packages/server/src/__tests__/github-app-callback-target-org.test.ts
+++ b/packages/server/src/__tests__/github-app-callback-target-org.test.ts
@@ -2,12 +2,13 @@ import { generateKeyPairSync } from "node:crypto";
 import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it, vi } from "vitest";
+import { readOAuthStateNonce } from "../api/auth/oauth-cookie.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { findInstallationByGithubId, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
 import { ensureMembership } from "../services/membership.js";
-import { STATE_NONCE_COOKIE_NAME, signOAuthState } from "../services/oauth-state.js";
+import { STATE_NONCE_COOKIE_NAME, signOAuthState, verifyOAuthState } from "../services/oauth-state.js";
 import { resolveDefaultOrgId } from "../services/organization.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -131,6 +132,168 @@ async function seedGithubIdentity(
 describe("/auth/github/callback honors targetOrganizationId in the state (codex P1-3)", () => {
   const getApp = useTestApp({ githubAppPrivateKeyPem: TEST_APP_PRIVATE_KEY_PEM });
 
+  it("continues a matching install identity preflight into the GitHub installation picker", async () => {
+    const app = getApp();
+    const githubId = 770_000;
+    const login = `preflight-match-${uuidv7().slice(0, 6)}`;
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, githubId, login);
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "identity",
+      provider: "github",
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    const restore = stubGithub({ githubId, login, installationIds: [] });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}`,
+        headers: { cookie: `${STATE_NONCE_COOKIE_NAME}=${nonce}` },
+      });
+
+      expect(res.statusCode).toBe(302);
+      const installUrl = new URL(res.headers.location ?? "");
+      expect(installUrl.origin).toBe("https://github.com");
+      expect(installUrl.pathname).toBe("/apps/test-app-slug/installations/new");
+      const installState = installUrl.searchParams.get("state") ?? "";
+      const installNonce = readOAuthStateNonce(
+        res.headers["set-cookie"],
+        STATE_NONCE_COOKIE_NAME,
+        app.config.secrets.encryptionKey,
+      );
+      expect(await verifyOAuthState(TEST_JWT_SECRET, installState, installNonce)).toMatchObject({
+        next: "/settings/github",
+        intent: "install",
+        installPhase: "installation",
+        provider: "github",
+        targetOrganizationId: admin.organizationId,
+        kickoffUserId: admin.userId,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("stops a mismatched install identity preflight before creating an account or installation request", async () => {
+    const app = getApp();
+    const linkedGithubId = 770_010;
+    const strangerGithubId = 770_011;
+    const login = `preflight-mismatch-${uuidv7().slice(0, 6)}`;
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, linkedGithubId, login);
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "identity",
+      provider: "github",
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    const restore = stubGithub({ githubId: strangerGithubId, login: `${login}-stranger`, installationIds: [] });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}`,
+        headers: { cookie: `${STATE_NONCE_COOKIE_NAME}=${nonce}` },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("error=install-not-verified");
+      expect(res.headers.location).toContain(`expectedGithubLogin=${encodeURIComponent(login)}`);
+      expect(res.headers.location).not.toContain("/installations/new");
+      const strangerIdentities = await app.db
+        .select({ id: authIdentities.id })
+        .from(authIdentities)
+        .where(eq(authIdentities.identifier, String(strangerGithubId)));
+      expect(strangerIdentities).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("stops the identity preflight if the kickoff admin loses the role before the callback", async () => {
+    const app = getApp();
+    const githubId = 770_012;
+    const login = `preflight-revoked-${uuidv7().slice(0, 6)}`;
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, githubId, login);
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "identity",
+      provider: "github",
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    await app.db.update(members).set({ role: "member" }).where(eq(members.userId, admin.userId));
+    const restore = stubGithub({ githubId, login, installationIds: [] });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}`,
+        headers: { cookie: `${STATE_NONCE_COOKIE_NAME}=${nonce}` },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("error=install-not-admin");
+      expect(res.headers.location).toContain("next=%2Fsettings%2Fgithub");
+      expect(res.headers.location).not.toContain("/installations/new");
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not treat an identity-preflight callback without an OAuth code as an installation request landing", async () => {
+    const app = getApp();
+    const githubId = 770_013;
+    const login = `preflight-no-code-${uuidv7().slice(0, 6)}`;
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, githubId, login);
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "identity",
+      provider: "github",
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/callback?state=${token}&setup_action=request`,
+      headers: { cookie: `${STATE_NONCE_COOKIE_NAME}=${nonce}` },
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toContain("error=install-not-verified");
+    expect(res.headers.location).toContain(`expectedGithubLogin=${encodeURIComponent(login)}`);
+    expect(res.headers.location).not.toBe("/settings/github");
+  });
+
+  it("returns a canceled identity preflight to the stable GitHub Settings panel", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `preflight-cancel-${uuidv7().slice(0, 6)}` });
+    await seedGithubIdentity(app, admin.userId, 770_014, "preflight-cancel");
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/onboarding/connected", {
+      intent: "install",
+      installPhase: "identity",
+      provider: "github",
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/callback?error=access_denied&state=${token}`,
+      headers: { cookie: `${STATE_NONCE_COOKIE_NAME}=${nonce}` },
+    });
+
+    expect(res.statusCode).toBe(302);
+    const fragment = new URLSearchParams(res.headers.location?.split("#")[1] ?? "");
+    expect(fragment.get("error")).toBe("provider-denied");
+    expect(fragment.get("callbackIntent")).toBe("install");
+    expect(fragment.get("next")).toBe("/settings/github");
+  });
+
   it("resolves + pins the target org (not the user's primary org) when the kickoff admin matches", async () => {
     const app = getApp();
     const githubId = 770_001;
@@ -160,6 +323,7 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
 
     const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
       intent: "install",
+      installPhase: "installation",
       provider: "github",
       targetOrganizationId: orgBId,
       kickoffUserId: admin.userId,
@@ -328,6 +492,7 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
       expect(res.statusCode).toBe(302);
       expect(res.headers.location).toContain("/auth/github/complete#");
       expect(res.headers.location).toContain("error=install-not-verified");
+      expect(res.headers.location).toContain(`expectedGithubLogin=${encodeURIComponent(login)}`);
       expect(res.headers.location).not.toContain("access=");
     } finally {
       restore();
@@ -335,6 +500,11 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
 
     // Nothing bound (and nothing upserted) by the callback.
     expect(await findInstallationByGithubId(app.db, installationId)).toBeNull();
+    const strangerIdentities = await app.db
+      .select({ id: authIdentities.id })
+      .from(authIdentities)
+      .where(eq(authIdentities.identifier, String(strangerGithubId)));
+    expect(strangerIdentities).toHaveLength(0);
   });
 
   it("does NOT bind when a matching installation row exists but the callback identity mismatches", async () => {
@@ -426,12 +596,10 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
       expect(res.headers.location).toContain("/auth/github/complete#");
       expect(res.headers.location).toContain("error=install-not-verified");
       expect(res.headers.location).not.toContain("access=");
-      // Review finding round 2: the error page renders `next` as its "Back
-      // to First Tree" link — it must NOT point at the auto-close
-      // "Connected" sentinel, or the error page offers a false-success
-      // escape hatch. The onboarding popup path normalizes to /onboarding.
+      // The install popup's error escape returns to the stable Team GitHub
+      // panel, never the auto-close success sentinel.
       const fragment = new URLSearchParams(res.headers.location?.split("#")[1] ?? "");
-      expect(fragment.get("next")).toBe("/onboarding");
+      expect(fragment.get("next")).toBe("/settings/github");
     } finally {
       restore();
     }
@@ -495,11 +663,16 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     // back WITHOUT an OAuth code. The browser goes back to `next` (the
     // panel), whose polling picks the installation up once approved.
     const app = getApp();
+    const githubId = 770_020;
+    const login = `request-landing-${uuidv7().slice(0, 6)}`;
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, githubId, login);
     const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
       intent: "install",
+      installPhase: "installation",
       provider: "github",
-      targetOrganizationId: uuidv7(),
-      kickoffUserId: uuidv7(),
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
     });
     const res = await app.inject({
       method: "GET",
@@ -508,6 +681,58 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     });
     expect(res.statusCode).toBe(302);
     expect(res.headers.location).toBe("/settings/github");
+  });
+
+  it("rejects an approval-request landing after the kickoff user loses Team admin authority", async () => {
+    const app = getApp();
+    const githubId = 770_021;
+    const login = `request-revoked-${uuidv7().slice(0, 6)}`;
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, githubId, login);
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "installation",
+      provider: "github",
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    await app.db.update(members).set({ role: "member" }).where(eq(members.userId, admin.userId));
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/callback?state=${token}&setup_action=request`,
+      headers: { cookie: `${STATE_NONCE_COOKIE_NAME}=${nonce}` },
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toContain("error=install-not-admin");
+    expect(res.headers.location).toContain("callbackIntent=install");
+  });
+
+  it("rejects an approval-request landing after the kickoff user unlinks GitHub", async () => {
+    const app = getApp();
+    const githubId = 770_022;
+    const login = `request-unlinked-${uuidv7().slice(0, 6)}`;
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, githubId, login);
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      intent: "install",
+      installPhase: "installation",
+      provider: "github",
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    await app.db.delete(authIdentities).where(eq(authIdentities.identifier, String(githubId)));
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/callback?state=${token}&setup_action=request`,
+      headers: { cookie: `${STATE_NONCE_COOKIE_NAME}=${nonce}` },
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toContain("error=install-not-verified");
+    expect(res.headers.location).toContain("callbackIntent=install");
   });
 
   it("ignores a targetOrganizationId naming an org the user isn't a member of", async () => {

--- a/packages/server/src/__tests__/github-app-install-url.test.ts
+++ b/packages/server/src/__tests__/github-app-install-url.test.ts
@@ -1,6 +1,9 @@
 import crypto from "node:crypto";
 import bcrypt from "bcrypt";
+import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
+import { readOAuthStateNonce } from "../api/auth/oauth-cookie.js";
+import { authIdentities } from "../db/schema/auth-identities.js";
 import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
@@ -12,19 +15,47 @@ import { createTestAdmin, useTestApp } from "./helpers.js";
 const TEST_JWT_SECRET = "test-jwt-secret-key-for-vitest";
 
 /** Pull `oauth_state_nonce` out of a Set-Cookie header. */
-function readStateCookie(setCookie: string | string[] | undefined): string | null {
-  if (!setCookie) return null;
-  const raw = Array.isArray(setCookie) ? setCookie.join("; ") : setCookie;
-  const m = new RegExp(`${STATE_NONCE_COOKIE_NAME}=([^;]+)`).exec(raw);
-  return m?.[1] ? decodeURIComponent(m[1]) : null;
+function readStateCookie(app: FastifyInstance, setCookie: string | string[] | undefined): string | null {
+  return readOAuthStateNonce(setCookie, STATE_NONCE_COOKIE_NAME, app.config.secrets.encryptionKey);
+}
+
+async function linkGithubIdentity(app: FastifyInstance, userId: string): Promise<void> {
+  await app.db.insert(authIdentities).values({
+    id: uuidv7(),
+    userId,
+    provider: "github",
+    identifier: String(Math.floor(700_000 + Math.random() * 99_999)),
+    email: null,
+    verifiedAt: new Date(),
+    metadata: { login: "install-requester" },
+  });
 }
 
 describe("GET /api/v1/orgs/:orgId/github-app-installation/install-url", () => {
   const getApp = useTestApp();
 
-  it("returns the GitHub installations/new URL + sets the state cookie", async () => {
+  it("blocks an admin without a linked GitHub identity before starting the installation flow", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `no-github-${crypto.randomUUID().slice(0, 8)}` });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/install-url`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({
+      code: "github_identity_required",
+      error: "Connect a GitHub account before installing the GitHub App",
+    });
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("returns a GitHub identity-preflight URL + sets the state cookie", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
+    await linkGithubIdentity(app, admin.userId);
 
     const res = await app.inject({
       method: "GET",
@@ -36,14 +67,14 @@ describe("GET /api/v1/orgs/:orgId/github-app-installation/install-url", () => {
     const body = res.json<{ installUrl: string }>();
     const url = new URL(body.installUrl);
     expect(url.origin).toBe("https://github.com");
-    // helpers.ts seeds slug="test-app-slug".
-    expect(url.pathname).toBe("/apps/test-app-slug/installations/new");
+    expect(url.pathname).toBe("/login/oauth/authorize");
+    expect(url.searchParams.get("client_id")).toBe("test-app-client-id");
     const state = url.searchParams.get("state");
     expect(state).toBeTruthy();
 
     // The state cookie nonce matches the JWT — verifyOAuthState would
     // accept this pair when the callback fires.
-    const cookieNonce = readStateCookie(res.headers["set-cookie"]);
+    const cookieNonce = readStateCookie(app, res.headers["set-cookie"]);
     expect(cookieNonce).toBeTruthy();
     const verified = await verifyOAuthState(TEST_JWT_SECRET, state ?? "", cookieNonce);
     expect(verified.next).toBe("/settings/github");
@@ -53,12 +84,14 @@ describe("GET /api/v1/orgs/:orgId/github-app-installation/install-url", () => {
     expect(verified.targetOrganizationId).toBe(admin.organizationId);
     expect(verified.kickoffUserId).toBe(admin.userId);
     expect(verified.intent).toBe("install");
+    expect(verified.installPhase).toBe("identity");
     expect(verified.provider).toBe("github");
   });
 
   it("bakes an allowlisted ?next= into the signed state (onboarding flow)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
+    await linkGithubIdentity(app, admin.userId);
 
     const res = await app.inject({
       method: "GET",
@@ -68,7 +101,7 @@ describe("GET /api/v1/orgs/:orgId/github-app-installation/install-url", () => {
 
     expect(res.statusCode).toBe(200);
     const state = new URL(res.json<{ installUrl: string }>().installUrl).searchParams.get("state");
-    const cookieNonce = readStateCookie(res.headers["set-cookie"]);
+    const cookieNonce = readStateCookie(app, res.headers["set-cookie"]);
     const verified = await verifyOAuthState(TEST_JWT_SECRET, state ?? "", cookieNonce);
     expect(verified.next).toBe("/onboarding");
   });
@@ -76,6 +109,7 @@ describe("GET /api/v1/orgs/:orgId/github-app-installation/install-url", () => {
   it("ignores a ?next= that isn't on the allowlist (no open redirect)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
+    await linkGithubIdentity(app, admin.userId);
 
     const res = await app.inject({
       method: "GET",
@@ -85,7 +119,7 @@ describe("GET /api/v1/orgs/:orgId/github-app-installation/install-url", () => {
 
     expect(res.statusCode).toBe(200);
     const state = new URL(res.json<{ installUrl: string }>().installUrl).searchParams.get("state");
-    const cookieNonce = readStateCookie(res.headers["set-cookie"]);
+    const cookieNonce = readStateCookie(app, res.headers["set-cookie"]);
     const verified = await verifyOAuthState(TEST_JWT_SECRET, state ?? "", cookieNonce);
     expect(verified.next).toBe("/settings/github");
   });
@@ -148,6 +182,7 @@ describe("install-url when the App slug is not configured", () => {
   it("503s with a slug-missing hint", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `noslug-${crypto.randomUUID().slice(0, 8)}` });
+    await linkGithubIdentity(app, admin.userId);
     const res = await app.inject({
       method: "GET",
       url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/install-url`,

--- a/packages/server/src/__tests__/github-auth-route-options.test.ts
+++ b/packages/server/src/__tests__/github-auth-route-options.test.ts
@@ -1,0 +1,57 @@
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { githubOauthRoutes } from "../api/auth/github.js";
+import { orgGithubAppRoutes } from "../api/orgs/github-app.js";
+
+type RegisteredRoute = {
+  method: "GET" | "POST" | "DELETE";
+  path: string;
+  options: unknown;
+};
+
+function routeCollector(): { app: FastifyInstance; routes: RegisteredRoute[] } {
+  const routes: RegisteredRoute[] = [];
+  const register =
+    (method: RegisteredRoute["method"]) =>
+    (...args: unknown[]) => {
+      const [path, maybeOptions] = args;
+      routes.push({
+        method,
+        path: String(path),
+        options: args.length === 3 ? maybeOptions : undefined,
+      });
+    };
+  return {
+    app: {
+      get: register("GET"),
+      post: register("POST"),
+      delete: register("DELETE"),
+    } as unknown as FastifyInstance,
+    routes,
+  };
+}
+
+describe("GitHub authorization route protection", () => {
+  it("rate-limits install URL authorization before OAuth state is minted", async () => {
+    const collector = routeCollector();
+    await orgGithubAppRoutes(collector.app);
+    const route = collector.routes.find((candidate) => candidate.method === "GET" && candidate.path === "/install-url");
+    const config =
+      route?.options && typeof route.options === "object" ? Reflect.get(route.options, "config") : undefined;
+
+    expect(route).toBeDefined();
+    expect(config).toEqual({ rateLimit: { max: 60, timeWindow: "1 minute" } });
+  });
+
+  it.each(["/start", "/callback"])("rate-limits the GitHub OAuth %s route", async (path) => {
+    const collector = routeCollector();
+    Reflect.set(collector.app, "config", { oauth: { githubApp: {} } });
+    await githubOauthRoutes(collector.app);
+    const route = collector.routes.find((candidate) => candidate.method === "GET" && candidate.path === path);
+    const config =
+      route?.options && typeof route.options === "object" ? Reflect.get(route.options, "config") : undefined;
+
+    expect(route).toBeDefined();
+    expect(config).toEqual({ rateLimit: { max: 60, timeWindow: "1 minute" } });
+  });
+});

--- a/packages/server/src/__tests__/me-auth-providers.test.ts
+++ b/packages/server/src/__tests__/me-auth-providers.test.ts
@@ -12,6 +12,72 @@ import { createTestApp, useTestApp } from "./helpers.js";
 describe("user authentication provider management", () => {
   const getApp = useTestApp({ googleOAuth: true });
 
+  it("pins a safe capability return path into GitHub account-link state", async () => {
+    const app = getApp();
+    const userId = uuidv7();
+    await app.db.insert(users).values({
+      id: userId,
+      username: "provider-link-return",
+      passwordHash: "x",
+      displayName: "Provider Link Return",
+    });
+    const tokens = await signTokensForUser(app.config.secrets.jwtSecret, userId, app.config.auth);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/auth-providers/github/link/start?next=%2Fsettings%2Fgithub",
+      headers: { authorization: `Bearer ${tokens.accessToken}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const state = new URL(response.json().redirectUrl).searchParams.get("state") ?? "";
+    const cookieNonce = readOAuthStateNonce(
+      response.headers["set-cookie"],
+      STATE_NONCE_COOKIE_NAME,
+      app.config.secrets.encryptionKey,
+    );
+    const verified = await verifyOAuthState(app.config.secrets.jwtSecret, state, cookieNonce);
+    expect(verified).toMatchObject({
+      intent: "link",
+      provider: "github",
+      userId,
+      next: "/settings/github",
+    });
+  });
+
+  it.each([
+    "https://evil.example/settings/github",
+    "//evil.example/settings/github",
+    "/settings/team",
+    "/settings/github?org=another-team",
+  ])("falls back to Account settings for unsupported account-link return path %s", async (next) => {
+    const app = getApp();
+    const userId = uuidv7();
+    await app.db.insert(users).values({
+      id: userId,
+      username: `provider-link-reject-${uuidv7().slice(0, 8)}`,
+      passwordHash: "x",
+      displayName: "Provider Link Reject",
+    });
+    const tokens = await signTokensForUser(app.config.secrets.jwtSecret, userId, app.config.auth);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/me/auth-providers/github/link/start?next=${encodeURIComponent(next)}`,
+      headers: { authorization: `Bearer ${tokens.accessToken}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const state = new URL(response.json().redirectUrl).searchParams.get("state") ?? "";
+    const cookieNonce = readOAuthStateNonce(
+      response.headers["set-cookie"],
+      STATE_NONCE_COOKIE_NAME,
+      app.config.secrets.encryptionKey,
+    );
+    const verified = await verifyOAuthState(app.config.secrets.jwtSecret, state, cookieNonce);
+    expect(verified.next).toBe("/user-settings");
+  });
+
   it("reports configured providers without exposing raw subjects", async () => {
     const app = getApp();
     const userId = uuidv7();

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -503,6 +503,103 @@ describe("GitHub OAuth invite-only single-org entry gate", () => {
   });
 });
 
+describe("GitHub account-link return path", () => {
+  const getApp = useTestApp();
+
+  it("returns a completed capability link to its signed internal destination", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `link-return-${randomUUID().slice(0, 8)}` });
+    const { signOAuthState } = await import("../services/oauth-state.js");
+    const { token, nonce } = await signOAuthState(app.config.secrets.jwtSecret, "/settings/github", {
+      intent: "link",
+      provider: "github",
+      userId: admin.userId,
+    });
+    const restore = stubGithubAppOauth({ githubId: 77_200_001, login: "linked-for-install" });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=ok-code&state=${token}`,
+        headers: { cookie: `oauth_state_nonce=${nonce}` },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe("/settings/github?connection=github-linked");
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns an identity conflict to GitHub Settings without replacing the existing session", async () => {
+    const app = getApp();
+    const target = await createTestAdmin(app, { username: `link-target-${randomUUID().slice(0, 8)}` });
+    const owner = await createTestAdmin(app, { username: `link-owner-${randomUUID().slice(0, 8)}` });
+    const githubId = 77_200_002;
+    await app.db.insert(authIdentities).values({
+      id: randomUUID(),
+      userId: owner.userId,
+      provider: "github",
+      identifier: String(githubId),
+      metadata: { accountName: "already-linked" },
+    });
+    const { signOAuthState } = await import("../services/oauth-state.js");
+    const { token, nonce } = await signOAuthState(app.config.secrets.jwtSecret, "/settings/github", {
+      intent: "link",
+      provider: "github",
+      userId: target.userId,
+    });
+    const restore = stubGithubAppOauth({ githubId, login: "already-linked" });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=ok-code&state=${token}`,
+        headers: { cookie: `oauth_state_nonce=${nonce}` },
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe("/settings/github?error=identity-conflict");
+      expect(res.headers.location).not.toContain("access=");
+      const targetIdentities = await app.db
+        .select({ provider: authIdentities.provider })
+        .from(authIdentities)
+        .where(eq(authIdentities.userId, target.userId));
+      expect(targetIdentities.some((identity) => identity.provider === "github")).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps a canceled account link side-effect free and preserves a retry route", async () => {
+    const app = getApp();
+    const target = await createTestAdmin(app, { username: `link-cancel-${randomUUID().slice(0, 8)}` });
+    const { signOAuthState } = await import("../services/oauth-state.js");
+    const { token, nonce } = await signOAuthState(app.config.secrets.jwtSecret, "/settings/github", {
+      intent: "link",
+      provider: "github",
+      userId: target.userId,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/callback?error=access_denied&state=${token}`,
+      headers: { cookie: `oauth_state_nonce=${nonce}` },
+    });
+
+    expect(res.statusCode).toBe(302);
+    const fragment = new URLSearchParams(res.headers.location?.split("#")[1] ?? "");
+    expect(fragment.get("error")).toBe("provider-denied");
+    expect(fragment.get("next")).toBe("/settings/github");
+    expect(fragment.get("callbackIntent")).toBe("link");
+    expect(fragment.get("access")).toBeNull();
+    expect(res.headers["set-cookie"]).toContain("Max-Age=0");
+    const targetIdentities = await app.db
+      .select({ provider: authIdentities.provider })
+      .from(authIdentities)
+      .where(eq(authIdentities.userId, target.userId));
+    expect(targetIdentities.some((identity) => identity.provider === "github")).toBe(false);
+  });
+});
+
 describe("OAuth callback rejects malformed state", () => {
   const getApp = useTestApp();
 

--- a/packages/server/src/__tests__/oauth-state.test.ts
+++ b/packages/server/src/__tests__/oauth-state.test.ts
@@ -23,6 +23,7 @@ describe("OAuth state JWT", () => {
   it("round-trips the GitHub App installation intent", async () => {
     const { token, nonce } = await signOAuthState(SECRET, "/settings/github", {
       intent: "install",
+      installPhase: "identity",
       provider: "github",
       targetOrganizationId: "01961234-aaaa-7000-8000-000000000001",
     });
@@ -30,6 +31,7 @@ describe("OAuth state JWT", () => {
     expect(result).toMatchObject({
       next: "/settings/github",
       intent: "install",
+      installPhase: "identity",
       provider: "github",
     });
   });

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -17,6 +17,7 @@ import {
   IdentityMismatchError,
   LastIdentityError,
   linkExternalIdentity,
+  refreshGithubInstallIdentity,
   unlinkExternalIdentity,
 } from "../../services/auth-identity.js";
 import { encryptValue } from "../../services/crypto.js";
@@ -84,7 +85,7 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
     );
   }
 
-  app.get("/start", async (request, reply) => {
+  app.get("/start", { config: { rateLimit: { max: 60, timeWindow: "1 minute" } } }, async (request, reply) => {
     const { next } = githubStartQuerySchema.parse(request.query);
     const safeNext = safeRedirectPath(next ?? null);
     if (!appCfg) {
@@ -115,7 +116,7 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
     return reply.redirect(buildAppAuthorizeUrl({ clientId: appCfg.clientId, redirectUri, state: token }), 302);
   });
 
-  app.get("/callback", async (request, reply) => {
+  app.get("/callback", { config: { rateLimit: { max: 60, timeWindow: "1 minute" } } }, async (request, reply) => {
     if (!appCfg) {
       return reply.status(503).send({ error: "GitHub App is not configured on this First Tree deployment" });
     }
@@ -192,6 +193,26 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
         "OAuth state provider does not match callback",
       );
       return redirectCallbackError(reply, "state-expired", next, { callbackIntent: intent });
+    }
+
+    // App-install callbacks are allowed to mutate only the kickoff user's
+    // already-linked GitHub identity. States minted before the complete
+    // two-phase contract cannot prove that user, so fail before exchanging a
+    // code or entering the generic account bootstrap. Users can recover by
+    // starting Install again from the Team's GitHub Settings panel.
+    if (
+      intent === "install" &&
+      (verified.intent !== "install" ||
+        verified.provider !== "github" ||
+        !targetOrganizationId ||
+        !kickoffUserId ||
+        !installPhase)
+    ) {
+      app.log.warn(
+        { event: "github_app.install_callback_incomplete_state", installPhase },
+        "install callback state lacks the verified kickoff authority tuple",
+      );
+      return redirectCallbackError(reply, "state-expired", "/settings/github", { callbackIntent: "install" });
     }
 
     if (providerError) {
@@ -282,7 +303,7 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
       installationIdRaw && Number.isFinite(Number(installationIdRaw)) ? Number(installationIdRaw) : null;
 
     if (intent === "install" && installPhase === "identity") {
-      return continueInstallAfterIdentityPreflight(app, reply, profile, next, {
+      return continueInstallAfterIdentityPreflight(app, reply, profile, tokens, next, {
         targetOrganizationId,
         kickoffUserId,
       });
@@ -578,6 +599,7 @@ async function continueInstallAfterIdentityPreflight(
   app: FastifyInstance,
   reply: FastifyReply,
   profile: GithubProfile,
+  oauthTokens: GithubTokenBundle,
   next: string,
   opts: { targetOrganizationId: string | null; kickoffUserId: string | null },
 ) {
@@ -586,23 +608,29 @@ async function continueInstallAfterIdentityPreflight(
     return redirectCallbackError(reply, "state-expired", "/settings/github", { callbackIntent: "install" });
   }
 
-  const installAuthority = await inspectInstallCallbackAuthority(app, profile, {
-    targetOrganizationId,
-    kickoffUserId,
+  const installAuthority = await refreshGithubInstallIdentity(app.db, {
+    userId: kickoffUserId,
+    organizationId: targetOrganizationId,
+    profile,
+    tokens: oauthTokens,
   });
   if (!installAuthority.ok) {
-    return redirectCallbackError(reply, installAuthority.code, "/settings/github", {
-      callbackIntent: "install",
-      expectedGithubLogin: installAuthority.expectedGithubLogin,
-    });
+    return redirectCallbackError(
+      reply,
+      installAuthority.reason === "not-admin" ? "install-not-admin" : "install-not-verified",
+      "/settings/github",
+      {
+        callbackIntent: "install",
+        expectedGithubLogin: installAuthority.expectedGithubLogin,
+      },
+    );
   }
-  const { linkedIdentity } = installAuthority;
 
   const appCfg = app.config.oauth?.githubApp;
   if (!appCfg?.slug) {
     return redirectCallbackError(reply, "provider-not-configured", "/settings/github", {
       callbackIntent: "install",
-      expectedGithubLogin: linkedIdentity.login,
+      expectedGithubLogin: installAuthority.githubLogin,
     });
   }
 
@@ -725,7 +753,50 @@ async function completeOauthFlow(
   } = {},
 ) {
   const { kickoffUserId = null, browserFacing = false, callbackIntent = "sign-in", devBindInstallation = false } = opts;
-  const account = await findOrCreateGithubAccount(app.db, profile, oauthTokens);
+  let account: Awaited<ReturnType<typeof findOrCreateGithubAccount>>;
+  if (callbackIntent === "install") {
+    if (!targetOrganizationId || !kickoffUserId) {
+      if (browserFacing) {
+        return redirectCallbackError(reply, "state-expired", "/settings/github", { callbackIntent });
+      }
+      return reply.status(409).send({ error: "GitHub App install authority is missing or expired" });
+    }
+    const installIdentity = await refreshGithubInstallIdentity(app.db, {
+      userId: kickoffUserId,
+      organizationId: targetOrganizationId,
+      profile,
+      tokens: oauthTokens,
+    });
+    if (!installIdentity.ok) {
+      const code = installIdentity.reason === "not-admin" ? "install-not-admin" : "install-not-verified";
+      app.log.warn(
+        {
+          event: "github_app.install_callback_atomic_authority_failed",
+          targetOrganizationId,
+          kickoffUserId,
+          githubId: profile.githubId,
+          githubLogin: profile.login,
+          reason: installIdentity.reason,
+        },
+        "install callback: live Team authority or exact GitHub identity changed before completion",
+      );
+      if (browserFacing) {
+        return redirectCallbackError(reply, code, "/settings/github", {
+          callbackIntent,
+          expectedGithubLogin: installIdentity.expectedGithubLogin,
+        });
+      }
+      return reply.status(code === "install-not-admin" ? 403 : 409).send({
+        error:
+          code === "install-not-admin"
+            ? "Not an admin of the First Tree organization this installation targets"
+            : "GitHub identity no longer matches the account that started this installation",
+      });
+    }
+    account = installIdentity.account;
+  } else {
+    account = await findOrCreateGithubAccount(app.db, profile, oauthTokens);
+  }
   const { userId } = account;
   const allowedOrganizationId = app.config.access?.allowedOrganizationId ?? null;
 
@@ -783,66 +854,10 @@ async function completeOauthFlow(
       );
     }
   } else {
-    // App-install flow: the org rode in the signed state minted by the
-    // admin-gated `/install-url` (codex P1-3). The bind rests on the
-    // KICKOFF user's authority — re-checked live against `members`,
-    // because the state JWT outlives a membership revoke — and NOT on the
-    // identity the OAuth code resolved to: the browser's github.com
-    // session is independent of the First Tree session, and a mismatch
-    // (second GitHub account, deleted-and-recreated account, someone
-    // else's First Tree session in the same browser) must not strand a
-    // completed install unbound. States minted before `kickoffUserId`
-    // existed (≤10min old at deploy time) fall back to the OAuth identity.
-    const bindAuthorityUserId = kickoffUserId ?? userId;
-    const authority = await findActiveMembership(app.db, bindAuthorityUserId, targetOrganizationId);
-    if (!authority || authority.role !== "admin") {
-      app.log.warn(
-        {
-          event: "github_app.install_callback_admin_check_failed",
-          targetOrganizationId,
-          kickoffUserId,
-          oauthUserId: userId,
-          githubId: profile.githubId,
-          githubLogin: profile.login,
-          installationId,
-        },
-        "install callback: bind authority is not an active admin of the target org — refusing to bind",
-      );
-      if (browserFacing)
-        return redirectCallbackError(reply, "install-not-admin", next, {
-          callbackIntent,
-          accountCreated: account.created,
-        });
-      return reply.status(403).send({ error: "Not an admin of the First Tree organization this installation targets" });
-    }
-    if (bindAuthorityUserId !== userId) {
-      // The install was completed under a DIFFERENT GitHub identity than the
-      // admin who kicked it off — the browser's github.com session differs
-      // from the First Tree kickoff admin (a second GitHub account, someone
-      // else's github.com session in the same browser, …). No bind side
-      // effect exists to worry about here (binding is a panel action), but
-      // completing the flow would sign the browser in as the foreign
-      // identity — replacing the kickoff admin's session in every tab.
-      // Surface it as an error instead: install must use the same GitHub
-      // account you signed in / started the install with.
-      app.log.warn(
-        {
-          event: "github_app.install_callback_identity_mismatch",
-          targetOrganizationId,
-          kickoffUserId: bindAuthorityUserId,
-          oauthUserId: userId,
-          githubId: profile.githubId,
-          githubLogin: profile.login,
-        },
-        "install callback: OAuth identity differs from the kickoff admin — refusing (install must use the same GitHub account)",
-      );
-      const expectedGithubLogin = (await findGithubIdentityForUser(app, bindAuthorityUserId))?.login;
-      return redirectCallbackError(reply, "install-not-verified", next, {
-        callbackIntent,
-        accountCreated: account.created,
-        expectedGithubLogin,
-      });
-    }
+    // The modern App-install state carries `kickoffUserId`; its exact GitHub
+    // subject, live active-admin authority, and token/snapshot refresh were
+    // already locked and committed atomically above. Incomplete legacy states
+    // fail before code exchange and never reach this branch.
     // No bind happens here: the `installation.created` webhook records the
     // installation (with its requester/installer anchors) and the admin
     // connects it from the panel `next` points back to. This branch only

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -5,7 +5,9 @@ import {
   githubStartQuerySchema,
   safeRedirectPath,
 } from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { authIdentities } from "../../db/schema/auth-identities.js";
 import { signTokensForUser } from "../../services/auth.js";
 import {
   findOrCreateGithubAccount,
@@ -18,7 +20,7 @@ import {
   unlinkExternalIdentity,
 } from "../../services/auth-identity.js";
 import { encryptValue } from "../../services/crypto.js";
-import { buildAppAuthorizeUrl, exchangeCodeForAppUserProfile } from "../../services/github-app.js";
+import { buildAppAuthorizeUrl, buildAppInstallUrl, exchangeCodeForAppUserProfile } from "../../services/github-app.js";
 import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../../services/github-app-installations.js";
 import { findActiveMembership } from "../../services/membership.js";
 import { completeExternalAccountBootstrap, OAuthBootstrapError } from "../../services/oauth-bootstrap.js";
@@ -48,10 +50,12 @@ const ACCOUNT_RETURN_PATH = "/user-settings";
  * installed it the authorize URL never surfaces the install dialog and
  * never returns an `installation_id` (codex P1-1; see
  * `services/github-app.ts`). So sign-in must not be relied on to install
- * the App. The reliable install entry is `installations/new`, exposed at
- * `GET /orgs/:orgId/github-app-installation/install-url` and surfaced both
- * in onboarding's "Connect your code" step and Settings → GitHub. After
- * that dialog GitHub redirects back here with `code + state +
+ * the App. `GET /orgs/:orgId/github-app-installation/install-url`, surfaced
+ * in onboarding and Settings → GitHub, starts a two-phase install: first this
+ * authorize endpoint proves the active github.com user matches the kickoff
+ * admin's linked numeric identity; only a successful callback receives fresh
+ * state and continues to `installations/new`. After that dialog GitHub
+ * redirects back here with `code + state +
  * installation_id` (or without `code` when the install is parked for
  * owner approval, and without `state` when GitHub's own settings UI is
  * the origin). The callback does NOT bind the installation: the trusted,
@@ -145,6 +149,7 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
     let next: string;
     let targetOrganizationId: string | null = null;
     let kickoffUserId: string | null = null;
+    let installPhase: "identity" | "installation" | null = null;
     let intent: CallbackIntent = "sign-in";
     let stateUserId: string | null = null;
     let targetIdentityId: string | null = null;
@@ -154,6 +159,7 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
       next = verified.next;
       targetOrganizationId = verified.targetOrganizationId ?? null;
       kickoffUserId = verified.kickoffUserId ?? null;
+      installPhase = verified.installPhase ?? null;
       intent = verified.intent ?? (targetOrganizationId ? "install" : "sign-in");
       stateUserId = verified.userId ?? null;
       targetIdentityId = verified.targetIdentityId ?? null;
@@ -193,17 +199,45 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
         { event: "oauth.provider_denied", provider: "github", intent },
         "GitHub authorization was denied or canceled",
       );
-      return redirectCallbackError(reply, "provider-denied", next, { callbackIntent: intent });
+      return redirectCallbackError(reply, "provider-denied", installErrorReturnPath(intent, next), {
+        callbackIntent: intent,
+      });
     }
 
     if (!code) {
+      if (intent === "install" && installPhase === "identity") {
+        app.log.warn(
+          { event: "github_app.install_identity_preflight_no_code", setupAction: parsed.setup_action ?? null },
+          "install identity preflight returned without an OAuth code",
+        );
+        return redirectCallbackError(reply, "install-not-verified", "/settings/github", {
+          callbackIntent: intent,
+          expectedGithubLogin: kickoffUserId ? (await findGithubIdentityForUser(app, kickoffUserId))?.login : null,
+        });
+      }
+      if (intent === "install") {
+        const landingAuthority = await inspectInstallLandingAuthority(app, {
+          targetOrganizationId,
+          kickoffUserId,
+        });
+        if (!landingAuthority.ok) {
+          return redirectCallbackError(reply, landingAuthority.code, "/settings/github", {
+            callbackIntent: "install",
+            expectedGithubLogin: landingAuthority.expectedGithubLogin,
+          });
+        }
+      }
       // Kickoff round-trip that produced no OAuth code — the
       // `setup_action=request` shape: the user asked to install on an org
       // they don't own and GitHub parked the install pending owner approval
-      // (observed on staging: no `code`, no `installation_id`). Their First
-      // Tree session is untouched; send them back to the surface they
-      // started from (`next` from the signed state), where the connect
-      // panel's poll picks the installation up once an owner approves.
+      // (observed on staging: no `code`, no `installation_id`). With no code,
+      // GitHub gives First Tree no way to prove the current github.com session
+      // still matches the preflight identity. The live Team-admin membership
+      // and continued presence of the linked GitHub identity are re-checked
+      // above, but a deliberate account switch after the picker opened can
+      // still produce an unbound webhook row. It cannot bind or cross Team
+      // boundaries. Send the browser back to the kickoff surface, where the
+      // panel remains in its explicit waiting/recovery state until approval.
       app.log.info(
         { event: "github_oauth.setup_landing_no_code", setupAction: parsed.setup_action ?? null },
         "github callback without code — landing back on the kickoff surface",
@@ -235,7 +269,9 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
       };
     } catch (err) {
       app.log.warn({ err, event: "oauth.exchange_failed", provider: "github" }, "GitHub OAuth exchange failed");
-      return redirectCallbackError(reply, "github-exchange-failed", next, { callbackIntent: intent });
+      return redirectCallbackError(reply, "github-exchange-failed", installErrorReturnPath(intent, next), {
+        callbackIntent: intent,
+      });
     }
 
     // Pass the URL `installation_id` (validated to a finite number, else null)
@@ -244,6 +280,32 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
     // (`devBindInstallation`); it rides along here purely for log context.
     const callbackInstallationId =
       installationIdRaw && Number.isFinite(Number(installationIdRaw)) ? Number(installationIdRaw) : null;
+
+    if (intent === "install" && installPhase === "identity") {
+      return continueInstallAfterIdentityPreflight(app, reply, profile, next, {
+        targetOrganizationId,
+        kickoffUserId,
+      });
+    }
+
+    // Re-check the same identity boundary after code-bearing picker callbacks.
+    // A user can pass the preflight, then switch github.com accounts in another
+    // tab before completing a direct install. Reject that race before
+    // findOrCreate can persist the foreign identity or replace the First Tree
+    // browser session. The no-code owner-approval limitation is documented in
+    // the branch above.
+    if (intent === "install" && targetOrganizationId && kickoffUserId) {
+      const installAuthority = await inspectInstallCallbackAuthority(app, profile, {
+        targetOrganizationId,
+        kickoffUserId,
+      });
+      if (!installAuthority.ok) {
+        return redirectCallbackError(reply, installAuthority.code, "/settings/github", {
+          callbackIntent: "install",
+          expectedGithubLogin: installAuthority.expectedGithubLogin,
+        });
+      }
+    }
 
     if (intent === "link" || intent === "unlink") {
       if (!stateUserId)
@@ -265,7 +327,7 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
         if (intent === "link") {
           await linkExternalIdentity(app.db, stateUserId, external);
           app.log.info({ event: "identity.linked", provider: "github", userId: stateUserId }, "Identity linked");
-          return reply.redirect(`${ACCOUNT_RETURN_PATH}?connection=github-linked`, 302);
+          return reply.redirect(withQueryParam(next, "connection", "github-linked"), 302);
         }
         await unlinkExternalIdentity(
           app.db,
@@ -282,9 +344,9 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
         return reply.redirect(`${ACCOUNT_RETURN_PATH}?connection=github-unlinked`, 302);
       } catch (error) {
         if (error instanceof IdentityConflictError)
-          return reply.redirect(`${ACCOUNT_RETURN_PATH}?error=identity-conflict`, 302);
+          return reply.redirect(withQueryParam(next, "error", "identity-conflict"), 302);
         if (error instanceof IdentityMismatchError)
-          return reply.redirect(`${ACCOUNT_RETURN_PATH}?error=identity-mismatch`, 302);
+          return reply.redirect(withQueryParam(next, "error", "identity-mismatch"), 302);
         if (error instanceof LastIdentityError)
           return reply.redirect(`${ACCOUNT_RETURN_PATH}?error=last-provider`, 302);
         throw error;
@@ -401,6 +463,16 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
   });
 }
 
+function withQueryParam(path: string, key: string, value: string): string {
+  const url = new URL(path, "https://first-tree.invalid");
+  url.searchParams.set(key, value);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function installErrorReturnPath(intent: CallbackIntent, next: string): string {
+  return intent === "install" ? "/settings/github" : next;
+}
+
 /**
  * Error codes the SPA's `/auth/github/complete` page renders friendly copy
  * for. Keep in sync with `packages/web/src/pages/oauth-complete.tsx`.
@@ -441,7 +513,7 @@ function redirectCallbackError(
   reply: FastifyReply,
   code: CallbackErrorCode,
   next?: string,
-  metadata: { callbackIntent?: CallbackIntent; accountCreated?: boolean } = {},
+  metadata: { callbackIntent?: CallbackIntent; accountCreated?: boolean; expectedGithubLogin?: string | null } = {},
 ) {
   const recoveryNext = next === "/onboarding/connected" ? "/onboarding" : next;
   const fragment = new URLSearchParams({
@@ -449,8 +521,151 @@ function redirectCallbackError(
     ...(recoveryNext ? { next: recoveryNext } : {}),
     ...(metadata.callbackIntent ? { callbackIntent: metadata.callbackIntent } : {}),
     ...(metadata.accountCreated !== undefined ? { accountCreated: metadata.accountCreated ? "1" : "0" } : {}),
+    ...(metadata.expectedGithubLogin ? { expectedGithubLogin: metadata.expectedGithubLogin } : {}),
   }).toString();
   return reply.redirect(`/auth/github/complete#${fragment}`, 302);
+}
+
+async function findGithubIdentityForUser(
+  app: FastifyInstance,
+  userId: string,
+): Promise<{ githubId: string; login: string | null } | null> {
+  const [identity] = await app.db
+    .select({ identifier: authIdentities.identifier, metadata: authIdentities.metadata })
+    .from(authIdentities)
+    .where(and(eq(authIdentities.userId, userId), eq(authIdentities.provider, "github")))
+    .limit(1);
+  if (!identity) return null;
+  const login = identity?.metadata.accountName ?? identity?.metadata.login;
+  return {
+    githubId: identity.identifier,
+    login: typeof login === "string" && login.length > 0 ? login.slice(0, 100) : null,
+  };
+}
+
+async function inspectInstallLandingAuthority(
+  app: FastifyInstance,
+  opts: { targetOrganizationId: string | null; kickoffUserId: string | null },
+): Promise<
+  { ok: true } | { ok: false; code: "install-not-admin" | "install-not-verified"; expectedGithubLogin: string | null }
+> {
+  const { targetOrganizationId, kickoffUserId } = opts;
+  if (!targetOrganizationId || !kickoffUserId) {
+    return { ok: false, code: "install-not-verified", expectedGithubLogin: null };
+  }
+  const [linkedIdentity, authority] = await Promise.all([
+    findGithubIdentityForUser(app, kickoffUserId),
+    findActiveMembership(app.db, kickoffUserId, targetOrganizationId),
+  ]);
+  if (!authority || authority.role !== "admin") {
+    app.log.warn(
+      { event: "github_app.install_request_landing_admin_check_failed", targetOrganizationId, kickoffUserId },
+      "install request landing: kickoff user is no longer an active team admin",
+    );
+    return { ok: false, code: "install-not-admin", expectedGithubLogin: linkedIdentity?.login ?? null };
+  }
+  if (!linkedIdentity) {
+    app.log.warn(
+      { event: "github_app.install_request_landing_identity_missing", targetOrganizationId, kickoffUserId },
+      "install request landing: kickoff user no longer has a linked GitHub identity",
+    );
+    return { ok: false, code: "install-not-verified", expectedGithubLogin: null };
+  }
+  return { ok: true };
+}
+
+async function continueInstallAfterIdentityPreflight(
+  app: FastifyInstance,
+  reply: FastifyReply,
+  profile: GithubProfile,
+  next: string,
+  opts: { targetOrganizationId: string | null; kickoffUserId: string | null },
+) {
+  const { targetOrganizationId, kickoffUserId } = opts;
+  if (!targetOrganizationId || !kickoffUserId) {
+    return redirectCallbackError(reply, "state-expired", "/settings/github", { callbackIntent: "install" });
+  }
+
+  const installAuthority = await inspectInstallCallbackAuthority(app, profile, {
+    targetOrganizationId,
+    kickoffUserId,
+  });
+  if (!installAuthority.ok) {
+    return redirectCallbackError(reply, installAuthority.code, "/settings/github", {
+      callbackIntent: "install",
+      expectedGithubLogin: installAuthority.expectedGithubLogin,
+    });
+  }
+  const { linkedIdentity } = installAuthority;
+
+  const appCfg = app.config.oauth?.githubApp;
+  if (!appCfg?.slug) {
+    return redirectCallbackError(reply, "provider-not-configured", "/settings/github", {
+      callbackIntent: "install",
+      expectedGithubLogin: linkedIdentity.login,
+    });
+  }
+
+  const { token, nonce } = await signOAuthState(app.config.secrets.jwtSecret, next, {
+    intent: "install",
+    installPhase: "installation",
+    provider: "github",
+    targetOrganizationId,
+    kickoffUserId,
+  });
+  // The callback consumed and expired the identity-phase nonce above. Replace
+  // that deletion header with the new installation-phase nonce so browsers
+  // receive exactly one authoritative cookie value for the next callback.
+  reply.removeHeader("Set-Cookie");
+  reply.header(
+    "Set-Cookie",
+    buildCookie({
+      name: STATE_NONCE_COOKIE_NAME,
+      value: protectOAuthStateNonce(nonce, app.config.secrets.encryptionKey),
+      maxAge: STATE_NONCE_COOKIE_TTL_SECONDS,
+      secure: process.env.NODE_ENV === "production",
+    }),
+  );
+  app.log.info(
+    { event: "github_app.install_identity_preflight_succeeded", targetOrganizationId, kickoffUserId },
+    "install identity preflight succeeded — continuing to GitHub App picker",
+  );
+  return reply.redirect(buildAppInstallUrl({ appSlug: appCfg.slug, state: token }), 302);
+}
+
+async function inspectInstallCallbackAuthority(
+  app: FastifyInstance,
+  profile: GithubProfile,
+  opts: { targetOrganizationId: string; kickoffUserId: string },
+): Promise<
+  | { ok: true; linkedIdentity: { githubId: string; login: string | null } }
+  | { ok: false; code: "install-not-admin" | "install-not-verified"; expectedGithubLogin: string | null }
+> {
+  const { targetOrganizationId, kickoffUserId } = opts;
+  const [linkedIdentity, authority] = await Promise.all([
+    findGithubIdentityForUser(app, kickoffUserId),
+    findActiveMembership(app.db, kickoffUserId, targetOrganizationId),
+  ]);
+  if (!authority || authority.role !== "admin") {
+    app.log.warn(
+      { event: "github_app.install_callback_admin_check_failed", targetOrganizationId, kickoffUserId },
+      "install callback: kickoff user is no longer an active team admin",
+    );
+    return { ok: false, code: "install-not-admin", expectedGithubLogin: linkedIdentity?.login ?? null };
+  }
+  if (!linkedIdentity || linkedIdentity.githubId !== String(profile.githubId)) {
+    app.log.warn(
+      {
+        event: "github_app.install_callback_identity_mismatch",
+        targetOrganizationId,
+        kickoffUserId,
+        actualGithubId: profile.githubId,
+      },
+      "install callback: github.com account does not match the linked GitHub identity",
+    );
+    return { ok: false, code: "install-not-verified", expectedGithubLogin: linkedIdentity?.login ?? null };
+  }
+  return { ok: true, linkedIdentity };
 }
 
 async function completeOauthFlow(
@@ -621,9 +836,11 @@ async function completeOauthFlow(
         },
         "install callback: OAuth identity differs from the kickoff admin — refusing (install must use the same GitHub account)",
       );
+      const expectedGithubLogin = (await findGithubIdentityForUser(app, bindAuthorityUserId))?.login;
       return redirectCallbackError(reply, "install-not-verified", next, {
         callbackIntent,
         accountCreated: account.created,
+        expectedGithubLogin,
       });
     }
     // No bind happens here: the `installation.created` webhook records the

--- a/packages/server/src/api/me-auth-providers.ts
+++ b/packages/server/src/api/me-auth-providers.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { authProviderParamsSchema } from "@first-tree/shared";
+import { authProviderParamsSchema, oauthStartQuerySchema, safeRedirectPath } from "@first-tree/shared";
 import { and, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { authIdentities } from "../db/schema/auth-identities.js";
@@ -23,6 +23,17 @@ import { buildCookie, protectOAuthStateNonce } from "./auth/oauth-cookie.js";
 // generations land on a working page. Switch this to /settings/account only
 // once pre-Account SPA builds are out of circulation.
 const ACCOUNT_RETURN_PATH = "/user-settings";
+const GITHUB_SETTINGS_RETURN_PATH = "/settings/github";
+const SUPPORTED_ACCOUNT_LINK_RETURN_PATHS: ReadonlySet<string> = new Set([
+  ACCOUNT_RETURN_PATH,
+  GITHUB_SETTINGS_RETURN_PATH,
+]);
+
+export function resolveAccountLinkReturnPath(requested: string | undefined): string {
+  if (requested === undefined) return ACCOUNT_RETURN_PATH;
+  const safe = safeRedirectPath(requested);
+  return SUPPORTED_ACCOUNT_LINK_RETURN_PATHS.has(safe) ? safe : ACCOUNT_RETURN_PATH;
+}
 
 export async function meAuthProviderRoutes(app: FastifyInstance): Promise<void> {
   app.get("/me/auth-providers", async (request) => {
@@ -79,7 +90,13 @@ export async function meAuthProviderRoutes(app: FastifyInstance): Promise<void> 
     async (request, reply) => {
       const { userId } = requireUser(request);
       const { provider } = authProviderParamsSchema.parse(request.params);
-      return startProviderAction(app, request, reply, { provider, userId, intent: "link" });
+      const { next } = oauthStartQuerySchema.parse(request.query);
+      return startProviderAction(app, request, reply, {
+        provider,
+        userId,
+        intent: "link",
+        next: resolveAccountLinkReturnPath(next),
+      });
     },
   );
 
@@ -138,6 +155,7 @@ async function startProviderAction(
     userId: string;
     intent: "link" | "unlink";
     targetIdentityId?: string;
+    next?: string;
   },
 ) {
   const availability = configuredProviders(app);
@@ -148,7 +166,7 @@ async function startProviderAction(
   }
   const publicUrl = resolvePublicUrl(app, request);
   const oidcNonce = input.provider === "google" ? randomBytes(24).toString("base64url") : undefined;
-  const { token, nonce } = await signOAuthState(app.config.secrets.jwtSecret, ACCOUNT_RETURN_PATH, {
+  const { token, nonce } = await signOAuthState(app.config.secrets.jwtSecret, input.next ?? ACCOUNT_RETURN_PATH, {
     ...input,
     oidcNonce,
   });

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -9,9 +9,9 @@ import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import type { Database } from "../../db/connection.js";
 import { authIdentities } from "../../db/schema/auth-identities.js";
-import { NotFoundError } from "../../errors.js";
+import { ConflictError, NotFoundError } from "../../errors.js";
 import { requireOrgAdmin, requireOrgMembership } from "../../scope/require-org.js";
-import { buildAppInstallUrl, listInstallationRepos } from "../../services/github-app.js";
+import { buildAppAuthorizeUrl, listInstallationRepos } from "../../services/github-app.js";
 import {
   connectInstallationToOrg,
   disconnectInstallationFromOrg,
@@ -20,12 +20,13 @@ import {
 } from "../../services/github-app-installations.js";
 import { mintContextTreeInstallationToken } from "../../services/github-app-token.js";
 import { STATE_NONCE_COOKIE_NAME, STATE_NONCE_COOKIE_TTL_SECONDS, signOAuthState } from "../../services/oauth-state.js";
-import { buildCookie } from "../auth/oauth-cookie.js";
+import { resolvePublicUrl } from "../../utils/public-url.js";
+import { buildCookie, protectOAuthStateNonce } from "../auth/oauth-cookie.js";
 
 /**
  * Where the post-install OAuth callback lands the user once the install
  * dialog is done. Default: back on the Settings → GitHub panel so it can
- * re-render with the now-bound installation. The callback resolves the
+ * surface the webhook-recorded installation for an explicit Connect. The callback resolves the
  * actual destination from the signed state JWT, not from a query param,
  * so this is tamper-proof.
  */
@@ -33,8 +34,8 @@ const POST_INSTALL_NEXT = "/settings/github";
 
 /**
  * Internal paths the install flow is allowed to return to. The onboarding
- * flow surfaces the App-install CTA too (the only reliable `installations/new`
- * entry), and wants the user back in setup rather than dumped on Settings.
+ * flow surfaces the App-install CTA too, and wants the user back in setup
+ * rather than dumped on Settings.
  * Allowlisted — never reflect a caller-supplied path verbatim into the
  * signed redirect, so a crafted `?next=` can't become an open redirect.
  */
@@ -215,16 +216,23 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
   //      identity, which only the server can authenticate.
   //
   // The SPA fetches this (with its bearer token), gets `{ installUrl }`
-  // back plus a `Set-Cookie`, then does `window.location = installUrl`.
-  // GitHub shows the install dialog, the user picks repos, GitHub
-  // redirects to `/auth/github/callback?code=…&state=…&installation_id=…`
-  // (or without `code` when the install is parked for owner approval).
-  // The callback only lands the browser back on the kickoff org's panel;
-  // the trusted `installation.created` webhook records the installation
-  // unbound, and connecting it is an explicit panel action.
+  // back plus a `Set-Cookie`, then navigates to the App's OAuth authorize
+  // endpoint. The callback first proves the active github.com account is
+  // the same numeric identity linked to the kickoff admin. Only then does
+  // it mint a fresh state/cookie pair and continue to the App picker. This
+  // prevents ordinary wrong-account starts. GitHub does not expose the
+  // requester identity on no-code approval landings, so a deliberate account
+  // switch after the picker opens can still leave a safe, unbound installation;
+  // it cannot bind or cross a First Tree Team boundary.
   app.get<{ Params: { orgId: string }; Querystring: { next?: string } }>("/install-url", async (request, reply) => {
     // Admin-gated: the resolved scope is the org the install binds to.
     const scope = await requireOrgAdmin(request, app.db);
+    const callerGithubId = await resolveCallerGithubId(app.db, scope.userId);
+    if (callerGithubId === null) {
+      throw new ConflictError("Connect a GitHub account before installing the GitHub App", {
+        code: "github_identity_required",
+      });
+    }
     const appCfg = app.config.oauth?.githubApp;
     if (!appCfg?.slug) {
       // The App may be configured for sign-in/webhooks but missing the
@@ -248,6 +256,7 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
       resolvePostInstallNext(request.query.next),
       {
         intent: "install",
+        installPhase: "identity",
         provider: "github",
         targetOrganizationId: scope.organizationId,
         kickoffUserId: scope.userId,
@@ -257,17 +266,16 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
       "Set-Cookie",
       buildCookie({
         name: STATE_NONCE_COOKIE_NAME,
-        value: nonce,
+        value: protectOAuthStateNonce(nonce, app.config.secrets.encryptionKey),
         maxAge: STATE_NONCE_COOKIE_TTL_SECONDS,
         secure: process.env.NODE_ENV === "production",
       }),
     );
 
-    // No DB write here: `installation_id` doesn't exist until the user
-    // completes the install, and even then the webhook records it unbound —
-    // the signed state only routes the browser back to this org's panel,
-    // where connecting the recorded installation is an explicit action.
-    return { installUrl: buildAppInstallUrl({ appSlug: appCfg.slug, state: token }) };
+    const redirectUri = `${resolvePublicUrl(app, request)}/api/v1/auth/github/callback`;
+    return {
+      installUrl: buildAppAuthorizeUrl({ clientId: appCfg.clientId, redirectUri, state: token }),
+    };
   });
 
   // ── Connect panel ────────────────────────────────────────────────────

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -224,59 +224,63 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
   // requester identity on no-code approval landings, so a deliberate account
   // switch after the picker opens can still leave a safe, unbound installation;
   // it cannot bind or cross a First Tree Team boundary.
-  app.get<{ Params: { orgId: string }; Querystring: { next?: string } }>("/install-url", async (request, reply) => {
-    // Admin-gated: the resolved scope is the org the install binds to.
-    const scope = await requireOrgAdmin(request, app.db);
-    const callerGithubId = await resolveCallerGithubId(app.db, scope.userId);
-    if (callerGithubId === null) {
-      throw new ConflictError("Connect a GitHub account before installing the GitHub App", {
-        code: "github_identity_required",
-      });
-    }
-    const appCfg = app.config.oauth?.githubApp;
-    if (!appCfg?.slug) {
-      // The App may be configured for sign-in/webhooks but missing the
-      // slug needed for the install dialog. 503 (not 404/400) — the
-      // operator can fix it by setting one env var; the panel renders a
-      // "ask your operator to set FIRST_TREE_GITHUB_APP_SLUG" hint.
-      return reply
-        .status(503)
-        .send({ error: "GitHub App install URL is unavailable — FIRST_TREE_GITHUB_APP_SLUG is not configured." });
-    }
+  app.get<{ Params: { orgId: string }; Querystring: { next?: string } }>(
+    "/install-url",
+    { config: { rateLimit: { max: 60, timeWindow: "1 minute" } } },
+    async (request, reply) => {
+      // Admin-gated: the resolved scope is the org the install binds to.
+      const scope = await requireOrgAdmin(request, app.db);
+      const callerGithubId = await resolveCallerGithubId(app.db, scope.userId);
+      if (callerGithubId === null) {
+        throw new ConflictError("Connect a GitHub account before installing the GitHub App", {
+          code: "github_identity_required",
+        });
+      }
+      const appCfg = app.config.oauth?.githubApp;
+      if (!appCfg?.slug) {
+        // The App may be configured for sign-in/webhooks but missing the
+        // slug needed for the install dialog. 503 (not 404/400) — the
+        // operator can fix it by setting one env var; the panel renders a
+        // "ask your operator to set FIRST_TREE_GITHUB_APP_SLUG" hint.
+        return reply
+          .status(503)
+          .send({ error: "GitHub App install URL is unavailable — FIRST_TREE_GITHUB_APP_SLUG is not configured." });
+      }
 
-    // `targetOrganizationId` rides inside the signed state so the callback
-    // can land the browser back on *this* org's panel rather than the
-    // caller's primary org (codex P1-3). `kickoffUserId` rides alongside it
-    // so the callback can detect the browser's github.com session resolving
-    // to a DIFFERENT identity than the kickoff admin — the github.com
-    // session and the First Tree session are independent, and a mismatch
-    // must not silently swap the signed-in user.
-    const { token, nonce } = await signOAuthState(
-      app.config.secrets.jwtSecret,
-      resolvePostInstallNext(request.query.next),
-      {
-        intent: "install",
-        installPhase: "identity",
-        provider: "github",
-        targetOrganizationId: scope.organizationId,
-        kickoffUserId: scope.userId,
-      },
-    );
-    reply.header(
-      "Set-Cookie",
-      buildCookie({
-        name: STATE_NONCE_COOKIE_NAME,
-        value: protectOAuthStateNonce(nonce, app.config.secrets.encryptionKey),
-        maxAge: STATE_NONCE_COOKIE_TTL_SECONDS,
-        secure: process.env.NODE_ENV === "production",
-      }),
-    );
+      // `targetOrganizationId` rides inside the signed state so the callback
+      // can land the browser back on *this* org's panel rather than the
+      // caller's primary org (codex P1-3). `kickoffUserId` rides alongside it
+      // so the callback can detect the browser's github.com session resolving
+      // to a DIFFERENT identity than the kickoff admin — the github.com
+      // session and the First Tree session are independent, and a mismatch
+      // must not silently swap the signed-in user.
+      const { token, nonce } = await signOAuthState(
+        app.config.secrets.jwtSecret,
+        resolvePostInstallNext(request.query.next),
+        {
+          intent: "install",
+          installPhase: "identity",
+          provider: "github",
+          targetOrganizationId: scope.organizationId,
+          kickoffUserId: scope.userId,
+        },
+      );
+      reply.header(
+        "Set-Cookie",
+        buildCookie({
+          name: STATE_NONCE_COOKIE_NAME,
+          value: protectOAuthStateNonce(nonce, app.config.secrets.encryptionKey),
+          maxAge: STATE_NONCE_COOKIE_TTL_SECONDS,
+          secure: process.env.NODE_ENV === "production",
+        }),
+      );
 
-    const redirectUri = `${resolvePublicUrl(app, request)}/api/v1/auth/github/callback`;
-    return {
-      installUrl: buildAppAuthorizeUrl({ clientId: appCfg.clientId, redirectUri, state: token }),
-    };
-  });
+      const redirectUri = `${resolvePublicUrl(app, request)}/api/v1/auth/github/callback`;
+      return {
+        installUrl: buildAppAuthorizeUrl({ clientId: appCfg.clientId, redirectUri, state: token }),
+      };
+    },
+  );
 
   // ── Connect panel ────────────────────────────────────────────────────
   //

--- a/packages/server/src/services/auth-identity.ts
+++ b/packages/server/src/services/auth-identity.ts
@@ -8,6 +8,7 @@ import {
 import { and, eq } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
+import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
 import { uuidv7 } from "../uuid.js";
 import { decryptValue } from "./crypto.js";
@@ -247,6 +248,108 @@ export async function findOrCreateGithubAccount(
   return findOrCreateUserFromExternalAccount(db, external);
 }
 
+export type GithubInstallIdentityRefreshResult =
+  | {
+      ok: true;
+      account: { userId: string; username: string; displayName: string; created: false };
+      githubLogin: string | null;
+    }
+  | {
+      ok: false;
+      reason: "not-admin" | "identity-mismatch";
+      expectedGithubLogin: string | null;
+    };
+
+/**
+ * Refresh the GitHub credential snapshot for an App-install callback without
+ * ever acquiring or creating an identity. The kickoff user, live Team-admin
+ * membership, and exact GitHub provider subject are locked and checked in one
+ * transaction before the token metadata is updated.
+ */
+export async function refreshGithubInstallIdentity(
+  db: Database,
+  input: {
+    userId: string;
+    organizationId: string;
+    profile: GithubProfile;
+    tokens?: GithubTokenBundle;
+  },
+): Promise<GithubInstallIdentityRefreshResult> {
+  const external = githubExternalProfile({
+    id: input.profile.githubId,
+    login: input.profile.login,
+    name: input.profile.displayName,
+    email: input.profile.email,
+    avatarUrl: input.profile.avatarUrl,
+    metadata: buildTokenMetadataPatch(input.profile, input.tokens ?? {}) ?? {},
+  });
+
+  return db.transaction(async (tx) => {
+    // Use the same user -> membership -> identity lock order as supported
+    // membership and provider-unlink mutations. A concurrent unlink/replace
+    // must finish before this transaction evaluates the exact provider subject.
+    const [user] = await tx
+      .select({ id: users.id, username: users.username, displayName: users.displayName })
+      .from(users)
+      .where(eq(users.id, input.userId))
+      .for("no key update")
+      .limit(1);
+    if (!user) return { ok: false, reason: "identity-mismatch", expectedGithubLogin: null };
+
+    const [membership] = await tx
+      .select({ role: members.role, status: members.status })
+      .from(members)
+      .where(and(eq(members.userId, input.userId), eq(members.organizationId, input.organizationId)))
+      .for("update")
+      .limit(1);
+    const [identity] = await tx
+      .select({ id: authIdentities.id, identifier: authIdentities.identifier, metadata: authIdentities.metadata })
+      .from(authIdentities)
+      .where(and(eq(authIdentities.userId, input.userId), eq(authIdentities.provider, "github")))
+      .for("update")
+      .limit(1);
+    const expectedGithubLogin = identity ? accountNameFromMetadata(identity.metadata) : null;
+
+    if (!membership || membership.status !== "active" || membership.role !== "admin") {
+      return { ok: false, reason: "not-admin", expectedGithubLogin };
+    }
+    if (!identity || identity.identifier !== external.subject) {
+      return { ok: false, reason: "identity-mismatch", expectedGithubLogin };
+    }
+
+    const updated = await tx
+      .update(authIdentities)
+      .set({
+        email: external.email,
+        metadata: {
+          ...identity.metadata,
+          ...external.metadata,
+          accountName: accountNameFromProfile(external),
+          avatarUrl: external.avatarUrl,
+        },
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(authIdentities.id, identity.id),
+          eq(authIdentities.userId, input.userId),
+          eq(authIdentities.provider, "github"),
+          eq(authIdentities.identifier, external.subject),
+        ),
+      )
+      .returning({ id: authIdentities.id });
+    if (updated.length !== 1) {
+      return { ok: false, reason: "identity-mismatch", expectedGithubLogin };
+    }
+
+    return {
+      ok: true,
+      account: { userId: user.id, username: user.username, displayName: user.displayName, created: false },
+      githubLogin: accountNameFromProfile(external),
+    };
+  });
+}
+
 export async function findOrCreateUserFromGithub(
   db: Database,
   profile: GithubProfile,
@@ -316,6 +419,11 @@ async function updateIdentitySnapshot(db: Database, userId: string, profile: Ext
 function accountNameFromProfile(profile: ExternalAccountProfile): string | null {
   const first = profile.usernameCandidates.find((candidate) => candidate.trim().length > 0);
   return first?.trim() || profile.displayName?.trim() || null;
+}
+
+function accountNameFromMetadata(metadata: Record<string, unknown>): string | null {
+  const value = metadata.accountName ?? metadata.login;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim().slice(0, 100) : null;
 }
 
 function buildTokenMetadataPatch(profile: GithubProfile, opts: GithubTokenBundle): Record<string, unknown> | null {

--- a/packages/server/src/services/oauth-state.ts
+++ b/packages/server/src/services/oauth-state.ts
@@ -47,6 +47,8 @@ type StatePayload = {
    * browser). Absent on the plain `/auth/github/start` sign-in flow.
    */
   kickoffUserId?: string;
+  /** Two-step App install: prove the linked user first, then open the picker. */
+  installPhase?: "identity" | "installation";
   intent?: "sign-in" | "link" | "unlink" | "install";
   userId?: string;
   provider?: "google" | "github";
@@ -59,6 +61,8 @@ export type SignOAuthStateOptions = {
   targetOrganizationId?: string;
   /** See `StatePayload.kickoffUserId`. */
   kickoffUserId?: string;
+  /** See `StatePayload.installPhase`. */
+  installPhase?: "identity" | "installation";
   intent?: "sign-in" | "link" | "unlink" | "install";
   userId?: string;
   provider?: "google" | "github";
@@ -84,6 +88,7 @@ export async function signOAuthState(
   if (opts.kickoffUserId) {
     claims.kickoffUserId = opts.kickoffUserId;
   }
+  if (opts.installPhase) claims.installPhase = opts.installPhase;
   if (opts.intent) claims.intent = opts.intent;
   if (opts.userId) claims.userId = opts.userId;
   if (opts.provider) claims.provider = opts.provider;
@@ -115,6 +120,7 @@ export async function verifyOAuthState(
   next: string;
   targetOrganizationId?: string;
   kickoffUserId?: string;
+  installPhase?: "identity" | "installation";
   intent?: "sign-in" | "link" | "unlink" | "install";
   userId?: string;
   provider?: "google" | "github";
@@ -139,6 +145,9 @@ export async function verifyOAuthState(
   if (payload.kickoffUserId !== undefined && typeof payload.kickoffUserId !== "string") {
     throw new Error("OAuth state payload malformed");
   }
+  if (payload.installPhase !== undefined && !["identity", "installation"].includes(payload.installPhase)) {
+    throw new Error("OAuth state payload malformed");
+  }
   if (payload.intent !== undefined && !["sign-in", "link", "unlink", "install"].includes(payload.intent)) {
     throw new Error("OAuth state payload malformed");
   }
@@ -160,6 +169,7 @@ export async function verifyOAuthState(
     next: payload.next,
     ...(payload.targetOrganizationId ? { targetOrganizationId: payload.targetOrganizationId } : {}),
     ...(payload.kickoffUserId ? { kickoffUserId: payload.kickoffUserId } : {}),
+    ...(payload.installPhase ? { installPhase: payload.installPhase } : {}),
     ...(payload.intent ? { intent: payload.intent } : {}),
     ...(payload.userId ? { userId: payload.userId } : {}),
     ...(payload.provider ? { provider: payload.provider } : {}),

--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -317,7 +317,10 @@ describe("App routes", () => {
     expect(window.location.search).toBe("?connection=google-linked");
     await resetRenderedApp();
 
-    expect(await renderAppAt("/settings/github")).toContain("settings github");
+    expect(await renderAppAt("/settings/github?connection=github-linked#connection")).toContain("settings github");
+    expect(window.location.pathname).toBe("/settings/integrations/github");
+    expect(window.location.search).toBe("?connection=github-linked");
+    expect(window.location.hash).toBe("#connection");
     await resetRenderedApp();
 
     expect(await renderAppAt("/settings/integrations/github")).toContain("settings github");

--- a/packages/web/src/api/__tests__/api-wrappers.test.ts
+++ b/packages/web/src/api/__tests__/api-wrappers.test.ts
@@ -81,6 +81,20 @@ afterEach(() => {
 });
 
 describe("api wrapper paths", () => {
+  it("carries the GitHub Settings return through authenticated account linking", async () => {
+    const userSettings = await import("../user-settings.js");
+
+    await userSettings.startProviderLink("github", "/settings/github");
+    await userSettings.startProviderLink("github");
+
+    expect(apiMock.post).toHaveBeenNthCalledWith(
+      1,
+      "/me/auth-providers/github/link/start?next=%2Fsettings%2Fgithub",
+      {},
+    );
+    expect(apiMock.post).toHaveBeenNthCalledWith(2, "/me/auth-providers/github/link/start", {});
+  });
+
   it("normalizes a legacy Attention pin without reviving the retired tier", async () => {
     const meChats = await import("../me-chats.js");
     const pinnedRequest = meChatRow({

--- a/packages/web/src/api/github-app.ts
+++ b/packages/web/src/api/github-app.ts
@@ -44,9 +44,11 @@ export async function getGithubAppInstallationExists(organizationId: string): Pr
 /**
  * Fetch the GitHub App install URL for the active org. The server mints a
  * signed `state` JWT, sets the `oauth_state_nonce` cookie alongside it,
- * and returns `https://github.com/apps/<slug>/installations/new?state=…`
- * — GitHub's install dialog (repo picker + permission review). The SPA
- * navigates the browser to it via `window.location`.
+ * and returns a GitHub OAuth authorize URL. That first hop verifies that the
+ * active github.com account matches the linked First Tree identity; only a
+ * matching callback receives a fresh state/cookie pair and continues to
+ * `https://github.com/apps/<slug>/installations/new?state=…`. The SPA navigates
+ * the browser to the returned preflight URL via `window.location`.
  *
  * codex P1-1: the previous implementation pointed the "Install on GitHub"
  * CTA at `/auth/github/start`, which builds the OAuth `authorize` URL.

--- a/packages/web/src/api/user-settings.ts
+++ b/packages/web/src/api/user-settings.ts
@@ -5,8 +5,9 @@ export function getAuthProviders(): Promise<AuthProviderConnectionsResponse> {
   return api.get<AuthProviderConnectionsResponse>("/me/auth-providers");
 }
 
-export function startProviderLink(provider: AuthProvider): Promise<AuthProviderActionResult> {
-  return api.post<AuthProviderActionResult>(`/me/auth-providers/${provider}/link/start`, {});
+export function startProviderLink(provider: AuthProvider, next?: string): Promise<AuthProviderActionResult> {
+  const query = next ? `?next=${encodeURIComponent(next)}` : "";
+  return api.post<AuthProviderActionResult>(`/me/auth-providers/${provider}/link/start${query}`, {});
 }
 
 export function startProviderUnlink(provider: AuthProvider): Promise<AuthProviderActionResult> {

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -536,7 +536,7 @@ export function App() {
                     <Route path="context" element={<SettingsContextTreePage />} />
                     <Route path="resources" element={<SettingsResourcesPage />} />
                     <Route path="computers" element={<SettingsComputersPage />} />
-                    <Route path="github" element={<Navigate to="/settings/integrations/github" replace />} />
+                    <Route path="github" element={<LegacyGithubSettingsRedirect />} />
                     <Route path="integrations" element={<SettingsIntegrationsLayout />}>
                       <Route index element={<Navigate to="github" replace />} />
                       <Route path="github" element={<SettingsGithubPage />} />
@@ -603,6 +603,16 @@ function ContextTreeSetupPreviewUnavailable() {
 function LegacyUserSettingsRedirect() {
   const location = useLocation();
   return <Navigate to={{ pathname: "/settings/account", search: location.search, hash: location.hash }} replace />;
+}
+
+function LegacyGithubSettingsRedirect() {
+  const location = useLocation();
+  return (
+    <Navigate
+      to={{ pathname: "/settings/integrations/github", search: location.search, hash: location.hash }}
+      replace
+    />
+  );
 }
 
 function LegacyMobileWorkRedirect() {

--- a/packages/web/src/lib/github-account-link-return.ts
+++ b/packages/web/src/lib/github-account-link-return.ts
@@ -1,0 +1,53 @@
+const STORAGE_KEY = "settings:github:account-link-return";
+const RETURN_TTL_MS = 30 * 60 * 1000;
+
+type AccountLinkReturn = {
+  organizationId: string;
+  startedAt: number;
+};
+
+/**
+ * Preserve UX context across the full-page GitHub account-link round trip.
+ * This marker is deliberately not authority: it contains no token and every
+ * later Team operation is still authorized by the server against live data.
+ */
+export function rememberGithubAccountLinkReturn(organizationId: string): void {
+  window.sessionStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ organizationId, startedAt: Date.now() } satisfies AccountLinkReturn),
+  );
+}
+
+export function readGithubAccountLinkReturn(): AccountLinkReturn | null {
+  const raw = window.sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      !("organizationId" in value) ||
+      typeof value.organizationId !== "string" ||
+      value.organizationId.length === 0 ||
+      value.organizationId.length > 200 ||
+      !("startedAt" in value) ||
+      typeof value.startedAt !== "number" ||
+      Date.now() - value.startedAt > RETURN_TTL_MS
+    ) {
+      clearGithubAccountLinkReturn();
+      return null;
+    }
+    return { organizationId: value.organizationId, startedAt: value.startedAt };
+  } catch {
+    clearGithubAccountLinkReturn();
+    return null;
+  }
+}
+
+export function clearGithubAccountLinkReturn(): void {
+  window.sessionStorage.removeItem(STORAGE_KEY);
+}
+
+export function githubSettingsErrorReturnPath(code: string, flow: "install" | "link"): string {
+  return `/settings/github?error=${encodeURIComponent(code)}&flow=${flow}`;
+}

--- a/packages/web/src/lib/github-install-attempt.ts
+++ b/packages/web/src/lib/github-install-attempt.ts
@@ -1,0 +1,59 @@
+const STORAGE_KEY = "settings:github:install-attempt";
+const ATTEMPT_TTL_MS = 30 * 60 * 1000;
+
+export type GithubInstallAttempt = {
+  organizationId: string;
+  startedAt: number;
+};
+
+export function rememberGithubInstallAttempt(organizationId: string): void {
+  window.sessionStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ organizationId, startedAt: Date.now() } satisfies GithubInstallAttempt),
+  );
+}
+
+export function readGithubInstallAttempt(): GithubInstallAttempt | null {
+  const raw = window.sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      !("organizationId" in value) ||
+      typeof value.organizationId !== "string" ||
+      value.organizationId.length === 0 ||
+      value.organizationId.length > 200 ||
+      !("startedAt" in value) ||
+      typeof value.startedAt !== "number" ||
+      Date.now() - value.startedAt > ATTEMPT_TTL_MS
+    ) {
+      clearGithubInstallAttempt();
+      return null;
+    }
+    return { organizationId: value.organizationId, startedAt: value.startedAt };
+  } catch {
+    clearGithubInstallAttempt();
+    return null;
+  }
+}
+
+export function hasGithubInstallAttempt(): boolean {
+  return readGithubInstallAttempt() !== null;
+}
+
+export function hasGithubInstallAttemptForOrganization(organizationId: string | null): boolean {
+  if (!organizationId) return false;
+  return readGithubInstallAttempt()?.organizationId === organizationId;
+}
+
+export function clearGithubInstallAttemptForOrganization(organizationId: string | null): void {
+  if (organizationId && readGithubInstallAttempt()?.organizationId === organizationId) {
+    clearGithubInstallAttempt();
+  }
+}
+
+export function clearGithubInstallAttempt(): void {
+  window.sessionStorage.removeItem(STORAGE_KEY);
+}

--- a/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
@@ -17,6 +17,11 @@ const githubMocks = vi.hoisted(() => ({
   disconnectGithubAppInstallation: vi.fn(),
 }));
 
+const providerMocks = vi.hoisted(() => ({
+  getAuthProviders: vi.fn(),
+  startProviderLink: vi.fn(),
+}));
+
 const authMock = vi.hoisted(() => ({
   value: {
     organizationId: "org-1" as string | null,
@@ -24,6 +29,7 @@ const authMock = vi.hoisted(() => ({
 }));
 
 vi.mock("../../api/github-app.js", () => githubMocks);
+vi.mock("../../api/user-settings.js", () => providerMocks);
 
 vi.mock("../../auth/auth-context.js", () => ({
   useAuth: () => authMock.value,
@@ -110,6 +116,16 @@ function buttonByText(container: ParentNode, text: string): HTMLButtonElement | 
   return [...container.querySelectorAll("button")].find((button) => button.textContent?.includes(text)) ?? null;
 }
 
+function mockInstallTab() {
+  const tab = { location: { href: "" }, close: vi.fn() };
+  const openSpy = vi.spyOn(window, "open").mockImplementation(() => {
+    // happy-dom's `window.open` type requires a complete Window, while this
+    // focused double intentionally exposes only the two properties the panel uses.
+    return tab as unknown as Window;
+  });
+  return { tab, openSpy };
+}
+
 beforeEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
@@ -122,6 +138,22 @@ beforeEach(() => {
   githubMocks.getGithubAppConnectPanel.mockResolvedValue({ installations: [] });
   githubMocks.connectGithubAppInstallation.mockResolvedValue(undefined);
   githubMocks.disconnectGithubAppInstallation.mockResolvedValue(undefined);
+  providerMocks.getAuthProviders.mockResolvedValue({
+    providers: [
+      {
+        provider: "github",
+        available: true,
+        connected: true,
+        accountName: "octocat",
+        email: null,
+        avatarUrl: null,
+        connectedAt: NOW,
+        canUnlink: true,
+        unlinkBlockedReason: null,
+      },
+    ],
+  });
+  providerMocks.startProviderLink.mockResolvedValue({ redirectUrl: "https://github.com/login/oauth/authorize" });
   Object.defineProperty(window, "location", {
     configurable: true,
     value: { assign: vi.fn() },
@@ -184,6 +216,210 @@ describe("GithubAppInstallationPanel", () => {
     await act(async () => root.unmount());
   });
 
+  it("requires a linked GitHub identity before exposing the install flow", async () => {
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    providerMocks.getAuthProviders.mockResolvedValue({
+      providers: [
+        {
+          provider: "github",
+          available: true,
+          connected: false,
+          accountName: null,
+          email: null,
+          avatarUrl: null,
+          connectedAt: null,
+          canUnlink: false,
+          unlinkBlockedReason: null,
+        },
+      ],
+    });
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(<GithubAppInstallationPanel initiallyOpen />);
+
+    await waitForText(container, "Required before installing the First Tree GitHub App");
+    expect(container.textContent).toContain("Connect your GitHub account");
+    expect(buttonByText(container, "Install on GitHub")).toBeNull();
+    expect(githubMocks.getGithubAppInstallUrl).not.toHaveBeenCalled();
+
+    await click(buttonByText(container, "Continue with GitHub"));
+
+    expect(providerMocks.startProviderLink).toHaveBeenCalledWith("github", "/settings/github");
+    expect(window.location.assign).toHaveBeenCalledWith("https://github.com/login/oauth/authorize");
+    expect(githubMocks.getGithubAppInstallUrl).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("treats an unavailable identity-status query as neutral and retryable", async () => {
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    providerMocks.getAuthProviders.mockRejectedValueOnce(new Error("status unavailable")).mockResolvedValueOnce({
+      providers: [
+        {
+          provider: "github",
+          available: true,
+          connected: true,
+          accountName: "octocat",
+          email: null,
+          avatarUrl: null,
+          connectedAt: NOW,
+          canUnlink: true,
+          unlinkBlockedReason: null,
+        },
+      ],
+    });
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(<GithubAppInstallationPanel initiallyOpen />);
+
+    await waitForText(container, "We couldn't check your GitHub connection");
+    const status = container.querySelector<HTMLElement>('[role="status"]');
+    expect(status?.style.color).toBe("var(--fg-3)");
+
+    await click(buttonByText(container, "Try again"));
+    await waitForText(container, "GitHub connected as @octocat");
+    expect(buttonByText(container, "Install on GitHub")).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("shows the linked GitHub login and keeps install as a second explicit action", async () => {
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(<GithubAppInstallationPanel initiallyOpen />);
+
+    await waitForText(container, "GitHub connected as @octocat");
+    expect(githubMocks.getGithubAppInstallUrl).not.toHaveBeenCalled();
+    expect(buttonByText(container, "Install on GitHub")).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("recovers inline when the linked GitHub identity disappears after the panel loads", async () => {
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    providerMocks.getAuthProviders
+      .mockResolvedValueOnce({
+        providers: [
+          {
+            provider: "github",
+            available: true,
+            connected: true,
+            accountName: "octocat",
+            email: null,
+            avatarUrl: null,
+            connectedAt: NOW,
+            canUnlink: true,
+            unlinkBlockedReason: null,
+          },
+        ],
+      })
+      .mockResolvedValue({
+        providers: [
+          {
+            provider: "github",
+            available: true,
+            connected: false,
+            accountName: null,
+            email: null,
+            avatarUrl: null,
+            connectedAt: null,
+            canUnlink: false,
+            unlinkBlockedReason: null,
+          },
+        ],
+      });
+    githubMocks.getGithubAppInstallUrl.mockRejectedValueOnce(
+      new ApiError(
+        409,
+        "Connect a GitHub account before installing the GitHub App",
+        undefined,
+        "github_identity_required",
+      ),
+    );
+    const { tab: fakeTab, openSpy } = mockInstallTab();
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(<GithubAppInstallationPanel initiallyOpen />);
+
+    await waitForText(container, "GitHub connected as @octocat");
+    await click(buttonByText(container, "Install on GitHub"));
+    await waitForText(container, "Connect your GitHub account");
+
+    expect(fakeTab.close).toHaveBeenCalledOnce();
+    expect(buttonByText(container, "Continue with GitHub")).not.toBeNull();
+    expect(buttonByText(container, "Install on GitHub")).toBeNull();
+
+    openSpy.mockRestore();
+    await act(async () => root.unmount());
+  });
+
+  it("keeps account-link conflicts inline with one clear retry action", async () => {
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    providerMocks.getAuthProviders.mockResolvedValue({
+      providers: [
+        {
+          provider: "github",
+          available: true,
+          connected: false,
+          accountName: null,
+          email: null,
+          avatarUrl: null,
+          connectedAt: null,
+          canUnlink: false,
+          unlinkBlockedReason: null,
+        },
+      ],
+    });
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(
+      <GithubAppInstallationPanel initiallyOpen accountLinkError="identity-conflict" />,
+    );
+
+    await waitForText(container, "already connected to another First Tree user");
+    expect(buttonByText(container, "Continue with GitHub")).not.toBeNull();
+    expect(buttonByText(container, "Install on GitHub")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps install identity errors inline after a linked admin returns", async () => {
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(
+      <GithubAppInstallationPanel initiallyOpen accountLinkError="install-not-verified" />,
+    );
+
+    await waitForText(container, "Use @octocat, then try again");
+    expect(buttonByText(container, "Install on GitHub")).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("distinguishes provider configuration failures from user login failures", async () => {
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    providerMocks.getAuthProviders.mockResolvedValue({
+      providers: [
+        {
+          provider: "github",
+          available: false,
+          connected: false,
+          accountName: null,
+          email: null,
+          avatarUrl: null,
+          connectedAt: null,
+          canUnlink: false,
+          unlinkBlockedReason: null,
+        },
+      ],
+    });
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(<GithubAppInstallationPanel initiallyOpen />);
+
+    await waitForText(container, "isn't configured on this First Tree deployment");
+    expect(buttonByText(container, "Continue with GitHub")).toBeNull();
+    expect(buttonByText(container, "Install on GitHub")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
   it("renders the summary read-only for members", async () => {
     const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
     const bound = await renderDom(<GithubAppInstallationPanel readOnly />);
@@ -205,8 +441,7 @@ describe("GithubAppInstallationPanel", () => {
 
   it("mints a fresh install URL into a new tab, then waits without leaving this tab", async () => {
     githubMocks.getGithubAppInstallation.mockResolvedValue(null);
-    const fakeTab = { location: { href: "" }, close: vi.fn() };
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(fakeTab as unknown as Window);
+    const { tab: fakeTab, openSpy } = mockInstallTab();
     const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
     const first = await renderDom(<GithubAppInstallationPanel />);
     await waitForText(first.container, "Connect GitHub");
@@ -250,13 +485,26 @@ describe("GithubAppInstallationPanel", () => {
     await act(async () => root.unmount());
   });
 
+  it("does not let another Team's install attempt lock this Team's panel", async () => {
+    const { rememberGithubInstallAttempt } = await import("../../lib/github-install-attempt.js");
+    rememberGithubInstallAttempt("org-other");
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(<GithubAppInstallationPanel initiallyOpen />);
+
+    await waitForText(container, "Install on GitHub");
+    expect(buttonByText(container, "Install on GitHub")?.disabled).toBe(false);
+    expect(container.textContent).not.toContain("Waiting for GitHub");
+
+    await act(async () => root.unmount());
+  });
+
   it("surfaces missing slug and reports generic install URL errors (closing the opened tab)", async () => {
     const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
 
     githubMocks.getGithubAppInstallation.mockResolvedValue(null);
     githubMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new ApiError(503, "slug missing"));
-    const slugTab = { location: { href: "" }, close: vi.fn() };
-    const slugOpen = vi.spyOn(window, "open").mockReturnValue(slugTab as unknown as Window);
+    const { tab: slugTab, openSpy: slugOpen } = mockInstallTab();
     const missingSlug = await renderDom(<GithubAppInstallationPanel />);
     await waitForText(missingSlug.container, "Connect GitHub");
     await click(buttonByText(missingSlug.container, "Connect GitHub"));
@@ -269,8 +517,7 @@ describe("GithubAppInstallationPanel", () => {
     await act(async () => missingSlug.root.unmount());
 
     githubMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new Error("oauth state failed"));
-    const genericTab = { location: { href: "" }, close: vi.fn() };
-    const genericOpen = vi.spyOn(window, "open").mockReturnValue(genericTab as unknown as Window);
+    const { tab: genericTab, openSpy: genericOpen } = mockInstallTab();
     const generic = await renderDom(<GithubAppInstallationPanel />);
     await waitForText(generic.container, "Connect GitHub");
     await click(buttonByText(generic.container, "Connect GitHub"));
@@ -336,8 +583,7 @@ describe("GithubAppInstallationPanel", () => {
     githubMocks.getGithubAppConnectPanel.mockResolvedValue({
       installations: [panelInstallation({ installationId: 22, accountLogin: "mine-org", status: "connected-here" })],
     });
-    const fakeTab = { location: { href: "" }, close: vi.fn() };
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(fakeTab as unknown as Window);
+    const { tab: fakeTab, openSpy } = mockInstallTab();
     const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
     const { container, root } = await renderDom(<GithubAppInstallationPanel />);
     await waitForText(container, "Connected to");
@@ -356,6 +602,39 @@ describe("GithubAppInstallationPanel", () => {
     await waitForText(container, "Waiting for GitHub… You may need a GitHub org admin to approve.");
 
     openSpy.mockRestore();
+    await act(async () => root.unmount());
+  });
+
+  it("requires a linked GitHub identity before reinstalling a connected Team", async () => {
+    providerMocks.getAuthProviders.mockResolvedValue({
+      providers: [
+        {
+          provider: "github",
+          available: true,
+          connected: false,
+          accountName: null,
+          email: null,
+          avatarUrl: null,
+          connectedAt: null,
+          canUnlink: false,
+          unlinkBlockedReason: null,
+        },
+      ],
+    });
+    githubMocks.getGithubAppConnectPanel.mockResolvedValue({
+      installations: [panelInstallation({ installationId: 22, accountLogin: "mine-org", status: "connected-here" })],
+    });
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(<GithubAppInstallationPanel />);
+    await waitForText(container, "Connected to");
+    await click(buttonByText(container, "Manage connection"));
+
+    await waitForText(container, "Required before installing the First Tree GitHub App");
+    expect(buttonByText(container, "Continue with GitHub")).not.toBeNull();
+    expect(buttonByText(container, "Reinstall")).toBeNull();
+    expect([...container.querySelectorAll("a")].some((a) => a.textContent?.includes("Manage on GitHub"))).toBe(true);
+    expect(buttonByText(container, "Disconnect")).not.toBeNull();
+
     await act(async () => root.unmount());
   });
 

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1438,6 +1438,7 @@ describe("web DOM interaction coverage", () => {
   it("renders friendly copy for callback error fragments", async () => {
     const { OAuthCompletePage } = await import("../oauth-complete.js");
     const { beginAuthAttempt } = await import("../../auth/auth-analytics.js");
+    const { rememberGithubAccountLinkReturn } = await import("../../lib/github-account-link-return.js");
     const replaceState = vi.fn();
     Object.defineProperty(window, "history", { configurable: true, value: { replaceState } });
 
@@ -1451,10 +1452,11 @@ describe("web DOM interaction coverage", () => {
         pathname: "/auth/github/complete",
       },
     });
+    rememberGithubAccountLinkReturn("org-1");
     const expired = await renderDom(<OAuthCompletePage />, "/auth/github/complete");
     await waitForText("took too long or was already used", expired.container);
     const back = expired.container.querySelector<HTMLAnchorElement>("a");
-    expect(back?.getAttribute("href")).toBe("/settings/github");
+    expect(back?.getAttribute("href")).toBe("/settings/github?error=state-expired&flow=link");
     await unmountRoot(expired.root);
 
     // Provider cancellation closes the paired sign-in attempt with a fixed,
@@ -1483,6 +1485,41 @@ describe("web DOM interaction coverage", () => {
     // No `next` in the fragment → the way out defaults to the app root.
     expect(notAdmin.container.querySelector<HTMLAnchorElement>("a")?.getAttribute("href")).toBe("/");
     await unmountRoot(notAdmin.root);
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        hash: "#error=install-not-verified&next=/settings/github&expectedGithubLogin=linked-user&callbackIntent=install",
+        pathname: "/auth/github/complete",
+      },
+    });
+    const mismatch = await renderDom(<OAuthCompletePage />, "/auth/github/complete");
+    await waitForText("Use @linked-user, then try again", mismatch.container);
+    expect(mismatch.container.querySelector<HTMLAnchorElement>("a")?.getAttribute("href")).toBe(
+      "/settings/github?error=install-not-verified&flow=install",
+    );
+    await unmountRoot(mismatch.root);
+
+    const { hasGithubInstallAttempt, rememberGithubInstallAttempt } = await import(
+      "../../lib/github-install-attempt.js"
+    );
+    rememberGithubInstallAttempt("org-original");
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        hash: "#error=state-expired",
+        pathname: "/auth/github/complete",
+      },
+    });
+    const expiredInstall = await renderDom(<OAuthCompletePage />, "/auth/github/complete");
+    await waitForText("took too long or was already used", expiredInstall.container);
+    expect(expiredInstall.container.querySelector<HTMLAnchorElement>("a")?.getAttribute("href")).toBe(
+      "/settings/github?error=state-expired&flow=install",
+    );
+    expect(hasGithubInstallAttempt()).toBe(true);
+    await unmountRoot(expiredInstall.root);
   });
 
   it("activates the callback org only when the server pins it", async () => {

--- a/packages/web/src/pages/github-app-installation-panel.tsx
+++ b/packages/web/src/pages/github-app-installation-panel.tsx
@@ -10,17 +10,15 @@ import {
   getGithubAppInstallation,
   getGithubAppInstallUrl,
 } from "../api/github-app.js";
+import { getAuthProviders, startProviderLink } from "../api/user-settings.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
-
-/**
- * Per-tab marker set when the admin kicks off an install. It locks the CTA (a
- * second mint would overwrite the first attempt's `oauth_state_nonce` cookie and
- * break its callback) and gates the "waiting for GitHub" affordance. Cleared once
- * a connectable installation shows up in the panel. Mirrors the connect-code /
- * Context-build entries, which use the same open-popup-in-a-new-tab-then-poll flow.
- */
-const INSTALL_ATTEMPT_KEY = "settings:github:install-attempt";
+import { clearGithubAccountLinkReturn, rememberGithubAccountLinkReturn } from "../lib/github-account-link-return.js";
+import {
+  clearGithubInstallAttemptForOrganization,
+  hasGithubInstallAttemptForOrganization,
+  rememberGithubInstallAttempt,
+} from "../lib/github-install-attempt.js";
 
 /**
  * How often the open connect panel refreshes its installation list. Two
@@ -44,9 +42,21 @@ const CONNECT_PANEL_POLL_MS = 2000;
  *     holds them. Binding is always an explicit click here — installs
  *     never auto-connect.
  */
-export function GithubAppInstallationPanel({ readOnly = false }: { readOnly?: boolean }) {
+export function GithubAppInstallationPanel({
+  readOnly = false,
+  initiallyOpen = false,
+  accountLinkError = null,
+}: {
+  readOnly?: boolean;
+  initiallyOpen?: boolean;
+  accountLinkError?: string | null;
+}) {
   const { organizationId } = useAuth();
-  const [panelOpen, setPanelOpen] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(initiallyOpen);
+
+  useEffect(() => {
+    if (initiallyOpen) setPanelOpen(true);
+  }, [initiallyOpen]);
 
   const installationQuery = useQuery({
     queryKey: ["github-app-installation", organizationId],
@@ -79,6 +89,7 @@ export function GithubAppInstallationPanel({ readOnly = false }: { readOnly?: bo
       <ConnectPanel
         organizationId={organizationId}
         bound={installationQuery.data ?? null}
+        accountLinkError={accountLinkError}
         onBack={() => setPanelOpen(false)}
       />
     );
@@ -207,11 +218,13 @@ function InstalledState({
 function ConnectPanel({
   organizationId,
   bound,
+  accountLinkError,
   onBack,
 }: {
   organizationId: string | null;
   /** The installation currently connected to this team (summary query), or null. */
   bound: GithubAppInstallationOutput | null;
+  accountLinkError: string | null;
   onBack: () => void;
 }) {
   const queryClient = useQueryClient();
@@ -223,34 +236,75 @@ function ConnectPanel({
     refetchInterval: CONNECT_PANEL_POLL_MS,
   });
 
+  // GitHub is a capability-specific identity requirement, not a core sign-in
+  // requirement. Google/OIDC users remain fully authenticated in First Tree;
+  // this one panel asks them to link GitHub before it can mint install state.
+  const providersQuery = useQuery({
+    queryKey: ["auth-providers"],
+    queryFn: getAuthProviders,
+  });
+  const githubProvider = providersQuery.data?.providers.find((provider) => provider.provider === "github");
+
+  const linkGithubMutation = useMutation({
+    mutationFn: async () => {
+      if (!organizationId) throw new Error("No organization selected");
+      rememberGithubAccountLinkReturn(organizationId);
+      try {
+        return await startProviderLink("github", "/settings/github");
+      } catch (error) {
+        clearGithubAccountLinkReturn();
+        throw error;
+      }
+    },
+    onSuccess: ({ redirectUrl }) => window.location.assign(redirectUrl),
+  });
+
   const installations = panelQuery.data?.installations ?? [];
   const connectable = installations.filter((i) => i.status === "connectable");
 
   // Install-attempt marker: locks the install CTA and shows the waiting
   // affordance until something connectable appears (the thing to click next).
   const [attempted, setAttempted] = useState(
-    () => typeof window !== "undefined" && !!window.sessionStorage.getItem(INSTALL_ATTEMPT_KEY),
+    () => typeof window !== "undefined" && hasGithubInstallAttemptForOrganization(organizationId),
   );
   useEffect(() => {
+    setAttempted(typeof window !== "undefined" && hasGithubInstallAttemptForOrganization(organizationId));
+  }, [organizationId]);
+  useEffect(() => {
     if (attempted && connectable.length > 0 && typeof window !== "undefined") {
-      window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+      clearGithubInstallAttemptForOrganization(organizationId);
       setAttempted(false);
     }
-  }, [attempted, connectable.length]);
+  }, [attempted, connectable.length, organizationId]);
 
   // The install URL is minted on click (not preloaded): the server signs a
   // `state` JWT and sets the matching `oauth_state_nonce` cookie before handing
-  // back the `installations/new?state=…` URL, and both expire after 10 minutes.
-  // Minting at click time keeps them fresh (codex P2 follow-up).
+  // back the GitHub identity-preflight URL. A matching callback mints a fresh
+  // state/cookie pair and continues to `installations/new`; both phases expire
+  // after 10 minutes. Minting at click time keeps them fresh.
   const installUrlMutation = useMutation({
     mutationFn: (next: string | undefined) => {
       if (!organizationId) throw new Error("No organization selected");
       return getGithubAppInstallUrl(organizationId, next);
     },
+    onError: (error) => {
+      // The identity can be unlinked in another tab after this panel loaded.
+      // Refresh the capability query so the UI recovers to the actionable
+      // Continue-with-GitHub state instead of leaving a stale Install button.
+      if (error instanceof ApiError && error.code === "github_identity_required") {
+        void providersQuery.refetch();
+      }
+    },
   });
 
   const handleInstall = (): void => {
     if (!organizationId) return;
+    // Set before opening so a same-origin blank popup inherits the marker. If
+    // state verification fails before the callback can recover its signed
+    // intent, the OAuth error surface can still return this install attempt to
+    // the stable GitHub panel rather than the app root.
+    rememberGithubInstallAttempt(organizationId);
+    setAttempted(true);
     // Open the tab synchronously inside the click gesture so the browser doesn't
     // treat the post-await open as a blocked popup; fill its location once the
     // URL is minted, or close it on failure. GitHub installs in that tab and
@@ -265,12 +319,14 @@ function ConnectPanel({
     const next = installTab ? "/onboarding/connected" : undefined;
     installUrlMutation.mutate(next, {
       onSuccess: (installUrl) => {
-        window.sessionStorage.setItem(INSTALL_ATTEMPT_KEY, String(Date.now()));
-        setAttempted(true);
         if (installTab) installTab.location.href = installUrl;
         else window.location.assign(installUrl); // popup blocked — full redirect
       },
-      onError: () => installTab?.close(),
+      onError: () => {
+        clearGithubInstallAttemptForOrganization(organizationId);
+        setAttempted(false);
+        installTab?.close();
+      },
     });
   };
 
@@ -278,7 +334,7 @@ function ConnectPanel({
   // installing): a fresh URL overwrites the nonce cookie, so retry is a
   // conscious action, never an auto re-click while the first tab may be mid-flow.
   const handleStartOver = (): void => {
-    window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+    clearGithubInstallAttemptForOrganization(organizationId);
     setAttempted(false);
     installUrlMutation.reset();
   };
@@ -307,6 +363,78 @@ function ConnectPanel({
   const slugMissing = installUrlMutation.error instanceof ApiError && installUrlMutation.error.status === 503;
   const installDisabled = !organizationId || installUrlMutation.isPending || attempted;
 
+  // Keep the ordinary connected-user path unchanged. Only the missing-
+  // identity edge case is intercepted, in place, before any install URL can
+  // be minted. The server independently enforces the same gate.
+  if (!bound && (providersQuery.isLoading || providersQuery.error || !githubProvider?.connected)) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)" }}>
+        <div>
+          <Button type="button" variant="ghost" size="sm" onClick={onBack}>
+            <ArrowLeft aria-hidden className="h-3 w-3" />
+            Back
+          </Button>
+        </div>
+        <div aria-live="polite">
+          <div className="text-body font-semibold" style={{ color: "var(--fg)", marginBottom: "var(--sp-1)" }}>
+            Connect your GitHub account
+          </div>
+          {providersQuery.isLoading ? (
+            <p className="text-body" role="status" style={{ color: "var(--fg-3)", margin: 0 }}>
+              Checking your GitHub connection…
+            </p>
+          ) : providersQuery.error ? (
+            <div>
+              <p className="text-body" role="status" style={{ color: "var(--fg-3)", margin: 0 }}>
+                We couldn't check your GitHub connection. Try again.
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void providersQuery.refetch()}
+                style={{ marginTop: "var(--sp-2)" }}
+              >
+                Try again
+              </Button>
+            </div>
+          ) : githubProvider?.available === false ? (
+            <p className="text-body" role="alert" style={{ color: "var(--state-error)", margin: 0 }}>
+              GitHub sign-in isn't configured on this First Tree deployment. Ask your operator to configure it.
+            </p>
+          ) : (
+            <div>
+              {accountLinkError ? (
+                <p className="text-body" role="alert" style={{ color: "var(--state-error)", margin: 0 }}>
+                  {accountLinkErrorCopy(accountLinkError)}
+                </p>
+              ) : null}
+              <p className="text-body" style={{ color: "var(--fg-2)", margin: 0 }}>
+                Required before installing the First Tree GitHub App.
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => linkGithubMutation.mutate()}
+                disabled={linkGithubMutation.isPending}
+                style={{ marginTop: "var(--sp-2)" }}
+              >
+                {linkGithubMutation.isPending ? "Opening GitHub…" : "Continue with GitHub"}
+              </Button>
+              {linkGithubMutation.error ? (
+                <p className="text-body" role="alert" style={{ color: "var(--state-error)", marginTop: "var(--sp-2)" }}>
+                  {linkGithubMutation.error instanceof Error
+                    ? linkGithubMutation.error.message
+                    : "Could not start GitHub account connection."}
+                </p>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)" }}>
       <div>
@@ -316,11 +444,22 @@ function ConnectPanel({
         </Button>
       </div>
 
+      {accountLinkError ? (
+        <p className="text-body" role="alert" style={{ color: "var(--state-error)", margin: 0 }}>
+          {accountLinkErrorCopy(accountLinkError, githubProvider?.accountName)}
+        </p>
+      ) : null}
+
       {/* ── Step 1: get the App installed on GitHub ──────────────────── */}
       <div>
         <div className="text-body font-semibold" style={{ color: "var(--fg)", marginBottom: "var(--sp-2)" }}>
           Step 1: Install the First Tree App on your GitHub
         </div>
+        {githubProvider?.connected ? (
+          <p className="text-label" style={{ color: "var(--fg-3)", margin: "0 0 var(--sp-2)" }}>
+            GitHub connected{githubProvider.accountName ? ` as @${githubProvider.accountName}` : ""}.
+          </p>
+        ) : null}
         {slugMissing ? (
           <p className="text-body" style={{ color: "var(--state-error)", margin: 0 }}>
             The GitHub App slug isn't configured on this First Tree deployment. Ask your operator to set{" "}
@@ -328,16 +467,51 @@ function ConnectPanel({
           </p>
         ) : bound ? (
           // This team already has a connected installation, so Step 1 is done —
-          // surface that state instead of a primary CTA. Reinstall kicks off a
-          // fresh install (e.g. on another GitHub account); Manage on GitHub
-          // opens the installed App's own settings page.
+          // surface that state instead of a primary CTA. Reinstall remains
+          // identity-gated, while Manage and Disconnect keep working even when
+          // the current First Tree admin has no linked GitHub identity.
           <div className="flex items-center" style={{ gap: "var(--sp-2_5)", flexWrap: "wrap" }}>
             <span className="text-body" style={{ color: "var(--fg-2)" }}>
               GitHub App installed.
             </span>
-            <Button type="button" variant="outline" size="sm" onClick={handleInstall} disabled={installDisabled}>
-              {installUrlMutation.isPending ? "Opening GitHub…" : "Reinstall"}
-            </Button>
+            {providersQuery.isLoading ? (
+              <span className="text-label" role="status" style={{ color: "var(--fg-3)" }}>
+                Checking your GitHub connection…
+              </span>
+            ) : providersQuery.error ? (
+              <>
+                <span className="text-label" role="status" style={{ color: "var(--fg-3)" }}>
+                  We couldn't check your GitHub connection.
+                </span>
+                <Button type="button" variant="outline" size="sm" onClick={() => void providersQuery.refetch()}>
+                  Try again
+                </Button>
+              </>
+            ) : githubProvider?.available === false ? (
+              <span className="text-label" role="alert" style={{ color: "var(--state-error)" }}>
+                GitHub sign-in isn't configured. Ask your operator to configure it before reinstalling.
+              </span>
+            ) : githubProvider?.connected ? (
+              <Button type="button" variant="outline" size="sm" onClick={handleInstall} disabled={installDisabled}>
+                {installUrlMutation.isPending ? "Opening GitHub…" : "Reinstall"}
+              </Button>
+            ) : (
+              <div>
+                <span className="text-label" style={{ color: "var(--fg-2)" }}>
+                  Required before installing the First Tree GitHub App.
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => linkGithubMutation.mutate()}
+                  disabled={linkGithubMutation.isPending}
+                  style={{ marginLeft: "var(--sp-2)" }}
+                >
+                  {linkGithubMutation.isPending ? "Opening GitHub…" : "Continue with GitHub"}
+                </Button>
+              </div>
+            )}
             <Button asChild variant="outline" size="sm">
               <a href={bound.manageUrl} target="_blank" rel="noreferrer">
                 Manage on GitHub
@@ -422,6 +596,27 @@ function ConnectPanel({
       </InstallationGroup>
     </div>
   );
+}
+
+function accountLinkErrorCopy(code: string, linkedGithubLogin?: string | null): string {
+  if (code === "identity-conflict") {
+    return "That GitHub account is already connected to another First Tree user. Continue with a different GitHub account.";
+  }
+  if (code === "identity-mismatch") {
+    return "You selected a different GitHub account. Continue with the account you want linked to this First Tree user.";
+  }
+  if (code === "provider-denied") return "GitHub authorization was canceled. Continue when you're ready.";
+  if (code === "state-expired") return "That GitHub connection request expired. Start again.";
+  if (code === "github-exchange-failed") return "GitHub didn't accept the connection. Try again in a moment.";
+  if (code === "install-not-verified") {
+    return linkedGithubLogin
+      ? `GitHub couldn't verify the account for this install. Use @${linkedGithubLogin}, then try again.`
+      : "GitHub couldn't verify the account for this install. Try again with your linked GitHub account.";
+  }
+  if (code === "install-not-admin") {
+    return "Your Team admin access changed during the install. Restore access or ask an active admin to try again.";
+  }
+  return "GitHub account connection did not complete. Try again.";
 }
 
 function connectError(error: unknown): string {

--- a/packages/web/src/pages/oauth-complete.tsx
+++ b/packages/web/src/pages/oauth-complete.tsx
@@ -8,6 +8,8 @@ import {
   normalizeAuthJoinPath,
 } from "../auth/auth-analytics.js";
 import { useAuth } from "../auth/auth-context.js";
+import { githubSettingsErrorReturnPath, readGithubAccountLinkReturn } from "../lib/github-account-link-return.js";
+import { readGithubInstallAttempt } from "../lib/github-install-attempt.js";
 import { markOnboardingResume } from "../utils/onboarding-flags.js";
 
 /**
@@ -77,6 +79,7 @@ export function OAuthCompletePage() {
     const org = params.get("org");
     const orgPinned = params.get("orgPinned") === "1";
     const errorCode = params.get("error");
+    const expectedGithubLogin = params.get("expectedGithubLogin");
     const provider = authProviderForCallbackPath(window.location.pathname);
     const accountCreatedRaw = params.get("accountCreated");
     const accountCreated = accountCreatedRaw === "1" ? true : accountCreatedRaw === "0" ? false : null;
@@ -96,8 +99,27 @@ export function OAuthCompletePage() {
           reasonCode: normalizeAuthFailureReason(errorCode),
           accountCreated,
         });
-      setError(CALLBACK_ERROR_COPY[errorCode] ?? "Sign-in did not complete. Please try again.");
-      setErrorNext(next);
+      setError(
+        errorCode === "install-not-verified" && expectedGithubLogin
+          ? `You selected a different GitHub account. Use @${expectedGithubLogin}, then try again.`
+          : (CALLBACK_ERROR_COPY[errorCode] ?? "Sign-in did not complete. Please try again."),
+      );
+      // A link-state nonce can expire before the server can trust its signed
+      // `next`. The browser marker is non-authoritative but is enough to give
+      // the already-authenticated user a friendly route back to the stable
+      // Settings panel; all Team actions there are authorized again server-side.
+      const accountLinkReturn = readGithubAccountLinkReturn();
+      const installReturn = readGithubInstallAttempt();
+      const returningFromInstall =
+        callbackIntent === "install" ||
+        (callbackIntent === null && errorCode === "state-expired" && installReturn !== null);
+      setErrorNext(
+        returningFromInstall
+          ? githubSettingsErrorReturnPath(errorCode, "install")
+          : callbackIntent === "link" || (callbackIntent === null && errorCode === "state-expired" && accountLinkReturn)
+            ? githubSettingsErrorReturnPath(errorCode, "link")
+            : next,
+      );
       return;
     }
 

--- a/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
@@ -18,8 +18,13 @@ const teamAgentMocks = vi.hoisted(() => ({
   putTeamAgentAssignment: vi.fn(),
 }));
 const authMock = vi.hoisted(() => ({
-  value: { role: "admin" as string | null, organizationId: "org-1" as string | null },
+  value: {
+    role: "admin" as string | null,
+    organizationId: "org-1" as string | null,
+    selectOrganization: vi.fn<(organizationId: string) => Promise<void>>(),
+  },
 }));
+const panelMock = vi.hoisted(() => ({ props: vi.fn() }));
 let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
 let scrollIntoView: ReturnType<typeof vi.fn>;
 
@@ -31,7 +36,10 @@ vi.mock("../../../api/setup-capabilities.js", () => ({
 }));
 vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
 vi.mock("../../github-app-installation-panel.js", () => ({
-  GithubAppInstallationPanel: () => <div data-testid="panel-stub">panel</div>,
+  GithubAppInstallationPanel: (props: unknown) => {
+    panelMock.props(props);
+    return <div data-testid="panel-stub">panel</div>;
+  },
 }));
 
 function createClient(): QueryClient {
@@ -89,7 +97,12 @@ async function waitForSelector<T extends Element>(
 beforeEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
-  authMock.value = { role: "admin", organizationId: "org-1" };
+  window.sessionStorage.clear();
+  authMock.value = {
+    role: "admin",
+    organizationId: "org-1",
+    selectOrganization: vi.fn(async () => undefined),
+  };
   originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
   scrollIntoView = vi.fn();
   HTMLElement.prototype.scrollIntoView = scrollIntoView;
@@ -162,6 +175,119 @@ describe("SettingsGithubPage — Context round-trip return", () => {
 
     await act(async () => root.unmount());
   });
+
+  it("reopens and focuses Connection after a GitHub account-link return", async () => {
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/github?connection=github-linked", <SettingsGithubPage />);
+    const connection = await waitForSelector<HTMLElement>(container, "#connection");
+
+    expect(panelMock.props).toHaveBeenLastCalledWith(
+      expect.objectContaining({ readOnly: false, initiallyOpen: true, accountLinkError: null }),
+    );
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(document.activeElement).toBe(connection);
+
+    await act(async () => root.unmount());
+  });
+
+  it("restores the Team that started account linking before reopening Connection", async () => {
+    const { rememberGithubAccountLinkReturn } = await import("../../../lib/github-account-link-return.js");
+    rememberGithubAccountLinkReturn("org-original");
+    authMock.value.organizationId = "org-other";
+    authMock.value.selectOrganization.mockImplementation(async (organizationId) => {
+      authMock.value.organizationId = organizationId;
+    });
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/github?connection=github-linked", <SettingsGithubPage />);
+
+    await waitForText(container, "panel");
+    expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-original");
+    expect(panelMock.props).toHaveBeenLastCalledWith(
+      expect.objectContaining({ initiallyOpen: true, accountLinkError: null }),
+    );
+    expect(window.sessionStorage.getItem("settings:github:account-link-return")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("restores the Team that started a failed install before reopening Connection", async () => {
+    const { rememberGithubInstallAttempt } = await import("../../../lib/github-install-attempt.js");
+    rememberGithubInstallAttempt("org-original");
+    authMock.value.organizationId = "org-other";
+    authMock.value.selectOrganization.mockImplementation(async (organizationId) => {
+      authMock.value.organizationId = organizationId;
+    });
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt(
+      "/settings/github?error=install-not-verified&flow=install",
+      <SettingsGithubPage />,
+    );
+
+    await waitForText(container, "panel");
+    expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-original");
+    expect(panelMock.props).toHaveBeenLastCalledWith(
+      expect.objectContaining({ initiallyOpen: true, accountLinkError: "install-not-verified" }),
+    );
+    expect(window.sessionStorage.getItem("settings:github:install-attempt")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("reopens the current Team's waiting panel after a full-page install return", async () => {
+    const { rememberGithubInstallAttempt } = await import("../../../lib/github-install-attempt.js");
+    rememberGithubInstallAttempt("org-1");
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/github", <SettingsGithubPage />);
+    const connection = await waitForSelector<HTMLElement>(container, "#connection");
+
+    expect(authMock.value.selectOrganization).not.toHaveBeenCalled();
+    expect(panelMock.props).toHaveBeenLastCalledWith(
+      expect.objectContaining({ initiallyOpen: true, accountLinkError: null }),
+    );
+    expect(window.sessionStorage.getItem("settings:github:install-attempt")).not.toBeNull();
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(document.activeElement).toBe(connection);
+
+    await act(async () => root.unmount());
+  });
+
+  it("restores the Team that started a full-page install before showing its waiting panel", async () => {
+    const { rememberGithubInstallAttempt } = await import("../../../lib/github-install-attempt.js");
+    rememberGithubInstallAttempt("org-original");
+    authMock.value.organizationId = "org-other";
+    authMock.value.selectOrganization.mockImplementation(async (organizationId) => {
+      authMock.value.organizationId = organizationId;
+    });
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/github", <SettingsGithubPage />);
+
+    await waitForText(container, "panel");
+    expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-original");
+    expect(panelMock.props).toHaveBeenLastCalledWith(
+      expect.objectContaining({ initiallyOpen: true, accountLinkError: null }),
+    );
+    expect(window.sessionStorage.getItem("settings:github:install-attempt")).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps a failed cross-Team return recoverable without applying the marker to the current Team", async () => {
+    const { rememberGithubInstallAttempt } = await import("../../../lib/github-install-attempt.js");
+    rememberGithubInstallAttempt("org-original");
+    authMock.value.organizationId = "org-other";
+    authMock.value.selectOrganization.mockRejectedValueOnce(new Error("membership changed"));
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/github", <SettingsGithubPage />);
+
+    await waitForText(container, "We couldn't return to the Team where you started");
+    expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-original");
+    expect(panelMock.props).toHaveBeenLastCalledWith(
+      expect.objectContaining({ initiallyOpen: false, accountLinkError: null }),
+    );
+    expect(window.sessionStorage.getItem("settings:github:install-attempt")).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
 });
 
 describe("SettingsGithubPage — task routing", () => {
@@ -210,7 +336,11 @@ describe("SettingsGithubPage — task routing", () => {
   });
 
   it("shows members the configured Agent without exposing assignment controls", async () => {
-    authMock.value = { role: "member", organizationId: "org-1" };
+    authMock.value = {
+      role: "member",
+      organizationId: "org-1",
+      selectOrganization: vi.fn(async () => undefined),
+    };
     orgSettingsMocks.getGithubFeaturesSetting.mockResolvedValue({
       teamAgent: {
         agentUuid: "dev-agent-1",

--- a/packages/web/src/pages/settings/github.tsx
+++ b/packages/web/src/pages/settings/github.tsx
@@ -1,16 +1,64 @@
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, Check } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useLocation, useSearchParams } from "react-router";
 import { getGithubAppInstallation } from "../../api/github-app.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
+import { clearGithubAccountLinkReturn, readGithubAccountLinkReturn } from "../../lib/github-account-link-return.js";
+import { clearGithubInstallAttempt, readGithubInstallAttempt } from "../../lib/github-install-attempt.js";
 import { GithubAppInstallationPanel } from "../github-app-installation-panel.js";
 import { GithubTaskAgentControls } from "./github-task-agent-controls.js";
 
 const CONNECTION_HASH = "#connection";
 const TASK_ROUTING_HASH = "#task-routing";
+
+type GithubReturnContext = {
+  kind: "account-link" | "install";
+  organizationId: string;
+  consumeBeforePanel: boolean;
+};
+
+function readGithubReturnContext(
+  completedAccountLink: boolean,
+  errorCode: string | null,
+  flow: string | null,
+): GithubReturnContext | null {
+  if (!completedAccountLink && errorCode === null) {
+    const installReturn = readGithubInstallAttempt();
+    return installReturn
+      ? { kind: "install", organizationId: installReturn.organizationId, consumeBeforePanel: false }
+      : null;
+  }
+  if (completedAccountLink || flow === "link") {
+    const accountLinkReturn = readGithubAccountLinkReturn();
+    return accountLinkReturn
+      ? { kind: "account-link", organizationId: accountLinkReturn.organizationId, consumeBeforePanel: true }
+      : null;
+  }
+  if (flow === "install") {
+    const installReturn = readGithubInstallAttempt();
+    return installReturn
+      ? { kind: "install", organizationId: installReturn.organizationId, consumeBeforePanel: true }
+      : null;
+  }
+
+  // Rolling compatibility for error URLs created before `flow` was added.
+  const accountLinkReturn = readGithubAccountLinkReturn();
+  if (accountLinkReturn) {
+    return { kind: "account-link", organizationId: accountLinkReturn.organizationId, consumeBeforePanel: true };
+  }
+  const installReturn = readGithubInstallAttempt();
+  return installReturn
+    ? { kind: "install", organizationId: installReturn.organizationId, consumeBeforePanel: true }
+    : null;
+}
+
+function clearGithubReturnContext(context: GithubReturnContext): void {
+  if (context.kind === "account-link") clearGithubAccountLinkReturn();
+  else clearGithubInstallAttempt();
+}
 
 /**
  * Settings → Integrations → GitHub. Members can read the team's GitHub
@@ -26,19 +74,57 @@ const TASK_ROUTING_HASH = "#task-routing";
  * their own way back to building.
  */
 export function SettingsGithubPage() {
-  const { role, organizationId } = useAuth();
+  const { role, organizationId, selectOrganization } = useAuth();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const fromContext = searchParams.get("from") === "context";
+  const accountLinkCompleted = searchParams.get("connection") === "github-linked";
+  const accountLinkError = searchParams.get("error");
+  const githubReturnFlow = searchParams.get("flow");
+  const explicitGithubReturn = accountLinkCompleted || accountLinkError !== null;
+  const [githubReturnContext] = useState(() =>
+    readGithubReturnContext(accountLinkCompleted, accountLinkError, githubReturnFlow),
+  );
+  // Hold the panel while its original Team is restored or an explicit error
+  // marker is consumed. A successful no-code install landing keeps its marker
+  // so the restored Team can render the real waiting/recovery state.
+  const [returnRestorePending, setReturnRestorePending] = useState(
+    () =>
+      githubReturnContext !== null &&
+      (githubReturnContext.consumeBeforePanel || githubReturnContext.organizationId !== organizationId),
+  );
+  const returningFromGithub =
+    explicitGithubReturn ||
+    returnRestorePending ||
+    (githubReturnContext?.consumeBeforePanel === false && githubReturnContext.organizationId === organizationId);
+  const [returnRestoreError, setReturnRestoreError] = useState(false);
+  const restoreAttemptedRef = useRef(false);
   const connectionRef = useRef<HTMLElement>(null);
   const taskRoutingRef = useRef<HTMLElement>(null);
 
   // React Router updates the fragment but not the app shell's persistent
   // overflow container. Position and focus the requested GitHub section.
   useEffect(() => {
-    if (role === null) return;
+    if (!githubReturnContext || restoreAttemptedRef.current) return;
+    restoreAttemptedRef.current = true;
+    if (githubReturnContext.organizationId === organizationId) {
+      if (githubReturnContext.consumeBeforePanel) clearGithubReturnContext(githubReturnContext);
+      setReturnRestorePending(false);
+      return;
+    }
+    void selectOrganization(githubReturnContext.organizationId)
+      .then(() => setReturnRestoreError(false))
+      .catch(() => setReturnRestoreError(true))
+      .finally(() => {
+        if (githubReturnContext.consumeBeforePanel) clearGithubReturnContext(githubReturnContext);
+        setReturnRestorePending(false);
+      });
+  }, [githubReturnContext, organizationId, selectOrganization]);
+
+  useEffect(() => {
+    if (role === null || returnRestorePending) return;
     const target =
-      location.hash === CONNECTION_HASH
+      location.hash === CONNECTION_HASH || returningFromGithub
         ? connectionRef.current
         : location.hash === TASK_ROUTING_HASH
           ? taskRoutingRef.current
@@ -46,7 +132,7 @@ export function SettingsGithubPage() {
     if (!target) return;
     target.scrollIntoView({ block: "start" });
     target.focus({ preventScroll: true });
-  }, [location.hash, role]);
+  }, [location.hash, returnRestorePending, returningFromGithub, role]);
 
   // Only needed to drive the "back to building" return for the Context round
   // trip. Shares the query key the connection panel invalidates on connect, so
@@ -65,12 +151,24 @@ export function SettingsGithubPage() {
       </div>
     );
   }
+  if (returnRestorePending) {
+    return (
+      <div className="text-body" role="status" style={{ padding: "var(--sp-5)", color: "var(--fg-3)" }}>
+        Returning to your Team's GitHub settings…
+      </div>
+    );
+  }
   const isAdmin = role === "admin";
 
   // Page heading + lead are owned by the Settings layout (see settings.tsx).
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-5)", padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
       {fromContext ? <ContextReturn connected={connected} /> : null}
+      {returnRestoreError ? (
+        <p className="text-body" role="alert" style={{ margin: 0, color: "var(--state-error)" }}>
+          We couldn't return to the Team where you started. Select that Team and try again.
+        </p>
+      ) : null}
       <section
         ref={connectionRef}
         id={CONNECTION_HASH.slice(1)}
@@ -79,7 +177,11 @@ export function SettingsGithubPage() {
         style={{ scrollMarginTop: "var(--sp-4)" }}
       >
         <Section title="Connection">
-          <GithubAppInstallationPanel readOnly={!isAdmin} />
+          <GithubAppInstallationPanel
+            readOnly={!isAdmin}
+            initiallyOpen={isAdmin && returningFromGithub && !returnRestoreError}
+            accountLinkError={accountLinkError}
+          />
         </Section>
       </section>
       <section


### PR DESCRIPTION
## Summary

- require an active Team admin to link a GitHub identity before minting GitHub App install state
- add a two-phase OAuth identity preflight that verifies the active github.com numeric ID before opening the App picker, then rechecks live Team and identity authority on callback
- keep Google/OIDC sign-in valid while adding an inline, recoverable GitHub capability gate and safe return to the originating Team

## Security and recovery

- missing identities fail with `409 github_identity_required` before state or nonce side effects
- account-link return paths are restricted to supported internal Settings paths
- mismatched GitHub accounts, role loss, identity unlink, cancel, expiry, replay, and provider configuration failures fail closed without switching the First Tree user or persisting a foreign identity
- no-code owner-approval landings recheck current Team-admin membership and the linked GitHub identity before returning to the waiting panel
- install-attempt markers are Team-scoped; full-page returns restore the originating Team, while failed restoration cannot apply another Team's marker
- existing explicit Connect and one-installation-per-Team constraints remain unchanged

## Provider limitation

GitHub does not include an OAuth code or verifiable requester identity when a non-owner installation request lands after the picker. A user who deliberately switches github.com accounts in another tab after passing the preflight can still cause a safe unbound installation row. This cannot bind the installation or cross a First Tree Team authority boundary. The limitation is documented in the QA case and deterministic tests; this PR does not add a Stage 2 handoff or support-override flow.

## Verification

- `pnpm --filter @first-tree/server exec vitest run ...` — 71 focused tests passed
- `pnpm --filter @first-tree/server exec vitest run --reporter=dot --silent` — 3,112 tests passed in independent QA
- `pnpm --filter @first-tree/web exec vitest run ...` — 84 focused tests passed
- `pnpm --filter @first-tree/web exec vitest run src --reporter=dot --silent` — 2,241 tests passed in independent QA
- `pnpm check` — passed with existing repository warnings only
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @first-tree/web build`
- `npx momentic@3.42.0 lint`
- exact-head Momentic `local`, 13/13 steps, uploaded by implementation verification: https://app.momentic.ai/run-groups/4221e204-1a31-4e3f-91c7-8c42c3392d46
- independent QA: `PASS` at exact commit `91bd94be92fdc0a409fd2b84da3d110de724d9b6`; uploaded Momentic run group: https://app.momentic.ai/run-groups/18e2d11b-b57f-4265-87b9-68b3664b614e
- independent Standards and Spec reviews: passed after resolving cross-Team return and marker-scoping blockers

The real github.com OAuth, App picker, and owner-approval UI were not driven with external credentials. Deterministic server integration tests cover nonce rotation, numeric-ID match/mismatch, role loss, identity unlink, no-code landing authority, and side-effect boundaries.

A full monorepo `pnpm test` run exposed three unrelated parallel-only failures outside this diff. The affected client file passed 36/36 and the affected CLI file passed 5/5 when rerun in isolation.
