### PR TITLE
fix: Chat Summary lead line + reading width

### DIFF
--- a/e2e/chat-summary-current-state.test.yaml
+++ b/e2e/chat-summary-current-state.test.yaml
@@ -13,8 +13,8 @@ steps:
   - waitForUrl: /?c=e2e-summary-
   - assert: The real Workspace has Mobile navigation polish selected. Its expanded panel is labeled Current state,
       presents Mobile navigation polish is awaiting product review as the visually stronger lead above quieter
-      supporting context and a distinct Next line, keeps freshness visible, and constrains the copy to a readable
-      left-aligned measure instead of stretching across the full message area.
+      supporting context and a distinct Next line, keeps freshness visible, and constrains the raised card to a
+      readable left-aligned measure instead of stretching as a full-bleed empty surface across the message area.
   - click: the Summary rollout validation chat in the conversation list
   - assert: Summary rollout validation is now selected and the Current state panel has changed to that chat's summary,
       led by Chat Summary hierarchy is ready in the real Workspace; none of the Mobile navigation polish summary remains

--- a/packages/qa/cases/web/chat-summary-chat-switch-reentry.md
+++ b/packages/qa/cases/web/chat-summary-chat-switch-reentry.md
@@ -11,16 +11,18 @@ Validate that Chat Summary acts as the selected chat's re-entry brief in the rea
 a detached task report.
 
 Use a disposable signed-in member with at least two visible chats in the same Team. Give each chat a clearly different
-topic and Markdown description containing a result line, short supporting context, and one next step. Exercise the real
-Workspace against a real server and database; do not substitute a `/preview/*` route or an operator's existing browser
-session.
+topic and Markdown description containing a result line, short supporting context, and one next step. Prefer the
+writing-contract shape (first physical line, then supporting lines) so lead promotion can be judged against real
+agent output, not only blank-line paragraphs. Exercise the real Workspace against a real server and database; do not
+substitute a `/preview/*` route or an operator's existing browser session.
 
 Switch between the chats from the conversation list and confirm that the selected topic, expanded Current state panel,
-freshness, and description all move together. The first prose block should be visibly scannable as the lead, supporting
-copy should be quieter and held to a readable measure, and content from the previously selected chat must not remain.
-Collapse the panel and confirm its one-line result preview still identifies the selected chat while the supporting copy
-no longer covers the message stream. Include legacy Markdown such as a reference link or block-first content when the
-run is intended to assess compatibility as well as the primary flow.
+freshness, and description all move together. The first physical line should be visibly scannable as the lead,
+supporting copy should be quieter and held to a readable card measure (~720–800px, not a full-bleed empty rail), and
+content from the previously selected chat must not remain. Collapse the panel and confirm its one-line result preview
+still identifies the selected chat while the supporting copy no longer covers the message stream. Include legacy
+Markdown such as a reference link or block-first content when the run is intended to assess compatibility as well as
+the primary flow.
 
 Credible evidence identifies the exact build, disposable identity and seeded chats, records both selections and the
 expanded-to-collapsed transition, and links an uploaded browser run or equivalent screenshots/video. A result is not a

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -544,10 +544,11 @@ video[data-onboarding-orientation-video]::cue {
   --sp-95: 23.75rem; /* 380px — chat-description popover card width (~60ch) */
   --mobile-tabbar-height: 3.5rem; /* 56px */
 
-  /* Readable measure for the expanded chat current-state brief. The overlay
-     remains full-width so it stays anchored to the stream, while copy avoids
-     stretching across a wide desktop canvas. */
-  --chat-summary-readable-rail: 68ch;
+  /* Readable measure for the expanded chat current-state card. Uses rem (not
+     ch) so CJK/Latin mixed copy keeps ~760px instead of shrinking with Latin
+     glyph width. The raised card itself is constrained, so the surface and
+     text share one edge rather than leaving empty half-width chrome. */
+  --chat-summary-readable-rail: 47.5rem; /* 760px */
 
   /* Agent detail shell: a compact local-navigation rail plus one readable
      configuration column. The sum stays below the Settings wrapper while the

--- a/packages/web/src/pages/chat-summary-preview.tsx
+++ b/packages/web/src/pages/chat-summary-preview.tsx
@@ -18,9 +18,7 @@ const hoursAgo = (h: number): string => new Date(Date.now() - h * 3_600_000).toI
 
 const CURRENT_STATE = [
   "Chat Summary now leads with the **current result and user impact**.",
-  "",
-  "Supporting context stays quieter and within a readable text measure, so a wide Workspace does not become one long scanning line.",
-  "",
+  "Supporting context stays quieter inside a rem-sized card measure, so a wide Workspace does not leave empty half-width chrome.",
   "**Next:** Validate the same hierarchy in the live Workspace.",
 ].join("\n");
 

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -179,15 +179,52 @@ describe("ChatSummary", () => {
 
     const card = overlayEl.querySelector<HTMLElement>('section[aria-label="Current state"]');
     const summaryDocument = card?.querySelector<HTMLElement>('[data-summary-part="document"]');
+    const lead = summaryDocument?.querySelector<HTMLElement>('[data-summary-part="lead"]');
     const paragraphs = summaryDocument?.querySelectorAll("p");
     expect(summaryDocument?.dataset.summaryLayout).toBe("lead");
-    expect(paragraphs?.[0]?.textContent).toContain("The current result is ready for readers.");
-    expect(paragraphs?.[0]?.querySelector("strong")?.textContent).toBe("current result");
+    expect(lead?.textContent).toContain("The current result is ready for readers.");
+    expect(lead?.className).toContain("text-subtitle");
+    expect(lead?.querySelector("strong")?.textContent).toBe("current result");
     expect(paragraphs?.[1]?.textContent).toContain("Supporting context is secondary.");
     expect(paragraphs?.[2]?.textContent).toContain("Next: Observe usage.");
     expect(summaryDocument?.style.color).toBe("var(--fg-2)");
-    expect(summaryDocument?.firstElementChild?.className).toContain("[&>p:first-of-type]:text-subtitle");
-    expect(card?.firstElementChild?.getAttribute("style")).toContain("var(--chat-summary-readable-rail)");
+    expect(card?.getAttribute("style")).toContain("var(--chat-summary-readable-rail)");
+    expect(card?.getAttribute("style")).toContain("max-width");
+    // Card is the constrained surface — no nested full-bleed wrapper.
+    expect(card?.firstElementChild?.getAttribute("data-summary-part")).toBe("document");
+
+    await act(async () => root.unmount());
+    container.remove();
+    overlayEl.remove();
+  });
+
+  it("promotes only the first physical line when the writing contract uses soft breaks", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const { container, overlayEl, root } = await renderSummary(scrollEl, {
+      description: [
+        "Chat Summary V1 已上线，后续摘要会优先展示用户可行动的当前状态。",
+        "旧摘要会在下一次实质进展时重写；用户无需关注 PR、CI 或版本号。",
+        "**下一步**：观察真实 Chat 切换反馈，再决定是否继续调整展示。",
+      ].join("\n"),
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    });
+
+    const summaryDocument = overlayEl.querySelector<HTMLElement>('[data-summary-part="document"]');
+    const lead = summaryDocument?.querySelector<HTMLElement>('[data-summary-part="lead"]');
+    const paragraphs = summaryDocument?.querySelectorAll("p");
+    expect(summaryDocument?.dataset.summaryLayout).toBe("lead");
+    // Soft breaks stay in one paragraph under remark-breaks.
+    expect(paragraphs?.length).toBe(1);
+    expect(lead?.tagName).toBe("SPAN");
+    expect(lead?.textContent).toBe("Chat Summary V1 已上线，后续摘要会优先展示用户可行动的当前状态。");
+    expect(lead?.className).toContain("text-subtitle");
+    // Supporting soft-break lines remain in the same <p> but outside the lead.
+    expect(paragraphs?.[0]?.textContent).toContain("旧摘要会在下一次实质进展时重写");
+    expect(paragraphs?.[0]?.textContent).toContain("下一步");
+    expect(lead?.textContent).not.toContain("旧摘要会在下一次实质进展时重写");
+    expect(lead?.textContent).not.toContain("下一步");
 
     await act(async () => root.unmount());
     container.remove();

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { act, createElement } from "react";
+import { act, createElement, StrictMode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { describe, expect, it } from "vitest";
 import { ChatSummary, descriptionFirstLine } from "../chat-summary.js";
@@ -108,6 +108,7 @@ describe("ChatSummary", () => {
   async function renderSummary(
     scrollEl: HTMLDivElement,
     overrides: Partial<SummaryProps> = {},
+    options: { strictMode?: boolean } = {},
   ): Promise<{
     container: HTMLDivElement;
     overlayEl: HTMLDivElement;
@@ -122,8 +123,12 @@ describe("ChatSummary", () => {
     document.body.appendChild(overlayEl);
     const root = createRoot(container);
     let props = summaryProps(scrollEl, overlayEl, overrides);
+    const renderTree = (nextProps: SummaryProps) => {
+      const summary = createElement(ChatSummary, nextProps);
+      return options.strictMode ? createElement(StrictMode, null, summary) : summary;
+    };
     await act(async () => {
-      root.render(createElement(ChatSummary, props));
+      root.render(renderTree(props));
     });
     return {
       container,
@@ -132,7 +137,7 @@ describe("ChatSummary", () => {
       rerender: async (next: Partial<SummaryProps>) => {
         props = { ...props, ...next };
         await act(async () => {
-          root.render(createElement(ChatSummary, props));
+          root.render(renderTree(props));
         });
       },
     };
@@ -182,8 +187,14 @@ describe("ChatSummary", () => {
     const lead = summaryDocument?.querySelector<HTMLElement>('[data-summary-part="lead"]');
     const paragraphs = summaryDocument?.querySelectorAll("p");
     expect(summaryDocument?.dataset.summaryLayout).toBe("lead");
+    // Blank-line lead must be a child span — never the <p> that receives [&_p]:text-body.
+    expect(lead?.tagName).toBe("SPAN");
+    expect(lead?.parentElement?.tagName).toBe("P");
+    expect(paragraphs?.[0]?.getAttribute("data-summary-part")).toBeNull();
+    expect(summaryDocument?.querySelectorAll('[data-summary-part="lead"]')).toHaveLength(1);
     expect(lead?.textContent).toContain("The current result is ready for readers.");
     expect(lead?.className).toContain("text-subtitle");
+    expect(lead?.style.fontSize).toBe("var(--text-subtitle)");
     expect(lead?.querySelector("strong")?.textContent).toBe("current result");
     expect(paragraphs?.[1]?.textContent).toContain("Supporting context is secondary.");
     expect(paragraphs?.[2]?.textContent).toContain("Next: Observe usage.");
@@ -218,13 +229,40 @@ describe("ChatSummary", () => {
     // Soft breaks stay in one paragraph under remark-breaks.
     expect(paragraphs?.length).toBe(1);
     expect(lead?.tagName).toBe("SPAN");
+    expect(paragraphs?.[0]?.getAttribute("data-summary-part")).toBeNull();
     expect(lead?.textContent).toBe("Chat Summary V1 已上线，后续摘要会优先展示用户可行动的当前状态。");
     expect(lead?.className).toContain("text-subtitle");
+    expect(lead?.style.fontSize).toBe("var(--text-subtitle)");
     // Supporting soft-break lines remain in the same <p> but outside the lead.
     expect(paragraphs?.[0]?.textContent).toContain("旧摘要会在下一次实质进展时重写");
     expect(paragraphs?.[0]?.textContent).toContain("下一步");
     expect(lead?.textContent).not.toContain("旧摘要会在下一次实质进展时重写");
     expect(lead?.textContent).not.toContain("下一步");
+
+    await act(async () => root.unmount());
+    container.remove();
+    overlayEl.remove();
+  });
+
+  it("keeps a unique lead under StrictMode for soft-break writing-contract copy", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const { container, overlayEl, root } = await renderSummary(
+      scrollEl,
+      {
+        description: ["首行是唯一 headline。", "第二行保持普通正文。", "第三行也是普通正文。"].join("\n"),
+        descriptionUpdatedAt: unreadVersionAt,
+        lastReadAt: readRecentlyAt,
+      },
+      { strictMode: true },
+    );
+
+    const leads = overlayEl.querySelectorAll('[data-summary-part="lead"]');
+    expect(leads).toHaveLength(1);
+    expect(leads[0]?.tagName).toBe("SPAN");
+    expect(leads[0]?.textContent).toBe("首行是唯一 headline。");
+    expect(leads[0]?.textContent).not.toContain("第二行");
+    expect(overlayEl.querySelector("p")?.getAttribute("data-summary-part")).toBeNull();
 
     await act(async () => root.unmount());
     container.remove();

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -1,6 +1,16 @@
 import { ChevronDown } from "lucide-react";
-import type { RefObject } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Children,
+  type HTMLAttributes,
+  isValidElement,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { Markdown } from "../../../components/ui/markdown.js";
 import { stripInlineMarkdown } from "../../../lib/strip-inline-markdown.js";
@@ -14,8 +24,9 @@ import { formatRelative } from "../../../lib/utils.js";
  * deliberately NO edit affordance anywhere here (correcting it means telling an
  * agent in chat). The component preserves the description's authored markdown
  * without inventing sections, fields, or a "stage". When the description follows
- * the current-state contract, its first prose block is promoted into a readable
- * lead and the remaining markdown stays as supporting copy. The description is
+ * the current-state contract, its first physical line is promoted into a readable
+ * lead and the remaining markdown stays as supporting copy — including when
+ * `remarkBreaks` keeps soft-break lines inside one `<p>`. The description is
  * always rendered as one markdown document so document-scoped syntax (reference
  * links, multiline constructs, and definitions) keeps working. Complex
  * block-first markdown falls back to the faithful full-document presentation.
@@ -185,6 +196,96 @@ function findDescriptionLead(description: string): DescriptionLead | null {
 
 export function descriptionFirstLine(description: string): string {
   return findDescriptionLead(description)?.preview ?? "";
+}
+
+function isBreakElement(node: ReactNode): boolean {
+  return isValidElement(node) && node.type === "br";
+}
+
+/** Split a paragraph's React children on soft-break `<br>` nodes. */
+function splitChildrenByBreak(children: ReactNode): ReactNode[][] {
+  const segments: ReactNode[][] = [[]];
+  Children.forEach(children, (child) => {
+    if (isBreakElement(child)) {
+      segments.push([]);
+      return;
+    }
+    const current = segments[segments.length - 1];
+    if (current) current.push(child);
+  });
+  return segments;
+}
+
+/** Join soft-break segments without inventing list keys for stable source order. */
+function joinSoftBreakSegments(segments: ReactNode[][]): ReactNode {
+  return segments.reduce<ReactNode>((acc, segment, index) => {
+    if (index === 0) return <>{segment}</>;
+    return (
+      <>
+        {acc}
+        <br />
+        {segment}
+      </>
+    );
+  }, null);
+}
+
+/**
+ * Promote only the first physical line of the first prose paragraph. Soft breaks
+ * from the writing contract (`line\nline`) stay in one Markdown `<p>`; styling
+ * the whole paragraph would bold the entire brief. Blank-line paragraphs still
+ * promote the whole first `<p>` when it has no soft breaks.
+ */
+function LeadAwareParagraph({
+  children,
+  promoteLead,
+  ...props
+}: HTMLAttributes<HTMLParagraphElement> & {
+  children?: ReactNode;
+  promoteLead: boolean;
+}) {
+  if (!promoteLead) {
+    return <p {...props}>{children}</p>;
+  }
+  const segments = splitChildrenByBreak(children);
+  const nonEmpty = segments.filter((segment) =>
+    segment.some((node) => {
+      if (typeof node === "string") return node.trim().length > 0;
+      return node != null && node !== false;
+    }),
+  );
+  if (nonEmpty.length <= 1) {
+    return (
+      <p
+        {...props}
+        data-summary-part="lead"
+        className={["text-subtitle mt-0 mb-[var(--sp-3)]", props.className].filter(Boolean).join(" ")}
+        style={{
+          ...(typeof props.style === "object" && props.style ? props.style : {}),
+          color: "var(--fg)",
+        }}
+      >
+        {children}
+      </p>
+    );
+  }
+  const [lead, ...rest] = nonEmpty;
+  return (
+    <p {...props}>
+      <span
+        data-summary-part="lead"
+        className="text-subtitle"
+        style={{
+          display: "block",
+          color: "var(--fg)",
+          marginBottom: "var(--sp-3)",
+        }}
+      >
+        {lead}
+      </span>
+      {joinSoftBreakSegments(rest)}
+    </p>
+  );
 }
 
 export function ChatSummary({
@@ -513,7 +614,11 @@ export function ChatSummary({
                 position: "absolute",
                 top: 0,
                 left: 0,
-                right: 0,
+                // Constrain the raised card itself (not only inner copy) so the
+                // surface and text share one readable edge. `width: 100%` keeps
+                // narrow message areas responsive under the rem max.
+                width: "100%",
+                maxWidth: "var(--chat-summary-readable-rail)",
                 background: amberActive ? "var(--bg-warn-soft)" : "var(--bg-raised)",
                 border: `var(--hairline) solid ${amberActive ? "var(--state-blocked-border)" : "var(--border)"}`,
                 borderRadius: "var(--radius-dialog)",
@@ -524,26 +629,44 @@ export function ChatSummary({
                 overscrollBehavior: "contain",
               }}
             >
-              <div style={{ maxWidth: "var(--chat-summary-readable-rail)" }}>
-                <div
-                  data-summary-part="document"
-                  data-summary-layout={promotesHeadline ? "lead" : "faithful"}
-                  className="text-body"
-                  style={{ color: promotesHeadline ? "var(--fg-2)" : "var(--fg)" }}
+              <div
+                data-summary-part="document"
+                data-summary-layout={promotesHeadline ? "lead" : "faithful"}
+                className="text-body"
+                style={{ color: promotesHeadline ? "var(--fg-2)" : "var(--fg)" }}
+              >
+                {/* Keep one markdown tree so reference definitions and other
+                    document-scoped syntax remain available to every block.
+                    The current-state contract promotes the first physical line;
+                    a custom first paragraph styles only that line when soft
+                    breaks stay inside one <p>. Legacy block-first markdown
+                    stays faithful. */}
+                <Markdown
+                  className={
+                    "[&_p]:text-body [&_li]:text-body [&_:is(h1,h2,h3,h4,h5,h6)]:text-[length:1em] [&_:is(h1,h2,h3,h4,h5,h6)]:font-semibold [&_:is(h1,h2,h3,h4,h5,h6)]:leading-snug [&_:is(h1,h2,h3,h4,h5,h6)]:mt-3.5 [&_:is(h1,h2,h3,h4,h5,h6)]:mb-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:pl-4 [&_ol]:pl-4"
+                  }
+                  components={
+                    promotesHeadline
+                      ? (() => {
+                          let leadApplied = false;
+                          return {
+                            p: ({ node, children, ...props }) => {
+                              void node;
+                              const promoteThis = !leadApplied;
+                              if (promoteThis) leadApplied = true;
+                              return (
+                                <LeadAwareParagraph promoteLead={promoteThis} {...props}>
+                                  {children}
+                                </LeadAwareParagraph>
+                              );
+                            },
+                          };
+                        })()
+                      : undefined
+                  }
                 >
-                  {/* Keep one markdown tree so reference definitions and other
-                      document-scoped syntax remain available to every block.
-                      The current-state contract makes the first top-level prose
-                      block the lead; legacy block-first markdown stays faithful. */}
-                  <Markdown
-                    className={
-                      `${promotesHeadline ? "[&>p:first-of-type]:text-subtitle [&>p:first-of-type]:text-[color:var(--fg)] [&>p:first-of-type]:mt-0 [&>p:first-of-type]:mb-[var(--sp-3)] " : ""}` +
-                      "[&_p]:text-body [&_li]:text-body [&_:is(h1,h2,h3,h4,h5,h6)]:text-[length:1em] [&_:is(h1,h2,h3,h4,h5,h6)]:font-semibold [&_:is(h1,h2,h3,h4,h5,h6)]:leading-snug [&_:is(h1,h2,h3,h4,h5,h6)]:mt-3.5 [&_:is(h1,h2,h3,h4,h5,h6)]:mb-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:pl-4 [&_ol]:pl-4"
-                    }
-                  >
-                    {markdownDescription}
-                  </Markdown>
-                </div>
+                  {markdownDescription}
+                </Markdown>
               </div>
             </section>,
             overlayEl,

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown } from "lucide-react";
 import {
   Children,
+  type CSSProperties,
   type HTMLAttributes,
   isValidElement,
   type ReactNode,
@@ -137,11 +138,13 @@ function clearDismissedVersion(chatId: string, version: string): void {
 type DescriptionLead = {
   preview: string;
   promotable: boolean;
+  /** 1-based source line of the lead physical line (matches mdast/hast positions). */
+  line: number;
 };
 
 function findDescriptionLead(description: string): DescriptionLead | null {
   const lines = description.split(/\r?\n/);
-  let headingFallback = "";
+  let headingFallback: { preview: string; line: number } | null = null;
   for (const [index, rawLine] of lines.entries()) {
     const line = rawLine.trim();
     if (!line) continue;
@@ -167,10 +170,11 @@ function findDescriptionLead(description: string): DescriptionLead | null {
       .replace(/\s+/g, " ")
       .trim();
     if (!stripped) continue;
+    const sourceLine = index + 1;
     if (isHeading) {
       // Remember the first heading as a fallback, but keep scanning for prose.
       if (!headingFallback) {
-        headingFallback = stripped;
+        headingFallback = { preview: stripped, line: sourceLine };
       }
       continue;
     }
@@ -185,17 +189,34 @@ function findDescriptionLead(description: string): DescriptionLead | null {
     return {
       preview: stripped,
       promotable: !startsComplexBlock,
+      line: sourceLine,
     };
   }
   if (!headingFallback) return null;
   return {
-    preview: headingFallback,
+    preview: headingFallback.preview,
     promotable: false,
+    line: headingFallback.line,
   };
 }
 
 export function descriptionFirstLine(description: string): string {
   return findDescriptionLead(description)?.preview ?? "";
+}
+
+type MarkdownParagraphNode = {
+  position?: {
+    start?: { line?: number };
+    end?: { line?: number };
+  };
+};
+
+/** Pure: true when this paragraph's source span covers the lead physical line. */
+function paragraphContainsLeadLine(node: MarkdownParagraphNode | undefined, leadLine: number): boolean {
+  const start = node?.position?.start?.line;
+  const end = node?.position?.end?.line;
+  if (start == null || end == null) return false;
+  return start <= leadLine && leadLine <= end;
 }
 
 function isBreakElement(node: ReactNode): boolean {
@@ -230,11 +251,31 @@ function joinSoftBreakSegments(segments: ReactNode[][]): ReactNode {
   }, null);
 }
 
+const LEAD_SPAN_STYLE: CSSProperties = {
+  display: "block",
+  color: "var(--fg)",
+  marginBottom: "var(--sp-3)",
+  // Inline measure beats parent `[&_p]:text-body` inheritance/specificity on <p>.
+  fontSize: "var(--text-subtitle)",
+  fontWeight: "var(--text-subtitle--font-weight)" as CSSProperties["fontWeight"],
+  lineHeight: "var(--text-subtitle--line-height)",
+  letterSpacing: "var(--text-subtitle--letter-spacing)",
+};
+
+function LeadSpan({ children }: { children: ReactNode }) {
+  return (
+    <span data-summary-part="lead" className="text-subtitle" style={LEAD_SPAN_STYLE}>
+      {children}
+    </span>
+  );
+}
+
 /**
- * Promote only the first physical line of the first prose paragraph. Soft breaks
- * from the writing contract (`line\nline`) stay in one Markdown `<p>`; styling
- * the whole paragraph would bold the entire brief. Blank-line paragraphs still
- * promote the whole first `<p>` when it has no soft breaks.
+ * Promote only the first physical line of the prose paragraph that covers the
+ * lead source line. Soft breaks from the writing contract stay in one Markdown
+ * `<p>`; the lead is always a child span so `[&_p]:text-body` cannot flatten
+ * headline weight back to body. Blank-line paragraphs wrap their sole segment
+ * the same way.
  */
 function LeadAwareParagraph({
   children,
@@ -256,33 +297,15 @@ function LeadAwareParagraph({
   );
   if (nonEmpty.length <= 1) {
     return (
-      <p
-        {...props}
-        data-summary-part="lead"
-        className={["text-subtitle mt-0 mb-[var(--sp-3)]", props.className].filter(Boolean).join(" ")}
-        style={{
-          ...(typeof props.style === "object" && props.style ? props.style : {}),
-          color: "var(--fg)",
-        }}
-      >
-        {children}
+      <p {...props}>
+        <LeadSpan>{children}</LeadSpan>
       </p>
     );
   }
   const [lead, ...rest] = nonEmpty;
   return (
     <p {...props}>
-      <span
-        data-summary-part="lead"
-        className="text-subtitle"
-        style={{
-          display: "block",
-          color: "var(--fg)",
-          marginBottom: "var(--sp-3)",
-        }}
-      >
-        {lead}
-      </span>
+      <LeadSpan>{lead}</LeadSpan>
       {joinSoftBreakSegments(rest)}
     </p>
   );
@@ -510,10 +533,30 @@ export function ChatSummary({
     };
   }, [expanded, dismiss]);
 
+  const descriptionLead = useMemo(() => findDescriptionLead(markdownDescription), [markdownDescription]);
+  const promotesHeadline = descriptionLead?.promotable ?? false;
+  const leadSourceLine = promotesHeadline ? (descriptionLead?.line ?? null) : null;
+  const summaryMarkdownComponents = useMemo(() => {
+    if (leadSourceLine == null) return undefined;
+    return {
+      p: ({
+        node,
+        children,
+        ...props
+      }: HTMLAttributes<HTMLParagraphElement> & {
+        node?: MarkdownParagraphNode;
+        children?: ReactNode;
+      }) => (
+        <LeadAwareParagraph promoteLead={paragraphContainsLeadLine(node, leadSourceLine)} {...props}>
+          {children}
+        </LeadAwareParagraph>
+      ),
+    };
+  }, [leadSourceLine]);
+
   if (!hasDescription) return null;
 
   const firstLine = descriptionFirstLine(markdownDescription);
-  const promotesHeadline = findDescriptionLead(markdownDescription)?.promotable ?? false;
   const freshnessText = updatedAtMs !== null ? formatRelative(descriptionUpdatedAt) : null;
   const showAmberChip = unread && !unreadCleared && !expanded;
   const amberActive = highlighted && expanded;
@@ -645,25 +688,7 @@ export function ChatSummary({
                   className={
                     "[&_p]:text-body [&_li]:text-body [&_:is(h1,h2,h3,h4,h5,h6)]:text-[length:1em] [&_:is(h1,h2,h3,h4,h5,h6)]:font-semibold [&_:is(h1,h2,h3,h4,h5,h6)]:leading-snug [&_:is(h1,h2,h3,h4,h5,h6)]:mt-3.5 [&_:is(h1,h2,h3,h4,h5,h6)]:mb-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:pl-4 [&_ol]:pl-4"
                   }
-                  components={
-                    promotesHeadline
-                      ? (() => {
-                          let leadApplied = false;
-                          return {
-                            p: ({ node, children, ...props }) => {
-                              void node;
-                              const promoteThis = !leadApplied;
-                              if (promoteThis) leadApplied = true;
-                              return (
-                                <LeadAwareParagraph promoteLead={promoteThis} {...props}>
-                                  {children}
-                                </LeadAwareParagraph>
-                              );
-                            },
-                          };
-                        })()
-                      : undefined
-                  }
+                  components={summaryMarkdownComponents}
                 >
                   {markdownDescription}
                 </Markdown>


### PR DESCRIPTION
## Summary

- Promote only the **first physical line** as the Current state headline, so writing-contract soft breaks (`remarkBreaks` → one `<p>`) no longer bold the entire brief
- Lead detection is a pure source-line / `node.position` check (StrictMode-safe; no mutable render flags)
- Lead always renders as a child span with explicit subtitle measure, so parent `[&_p]:text-body` cannot flatten blank-line headlines
- Keep one Markdown document and existing block-first / reference-link fallbacks
- Move the readable measure onto the raised card itself and replace `68ch` with `47.5rem` (~760px) so CJK/Latin mix is not squeezed and the card no longer stretches full-bleed with empty chrome
- Add soft-break + StrictMode regressions plus QA/Momentic wording aligned to the physical-line contract

## Test plan

- [x] `pnpm --filter @first-tree/web exec vitest run src/pages/workspace/center/__tests__/chat-summary.test.ts` — 33 passed
- [x] `pnpm --filter @first-tree/web typecheck`
- [x] `pnpm check` (no new errors on changed files)
- [x] `npx momentic@3.42.0 lint e2e/chat-summary-current-state.test.yaml`
- [ ] Independent exact-head QA (owned separately; PR stays Draft)