### PR TITLE
refactor(client): S1c close CLI session-internals boundary

### DIFF
--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -52,7 +52,6 @@ const coreMocks = vi.hoisted(() => ({
 
 const clientMocks = vi.hoisted(() => ({
   cleanAgentWorkspaces: vi.fn(),
-  DEFAULT_WORKSPACE_TTL_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 const localAgentMocks = vi.hoisted(() => ({

--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -51,8 +51,8 @@ const coreMocks = vi.hoisted(() => ({
 }));
 
 const clientMocks = vi.hoisted(() => ({
-  SessionRegistry: vi.fn(),
-  cleanWorkspaces: vi.fn(),
+  cleanAgentWorkspaces: vi.fn(),
+  DEFAULT_WORKSPACE_TTL_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 const localAgentMocks = vi.hoisted(() => ({
@@ -145,8 +145,7 @@ beforeEach(() => {
     unitPath: "/tmp/unit.plist",
     state: "active",
   });
-  clientMocks.SessionRegistry.mockImplementation(() => ({ load: vi.fn(() => new Map()) }));
-  clientMocks.cleanWorkspaces.mockReturnValue([]);
+  clientMocks.cleanAgentWorkspaces.mockReturnValue({ kind: "cleaned", removed: [] });
   localAgentMocks.createSdk.mockReturnValue({
     addChatParticipant: vi.fn(async () => [{ agentId: "agent-2" }]),
     listChats: vi.fn(async () => ({ items: [], nextCursor: null })),
@@ -482,32 +481,29 @@ describe("agent admin and local commands", () => {
   });
 
   it("cleans workspaces across all agents or one agent", async () => {
-    const workspaces = join(tempDir, "data", "workspaces");
-    mkdirSync(join(workspaces, "nova"), { recursive: true });
-    mkdirSync(join(workspaces, "mira"), { recursive: true });
-    clientMocks.SessionRegistry.mockImplementation(() => ({
-      load: vi.fn(
-        () =>
-          new Map([
-            ["chat-active", { status: "active" }],
-            ["chat-evicted", { status: "evicted" }],
-          ]),
-      ),
-    }));
-    clientMocks.cleanWorkspaces.mockReturnValueOnce(["chat-old"]).mockReturnValueOnce([]);
+    clientMocks.cleanAgentWorkspaces.mockReturnValueOnce({
+      kind: "cleaned",
+      removed: [{ agentName: "nova", chatId: "chat-old" }],
+    });
 
     await runAgent(["workspace", "clean", "--ttl", "3"]);
-    expect(clientMocks.cleanWorkspaces).toHaveBeenCalledWith(
-      join(workspaces, "nova"),
-      new Set(["chat-active"]),
-      3 * 24 * 60 * 60 * 1000,
-    );
+    expect(clientMocks.cleanAgentWorkspaces).toHaveBeenCalledTimes(1);
+    expect(clientMocks.cleanAgentWorkspaces).toHaveBeenCalledWith({
+      agentName: undefined,
+      ttlMs: 3 * 24 * 60 * 60 * 1000,
+    });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Removed: nova/chat-old");
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("1 workspace(s) cleaned");
 
+    clientMocks.cleanAgentWorkspaces.mockReturnValueOnce({ kind: "cleaned", removed: [] });
     await runAgent(["workspace", "clean", "missing"]);
+    expect(clientMocks.cleanAgentWorkspaces).toHaveBeenLastCalledWith({
+      agentName: "missing",
+      ttlMs: 7 * 24 * 60 * 60 * 1000,
+    });
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("0 workspace(s) cleaned");
 
-    rmSync(workspaces, { recursive: true, force: true });
+    clientMocks.cleanAgentWorkspaces.mockReturnValueOnce({ kind: "missing-root" });
     await runAgent(["workspace", "clean"]);
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("No workspaces found");
   });

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -1320,4 +1320,40 @@ describe("ClientRuntime context-tree wiring", () => {
     expect(close).toHaveBeenCalled();
     await rt.stop();
   });
+
+  for (const prototypeKey of ["toString", "constructor", "__proto__"] as const) {
+    it(`resolveHandlerFactory rejects Object.prototype key ${prototypeKey} without constructing AgentSlot`, async () => {
+      const { ClientRuntime } = await import("../core/client-runtime.js");
+      const rt = new ClientRuntime("https://first-tree.test", "client-test");
+      const before = slotInstances.length;
+
+      expect(() =>
+        (
+          rt as unknown as {
+            resolveHandlerFactory: (type: string) => unknown;
+          }
+        ).resolveHandlerFactory(prototypeKey),
+      ).toThrow(new RegExp(`Unknown handler type "${prototypeKey}".*Available:`));
+      expect(slotInstances.length).toBe(before);
+
+      expect(() =>
+        (
+          rt as unknown as {
+            createAgentSlot: (
+              name: string,
+              config: { runtime: string; agentId: string; session: object; concurrency: number },
+            ) => unknown;
+          }
+        ).createAgentSlot("poisoned", {
+          agentId: "agent-poisoned",
+          runtime: prototypeKey,
+          session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+          concurrency: 1,
+        }),
+      ).toThrow(new RegExp(`Unknown handler type "${prototypeKey}"`));
+      expect(slotInstances.length).toBe(before);
+
+      await rt.stop();
+    });
+  }
 });

--- a/apps/cli/src/commands/agent/workspace/clean.ts
+++ b/apps/cli/src/commands/agent/workspace/clean.ts
@@ -1,11 +1,6 @@
-import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
-import { cleanWorkspaces, SessionRegistry } from "@first-tree/client";
-import { defaultDataDir } from "@first-tree/shared/config";
+import { cleanAgentWorkspaces, DEFAULT_WORKSPACE_TTL_MS } from "@first-tree/client";
 import type { Command } from "commander";
 import { print } from "../../../core/output.js";
-
-const DEFAULT_WORKSPACE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export function registerAgentWorkspaceCleanCommand(workspace: Command): void {
   workspace
@@ -15,37 +10,16 @@ export function registerAgentWorkspaceCleanCommand(workspace: Command): void {
     .action((agentName?: string, options?: { ttl: string }) => {
       const defaultDays = DEFAULT_WORKSPACE_TTL_MS / (24 * 60 * 60 * 1000);
       const ttlMs = Number.parseInt(options?.ttl ?? String(defaultDays), 10) * 24 * 60 * 60 * 1000;
-      const workspacesDir = join(defaultDataDir(), "workspaces");
 
-      if (!existsSync(workspacesDir)) {
+      const result = cleanAgentWorkspaces({ agentName, ttlMs });
+      if (result.kind === "missing-root") {
         print.line("  No workspaces found.\n");
         return;
       }
 
-      const agentNames = agentName ? [agentName] : readdirSync(workspacesDir);
-      let totalRemoved = 0;
-
-      for (const name of agentNames) {
-        const agentWorkspaceRoot = join(workspacesDir, name);
-        if (!existsSync(agentWorkspaceRoot)) continue;
-
-        const registryPath = join(defaultDataDir(), "sessions", `${name}.json`);
-        const registry = new SessionRegistry(registryPath);
-        const persisted = registry.load();
-        const activeChatIds = new Set<string>();
-        for (const [chatId, data] of persisted) {
-          if (data.status !== "evicted") {
-            activeChatIds.add(chatId);
-          }
-        }
-
-        const removed = cleanWorkspaces(agentWorkspaceRoot, activeChatIds, ttlMs);
-        totalRemoved += removed.length;
-        for (const chatId of removed) {
-          print.line(`  Removed: ${name}/${chatId}\n`);
-        }
+      for (const entry of result.removed) {
+        print.line(`  Removed: ${entry.agentName}/${entry.chatId}\n`);
       }
-
-      print.line(`  ${totalRemoved} workspace(s) cleaned.\n`);
+      print.line(`  ${result.removed.length} workspace(s) cleaned.\n`);
     });
 }

--- a/apps/cli/src/commands/agent/workspace/clean.ts
+++ b/apps/cli/src/commands/agent/workspace/clean.ts
@@ -1,6 +1,9 @@
-import { cleanAgentWorkspaces, DEFAULT_WORKSPACE_TTL_MS } from "@first-tree/client";
+import { cleanAgentWorkspaces } from "@first-tree/client";
 import type { Command } from "commander";
 import { print } from "../../../core/output.js";
+
+/** Presentation default for `--ttl` (days). Kept local so CLI Client mocks need not know it. */
+const DEFAULT_WORKSPACE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export function registerAgentWorkspaceCleanCommand(workspace: Command): void {
   workspace

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -349,6 +349,13 @@ export class ClientRuntime {
   }
 
   private resolveHandlerFactory(type: string): HandlerFactory {
+    // Own-key guard lives in the resolver itself so future callers cannot
+    // index Object.prototype (`toString` / `constructor` / `__proto__`) and
+    // treat inherited values as factories.
+    if (!Object.hasOwn(this.handlerFactories, type)) {
+      const available = Object.keys(this.handlerFactories).join(", ") || "(none)";
+      throw new Error(`Unknown handler type "${type}". Available: ${available}`);
+    }
     const factory = (this.handlerFactories as Readonly<Record<string, HandlerFactory>>)[type];
     if (!factory) {
       const available = Object.keys(this.handlerFactories).join(", ") || "(none)";

--- a/packages/client/src/__tests__/barrel-exports.test.ts
+++ b/packages/client/src/__tests__/barrel-exports.test.ts
@@ -10,6 +10,7 @@ describe("public barrel exports", { timeout: 30_000 }, () => {
     expect(api.AgentSlot).toBeDefined();
     expect(api.AgentRuntime).toBeDefined();
     expect(api.cleanAgentWorkspaces).toBeDefined();
+    expect(api).not.toHaveProperty("cleanAgentWorkspacesWithDeps");
     expect(api).not.toHaveProperty("SessionManager");
     expect(api).not.toHaveProperty("SessionRegistry");
     expect(api.createBuiltinHandlerRegistry).toBeDefined();
@@ -26,6 +27,7 @@ describe("public barrel exports", { timeout: 30_000 }, () => {
     expect(runtime.AgentSlot).toBeDefined();
     expect(runtime.AgentRuntime).toBeDefined();
     expect(runtime.cleanAgentWorkspaces).toBeDefined();
+    expect(runtime).not.toHaveProperty("cleanAgentWorkspacesWithDeps");
     expect(runtime).not.toHaveProperty("SessionManager");
     expect(runtime).not.toHaveProperty("SessionRegistry");
     expect(runtime.resolveAgentContextTreeBinding).toBeDefined();

--- a/packages/client/src/__tests__/barrel-exports.test.ts
+++ b/packages/client/src/__tests__/barrel-exports.test.ts
@@ -9,7 +9,9 @@ describe("public barrel exports", { timeout: 30_000 }, () => {
     expect(api.ClientConnection).toBeDefined();
     expect(api.AgentSlot).toBeDefined();
     expect(api.AgentRuntime).toBeDefined();
-    expect(api.SessionManager).toBeDefined();
+    expect(api.cleanAgentWorkspaces).toBeDefined();
+    expect(api).not.toHaveProperty("SessionManager");
+    expect(api).not.toHaveProperty("SessionRegistry");
     expect(api.createBuiltinHandlerRegistry).toBeDefined();
     expect(api.resolveAndLogClaudeExecutable).toBeDefined();
     expect(api).not.toHaveProperty("registerBuiltinHandlers");
@@ -23,6 +25,9 @@ describe("public barrel exports", { timeout: 30_000 }, () => {
 
     expect(runtime.AgentSlot).toBeDefined();
     expect(runtime.AgentRuntime).toBeDefined();
+    expect(runtime.cleanAgentWorkspaces).toBeDefined();
+    expect(runtime).not.toHaveProperty("SessionManager");
+    expect(runtime).not.toHaveProperty("SessionRegistry");
     expect(runtime.resolveAgentContextTreeBinding).toBeDefined();
     expect(runtime.registerShutdownHook).toBeDefined();
   });

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -353,9 +353,32 @@ describe("runtime provider architecture guard", () => {
 
     const cleanCommand = readFileSync(join(repoRoot, "apps/cli/src/commands/agent/workspace/clean.ts"), "utf8");
     expect(cleanCommand).toContain("cleanAgentWorkspaces");
+    const clientImport = cleanCommand.match(/import\s*\{([^}]*)\}\s*from\s*["']@first-tree\/client["']/);
+    expect(clientImport?.[1]?.replace(/\s+/g, " ").trim()).toBe("cleanAgentWorkspaces");
+    expect(cleanCommand).toMatch(/const DEFAULT_WORKSPACE_TTL_MS = 7 \* 24 \* 60 \* 60 \* 1000/);
     expect(cleanCommand).not.toMatch(/\bfrom ["']node:fs["']/);
     expect(cleanCommand).not.toMatch(/\bfrom ["']node:path["']/);
     expect(cleanCommand).not.toContain("defaultDataDir");
+
+    const maintenance = readFileSync(join(clientSrc, "runtime/workspace-maintenance.ts"), "utf8");
+    const optionsMatch = maintenance.match(/export type CleanAgentWorkspacesOptions = \{([\s\S]*?)\n\};/);
+    expect(optionsMatch?.[1], "CleanAgentWorkspacesOptions must be declared").toBeTruthy();
+    const optionsBody = optionsMatch?.[1] ?? "";
+    expect(optionsBody).toMatch(/\bagentName\?:/);
+    expect(optionsBody).toMatch(/\bttlMs:/);
+    expect(optionsBody).not.toMatch(/\bdataDir\b/);
+    expect(optionsBody).not.toMatch(/\bcleanWorkspacesFn\b/);
+    for (const [label, source] of [
+      ["packages/client/src/index.ts", rootIndex],
+      ["packages/client/src/runtime/index.ts", runtimeIndex],
+    ] as const) {
+      expect(source, `${label} must not re-export cleanAgentWorkspacesWithDeps`).not.toMatch(
+        /\bcleanAgentWorkspacesWithDeps\b/,
+      );
+      expect(source, `${label} must not re-export CleanAgentWorkspacesTestDeps`).not.toMatch(
+        /\bCleanAgentWorkspacesTestDeps\b/,
+      );
+    }
 
     const cliRuntime = readFileSync(join(repoRoot, "apps/cli/src/core/client-runtime.ts"), "utf8");
     expect(cliRuntime).toMatch(/resolveHandlerFactory[\s\S]*Object\.hasOwn/);

--- a/packages/client/src/__tests__/provider-boundary-guard.test.ts
+++ b/packages/client/src/__tests__/provider-boundary-guard.test.ts
@@ -327,6 +327,40 @@ describe("runtime provider architecture guard", () => {
     expect(agentRuntime).not.toMatch(/\bHANDLER_REGISTRY\b/);
   });
 
+  it("keeps SessionManager/SessionRegistry off public barrels and out of CLI production", () => {
+    const rootIndex = readFileSync(join(clientSrc, "index.ts"), "utf8");
+    const runtimeIndex = readFileSync(join(clientSrc, "runtime/index.ts"), "utf8");
+    for (const [label, source] of [
+      ["packages/client/src/index.ts", rootIndex],
+      ["packages/client/src/runtime/index.ts", runtimeIndex],
+    ] as const) {
+      expect(source, `${label} must not re-export SessionManager`).not.toMatch(/export\s*\{[^}]*\bSessionManager\b/);
+      expect(source, `${label} must not re-export SessionRegistry`).not.toMatch(/export\s*\{[^}]*\bSessionRegistry\b/);
+      expect(source, `${label} must expose cleanAgentWorkspaces`).toContain("cleanAgentWorkspaces");
+    }
+
+    const cliProduction = listFilesRecursive(join(repoRoot, "apps/cli/src"), (p) => {
+      return p.endsWith(".ts") && !p.includes("__tests__") && !p.includes("/__mocks__/");
+    });
+    for (const file of cliProduction) {
+      const source = readFileSync(file, "utf8");
+      const rel = relative(repoRoot, file).replaceAll("\\", "/");
+      expect(source, `${rel} must not import SessionRegistry`).not.toMatch(/\bSessionRegistry\b/);
+      expect(source, `${rel} must not import SessionManager`).not.toMatch(/\bSessionManager\b/);
+      expect(source, `${rel} must not call low-level cleanWorkspaces`).not.toMatch(/\bcleanWorkspaces\b/);
+      expect(source, `${rel} must not deep-import client`).not.toMatch(/from ["']@first-tree\/client\//);
+    }
+
+    const cleanCommand = readFileSync(join(repoRoot, "apps/cli/src/commands/agent/workspace/clean.ts"), "utf8");
+    expect(cleanCommand).toContain("cleanAgentWorkspaces");
+    expect(cleanCommand).not.toMatch(/\bfrom ["']node:fs["']/);
+    expect(cleanCommand).not.toMatch(/\bfrom ["']node:path["']/);
+    expect(cleanCommand).not.toContain("defaultDataDir");
+
+    const cliRuntime = readFileSync(join(repoRoot, "apps/cli/src/core/client-runtime.ts"), "utf8");
+    expect(cliRuntime).toMatch(/resolveHandlerFactory[\s\S]*Object\.hasOwn/);
+  });
+
   it("keeps the runtime-auth driver projection in one frozen, schema-exhaustive composition root", () => {
     const drivers = readFileSync(join(clientSrc, "providers/auth-drivers.ts"), "utf8");
     expect(drivers).toContain("Object.freeze");

--- a/packages/client/src/__tests__/workspace-maintenance.test.ts
+++ b/packages/client/src/__tests__/workspace-maintenance.test.ts
@@ -2,7 +2,11 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanAgentWorkspaces } from "../runtime/workspace-maintenance.js";
+import {
+  type CleanAgentWorkspacesOptions,
+  cleanAgentWorkspaces,
+  cleanAgentWorkspacesWithDeps,
+} from "../runtime/workspace-maintenance.js";
 
 function writeRegistry(
   dataDir: string,
@@ -36,9 +40,20 @@ describe("cleanAgentWorkspaces", () => {
     vi.restoreAllMocks();
   });
 
+  it("locks the public option surface to agentName and ttlMs only", () => {
+    type PublicKeys = keyof CleanAgentWorkspacesOptions;
+    const keys: PublicKeys[] = ["agentName", "ttlMs"];
+    expect(keys).toEqual(["agentName", "ttlMs"]);
+    // Structural: no other declared public keys.
+    const sample: CleanAgentWorkspacesOptions = { ttlMs: 0 };
+    expect(Object.keys(sample).sort()).toEqual(["ttlMs"]);
+    const withAgent: CleanAgentWorkspacesOptions = { agentName: "nova", ttlMs: 1 };
+    expect(Object.keys(withAgent).sort()).toEqual(["agentName", "ttlMs"]);
+  });
+
   it("returns missing-root when the workspaces directory does not exist", () => {
     dataDir = mkdtempSync(join(tmpdir(), "ft-clean-missing-"));
-    const result = cleanAgentWorkspaces({ dataDir, ttlMs: 0 });
+    const result = cleanAgentWorkspacesWithDeps({ ttlMs: 0 }, { dataDir });
     expect(result).toEqual({ kind: "missing-root" });
   });
 
@@ -66,11 +81,10 @@ describe("cleanAgentWorkspaces", () => {
       return [];
     });
 
-    const result = cleanAgentWorkspaces({
-      dataDir,
-      ttlMs: 3 * 24 * 60 * 60 * 1000,
-      cleanWorkspacesFn: cleanFn,
-    });
+    const result = cleanAgentWorkspacesWithDeps(
+      { ttlMs: 3 * 24 * 60 * 60 * 1000 },
+      { dataDir, cleanWorkspacesFn: cleanFn },
+    );
 
     expect(result).toEqual({
       kind: "cleaned",
@@ -89,12 +103,10 @@ describe("cleanAgentWorkspaces", () => {
     const cleanFn = vi.fn((_workspaceRoot: string, _activeChatIds: Set<string>, _ttlMs: number): string[] => [
       "chat-stale",
     ]);
-    const result = cleanAgentWorkspaces({
-      agentName: "nova",
-      dataDir,
-      ttlMs: 7 * 24 * 60 * 60 * 1000,
-      cleanWorkspacesFn: cleanFn,
-    });
+    const result = cleanAgentWorkspacesWithDeps(
+      { agentName: "nova", ttlMs: 7 * 24 * 60 * 60 * 1000 },
+      { dataDir, cleanWorkspacesFn: cleanFn },
+    );
 
     expect(cleanFn).toHaveBeenCalledTimes(1);
     expect(cleanFn.mock.calls[0]?.[0]).toBe(join(dataDir, "workspaces", "nova"));
@@ -108,17 +120,15 @@ describe("cleanAgentWorkspaces", () => {
     dataDir = mkdtempSync(join(tmpdir(), "ft-clean-skip-"));
     mkdirSync(join(dataDir, "workspaces"), { recursive: true });
     const cleanFn = vi.fn(() => ["should-not-run"]);
-    const result = cleanAgentWorkspaces({
-      agentName: "missing",
-      dataDir,
-      ttlMs: 0,
-      cleanWorkspacesFn: cleanFn,
-    });
+    const result = cleanAgentWorkspacesWithDeps(
+      { agentName: "missing", ttlMs: 0 },
+      { dataDir, cleanWorkspacesFn: cleanFn },
+    );
     expect(cleanFn).not.toHaveBeenCalled();
     expect(result).toEqual({ kind: "cleaned", removed: [] });
   });
 
-  it("never mutates on-disk files when the low-level cleaner is the zero-deletion no-op", () => {
+  it("never mutates on-disk files when the production wrapper uses the zero-deletion no-op", () => {
     dataDir = mkdtempSync(join(tmpdir(), "ft-clean-zero-"));
     const agentHome = join(dataDir, "workspaces", "nova");
     mkdirSync(agentHome, { recursive: true });
@@ -126,10 +136,17 @@ describe("cleanAgentWorkspaces", () => {
     writeFileSync(marker, "intact", "utf-8");
     writeRegistry(dataDir, "nova", {});
 
-    // Production path: no cleanWorkspacesFn inject → real no-op cleaner.
-    const result = cleanAgentWorkspaces({ dataDir, ttlMs: 0 });
+    // Production wrapper path via deps seam with real cleanWorkspaces omitted →
+    // same zero-deletion no-op the public API binds.
+    const result = cleanAgentWorkspacesWithDeps({ ttlMs: 0 }, { dataDir });
     expect(result).toEqual({ kind: "cleaned", removed: [] });
     expect(readFileSync(marker, "utf-8")).toBe("intact");
     expect(readFileSync(join(dataDir, "sessions", "nova.json"), "utf-8")).toContain('"version":1');
+  });
+
+  it("public cleanAgentWorkspaces only accepts agentName and ttlMs at the call site", () => {
+    // Compile-time + runtime smoke: public entry is the thin channel-bound wrapper.
+    expect(typeof cleanAgentWorkspaces).toBe("function");
+    expect(cleanAgentWorkspaces.length).toBe(1);
   });
 });

--- a/packages/client/src/__tests__/workspace-maintenance.test.ts
+++ b/packages/client/src/__tests__/workspace-maintenance.test.ts
@@ -1,0 +1,135 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanAgentWorkspaces } from "../runtime/workspace-maintenance.js";
+
+function writeRegistry(
+  dataDir: string,
+  agentName: string,
+  entries: Record<string, { status: string; claudeSessionId?: string }>,
+): void {
+  const sessionsDir = join(dataDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  const payload = {
+    version: 1,
+    entries: Object.fromEntries(
+      Object.entries(entries).map(([chatId, entry]) => [
+        chatId,
+        {
+          claudeSessionId: entry.claudeSessionId ?? `sess-${chatId}`,
+          lastActivity: new Date(1_700_000_000_000).toISOString(),
+          status: entry.status,
+        },
+      ]),
+    ),
+  };
+  writeFileSync(join(sessionsDir, `${agentName}.json`), JSON.stringify(payload), "utf-8");
+}
+
+describe("cleanAgentWorkspaces", () => {
+  let dataDir = "";
+
+  afterEach(() => {
+    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+    dataDir = "";
+    vi.restoreAllMocks();
+  });
+
+  it("returns missing-root when the workspaces directory does not exist", () => {
+    dataDir = mkdtempSync(join(tmpdir(), "ft-clean-missing-"));
+    const result = cleanAgentWorkspaces({ dataDir, ttlMs: 0 });
+    expect(result).toEqual({ kind: "missing-root" });
+  });
+
+  it("orchestrates all agents and maps removed chat ids with active-vs-evicted selection", () => {
+    dataDir = mkdtempSync(join(tmpdir(), "ft-clean-all-"));
+    mkdirSync(join(dataDir, "workspaces", "nova"), { recursive: true });
+    mkdirSync(join(dataDir, "workspaces", "mira"), { recursive: true });
+    writeRegistry(dataDir, "nova", {
+      "chat-active": { status: "active" },
+      "chat-suspended": { status: "suspended" },
+      "chat-evicted": { status: "evicted" },
+    });
+    writeRegistry(dataDir, "mira", {
+      "chat-only-active": { status: "active" },
+    });
+
+    const cleanFn = vi.fn((workspaceRoot: string, activeChatIds: Set<string>, ttlMs: number) => {
+      if (workspaceRoot === join(dataDir, "workspaces", "nova")) {
+        expect(activeChatIds).toEqual(new Set(["chat-active", "chat-suspended"]));
+        expect(ttlMs).toBe(3 * 24 * 60 * 60 * 1000);
+        return ["chat-old"];
+      }
+      expect(workspaceRoot).toBe(join(dataDir, "workspaces", "mira"));
+      expect(activeChatIds).toEqual(new Set(["chat-only-active"]));
+      return [];
+    });
+
+    const result = cleanAgentWorkspaces({
+      dataDir,
+      ttlMs: 3 * 24 * 60 * 60 * 1000,
+      cleanWorkspacesFn: cleanFn,
+    });
+
+    expect(result).toEqual({
+      kind: "cleaned",
+      removed: [{ agentName: "nova", chatId: "chat-old" }],
+    });
+    expect(cleanFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("limits orchestration to a single named agent", () => {
+    dataDir = mkdtempSync(join(tmpdir(), "ft-clean-one-"));
+    mkdirSync(join(dataDir, "workspaces", "nova"), { recursive: true });
+    mkdirSync(join(dataDir, "workspaces", "mira"), { recursive: true });
+    writeRegistry(dataDir, "nova", { "chat-a": { status: "active" } });
+    writeRegistry(dataDir, "mira", { "chat-b": { status: "active" } });
+
+    const cleanFn = vi.fn((_workspaceRoot: string, _activeChatIds: Set<string>, _ttlMs: number): string[] => [
+      "chat-stale",
+    ]);
+    const result = cleanAgentWorkspaces({
+      agentName: "nova",
+      dataDir,
+      ttlMs: 7 * 24 * 60 * 60 * 1000,
+      cleanWorkspacesFn: cleanFn,
+    });
+
+    expect(cleanFn).toHaveBeenCalledTimes(1);
+    expect(cleanFn.mock.calls[0]?.[0]).toBe(join(dataDir, "workspaces", "nova"));
+    expect(result).toEqual({
+      kind: "cleaned",
+      removed: [{ agentName: "nova", chatId: "chat-stale" }],
+    });
+  });
+
+  it("skips a named agent whose workspace root is absent without failing", () => {
+    dataDir = mkdtempSync(join(tmpdir(), "ft-clean-skip-"));
+    mkdirSync(join(dataDir, "workspaces"), { recursive: true });
+    const cleanFn = vi.fn(() => ["should-not-run"]);
+    const result = cleanAgentWorkspaces({
+      agentName: "missing",
+      dataDir,
+      ttlMs: 0,
+      cleanWorkspacesFn: cleanFn,
+    });
+    expect(cleanFn).not.toHaveBeenCalled();
+    expect(result).toEqual({ kind: "cleaned", removed: [] });
+  });
+
+  it("never mutates on-disk files when the low-level cleaner is the zero-deletion no-op", () => {
+    dataDir = mkdtempSync(join(tmpdir(), "ft-clean-zero-"));
+    const agentHome = join(dataDir, "workspaces", "nova");
+    mkdirSync(agentHome, { recursive: true });
+    const marker = join(agentHome, "keep-me.txt");
+    writeFileSync(marker, "intact", "utf-8");
+    writeRegistry(dataDir, "nova", {});
+
+    // Production path: no cleanWorkspacesFn inject → real no-op cleaner.
+    const result = cleanAgentWorkspaces({ dataDir, ttlMs: 0 });
+    expect(result).toEqual({ kind: "cleaned", removed: [] });
+    expect(readFileSync(marker, "utf-8")).toBe("intact");
+    expect(readFileSync(join(dataDir, "sessions", "nova.json"), "utf-8")).toContain('"version":1');
+  });
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -200,8 +200,6 @@ export {
   type LoginOutcome,
   stripAnsi,
 } from "./runtime/runtime-login.js";
-export { SessionManager } from "./runtime/session-manager.js";
-export { SessionRegistry } from "./runtime/session-registry.js";
 // Skills (slash-command discovery)
 export { discoverClaudeCodeSkills } from "./runtime/skills/index.js";
 export type {
@@ -226,6 +224,12 @@ export {
   INIT_COMPLETE_SENTINEL_REL,
   markWorkspaceInitComplete,
 } from "./runtime/workspace.js";
+export type {
+  CleanAgentWorkspacesOptions,
+  CleanAgentWorkspacesResult,
+  CleanedWorkspaceEntry,
+} from "./runtime/workspace-maintenance.js";
+export { cleanAgentWorkspaces } from "./runtime/workspace-maintenance.js";
 export type {
   AccessTokenProvider,
   ContextReviewRuntimeConfig,

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -22,5 +22,9 @@ export type { ReplayFenceEntry, ReplayFenceWriter } from "./replay-fence.js";
 export { ReplayFenceError, ReplayFenceStore } from "./replay-fence.js";
 export type { AgentRuntimeOptions } from "./runtime.js";
 export { AgentRuntime } from "./runtime.js";
-export { SessionManager } from "./session-manager.js";
-export { SessionRegistry } from "./session-registry.js";
+export type {
+  CleanAgentWorkspacesOptions,
+  CleanAgentWorkspacesResult,
+  CleanedWorkspaceEntry,
+} from "./workspace-maintenance.js";
+export { cleanAgentWorkspaces } from "./workspace-maintenance.js";

--- a/packages/client/src/runtime/workspace-maintenance.ts
+++ b/packages/client/src/runtime/workspace-maintenance.ts
@@ -2,23 +2,17 @@ import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { defaultDataDir } from "@first-tree/shared/config";
 import { SessionRegistry } from "./session-registry.js";
-import { cleanWorkspaces, DEFAULT_WORKSPACE_TTL_MS } from "./workspace.js";
+import { cleanWorkspaces } from "./workspace.js";
 
+/**
+ * Public options for {@link cleanAgentWorkspaces}.
+ * Channel data-root and the low-level cleaner stay inside Client — not package API.
+ */
 export type CleanAgentWorkspacesOptions = {
   /** When set, clean only this agent home. When omitted, enumerate every agent under workspaces/. */
   agentName?: string;
   /** TTL forwarded to the low-level cleaner (currently a no-op). */
   ttlMs: number;
-  /**
-   * Override the Client data directory. Production callers omit this and use
-   * `defaultDataDir()`; tests inject a temp root.
-   */
-  dataDir?: string;
-  /**
-   * Test seam for the low-level cleaner. Production uses {@link cleanWorkspaces}.
-   * Kept minimal so orchestration (paths, registry, active-set) stays owned here.
-   */
-  cleanWorkspacesFn?: (workspaceRoot: string, activeChatIds: Set<string>, ttlMs: number) => string[];
 };
 
 export type CleanedWorkspaceEntry = {
@@ -29,6 +23,16 @@ export type CleanedWorkspaceEntry = {
 export type CleanAgentWorkspacesResult =
   | { kind: "missing-root" }
   | { kind: "cleaned"; removed: CleanedWorkspaceEntry[] };
+
+/**
+ * @internal Test-only dependency seam. Not re-exported from package barrels.
+ * Production {@link cleanAgentWorkspaces} always binds channel `defaultDataDir()`
+ * and the real zero-deletion {@link cleanWorkspaces}.
+ */
+export type CleanAgentWorkspacesTestDeps = {
+  dataDir: string;
+  cleanWorkspacesFn?: (workspaceRoot: string, activeChatIds: Set<string>, ttlMs: number) => string[];
+};
 
 /**
  * High-level agent-workspace maintenance for the CLI `agent workspace clean`
@@ -44,9 +48,23 @@ export type CleanAgentWorkspacesResult =
  * never auto-deletes agent homes, clones, worktrees, or legacy chat dirs.
  */
 export function cleanAgentWorkspaces(options: CleanAgentWorkspacesOptions): CleanAgentWorkspacesResult {
-  const dataDir = options.dataDir ?? defaultDataDir();
+  return cleanAgentWorkspacesWithDeps(options, {
+    dataDir: defaultDataDir(),
+    cleanWorkspacesFn: cleanWorkspaces,
+  });
+}
+
+/**
+ * @internal Orchestration core with injectable data-root / cleaner for tests.
+ * Import only via the module path — never from `@first-tree/client` barrels.
+ */
+export function cleanAgentWorkspacesWithDeps(
+  options: CleanAgentWorkspacesOptions,
+  deps: CleanAgentWorkspacesTestDeps,
+): CleanAgentWorkspacesResult {
+  const dataDir = deps.dataDir;
   const ttlMs = options.ttlMs;
-  const cleanFn = options.cleanWorkspacesFn ?? cleanWorkspaces;
+  const cleanFn = deps.cleanWorkspacesFn ?? cleanWorkspaces;
   const workspacesDir = join(dataDir, "workspaces");
 
   if (!existsSync(workspacesDir)) {
@@ -78,5 +96,3 @@ export function cleanAgentWorkspaces(options: CleanAgentWorkspacesOptions): Clea
 
   return { kind: "cleaned", removed };
 }
-
-export { DEFAULT_WORKSPACE_TTL_MS };

--- a/packages/client/src/runtime/workspace-maintenance.ts
+++ b/packages/client/src/runtime/workspace-maintenance.ts
@@ -1,0 +1,82 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { defaultDataDir } from "@first-tree/shared/config";
+import { SessionRegistry } from "./session-registry.js";
+import { cleanWorkspaces, DEFAULT_WORKSPACE_TTL_MS } from "./workspace.js";
+
+export type CleanAgentWorkspacesOptions = {
+  /** When set, clean only this agent home. When omitted, enumerate every agent under workspaces/. */
+  agentName?: string;
+  /** TTL forwarded to the low-level cleaner (currently a no-op). */
+  ttlMs: number;
+  /**
+   * Override the Client data directory. Production callers omit this and use
+   * `defaultDataDir()`; tests inject a temp root.
+   */
+  dataDir?: string;
+  /**
+   * Test seam for the low-level cleaner. Production uses {@link cleanWorkspaces}.
+   * Kept minimal so orchestration (paths, registry, active-set) stays owned here.
+   */
+  cleanWorkspacesFn?: (workspaceRoot: string, activeChatIds: Set<string>, ttlMs: number) => string[];
+};
+
+export type CleanedWorkspaceEntry = {
+  agentName: string;
+  chatId: string;
+};
+
+export type CleanAgentWorkspacesResult =
+  | { kind: "missing-root" }
+  | { kind: "cleaned"; removed: CleanedWorkspaceEntry[] };
+
+/**
+ * High-level agent-workspace maintenance for the CLI `agent workspace clean`
+ * command.
+ *
+ * Owns `<dataDir>/workspaces` / `<dataDir>/sessions/<agent>.json` layout,
+ * agent enumeration, SessionRegistry reads, active/evicted selection, and the
+ * low-level {@link cleanWorkspaces} call. The CLI command layer only parses
+ * flags and prints the returned structure.
+ *
+ * Behavior is intentionally unchanged from the prior CLI orchestration:
+ * {@link cleanWorkspaces} remains a deprecated zero-deletion no-op, so this
+ * never auto-deletes agent homes, clones, worktrees, or legacy chat dirs.
+ */
+export function cleanAgentWorkspaces(options: CleanAgentWorkspacesOptions): CleanAgentWorkspacesResult {
+  const dataDir = options.dataDir ?? defaultDataDir();
+  const ttlMs = options.ttlMs;
+  const cleanFn = options.cleanWorkspacesFn ?? cleanWorkspaces;
+  const workspacesDir = join(dataDir, "workspaces");
+
+  if (!existsSync(workspacesDir)) {
+    return { kind: "missing-root" };
+  }
+
+  const agentNames = options.agentName ? [options.agentName] : readdirSync(workspacesDir);
+  const removed: CleanedWorkspaceEntry[] = [];
+
+  for (const name of agentNames) {
+    const agentWorkspaceRoot = join(workspacesDir, name);
+    if (!existsSync(agentWorkspaceRoot)) continue;
+
+    const registryPath = join(dataDir, "sessions", `${name}.json`);
+    const registry = new SessionRegistry(registryPath);
+    const persisted = registry.load();
+    const activeChatIds = new Set<string>();
+    for (const [chatId, data] of persisted) {
+      if (data.status !== "evicted") {
+        activeChatIds.add(chatId);
+      }
+    }
+
+    const cleaned = cleanFn(agentWorkspaceRoot, activeChatIds, ttlMs);
+    for (const chatId of cleaned) {
+      removed.push({ agentName: name, chatId });
+    }
+  }
+
+  return { kind: "cleaned", removed };
+}
+
+export { DEFAULT_WORKSPACE_TTL_MS };


### PR DESCRIPTION
## Summary
- Add Client-owned `cleanAgentWorkspaces` that owns workspaces/sessions layout, SessionRegistry reads, active/evicted selection, and the existing zero-deletion `cleanWorkspaces` call; thin CLI `agent workspace clean` to one Client call with unchanged output.
- Remove `SessionManager` / `SessionRegistry` from Client root and runtime public barrels (files and internal lifecycle unchanged).
- Fold own-key guarding into CLI `ClientRuntime.resolveHandlerFactory` so prototype keys (`toString` / `constructor` / `__proto__`) fail closed without constructing an `AgentSlot`.

## Test plan
- [x] Client focused: workspace-maintenance, barrel-exports, provider-boundary-guard
- [x] CLI focused: cli-command-matrix-extra, client-runtime-context-tree (includes prototype-key resolver characterization)
- [x] `@first-tree/client` full suite: 2421 passed / 7 skipped
- [x] Client + CLI typecheck/build, root `pnpm check`, `git diff --check`
- [x] Source/dist boundary: barrels no longer export SessionManager/SessionRegistry; CLI production has no SessionManager/SessionRegistry/cleanWorkspaces
- [ ] Exact-head independent QA on frozen Draft head (do not Ready/merge until PASS)

## Scope / non-goals
S1c only. Does not delete or split SessionManager/SessionRegistry lifecycle, move packages, converge provider `contracts` / `provider-support`, or change user-visible clean behavior (still deprecated no-op / zero deletion).

Made with [Cursor](https://cursor.com)