### PR TITLE
fix(cli): verify BYO Context readiness before setup

### DIFF
--- a/apps/cli/src/__tests__/context-enable-command.test.ts
+++ b/apps/cli/src/__tests__/context-enable-command.test.ts
@@ -25,10 +25,9 @@ const mocks = vi.hoisted(() => ({
   inspectLocation: vi.fn(),
   inspectRuntime: vi.fn(),
   inspectStore: vi.fn(),
-  fetchScope: vi.fn(),
-  getBinding: vi.fn(),
   issueSession: vi.fn(),
   planInstall: vi.fn(),
+  preflightScope: vi.fn(),
   readAccount: vi.fn(() => "client-1"),
   readConfig: vi.fn(),
   resolveRelease: vi.fn(),
@@ -77,13 +76,26 @@ vi.mock("../core/context-integration/release.js", () => ({
 vi.mock("../core/context-integration/runtime-health.js", () => ({
   inspectContextIntegrationRuntime: mocks.inspectRuntime,
 }));
-vi.mock("../core/context-integration/context-route.js", () => ({
-  fetchExactScope: mocks.fetchScope,
-}));
+vi.mock("../core/context-integration/context-enable-scope-preflight.js", () => {
+  class ContextEnableScopePreflightError extends Error {
+    readonly stage: "authority" | "binding" | "scope" | "fetch";
+    readonly exitCode: 1 | 3 | 6;
+
+    constructor(
+      readonly code: string,
+      message: string,
+      options: { stage: "authority" | "binding" | "scope" | "fetch"; exitCode: 1 | 3 | 6 },
+    ) {
+      super(message);
+      this.stage = options.stage;
+      this.exitCode = options.exitCode;
+    }
+  }
+  return { ContextEnableScopePreflightError, preflightContextEnableScope: mocks.preflightScope };
+});
 vi.mock("../commands/_shared/member.js", () => ({
   createMemberSdk: () => ({
     validateMemberContextActivation: mocks.validateActivation,
-    getMemberContextTreeSetting: mocks.getBinding,
     issueMemberContextSessionCandidate: mocks.issueSession,
   }),
 }));
@@ -93,6 +105,7 @@ vi.mock("../commands/context/shared.js", () => ({
 }));
 
 import { runContextEnable } from "../commands/context/enable.js";
+import { ContextEnableScopePreflightError } from "../core/context-integration/context-enable-scope-preflight.js";
 
 const team = { organizationId: "org-a", displayName: "Team A", role: "member" as const };
 const project = { kind: "path" as const, root: "/work/repo" };
@@ -119,15 +132,7 @@ beforeEach(() => {
   });
   mocks.resolveRelease.mockReturnValue({ root: "/release", manifest: { release: "manifest" } });
   mocks.validateActivation.mockResolvedValue({ schemaVersion: 2, outcome: "connected", team });
-  mocks.getBinding.mockResolvedValue({
-    provider: "github",
-    repo: "https://github.com/acme/context-tree.git",
-    branch: "main",
-  });
-  mocks.fetchScope.mockReturnValue({
-    commit: "c".repeat(40),
-    scope: { schemaVersion: 1, relatedRepositories: [], body: "Team A context." },
-  });
+  mocks.preflightScope.mockResolvedValue(undefined);
   mocks.issueSession.mockResolvedValue({ receipt: "signed-session" });
   mocks.buildHandoff.mockReturnValue({ schemaVersion: 3, consumerKind: "byo", provider: "codex", project });
   mocks.readConfig.mockReturnValue({
@@ -175,81 +180,23 @@ describe("context enable v3 command", () => {
     expect(mocks.enableOperation).not.toHaveBeenCalled();
     expect(mocks.issueSession).not.toHaveBeenCalled();
     expect(mocks.assertFingerprint).not.toHaveBeenCalled();
-    expect(mocks.getBinding).toHaveBeenCalledWith("org-a", { retry: false });
-    expect(mocks.fetchScope).toHaveBeenCalledWith({
-      provider: "github",
-      repo: "https://github.com/acme/context-tree.git",
-      branch: "main",
-    });
-  });
-
-  it("rejects a missing or non-regular root SCOPE before any setup mutation", async () => {
-    mocks.fetchScope.mockImplementationOnce(() => {
-      throw new Error("Root SCOPE.md is missing or is not a regular file.");
-    });
-
-    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
-      code: "CONTEXT_ENABLE_SCOPE_MISSING",
-    });
-    expect(output.fail).toHaveBeenCalledWith(
-      "CONTEXT_ENABLE_SCOPE_MISSING",
-      expect.stringContaining("must contain root SCOPE.md as a regular file"),
-      1,
-      { status: "scope" },
-    );
-    expectNoSetupMutation();
+    expect(mocks.preflightScope).toHaveBeenCalledWith(expect.anything(), "org-a");
   });
 
   it.each([
-    ["schema-invalid", new Error("SCOPE.md must contain YAML frontmatter.")],
-    ["non-UTF-8", new Error("Root SCOPE.md is not valid UTF-8.")],
-  ])("rejects %s root SCOPE before any setup mutation", async (_label, scopeError) => {
-    mocks.fetchScope.mockImplementationOnce(() => {
-      throw scopeError;
-    });
-
-    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
-      code: "CONTEXT_ENABLE_SCOPE_INVALID",
-    });
-    expect(output.fail).toHaveBeenCalledWith(
-      "CONTEXT_ENABLE_SCOPE_INVALID",
-      expect.stringContaining("valid UTF-8 and satisfy SCOPE schema version 1"),
-      1,
-      { status: "scope" },
+    ["authentication", "CONTEXT_ENABLE_SCOPE_AUTHENTICATION_REQUIRED", "authority", 3],
+    ["binding", "CONTEXT_ENABLE_BINDING_UNREADABLE", "binding", 1],
+    ["missing", "CONTEXT_ENABLE_SCOPE_MISSING", "scope", 1],
+    ["invalid", "CONTEXT_ENABLE_SCOPE_INVALID", "scope", 1],
+    ["fetch", "CONTEXT_ENABLE_SCOPE_FETCH_FAILED", "fetch", 6],
+  ] as const)("renders a stable %s preflight failure before any setup mutation", async (_label, code, stage, exitCode) => {
+    const message = `stable ${stage} guidance`;
+    mocks.preflightScope.mockRejectedValueOnce(
+      new ContextEnableScopePreflightError(code, message, { stage, exitCode }),
     );
-    expectNoSetupMutation();
-  });
 
-  it("rejects an unreadable binding before any setup mutation", async () => {
-    mocks.getBinding.mockResolvedValueOnce({ branch: "main" });
-
-    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
-      code: "CONTEXT_ENABLE_BINDING_UNREADABLE",
-    });
-    expect(mocks.fetchScope).not.toHaveBeenCalled();
-    expectNoSetupMutation();
-  });
-
-  it("rejects a root SCOPE fetch failure before any setup mutation", async () => {
-    mocks.fetchScope.mockImplementationOnce(() => {
-      throw new Error("git fetch failed with private upstream details");
-    });
-
-    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
-      code: "CONTEXT_ENABLE_SCOPE_FETCH_FAILED",
-    });
-    expect(output.fail.mock.calls[0]?.[1]).not.toContain("private upstream details");
-    expectNoSetupMutation();
-  });
-
-  it("returns a stable authentication error before any setup mutation", async () => {
-    mocks.getBinding.mockRejectedValueOnce(Object.assign(new Error("private credential detail"), { statusCode: 401 }));
-
-    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
-      code: "CONTEXT_ENABLE_SCOPE_AUTHENTICATION_REQUIRED",
-    });
-    expect(output.fail.mock.calls[0]?.[1]).not.toContain("private credential detail");
-    expect(mocks.fetchScope).not.toHaveBeenCalled();
+    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({ code });
+    expect(output.fail).toHaveBeenCalledWith(code, message, exitCode, { status: stage });
     expectNoSetupMutation();
   });
 
@@ -258,14 +205,18 @@ describe("context enable v3 command", () => {
     "session",
   ] as const)("rechecks root SCOPE on apply before %s setup can mutate state", async (scope) => {
     const planId = await createPlanId();
-    mocks.fetchScope.mockImplementationOnce(() => {
-      throw new Error("Root SCOPE.md is missing or is not a regular file.");
-    });
+    mocks.preflightScope.mockRejectedValueOnce(
+      new ContextEnableScopePreflightError(
+        "CONTEXT_ENABLE_SCOPE_MISSING",
+        "The selected Team's binding branch must contain root SCOPE.md as a regular file before Context setup can continue.",
+        { stage: "scope", exitCode: 1 },
+      ),
+    );
 
     await expect(runContextEnable(context({ scope, planId, yes: true }))).rejects.toMatchObject({
       code: "CONTEXT_ENABLE_SCOPE_MISSING",
     });
-    expect(mocks.fetchScope).toHaveBeenCalledTimes(2);
+    expect(mocks.preflightScope).toHaveBeenCalledTimes(2);
     expectNoSetupMutation();
   });
 

--- a/apps/cli/src/__tests__/context-enable-command.test.ts
+++ b/apps/cli/src/__tests__/context-enable-command.test.ts
@@ -25,6 +25,8 @@ const mocks = vi.hoisted(() => ({
   inspectLocation: vi.fn(),
   inspectRuntime: vi.fn(),
   inspectStore: vi.fn(),
+  fetchScope: vi.fn(),
+  getBinding: vi.fn(),
   issueSession: vi.fn(),
   planInstall: vi.fn(),
   readAccount: vi.fn(() => "client-1"),
@@ -75,9 +77,13 @@ vi.mock("../core/context-integration/release.js", () => ({
 vi.mock("../core/context-integration/runtime-health.js", () => ({
   inspectContextIntegrationRuntime: mocks.inspectRuntime,
 }));
+vi.mock("../core/context-integration/context-route.js", () => ({
+  fetchExactScope: mocks.fetchScope,
+}));
 vi.mock("../commands/_shared/member.js", () => ({
   createMemberSdk: () => ({
     validateMemberContextActivation: mocks.validateActivation,
+    getMemberContextTreeSetting: mocks.getBinding,
     issueMemberContextSessionCandidate: mocks.issueSession,
   }),
 }));
@@ -113,6 +119,15 @@ beforeEach(() => {
   });
   mocks.resolveRelease.mockReturnValue({ root: "/release", manifest: { release: "manifest" } });
   mocks.validateActivation.mockResolvedValue({ schemaVersion: 2, outcome: "connected", team });
+  mocks.getBinding.mockResolvedValue({
+    provider: "github",
+    repo: "https://github.com/acme/context-tree.git",
+    branch: "main",
+  });
+  mocks.fetchScope.mockReturnValue({
+    commit: "c".repeat(40),
+    scope: { schemaVersion: 1, relatedRepositories: [], body: "Team A context." },
+  });
   mocks.issueSession.mockResolvedValue({ receipt: "signed-session" });
   mocks.buildHandoff.mockReturnValue({ schemaVersion: 3, consumerKind: "byo", provider: "codex", project });
   mocks.readConfig.mockReturnValue({
@@ -160,6 +175,98 @@ describe("context enable v3 command", () => {
     expect(mocks.enableOperation).not.toHaveBeenCalled();
     expect(mocks.issueSession).not.toHaveBeenCalled();
     expect(mocks.assertFingerprint).not.toHaveBeenCalled();
+    expect(mocks.getBinding).toHaveBeenCalledWith("org-a", { retry: false });
+    expect(mocks.fetchScope).toHaveBeenCalledWith({
+      provider: "github",
+      repo: "https://github.com/acme/context-tree.git",
+      branch: "main",
+    });
+  });
+
+  it("rejects a missing or non-regular root SCOPE before any setup mutation", async () => {
+    mocks.fetchScope.mockImplementationOnce(() => {
+      throw new Error("Root SCOPE.md is missing or is not a regular file.");
+    });
+
+    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
+      code: "CONTEXT_ENABLE_SCOPE_MISSING",
+    });
+    expect(output.fail).toHaveBeenCalledWith(
+      "CONTEXT_ENABLE_SCOPE_MISSING",
+      expect.stringContaining("must contain root SCOPE.md as a regular file"),
+      1,
+      { status: "scope" },
+    );
+    expectNoSetupMutation();
+  });
+
+  it.each([
+    ["schema-invalid", new Error("SCOPE.md must contain YAML frontmatter.")],
+    ["non-UTF-8", new Error("Root SCOPE.md is not valid UTF-8.")],
+  ])("rejects %s root SCOPE before any setup mutation", async (_label, scopeError) => {
+    mocks.fetchScope.mockImplementationOnce(() => {
+      throw scopeError;
+    });
+
+    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
+      code: "CONTEXT_ENABLE_SCOPE_INVALID",
+    });
+    expect(output.fail).toHaveBeenCalledWith(
+      "CONTEXT_ENABLE_SCOPE_INVALID",
+      expect.stringContaining("valid UTF-8 and satisfy SCOPE schema version 1"),
+      1,
+      { status: "scope" },
+    );
+    expectNoSetupMutation();
+  });
+
+  it("rejects an unreadable binding before any setup mutation", async () => {
+    mocks.getBinding.mockResolvedValueOnce({ branch: "main" });
+
+    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
+      code: "CONTEXT_ENABLE_BINDING_UNREADABLE",
+    });
+    expect(mocks.fetchScope).not.toHaveBeenCalled();
+    expectNoSetupMutation();
+  });
+
+  it("rejects a root SCOPE fetch failure before any setup mutation", async () => {
+    mocks.fetchScope.mockImplementationOnce(() => {
+      throw new Error("git fetch failed with private upstream details");
+    });
+
+    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
+      code: "CONTEXT_ENABLE_SCOPE_FETCH_FAILED",
+    });
+    expect(output.fail.mock.calls[0]?.[1]).not.toContain("private upstream details");
+    expectNoSetupMutation();
+  });
+
+  it("returns a stable authentication error before any setup mutation", async () => {
+    mocks.getBinding.mockRejectedValueOnce(Object.assign(new Error("private credential detail"), { statusCode: 401 }));
+
+    await expect(runContextEnable(context({ plan: true }))).rejects.toMatchObject({
+      code: "CONTEXT_ENABLE_SCOPE_AUTHENTICATION_REQUIRED",
+    });
+    expect(output.fail.mock.calls[0]?.[1]).not.toContain("private credential detail");
+    expect(mocks.fetchScope).not.toHaveBeenCalled();
+    expectNoSetupMutation();
+  });
+
+  it.each([
+    "global",
+    "session",
+  ] as const)("rechecks root SCOPE on apply before %s setup can mutate state", async (scope) => {
+    const planId = await createPlanId();
+    mocks.fetchScope.mockImplementationOnce(() => {
+      throw new Error("Root SCOPE.md is missing or is not a regular file.");
+    });
+
+    await expect(runContextEnable(context({ scope, planId, yes: true }))).rejects.toMatchObject({
+      code: "CONTEXT_ENABLE_SCOPE_MISSING",
+    });
+    expect(mocks.fetchScope).toHaveBeenCalledTimes(2);
+    expectNoSetupMutation();
   });
 
   it("rejects setup before planning when the Core loader root is mutable", async () => {
@@ -517,6 +624,16 @@ async function createPlanId(): Promise<string> {
   output.result.mockClear();
   await runContextEnable(context({ plan: true }));
   return (output.result.mock.calls[0]?.[0] as { plan: { planId: string } }).plan.planId;
+}
+
+function expectNoSetupMutation(): void {
+  expect(mocks.enableOperation).not.toHaveBeenCalled();
+  expect(mocks.issueSession).not.toHaveBeenCalled();
+  expect(mocks.assertFingerprint).not.toHaveBeenCalled();
+  expect(mocks.createDriver).not.toHaveBeenCalled();
+  expect(mocks.registerPendingReload).not.toHaveBeenCalled();
+  expect(mocks.consumeReload).not.toHaveBeenCalled();
+  expect(mocks.buildHandoff).not.toHaveBeenCalled();
 }
 
 function readApplyCommand(kind: "global" | "directory" | "session"): string {

--- a/apps/cli/src/__tests__/context-enable-scope-preflight.test.ts
+++ b/apps/cli/src/__tests__/context-enable-scope-preflight.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchScope: vi.fn(),
+}));
+
+vi.mock("../core/context-integration/exact-root-scope.js", () => {
+  class ContextRootScopeError extends Error {
+    constructor(
+      readonly kind: "missing" | "invalid" | "fetch",
+      message: string,
+    ) {
+      super(message);
+    }
+  }
+  return { ContextRootScopeError, fetchExactScope: mocks.fetchScope };
+});
+
+import {
+  ContextEnableScopePreflightError,
+  type ContextEnableScopePreflightErrorCode,
+  preflightContextEnableScope,
+} from "../core/context-integration/context-enable-scope-preflight.js";
+import { ContextRootScopeError } from "../core/context-integration/exact-root-scope.js";
+
+const binding = {
+  provider: "github" as const,
+  repo: "https://github.com/acme/context-tree.git",
+  branch: "main",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("context enable root-SCOPE preflight", () => {
+  it("accepts a member-readable binding with a valid root SCOPE", async () => {
+    const getMemberContextTreeSetting = vi.fn().mockResolvedValue(binding);
+    mocks.fetchScope.mockReturnValueOnce({
+      commit: "a".repeat(40),
+      scope: { schemaVersion: 1, relatedRepositories: [], body: "Customer operations." },
+    });
+
+    await expect(preflightContextEnableScope({ getMemberContextTreeSetting }, "org-a")).resolves.toBeUndefined();
+    expect(getMemberContextTreeSetting).toHaveBeenCalledWith("org-a", { retry: false });
+    expect(mocks.fetchScope).toHaveBeenCalledWith(binding);
+  });
+
+  it("rejects an invalid member binding response before fetching SCOPE", async () => {
+    const error = await expectFailure(
+      preflightContextEnableScope(
+        { getMemberContextTreeSetting: vi.fn().mockResolvedValue({ branch: "main" }) },
+        "org-a",
+      ),
+      "CONTEXT_ENABLE_BINDING_UNREADABLE",
+    );
+
+    expect(error.stage).toBe("binding");
+    expect(error.exitCode).toBe(1);
+    expect(mocks.fetchScope).not.toHaveBeenCalled();
+  });
+
+  it("returns stable binding errors for unreadable and authentication failures", async () => {
+    const unreadable = await expectFailure(
+      preflightContextEnableScope(
+        {
+          getMemberContextTreeSetting: vi
+            .fn()
+            .mockRejectedValue(Object.assign(new Error("private upstream detail"), { statusCode: 503 })),
+        },
+        "org-a",
+      ),
+      "CONTEXT_ENABLE_BINDING_UNREADABLE",
+    );
+    expect(unreadable.message).not.toContain("private upstream detail");
+    expect(unreadable.stage).toBe("binding");
+
+    const authentication = await expectFailure(
+      preflightContextEnableScope(
+        {
+          getMemberContextTreeSetting: vi
+            .fn()
+            .mockRejectedValue(Object.assign(new Error("private credential detail"), { statusCode: 401 })),
+        },
+        "org-a",
+      ),
+      "CONTEXT_ENABLE_SCOPE_AUTHENTICATION_REQUIRED",
+    );
+    expect(authentication.message).not.toContain("private credential detail");
+    expect(authentication.stage).toBe("authority");
+    expect(authentication.exitCode).toBe(3);
+  });
+
+  it.each([
+    ["missing", "CONTEXT_ENABLE_SCOPE_MISSING", "scope", 1],
+    ["invalid", "CONTEXT_ENABLE_SCOPE_INVALID", "scope", 1],
+    ["fetch", "CONTEXT_ENABLE_SCOPE_FETCH_FAILED", "fetch", 6],
+  ] as const)("maps %s root SCOPE failures to the setup contract", async (kind, code, stage, exitCode) => {
+    mocks.fetchScope.mockImplementationOnce(() => {
+      throw new ContextRootScopeError(kind, "private exact-root detail");
+    });
+
+    const error = await expectFailure(
+      preflightContextEnableScope({ getMemberContextTreeSetting: vi.fn().mockResolvedValue(binding) }, "org-a"),
+      code,
+    );
+    expect(error.message).not.toContain("private exact-root detail");
+    expect(error.stage).toBe(stage);
+    expect(error.exitCode).toBe(exitCode);
+  });
+
+  it("maps unexpected exact-root failures to fetch failed", async () => {
+    mocks.fetchScope.mockImplementationOnce(() => {
+      throw new Error("private unexpected detail");
+    });
+
+    const error = await expectFailure(
+      preflightContextEnableScope({ getMemberContextTreeSetting: vi.fn().mockResolvedValue(binding) }, "org-a"),
+      "CONTEXT_ENABLE_SCOPE_FETCH_FAILED",
+    );
+    expect(error.message).not.toContain("private unexpected detail");
+    expect(error.stage).toBe("fetch");
+    expect(error.exitCode).toBe(6);
+  });
+});
+
+async function expectFailure(
+  promise: Promise<void>,
+  code: ContextEnableScopePreflightErrorCode,
+): Promise<ContextEnableScopePreflightError> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(ContextEnableScopePreflightError);
+    if (error instanceof ContextEnableScopePreflightError) {
+      expect(error.code).toBe(code);
+      return error;
+    }
+    throw error;
+  }
+  throw new Error(`Expected ContextEnableScopePreflightError with code ${code}.`);
+}

--- a/apps/cli/src/__tests__/context-route.test.ts
+++ b/apps/cli/src/__tests__/context-route.test.ts
@@ -3,11 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  fetchExactScope,
-  readContextRouteReceipt,
-  resolveContextRoute,
-} from "../core/context-integration/context-route.js";
+import { readContextRouteReceipt, resolveContextRoute } from "../core/context-integration/context-route.js";
 
 const SESSION_RECEIPT = "server-signed-session-candidate-receipt-value";
 const ACCOUNT_CLIENT_ID = "client_1234abcd";
@@ -156,24 +152,6 @@ describe("BYO SCOPE router", () => {
     expect(result.unavailable[0]?.reason).toContain("SCOPE.md");
     expect(result.selectionBlocked).toBe(true);
     expect(result.instruction).toContain("no remaining candidate may be selected automatically");
-  });
-
-  it("rejects an exact root SCOPE blob that is not valid UTF-8", () => {
-    const repository = tree("temporary");
-    writeFileSync(
-      join(repository, "SCOPE.md"),
-      Buffer.concat([Buffer.from("---\nschemaVersion: 1\n---\n", "utf8"), Buffer.from([0xc3, 0x28])]),
-    );
-    execFileSync("git", ["add", "SCOPE.md"], { cwd: repository });
-    execFileSync("git", ["commit", "-m", "invalid utf8 scope"], { cwd: repository });
-
-    expect(() =>
-      fetchExactScope({
-        provider: "github",
-        repo: repository,
-        branch: "main",
-      }),
-    ).toThrow("Root SCOPE.md is not valid UTF-8");
   });
 
   it("blocks automatic selection when one peer is readable and another is unavailable", async () => {

--- a/apps/cli/src/__tests__/exact-root-scope.test.ts
+++ b/apps/cli/src/__tests__/exact-root-scope.test.ts
@@ -1,0 +1,124 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CONTEXT_TREE_SCOPE_MAX_BYTES } from "@first-tree/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ContextRootScopeError,
+  type ContextRootScopeErrorKind,
+  fetchExactScope,
+} from "../core/context-integration/exact-root-scope.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("exact root SCOPE reader", () => {
+  it("returns the exact commit and parsed root SCOPE", () => {
+    const repository = createRepository();
+    writeFileSync(join(repository, "SCOPE.md"), "---\nschemaVersion: 1\n---\n\nCustomer operations.\n");
+    commitAll(repository, "valid scope");
+
+    expect(fetchScope(repository)).toMatchObject({
+      commit: expect.stringMatching(/^[0-9a-f]{40,64}$/u),
+      scope: { schemaVersion: 1, relatedRepositories: [], body: "Customer operations." },
+    });
+  });
+
+  it("classifies a missing root SCOPE as missing", () => {
+    const repository = createRepository();
+    writeFileSync(join(repository, "README.md"), "No root scope.\n");
+    commitAll(repository, "missing scope");
+
+    expectFailure(() => fetchScope(repository), "missing");
+  });
+
+  it("classifies a non-regular root SCOPE as missing", () => {
+    const repository = createRepository();
+    writeFileSync(join(repository, "scope-target.md"), "---\nschemaVersion: 1\n---\n\nLinked scope.\n");
+    symlinkSync("scope-target.md", join(repository, "SCOPE.md"));
+    commitAll(repository, "linked scope");
+
+    expectFailure(() => fetchScope(repository), "missing");
+  });
+
+  it("classifies oversized content before reading the blob", () => {
+    const repository = createRepository();
+    writeFileSync(
+      join(repository, "SCOPE.md"),
+      `---\nschemaVersion: 1\n---\n\n${"x".repeat(CONTEXT_TREE_SCOPE_MAX_BYTES)}`,
+    );
+    commitAll(repository, "oversized scope");
+
+    const error = expectFailure(() => fetchScope(repository), "invalid");
+    expect(error.message).toContain(`${CONTEXT_TREE_SCOPE_MAX_BYTES}-byte limit`);
+  });
+
+  it("classifies non-UTF-8 content as invalid", () => {
+    const repository = createRepository();
+    writeFileSync(
+      join(repository, "SCOPE.md"),
+      Buffer.concat([Buffer.from("---\nschemaVersion: 1\n---\n", "utf8"), Buffer.from([0xc3, 0x28])]),
+    );
+    commitAll(repository, "non-utf8 scope");
+
+    expectFailure(() => fetchScope(repository), "invalid");
+  });
+
+  it("classifies schema-invalid content as invalid", () => {
+    const repository = createRepository();
+    writeFileSync(join(repository, "SCOPE.md"), "No frontmatter.\n");
+    commitAll(repository, "invalid scope");
+
+    expectFailure(() => fetchScope(repository), "invalid");
+  });
+
+  it("classifies repository and branch failures as fetch failures", () => {
+    const repository = createRepository();
+
+    expectFailure(
+      () =>
+        fetchExactScope({
+          provider: "github",
+          repo: repository,
+          branch: "missing-branch",
+        }),
+      "fetch",
+    );
+  });
+});
+
+function createRepository(): string {
+  const root = mkdtempSync(join(tmpdir(), "exact-root-scope-"));
+  roots.push(root);
+  execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: root });
+  return root;
+}
+
+function commitAll(repository: string, message: string): void {
+  execFileSync("git", ["add", "."], { cwd: repository });
+  execFileSync("git", ["commit", "-m", message], { cwd: repository, stdio: "ignore" });
+}
+
+function fetchScope(repository: string): ReturnType<typeof fetchExactScope> {
+  return fetchExactScope({ provider: "github", repo: repository, branch: "main" });
+}
+
+function expectFailure(action: () => unknown, kind: ContextRootScopeErrorKind): ContextRootScopeError {
+  try {
+    action();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ContextRootScopeError);
+    if (error instanceof ContextRootScopeError) {
+      expect(error.kind).toBe(kind);
+      return error;
+    }
+    throw error;
+  }
+  throw new Error(`Expected ContextRootScopeError with kind ${kind}.`);
+}

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -1,5 +1,10 @@
 import { createHash } from "node:crypto";
-import type { ContextActivationScope, ContextIntegrationGrant, ContextIntegrationProvider } from "@first-tree/shared";
+import {
+  type ContextActivationScope,
+  type ContextIntegrationGrant,
+  type ContextIntegrationProvider,
+  contextTreeActiveBindingSchema,
+} from "@first-tree/shared";
 import { confirm } from "@inquirer/prompts";
 import type { Command } from "commander";
 import {
@@ -21,6 +26,7 @@ import {
   inspectContextGrantStore,
   readContextIntegrationConfig,
 } from "../../core/context-integration/context-binding-store.js";
+import { fetchExactScope } from "../../core/context-integration/context-route.js";
 import {
   buildCurrentSessionHandoff,
   type CurrentSessionHandoff,
@@ -30,6 +36,7 @@ import { enableContextIntegrationOperation } from "../../core/context-integratio
 import { providerPluginRoot, resolveContextIntegrationRelease } from "../../core/context-integration/release.js";
 import { inspectContextIntegrationRuntime } from "../../core/context-integration/runtime-health.js";
 import { buildContextSetupChoices, type ContextSetupChoice } from "../../core/context-integration/setup-plan.js";
+import { classifyContextTreeReadError } from "../../core/context-tree-binding.js";
 import { print } from "../../core/output.js";
 import { createMemberSdk } from "../_shared/member.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
@@ -180,6 +187,7 @@ async function buildSetupPlan(
   if (activation.outcome !== "connected") {
     print.fail(activation.reasonCode, activation.nextAction.message, 1);
   }
+  await verifyRootScopeReadiness(sdk, activation.team.organizationId);
   // Verify the exact immutable Core root during planning. Every apply rebuilds
   // this plan, so an unusable loader is rejected before setup mutates state or
   // returns a handoff that cannot load its canonical workflow.
@@ -233,6 +241,76 @@ async function buildSetupPlan(
     }),
     [setupPlanAccountClientId]: accountClientId,
   };
+}
+
+async function verifyRootScopeReadiness(
+  sdk: ReturnType<typeof createMemberSdk>,
+  organizationId: string,
+): Promise<void> {
+  let rawBinding: unknown;
+  try {
+    rawBinding = await sdk.getMemberContextTreeSetting(organizationId, { retry: false });
+  } catch (error) {
+    const classified = classifyContextTreeReadError(error);
+    if (classified.category === "authentication") {
+      print.fail(
+        "CONTEXT_ENABLE_SCOPE_AUTHENTICATION_REQUIRED",
+        "Authentication failed while checking the selected Team's Context Tree readiness. Sign in again and retry.",
+        3,
+        { status: "authority" },
+      );
+    }
+    print.fail(
+      "CONTEXT_ENABLE_BINDING_UNREADABLE",
+      "The selected Team's current Context Tree binding could not be read online. Confirm active membership and repair the binding before retrying.",
+      classified.exitCode,
+      { status: "binding" },
+    );
+  }
+
+  const binding = contextTreeActiveBindingSchema.safeParse(rawBinding);
+  const currentBinding = binding.data;
+  if (currentBinding === undefined) {
+    print.fail(
+      "CONTEXT_ENABLE_BINDING_UNREADABLE",
+      "The selected Team does not have a readable current Context Tree binding. Repair the binding before retrying.",
+      1,
+      { status: "binding" },
+    );
+    throw new Error("unreachable");
+  }
+
+  try {
+    fetchExactScope(currentBinding);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    if (errorMessage === "Root SCOPE.md is missing or is not a regular file.") {
+      print.fail(
+        "CONTEXT_ENABLE_SCOPE_MISSING",
+        "The selected Team's binding branch must contain root SCOPE.md as a regular file before Context setup can continue.",
+        1,
+        { status: "scope" },
+      );
+    }
+    if (
+      errorMessage === "Root SCOPE.md is not valid UTF-8." ||
+      errorMessage.startsWith("SCOPE.md ") ||
+      (typeof error === "object" && error !== null && Reflect.get(error, "name") === "ZodError")
+    ) {
+      print.fail(
+        "CONTEXT_ENABLE_SCOPE_INVALID",
+        "The selected Team's root SCOPE.md must be valid UTF-8 and satisfy SCOPE schema version 1. Repair it and retry Context setup.",
+        1,
+        { status: "scope" },
+      );
+    }
+    print.fail(
+      "CONTEXT_ENABLE_SCOPE_FETCH_FAILED",
+      "Could not fetch root SCOPE.md from the selected Team's current binding. Confirm repository access, network connectivity, and the bound branch, then retry.",
+      6,
+      { status: "fetch" },
+    );
+  }
 }
 
 function parseActivationScope(scope: string, plan: SetupPlan): ContextActivationScope {

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -1,10 +1,5 @@
 import { createHash } from "node:crypto";
-import {
-  type ContextActivationScope,
-  type ContextIntegrationGrant,
-  type ContextIntegrationProvider,
-  contextTreeActiveBindingSchema,
-} from "@first-tree/shared";
+import type { ContextActivationScope, ContextIntegrationGrant, ContextIntegrationProvider } from "@first-tree/shared";
 import { confirm } from "@inquirer/prompts";
 import type { Command } from "commander";
 import {
@@ -26,7 +21,10 @@ import {
   inspectContextGrantStore,
   readContextIntegrationConfig,
 } from "../../core/context-integration/context-binding-store.js";
-import { fetchExactScope } from "../../core/context-integration/context-route.js";
+import {
+  ContextEnableScopePreflightError,
+  preflightContextEnableScope,
+} from "../../core/context-integration/context-enable-scope-preflight.js";
 import {
   buildCurrentSessionHandoff,
   type CurrentSessionHandoff,
@@ -36,7 +34,6 @@ import { enableContextIntegrationOperation } from "../../core/context-integratio
 import { providerPluginRoot, resolveContextIntegrationRelease } from "../../core/context-integration/release.js";
 import { inspectContextIntegrationRuntime } from "../../core/context-integration/runtime-health.js";
 import { buildContextSetupChoices, type ContextSetupChoice } from "../../core/context-integration/setup-plan.js";
-import { classifyContextTreeReadError } from "../../core/context-tree-binding.js";
 import { print } from "../../core/output.js";
 import { createMemberSdk } from "../_shared/member.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
@@ -187,7 +184,14 @@ async function buildSetupPlan(
   if (activation.outcome !== "connected") {
     print.fail(activation.reasonCode, activation.nextAction.message, 1);
   }
-  await verifyRootScopeReadiness(sdk, activation.team.organizationId);
+  try {
+    await preflightContextEnableScope(sdk, activation.team.organizationId);
+  } catch (error) {
+    if (error instanceof ContextEnableScopePreflightError) {
+      print.fail(error.code, error.message, error.exitCode, { status: error.stage });
+    }
+    throw error;
+  }
   // Verify the exact immutable Core root during planning. Every apply rebuilds
   // this plan, so an unusable loader is rejected before setup mutates state or
   // returns a handoff that cannot load its canonical workflow.
@@ -241,76 +245,6 @@ async function buildSetupPlan(
     }),
     [setupPlanAccountClientId]: accountClientId,
   };
-}
-
-async function verifyRootScopeReadiness(
-  sdk: ReturnType<typeof createMemberSdk>,
-  organizationId: string,
-): Promise<void> {
-  let rawBinding: unknown;
-  try {
-    rawBinding = await sdk.getMemberContextTreeSetting(organizationId, { retry: false });
-  } catch (error) {
-    const classified = classifyContextTreeReadError(error);
-    if (classified.category === "authentication") {
-      print.fail(
-        "CONTEXT_ENABLE_SCOPE_AUTHENTICATION_REQUIRED",
-        "Authentication failed while checking the selected Team's Context Tree readiness. Sign in again and retry.",
-        3,
-        { status: "authority" },
-      );
-    }
-    print.fail(
-      "CONTEXT_ENABLE_BINDING_UNREADABLE",
-      "The selected Team's current Context Tree binding could not be read online. Confirm active membership and repair the binding before retrying.",
-      classified.exitCode,
-      { status: "binding" },
-    );
-  }
-
-  const binding = contextTreeActiveBindingSchema.safeParse(rawBinding);
-  const currentBinding = binding.data;
-  if (currentBinding === undefined) {
-    print.fail(
-      "CONTEXT_ENABLE_BINDING_UNREADABLE",
-      "The selected Team does not have a readable current Context Tree binding. Repair the binding before retrying.",
-      1,
-      { status: "binding" },
-    );
-    throw new Error("unreachable");
-  }
-
-  try {
-    fetchExactScope(currentBinding);
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    if (errorMessage === "Root SCOPE.md is missing or is not a regular file.") {
-      print.fail(
-        "CONTEXT_ENABLE_SCOPE_MISSING",
-        "The selected Team's binding branch must contain root SCOPE.md as a regular file before Context setup can continue.",
-        1,
-        { status: "scope" },
-      );
-    }
-    if (
-      errorMessage === "Root SCOPE.md is not valid UTF-8." ||
-      errorMessage.startsWith("SCOPE.md ") ||
-      (typeof error === "object" && error !== null && Reflect.get(error, "name") === "ZodError")
-    ) {
-      print.fail(
-        "CONTEXT_ENABLE_SCOPE_INVALID",
-        "The selected Team's root SCOPE.md must be valid UTF-8 and satisfy SCOPE schema version 1. Repair it and retry Context setup.",
-        1,
-        { status: "scope" },
-      );
-    }
-    print.fail(
-      "CONTEXT_ENABLE_SCOPE_FETCH_FAILED",
-      "Could not fetch root SCOPE.md from the selected Team's current binding. Confirm repository access, network connectivity, and the bound branch, then retry.",
-      6,
-      { status: "fetch" },
-    );
-  }
 }
 
 function parseActivationScope(scope: string, plan: SetupPlan): ContextActivationScope {

--- a/apps/cli/src/core/context-integration/context-enable-scope-preflight.ts
+++ b/apps/cli/src/core/context-integration/context-enable-scope-preflight.ts
@@ -1,0 +1,119 @@
+import { contextTreeActiveBindingSchema } from "@first-tree/shared";
+import { classifyContextTreeReadError } from "../context-tree-binding.js";
+import { ContextRootScopeError, fetchExactScope } from "./exact-root-scope.js";
+
+export type ContextEnableScopePreflightErrorCode =
+  | "CONTEXT_ENABLE_SCOPE_AUTHENTICATION_REQUIRED"
+  | "CONTEXT_ENABLE_BINDING_UNREADABLE"
+  | "CONTEXT_ENABLE_SCOPE_MISSING"
+  | "CONTEXT_ENABLE_SCOPE_INVALID"
+  | "CONTEXT_ENABLE_SCOPE_FETCH_FAILED";
+
+export type ContextEnableScopePreflightStage = "authority" | "binding" | "scope" | "fetch";
+
+export type ContextEnableScopePreflightReader = {
+  getMemberContextTreeSetting(teamId: string, options: { retry: false }): Promise<unknown>;
+};
+
+type ContextEnableScopePreflightErrorOptions = {
+  stage: ContextEnableScopePreflightStage;
+  exitCode: 1 | 3 | 6;
+  httpStatus?: number;
+  cause?: unknown;
+};
+
+export class ContextEnableScopePreflightError extends Error {
+  readonly stage: ContextEnableScopePreflightStage;
+  readonly exitCode: 1 | 3 | 6;
+  readonly httpStatus?: number;
+
+  constructor(
+    readonly code: ContextEnableScopePreflightErrorCode,
+    message: string,
+    options: ContextEnableScopePreflightErrorOptions,
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "ContextEnableScopePreflightError";
+    this.stage = options.stage;
+    this.exitCode = options.exitCode;
+    this.httpStatus = options.httpStatus;
+  }
+}
+
+/** Verify the selected Team's minimum root-SCOPE routing preconditions without mutation. */
+export async function preflightContextEnableScope(
+  reader: ContextEnableScopePreflightReader,
+  teamId: string,
+): Promise<void> {
+  let rawBinding: unknown;
+  try {
+    rawBinding = await reader.getMemberContextTreeSetting(teamId, { retry: false });
+  } catch (error) {
+    throw bindingReadFailure(error);
+  }
+
+  const binding = contextTreeActiveBindingSchema.safeParse(rawBinding);
+  if (!binding.success) {
+    throw new ContextEnableScopePreflightError(
+      "CONTEXT_ENABLE_BINDING_UNREADABLE",
+      "The selected Team does not have a readable current Context Tree binding. Repair the binding before retrying.",
+      { stage: "binding", exitCode: 1, cause: binding.error },
+    );
+  }
+
+  try {
+    fetchExactScope(binding.data);
+  } catch (error) {
+    throw rootScopeFailure(error);
+  }
+}
+
+function bindingReadFailure(error: unknown): ContextEnableScopePreflightError {
+  const classified = classifyContextTreeReadError(error);
+  if (classified.category === "authentication") {
+    return new ContextEnableScopePreflightError(
+      "CONTEXT_ENABLE_SCOPE_AUTHENTICATION_REQUIRED",
+      "Authentication failed while checking the selected Team's Context Tree readiness. Sign in again and retry.",
+      {
+        stage: "authority",
+        exitCode: 3,
+        ...(classified.httpStatus === undefined ? {} : { httpStatus: classified.httpStatus }),
+        cause: error,
+      },
+    );
+  }
+  return new ContextEnableScopePreflightError(
+    "CONTEXT_ENABLE_BINDING_UNREADABLE",
+    "The selected Team's current Context Tree binding could not be read online. Confirm active membership and repair the binding before retrying.",
+    {
+      stage: "binding",
+      exitCode: classified.exitCode,
+      ...(classified.httpStatus === undefined ? {} : { httpStatus: classified.httpStatus }),
+      cause: error,
+    },
+  );
+}
+
+function rootScopeFailure(error: unknown): ContextEnableScopePreflightError {
+  if (error instanceof ContextRootScopeError) {
+    if (error.kind === "missing") {
+      return new ContextEnableScopePreflightError(
+        "CONTEXT_ENABLE_SCOPE_MISSING",
+        "The selected Team's binding branch must contain root SCOPE.md as a regular file before Context setup can continue.",
+        { stage: "scope", exitCode: 1, cause: error },
+      );
+    }
+    if (error.kind === "invalid") {
+      return new ContextEnableScopePreflightError(
+        "CONTEXT_ENABLE_SCOPE_INVALID",
+        "The selected Team's root SCOPE.md must be valid UTF-8 and satisfy SCOPE schema version 1. Repair it and retry Context setup.",
+        { stage: "scope", exitCode: 1, cause: error },
+      );
+    }
+  }
+  return new ContextEnableScopePreflightError(
+    "CONTEXT_ENABLE_SCOPE_FETCH_FAILED",
+    "Could not fetch root SCOPE.md from the selected Team's current binding. Confirm repository access, network connectivity, and the bound branch, then retry.",
+    { stage: "fetch", exitCode: 6, cause: error },
+  );
+}

--- a/apps/cli/src/core/context-integration/context-route.ts
+++ b/apps/cli/src/core/context-integration/context-route.ts
@@ -1,7 +1,5 @@
-import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   type ContextIntegrationProject,
@@ -19,6 +17,7 @@ import { z } from "zod";
 import { readActiveContextAccountClientId } from "./account-state-guard.js";
 import { assertContextAdapterReadyForRouting } from "./adapter-observation.js";
 import { resolveContextGrantCandidates } from "./context-binding-store.js";
+import { fetchExactScope } from "./exact-root-scope.js";
 
 const ROUTE_RECEIPT_TTL_MS = 24 * 60 * 60_000;
 const EXACT_COMMIT_RE = /^[0-9a-f]{40,64}$/u;
@@ -288,42 +287,6 @@ export function readContextRouteReceipt(
   return parsed;
 }
 
-export function fetchExactScope(binding: ContextTreeActiveBinding): {
-  commit: string;
-  scope: ContextRouteCandidate["scope"];
-} {
-  const root = mkdtempSync(join(tmpdir(), "first-tree-scope-"));
-  try {
-    git(root, ["init", "--quiet"]);
-    git(root, ["remote", "add", "origin", binding.repo]);
-    git(root, ["fetch", "--no-tags", "--depth=1", "origin", `refs/heads/${binding.branch}`]);
-    const commit = git(root, ["rev-parse", "--verify", "FETCH_HEAD^{commit}"]).toLowerCase();
-    if (!EXACT_COMMIT_RE.test(commit)) throw new Error("Context Tree branch did not resolve to an exact commit.");
-    const entry = git(root, ["ls-tree", commit, "--", "SCOPE.md"]);
-    if (!/^(100644|100755) blob [0-9a-f]{40,64}\tSCOPE\.md$/u.test(entry)) {
-      throw new Error("Root SCOPE.md is missing or is not a regular file.");
-    }
-    const scopeBytes = gitBytes(root, ["show", `${commit}:SCOPE.md`], 16 * 1024 + 1);
-    let markdown: string;
-    try {
-      markdown = new TextDecoder("utf-8", { fatal: true }).decode(scopeBytes);
-    } catch (error) {
-      throw new Error("Root SCOPE.md is not valid UTF-8.", { cause: error });
-    }
-    const parsed = parseContextTreeScopeMarkdown(markdown);
-    return {
-      commit,
-      scope: {
-        schemaVersion: 1,
-        relatedRepositories: parsed.frontmatter.relatedRepositories ?? [],
-        body: parsed.body,
-      },
-    };
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-}
-
 function writeRouteReceipt(candidate: ContextRouteCandidate): void {
   const path = routeReceiptPath(candidate.candidateId);
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
@@ -353,25 +316,6 @@ function parseConnectedActivation(value: unknown): { team: { displayName: string
     throw new Error("Team activation response is incomplete.");
   }
   return { team: { displayName: String(Reflect.get(team, "displayName")), role: String(Reflect.get(team, "role")) } };
-}
-
-function git(cwd: string, args: readonly string[], maxBuffer = 1024 * 1024): string {
-  return execFileSync("git", args, {
-    cwd,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    maxBuffer,
-    timeout: 30_000,
-  }).trim();
-}
-
-function gitBytes(cwd: string, args: readonly string[], maxBuffer: number): Buffer {
-  return execFileSync("git", args, {
-    cwd,
-    stdio: ["ignore", "pipe", "pipe"],
-    maxBuffer,
-    timeout: 30_000,
-  });
 }
 
 function message(error: unknown): string {

--- a/apps/cli/src/core/context-integration/exact-root-scope.ts
+++ b/apps/cli/src/core/context-integration/exact-root-scope.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CONTEXT_TREE_SCOPE_MAX_BYTES,
+  type ContextTreeActiveBinding,
+  parseContextTreeScopeMarkdown,
+} from "@first-tree/shared";
+
+const EXACT_COMMIT_RE = /^[0-9a-f]{40,64}$/u;
+const ROOT_SCOPE_ENTRY_RE = /^(100644|100755) blob ([0-9a-f]{40,64})\tSCOPE\.md$/u;
+
+export type ContextRootScopeErrorKind = "missing" | "invalid" | "fetch";
+
+export type ExactRootScope = {
+  commit: string;
+  scope: { schemaVersion: 1; relatedRepositories: string[]; body: string };
+};
+
+export class ContextRootScopeError extends Error {
+  constructor(
+    readonly kind: ContextRootScopeErrorKind,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "ContextRootScopeError";
+  }
+}
+
+/** Fetch and validate only the exact root SCOPE.md from the binding branch. */
+export function fetchExactScope(binding: ContextTreeActiveBinding): ExactRootScope {
+  let root: string;
+  try {
+    root = mkdtempSync(join(tmpdir(), "first-tree-scope-"));
+  } catch (error) {
+    throw fetchFailure(error);
+  }
+
+  try {
+    git(root, ["init", "--quiet"]);
+    git(root, ["remote", "add", "origin", binding.repo]);
+    git(root, ["fetch", "--no-tags", "--depth=1", "origin", `refs/heads/${binding.branch}`]);
+    const commit = git(root, ["rev-parse", "--verify", "FETCH_HEAD^{commit}"]).toLowerCase();
+    if (!EXACT_COMMIT_RE.test(commit)) throw fetchFailure();
+
+    const entry = ROOT_SCOPE_ENTRY_RE.exec(git(root, ["ls-tree", commit, "--", "SCOPE.md"]));
+    const objectId = entry?.[2];
+    if (!objectId) {
+      throw new ContextRootScopeError("missing", "Root SCOPE.md is missing or is not a regular file.");
+    }
+
+    const size = Number(git(root, ["cat-file", "-s", objectId]));
+    if (!Number.isSafeInteger(size) || size < 0) throw fetchFailure();
+    if (size > CONTEXT_TREE_SCOPE_MAX_BYTES) {
+      throw new ContextRootScopeError(
+        "invalid",
+        `Root SCOPE.md exceeds the ${CONTEXT_TREE_SCOPE_MAX_BYTES}-byte limit.`,
+      );
+    }
+
+    const scopeBytes = gitBytes(root, ["cat-file", "blob", objectId], CONTEXT_TREE_SCOPE_MAX_BYTES + 1);
+    let markdown: string;
+    try {
+      markdown = new TextDecoder("utf-8", { fatal: true }).decode(scopeBytes);
+    } catch (error) {
+      throw new ContextRootScopeError("invalid", "Root SCOPE.md is not valid UTF-8.", { cause: error });
+    }
+
+    let parsed: ReturnType<typeof parseContextTreeScopeMarkdown>;
+    try {
+      parsed = parseContextTreeScopeMarkdown(markdown);
+    } catch (error) {
+      throw new ContextRootScopeError("invalid", "Root SCOPE.md does not satisfy SCOPE schema version 1.", {
+        cause: error,
+      });
+    }
+
+    return {
+      commit,
+      scope: {
+        schemaVersion: 1,
+        relatedRepositories: parsed.frontmatter.relatedRepositories ?? [],
+        body: parsed.body,
+      },
+    };
+  } catch (error) {
+    if (error instanceof ContextRootScopeError) throw error;
+    throw fetchFailure(error);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function fetchFailure(cause?: unknown): ContextRootScopeError {
+  return new ContextRootScopeError(
+    "fetch",
+    "Could not fetch exact root SCOPE.md from the Context Tree binding.",
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+function git(cwd: string, args: readonly string[], maxBuffer = 1024 * 1024): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer,
+    timeout: 30_000,
+  }).trim();
+}
+
+function gitBytes(cwd: string, args: readonly string[], maxBuffer: number): Buffer {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer,
+    timeout: 30_000,
+  });
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1231,6 +1231,15 @@ choices:
 - `directory`: make it eligible under the displayed canonical directory;
 - `session`: use it only now, without a Plugin, Hook or persistent grant.
 
+Before returning those choices, the CLI validates live Team activation, reads
+that member's current Tree binding, and fetches only the binding branch's exact
+root `SCOPE.md`. The probe requires a regular UTF-8 file that satisfies the
+current SCOPE schema. It does not read or materialize the full Context Tree.
+Missing, invalid, unreadable, authentication-blocked, or fetch-failed SCOPE
+readiness stops planning before any Plugin, persistent grant, or session-only
+candidate receipt can be created. Apply rebuilds the plan and repeats this
+probe before mutation.
+
 Every available choice includes an authoritative `applyCommand` that is ready
 to execute unchanged. It pins the channel-appropriate executable (the portable
 CLI path outside development), provider, Team, canonical `--project-root` or

--- a/docs/context-integration.md
+++ b/docs/context-integration.md
@@ -105,6 +105,14 @@ grants. It does not preselect or inject a Team's full Context. SessionStart
 handles startup, resume, clear and compact, but session-only deliberately does
 not survive those lifecycle boundaries.
 
+`context enable --plan` is also the local BYO readiness boundary. After live
+Team activation, it reads the member-safe current binding and uses the same
+exact root `SCOPE.md` fetch and parser as task routing. The probe verifies a
+regular UTF-8 file against the current schema; it does not read or materialize
+the rest of the Tree. Failure returns before Plugin installation/update,
+persistent grant writes, or session candidate receipt issuance. Apply rebuilds
+the plan, so it repeats the same readiness check immediately before setup.
+
 ## Per-task Team routing
 
 Every new BYO task starts with the hidden `context route` boundary. Candidate


### PR DESCRIPTION
## Summary

- gate `first-tree context enable --plan` on the selected Team's live member-safe Context Tree binding
- reuse one canonical exact root `SCOPE.md` reader for setup and task routing
- validate regular-file mode, bounded blob size, UTF-8, and the current SCOPE schema before setup choices
- return stable, sanitized CLI errors for authentication, binding, missing/invalid SCOPE, and fetch failures
- prove plan and apply failures occur before Plugin/grant mutation or session candidate receipt issuance
- document that the local preflight reads only root `SCOPE.md`, not the full Tree

## Why

The Web setup flow intentionally uses coarse binding eligibility. A Team with a bound Tree but a missing or invalid root `SCOPE.md` could therefore reach CLI setup choices and mutate local activation state before task routing discovered that the Tree was unusable.

The CLI plan is the correct local preflight seam. Apply already rebuilds that plan, so the same check also protects the mutation path without adding Server state, endpoints, or Web polling.

## Design

- `exact-root-scope.ts` owns the Git fetch, exact commit/root blob lookup, bounded size check, UTF-8 decode, schema parse, cleanup, and typed `missing | invalid | fetch` failures.
- `context-enable-scope-preflight.ts` owns the member binding read and maps binding/root failures to the stable `CONTEXT_ENABLE_*` CLI contract.
- `enable.ts` remains thin: it invokes the preflight after live Team activation and renders typed errors.

## Impact

BYO Context setup now fails early with actionable errors until the selected Team's exact root `SCOPE.md` is readable and valid. Oversized SCOPE content is reported as invalid rather than as a repository/network failure. Web eligibility behavior, provider selection, onboarding completion, write confirmation, and the wider architecture are unchanged.

## Validation

- `pnpm --filter ./apps/cli exec vitest run src/__tests__/exact-root-scope.test.ts src/__tests__/context-enable-scope-preflight.test.ts src/__tests__/context-enable-command.test.ts src/__tests__/context-route.test.ts` (44 tests passed)
- packaged-CLI focused-local E2E: valid, missing, nonregular, invalid, non-UTF-8, oversized, binding-invalid/unreadable, auth, fetch, and plan/apply recheck paths passed; failure paths produced no Plugin, grant, BYO repo, or session receipt mutation
- `pnpm check`
- `pnpm typecheck`
- `pnpm test` was attempted; the parallel monorepo run hit the pre-existing 10-second build-hook timeout in `tests/context-policy-runtime-layout.test.ts`. The same suite passed standalone (5/5).
