### PR TITLE
fix: stabilize Claude Context repair adoption

### DIFF
--- a/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
+++ b/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
@@ -142,6 +142,7 @@ describe("client switch transaction recovery", () => {
       join(home, "state", "context", "providers", "claude-code", "reload-consumed", "old.json"),
       join(home, "state", "context", "providers", "codex", "adapter-sync", "old.json"),
       join(home, "state", "context", "providers", "claude-code", "reload-required.json"),
+      join(home, "state", "context", "providers", "claude-code", "next-session-required.json"),
     ]) {
       writeJson(path, { accountClientId: "client_aabbccdd" });
     }
@@ -182,6 +183,9 @@ describe("client switch transaction recovery", () => {
     expect(existsSync(join(home, "state", "context", "providers", "claude-code", "reload-consumed"))).toBe(false);
     expect(existsSync(join(home, "state", "context", "providers", "codex", "adapter-sync"))).toBe(false);
     expect(existsSync(join(home, "state", "context", "providers", "claude-code", "reload-required.json"))).toBe(false);
+    expect(existsSync(join(home, "state", "context", "providers", "claude-code", "next-session-required.json"))).toBe(
+      false,
+    );
     expect(existsSync(clientSwitchJournalPath(home))).toBe(false);
     expect(existsSync(clientSwitchLockPath(home))).toBe(false);
 

--- a/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
+++ b/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
@@ -140,6 +140,7 @@ describe("client switch transaction recovery", () => {
       join(home, "state", "context", "route-receipts", "old.json"),
       join(home, "state", "context", "providers", "claude-code", "reload-pending", "old.json"),
       join(home, "state", "context", "providers", "claude-code", "reload-consumed", "old.json"),
+      join(home, "state", "context", "providers", "claude-code", "compatible-sessions", "old.json"),
       join(home, "state", "context", "providers", "codex", "adapter-sync", "old.json"),
       join(home, "state", "context", "providers", "claude-code", "reload-required.json"),
       join(home, "state", "context", "providers", "claude-code", "next-session-required.json"),
@@ -181,6 +182,7 @@ describe("client switch transaction recovery", () => {
     expect(existsSync(join(home, "state", "context", "route-receipts"))).toBe(false);
     expect(existsSync(join(home, "state", "context", "providers", "claude-code", "reload-pending"))).toBe(false);
     expect(existsSync(join(home, "state", "context", "providers", "claude-code", "reload-consumed"))).toBe(false);
+    expect(existsSync(join(home, "state", "context", "providers", "claude-code", "compatible-sessions"))).toBe(false);
     expect(existsSync(join(home, "state", "context", "providers", "codex", "adapter-sync"))).toBe(false);
     expect(existsSync(join(home, "state", "context", "providers", "claude-code", "reload-required.json"))).toBe(false);
     expect(existsSync(join(home, "state", "context", "providers", "claude-code", "next-session-required.json"))).toBe(

--- a/apps/cli/src/__tests__/context-activate-command.test.ts
+++ b/apps/cli/src/__tests__/context-activate-command.test.ts
@@ -197,12 +197,13 @@ describe("context activate command", () => {
     });
 
     await runContextActivate(context({ provider: "claude-code", adapterDigest: "sha256:current" }), {
-      readHookInput: () => ({ session_id: "session-new", cwd: "/work" }),
+      readHookInput: () => ({ session_id: "session-new", cwd: "/work", source: "startup" }),
     });
 
     expect(mocks.consumeNextSession).toHaveBeenCalledWith({
       provider: "claude-code",
       adapterDigest: "sha256:current",
+      sessionStartSource: "startup",
     });
     expect(mocks.resolveProject).toHaveBeenCalledAfter(mocks.consumeNextSession);
     expect(mocks.activateExternal).toHaveBeenCalledOnce();

--- a/apps/cli/src/__tests__/context-activate-command.test.ts
+++ b/apps/cli/src/__tests__/context-activate-command.test.ts
@@ -56,6 +56,7 @@ describe("context activate command", () => {
     vi.clearAllMocks();
     vi.stubEnv("FIRST_TREE_AGENT_ID", "");
     vi.stubEnv("FIRST_TREE_CHAT_ID", "");
+    vi.stubEnv("FIRST_TREE_SERVER_URL", "https://first-tree.example");
     mocks.readInstall.mockReturnValue({
       accountClientId: "client_1234abcd",
       channel: "dev",

--- a/apps/cli/src/__tests__/context-activate-command.test.ts
+++ b/apps/cli/src/__tests__/context-activate-command.test.ts
@@ -5,6 +5,7 @@ import type { CommandContext } from "../commands/types.js";
 const mocks = vi.hoisted(() => ({
   hook: vi.fn(),
   issueSync: vi.fn(),
+  knownCompatibleSession: vi.fn(),
   readInstall: vi.fn(),
   resolveRelease: vi.fn(),
   assertPayloadHealthy: vi.fn(),
@@ -18,6 +19,7 @@ vi.mock("../core/output.js", () => ({ print: { hook: mocks.hook } }));
 vi.mock("../core/channel.js", () => ({ channelConfig: { channel: "dev" } }));
 vi.mock("../core/context-integration/adapter-sync.js", () => ({
   AdapterSyncRejectedError: class AdapterSyncRejectedError extends Error {},
+  hasKnownCompatibleContextAdapterSession: mocks.knownCompatibleSession,
   issueAdapterSyncAction: mocks.issueSync,
 }));
 vi.mock("../core/context-integration/manifest.js", () => ({
@@ -69,6 +71,7 @@ describe("context activate command", () => {
       command: "first-tree-dev --json context adapter-sync --provider codex --challenge opaque",
     });
     mocks.assertPayloadHealthy.mockReturnValue(undefined);
+    mocks.knownCompatibleSession.mockReturnValue(false);
     mocks.resolveProject.mockReturnValue({ kind: "pathless", project: { kind: "pathless" } });
     mocks.activateExternal.mockResolvedValue({ outcome: "connected" });
     mocks.renderResponse.mockReturnValue({ continue: true, systemMessage: "connected" });
@@ -208,5 +211,46 @@ describe("context activate command", () => {
     expect(mocks.resolveProject).toHaveBeenCalledAfter(mocks.consumeNextSession);
     expect(mocks.activateExternal).toHaveBeenCalledOnce();
     expect(mocks.hook).toHaveBeenCalledWith({ continue: true, systemMessage: "connected" });
+  });
+
+  it.each([
+    "resume",
+    "clear",
+    "compact",
+  ])("keeps an upgraded Claude %s lifecycle event on its session-bound compatible adapter", async (source) => {
+    mocks.readInstall.mockReturnValue({
+      accountClientId: "client_1234abcd",
+      channel: "dev",
+      loaderProtocolVersion: 1,
+      adapterVersion: "1.0.2",
+      adapterDigest: "sha256:current",
+    });
+    mocks.resolveRelease.mockReturnValue({
+      manifest: {
+        providers: { "claude-code": { adapterVersion: "1.0.2", adapterDigest: "sha256:current" } },
+      },
+    });
+    mocks.knownCompatibleSession.mockReturnValue(true);
+
+    await runContextActivate(context({ provider: "claude-code", adapterDigest: "sha256:old" }), {
+      readHookInput: () => ({ session_id: "session-existing", cwd: "/work", source }),
+    });
+
+    expect(mocks.knownCompatibleSession).toHaveBeenCalledWith(
+      {
+        provider: "claude-code",
+        sessionId: "session-existing",
+        suppliedAdapterDigest: "sha256:old",
+      },
+      expect.objectContaining({ driver: expect.anything() }),
+    );
+    expect(mocks.issueSync).not.toHaveBeenCalled();
+    expect(mocks.consumeNextSession).toHaveBeenCalledWith({
+      provider: "claude-code",
+      adapterDigest: "sha256:old",
+      sessionStartSource: source,
+    });
+    expect(mocks.activateExternal).toHaveBeenCalledOnce();
+    expect(JSON.stringify(mocks.hook.mock.calls[0]?.[0])).not.toContain("context repair");
   });
 });

--- a/apps/cli/src/__tests__/context-activate-command.test.ts
+++ b/apps/cli/src/__tests__/context-activate-command.test.ts
@@ -8,6 +8,10 @@ const mocks = vi.hoisted(() => ({
   readInstall: vi.fn(),
   resolveRelease: vi.fn(),
   assertPayloadHealthy: vi.fn(),
+  consumeNextSession: vi.fn(),
+  resolveProject: vi.fn(),
+  activateExternal: vi.fn(),
+  renderResponse: vi.fn(),
 }));
 
 vi.mock("../core/output.js", () => ({ print: { hook: mocks.hook } }));
@@ -24,6 +28,16 @@ vi.mock("../core/context-integration/release.js", () => ({
 }));
 vi.mock("../core/context-integration/adapter-payload-health.js", () => ({
   assertContextAdapterPayloadHealthy: mocks.assertPayloadHealthy,
+}));
+vi.mock("../core/context-integration/adapter-observation.js", () => ({
+  consumeContextAdapterNextSessionObligation: mocks.consumeNextSession,
+}));
+vi.mock("../core/context-integration/client-preflight.js", () => ({
+  resolveSessionContextProject: mocks.resolveProject,
+}));
+vi.mock("../core/context-integration/activation.js", () => ({
+  activateExternalContext: mocks.activateExternal,
+  renderProviderSessionStartResponse: mocks.renderResponse,
 }));
 
 import { runContextActivate } from "../commands/context/activate.js";
@@ -55,6 +69,9 @@ describe("context activate command", () => {
       command: "first-tree-dev --json context adapter-sync --provider codex --challenge opaque",
     });
     mocks.assertPayloadHealthy.mockReturnValue(undefined);
+    mocks.resolveProject.mockReturnValue({ kind: "pathless", project: { kind: "pathless" } });
+    mocks.activateExternal.mockResolvedValue({ outcome: "connected" });
+    mocks.renderResponse.mockReturnValue({ continue: true, systemMessage: "connected" });
   });
 
   afterEach(() => {
@@ -163,5 +180,32 @@ describe("context activate command", () => {
     const response = mocks.hook.mock.calls[0]?.[0];
     expect(response.systemMessage).toContain("needs attention");
     expect(response.hookSpecificOutput.additionalContext).toContain("context repair");
+  });
+
+  it("consumes the Claude next-session marker before automatic routing", async () => {
+    mocks.readInstall.mockReturnValue({
+      accountClientId: "client_1234abcd",
+      channel: "dev",
+      loaderProtocolVersion: 1,
+      adapterVersion: "1.0.2",
+      adapterDigest: "sha256:current",
+    });
+    mocks.resolveRelease.mockReturnValue({
+      manifest: {
+        providers: { "claude-code": { adapterVersion: "1.0.2", adapterDigest: "sha256:current" } },
+      },
+    });
+
+    await runContextActivate(context({ provider: "claude-code", adapterDigest: "sha256:current" }), {
+      readHookInput: () => ({ session_id: "session-new", cwd: "/work" }),
+    });
+
+    expect(mocks.consumeNextSession).toHaveBeenCalledWith({
+      provider: "claude-code",
+      adapterDigest: "sha256:current",
+    });
+    expect(mocks.resolveProject).toHaveBeenCalledAfter(mocks.consumeNextSession);
+    expect(mocks.activateExternal).toHaveBeenCalledOnce();
+    expect(mocks.hook).toHaveBeenCalledWith({ continue: true, systemMessage: "connected" });
   });
 });

--- a/apps/cli/src/__tests__/context-adapter-observation.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-observation.test.ts
@@ -51,7 +51,11 @@ describe("Claude next-session adapter adoption", () => {
     );
     expect(
       consumeContextAdapterNextSessionObligation(
-        { provider: "claude-code", adapterDigest: `sha256:${"0".repeat(64)}` },
+        {
+          provider: "claude-code",
+          adapterDigest: `sha256:${"0".repeat(64)}`,
+          sessionStartSource: "startup",
+        },
         { releaseRoot, coreRoot },
       ),
     ).toBeNull();
@@ -59,12 +63,34 @@ describe("Claude next-session adapter adoption", () => {
 
     expect(
       consumeContextAdapterNextSessionObligation(
-        { provider: "claude-code", adapterDigest: target.adapterDigest },
+        { provider: "claude-code", adapterDigest: target.adapterDigest, sessionStartSource: "startup" },
         { releaseRoot, coreRoot },
       ),
     ).toBe("standalone_repair");
     expect(inspectContextAdapterNextSessionObligation()).toBeNull();
     expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).not.toThrow();
+  });
+
+  it.each([
+    "resume",
+    "clear",
+    "compact",
+    undefined,
+  ])("does not consume the repair marker for an existing-session lifecycle source (%s)", (sessionStartSource) => {
+    const release = installCurrentAdapter();
+    const target = release.manifest.providers["claude-code"];
+    beginContextAdapterNextSessionObligation(release.manifest, "standalone_repair");
+
+    expect(
+      consumeContextAdapterNextSessionObligation(
+        { provider: "claude-code", adapterDigest: target.adapterDigest, sessionStartSource },
+        { releaseRoot, coreRoot },
+      ),
+    ).toBeNull();
+    expect(inspectContextAdapterNextSessionObligation()).toBe("standalone_repair");
+    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
+      "Start a new session",
+    );
   });
 
   it("restores the previous marker if provider installation fails", () => {

--- a/apps/cli/src/__tests__/context-adapter-observation.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-observation.test.ts
@@ -1,29 +1,21 @@
-import { execFileSync, spawn } from "node:child_process";
-import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   assertContextAdapterReadyForRouting,
-  consumeContextAdapterReloadReceipt,
-  consumeContextAdapterReloadRequiredMarker,
-  hasPendingContextAdapterReload,
-  inspectContextAdapterLoadedObservationObligation,
-  issueContextAdapterSessionLoadedReceipt,
-  markContextAdapterReloadRequired,
-  registerPendingContextAdapterReload as registerPendingContextAdapterReloadImpl,
+  beginContextAdapterNextSessionObligation,
+  consumeContextAdapterNextSessionObligation,
+  inspectContextAdapterNextSessionObligation,
 } from "../core/context-integration/adapter-observation.js";
-import {
-  readContextIntegrationInstallManifest,
-  writeContextIntegrationInstallManifest,
-} from "../core/context-integration/manifest.js";
+import { writeContextIntegrationInstallManifest } from "../core/context-integration/manifest.js";
 import { contextPluginTreeDigest } from "../core/context-integration/payload-integrity.js";
 import type { ContextIntegrationProviderDriver } from "../core/context-integration/provider-driver.js";
 import { resolveContextIntegrationRelease } from "../core/context-integration/release.js";
 import { COMMAND_VERSION } from "../core/version.js";
 
 const roots: string[] = [];
-const ADOPTION_GENERATION = "a".repeat(48);
 const originalHome = process.env.FIRST_TREE_HOME;
 let home = "";
 let coreRoot = "";
@@ -42,322 +34,58 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.useRealTimers();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
   else process.env.FIRST_TREE_HOME = originalHome;
 });
 
-describe("Claude adapter reload observation", () => {
-  it("does not observe a healthy adapter when no reload obligation exists", () => {
-    const release = installCurrentAdapter();
-    expect(
-      inspectContextAdapterLoadedObservationObligation({
-        provider: "claude-code",
-        adapterDigest: release.manifest.providers["claude-code"].adapterDigest,
-        adoptionGeneration: ADOPTION_GENERATION,
-      }),
-    ).toBeNull();
-  });
-
-  it("blocks Context routing while a repair marker or exact setup reload is still pending", () => {
-    const release = installCurrentAdapter();
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).not.toThrow();
-
-    markContextAdapterReloadRequired(release.manifest);
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
-      "Reload the provider Plugin",
-    );
-    expect(consumeContextAdapterReloadRequiredMarker(release.manifest)).toBe(true);
-
-    const challenge = "0".repeat(64);
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
-      "Reload the provider Plugin",
-    );
-    const receipt = loadedReceipt("session-ready", release.manifest.providers["claude-code"].adapterDigest);
-    consumeContextAdapterReloadReceipt({ planChallenge: challenge, receipt, release: release.manifest });
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).not.toThrow();
-  });
-
-  it("ignores an expired old-target pending reload while a compatible loaded adapter remains usable", () => {
-    const release = installCurrentAdapter();
-    const challenge = "8".repeat(64);
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const path = join(home, "state", "context", "providers", "claude-code", "reload-pending", `${challenge}.json`);
-    const pending = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
-    writeFileSync(
-      path,
-      `${JSON.stringify({ ...pending, adapterVersion: "0.0.0", expiresAt: "2000-01-01T00:00:00.000Z" })}\n`,
-    );
-    const install = readContextIntegrationInstallManifest("claude-code");
-    if (!install) throw new Error("missing test install manifest");
-    writeContextIntegrationInstallManifest({ ...install, adapterVersion: "0.0.0" });
-
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).not.toThrow();
-    expect(readFileSync(path, "utf8")).toContain("2000-01-01T00:00:00.000Z");
-    expect(
-      inspectContextAdapterLoadedObservationObligation({
-        provider: "claude-code",
-        adapterDigest: release.manifest.providers["claude-code"].adapterDigest,
-        adoptionGeneration: ADOPTION_GENERATION,
-      }),
-    ).toBeNull();
-    expect(readFileSync(path, "utf8")).toContain("2000-01-01T00:00:00.000Z");
-
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const unexpired = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
-    writeFileSync(path, `${JSON.stringify({ ...unexpired, adapterVersion: "0.0.0" })}\n`);
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
-      "another account or adapter target",
-    );
-  });
-
-  it("consumes a standalone repair marker once and rejects it after an account switch", () => {
-    const release = installCurrentAdapter();
-    markContextAdapterReloadRequired(release.manifest);
-    expect(consumeContextAdapterReloadRequiredMarker(release.manifest)).toBe(true);
-    expect(consumeContextAdapterReloadRequiredMarker(release.manifest)).toBe(false);
-
-    markContextAdapterReloadRequired(release.manifest);
-    writeFileSync(join(home, "config", "client.yaml"), "client:\n  id: client_ffffffff\n");
-    expect(() => consumeContextAdapterReloadRequiredMarker(release.manifest)).toThrow("does not match");
-  });
-
-  it("lets the verified reloaded hook complete standalone repair adoption", () => {
-    const release = installCurrentAdapter();
-    markContextAdapterReloadRequired(release.manifest, "standalone_repair");
-
-    expect(observeLoaded("session-after-repair", release.manifest.providers["claude-code"].adapterDigest)).toBeNull();
-
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).not.toThrow();
-    expect(consumeContextAdapterReloadRequiredMarker(release.manifest)).toBe(false);
-  });
-
-  it("rejects a pre-repair hook generation even when the adapter digest did not change", () => {
-    const release = installCurrentAdapter();
-    const repairedGeneration = "b".repeat(48);
-    const install = readContextIntegrationInstallManifest("claude-code");
-    if (!install) throw new Error("missing test install manifest");
-    writeContextIntegrationInstallManifest({ ...install, adoptionGeneration: repairedGeneration });
-    markContextAdapterReloadRequired(release.manifest, "standalone_repair", repairedGeneration);
-
-    expect(() =>
-      loadedReceipt(
-        "session-still-running-old-hook",
-        release.manifest.providers["claude-code"].adapterDigest,
-        ADOPTION_GENERATION,
-      ),
-    ).toThrow();
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
-      "Reload the provider Plugin",
-    );
-
-    expect(
-      observeLoaded(
-        "session-after-reload",
-        release.manifest.providers["claude-code"].adapterDigest,
-        repairedGeneration,
-      ),
-    ).toBeNull();
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).not.toThrow();
-  });
-
-  it("keeps the hook non-mutating while another process owns the account-state lock", async () => {
-    const release = installCurrentAdapter();
-    const lock = join(home, "state", "account-state.lock");
-    const child = spawn(
-      process.execPath,
-      [
-        "-e",
-        "const fs=require('node:fs');const p=process.argv[1];fs.mkdirSync(require('node:path').dirname(p),{recursive:true});fs.writeFileSync(p,process.pid+'\\n',{flag:'wx'});process.stdout.write('ready\\n');setInterval(()=>{},1000);",
-        lock,
-      ],
-      { stdio: ["ignore", "pipe", "inherit"] },
-    );
-    try {
-      await new Promise<void>((resolveReady, reject) => {
-        const timeout = setTimeout(() => reject(new Error("lock holder did not become ready")), 5_000);
-        child.once("error", reject);
-        child.stdout.once("data", () => {
-          clearTimeout(timeout);
-          resolveReady();
-        });
-      });
-      expect(() => loadedReceipt("session-locked", release.manifest.providers["claude-code"].adapterDigest)).toThrow(
-        "Another First Tree account or Context state change",
-      );
-    } finally {
-      child.kill("SIGTERM");
-      await new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
-      rmSync(lock, { force: true });
-    }
-  });
-
-  it("accepts one signed current-session receipt for one exact pending plan", () => {
-    const release = installCurrentAdapter();
-    const challenge = "a".repeat(64);
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const receipt = loadedReceipt("session-a", release.manifest.providers["claude-code"].adapterDigest);
-
-    consumeContextAdapterReloadReceipt({ planChallenge: challenge, receipt, release: release.manifest });
-
-    expect(hasPendingContextAdapterReload(challenge, release.manifest)).toBe(false);
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    expect(() =>
-      consumeContextAdapterReloadReceipt({ planChallenge: challenge, receipt, release: release.manifest }),
-    ).toThrow("already consumed");
-  });
-
-  it("binds receipts to the active account without treating the user-level Plugin install as account-owned", () => {
-    const release = installCurrentAdapter();
-    writeFileSync(join(home, "config", "client.yaml"), "client:\n  id: client_ffffffff\n");
-    const challenge = "f".repeat(64);
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const receipt = loadedReceipt("session-new-account", release.manifest.providers["claude-code"].adapterDigest);
-
-    consumeContextAdapterReloadReceipt({ planChallenge: challenge, receipt, release: release.manifest });
-
-    expect(hasPendingContextAdapterReload(challenge, release.manifest)).toBe(false);
-  });
-
-  it("rejects old adapter hooks, forged tokens, missing session identity, account changes, and expiry", () => {
-    const release = installCurrentAdapter();
-    const targetDigest = release.manifest.providers["claude-code"].adapterDigest;
-    const challenge = "b".repeat(64);
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    expect(() => loadedReceipt("session-a", `sha256:${"0".repeat(64)}`)).toThrow("no matching");
-    expect(() => loadedReceipt("", targetDigest)).toThrow("session identity");
-    expect(() =>
-      consumeContextAdapterReloadReceipt({
-        planChallenge: challenge,
-        receipt: "v1.fake.fake",
-        release: release.manifest,
-      }),
-    ).toThrow("signature");
-
-    const accountReceipt = loadedReceipt("session-a", targetDigest);
-    writeFileSync(join(home, "config", "client.yaml"), "client:\n  id: client_ffffffff\n");
-    expect(() =>
-      consumeContextAdapterReloadReceipt({
-        planChallenge: challenge,
-        receipt: accountReceipt,
-        release: release.manifest,
-      }),
-    ).toThrow("does not match");
-
-    writeFileSync(join(home, "config", "client.yaml"), "client:\n  id: client_1234abcd\n");
-    const expires = loadedReceipt("session-a", targetDigest);
-    vi.useFakeTimers();
-    vi.setSystemTime(Date.now() + 6 * 60 * 1000);
-    expect(() =>
-      consumeContextAdapterReloadReceipt({ planChallenge: challenge, receipt: expires, release: release.manifest }),
-    ).toThrow("does not match");
-  });
-
-  it("keeps concurrent pending plans independent instead of scanning or globally unlocking them", () => {
-    const release = installCurrentAdapter();
-    const first = "c".repeat(64);
-    const second = "d".repeat(64);
-    registerPendingContextAdapterReload(first, release.manifest);
-    registerPendingContextAdapterReload(second, release.manifest);
-    const receipt = loadedReceipt("session-a", release.manifest.providers["claude-code"].adapterDigest);
-
-    consumeContextAdapterReloadReceipt({ planChallenge: first, receipt, release: release.manifest });
-
-    expect(hasPendingContextAdapterReload(first, release.manifest)).toBe(false);
-    expect(hasPendingContextAdapterReload(second, release.manifest)).toBe(true);
-    expect(() =>
-      consumeContextAdapterReloadReceipt({ planChallenge: second, receipt, release: release.manifest }),
-    ).toThrow("already consumed");
-  });
-
-  it("does not let another session take over a plan that was already bound before a crash", () => {
-    const release = installCurrentAdapter();
-    const challenge = "e".repeat(64);
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const path = join(home, "state", "context", "providers", "claude-code", "reload-pending", `${challenge}.json`);
-    const pending = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
-    writeFileSync(path, `${JSON.stringify({ ...pending, boundSessionId: "session-a" })}\n`);
-    const otherSession = loadedReceipt("session-b", release.manifest.providers["claude-code"].adapterDigest);
-
-    expect(() =>
-      consumeContextAdapterReloadReceipt({
-        planChallenge: challenge,
-        receipt: otherSession,
-        release: release.manifest,
-      }),
-    ).toThrow("does not match");
-    expect(hasPendingContextAdapterReload(challenge, release.manifest)).toBe(true);
-  });
-
-  it("finishes pending removal idempotently after the consumed nonce became durable", () => {
-    const release = installCurrentAdapter();
-    const challenge = "2".repeat(64);
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const receipt = loadedReceipt("session-crash", release.manifest.providers["claude-code"].adapterDigest);
-    consumeContextAdapterReloadReceipt({ planChallenge: challenge, receipt, release: release.manifest });
-
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const path = join(home, "state", "context", "providers", "claude-code", "reload-pending", `${challenge}.json`);
-    const pending = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
-    writeFileSync(path, `${JSON.stringify({ ...pending, boundSessionId: "session-crash" })}\n`);
-
-    expect(() =>
-      consumeContextAdapterReloadReceipt({ planChallenge: challenge, receipt, release: release.manifest }),
-    ).not.toThrow();
-    expect(hasPendingContextAdapterReload(challenge, release.manifest)).toBe(false);
-  });
-
-  it("fails closed for malformed pending and consumed reload recovery state", () => {
-    const release = installCurrentAdapter();
-    const challenge = "1".repeat(64);
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const pendingPath = join(
-      home,
-      "state",
-      "context",
-      "providers",
-      "claude-code",
-      "reload-pending",
-      `${challenge}.json`,
-    );
-    writeFileSync(pendingPath, "{broken\n");
-    expect(() => hasPendingContextAdapterReload(challenge, release.manifest)).toThrow("unreadable or invalid");
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
-      "unreadable or invalid",
-    );
-
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const invalidExpiry = JSON.parse(readFileSync(pendingPath, "utf8")) as Record<string, unknown>;
-    writeFileSync(pendingPath, `${JSON.stringify({ ...invalidExpiry, expiresAt: "not-a-date" })}\n`);
-    expect(() => hasPendingContextAdapterReload(challenge, release.manifest)).toThrow("unreadable or invalid");
-
-    registerPendingContextAdapterReload(challenge, release.manifest);
-    const receipt = loadedReceipt("session-corrupt-consumed", release.manifest.providers["claude-code"].adapterDigest);
-    const payload = JSON.parse(Buffer.from(receipt.split(".")[1] ?? "", "base64url").toString("utf8")) as {
-      nonce: string;
-    };
-    const consumedPath = join(
-      home,
-      "state",
-      "context",
-      "providers",
-      "claude-code",
-      "reload-consumed",
-      `${payload.nonce}.json`,
-    );
-    mkdirSync(join(consumedPath, ".."), { recursive: true });
-    writeFileSync(consumedPath, "{broken\n");
-    expect(() =>
-      consumeContextAdapterReloadReceipt({ planChallenge: challenge, receipt, release: release.manifest }),
-    ).toThrow("consumed Claude reload state is unreadable or invalid");
-  });
-
-  it("leaves payload health enforcement at the task routing boundary", () => {
+describe("Claude next-session adapter adoption", () => {
+  it("blocks manual routing until a current SessionStart consumes the repair marker", () => {
     const release = installCurrentAdapter();
     const target = release.manifest.providers["claude-code"];
-    const stableStub = join(
+    beginContextAdapterNextSessionObligation(release.manifest, "standalone_repair");
+
+    expect(inspectContextAdapterNextSessionObligation()).toBe("standalone_repair");
+    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
+      "Start a new session",
+    );
+    expect(
+      consumeContextAdapterNextSessionObligation(
+        { provider: "claude-code", adapterDigest: `sha256:${"0".repeat(64)}` },
+        { releaseRoot, coreRoot },
+      ),
+    ).toBeNull();
+    expect(inspectContextAdapterNextSessionObligation()).toBe("standalone_repair");
+
+    expect(
+      consumeContextAdapterNextSessionObligation(
+        { provider: "claude-code", adapterDigest: target.adapterDigest },
+        { releaseRoot, coreRoot },
+      ),
+    ).toBe("standalone_repair");
+    expect(inspectContextAdapterNextSessionObligation()).toBeNull();
+    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).not.toThrow();
+  });
+
+  it("restores the previous marker if provider installation fails", () => {
+    const release = installCurrentAdapter();
+    const rollback = beginContextAdapterNextSessionObligation(release.manifest, "setup");
+    expect(inspectContextAdapterNextSessionObligation()).toBe("setup");
+    rollback();
+    expect(inspectContextAdapterNextSessionObligation()).toBeNull();
+  });
+
+  it("fails closed for malformed next-session state", () => {
+    installCurrentAdapter();
+    const marker = join(home, "state", "context", "providers", "claude-code", "next-session-required.json");
+    mkdirSync(join(marker, ".."), { recursive: true });
+    writeFileSync(marker, "not-json\n");
+    expect(() => inspectContextAdapterNextSessionObligation()).toThrow("next-session state is unreadable or invalid");
+  });
+
+  it("still rejects drift in stable or provider-owned Plugin bytes", () => {
+    installCurrentAdapter();
+    const stableSkill = join(
       home,
       "state",
       "context",
@@ -370,36 +98,14 @@ describe("Claude adapter reload observation", () => {
       "first-tree-read",
       "SKILL.md",
     );
-    writeFileSync(stableStub, "tampered stable stub\n");
+    writeFileSync(stableSkill, "tampered stable stub\n");
     expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
       "payload has drifted",
     );
 
     installCurrentAdapter();
-    const providerStub = join(home, "provider-cache", "first-tree-context", "skills", "first-tree-read", "SKILL.md");
-    writeFileSync(providerStub, "tampered provider stub\n");
-    const providerChallenge = "6".repeat(64);
-    registerPendingContextAdapterReload(providerChallenge, release.manifest);
-    const providerReceipt = loadedReceipt("session-provider-drift", target.adapterDigest);
-    consumeContextAdapterReloadReceipt({
-      planChallenge: providerChallenge,
-      receipt: providerReceipt,
-      release: release.manifest,
-    });
-    expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
-      "payload has drifted",
-    );
-
-    installCurrentAdapter();
-    rmSync(join(home, "provider-cache", "first-tree-context", "bin", "context-observe-loaded"));
-    const partialChallenge = "7".repeat(64);
-    registerPendingContextAdapterReload(partialChallenge, release.manifest);
-    const partialReceipt = loadedReceipt("session-partial-cache", target.adapterDigest);
-    consumeContextAdapterReloadReceipt({
-      planChallenge: partialChallenge,
-      receipt: partialReceipt,
-      release: release.manifest,
-    });
+    const providerSkill = join(home, "provider-cache", "first-tree-context", "skills", "first-tree-read", "SKILL.md");
+    writeFileSync(providerSkill, "tampered provider stub\n");
     expect(() => assertContextAdapterReadyForRouting("claude-code", observationOptions())).toThrow(
       "payload has drifted",
     );
@@ -412,14 +118,14 @@ function installCurrentAdapter() {
   const stableMarketplace = join(home, "state", "context", "providers", "claude-code", "marketplace");
   const stablePlugin = join(stableMarketplace, "plugins", "first-tree-context");
   const providerPlugin = join(home, "provider-cache", "first-tree-context");
+  rmSync(stableMarketplace, { recursive: true, force: true });
+  rmSync(providerPlugin, { recursive: true, force: true });
   mkdirSync(join(stablePlugin, "bin"), { recursive: true });
   mkdirSync(join(stablePlugin, "skills", "first-tree-read"), { recursive: true });
   writeFileSync(join(stableMarketplace, "marketplace.json"), "{}\n");
-  for (const launcher of ["context-session-start", "context-observe-loaded"]) {
-    const path = join(stablePlugin, "bin", launcher);
-    writeFileSync(path, "#!/bin/sh\nexit 0\n");
-    chmodSync(path, 0o700);
-  }
+  const launcher = join(stablePlugin, "bin", "context-session-start");
+  writeFileSync(launcher, "#!/bin/sh\nexit 0\n");
+  chmodSync(launcher, 0o700);
   writeFileSync(join(stablePlugin, "skills", "first-tree-read", "SKILL.md"), "---\nname: first-tree-read\n---\n");
   cpSync(stablePlugin, providerPlugin, { recursive: true });
   writeContextIntegrationInstallManifest({
@@ -436,36 +142,11 @@ function installCurrentAdapter() {
     adapterDigest: adapter.adapterDigest,
     marketplaceName: "first-tree-dev",
     pluginName: "first-tree-context",
-    adoptionGeneration: ADOPTION_GENERATION,
     materializedPayloadDigest: contextPluginTreeDigest(stablePlugin),
     materializedMarketplaceDigest: contextPluginTreeDigest(stableMarketplace),
     installedAt: new Date().toISOString(),
   });
   return release;
-}
-
-function loadedReceipt(sessionId: string, adapterDigest: string, adoptionGeneration = ADOPTION_GENERATION): string {
-  const receipt = observeLoaded(sessionId, adapterDigest, adoptionGeneration);
-  if (receipt === null) throw new Error("expected a setup reload receipt");
-  return receipt;
-}
-
-function observeLoaded(sessionId: string, adapterDigest: string, adoptionGeneration = ADOPTION_GENERATION) {
-  return issueContextAdapterSessionLoadedReceipt({
-    provider: "claude-code",
-    adapterDigest,
-    adoptionGeneration,
-    sessionId,
-  });
-}
-
-function registerPendingContextAdapterReload(
-  planChallenge: string,
-  release: ReturnType<typeof installCurrentAdapter>["manifest"],
-): void {
-  markContextAdapterReloadRequired(release, "setup", ADOPTION_GENERATION);
-  registerPendingContextAdapterReloadImpl(planChallenge, release);
-  consumeContextAdapterReloadRequiredMarker(release, "setup");
 }
 
 function observationOptions() {

--- a/apps/cli/src/__tests__/context-adapter-sync-command.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-sync-command.test.ts
@@ -82,4 +82,19 @@ describe("context adapter-sync command", () => {
     expect(mocks.hasKnownGood).not.toHaveBeenCalled();
     expect(mocks.result).not.toHaveBeenCalled();
   });
+
+  it("does not misclassify a non-busy lock I/O failure as next-session recovery", () => {
+    const ioError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    mocks.synchronize.mockImplementation(() => {
+      throw ioError;
+    });
+    mocks.inspectNextSession.mockReturnValue(null);
+
+    expect(() => runContextAdapterSync(context())).not.toThrow();
+    expect(mocks.fail).not.toHaveBeenCalled();
+    expect(mocks.hasKnownGood).toHaveBeenCalledWith(mocks.driver);
+    expect(mocks.result).toHaveBeenCalledWith(
+      expect.objectContaining({ updated: false, currentAdapterUsable: true, status: "update_deferred" }),
+    );
+  });
 });

--- a/apps/cli/src/__tests__/context-adapter-sync-command.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-sync-command.test.ts
@@ -1,0 +1,67 @@
+import type { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandContext } from "../commands/types.js";
+
+const mocks = vi.hoisted(() => ({
+  fail: vi.fn((code: string, message: string) => {
+    throw Object.assign(new Error(message), { code });
+  }),
+  result: vi.fn(),
+  synchronize: vi.fn(),
+  hasKnownGood: vi.fn(),
+  inspectNextSession: vi.fn(),
+  driver: { provider: "claude-code" as const },
+}));
+
+vi.mock("../core/output.js", () => ({ print: { fail: mocks.fail, result: mocks.result } }));
+vi.mock("../core/context-integration/adapter-observation.js", () => ({
+  inspectContextAdapterNextSessionObligation: mocks.inspectNextSession,
+}));
+vi.mock("../core/context-integration/adapter-sync.js", () => ({
+  AdapterNextSessionRequiredError: class AdapterNextSessionRequiredError extends Error {},
+  AdapterSyncRejectedError: class AdapterSyncRejectedError extends Error {},
+  hasKnownGoodCompatibleContextAdapter: mocks.hasKnownGood,
+  synchronizeContextAdapter: mocks.synchronize,
+}));
+vi.mock("../commands/context/shared.js", () => ({
+  createContextIntegrationDriver: () => mocks.driver,
+  parseContextProvider: (value: string) => value,
+}));
+
+import { runContextAdapterSync } from "../commands/context/adapter-sync.js";
+
+function context(): CommandContext {
+  return {
+    command: {
+      opts: () => ({ provider: "claude-code", challenge: "a".repeat(48) }),
+    } as unknown as Command,
+    options: { json: true, debug: false, quiet: false },
+  };
+}
+
+describe("context adapter-sync command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.inspectNextSession.mockReturnValue(null);
+    mocks.hasKnownGood.mockReturnValue(true);
+  });
+
+  it("requires a new Claude session instead of reporting currentAdapterUsable while an obligation is pending", () => {
+    mocks.synchronize.mockImplementation(() => {
+      throw new Error("Another First Tree account or Context state change is already running.");
+    });
+    mocks.inspectNextSession.mockReturnValue("standalone_repair");
+
+    expect(() => runContextAdapterSync(context())).toThrow(
+      "This Claude session cannot use the repaired First Tree Context Plugin",
+    );
+    expect(mocks.fail).toHaveBeenCalledWith(
+      "CONTEXT_PLUGIN_RELOAD_REQUIRED",
+      expect.stringContaining("Start a new Claude session"),
+      2,
+      { nextActions: [expect.stringContaining("Start a new Claude session")] },
+    );
+    expect(mocks.hasKnownGood).not.toHaveBeenCalled();
+    expect(mocks.result).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/__tests__/context-adapter-sync-command.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-sync-command.test.ts
@@ -29,6 +29,7 @@ vi.mock("../commands/context/shared.js", () => ({
 }));
 
 import { runContextAdapterSync } from "../commands/context/adapter-sync.js";
+import { AccountStateMutationBusyError } from "../core/context-integration/account-state-guard.js";
 
 function context(): CommandContext {
   return {
@@ -55,6 +56,23 @@ describe("context adapter-sync command", () => {
     expect(() => runContextAdapterSync(context())).toThrow(
       "This Claude session cannot use the repaired First Tree Context Plugin",
     );
+    expect(mocks.fail).toHaveBeenCalledWith(
+      "CONTEXT_PLUGIN_RELOAD_REQUIRED",
+      expect.stringContaining("Start a new Claude session"),
+      2,
+      { nextActions: [expect.stringContaining("Start a new Claude session")] },
+    );
+    expect(mocks.hasKnownGood).not.toHaveBeenCalled();
+    expect(mocks.result).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when repair holds the account lock before writing its next-session obligation", () => {
+    mocks.synchronize.mockImplementation(() => {
+      throw new AccountStateMutationBusyError();
+    });
+    mocks.inspectNextSession.mockReturnValue(null);
+
+    expect(() => runContextAdapterSync(context())).toThrow("Start a new Claude session");
     expect(mocks.fail).toHaveBeenCalledWith(
       "CONTEXT_PLUGIN_RELOAD_REQUIRED",
       expect.stringContaining("Start a new Claude session"),

--- a/apps/cli/src/__tests__/context-adapter-sync.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-sync.test.ts
@@ -18,6 +18,7 @@ import {
   readContextIntegrationInstallManifest,
   writeContextIntegrationInstallManifest,
 } from "../core/context-integration/manifest.js";
+import { repairContextIntegrationOperation } from "../core/context-integration/operation.js";
 import { contextPluginTreeDigest } from "../core/context-integration/payload-integrity.js";
 import type { ContextIntegrationProviderDriver } from "../core/context-integration/provider-driver.js";
 import { resolveContextIntegrationRelease } from "../core/context-integration/release.js";
@@ -267,6 +268,67 @@ describe("lazy Context adapter sync", () => {
         { releaseRoot, driver: driver("claude-code") },
       ),
     ).toBe(false);
+  });
+
+  it("preserves an action issued after the operation snapshot when the provider update rolls back", () => {
+    const fixture = prepareOldCompatibleInstall();
+    const first = issueAdapterSyncAction(
+      { provider: "claude-code", sessionId: "session-a", suppliedAdapterDigest: fixture.previous.adapterDigest },
+      { releaseRoot, driver: driver("claude-code") },
+    );
+    let concurrent: ReturnType<typeof issueAdapterSyncAction> | undefined;
+    const rollbackDriver = driver("claude-code");
+    rollbackDriver.install = () => rollbackDriver.probe("first-tree-dev", "first-tree-context");
+
+    expect(() =>
+      synchronizeContextAdapter(rollbackDriver, first.challenge, {
+        releaseRoot,
+        planInstall: () => fixture.plan,
+        repairOperation: (providerDriver, plan) =>
+          repairContextIntegrationOperation(providerDriver, plan, {
+            install: () => {
+              concurrent = issueAdapterSyncAction(
+                {
+                  provider: "claude-code",
+                  sessionId: "session-after-snapshot",
+                  suppliedAdapterDigest: fixture.previous.adapterDigest,
+                },
+                { releaseRoot, driver: rollbackDriver },
+              );
+              throw new Error("provider update failed after concurrent issuance");
+            },
+          }),
+      }),
+    ).toThrow("provider update failed after concurrent issuance");
+
+    const concurrentAction = concurrent;
+    expect(concurrentAction).toBeDefined();
+    if (!concurrentAction) throw new Error("concurrent action was not issued");
+    expect(readContextIntegrationInstallManifest("claude-code")?.adapterDigest).toBe(fixture.previous.adapterDigest);
+
+    expect(
+      synchronizeContextAdapter(driver("claude-code"), concurrentAction.challenge, {
+        releaseRoot,
+        planInstall: () => fixture.plan,
+        repairOperation: () => {
+          writeContextIntegrationInstallManifest({
+            ...fixture.previous,
+            adapterVersion: fixture.target.adapterVersion,
+            adapterDigest: fixture.target.adapterDigest,
+          });
+        },
+      }),
+    ).toMatchObject({ updated: true, currentSessionAdoption: "next_session" });
+    expect(
+      hasKnownCompatibleContextAdapterSession(
+        {
+          provider: "claude-code",
+          sessionId: "session-after-snapshot",
+          suppliedAdapterDigest: fixture.previous.adapterDigest,
+        },
+        { releaseRoot, driver: driver("claude-code") },
+      ),
+    ).toBe(true);
   });
 
   it("activates the prepared session fact if the process exits after the provider update commits", () => {

--- a/apps/cli/src/__tests__/context-adapter-sync.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-sync.test.ts
@@ -3,7 +3,11 @@ import { chmodSync, cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { issueAdapterSyncAction, synchronizeContextAdapter } from "../core/context-integration/adapter-sync.js";
+import {
+  hasKnownCompatibleContextAdapterSession,
+  issueAdapterSyncAction,
+  synchronizeContextAdapter,
+} from "../core/context-integration/adapter-sync.js";
 import {
   readContextIntegrationInstallManifest,
   writeContextIntegrationInstallManifest,
@@ -58,6 +62,62 @@ describe("lazy Context adapter sync", () => {
         repairOperation: repair,
       }),
     ).toThrow("missing or invalid");
+  });
+
+  it("keeps the exact upgraded Claude session compatible across later lifecycle events", () => {
+    const fixture = prepareOldCompatibleInstall();
+    const action = issueAdapterSyncAction(
+      {
+        provider: "claude-code",
+        sessionId: "session-lifecycle",
+        suppliedAdapterDigest: fixture.previous.adapterDigest,
+      },
+      { releaseRoot, driver: driver("claude-code") },
+    );
+    const repair = vi.fn(() => {
+      writeContextIntegrationInstallManifest({
+        ...fixture.previous,
+        adapterVersion: fixture.target.adapterVersion,
+        adapterDigest: fixture.target.adapterDigest,
+      });
+    });
+
+    synchronizeContextAdapter(driver("claude-code"), action.challenge, {
+      releaseRoot,
+      planInstall: () => fixture.plan,
+      repairOperation: repair,
+    });
+
+    expect(
+      hasKnownCompatibleContextAdapterSession(
+        {
+          provider: "claude-code",
+          sessionId: "session-lifecycle",
+          suppliedAdapterDigest: fixture.previous.adapterDigest,
+        },
+        { releaseRoot, driver: driver("claude-code") },
+      ),
+    ).toBe(true);
+    expect(
+      hasKnownCompatibleContextAdapterSession(
+        {
+          provider: "claude-code",
+          sessionId: "another-session",
+          suppliedAdapterDigest: fixture.previous.adapterDigest,
+        },
+        { releaseRoot, driver: driver("claude-code") },
+      ),
+    ).toBe(false);
+    expect(
+      hasKnownCompatibleContextAdapterSession(
+        {
+          provider: "claude-code",
+          sessionId: "session-lifecycle",
+          suppliedAdapterDigest: `sha256:${"f".repeat(64)}`,
+        },
+        { releaseRoot, driver: driver("claude-code") },
+      ),
+    ).toBe(false);
   });
 
   it("retains the exact action after a rolled-back update so a bounded retry can succeed", () => {

--- a/apps/cli/src/__tests__/context-adapter-sync.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-sync.test.ts
@@ -45,7 +45,13 @@ describe("lazy Context adapter sync", () => {
       { provider: "claude-code", sessionId: "session-a", suppliedAdapterDigest: fixture.previous.adapterDigest },
       { releaseRoot, driver: driver("claude-code") },
     );
-    const repair = vi.fn();
+    const repair = vi.fn(() => {
+      writeContextIntegrationInstallManifest({
+        ...fixture.previous,
+        adapterVersion: fixture.target.adapterVersion,
+        adapterDigest: fixture.target.adapterDigest,
+      });
+    });
 
     const result = synchronizeContextAdapter(driver("claude-code"), action.challenge, {
       releaseRoot,
@@ -55,13 +61,14 @@ describe("lazy Context adapter sync", () => {
 
     expect(result).toMatchObject({ updated: true, currentSessionAdoption: "next_session" });
     expect(repair).toHaveBeenCalledOnce();
-    expect(() =>
+    expect(
       synchronizeContextAdapter(driver("claude-code"), action.challenge, {
         releaseRoot,
         planInstall: () => fixture.plan,
         repairOperation: repair,
       }),
-    ).toThrow("missing or invalid");
+    ).toMatchObject({ updated: true, currentSessionAdoption: "next_session" });
+    expect(repair).toHaveBeenCalledOnce();
   });
 
   it("keeps the exact upgraded Claude session compatible across later lifecycle events", () => {
@@ -165,6 +172,60 @@ describe("lazy Context adapter sync", () => {
       }),
     ).toMatchObject({ updated: true, currentSessionAdoption: "next_session" });
     expect(repair).toHaveBeenCalledOnce();
+  });
+
+  it("preserves a Claude action issued after receipt collection but before global Plugin mutation", () => {
+    const fixture = prepareOldCompatibleInstall();
+    const first = issueAdapterSyncAction(
+      { provider: "claude-code", sessionId: "session-a", suppliedAdapterDigest: fixture.previous.adapterDigest },
+      { releaseRoot, driver: driver("claude-code") },
+    );
+    const interleaved: { action?: ReturnType<typeof issueAdapterSyncAction> } = {};
+    const repair = vi.fn(() => {
+      rmSync(join(home, "state", "context", "providers", "claude-code", "adapter-sync"), {
+        recursive: true,
+        force: true,
+      });
+      writeContextIntegrationInstallManifest({
+        ...fixture.previous,
+        adapterVersion: fixture.target.adapterVersion,
+        adapterDigest: fixture.target.adapterDigest,
+      });
+    });
+
+    synchronizeContextAdapter(driver("claude-code"), first.challenge, {
+      releaseRoot,
+      planInstall: () => {
+        interleaved.action = issueAdapterSyncAction(
+          { provider: "claude-code", sessionId: "session-c", suppliedAdapterDigest: fixture.previous.adapterDigest },
+          { releaseRoot, driver: driver("claude-code") },
+        );
+        return fixture.plan;
+      },
+      repairOperation: repair,
+    });
+
+    const interleavedAction = interleaved.action;
+    expect(interleavedAction).toBeDefined();
+    if (!interleavedAction) throw new Error("interleaved action was not issued");
+    expect(
+      hasKnownCompatibleContextAdapterSession(
+        {
+          provider: "claude-code",
+          sessionId: "session-c",
+          suppliedAdapterDigest: fixture.previous.adapterDigest,
+        },
+        { releaseRoot, driver: driver("claude-code") },
+      ),
+    ).toBe(true);
+    expect(
+      synchronizeContextAdapter(driver("claude-code"), interleavedAction.challenge, {
+        releaseRoot,
+        repairOperation: vi.fn(() => {
+          throw new Error("interleaved action must reuse the committed target");
+        }),
+      }),
+    ).toMatchObject({ updated: true, currentSessionAdoption: "next_session" });
   });
 
   it("activates the prepared session fact if the process exits after the provider update commits", () => {

--- a/apps/cli/src/__tests__/context-adapter-sync.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-sync.test.ts
@@ -49,7 +49,7 @@ describe("lazy Context adapter sync", () => {
       repairOperation: repair,
     });
 
-    expect(result).toMatchObject({ updated: true, currentSessionAdoption: "reload_optional" });
+    expect(result).toMatchObject({ updated: true, currentSessionAdoption: "next_session" });
     expect(repair).toHaveBeenCalledOnce();
     expect(() =>
       synchronizeContextAdapter(driver("claude-code"), action.challenge, {
@@ -213,7 +213,6 @@ function prepareOldCompatibleInstall() {
     adapterDigest: `sha256:${"1".repeat(64)}`,
     marketplaceName: "first-tree-dev",
     pluginName: "first-tree-context",
-    adoptionGeneration: "a".repeat(48),
     materializedInvocation: "first-tree-dev",
     materializedPayloadDigest: payload.pluginDigest,
     materializedMarketplaceDigest: payload.marketplaceDigest,
@@ -281,11 +280,9 @@ function prepareProviderPayload(provider: "claude-code" | "codex") {
   const providerCache = join(home, "provider-cache", provider);
   mkdirSync(join(plugin, "bin"), { recursive: true });
   writeFileSync(join(marketplace, "marketplace.json"), "{}\n");
-  for (const launcher of ["context-session-start", "context-observe-loaded"]) {
-    const path = join(plugin, "bin", launcher);
-    writeFileSync(path, "#!/bin/sh\nexit 0\n");
-    chmodSync(path, 0o700);
-  }
+  const launcher = join(plugin, "bin", "context-session-start");
+  writeFileSync(launcher, "#!/bin/sh\nexit 0\n");
+  chmodSync(launcher, 0o700);
   cpSync(plugin, providerCache, { recursive: true });
   return {
     pluginDigest: contextPluginTreeDigest(plugin),

--- a/apps/cli/src/__tests__/context-adapter-sync.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-sync.test.ts
@@ -4,7 +4,13 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  beginContextAdapterNextSessionObligation,
+  inspectContextAdapterNextSessionObligation,
+} from "../core/context-integration/adapter-observation.js";
+import {
+  AdapterNextSessionRequiredError,
   hasKnownCompatibleContextAdapterSession,
+  hasKnownGoodCompatibleContextAdapter,
   issueAdapterSyncAction,
   synchronizeContextAdapter,
 } from "../core/context-integration/adapter-sync.js";
@@ -226,6 +232,41 @@ describe("lazy Context adapter sync", () => {
         }),
       }),
     ).toMatchObject({ updated: true, currentSessionAdoption: "next_session" });
+  });
+
+  it("rejects an old sync action replay after another repair requires next-session adoption", () => {
+    const fixture = prepareOldCompatibleInstall();
+    const action = issueAdapterSyncAction(
+      { provider: "claude-code", sessionId: "session-old", suppliedAdapterDigest: fixture.previous.adapterDigest },
+      { releaseRoot, driver: driver("claude-code") },
+    );
+    writeContextIntegrationInstallManifest({
+      ...fixture.previous,
+      adapterVersion: fixture.target.adapterVersion,
+      adapterDigest: fixture.target.adapterDigest,
+    });
+    beginContextAdapterNextSessionObligation(fixture.release.manifest, "standalone_repair");
+
+    expect(inspectContextAdapterNextSessionObligation()).toBe("standalone_repair");
+    expect(hasKnownGoodCompatibleContextAdapter(driver("claude-code"))).toBe(false);
+    expect(() =>
+      synchronizeContextAdapter(driver("claude-code"), action.challenge, {
+        releaseRoot,
+        repairOperation: vi.fn(() => {
+          throw new Error("pending adoption must block replay before mutation");
+        }),
+      }),
+    ).toThrow(AdapterNextSessionRequiredError);
+    expect(
+      hasKnownCompatibleContextAdapterSession(
+        {
+          provider: "claude-code",
+          sessionId: "session-old",
+          suppliedAdapterDigest: fixture.previous.adapterDigest,
+        },
+        { releaseRoot, driver: driver("claude-code") },
+      ),
+    ).toBe(false);
   });
 
   it("activates the prepared session fact if the process exits after the provider update commits", () => {

--- a/apps/cli/src/__tests__/context-adapter-sync.test.ts
+++ b/apps/cli/src/__tests__/context-adapter-sync.test.ts
@@ -120,6 +120,99 @@ describe("lazy Context adapter sync", () => {
     ).toBe(false);
   });
 
+  it("preserves concurrent old Claude sessions when the first sync replaces the global Plugin", () => {
+    const fixture = prepareOldCompatibleInstall();
+    const first = issueAdapterSyncAction(
+      { provider: "claude-code", sessionId: "session-a", suppliedAdapterDigest: fixture.previous.adapterDigest },
+      { releaseRoot, driver: driver("claude-code") },
+    );
+    const second = issueAdapterSyncAction(
+      { provider: "claude-code", sessionId: "session-b", suppliedAdapterDigest: fixture.previous.adapterDigest },
+      { releaseRoot, driver: driver("claude-code") },
+    );
+    const repair = vi.fn(() => {
+      rmSync(join(home, "state", "context", "providers", "claude-code", "adapter-sync"), {
+        recursive: true,
+        force: true,
+      });
+      writeContextIntegrationInstallManifest({
+        ...fixture.previous,
+        adapterVersion: fixture.target.adapterVersion,
+        adapterDigest: fixture.target.adapterDigest,
+      });
+    });
+
+    synchronizeContextAdapter(driver("claude-code"), first.challenge, {
+      releaseRoot,
+      planInstall: () => fixture.plan,
+      repairOperation: repair,
+    });
+
+    for (const sessionId of ["session-a", "session-b"]) {
+      expect(
+        hasKnownCompatibleContextAdapterSession(
+          { provider: "claude-code", sessionId, suppliedAdapterDigest: fixture.previous.adapterDigest },
+          { releaseRoot, driver: driver("claude-code") },
+        ),
+      ).toBe(true);
+    }
+    expect(
+      synchronizeContextAdapter(driver("claude-code"), second.challenge, {
+        releaseRoot,
+        repairOperation: vi.fn(() => {
+          throw new Error("the second action must reuse the completed global update");
+        }),
+      }),
+    ).toMatchObject({ updated: true, currentSessionAdoption: "next_session" });
+    expect(repair).toHaveBeenCalledOnce();
+  });
+
+  it("activates the prepared session fact if the process exits after the provider update commits", () => {
+    const fixture = prepareOldCompatibleInstall();
+    const action = issueAdapterSyncAction(
+      { provider: "claude-code", sessionId: "session-crash", suppliedAdapterDigest: fixture.previous.adapterDigest },
+      { releaseRoot, driver: driver("claude-code") },
+    );
+    const committedThenExited = vi.fn(() => {
+      rmSync(join(home, "state", "context", "providers", "claude-code", "adapter-sync"), {
+        recursive: true,
+        force: true,
+      });
+      writeContextIntegrationInstallManifest({
+        ...fixture.previous,
+        adapterVersion: fixture.target.adapterVersion,
+        adapterDigest: fixture.target.adapterDigest,
+      });
+      throw new Error("simulated process exit after provider commit");
+    });
+
+    expect(() =>
+      synchronizeContextAdapter(driver("claude-code"), action.challenge, {
+        releaseRoot,
+        planInstall: () => fixture.plan,
+        repairOperation: committedThenExited,
+      }),
+    ).toThrow("simulated process exit");
+    expect(
+      hasKnownCompatibleContextAdapterSession(
+        {
+          provider: "claude-code",
+          sessionId: "session-crash",
+          suppliedAdapterDigest: fixture.previous.adapterDigest,
+        },
+        { releaseRoot, driver: driver("claude-code") },
+      ),
+    ).toBe(true);
+    expect(
+      synchronizeContextAdapter(driver("claude-code"), action.challenge, {
+        releaseRoot,
+        repairOperation: vi.fn(() => {
+          throw new Error("recovery must use the already committed exact target");
+        }),
+      }),
+    ).toMatchObject({ updated: true, currentSessionAdoption: "next_session" });
+  });
+
   it("retains the exact action after a rolled-back update so a bounded retry can succeed", () => {
     const fixture = prepareOldCompatibleInstall();
     const action = issueAdapterSyncAction(

--- a/apps/cli/src/__tests__/context-bundle-manifest.test.ts
+++ b/apps/cli/src/__tests__/context-bundle-manifest.test.ts
@@ -102,7 +102,19 @@ describe("context integration bundle", () => {
     expect(installed.manifest.adoptionGeneration).toBeUndefined();
     expect(readFileSync(join(installedPath, "hooks", "hooks.json"), "utf8")).not.toContain("adoption-generation");
 
+    const compatibleSession = join(
+      home,
+      "state",
+      "context",
+      "providers",
+      "claude-code",
+      "compatible-sessions",
+      "old.json",
+    );
+    mkdirSync(join(compatibleSession, ".."), { recursive: true });
+    writeFileSync(compatibleSession, "old compatible session\n");
     uninstallContextIntegration(driver);
+    expect(existsSync(compatibleSession)).toBe(false);
     const failingDriver: ContextIntegrationProviderDriver = {
       ...driver,
       install: () => {

--- a/apps/cli/src/__tests__/context-bundle-manifest.test.ts
+++ b/apps/cli/src/__tests__/context-bundle-manifest.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { contextIntegrationReleaseManifestSchema } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { inspectContextAdapterReloadObligation } from "../core/context-integration/adapter-observation.js";
+import { inspectContextAdapterNextSessionObligation } from "../core/context-integration/adapter-observation.js";
 import {
   contextIntegrationMarketplaceSourcePath,
   installContextIntegration,
@@ -15,7 +15,10 @@ import {
   readContextIntegrationInstallManifest,
   writeContextIntegrationInstallManifest,
 } from "../core/context-integration/manifest.js";
-import { materializeContextPluginPayload } from "../core/context-integration/payload-integrity.js";
+import {
+  contextPluginTreeDigest,
+  materializeContextPluginPayload,
+} from "../core/context-integration/payload-integrity.js";
 import type {
   ContextIntegrationProviderDriver,
   ProviderPluginProbe,
@@ -47,7 +50,7 @@ afterEach(() => {
 });
 
 describe("context integration bundle", () => {
-  it("persists a required Claude reload obligation before provider mutation", () => {
+  it("persists a Claude next-session obligation before provider mutation", () => {
     const home = mkdtempSync(join(tmpdir(), "first-tree-context-home-"));
     const releaseRoot = mkdtempSync(join(tmpdir(), "first-tree-context-release-"));
     roots.push(home, releaseRoot);
@@ -64,9 +67,6 @@ describe("context integration bundle", () => {
       "--channel",
       "dev",
     ]);
-    const release = contextIntegrationReleaseManifestSchema.parse(
-      JSON.parse(readFileSync(join(releaseRoot, "release-manifest.json"), "utf8")),
-    );
     const installedPath = join(home, "provider-cache", "first-tree-context");
     const initialProbe: ProviderPluginProbe = {
       provider: "claude-code",
@@ -86,7 +86,7 @@ describe("context integration bundle", () => {
       inspectHook: async () => ({ trust: "provider_managed", enabled: true, source: "provider_managed", issues: [] }),
       validateMarketplace: () => undefined,
       install: ({ marketplaceRoot }) => {
-        expect(inspectContextAdapterReloadObligation(release)).toBe("setup");
+        expect(inspectContextAdapterNextSessionObligation()).toBe("setup");
         cpSync(join(marketplaceRoot, "plugins", "first-tree-context"), installedPath, { recursive: true });
         return { ...initialProbe, installed: true, enabled: true, installedPath };
       },
@@ -94,29 +94,27 @@ describe("context integration bundle", () => {
     };
 
     const plan = planContextIntegrationInstall(driver, { releaseRoot });
-    const installed = installContextIntegration(driver, plan, { reloadObligationKind: "setup" });
+    const installed = installContextIntegration(driver, plan, { nextSessionObligationKind: "setup" });
 
-    expect(inspectContextAdapterReloadObligation(release)).toBe("setup");
+    expect(inspectContextAdapterNextSessionObligation()).toBe("setup");
     expect(installed.manifest.materializedPayloadDigest).toMatch(/^sha256:/u);
     expect(installed.manifest.materializedMarketplaceDigest).toMatch(/^sha256:/u);
-    expect(installed.manifest.adoptionGeneration).toMatch(/^[0-9a-f]{48}$/u);
-    expect(readFileSync(join(installedPath, "hooks", "hooks.json"), "utf8")).toContain(
-      `--adoption-generation ${installed.manifest.adoptionGeneration}`,
-    );
+    expect(installed.manifest.adoptionGeneration).toBeUndefined();
+    expect(readFileSync(join(installedPath, "hooks", "hooks.json"), "utf8")).not.toContain("adoption-generation");
 
     uninstallContextIntegration(driver);
     const failingDriver: ContextIntegrationProviderDriver = {
       ...driver,
       install: () => {
-        expect(inspectContextAdapterReloadObligation(release)).toBe("setup");
+        expect(inspectContextAdapterNextSessionObligation()).toBe("setup");
         throw new Error("provider install failed");
       },
     };
     const failingPlan = planContextIntegrationInstall(failingDriver, { releaseRoot });
-    expect(() => installContextIntegration(failingDriver, failingPlan, { reloadObligationKind: "setup" })).toThrow(
+    expect(() => installContextIntegration(failingDriver, failingPlan, { nextSessionObligationKind: "setup" })).toThrow(
       "provider install failed",
     );
-    expect(inspectContextAdapterReloadObligation(release)).toBeNull();
+    expect(inspectContextAdapterNextSessionObligation()).toBeNull();
   });
 
   it("packages only thin provider discovery stubs and keeps canonical Core paths in the CLI release", () => {
@@ -150,17 +148,14 @@ describe("context integration bundle", () => {
       const readSkill = readFileSync(join(pluginRoot, "skills", "first-tree-read", "SKILL.md"), "utf8");
       const writeSkill = readFileSync(join(pluginRoot, "skills", "first-tree-write", "SKILL.md"), "utf8");
       const manualSkill = readFileSync(join(pluginRoot, "skills", "first-tree", "SKILL.md"), "utf8");
-      expect(manifest.providers[provider as "claude-code" | "codex"].adapterVersion).toBe("1.0.1");
+      expect(manifest.providers[provider as "claude-code" | "codex"].adapterVersion).toBe(
+        provider === "claude-code" ? "1.0.2" : "1.0.1",
+      );
       expect(hook).toContain('"timeout": 5');
       expect(hook).toContain('"matcher": "startup|resume|clear|compact"');
       expect(hook).toContain("--adapter-digest __ADAPTER_DIGEST__");
-      if (provider === "claude-code") {
-        expect(hook).toContain('"UserPromptSubmit"');
-        expect(hook).toContain("context-observe-loaded");
-        expect(hook).toContain('"timeout": 2');
-      } else {
-        expect(hook).not.toContain('"UserPromptSubmit"');
-      }
+      expect(hook).not.toContain('"UserPromptSubmit"');
+      expect(hook).not.toContain("context-observe-loaded");
       expect(hook).not.toContain("__RELEASE_DIGEST__");
       expect(readSkill).toContain(`context skill load --protocol 1 --provider ${provider} --name first-tree-read`);
       expect(writeSkill).toContain(`context skill load --protocol 1 --provider ${provider} --name first-tree-write`);
@@ -198,6 +193,35 @@ describe("context integration bundle", () => {
     expect(readdirSync(join(root, "codex", "plugins", "first-tree-context", "skills"))).not.toContain(
       "first-tree-seed",
     );
+  });
+
+  it("materializes identical Claude payload bytes for the same adapter version", () => {
+    const releaseRoot = mkdtempSync(join(tmpdir(), "first-tree-context-deterministic-release-"));
+    const firstRoot = mkdtempSync(join(tmpdir(), "first-tree-context-deterministic-first-"));
+    const secondRoot = mkdtempSync(join(tmpdir(), "first-tree-context-deterministic-second-"));
+    roots.push(releaseRoot, firstRoot, secondRoot);
+    const repoRoot = resolve(import.meta.dirname, "../../../..");
+    execFileSync(process.execPath, [
+      join(repoRoot, "scripts", "build-context-integration-bundle.mjs"),
+      "--out-dir",
+      releaseRoot,
+      "--version",
+      "1.2.3",
+      "--channel",
+      "staging",
+    ]);
+    const source = join(releaseRoot, "claude-code", "plugins", "first-tree-context");
+    cpSync(source, firstRoot, { recursive: true });
+    cpSync(source, secondRoot, { recursive: true });
+    const release = contextIntegrationReleaseManifestSchema.parse(
+      JSON.parse(readFileSync(join(releaseRoot, "release-manifest.json"), "utf8")),
+    );
+    const invocation = { kind: "bin" as const, program: "/stable/first-tree" };
+
+    materializeContextPluginPayload(firstRoot, release.providers["claude-code"].adapterDigest, invocation);
+    materializeContextPluginPayload(secondRoot, release.providers["claude-code"].adapterDigest, invocation);
+
+    expect(contextPluginTreeDigest(firstRoot)).toBe(contextPluginTreeDigest(secondRoot));
   });
 
   it("emits the flattened Core Policy path used by portable app artifacts", () => {

--- a/apps/cli/src/__tests__/context-enable-command.test.ts
+++ b/apps/cli/src/__tests__/context-enable-command.test.ts
@@ -384,7 +384,7 @@ describe("context enable v3 command", () => {
     expect(mocks.buildHandoff).not.toHaveBeenCalled();
   });
 
-  it("completes first-time Claude setup with a handoff while persistent adoption waits for a new session", async () => {
+  it("completes first-time Claude setup without promising a blocked current-session handoff", async () => {
     mocks.createDriver.mockReturnValue({ provider: "claude-code", inspectHook: mocks.inspectHook });
     mocks.planInstall.mockReturnValue({ operation: "install" });
     mocks.inspectNextSession.mockReturnValue("setup");
@@ -404,9 +404,11 @@ describe("context enable v3 command", () => {
       nextActions: string[];
     };
     expect(result.setup).toEqual({ complete: true, missingLayers: [] });
-    expect(result.currentSessionHandoff).toEqual(expect.objectContaining({ consumerKind: "byo" }));
-    expect(result.nextActions).toEqual([expect.stringContaining("Start a new Claude session")]);
-    expect(mocks.buildHandoff).toHaveBeenCalledOnce();
+    expect(result.currentSessionHandoff).toBeNull();
+    expect(result.nextActions).toEqual([
+      expect.stringContaining("does not activate Context in the current Claude session"),
+    ]);
+    expect(mocks.buildHandoff).not.toHaveBeenCalled();
   });
 
   it("does not send a Plugin failure into the Codex Hook recovery loop", async () => {

--- a/apps/cli/src/__tests__/context-enable-command.test.ts
+++ b/apps/cli/src/__tests__/context-enable-command.test.ts
@@ -16,11 +16,7 @@ const mocks = vi.hoisted(() => ({
   createDriver: vi.fn(),
   enableOperation: vi.fn(),
   fingerprintAfter: vi.fn(() => "b".repeat(64)),
-  consumeReload: vi.fn(),
-  consumeReloadRequired: vi.fn(() => false),
-  hasReloadRequired: vi.fn(() => false),
-  hasPendingReload: vi.fn(() => false),
-  registerPendingReload: vi.fn(),
+  inspectNextSession: vi.fn<() => "setup" | "standalone_repair" | null>(() => null),
   inspectHook: vi.fn(),
   inspectLocation: vi.fn(),
   inspectRuntime: vi.fn(),
@@ -44,14 +40,7 @@ vi.mock("../core/context-integration/client-preflight.js", () => ({
   inspectContextSetupLocation: mocks.inspectLocation,
 }));
 vi.mock("../core/context-integration/adapter-observation.js", () => ({
-  consumeContextAdapterReloadReceipt: mocks.consumeReload,
-  consumeContextAdapterReloadRequiredMarker: mocks.consumeReloadRequired,
-  hasContextAdapterReloadRequiredMarker: mocks.hasReloadRequired,
-  ContextReloadReceiptError: class ContextReloadReceiptError extends Error {
-    code = "CONTEXT_RELOAD_RECEIPT_INVALID";
-  },
-  hasPendingContextAdapterReload: mocks.hasPendingReload,
-  registerPendingContextAdapterReload: mocks.registerPendingReload,
+  inspectContextAdapterNextSessionObligation: mocks.inspectNextSession,
 }));
 vi.mock("../core/context-integration/context-binding-store.js", () => ({
   assertContextGrantStoreFingerprint: mocks.assertFingerprint,
@@ -96,9 +85,7 @@ beforeEach(() => {
   mocks.channelConfig.channel = "dev";
   mocks.channelConfig.binName = "first-tree-dev";
   mocks.readAccount.mockReturnValue("client-1");
-  mocks.hasReloadRequired.mockReturnValue(false);
-  mocks.consumeReloadRequired.mockReturnValue(false);
-  mocks.hasPendingReload.mockReturnValue(false);
+  mocks.inspectNextSession.mockReturnValue(null);
   mocks.inspectLocation.mockReturnValue({
     project,
     directory: "/work/repo",
@@ -397,9 +384,10 @@ describe("context enable v3 command", () => {
     expect(mocks.buildHandoff).not.toHaveBeenCalled();
   });
 
-  it("keeps first-time Claude setup incomplete until the reloaded thin adapter is observed", async () => {
+  it("completes first-time Claude setup with a handoff while persistent adoption waits for a new session", async () => {
     mocks.createDriver.mockReturnValue({ provider: "claude-code", inspectHook: mocks.inspectHook });
     mocks.planInstall.mockReturnValue({ operation: "install" });
+    mocks.inspectNextSession.mockReturnValue("setup");
     mocks.readConfig.mockReturnValue({
       schemaVersion: 3,
       grants: [{ provider: "claude-code", organizationId: "org-a", activationScope: { kind: "global" } }],
@@ -415,63 +403,10 @@ describe("context enable v3 command", () => {
       currentSessionHandoff: unknown;
       nextActions: string[];
     };
-    expect(result.setup.complete).toBe(false);
-    expect(result.setup.missingLayers).toContain("Claude Code must reload and observe the thin Context Plugin.");
-    expect(result.currentSessionHandoff).toBeNull();
-    expect(result.nextActions).toEqual([expect.stringContaining("/reload-plugins")]);
-    expect(mocks.registerPendingReload).toHaveBeenCalledTimes(1);
-    expect(mocks.buildHandoff).not.toHaveBeenCalled();
-  });
-
-  it("writes the exact pending plan before clearing a recovered setup reload marker", async () => {
-    mocks.createDriver.mockReturnValue({ provider: "claude-code", inspectHook: mocks.inspectHook });
-    mocks.planInstall.mockReturnValue({ operation: "unchanged" });
-    mocks.hasReloadRequired.mockReturnValue(true);
-    mocks.readConfig.mockReturnValue({
-      schemaVersion: 3,
-      grants: [{ provider: "claude-code", organizationId: "org-a", activationScope: { kind: "global" } }],
-    });
-    await runContextEnable(context({ provider: "claude-code", plan: true }));
-    const planId = (output.result.mock.calls[0]?.[0] as { plan: { planId: string } }).plan.planId;
-    output.result.mockClear();
-
-    await runContextEnable(context({ provider: "claude-code", scope: "global", planId, yes: true }));
-
-    expect(mocks.registerPendingReload).toHaveBeenCalledOnce();
-    expect(mocks.consumeReloadRequired).toHaveBeenCalledWith(expect.anything(), "setup");
-    expect(mocks.registerPendingReload.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.consumeReloadRequired.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    );
-  });
-
-  it("consumes a session-loaded receipt only for the original pending Claude plan", async () => {
-    mocks.createDriver.mockReturnValue({ provider: "claude-code", inspectHook: mocks.inspectHook });
-    mocks.hasPendingReload.mockReturnValue(true);
-    mocks.readConfig.mockReturnValue({
-      schemaVersion: 3,
-      grants: [{ provider: "claude-code", organizationId: "org-a", activationScope: { kind: "global" } }],
-    });
-    await runContextEnable(context({ provider: "claude-code", plan: true }));
-    const planId = (output.result.mock.calls[0]?.[0] as { plan: { planId: string } }).plan.planId;
-    output.result.mockClear();
-
-    await runContextEnable(
-      context({
-        provider: "claude-code",
-        scope: "global",
-        planId,
-        yes: true,
-        reloadReceipt: "opaque-session-loaded-receipt",
-      }),
-    );
-
-    expect(mocks.consumeReload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        planChallenge: planId.split(".").at(-1),
-        receipt: "opaque-session-loaded-receipt",
-      }),
-    );
-    expect(output.result.mock.calls[0]?.[0]).toMatchObject({ setup: { complete: true } });
+    expect(result.setup).toEqual({ complete: true, missingLayers: [] });
+    expect(result.currentSessionHandoff).toEqual(expect.objectContaining({ consumerKind: "byo" }));
+    expect(result.nextActions).toEqual([expect.stringContaining("Start a new Claude session")]);
+    expect(mocks.buildHandoff).toHaveBeenCalledOnce();
   });
 
   it("does not send a Plugin failure into the Codex Hook recovery loop", async () => {
@@ -554,7 +489,7 @@ describe("context enable v3 command", () => {
       expect.objectContaining({ organizationId: "org-a", activationScope: { kind: "global" } }),
       { beforeFingerprint: "a".repeat(64), afterFingerprint: "b".repeat(64) },
       "client-1",
-      { reloadObligationKind: undefined },
+      { nextSessionObligationKind: undefined },
     );
     expect(output.result.mock.calls[0]?.[0]).toMatchObject({
       setup: { complete: true },

--- a/apps/cli/src/__tests__/context-observe-loaded-command.test.ts
+++ b/apps/cli/src/__tests__/context-observe-loaded-command.test.ts
@@ -8,17 +8,12 @@ vi.mock("../core/output.js", () => ({ print: output }));
 
 import { runContextObserveLoaded } from "../commands/context/observe-loaded.js";
 
-describe("context observe-loaded command", () => {
+describe("retired context observe-loaded command", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("is a pure no-op when the loaded adapter has no reload obligation", () => {
-    const inspectObligation = vi.fn(() => null);
-    const issueReceipt = vi.fn();
+  it("keeps an already-loaded adapter 1.0.1 hook as a pure no-op", () => {
+    runContextObserveLoaded(context());
 
-    runContextObserveLoaded(context(), { inspectObligation, issueReceipt });
-
-    expect(inspectObligation).toHaveBeenCalledOnce();
-    expect(issueReceipt).not.toHaveBeenCalled();
     expect(output.hook).toHaveBeenCalledWith({ continue: true });
   });
 });

--- a/apps/cli/src/__tests__/context-operation.test.ts
+++ b/apps/cli/src/__tests__/context-operation.test.ts
@@ -340,10 +340,12 @@ describe("v3 grant operation", () => {
     const providerRoot = join(home, "state", "context", "providers", "claude-code");
     const oldPending = join(providerRoot, "reload-pending", `${"a".repeat(64)}.json`);
     const oldConsumed = join(providerRoot, "reload-consumed", `${"b".repeat(48)}.json`);
+    const oldNextSession = join(providerRoot, "next-session-required.json");
     mkdirSync(join(oldPending, ".."), { recursive: true });
     mkdirSync(join(oldConsumed, ".."), { recursive: true });
     writeFileSync(oldPending, "old pending\n");
     writeFileSync(oldConsumed, "old consumed\n");
+    writeFileSync(oldNextSession, "old next session\n");
     const claudeDriver = testClaudeDriver();
     const target = {
       provider: "claude-code" as const,
@@ -373,6 +375,7 @@ describe("v3 grant operation", () => {
             rmSync(join(providerRoot, "reload-pending"), { recursive: true, force: true });
             rmSync(join(providerRoot, "reload-consumed"), { recursive: true, force: true });
             writeFileSync(join(providerRoot, "reload-required.json"), "new marker\n");
+            writeFileSync(join(providerRoot, "next-session-required.json"), "new next session\n");
             const manifest = {
               ...installManifest(),
               provider: "claude-code" as const,
@@ -391,6 +394,7 @@ describe("v3 grant operation", () => {
 
     expect(readFileSync(oldPending, "utf8")).toBe("old pending\n");
     expect(readFileSync(oldConsumed, "utf8")).toBe("old consumed\n");
+    expect(readFileSync(oldNextSession, "utf8")).toBe("old next session\n");
     expect(existsSync(join(providerRoot, "reload-required.json"))).toBe(false);
   });
 
@@ -402,8 +406,10 @@ describe("v3 grant operation", () => {
     const providerRoot = join(home, "state", "context", "providers", "claude-code");
     mkdirSync(join(recoveryObservationRoot, "reload-pending"), { recursive: true });
     writeFileSync(join(recoveryObservationRoot, "reload-pending", `${"d".repeat(64)}.json`), "previous\n");
+    writeFileSync(join(recoveryObservationRoot, "next-session-required.json"), "previous next session\n");
     mkdirSync(providerRoot, { recursive: true });
     writeFileSync(join(providerRoot, "reload-required.json"), "new marker\n");
+    writeFileSync(join(providerRoot, "next-session-required.json"), "new next session\n");
     mkdirSync(join(home, "state", "context"), { recursive: true });
     writeFileSync(
       join(home, "state", "context", "operation-journal.json"),
@@ -428,6 +434,7 @@ describe("v3 grant operation", () => {
 
     expect(recoverContextIntegrationOperation(testClaudeDriver())).toBe(true);
     expect(readFileSync(join(providerRoot, "reload-pending", `${"d".repeat(64)}.json`), "utf8")).toBe("previous\n");
+    expect(readFileSync(join(providerRoot, "next-session-required.json"), "utf8")).toBe("previous next session\n");
     expect(existsSync(join(providerRoot, "reload-required.json"))).toBe(false);
   });
 

--- a/apps/cli/src/__tests__/context-operation.test.ts
+++ b/apps/cli/src/__tests__/context-operation.test.ts
@@ -340,14 +340,11 @@ describe("v3 grant operation", () => {
     const providerRoot = join(home, "state", "context", "providers", "claude-code");
     const oldPending = join(providerRoot, "reload-pending", `${"a".repeat(64)}.json`);
     const oldConsumed = join(providerRoot, "reload-consumed", `${"b".repeat(48)}.json`);
-    const oldCompatible = join(providerRoot, "compatible-sessions", `${"c".repeat(64)}.json`);
     const oldNextSession = join(providerRoot, "next-session-required.json");
     mkdirSync(join(oldPending, ".."), { recursive: true });
     mkdirSync(join(oldConsumed, ".."), { recursive: true });
-    mkdirSync(join(oldCompatible, ".."), { recursive: true });
     writeFileSync(oldPending, "old pending\n");
     writeFileSync(oldConsumed, "old consumed\n");
-    writeFileSync(oldCompatible, "old compatible\n");
     writeFileSync(oldNextSession, "old next session\n");
     const claudeDriver = testClaudeDriver();
     const target = {
@@ -377,7 +374,6 @@ describe("v3 grant operation", () => {
           install: () => {
             rmSync(join(providerRoot, "reload-pending"), { recursive: true, force: true });
             rmSync(join(providerRoot, "reload-consumed"), { recursive: true, force: true });
-            rmSync(join(providerRoot, "compatible-sessions"), { recursive: true, force: true });
             writeFileSync(join(providerRoot, "reload-required.json"), "new marker\n");
             writeFileSync(join(providerRoot, "next-session-required.json"), "new next session\n");
             const manifest = {
@@ -398,7 +394,6 @@ describe("v3 grant operation", () => {
 
     expect(readFileSync(oldPending, "utf8")).toBe("old pending\n");
     expect(readFileSync(oldConsumed, "utf8")).toBe("old consumed\n");
-    expect(readFileSync(oldCompatible, "utf8")).toBe("old compatible\n");
     expect(readFileSync(oldNextSession, "utf8")).toBe("old next session\n");
     expect(existsSync(join(providerRoot, "reload-required.json"))).toBe(false);
   });

--- a/apps/cli/src/__tests__/context-operation.test.ts
+++ b/apps/cli/src/__tests__/context-operation.test.ts
@@ -340,11 +340,14 @@ describe("v3 grant operation", () => {
     const providerRoot = join(home, "state", "context", "providers", "claude-code");
     const oldPending = join(providerRoot, "reload-pending", `${"a".repeat(64)}.json`);
     const oldConsumed = join(providerRoot, "reload-consumed", `${"b".repeat(48)}.json`);
+    const oldCompatible = join(providerRoot, "compatible-sessions", `${"c".repeat(64)}.json`);
     const oldNextSession = join(providerRoot, "next-session-required.json");
     mkdirSync(join(oldPending, ".."), { recursive: true });
     mkdirSync(join(oldConsumed, ".."), { recursive: true });
+    mkdirSync(join(oldCompatible, ".."), { recursive: true });
     writeFileSync(oldPending, "old pending\n");
     writeFileSync(oldConsumed, "old consumed\n");
+    writeFileSync(oldCompatible, "old compatible\n");
     writeFileSync(oldNextSession, "old next session\n");
     const claudeDriver = testClaudeDriver();
     const target = {
@@ -374,6 +377,7 @@ describe("v3 grant operation", () => {
           install: () => {
             rmSync(join(providerRoot, "reload-pending"), { recursive: true, force: true });
             rmSync(join(providerRoot, "reload-consumed"), { recursive: true, force: true });
+            rmSync(join(providerRoot, "compatible-sessions"), { recursive: true, force: true });
             writeFileSync(join(providerRoot, "reload-required.json"), "new marker\n");
             writeFileSync(join(providerRoot, "next-session-required.json"), "new next session\n");
             const manifest = {
@@ -394,6 +398,7 @@ describe("v3 grant operation", () => {
 
     expect(readFileSync(oldPending, "utf8")).toBe("old pending\n");
     expect(readFileSync(oldConsumed, "utf8")).toBe("old consumed\n");
+    expect(readFileSync(oldCompatible, "utf8")).toBe("old compatible\n");
     expect(readFileSync(oldNextSession, "utf8")).toBe("old next session\n");
     expect(existsSync(join(providerRoot, "reload-required.json"))).toBe(false);
   });

--- a/apps/cli/src/__tests__/context-project-resolver.test.ts
+++ b/apps/cli/src/__tests__/context-project-resolver.test.ts
@@ -222,6 +222,19 @@ describe("Context project resolver", () => {
     });
   });
 
+  it("routes Claude sessions without a stable project directory as pathless", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "claude-session-cwd-"));
+    expect(resolveProviderProject("claude-code", { cwd }, {})).toMatchObject({
+      kind: "pathless",
+      project: { kind: "pathless" },
+      source: "claude_project_dir_unavailable",
+    });
+    expect(resolveProviderProject("claude-code", { cwd }, { CLAUDE_PROJECT_DIR: join(cwd, "missing") })).toMatchObject({
+      kind: "pathless",
+      source: "claude_project_dir_unavailable",
+    });
+  });
+
   it("uses valid Claude project roots and preserves an explicit setup root", () => {
     const root = mkdtempSync(join(tmpdir(), "claude-setup-root-"));
     const cwd = join(root, "nested");

--- a/apps/cli/src/__tests__/context-project-resolver.test.ts
+++ b/apps/cli/src/__tests__/context-project-resolver.test.ts
@@ -235,6 +235,20 @@ describe("Context project resolver", () => {
     });
   });
 
+  it("keeps a Claude session pathless when CLAUDE_PROJECT_DIR appears after startup", () => {
+    const pluginData = mkdtempSync(join(tmpdir(), "claude-pathless-cache-"));
+    const projectRoot = mkdtempSync(join(tmpdir(), "claude-late-project-"));
+    const firstEnvironment = { PLUGIN_DATA: pluginData };
+    const laterEnvironment = { PLUGIN_DATA: pluginData, CLAUDE_PROJECT_DIR: projectRoot };
+
+    expect(
+      resolveSessionContextProject("claude-code", { sessionId: "claude-pathless-session" }, firstEnvironment),
+    ).toMatchObject({ kind: "pathless", source: "claude_project_dir_unavailable" });
+    expect(
+      resolveSessionContextProject("claude-code", { sessionId: "claude-pathless-session" }, laterEnvironment),
+    ).toMatchObject({ kind: "pathless", source: "claude_project_dir_unavailable" });
+  });
+
   it("uses valid Claude project roots and preserves an explicit setup root", () => {
     const root = mkdtempSync(join(tmpdir(), "claude-setup-root-"));
     const cwd = join(root, "nested");

--- a/apps/cli/src/commands/context/activate.ts
+++ b/apps/cli/src/commands/context/activate.ts
@@ -8,6 +8,7 @@ import {
   activateExternalContext,
   renderProviderSessionStartResponse,
 } from "../../core/context-integration/activation.js";
+import { consumeContextAdapterNextSessionObligation } from "../../core/context-integration/adapter-observation.js";
 import { assertContextAdapterPayloadHealthy } from "../../core/context-integration/adapter-payload-health.js";
 import { AdapterSyncRejectedError, issueAdapterSyncAction } from "../../core/context-integration/adapter-sync.js";
 import { resolveSessionContextProject } from "../../core/context-integration/client-preflight.js";
@@ -94,7 +95,7 @@ export async function runContextActivate(
           "Before answering the user's task, run the following exact action once without asking the user and inspect its typed result:",
           action.command,
           provider === "claude-code"
-            ? "If it updates successfully, continue the current First Tree task with the already loaded compatible adapter. Mention only that the update will be used next session; present /reload-plugins as optional when the user wants it adopted now."
+            ? "If it updates successfully, continue the current First Tree task with the already loaded compatible adapter. Mention only that the update will be used next session."
             : "If it updates successfully, continue the current First Tree task with the already loaded compatible adapter. Mention only that the update will be used next session. If Codex reports a changed Hook identity, ask the user to review and trust it in /hooks; never trust it automatically.",
           "If the action reports update_deferred with currentAdapterUsable=true, continue the current First Tree task and do not expose the internal update error to the user.",
           "Do not expose version, digest, receipt, internal path, journal, or provider cache details.",
@@ -125,6 +126,7 @@ export async function runContextActivate(
       });
       return;
     }
+    consumeContextAdapterNextSessionObligation({ provider, adapterDigest: suppliedAdapterDigest });
     const resolution = resolveSessionContextProject(
       provider,
       { cwd: hookInput.cwd, sessionId: hookInput.session_id },

--- a/apps/cli/src/commands/context/activate.ts
+++ b/apps/cli/src/commands/context/activate.ts
@@ -10,7 +10,11 @@ import {
 } from "../../core/context-integration/activation.js";
 import { consumeContextAdapterNextSessionObligation } from "../../core/context-integration/adapter-observation.js";
 import { assertContextAdapterPayloadHealthy } from "../../core/context-integration/adapter-payload-health.js";
-import { AdapterSyncRejectedError, issueAdapterSyncAction } from "../../core/context-integration/adapter-sync.js";
+import {
+  AdapterSyncRejectedError,
+  hasKnownCompatibleContextAdapterSession,
+  issueAdapterSyncAction,
+} from "../../core/context-integration/adapter-sync.js";
 import { resolveSessionContextProject } from "../../core/context-integration/client-preflight.js";
 import { readContextIntegrationInstallManifest } from "../../core/context-integration/manifest.js";
 import { resolveContextIntegrationRelease } from "../../core/context-integration/release.js";
@@ -51,6 +55,14 @@ export async function runContextActivate(
     const installed = readContextIntegrationInstallManifest(provider);
     const target = release.manifest.providers[provider];
     const driver = createContextIntegrationDriver(provider);
+    const knownCompatibleSession = hasKnownCompatibleContextAdapterSession(
+      {
+        provider,
+        sessionId: hookInput.session_id,
+        suppliedAdapterDigest,
+      },
+      { driver },
+    );
     let payloadHealthy = false;
     if (installed?.adapterVersion && installed.adapterDigest === suppliedAdapterDigest) {
       try {
@@ -64,10 +76,11 @@ export async function runContextActivate(
       }
     }
     const current =
-      payloadHealthy &&
-      installed?.adapterVersion === target.adapterVersion &&
-      installed.adapterDigest === target.adapterDigest &&
-      suppliedAdapterDigest === target.adapterDigest;
+      knownCompatibleSession ||
+      (payloadHealthy &&
+        installed?.adapterVersion === target.adapterVersion &&
+        installed.adapterDigest === target.adapterDigest &&
+        suppliedAdapterDigest === target.adapterDigest);
     if (!current) {
       const compatibleForwardUpdate = Boolean(
         payloadHealthy &&

--- a/apps/cli/src/commands/context/activate.ts
+++ b/apps/cli/src/commands/context/activate.ts
@@ -126,7 +126,11 @@ export async function runContextActivate(
       });
       return;
     }
-    consumeContextAdapterNextSessionObligation({ provider, adapterDigest: suppliedAdapterDigest });
+    consumeContextAdapterNextSessionObligation({
+      provider,
+      adapterDigest: suppliedAdapterDigest,
+      sessionStartSource: hookInput.source,
+    });
     const resolution = resolveSessionContextProject(
       provider,
       { cwd: hookInput.cwd, sessionId: hookInput.session_id },
@@ -156,14 +160,15 @@ export async function runContextActivate(
   }
 }
 
-function readHookInput(): { cwd?: string; session_id?: string } {
+function readHookInput(): { cwd?: string; session_id?: string; source?: string } {
   const input = readFileSync(0, "utf8");
   if (Buffer.byteLength(input) > 64 * 1024) throw new Error("hook input is too large");
   if (!input.trim()) return {};
-  const parsed = JSON.parse(input) as { cwd?: unknown; session_id?: unknown };
+  const parsed = JSON.parse(input) as { cwd?: unknown; session_id?: unknown; source?: unknown };
   return {
     ...(typeof parsed.cwd === "string" && parsed.cwd.length > 0 ? { cwd: parsed.cwd } : {}),
     ...(typeof parsed.session_id === "string" && parsed.session_id.length > 0 ? { session_id: parsed.session_id } : {}),
+    ...(typeof parsed.source === "string" && parsed.source.length > 0 ? { source: parsed.source } : {}),
   };
 }
 

--- a/apps/cli/src/commands/context/adapter-sync.ts
+++ b/apps/cli/src/commands/context/adapter-sync.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { AccountStateMutationBusyError } from "../../core/context-integration/account-state-guard.js";
 import { inspectContextAdapterNextSessionObligation } from "../../core/context-integration/adapter-observation.js";
 import {
   AdapterNextSessionRequiredError,
@@ -32,7 +33,8 @@ export function runContextAdapterSync(context: CommandContext): void {
   } catch (error) {
     if (
       error instanceof AdapterNextSessionRequiredError ||
-      (provider === "claude-code" && inspectContextAdapterNextSessionObligation() !== null)
+      (provider === "claude-code" &&
+        (error instanceof AccountStateMutationBusyError || inspectContextAdapterNextSessionObligation() !== null))
     ) {
       print.fail(
         "CONTEXT_PLUGIN_RELOAD_REQUIRED",

--- a/apps/cli/src/commands/context/adapter-sync.ts
+++ b/apps/cli/src/commands/context/adapter-sync.ts
@@ -24,7 +24,7 @@ export function runContextAdapterSync(context: CommandContext): void {
       ...result,
       message:
         provider === "claude-code"
-          ? "First Tree Context was updated. It will be used next session; /reload-plugins can adopt it now."
+          ? "First Tree Context was updated. It will be used in the next Claude session."
           : "First Tree Context was updated. Review /hooks if Codex asks you to trust the updated Hook; otherwise it is guaranteed for the next session.",
     });
   } catch (error) {

--- a/apps/cli/src/commands/context/adapter-sync.ts
+++ b/apps/cli/src/commands/context/adapter-sync.ts
@@ -1,5 +1,7 @@
 import type { Command } from "commander";
+import { inspectContextAdapterNextSessionObligation } from "../../core/context-integration/adapter-observation.js";
 import {
+  AdapterNextSessionRequiredError,
   AdapterSyncRejectedError,
   hasKnownGoodCompatibleContextAdapter,
   synchronizeContextAdapter,
@@ -28,6 +30,17 @@ export function runContextAdapterSync(context: CommandContext): void {
           : "First Tree Context was updated. Review /hooks if Codex asks you to trust the updated Hook; otherwise it is guaranteed for the next session.",
     });
   } catch (error) {
+    if (
+      error instanceof AdapterNextSessionRequiredError ||
+      (provider === "claude-code" && inspectContextAdapterNextSessionObligation() !== null)
+    ) {
+      print.fail(
+        "CONTEXT_PLUGIN_RELOAD_REQUIRED",
+        "This Claude session cannot use the repaired First Tree Context Plugin. Start a new Claude session.",
+        2,
+        { nextActions: ["Start a new Claude session before using persistent First Tree Context."] },
+      );
+    }
     if (!(error instanceof AdapterSyncRejectedError) && hasKnownGoodCompatibleContextAdapter(driver)) {
       print.result({
         updated: false,

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -364,7 +364,7 @@ async function applyPersistent(
       ...(authorityMissing ? [`Team authority: ${finalActivation.message}`] : []),
     ];
     let currentSessionHandoff: CurrentSessionHandoff | null = null;
-    if (missingLayers.length === 0 && health.probe.installedPath) {
+    if (missingLayers.length === 0 && health.probe.installedPath && !claudeNextSessionRequired) {
       currentSessionHandoff = buildCurrentSessionHandoff({
         provider,
         project: plan.location.project,
@@ -374,11 +374,11 @@ async function applyPersistent(
       });
     }
     assertPlannedAccount(plan);
-    const setupComplete = missingLayers.length === 0 && currentSessionHandoff !== null;
+    const setupComplete = missingLayers.length === 0 && (currentSessionHandoff !== null || claudeNextSessionRequired);
     const nextActions = setupComplete
       ? [
           claudeNextSessionRequired
-            ? "Adopt the verified handoff in this session. Start a new Claude session for persistent auto-activation."
+            ? "Start a new Claude session for persistent auto-activation. This setup does not activate Context in the current Claude session."
             : "Adopt the verified handoff in this session. Future sessions will load the neutral Team router automatically.",
         ]
       : [

--- a/apps/cli/src/commands/context/enable.ts
+++ b/apps/cli/src/commands/context/enable.ts
@@ -6,14 +6,7 @@ import {
   readActiveContextAccountClientId,
   withAccountStateMutationLockAsync,
 } from "../../core/context-integration/account-state-guard.js";
-import {
-  ContextReloadReceiptError,
-  consumeContextAdapterReloadReceipt,
-  consumeContextAdapterReloadRequiredMarker,
-  hasContextAdapterReloadRequiredMarker,
-  hasPendingContextAdapterReload,
-  registerPendingContextAdapterReload,
-} from "../../core/context-integration/adapter-observation.js";
+import { inspectContextAdapterNextSessionObligation } from "../../core/context-integration/adapter-observation.js";
 import { inspectContextSetupLocation } from "../../core/context-integration/client-preflight.js";
 import {
   assertContextGrantStoreFingerprint,
@@ -44,7 +37,6 @@ type EnableOptions = {
   yes?: boolean;
   projectRoot?: string;
   pathless?: boolean;
-  reloadReceipt?: string;
 };
 
 const setupPlanAccountClientId = Symbol("setupPlanAccountClientId");
@@ -80,7 +72,6 @@ function configure(command: Command): void {
     .option("--plan-id <plan-id>", "exact plan id returned by --plan")
     .option("--project-root <directory>", "explicit provider directory")
     .option("--pathless", "provider session without a usable directory")
-    .option("--reload-receipt <receipt>", "opaque Claude session-loaded receipt")
     .option("--yes", "accept the selected activation change");
 }
 
@@ -132,17 +123,10 @@ export async function runContextEnable(context: CommandContext): Promise<void> {
   const result =
     activationScope.kind === "session"
       ? await applySessionOnly(provider, plan, activationScope, acceptedPlan.beforeFingerprint)
-      : await applyPersistent(
-          provider,
-          plan,
-          activationScope,
-          {
-            beforeFingerprint: acceptedPlan.beforeFingerprint,
-            afterFingerprint: requireAfterFingerprint(expectedAfterFingerprint),
-          },
-          acceptedPlan.planChallenge,
-          options.reloadReceipt,
-        );
+      : await applyPersistent(provider, plan, activationScope, {
+          beforeFingerprint: acceptedPlan.beforeFingerprint,
+          afterFingerprint: requireAfterFingerprint(expectedAfterFingerprint),
+        });
   if (context.options.json) {
     print.result(result);
     return;
@@ -320,8 +304,6 @@ async function applyPersistent(
   plan: SetupPlan,
   activationScope: Exclude<ContextActivationScope, { kind: "session" }>,
   expectedStore: { beforeFingerprint: string; afterFingerprint: string },
-  planChallenge: string,
-  reloadReceipt: string | undefined,
 ) {
   return withAccountStateMutationLockAsync(async () => {
     assertPlannedAccount(plan);
@@ -333,7 +315,8 @@ async function applyPersistent(
       activationScope,
     };
     enableContextIntegrationOperation(driver, installPlan, grant, expectedStore, plan[setupPlanAccountClientId], {
-      reloadObligationKind: provider === "claude-code" && installPlan.operation !== "unchanged" ? "setup" : undefined,
+      nextSessionObligationKind:
+        provider === "claude-code" && installPlan.operation !== "unchanged" ? "setup" : undefined,
     });
     const health = inspectContextIntegrationRuntime(driver);
     const grantReady = readContextIntegrationConfig().grants.some(
@@ -361,51 +344,13 @@ async function applyPersistent(
     }));
     assertPlannedAccount(plan);
     const pluginMissing = !health.healthy;
-    let claudeReloadRequired = false;
-    if (provider === "claude-code" && health.release !== null) {
-      const durableSetupMarker =
-        installPlan.operation !== "unchanged" ||
-        hasContextAdapterReloadRequiredMarker(health.release.manifest, "setup");
-      if (durableSetupMarker) {
-        registerPendingContextAdapterReload(planChallenge, health.release.manifest);
-        // Pending is durable before the setup marker is removed. A
-        // crash can therefore leave duplicate obligations, never no
-        // obligation. The next exact apply safely repeats this conversion.
-        consumeContextAdapterReloadRequiredMarker(health.release.manifest, "setup");
-        claudeReloadRequired = true;
-      } else if (hasPendingContextAdapterReload(planChallenge, health.release.manifest)) {
-        if (reloadReceipt) {
-          try {
-            consumeContextAdapterReloadReceipt({
-              planChallenge,
-              receipt: reloadReceipt,
-              release: health.release.manifest,
-            });
-          } catch (error) {
-            if (error instanceof ContextReloadReceiptError) {
-              print.fail(error.code, error.message, 2, {
-                nextActions: [
-                  "Run /reload-plugins, reply Continue in this Claude session, then retry the original exact apply.",
-                ],
-              });
-            }
-            throw error;
-          }
-        } else {
-          claudeReloadRequired = true;
-        }
-      } else if (reloadReceipt) {
-        print.fail(
-          "CONTEXT_RELOAD_RECEIPT_INVALID",
-          "This Claude reload proof does not belong to a pending exact setup plan.",
-          2,
-        );
-      }
-    }
+    const claudeNextSessionRequired =
+      provider === "claude-code" && health.release !== null
+        ? inspectContextAdapterNextSessionObligation() !== null
+        : false;
     const authorityMissing = finalActivation.outcome !== "connected";
     const missingLayers = [
       ...(pluginMissing ? health.issues.map((issue) => `Plugin: ${issue}`) : []),
-      ...(claudeReloadRequired ? ["Claude Code must reload and observe the thin Context Plugin."] : []),
       ...(grantReady ? [] : ["Activation grant was not found after apply."]),
       ...(hookInspectionUnavailable
         ? hook.issues.length > 0
@@ -431,7 +376,11 @@ async function applyPersistent(
     assertPlannedAccount(plan);
     const setupComplete = missingLayers.length === 0 && currentSessionHandoff !== null;
     const nextActions = setupComplete
-      ? ["Adopt the verified handoff in this session. Future sessions will load the neutral Team router automatically."]
+      ? [
+          claudeNextSessionRequired
+            ? "Adopt the verified handoff in this session. Start a new Claude session for persistent auto-activation."
+            : "Adopt the verified handoff in this session. Future sessions will load the neutral Team router automatically.",
+        ]
       : [
           ...(pluginMissing ? ["Repair the reported Plugin payload/state, then rerun the exact apply command."] : []),
           ...(grantReady
@@ -441,11 +390,6 @@ async function applyPersistent(
               ]),
           ...(authorityMissing
             ? ["Restore the reported Team membership/binding authority, create a fresh plan, and ask the user again."]
-            : []),
-          ...(!pluginMissing && claudeReloadRequired
-            ? [
-                "Run /reload-plugins in Claude Code, reply Continue, then rerun the original exact apply with the opaque reload receipt supplied by the new Plugin.",
-              ]
             : []),
           ...(!pluginMissing && hookInspectionUnavailable
             ? ["Restore Codex Hook inspection/provider API availability, then rerun the exact apply command."]

--- a/apps/cli/src/commands/context/observe-loaded.ts
+++ b/apps/cli/src/commands/context/observe-loaded.ts
@@ -1,15 +1,6 @@
-import { readFileSync } from "node:fs";
 import type { Command } from "commander";
-import {
-  ContextReloadReceiptError,
-  inspectContextAdapterLoadedObservationObligation,
-  issueContextAdapterSessionLoadedReceipt,
-} from "../../core/context-integration/adapter-observation.js";
 import { print } from "../../core/output.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
-import { parseContextProvider } from "./shared.js";
-
-type Options = { provider?: string; adapterDigest?: string; adoptionGeneration?: string };
 
 function configure(command: Command): void {
   command
@@ -18,69 +9,13 @@ function configure(command: Command): void {
     .requiredOption("--adoption-generation <generation>");
 }
 
-export function runContextObserveLoaded(
-  context: CommandContext,
-  dependencies: {
-    inspectObligation?: typeof inspectContextAdapterLoadedObservationObligation;
-    issueReceipt?: typeof issueContextAdapterSessionLoadedReceipt;
-  } = {},
-): void {
-  const options = context.command.opts<Options>();
-  const provider = parseContextProvider(options.provider ?? "");
-  try {
-    const identity = {
-      provider,
-      adapterDigest: options.adapterDigest ?? "",
-      adoptionGeneration: options.adoptionGeneration ?? "",
-    };
-    const obligation = (dependencies.inspectObligation ?? inspectContextAdapterLoadedObservationObligation)(identity);
-    if (obligation === null) {
-      print.hook({ continue: true });
-      return;
-    }
-    const input = readHookInput();
-    const receipt = (dependencies.issueReceipt ?? issueContextAdapterSessionLoadedReceipt)({
-      ...identity,
-      sessionId: input.session_id,
-    });
-    if (receipt === null) {
-      print.hook({
-        continue: true,
-        hookSpecificOutput: {
-          hookEventName: "UserPromptSubmit",
-          additionalContext: "First Tree Context repair was adopted by this Claude session.",
-        },
-      });
-      return;
-    }
-    print.hook({
-      continue: true,
-      hookSpecificOutput: {
-        hookEventName: "UserPromptSubmit",
-        additionalContext: [
-          "First Tree Context is loaded for this Claude session.",
-          `When rerunning an exact pending First Tree setup apply, append --reload-receipt '${receipt}'.`,
-          "Treat this opaque receipt as session-local. Do not display it, reuse it, or attach it to another plan.",
-        ].join("\n"),
-      },
-    });
-  } catch {
-    // An old compatible hook continues to run until Claude reloads the
-    // Plugin. A target mismatch or missing host session identity therefore
-    // leaves any pending setup incomplete without turning routine forward
-    // updates into user-visible failures.
-    print.hook({ continue: true });
-  }
-}
-
-function readHookInput(): { session_id: string } {
-  const raw = readFileSync(0, "utf8");
-  if (Buffer.byteLength(raw) > 64 * 1024) throw new ContextReloadReceiptError("Hook input is too large.");
-  const value = JSON.parse(raw) as { session_id?: unknown };
-  if (typeof value.session_id !== "string" || !value.session_id) {
-    throw new ContextReloadReceiptError("Claude did not provide a trustworthy session identity.");
-  }
-  return { session_id: value.session_id };
+/**
+ * Adapter 1.0.1 may remain loaded in an existing Claude session after the CLI
+ * upgrades. Keep its retired UserPromptSubmit command harmless until that
+ * session ends, without issuing receipts or mutating adoption state.
+ */
+export function runContextObserveLoaded(_context: CommandContext): void {
+  print.hook({ continue: true });
 }
 
 export const contextObserveLoadedCommand: SubcommandModule = {
@@ -88,7 +23,7 @@ export const contextObserveLoadedCommand: SubcommandModule = {
   hidden: true,
   alias: "",
   summary: "",
-  description: "Internal Claude lifecycle bridge for a session-loaded adapter receipt.",
+  description: "Retired Claude same-session lifecycle bridge.",
   configure,
   action: runContextObserveLoaded,
 };

--- a/apps/cli/src/commands/context/repair.ts
+++ b/apps/cli/src/commands/context/repair.ts
@@ -3,7 +3,7 @@ import {
   assertContextMutationCanStart,
   withAccountStateMutationLock,
 } from "../../core/context-integration/account-state-guard.js";
-import { inspectContextAdapterReloadObligation } from "../../core/context-integration/adapter-observation.js";
+import { inspectContextAdapterNextSessionObligation } from "../../core/context-integration/adapter-observation.js";
 import { planContextIntegrationInstall } from "../../core/context-integration/installer.js";
 import { readContextIntegrationInstallManifest } from "../../core/context-integration/manifest.js";
 import {
@@ -27,22 +27,16 @@ export function runContextRepair(context: CommandContext): void {
     const plan = planContextIntegrationInstall(driver);
     if (plan.operation !== "unchanged") {
       repairContextIntegrationOperation(driver, plan, {
-        reloadObligationKind: provider === "claude-code" ? "standalone_repair" : undefined,
+        nextSessionObligationKind: provider === "claude-code" ? "standalone_repair" : undefined,
       });
     }
-    const reloadObligation =
-      provider === "claude-code" ? inspectContextAdapterReloadObligation(plan.release.manifest) : null;
+    const nextSessionObligation = provider === "claude-code" ? inspectContextAdapterNextSessionObligation() : null;
     return {
       manifest: readContextIntegrationInstallManifest(provider),
       probe: driver.probe(plan.marketplaceName, "first-tree-context"),
       repaired: recoveredOperation || plan.operation !== "unchanged",
-      reloadPending: reloadObligation !== null,
-      nextActions:
-        reloadObligation === "standalone_repair"
-          ? ["Run /reload-plugins, then send one message so Claude can verify the repaired Plugin."]
-          : reloadObligation === "setup"
-            ? ["Rerun the original exact Team setup apply so it can bind and finish the Claude reload flow."]
-            : [],
+      nextSessionPending: nextSessionObligation !== null,
+      nextActions: nextSessionObligation ? ["Start a new Claude session to use the repaired Context Plugin."] : [],
     };
   });
   if (context.options.json) print.result(result);

--- a/apps/cli/src/commands/context/route.ts
+++ b/apps/cli/src/commands/context/route.ts
@@ -63,7 +63,10 @@ export async function runContextRoute(context: CommandContext): Promise<void> {
   } catch (error) {
     if (error instanceof ContextPluginReloadRequiredError) {
       print.fail(error.code, error.message, 2, {
-        nextActions: ["Reload the First Tree Context Plugin, then retry the same route command."],
+        nextActions:
+          provider === "claude-code"
+            ? ["Start a new Claude session, then retry the same route command."]
+            : ["Repair the Codex Context Plugin, then retry the same route command."],
       });
     }
     throw error;

--- a/apps/cli/src/commands/context/status.ts
+++ b/apps/cli/src/commands/context/status.ts
@@ -1,10 +1,9 @@
 import type { Command } from "commander";
 import { channelConfig } from "../../core/channel.js";
-import { inspectContextAdapterReloadObligation } from "../../core/context-integration/adapter-observation.js";
+import { inspectContextAdapterNextSessionObligation } from "../../core/context-integration/adapter-observation.js";
 import { readContextIntegrationInstallJournal } from "../../core/context-integration/installer.js";
 import { inspectContextIntegrationOperation } from "../../core/context-integration/operation.js";
 import type { ProviderHookProbe } from "../../core/context-integration/provider-driver.js";
-import { resolveContextIntegrationRelease } from "../../core/context-integration/release.js";
 import {
   type ContextIntegrationStatus,
   inspectContextIntegrationStatus,
@@ -31,17 +30,7 @@ export async function runContextStatus(context: CommandContext): Promise<void> {
   });
   const incompleteInstall = readContextIntegrationInstallJournal();
   const incompleteOperation = inspectContextIntegrationOperation();
-  let reloadObligation: ReturnType<typeof inspectContextAdapterReloadObligation> = null;
-  if (provider === "claude-code") {
-    let release: ReturnType<typeof resolveContextIntegrationRelease> | null = null;
-    try {
-      release = resolveContextIntegrationRelease();
-    } catch {
-      // Runtime health already reports an untrusted release; status remains
-      // inspectable rather than becoming another mutation.
-    }
-    if (release) reloadObligation = inspectContextAdapterReloadObligation(release.manifest);
-  }
+  const nextSessionObligation = provider === "claude-code" ? inspectContextAdapterNextSessionObligation() : null;
   const recovery = [
     ...(incompleteInstall?.provider === provider
       ? [`Incomplete ${incompleteInstall.phase}; run ${channelConfig.binName} context repair --provider ${provider}`]
@@ -51,10 +40,10 @@ export async function runContextStatus(context: CommandContext): Promise<void> {
           `Incomplete ${incompleteOperation.operation}/${incompleteOperation.phase}; run ${channelConfig.binName} context repair --provider ${provider}`,
         ]
       : []),
-    ...(reloadObligation === "standalone_repair"
-      ? ["Claude must run /reload-plugins and submit one message to adopt the repaired Context Plugin"]
-      : reloadObligation === "setup"
-        ? ["Claude setup must finish its exact reload/apply flow"]
+    ...(nextSessionObligation === "standalone_repair"
+      ? ["Start a new Claude session to adopt the repaired Context Plugin"]
+      : nextSessionObligation === "setup"
+        ? ["Start a new Claude session for persistent Context auto-activation"]
         : []),
   ];
   const result = { ...status, recovery };

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -270,7 +270,7 @@ export async function runLogout(opts: {
       print.line(`  ✓ Removed ${entry.label}\n`);
     }
     for (const provider of ["claude-code", "codex"] as const) {
-      for (const state of ["adapter-sync", "reload-pending", "reload-consumed"]) {
+      for (const state of ["adapter-sync", "compatible-sessions", "reload-pending", "reload-consumed"]) {
         rmSync(join(home, "state", "context", "providers", provider, state), { recursive: true, force: true });
       }
       rmSync(join(home, "state", "context", "providers", provider, "reload-required.json"), { force: true });

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -274,6 +274,7 @@ export async function runLogout(opts: {
         rmSync(join(home, "state", "context", "providers", provider, state), { recursive: true, force: true });
       }
       rmSync(join(home, "state", "context", "providers", provider, "reload-required.json"), { force: true });
+      rmSync(join(home, "state", "context", "providers", provider, "next-session-required.json"), { force: true });
     }
   }
   print.line(`\n  Logged out. Run \`${channelConfig.binName} login <code>\` to reconnect.\n\n`);

--- a/apps/cli/src/core/client-switch.ts
+++ b/apps/cli/src/core/client-switch.ts
@@ -987,7 +987,7 @@ function throwSwitchFailure(code: string, message: string): never {
 function clearAccountBoundContextReceipts(home: string): void {
   rmSync(join(home, "state", "context", "route-receipts"), { recursive: true, force: true });
   for (const provider of ["claude-code", "codex"]) {
-    for (const entry of ["adapter-sync", "reload-pending", "reload-consumed"]) {
+    for (const entry of ["adapter-sync", "compatible-sessions", "reload-pending", "reload-consumed"]) {
       rmSync(join(home, "state", "context", "providers", provider, entry), { recursive: true, force: true });
     }
     rmSync(join(home, "state", "context", "providers", provider, "reload-required.json"), { force: true });

--- a/apps/cli/src/core/client-switch.ts
+++ b/apps/cli/src/core/client-switch.ts
@@ -991,6 +991,7 @@ function clearAccountBoundContextReceipts(home: string): void {
       rmSync(join(home, "state", "context", "providers", provider, entry), { recursive: true, force: true });
     }
     rmSync(join(home, "state", "context", "providers", provider, "reload-required.json"), { force: true });
+    rmSync(join(home, "state", "context", "providers", provider, "next-session-required.json"), { force: true });
   }
 }
 

--- a/apps/cli/src/core/context-integration/account-state-guard.ts
+++ b/apps/cli/src/core/context-integration/account-state-guard.ts
@@ -114,7 +114,8 @@ function acquireAccountStateMutationLock(home: string): () => void {
   try {
     descriptor = openSync(path, "wx", 0o600);
   } catch (error) {
-    throw new AccountStateMutationBusyError({ cause: error });
+    if (errorCode(error) === "EEXIST") throw new AccountStateMutationBusyError({ cause: error });
+    throw error;
   }
   heldAccountLocks.add(path);
   writeFileSync(descriptor, `${process.pid}\n`, "utf8");
@@ -142,7 +143,11 @@ function removeStalePidLock(path: string): void {
 }
 
 function isMissing(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "code" in error && Reflect.get(error, "code") === "ENOENT";
+  return errorCode(error) === "ENOENT";
+}
+
+function errorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? Reflect.get(error, "code") : undefined;
 }
 
 function readBlockingJournalProvider(path: string) {

--- a/apps/cli/src/core/context-integration/account-state-guard.ts
+++ b/apps/cli/src/core/context-integration/account-state-guard.ts
@@ -13,6 +13,13 @@ import { contextRepairCommand } from "./repair-guidance.js";
 
 const heldAccountLocks = new Set<string>();
 
+export class AccountStateMutationBusyError extends Error {
+  constructor(options?: ErrorOptions) {
+    super("Another First Tree account or Context state change is already running.", options);
+    this.name = "AccountStateMutationBusyError";
+  }
+}
+
 export function withAccountStateMutationLock<T>(action: () => T, home = defaultHome()): T {
   const release = acquireAccountStateMutationLock(home);
   try {
@@ -107,7 +114,7 @@ function acquireAccountStateMutationLock(home: string): () => void {
   try {
     descriptor = openSync(path, "wx", 0o600);
   } catch (error) {
-    throw new Error("Another First Tree account or Context state change is already running.", { cause: error });
+    throw new AccountStateMutationBusyError({ cause: error });
   }
   heldAccountLocks.add(path);
   writeFileSync(descriptor, `${process.pid}\n`, "utf8");

--- a/apps/cli/src/core/context-integration/adapter-observation.ts
+++ b/apps/cli/src/core/context-integration/adapter-observation.ts
@@ -1,200 +1,40 @@
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
-import { mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { ContextIntegrationProvider, ContextIntegrationReleaseManifest } from "@first-tree/shared";
 import { defaultHome } from "@first-tree/shared/config";
 import semver from "semver";
 import { channelConfig } from "../channel.js";
-import {
-  assertContextMutationCanStart,
-  readActiveContextAccountClientId,
-  withAccountStateMutationLock,
-} from "./account-state-guard.js";
+import { readActiveContextAccountClientId, withAccountStateMutationLock } from "./account-state-guard.js";
 import { assertContextAdapterPayloadHealthy } from "./adapter-payload-health.js";
 import { readContextIntegrationInstallManifest } from "./manifest.js";
 import type { ContextIntegrationProviderDriver } from "./provider-driver.js";
 import { createContextIntegrationProviderDriver } from "./provider-factory.js";
 import { resolveContextIntegrationRelease } from "./release.js";
 
-const RECEIPT_TTL_MS = 5 * 60 * 1000;
-const PENDING_TTL_MS = 24 * 60 * 60 * 1000;
-const ADOPTION_GENERATION_RE = /^[0-9a-f]{48}$/u;
+export type ContextAdapterNextSessionObligationKind = "setup" | "standalone_repair";
 
-type SessionLoadedReceipt = {
+type NextSessionRequiredMarker = {
   schemaVersion: 1;
   accountClientId: string;
   provider: "claude-code";
   adapterVersion: string;
   adapterDigest: string;
-  adoptionGeneration: string;
-  sessionId: string;
-  nonce: string;
-  expiresAt: string;
+  kind: ContextAdapterNextSessionObligationKind;
+  createdAt: string;
 };
 
-type PendingReloadPlan = {
-  schemaVersion: 1;
-  accountClientId: string;
-  provider: "claude-code";
-  adapterVersion: string;
-  adapterDigest: string;
-  adoptionGeneration: string;
-  planChallenge: string;
-  boundSessionId: string | null;
-  expiresAt: string;
-};
-
-type ConsumedReloadReceipt = {
-  schemaVersion: 1;
-  nonce: string;
-  accountClientId: string;
-  planChallenge: string;
-  sessionId: string;
-  expiresAt: string;
-  consumedAt: string;
-};
-
-export function issueContextAdapterSessionLoadedReceipt(input: {
-  provider: ContextIntegrationProvider;
-  adapterDigest: string;
-  adoptionGeneration: string;
-  sessionId: string;
-}): string | null {
-  return withAccountStateMutationLock(() => {
-    assertContextMutationCanStart();
-    return issueContextAdapterSessionLoadedReceiptLocked(input);
-  });
-}
-
-function issueContextAdapterSessionLoadedReceiptLocked(input: {
-  provider: ContextIntegrationProvider;
-  adapterDigest: string;
-  adoptionGeneration: string;
-  sessionId: string;
-}): string | null {
-  if (input.provider !== "claude-code") throw new ContextReloadReceiptError("Only Claude reloads use this receipt.");
-  assertSessionId(input.sessionId);
-  const obligation = inspectContextAdapterLoadedObservationObligation(input);
-  if (obligation === null) {
-    throw new ContextReloadReceiptError("This Claude session has no matching adapter adoption obligation.");
-  }
-  const install = readContextIntegrationInstallManifest(input.provider);
-  if (
-    input.adapterDigest !== install?.adapterDigest ||
-    input.adoptionGeneration !== install?.adoptionGeneration ||
-    !ADOPTION_GENERATION_RE.test(input.adoptionGeneration) ||
-    !install.adapterVersion
-  ) {
-    throw new ContextReloadReceiptError("This Claude hook did not load the current First Tree Context adapter.");
-  }
-  if (obligation === "standalone_repair") {
-    rmSync(join(providerStateRoot("claude-code"), "reload-required.json"), { force: true });
-    return null;
-  }
-  const payload: SessionLoadedReceipt = {
-    schemaVersion: 1,
-    accountClientId: readActiveContextAccountClientId(),
-    provider: "claude-code",
-    adapterVersion: install.adapterVersion,
-    adapterDigest: install.adapterDigest,
-    adoptionGeneration: input.adoptionGeneration,
-    sessionId: input.sessionId,
-    nonce: randomBytes(24).toString("hex"),
-    expiresAt: new Date(Date.now() + RECEIPT_TTL_MS).toISOString(),
-  };
-  return signReceipt(payload);
-}
-
-export function inspectContextAdapterLoadedObservationObligation(input: {
-  provider: ContextIntegrationProvider;
-  adapterDigest: string;
-  adoptionGeneration: string;
-}): ContextAdapterReloadObligationKind | null {
-  if (
-    input.provider !== "claude-code" ||
-    !/^sha256:[0-9a-f]{64}$/u.test(input.adapterDigest) ||
-    !ADOPTION_GENERATION_RE.test(input.adoptionGeneration)
-  ) {
-    return null;
-  }
-  const install = readContextIntegrationInstallManifest("claude-code");
-  if (
-    !install?.adapterVersion ||
-    install.adapterDigest !== input.adapterDigest ||
-    install.adoptionGeneration !== input.adoptionGeneration
-  ) {
-    return null;
-  }
-  const target = { adapterVersion: install.adapterVersion, adapterDigest: install.adapterDigest };
-  const accountClientId = readActiveContextAccountClientId();
-  const required = readContextAdapterReloadRequiredMarkerForTarget(target, accountClientId);
-  if (required) {
-    return required.adoptionGeneration === input.adoptionGeneration ? required.kind : null;
-  }
-  return hasAnyPendingContextAdapterReloadForTarget(target, input.adoptionGeneration, accountClientId) ? "setup" : null;
-}
-
-export function registerPendingContextAdapterReload(
-  planChallenge: string,
+export function beginContextAdapterNextSessionObligation(
   release: ContextIntegrationReleaseManifest,
-): void {
-  assertPlanChallenge(planChallenge);
-  const target = release.providers["claude-code"];
-  const install = readContextIntegrationInstallManifest("claude-code");
-  const required = readContextAdapterReloadRequiredMarker(release);
-  if (!required || required.kind !== "setup" || required.adoptionGeneration !== install?.adoptionGeneration) {
-    throw new ContextReloadRecoveryStateError("The exact setup plan has no matching durable Claude reload obligation.");
-  }
-  const pending: PendingReloadPlan = {
-    schemaVersion: 1,
-    accountClientId: readActiveContextAccountClientId(),
-    provider: "claude-code",
-    adapterVersion: target.adapterVersion,
-    adapterDigest: target.adapterDigest,
-    adoptionGeneration: required.adoptionGeneration,
-    planChallenge,
-    boundSessionId: null,
-    expiresAt: new Date(Date.now() + PENDING_TTL_MS).toISOString(),
-  };
-  writeJson(pendingPath(planChallenge), pending);
-}
-
-export type ContextAdapterReloadObligationKind = "setup" | "standalone_repair";
-
-export function markContextAdapterReloadRequired(
-  release: ContextIntegrationReleaseManifest,
-  kind: ContextAdapterReloadObligationKind = "standalone_repair",
-  adoptionGeneration = readContextIntegrationInstallManifest("claude-code")?.adoptionGeneration,
-): void {
-  if (!ADOPTION_GENERATION_RE.test(adoptionGeneration ?? "")) {
-    throw new ContextReloadRecoveryStateError("The Claude reload obligation lacks an exact adoption generation.");
-  }
-  const target = release.providers["claude-code"];
-  writeJson(join(providerStateRoot("claude-code"), "reload-required.json"), {
-    schemaVersion: 1,
-    accountClientId: readActiveContextAccountClientId(),
-    provider: "claude-code",
-    adapterVersion: target.adapterVersion,
-    adapterDigest: target.adapterDigest,
-    adoptionGeneration,
-    kind,
-    createdAt: new Date().toISOString(),
-  });
-}
-
-export function beginContextAdapterReloadObligation(
-  release: ContextIntegrationReleaseManifest,
-  kind: ContextAdapterReloadObligationKind,
-  adoptionGeneration: string,
+  kind: ContextAdapterNextSessionObligationKind,
 ): () => void {
-  const path = join(providerStateRoot("claude-code"), "reload-required.json");
+  const path = nextSessionRequiredPath();
   let previous: string | null = null;
   try {
     previous = readFileSync(path, "utf8");
   } catch (error) {
     if (!isMissing(error)) throw error;
   }
-  markContextAdapterReloadRequired(release, kind, adoptionGeneration);
+  writeNextSessionRequiredMarker(release, kind);
   return () => {
     if (previous === null) {
       rmSync(path, { force: true });
@@ -204,159 +44,58 @@ export function beginContextAdapterReloadObligation(
   };
 }
 
-export function consumeContextAdapterReloadRequiredMarker(
-  release: ContextIntegrationReleaseManifest,
-  expectedKind?: ContextAdapterReloadObligationKind,
-): boolean {
-  const required = readContextAdapterReloadRequiredMarker(release);
-  if (required && expectedKind && required.kind !== expectedKind) {
-    throw new ContextReloadRecoveryStateError("The pending Claude reload obligation has the wrong recovery kind.");
-  }
-  if (required) rmSync(join(providerStateRoot("claude-code"), "reload-required.json"), { force: true });
-  return required !== null;
+export function inspectContextAdapterNextSessionObligation(): ContextAdapterNextSessionObligationKind | null {
+  return readNextSessionRequiredMarker()?.kind ?? null;
 }
 
-export function hasContextAdapterReloadRequiredMarker(
-  release: ContextIntegrationReleaseManifest,
-  expectedKind?: ContextAdapterReloadObligationKind,
-): boolean {
-  const required = readContextAdapterReloadRequiredMarker(release);
-  if (required && expectedKind && required.kind !== expectedKind) {
-    throw new ContextReloadRecoveryStateError("The pending Claude reload obligation has the wrong recovery kind.");
-  }
-  return required !== null;
-}
-
-export function inspectContextAdapterReloadObligation(
-  release: ContextIntegrationReleaseManifest,
-): ContextAdapterReloadObligationKind | null {
-  return readContextAdapterReloadRequiredMarker(release)?.kind ?? null;
-}
-
-function readContextAdapterReloadRequiredMarker(
-  release: ContextIntegrationReleaseManifest,
-): { kind: ContextAdapterReloadObligationKind; adoptionGeneration: string } | null {
-  return readContextAdapterReloadRequiredMarkerForTarget(
-    release.providers["claude-code"],
-    readActiveContextAccountClientId(),
-  );
-}
-
-function readContextAdapterReloadRequiredMarkerForTarget(
-  target: { adapterVersion: string; adapterDigest: string },
-  accountClientId: string,
-): { kind: ContextAdapterReloadObligationKind; adoptionGeneration: string } | null {
-  const path = join(providerStateRoot("claude-code"), "reload-required.json");
-  try {
-    const value = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+/**
+ * A Claude SessionStart from the current deterministic adapter is the adoption
+ * boundary. The session may be a fresh task or another provider lifecycle
+ * start, but it can never be an event from the pre-repair adapter.
+ */
+export function consumeContextAdapterNextSessionObligation(
+  input: {
+    provider: ContextIntegrationProvider;
+    adapterDigest: string;
+  },
+  options: { releaseRoot?: string; coreRoot?: string } = {},
+): ContextAdapterNextSessionObligationKind | null {
+  if (input.provider !== "claude-code") return null;
+  return withAccountStateMutationLock(() => {
+    const release = resolveContextIntegrationRelease(options.releaseRoot, { coreRoot: options.coreRoot });
+    const install = readContextIntegrationInstallManifest("claude-code");
+    const target = release.manifest.providers["claude-code"];
     if (
-      value.schemaVersion !== 1 ||
-      value.accountClientId !== accountClientId ||
-      value.provider !== "claude-code" ||
-      value.adapterVersion !== target.adapterVersion ||
-      value.adapterDigest !== target.adapterDigest ||
-      !ADOPTION_GENERATION_RE.test(String(value.adoptionGeneration ?? "")) ||
-      (value.kind !== "setup" && value.kind !== "standalone_repair") ||
-      typeof value.createdAt !== "string" ||
-      !Number.isFinite(Date.parse(value.createdAt))
+      !install?.adapterVersion ||
+      input.adapterDigest !== install.adapterDigest ||
+      install.adapterVersion !== target.adapterVersion ||
+      install.adapterDigest !== target.adapterDigest
     ) {
-      throw new ContextReloadReceiptError("The pending Claude reload state does not match this account or adapter.");
+      return null;
     }
-    return { kind: value.kind, adoptionGeneration: value.adoptionGeneration as string };
-  } catch (error) {
-    if (isMissing(error)) return null;
-    throw error;
-  }
-}
-
-export function hasPendingContextAdapterReload(
-  planChallenge: string,
-  release: ContextIntegrationReleaseManifest,
-): boolean {
-  const pending = readPending(planChallenge);
-  if (pending && Date.parse(pending.expiresAt) <= Date.now()) {
-    rmSync(pendingPath(planChallenge), { force: true });
-    return false;
-  }
-  const target = release.providers["claude-code"];
-  const install = readContextIntegrationInstallManifest("claude-code");
-  if (!pending) return false;
-  if (
-    pending.accountClientId !== readActiveContextAccountClientId() ||
-    pending.adapterVersion !== target.adapterVersion ||
-    pending.adapterDigest !== target.adapterDigest ||
-    pending.adoptionGeneration !== install?.adoptionGeneration
-  ) {
-    throw new ContextReloadRecoveryStateError(
-      "The pending Claude reload state belongs to another account or adapter target.",
-    );
-  }
-  return true;
-}
-
-export function consumeContextAdapterReloadReceipt(input: {
-  planChallenge: string;
-  receipt: string;
-  release: ContextIntegrationReleaseManifest;
-}): void {
-  const pending = readPending(input.planChallenge);
-  const loaded = verifyReceipt(input.receipt);
-  const target = input.release.providers["claude-code"];
-  const install = readContextIntegrationInstallManifest("claude-code");
-  if (
-    !pending ||
-    pending.accountClientId !== readActiveContextAccountClientId() ||
-    pending.adapterVersion !== target.adapterVersion ||
-    pending.adapterDigest !== target.adapterDigest ||
-    pending.adoptionGeneration !== install?.adoptionGeneration ||
-    Date.parse(pending.expiresAt) <= Date.now() ||
-    loaded.accountClientId !== pending.accountClientId ||
-    loaded.provider !== pending.provider ||
-    loaded.adapterVersion !== pending.adapterVersion ||
-    loaded.adapterDigest !== pending.adapterDigest ||
-    loaded.adoptionGeneration !== pending.adoptionGeneration ||
-    Date.parse(loaded.expiresAt) <= Date.now() ||
-    (pending.boundSessionId !== null && pending.boundSessionId !== loaded.sessionId)
-  ) {
-    throw new ContextReloadReceiptError("The Claude reload proof does not match this exact setup plan and session.");
-  }
-  const consumed = readConsumedNonce(loaded.nonce);
-  if (consumed) {
-    if (
-      pending.boundSessionId === loaded.sessionId &&
-      consumed.accountClientId === loaded.accountClientId &&
-      consumed.planChallenge === input.planChallenge &&
-      consumed.sessionId === loaded.sessionId
-    ) {
-      // Crash recovery: the nonce marker was durable before pending removal.
-      rmSync(pendingPath(input.planChallenge), { force: true });
-      return;
+    const required = readNextSessionRequiredMarker();
+    if (!required) return null;
+    if (required.adapterVersion !== target.adapterVersion || required.adapterDigest !== target.adapterDigest) {
+      return null;
     }
-    throw new ContextReloadReceiptError("The Claude reload proof was already consumed by another setup plan.");
-  }
-  const bound = { ...pending, boundSessionId: loaded.sessionId };
-  writeJson(pendingPath(input.planChallenge), bound);
-  writeJson(consumedPath(loaded.nonce), {
-    schemaVersion: 1,
-    nonce: loaded.nonce,
-    accountClientId: loaded.accountClientId,
-    planChallenge: input.planChallenge,
-    sessionId: loaded.sessionId,
-    expiresAt: loaded.expiresAt,
-    consumedAt: new Date().toISOString(),
+    rmSync(nextSessionRequiredPath(), { force: true });
+    return required.kind;
   });
-  rmSync(pendingPath(input.planChallenge), { force: true });
 }
 
 export function clearContextAdapterObservation(
   provider: ContextIntegrationProvider,
-  options: { includeReloadRequired?: boolean } = {},
+  options: { includeNextSessionRequired?: boolean } = {},
 ): void {
-  rmSync(join(providerStateRoot(provider), "adapter-sync"), { recursive: true, force: true });
-  rmSync(join(providerStateRoot(provider), "reload-pending"), { recursive: true, force: true });
-  rmSync(join(providerStateRoot(provider), "reload-consumed"), { recursive: true, force: true });
-  if (options.includeReloadRequired) {
-    rmSync(join(providerStateRoot(provider), "reload-required.json"), { force: true });
+  const root = providerStateRoot(provider);
+  rmSync(join(root, "adapter-sync"), { recursive: true, force: true });
+  // Retire the former same-session reload proof state whenever a deterministic
+  // adapter is installed. It is never consulted by the next-session contract.
+  rmSync(join(root, "reload-pending"), { recursive: true, force: true });
+  rmSync(join(root, "reload-consumed"), { recursive: true, force: true });
+  rmSync(join(root, "reload-required.json"), { force: true });
+  if (provider === "claude-code" && options.includeNextSessionRequired) {
+    rmSync(nextSessionRequiredPath(), { force: true });
   }
 }
 
@@ -367,11 +106,10 @@ export function assertContextAdapterReadyForRouting(
   const release = resolveContextIntegrationRelease(options.releaseRoot, { coreRoot: options.coreRoot });
   const expected = release.manifest.providers[provider];
   const install = readContextIntegrationInstallManifest(provider);
-  if (
-    provider === "claude-code" &&
-    (readContextAdapterReloadRequiredMarker(release.manifest) || hasAnyPendingContextAdapterReload(release.manifest))
-  ) {
-    throw new ContextPluginReloadRequiredError();
+  if (provider === "claude-code" && readNextSessionRequiredMarker()) {
+    throw new ContextPluginReloadRequiredError(
+      "This Claude session has not adopted the repaired First Tree Context Plugin. Start a new session, then retry.",
+    );
   }
   const exact = install?.adapterVersion === expected.adapterVersion && install.adapterDigest === expected.adapterDigest;
   const compatibleLoadedAdapter =
@@ -399,54 +137,11 @@ export function assertContextAdapterReadyForRouting(
   }
 }
 
-function hasAnyPendingContextAdapterReload(release: ContextIntegrationReleaseManifest): boolean {
-  const target = release.providers["claude-code"];
-  const accountClientId = readActiveContextAccountClientId();
-  const install = readContextIntegrationInstallManifest("claude-code");
-  return install?.adoptionGeneration
-    ? hasAnyPendingContextAdapterReloadForTarget(target, install.adoptionGeneration, accountClientId)
-    : false;
-}
-
-function hasAnyPendingContextAdapterReloadForTarget(
-  target: { adapterVersion: string; adapterDigest: string },
-  adoptionGeneration: string,
-  accountClientId: string,
-): boolean {
-  const root = join(providerStateRoot("claude-code"), "reload-pending");
-  let entries: string[];
-  try {
-    entries = readdirSync(root).filter((entry) => entry.endsWith(".json"));
-  } catch (error) {
-    if (isMissing(error)) return false;
-    throw error;
-  }
-  return entries.some((entry) => {
-    if (!/^[0-9a-f]{64}\.json$/u.test(entry)) {
-      throw new ContextReloadRecoveryStateError("The pending Claude reload state contains an invalid entry.");
-    }
-    const pending = readPending(entry.slice(0, -5));
-    if (!pending) return false;
-    if (Date.parse(pending.expiresAt) <= Date.now()) return false;
-    if (
-      pending.accountClientId !== accountClientId ||
-      pending.adapterVersion !== target.adapterVersion ||
-      pending.adapterDigest !== target.adapterDigest ||
-      pending.adoptionGeneration !== adoptionGeneration
-    ) {
-      throw new ContextReloadRecoveryStateError(
-        "The pending Claude reload state belongs to another account or adapter target.",
-      );
-    }
-    return true;
-  });
-}
-
 export class ContextPluginReloadRequiredError extends Error {
   readonly code = "CONTEXT_PLUGIN_RELOAD_REQUIRED";
 
   constructor(
-    message = "This session is still using an older First Tree Context Plugin. Reload the provider Plugin, then retry.",
+    message = "This provider session is not using a compatible First Tree Context Plugin. Repair the Plugin or start a new session, then retry.",
     options?: ErrorOptions,
   ) {
     super(message, options);
@@ -454,119 +149,63 @@ export class ContextPluginReloadRequiredError extends Error {
   }
 }
 
-export class ContextReloadRecoveryStateError extends Error {
-  readonly code = "CONTEXT_RELOAD_RECOVERY_STATE_INVALID";
+export class ContextNextSessionRecoveryStateError extends Error {
+  readonly code = "CONTEXT_NEXT_SESSION_RECOVERY_STATE_INVALID";
 
   constructor(message: string) {
     super(message);
-    this.name = "ContextReloadRecoveryStateError";
+    this.name = "ContextNextSessionRecoveryStateError";
   }
 }
 
-export class ContextReloadReceiptError extends Error {
-  readonly code = "CONTEXT_RELOAD_RECEIPT_INVALID";
-
-  constructor(message: string) {
-    super(message);
-    this.name = "ContextReloadReceiptError";
-  }
+function writeNextSessionRequiredMarker(
+  release: ContextIntegrationReleaseManifest,
+  kind: ContextAdapterNextSessionObligationKind,
+): void {
+  const target = release.providers["claude-code"];
+  const marker: NextSessionRequiredMarker = {
+    schemaVersion: 1,
+    accountClientId: readActiveContextAccountClientId(),
+    provider: "claude-code",
+    adapterVersion: target.adapterVersion,
+    adapterDigest: target.adapterDigest,
+    kind,
+    createdAt: new Date().toISOString(),
+  };
+  writeJson(nextSessionRequiredPath(), marker);
 }
 
-function signReceipt(payload: SessionLoadedReceipt): string {
-  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  const signature = createHmac("sha256", signingKey()).update(encoded).digest("base64url");
-  return `v1.${encoded}.${signature}`;
-}
-
-function verifyReceipt(token: string): SessionLoadedReceipt {
-  const [version, encoded, signature] = token.split(".");
-  if (version !== "v1" || !encoded || !signature) throw new ContextReloadReceiptError("Invalid reload proof.");
-  const expected = createHmac("sha256", signingKey()).update(encoded).digest();
-  let actual: Buffer;
+function readNextSessionRequiredMarker(): NextSessionRequiredMarker | null {
   try {
-    actual = Buffer.from(signature, "base64url");
-  } catch {
-    throw new ContextReloadReceiptError("Invalid reload proof.");
-  }
-  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
-    throw new ContextReloadReceiptError("Invalid reload proof signature.");
-  }
-  try {
-    const value = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as Partial<SessionLoadedReceipt>;
+    const value = JSON.parse(readFileSync(nextSessionRequiredPath(), "utf8")) as Partial<NextSessionRequiredMarker>;
     if (
       value.schemaVersion !== 1 ||
       value.provider !== "claude-code" ||
       typeof value.accountClientId !== "string" ||
       typeof value.adapterVersion !== "string" ||
       !/^sha256:[0-9a-f]{64}$/u.test(value.adapterDigest ?? "") ||
-      !ADOPTION_GENERATION_RE.test(value.adoptionGeneration ?? "") ||
-      typeof value.sessionId !== "string" ||
-      typeof value.nonce !== "string" ||
-      typeof value.expiresAt !== "string" ||
-      !Number.isFinite(Date.parse(value.expiresAt))
+      (value.kind !== "setup" && value.kind !== "standalone_repair") ||
+      typeof value.createdAt !== "string" ||
+      !Number.isFinite(Date.parse(value.createdAt))
     ) {
-      throw new Error("invalid payload");
+      throw new Error("invalid next-session marker");
     }
-    return value as SessionLoadedReceipt;
-  } catch {
-    throw new ContextReloadReceiptError("Invalid reload proof payload.");
-  }
-}
-
-function readPending(planChallenge: string): PendingReloadPlan | null {
-  assertPlanChallenge(planChallenge);
-  try {
-    const value = JSON.parse(readFileSync(pendingPath(planChallenge), "utf8")) as Partial<PendingReloadPlan>;
-    if (
-      value.schemaVersion !== 1 ||
-      value.accountClientId === undefined ||
-      !/^client_[a-f0-9]{8}$/u.test(value.accountClientId) ||
-      value.provider !== "claude-code" ||
-      typeof value.adapterVersion !== "string" ||
-      !/^sha256:[0-9a-f]{64}$/u.test(value.adapterDigest ?? "") ||
-      !ADOPTION_GENERATION_RE.test(value.adoptionGeneration ?? "") ||
-      value.planChallenge !== planChallenge ||
-      (value.boundSessionId !== null && typeof value.boundSessionId !== "string") ||
-      typeof value.expiresAt !== "string" ||
-      !Number.isFinite(Date.parse(value.expiresAt))
-    ) {
-      throw new Error("invalid pending reload state");
+    if (value.accountClientId !== readActiveContextAccountClientId()) {
+      throw new Error("next-session marker belongs to another account");
     }
-    return value as PendingReloadPlan;
+    return value as NextSessionRequiredMarker;
   } catch (error) {
     if (isMissing(error)) return null;
-    throw new ContextReloadRecoveryStateError("The pending Claude reload state is unreadable or invalid.");
+    throw new ContextNextSessionRecoveryStateError("The pending Claude next-session state is unreadable or invalid.");
   }
 }
 
-function signingKey(): Buffer {
-  const path = join(providerStateRoot("claude-code"), "reload-signing.key");
-  try {
-    const key = Buffer.from(readFileSync(path, "utf8").trim(), "base64url");
-    if (key.length !== 32) throw new Error("invalid key");
-    return key;
-  } catch (error) {
-    if (typeof error !== "object" || error === null || !("code" in error) || Reflect.get(error, "code") !== "ENOENT") {
-      throw new ContextReloadReceiptError("The Claude reload receipt signing state is invalid.");
-    }
-    const key = randomBytes(32);
-    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-    try {
-      writeFileSync(path, `${key.toString("base64url")}\n`, { mode: 0o600, flag: "wx" });
-      return key;
-    } catch (writeError) {
-      if (
-        typeof writeError === "object" &&
-        writeError !== null &&
-        "code" in writeError &&
-        Reflect.get(writeError, "code") === "EEXIST"
-      ) {
-        const concurrentKey = Buffer.from(readFileSync(path, "utf8").trim(), "base64url");
-        if (concurrentKey.length === 32) return concurrentKey;
-      }
-      throw writeError;
-    }
-  }
+function providerStateRoot(provider: ContextIntegrationProvider): string {
+  return join(defaultHome(), "state", "context", "providers", provider);
+}
+
+function nextSessionRequiredPath(): string {
+  return join(providerStateRoot("claude-code"), "next-session-required.json");
 }
 
 function writeJson(path: string, value: unknown): void {
@@ -580,68 +219,15 @@ function writeJson(path: string, value: unknown): void {
   }
 }
 
-function writeRaw(path: string, value: string): void {
+function writeRaw(path: string, content: string): void {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const temporary = `${path}.tmp.${process.pid}.${Date.now()}`;
   try {
-    writeFileSync(temporary, value, { mode: 0o600 });
+    writeFileSync(temporary, content, { mode: 0o600 });
     renameSync(temporary, path);
   } finally {
     rmSync(temporary, { force: true });
   }
-}
-
-function providerStateRoot(provider: ContextIntegrationProvider): string {
-  return join(defaultHome(), "state", "context", "providers", provider);
-}
-
-function pendingPath(challenge: string): string {
-  return join(providerStateRoot("claude-code"), "reload-pending", `${challenge}.json`);
-}
-
-function consumedPath(nonce: string): string {
-  return join(providerStateRoot("claude-code"), "reload-consumed", `${nonce}.json`);
-}
-
-function readConsumedNonce(nonce: string): ConsumedReloadReceipt | null {
-  if (!/^[0-9a-f]{48}$/u.test(nonce)) throw new ContextReloadReceiptError("Invalid reload proof nonce.");
-  try {
-    const path = consumedPath(nonce);
-    const value = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
-    if (
-      value.schemaVersion !== 1 ||
-      value.nonce !== nonce ||
-      typeof value.accountClientId !== "string" ||
-      !/^client_[a-f0-9]{8}$/u.test(value.accountClientId) ||
-      typeof value.planChallenge !== "string" ||
-      !/^[0-9a-f]{64}$/u.test(value.planChallenge) ||
-      typeof value.sessionId !== "string" ||
-      typeof value.expiresAt !== "string" ||
-      !Number.isFinite(Date.parse(value.expiresAt)) ||
-      typeof value.consumedAt !== "string" ||
-      !Number.isFinite(Date.parse(value.consumedAt))
-    ) {
-      throw new Error("invalid consumed reload state");
-    }
-    if (Date.parse(value.expiresAt) <= Date.now()) {
-      rmSync(path, { force: true });
-      return null;
-    }
-    return value as ConsumedReloadReceipt;
-  } catch (error) {
-    if (isMissing(error)) return null;
-    throw new ContextReloadRecoveryStateError("The consumed Claude reload state is unreadable or invalid.");
-  }
-}
-
-function assertSessionId(value: string): void {
-  if (!value || value.length > 256 || !/^[0-9A-Za-z._:-]+$/u.test(value)) {
-    throw new ContextReloadReceiptError("Claude did not provide a trustworthy session identity.");
-  }
-}
-
-function assertPlanChallenge(value: string): void {
-  if (!/^[0-9a-f]{64}$/u.test(value)) throw new ContextReloadReceiptError("Invalid setup plan challenge.");
 }
 
 function isMissing(error: unknown): boolean {

--- a/apps/cli/src/core/context-integration/adapter-observation.ts
+++ b/apps/cli/src/core/context-integration/adapter-observation.ts
@@ -82,7 +82,7 @@ export function consumeContextAdapterNextSessionObligation(
 
 export function clearContextAdapterObservation(
   provider: ContextIntegrationProvider,
-  options: { includeNextSessionRequired?: boolean } = {},
+  options: { includeNextSessionRequired?: boolean; includeCompatibleSessions?: boolean } = {},
 ): void {
   const root = providerStateRoot(provider);
   rmSync(join(root, "adapter-sync"), { recursive: true, force: true });
@@ -93,6 +93,9 @@ export function clearContextAdapterObservation(
   rmSync(join(root, "reload-required.json"), { force: true });
   if (provider === "claude-code" && options.includeNextSessionRequired) {
     rmSync(nextSessionRequiredPath(), { force: true });
+  }
+  if (provider === "claude-code" && options.includeCompatibleSessions) {
+    rmSync(join(root, "compatible-sessions"), { recursive: true, force: true });
   }
 }
 

--- a/apps/cli/src/core/context-integration/adapter-observation.ts
+++ b/apps/cli/src/core/context-integration/adapter-observation.ts
@@ -48,19 +48,16 @@ export function inspectContextAdapterNextSessionObligation(): ContextAdapterNext
   return readNextSessionRequiredMarker()?.kind ?? null;
 }
 
-/**
- * A Claude SessionStart from the current deterministic adapter is the adoption
- * boundary. The session may be a fresh task or another provider lifecycle
- * start, but it can never be an event from the pre-repair adapter.
- */
+/** A fresh Claude startup from the current deterministic adapter is the adoption boundary. */
 export function consumeContextAdapterNextSessionObligation(
   input: {
     provider: ContextIntegrationProvider;
     adapterDigest: string;
+    sessionStartSource?: string;
   },
   options: { releaseRoot?: string; coreRoot?: string } = {},
 ): ContextAdapterNextSessionObligationKind | null {
-  if (input.provider !== "claude-code") return null;
+  if (input.provider !== "claude-code" || input.sessionStartSource !== "startup") return null;
   return withAccountStateMutationLock(() => {
     const release = resolveContextIntegrationRelease(options.releaseRoot, { coreRoot: options.coreRoot });
     const install = readContextIntegrationInstallManifest("claude-code");

--- a/apps/cli/src/core/context-integration/adapter-payload-health.ts
+++ b/apps/cli/src/core/context-integration/adapter-payload-health.ts
@@ -15,7 +15,6 @@ export function assertContextAdapterPayloadHealthy(
     !install ||
     install.adapterVersion !== expected.adapterVersion ||
     install.adapterDigest !== expected.adapterDigest ||
-    (driver.provider === "claude-code" && !/^[0-9a-f]{48}$/u.test(install.adoptionGeneration ?? "")) ||
     !install.materializedPayloadDigest ||
     !install.materializedMarketplaceDigest
   ) {

--- a/apps/cli/src/core/context-integration/adapter-sync.ts
+++ b/apps/cli/src/core/context-integration/adapter-sync.ts
@@ -114,6 +114,7 @@ export function issueAdapterSyncAction(
     targetAdapterDigest: target.adapterDigest,
     expiresAt: new Date(Date.now() + SYNC_TTL_MS).toISOString(),
   };
+  if (input.provider === "claude-code") prepareCompatibleAdapterSession(receipt);
   writeReceipt(receipt);
   return {
     code: "adapter_sync_required",
@@ -156,9 +157,8 @@ export function synchronizeContextAdapter(
         adapterVersion: target.adapterVersion,
         adapterDigest: target.adapterDigest,
       });
-      if (driver.provider === "claude-code") writeCompatibleAdapterSession(receipt);
+      if (driver.provider === "claude-code") prepareCompatibleAdapterSession(receipt);
       rmSync(receiptPath(driver.provider, challenge), { force: true });
-      rmSync(receiptBackupPath(challenge), { force: true });
       return {
         updated: true as const,
         provider: driver.provider,
@@ -215,7 +215,6 @@ export function synchronizeContextAdapter(
       }
     }
     rmSync(receiptPath(driver.provider, challenge), { force: true });
-    if (driver.provider === "claude-code") rmSync(receiptBackupPath(challenge), { force: true });
     return {
       updated: true as const,
       provider: driver.provider,
@@ -242,8 +241,11 @@ function collectMatchingClaudeSyncReceipts(current: AdapterSyncReceipt): Adapter
     receiptNames = readdirSync(root, { withFileTypes: true })
       .filter((entry) => entry.isFile() && /^([0-9a-f]{48})\.json$/u.test(entry.name))
       .map((entry) => entry.name);
-  } catch {
-    return [current];
+  } catch (error) {
+    if (isMissing(error)) return [current];
+    throw new AdapterSyncRejectedError(
+      `The concurrent Claude Context update actions could not be inspected safely: ${message(error)}`,
+    );
   }
   const receipts = new Map<string, AdapterSyncReceipt>([[current.challenge, current]]);
   for (const receiptName of receiptNames) {

--- a/apps/cli/src/core/context-integration/adapter-sync.ts
+++ b/apps/cli/src/core/context-integration/adapter-sync.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { ContextIntegrationProvider } from "@first-tree/shared";
@@ -19,15 +19,30 @@ import { createContextIntegrationProviderDriver } from "./provider-factory.js";
 import { resolveContextIntegrationRelease } from "./release.js";
 
 const SYNC_TTL_MS = 10 * 60 * 1000;
+const COMPATIBLE_SESSION_TTL_MS = 30 * 24 * 60 * 60_000;
 
 type AdapterSyncReceipt = {
   schemaVersion: 1;
   accountClientId: string;
   channel: "prod" | "staging" | "dev";
   provider: ContextIntegrationProvider;
+  sessionId: string;
   challenge: string;
   fromAdapterVersion: string;
   fromAdapterDigest: string;
+  targetAdapterVersion: string;
+  targetAdapterDigest: string;
+  expiresAt: string;
+};
+
+type CompatibleAdapterSession = {
+  schemaVersion: 1;
+  accountClientId: string;
+  channel: "prod" | "staging" | "dev";
+  provider: "claude-code";
+  sessionIdHash: string;
+  adapterVersion: string;
+  adapterDigest: string;
   targetAdapterVersion: string;
   targetAdapterDigest: string;
   expiresAt: string;
@@ -90,6 +105,7 @@ export function issueAdapterSyncAction(
     accountClientId,
     channel: channelConfig.channel,
     provider: input.provider,
+    sessionId: input.sessionId,
     challenge,
     fromAdapterVersion: installed.adapterVersion,
     fromAdapterDigest: installed.adapterDigest,
@@ -159,6 +175,7 @@ export function synchronizeContextAdapter(
     assertReceiptAccountAndTargetStillCurrent(receipt, release.manifest.providers[driver.provider]);
     (dependencies.repairOperation ?? repairContextIntegrationOperation)(driver, plan, {});
     assertReceiptAccountAndTargetStillCurrent(receipt, release.manifest.providers[driver.provider]);
+    if (driver.provider === "claude-code") writeCompatibleAdapterSession(receipt);
     rmSync(receiptPath(driver.provider, challenge), { force: true });
     return {
       updated: true as const,
@@ -166,6 +183,47 @@ export function synchronizeContextAdapter(
       currentSessionAdoption: "next_session" as const,
     };
   });
+}
+
+export function hasKnownCompatibleContextAdapterSession(
+  input: {
+    provider: ContextIntegrationProvider;
+    sessionId?: string;
+    suppliedAdapterDigest: string;
+  },
+  options: { releaseRoot?: string; coreRoot?: string; driver?: ContextIntegrationProviderDriver } = {},
+): boolean {
+  if (input.provider !== "claude-code" || !input.sessionId) return false;
+  try {
+    assertSessionId(input.sessionId);
+    const marker = readCompatibleAdapterSession(input.sessionId);
+    if (!marker) return false;
+    const release = resolveContextIntegrationRelease(options.releaseRoot, { coreRoot: options.coreRoot });
+    const target = release.manifest.providers["claude-code"];
+    const installed = readContextIntegrationInstallManifest("claude-code");
+    if (
+      marker.accountClientId !== readActiveContextAccountClientId() ||
+      marker.channel !== channelConfig.channel ||
+      marker.sessionIdHash !== sessionIdHash(input.sessionId) ||
+      marker.adapterDigest !== input.suppliedAdapterDigest ||
+      marker.targetAdapterVersion !== target.adapterVersion ||
+      marker.targetAdapterDigest !== target.adapterDigest ||
+      installed?.adapterVersion !== target.adapterVersion ||
+      installed.adapterDigest !== target.adapterDigest ||
+      !semver.valid(marker.adapterVersion) ||
+      !semver.valid(marker.targetAdapterVersion) ||
+      !semver.lt(marker.adapterVersion, marker.targetAdapterVersion)
+    ) {
+      return false;
+    }
+    assertContextAdapterPayloadHealthy(options.driver ?? createContextIntegrationProviderDriver("claude-code"), {
+      adapterVersion: installed.adapterVersion,
+      adapterDigest: installed.adapterDigest,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function assertReceiptAccountAndTargetStillCurrent(
@@ -236,6 +294,9 @@ function readReceipt(provider: ContextIntegrationProvider, challenge: string): A
       value.schemaVersion !== 1 ||
       value.provider !== provider ||
       value.challenge !== challenge ||
+      typeof value.sessionId !== "string" ||
+      value.sessionId.length > 256 ||
+      !/^[0-9A-Za-z._:-]+$/u.test(value.sessionId) ||
       typeof value.accountClientId !== "string" ||
       typeof value.fromAdapterVersion !== "string" ||
       typeof value.fromAdapterDigest !== "string" ||
@@ -255,6 +316,79 @@ function readReceipt(provider: ContextIntegrationProvider, challenge: string): A
   } catch (error) {
     if (error instanceof AdapterSyncRejectedError) throw error;
     throw new AdapterSyncRejectedError("The automatic First Tree Context update action is missing or invalid.");
+  }
+}
+
+function writeCompatibleAdapterSession(receipt: AdapterSyncReceipt): void {
+  const marker: CompatibleAdapterSession = {
+    schemaVersion: 1,
+    accountClientId: receipt.accountClientId,
+    channel: receipt.channel,
+    provider: "claude-code",
+    sessionIdHash: sessionIdHash(receipt.sessionId),
+    adapterVersion: receipt.fromAdapterVersion,
+    adapterDigest: receipt.fromAdapterDigest,
+    targetAdapterVersion: receipt.targetAdapterVersion,
+    targetAdapterDigest: receipt.targetAdapterDigest,
+    expiresAt: new Date(Date.now() + COMPATIBLE_SESSION_TTL_MS).toISOString(),
+  };
+  writeJson(compatibleSessionPath(receipt.sessionId), marker);
+}
+
+function readCompatibleAdapterSession(sessionId: string): CompatibleAdapterSession | null {
+  const path = compatibleSessionPath(sessionId);
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8")) as Partial<CompatibleAdapterSession>;
+    if (
+      value.schemaVersion !== 1 ||
+      value.provider !== "claude-code" ||
+      typeof value.accountClientId !== "string" ||
+      !["prod", "staging", "dev"].includes(value.channel ?? "") ||
+      !/^sha256:[0-9a-f]{64}$/u.test(value.adapterDigest ?? "") ||
+      !/^sha256:[0-9a-f]{64}$/u.test(value.targetAdapterDigest ?? "") ||
+      !/^[0-9a-f]{64}$/u.test(value.sessionIdHash ?? "") ||
+      typeof value.adapterVersion !== "string" ||
+      typeof value.targetAdapterVersion !== "string" ||
+      typeof value.expiresAt !== "string" ||
+      !Number.isFinite(Date.parse(value.expiresAt))
+    ) {
+      return null;
+    }
+    if (Date.parse(value.expiresAt) <= Date.now()) {
+      rmSync(path, { force: true });
+      return null;
+    }
+    return value as CompatibleAdapterSession;
+  } catch {
+    return null;
+  }
+}
+
+function compatibleSessionPath(sessionId: string): string {
+  return join(
+    defaultHome(),
+    "state",
+    "context",
+    "providers",
+    "claude-code",
+    "adapter-sync",
+    "compatible-sessions",
+    `${sessionIdHash(sessionId)}.json`,
+  );
+}
+
+function sessionIdHash(sessionId: string): string {
+  return createHash("sha256").update(sessionId).digest("hex");
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.tmp.${process.pid}.${Date.now()}`;
+  try {
+    writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+    renameSync(temporary, path);
+  } finally {
+    rmSync(temporary, { force: true });
   }
 }
 

--- a/apps/cli/src/core/context-integration/adapter-sync.ts
+++ b/apps/cli/src/core/context-integration/adapter-sync.ts
@@ -117,7 +117,7 @@ export function synchronizeContextAdapter(
 ): {
   updated: true;
   provider: ContextIntegrationProvider;
-  currentSessionAdoption: "reload_optional" | "next_session";
+  currentSessionAdoption: "next_session";
 } {
   return withAccountStateMutationLock(() => {
     assertContextMutationCanStart();
@@ -163,8 +163,7 @@ export function synchronizeContextAdapter(
     return {
       updated: true as const,
       provider: driver.provider,
-      currentSessionAdoption:
-        driver.provider === "claude-code" ? ("reload_optional" as const) : ("next_session" as const),
+      currentSessionAdoption: "next_session" as const,
     };
   });
 }

--- a/apps/cli/src/core/context-integration/adapter-sync.ts
+++ b/apps/cli/src/core/context-integration/adapter-sync.ts
@@ -144,6 +144,9 @@ export function synchronizeContextAdapter(
     const release = resolveContextIntegrationRelease(dependencies.releaseRoot, { coreRoot: dependencies.coreRoot });
     const installed = readContextIntegrationInstallManifest(driver.provider);
     const target = release.manifest.providers[driver.provider];
+    if (driver.provider === "claude-code" && inspectContextAdapterNextSessionObligation() !== null) {
+      throw new AdapterNextSessionRequiredError();
+    }
     if (
       receipt.accountClientId === accountClientId &&
       receipt.channel === channelConfig.channel &&
@@ -333,6 +336,7 @@ function assertReceiptAccountAndTargetStillCurrent(
 
 export function hasKnownGoodCompatibleContextAdapter(driver: ContextIntegrationProviderDriver): boolean {
   try {
+    if (driver.provider === "claude-code" && inspectContextAdapterNextSessionObligation() !== null) return false;
     const installed = readContextIntegrationInstallManifest(driver.provider);
     if (
       installed?.channel !== channelConfig.channel ||
@@ -349,6 +353,15 @@ export function hasKnownGoodCompatibleContextAdapter(driver: ContextIntegrationP
     return true;
   } catch {
     return false;
+  }
+}
+
+export class AdapterNextSessionRequiredError extends Error {
+  readonly code = "CONTEXT_PLUGIN_RELOAD_REQUIRED";
+
+  constructor() {
+    super("This Claude session cannot use the repaired First Tree Context Plugin. Start a new Claude session.");
+    this.name = "AdapterNextSessionRequiredError";
   }
 }
 

--- a/apps/cli/src/core/context-integration/adapter-sync.ts
+++ b/apps/cli/src/core/context-integration/adapter-sync.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { ContextIntegrationProvider } from "@first-tree/shared";
 import { defaultHome } from "@first-tree/shared/config";
@@ -10,6 +10,7 @@ import {
   readActiveContextAccountClientId,
   withAccountStateMutationLock,
 } from "./account-state-guard.js";
+import { inspectContextAdapterNextSessionObligation } from "./adapter-observation.js";
 import { assertContextAdapterPayloadHealthy } from "./adapter-payload-health.js";
 import { planContextIntegrationInstall } from "./installer.js";
 import { readContextIntegrationInstallManifest } from "./manifest.js";
@@ -143,6 +144,28 @@ export function synchronizeContextAdapter(
     const installed = readContextIntegrationInstallManifest(driver.provider);
     const target = release.manifest.providers[driver.provider];
     if (
+      receipt.accountClientId === accountClientId &&
+      receipt.channel === channelConfig.channel &&
+      receipt.provider === driver.provider &&
+      receipt.targetAdapterVersion === target.adapterVersion &&
+      receipt.targetAdapterDigest === target.adapterDigest &&
+      installed?.adapterVersion === target.adapterVersion &&
+      installed.adapterDigest === target.adapterDigest
+    ) {
+      assertSynchronizedPayloadHealthy(driver, {
+        adapterVersion: target.adapterVersion,
+        adapterDigest: target.adapterDigest,
+      });
+      if (driver.provider === "claude-code") writeCompatibleAdapterSession(receipt);
+      rmSync(receiptPath(driver.provider, challenge), { force: true });
+      rmSync(receiptBackupPath(challenge), { force: true });
+      return {
+        updated: true as const,
+        provider: driver.provider,
+        currentSessionAdoption: "next_session" as const,
+      };
+    }
+    if (
       receipt.accountClientId !== accountClientId ||
       receipt.channel !== channelConfig.channel ||
       receipt.provider !== driver.provider ||
@@ -160,6 +183,8 @@ export function synchronizeContextAdapter(
         "First Tree Context changed after the automatic update action was issued. Run an explicit Context repair.",
       );
     }
+    const concurrentClaudeReceipts =
+      driver.provider === "claude-code" ? collectMatchingClaudeSyncReceipts(receipt) : [];
     const plan = (dependencies.planInstall ?? planContextIntegrationInstall)(driver, {
       releaseRoot: dependencies.releaseRoot,
     });
@@ -172,17 +197,75 @@ export function synchronizeContextAdapter(
     ) {
       throw new AdapterSyncRejectedError("The exact automatic update plan no longer matches local Plugin state.");
     }
+    if (driver.provider === "claude-code") {
+      // These prepared facts are inert while the old install remains current
+      // and become valid only after the exact target payload is healthy. Write
+      // every concurrent session before provider mutation so a crash cannot
+      // strand an already-loaded compatible adapter without recoverable proof.
+      for (const compatibleReceipt of concurrentClaudeReceipts) {
+        prepareCompatibleAdapterSession(compatibleReceipt);
+      }
+    }
     assertReceiptAccountAndTargetStillCurrent(receipt, release.manifest.providers[driver.provider]);
     (dependencies.repairOperation ?? repairContextIntegrationOperation)(driver, plan, {});
     assertReceiptAccountAndTargetStillCurrent(receipt, release.manifest.providers[driver.provider]);
-    if (driver.provider === "claude-code") writeCompatibleAdapterSession(receipt);
+    if (driver.provider === "claude-code") {
+      for (const compatibleReceipt of concurrentClaudeReceipts) {
+        if (compatibleReceipt.challenge !== receipt.challenge) writeReceipt(compatibleReceipt);
+      }
+    }
     rmSync(receiptPath(driver.provider, challenge), { force: true });
+    if (driver.provider === "claude-code") rmSync(receiptBackupPath(challenge), { force: true });
     return {
       updated: true as const,
       provider: driver.provider,
       currentSessionAdoption: "next_session" as const,
     };
   });
+}
+
+function assertSynchronizedPayloadHealthy(
+  driver: ContextIntegrationProviderDriver,
+  installed: { adapterVersion: string; adapterDigest: string },
+): void {
+  try {
+    assertContextAdapterPayloadHealthy(driver, installed);
+  } catch (error) {
+    throw new AdapterSyncRejectedError(`The synchronized First Tree Context payload is not healthy: ${message(error)}`);
+  }
+}
+
+function collectMatchingClaudeSyncReceipts(current: AdapterSyncReceipt): AdapterSyncReceipt[] {
+  const root = adapterSyncRoot("claude-code");
+  let receiptNames: string[];
+  try {
+    receiptNames = readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && /^([0-9a-f]{48})\.json$/u.test(entry.name))
+      .map((entry) => entry.name);
+  } catch {
+    return [current];
+  }
+  const receipts = new Map<string, AdapterSyncReceipt>([[current.challenge, current]]);
+  for (const receiptName of receiptNames) {
+    const challenge = receiptName.slice(0, -5);
+    try {
+      const candidate = readReceipt("claude-code", challenge);
+      if (
+        candidate.accountClientId === current.accountClientId &&
+        candidate.channel === current.channel &&
+        candidate.provider === current.provider &&
+        candidate.fromAdapterVersion === current.fromAdapterVersion &&
+        candidate.fromAdapterDigest === current.fromAdapterDigest &&
+        candidate.targetAdapterVersion === current.targetAdapterVersion &&
+        candidate.targetAdapterDigest === current.targetAdapterDigest
+      ) {
+        receipts.set(candidate.challenge, candidate);
+      }
+    } catch {
+      // Invalid, expired, or unrelated actions are not restored across the global Plugin update.
+    }
+  }
+  return [...receipts.values()];
 }
 
 export function hasKnownCompatibleContextAdapterSession(
@@ -193,7 +276,9 @@ export function hasKnownCompatibleContextAdapterSession(
   },
   options: { releaseRoot?: string; coreRoot?: string; driver?: ContextIntegrationProviderDriver } = {},
 ): boolean {
-  if (input.provider !== "claude-code" || !input.sessionId) return false;
+  if (input.provider !== "claude-code" || !input.sessionId || inspectContextAdapterNextSessionObligation() !== null) {
+    return false;
+  }
   try {
     assertSessionId(input.sessionId);
     const marker = readCompatibleAdapterSession(input.sessionId);
@@ -288,8 +373,16 @@ function writeReceipt(receipt: AdapterSyncReceipt): void {
 
 function readReceipt(provider: ContextIntegrationProvider, challenge: string): AdapterSyncReceipt {
   if (!/^[0-9a-f]{48}$/u.test(challenge)) throw new AdapterSyncRejectedError("Invalid Context update action.");
+  const primaryPath = receiptPath(provider, challenge);
   try {
-    const value = JSON.parse(readFileSync(receiptPath(provider, challenge), "utf8")) as Partial<AdapterSyncReceipt>;
+    let serialized: string;
+    try {
+      serialized = readFileSync(primaryPath, "utf8");
+    } catch (error) {
+      if (!isMissing(error) || provider !== "claude-code") throw error;
+      serialized = readFileSync(receiptBackupPath(challenge), "utf8");
+    }
+    const value = JSON.parse(serialized) as Partial<AdapterSyncReceipt>;
     if (
       value.schemaVersion !== 1 ||
       value.provider !== provider ||
@@ -309,7 +402,8 @@ function readReceipt(provider: ContextIntegrationProvider, challenge: string): A
       throw new Error("invalid receipt");
     }
     if (Date.parse(value.expiresAt) <= Date.now()) {
-      rmSync(receiptPath(provider, challenge), { force: true });
+      rmSync(primaryPath, { force: true });
+      if (provider === "claude-code") rmSync(receiptBackupPath(challenge), { force: true });
       throw new AdapterSyncRejectedError("The automatic First Tree Context update action expired.");
     }
     return value as AdapterSyncReceipt;
@@ -317,6 +411,11 @@ function readReceipt(provider: ContextIntegrationProvider, challenge: string): A
     if (error instanceof AdapterSyncRejectedError) throw error;
     throw new AdapterSyncRejectedError("The automatic First Tree Context update action is missing or invalid.");
   }
+}
+
+function prepareCompatibleAdapterSession(receipt: AdapterSyncReceipt): void {
+  writeCompatibleAdapterSession(receipt);
+  writeJson(receiptBackupPath(receipt.challenge), receipt);
 }
 
 function writeCompatibleAdapterSession(receipt: AdapterSyncReceipt): void {
@@ -371,9 +470,21 @@ function compatibleSessionPath(sessionId: string): string {
     "context",
     "providers",
     "claude-code",
-    "adapter-sync",
     "compatible-sessions",
     `${sessionIdHash(sessionId)}.json`,
+  );
+}
+
+function receiptBackupPath(challenge: string): string {
+  return join(
+    defaultHome(),
+    "state",
+    "context",
+    "providers",
+    "claude-code",
+    "compatible-sessions",
+    "actions",
+    `${challenge}.json`,
   );
 }
 
@@ -393,7 +504,11 @@ function writeJson(path: string, value: unknown): void {
 }
 
 function receiptPath(provider: ContextIntegrationProvider, challenge: string): string {
-  return join(defaultHome(), "state", "context", "providers", provider, "adapter-sync", `${challenge}.json`);
+  return join(adapterSyncRoot(provider), `${challenge}.json`);
+}
+
+function adapterSyncRoot(provider: ContextIntegrationProvider): string {
+  return join(defaultHome(), "state", "context", "providers", provider, "adapter-sync");
 }
 
 function assertSessionId(value: string): void {
@@ -404,4 +519,8 @@ function assertSessionId(value: string): void {
 
 function message(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isMissing(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && Reflect.get(error, "code") === "ENOENT";
 }

--- a/apps/cli/src/core/context-integration/client-preflight.ts
+++ b/apps/cli/src/core/context-integration/client-preflight.ts
@@ -414,7 +414,7 @@ function validCachedResolution(value: unknown): value is CachedSessionProject["r
       typeof project === "object" &&
       project !== null &&
       Reflect.get(project, "kind") === "pathless" &&
-      (source === "codex_documents_v1" || source === "explicit_pathless")
+      (source === "claude_project_dir_unavailable" || source === "codex_documents_v1" || source === "explicit_pathless")
     );
   }
   return (

--- a/apps/cli/src/core/context-integration/client-preflight.ts
+++ b/apps/cli/src/core/context-integration/client-preflight.ts
@@ -17,11 +17,11 @@ export type ContextProjectResolution =
   | {
       kind: "pathless";
       project: Extract<ContextIntegrationProject, { kind: "pathless" }>;
-      source: "codex_documents_v1" | "explicit_pathless";
+      source: "claude_project_dir_unavailable" | "codex_documents_v1" | "explicit_pathless";
     }
   | {
       kind: "unknown";
-      source: "claude_project_dir_missing" | "cwd_missing" | "path_unreadable";
+      source: "cwd_missing" | "path_unreadable";
       message: string;
     };
 
@@ -183,12 +183,15 @@ export function resolveProviderProject(
     const projectRoot = env.CLAUDE_PROJECT_DIR;
     if (!projectRoot) {
       return {
-        kind: "unknown",
-        source: "claude_project_dir_missing",
-        message: "Claude Code did not provide CLAUDE_PROJECT_DIR for this session.",
+        kind: "pathless",
+        project: { kind: "pathless" },
+        source: "claude_project_dir_unavailable",
       };
     }
-    return resolvePathProject(projectRoot, "claude_project_dir", classifierOptions);
+    const resolution = resolvePathProject(projectRoot, "claude_project_dir", classifierOptions);
+    return resolution.kind === "unknown"
+      ? { kind: "pathless", project: { kind: "pathless" }, source: "claude_project_dir_unavailable" }
+      : resolution;
   }
   if (!input.cwd) {
     return {

--- a/apps/cli/src/core/context-integration/installer.ts
+++ b/apps/cli/src/core/context-integration/installer.ts
@@ -322,7 +322,10 @@ function uninstallContextIntegrationLocked(driver: ContextIntegrationProviderDri
     });
     rmSync(contextIntegrationMarketplaceSourcePath(driver.provider), { recursive: true, force: true });
     if (manifest) removeContextIntegrationInstallManifest(driver.provider);
-    clearContextAdapterObservation(driver.provider, { includeNextSessionRequired: true });
+    clearContextAdapterObservation(driver.provider, {
+      includeNextSessionRequired: true,
+      includeCompatibleSessions: true,
+    });
     removeInstallJournal();
   } catch (error) {
     writeInstallJournal({ ...journal, phase: "uninstall_failed" });

--- a/apps/cli/src/core/context-integration/installer.ts
+++ b/apps/cli/src/core/context-integration/installer.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from "node:crypto";
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
@@ -13,8 +12,8 @@ import { channelConfig } from "../channel.js";
 import { COMMAND_VERSION } from "../version.js";
 import { readActiveContextAccountClientId } from "./account-state-guard.js";
 import {
-  beginContextAdapterReloadObligation,
-  type ContextAdapterReloadObligationKind,
+  beginContextAdapterNextSessionObligation,
+  type ContextAdapterNextSessionObligationKind,
   clearContextAdapterObservation,
 } from "./adapter-observation.js";
 import { withContextIntegrationLock } from "./context-binding-store.js";
@@ -70,7 +69,6 @@ export function planContextIntegrationInstall(
     release,
     driver.provider,
     previous?.materializedInvocation,
-    previous?.adoptionGeneration,
   );
   const incomplete = readContextIntegrationInstallJournal();
   const operation =
@@ -92,7 +90,7 @@ export function planContextIntegrationInstall(
 export function installContextIntegration(
   driver: ContextIntegrationProviderDriver,
   plan: ContextIntegrationInstallPlan,
-  options: { reloadObligationKind?: ContextAdapterReloadObligationKind } = {},
+  options: { nextSessionObligationKind?: ContextAdapterNextSessionObligationKind } = {},
 ): {
   manifest: ContextIntegrationInstallManifest;
   probe: ProviderPluginProbe;
@@ -103,7 +101,7 @@ export function installContextIntegration(
 function installContextIntegrationLocked(
   driver: ContextIntegrationProviderDriver,
   plan: ContextIntegrationInstallPlan,
-  options: { reloadObligationKind?: ContextAdapterReloadObligationKind },
+  options: { nextSessionObligationKind?: ContextAdapterNextSessionObligationKind },
 ): {
   manifest: ContextIntegrationInstallManifest;
   probe: ProviderPluginProbe;
@@ -140,15 +138,13 @@ function installContextIntegrationLocked(
   let rollbackMarketplaceRoot: string | null = null;
   let providerMutationStarted = false;
   let marketplaceSourcePromoted = false;
-  let rollbackReloadObligation: (() => void) | null = null;
+  let rollbackNextSessionObligation: (() => void) | null = null;
   const providerReleaseRoot = join(plan.release.root, driver.provider);
-  const adoptionGeneration = driver.provider === "claude-code" ? randomBytes(24).toString("hex") : undefined;
   try {
-    if (driver.provider === "claude-code" && options.reloadObligationKind) {
-      rollbackReloadObligation = beginContextAdapterReloadObligation(
+    if (driver.provider === "claude-code" && options.nextSessionObligationKind) {
+      rollbackNextSessionObligation = beginContextAdapterNextSessionObligation(
         plan.release.manifest,
-        options.reloadObligationKind,
-        adoptionGeneration ?? "",
+        options.nextSessionObligationKind,
       );
     }
     rollbackMarketplaceRoot =
@@ -157,8 +153,6 @@ function installContextIntegrationLocked(
     const materializedInvocation = materializeContextPluginPayload(
       join(stagedMarketplaceRoot, "plugins", PLUGIN_NAME),
       plan.release.manifest.providers[driver.provider].adapterDigest,
-      undefined,
-      adoptionGeneration,
     );
     driver.validateMarketplace(stagedMarketplaceRoot);
     promoteMarketplaceSource(stagedMarketplaceRoot, stableMarketplaceRoot, previousMarketplaceSource);
@@ -175,7 +169,6 @@ function installContextIntegrationLocked(
       plan.release,
       driver.provider,
       materializedInvocation,
-      adoptionGeneration,
     );
     verifyProviderInstalledContextPlugin(probe, installedPayloadDigest);
     writeInstallJournal({ ...journal, phase: "provider_installed" });
@@ -193,14 +186,15 @@ function installContextIntegrationLocked(
       adapterDigest: plan.release.manifest.providers[driver.provider].adapterDigest,
       marketplaceName: plan.marketplaceName,
       pluginName: PLUGIN_NAME,
-      adoptionGeneration,
       materializedInvocation,
       materializedPayloadDigest: installedPayloadDigest,
       materializedMarketplaceDigest: contextPluginTreeDigest(stableMarketplaceRoot),
       installedAt: new Date().toISOString(),
     };
     writeContextIntegrationInstallManifest(manifest);
-    clearContextAdapterObservation(driver.provider);
+    clearContextAdapterObservation(driver.provider, {
+      includeNextSessionRequired: driver.provider === "claude-code" && !options.nextSessionObligationKind,
+    });
     removeInstallJournal();
     return { manifest, probe };
   } catch (error) {
@@ -246,7 +240,7 @@ function installContextIntegrationLocked(
         );
       }
     }
-    rollbackReloadObligation?.();
+    rollbackNextSessionObligation?.();
     throw error;
   } finally {
     rmSync(stagingRoot, { recursive: true, force: true });
@@ -328,7 +322,7 @@ function uninstallContextIntegrationLocked(driver: ContextIntegrationProviderDri
     });
     rmSync(contextIntegrationMarketplaceSourcePath(driver.provider), { recursive: true, force: true });
     if (manifest) removeContextIntegrationInstallManifest(driver.provider);
-    clearContextAdapterObservation(driver.provider, { includeReloadRequired: true });
+    clearContextAdapterObservation(driver.provider, { includeNextSessionRequired: true });
     removeInstallJournal();
   } catch (error) {
     writeInstallJournal({ ...journal, phase: "uninstall_failed" });

--- a/apps/cli/src/core/context-integration/operation.ts
+++ b/apps/cli/src/core/context-integration/operation.ts
@@ -525,6 +525,7 @@ function validateProviderRecoveryState(
 
 const OBSERVATION_STATE_ENTRIES = [
   "adapter-sync",
+  "compatible-sessions",
   "reload-pending",
   "reload-consumed",
   "reload-required.json",

--- a/apps/cli/src/core/context-integration/operation.ts
+++ b/apps/cli/src/core/context-integration/operation.ts
@@ -525,7 +525,9 @@ function validateProviderRecoveryState(
 
 const OBSERVATION_STATE_ENTRIES = [
   "adapter-sync",
-  "compatible-sessions",
+  // compatible-sessions contains exact-target-gated facts and action backups
+  // issued independently of this provider operation. Restoring an earlier
+  // operation snapshot must not erase actions issued while the operation ran.
   "reload-pending",
   "reload-consumed",
   "reload-required.json",

--- a/apps/cli/src/core/context-integration/operation.ts
+++ b/apps/cli/src/core/context-integration/operation.ts
@@ -28,7 +28,7 @@ import {
 import { defaultHome } from "@first-tree/shared/config";
 import { channelConfig } from "../channel.js";
 import { readActiveContextAccountClientId } from "./account-state-guard.js";
-import type { ContextAdapterReloadObligationKind } from "./adapter-observation.js";
+import type { ContextAdapterNextSessionObligationKind } from "./adapter-observation.js";
 import {
   assertContextIntegrationConfig,
   prepareContextGrantStoreForApply,
@@ -98,7 +98,7 @@ export function enableContextIntegrationOperation(
   dependencies: {
     install?: typeof installContextIntegration;
     writeGrant?: typeof writeContextGrant;
-    reloadObligationKind?: ContextAdapterReloadObligationKind;
+    nextSessionObligationKind?: ContextAdapterNextSessionObligationKind;
   } = {},
 ): { pluginOperation: ContextIntegrationInstallPlan["operation"] } {
   return withContextIntegrationLock(() => {
@@ -117,7 +117,7 @@ export function enableContextIntegrationOperation(
       if (plan.operation !== "unchanged") {
         providerChanged = true;
         (dependencies.install ?? installContextIntegration)(driver, plan, {
-          reloadObligationKind: dependencies.reloadObligationKind,
+          nextSessionObligationKind: dependencies.nextSessionObligationKind,
         });
         writeOperationJournal({ ...journal, phase: "provider_changed" });
       }
@@ -159,7 +159,7 @@ export function repairContextIntegrationOperation(
   plan: ContextIntegrationInstallPlan,
   dependencies: {
     install?: typeof installContextIntegration;
-    reloadObligationKind?: ContextAdapterReloadObligationKind;
+    nextSessionObligationKind?: ContextAdapterNextSessionObligationKind;
   } = {},
 ): void {
   withContextIntegrationLock(() => {
@@ -168,7 +168,7 @@ export function repairContextIntegrationOperation(
     const journal = createOperationJournal("repair", driver, snapshot);
     try {
       (dependencies.install ?? installContextIntegration)(driver, plan, {
-        reloadObligationKind: dependencies.reloadObligationKind,
+        nextSessionObligationKind: dependencies.nextSessionObligationKind,
       });
       writeOperationJournal({ ...journal, phase: "provider_changed" });
       completeOperation(snapshot);
@@ -528,6 +528,7 @@ const OBSERVATION_STATE_ENTRIES = [
   "reload-pending",
   "reload-consumed",
   "reload-required.json",
+  "next-session-required.json",
 ] as const;
 
 function captureObservationState(provider: ContextIntegrationProvider, recoveryRoot: string): string {
@@ -542,7 +543,7 @@ function captureObservationState(provider: ContextIntegrationProvider, recoveryR
       if (isMissing(error)) continue;
       throw error;
     }
-    const expectedFile = entry === "reload-required.json";
+    const expectedFile = entry === "reload-required.json" || entry === "next-session-required.json";
     if (stat.isSymbolicLink() || (expectedFile && !stat.isFile()) || (!expectedFile && !stat.isDirectory())) {
       throw new Error(`The Context observation state contains an invalid ${entry} entry.`);
     }

--- a/apps/cli/src/core/context-integration/payload-integrity.ts
+++ b/apps/cli/src/core/context-integration/payload-integrity.ts
@@ -8,40 +8,28 @@ import type { ResolvedBinary } from "../supervisor/types.js";
 import type { ProviderPluginProbe } from "./provider-driver.js";
 import { type ContextIntegrationRelease, providerPluginRoot } from "./release.js";
 
-const LAUNCHER_PATHS = ["bin/context-session-start", "bin/context-observe-loaded"] as const;
+const LAUNCHER_PATHS = ["bin/context-session-start"] as const;
 const HOOK_PATH = "hooks/hooks.json";
 
 export function materializeContextPluginPayload(
   pluginRoot: string,
   adapterDigest: string,
   invocation: ResolvedBinary = resolveCliInvocation(),
-  adoptionGeneration?: string,
 ): string {
   const renderedInvocation = renderCliInvocation(invocation);
   for (const name of LAUNCHER_PATHS) {
     const launcherPath = join(pluginRoot, name);
-    try {
-      writeFileSync(
-        launcherPath,
-        materializedFile(name, readFileSync(launcherPath), adapterDigest, renderedInvocation, adoptionGeneration),
-        {
-          mode: 0o700,
-        },
-      );
-      chmodSync(launcherPath, 0o700);
-    } catch (error) {
-      if (name === "bin/context-observe-loaded" && isMissing(error)) continue;
-      throw error;
-    }
+    writeFileSync(launcherPath, materializedFile(name, readFileSync(launcherPath), adapterDigest, renderedInvocation), {
+      mode: 0o700,
+    });
+    chmodSync(launcherPath, 0o700);
   }
 
   const hookPath = join(pluginRoot, HOOK_PATH);
   const temporary = `${hookPath}.tmp`;
-  writeFileSync(
-    temporary,
-    materializedFile(HOOK_PATH, readFileSync(hookPath), adapterDigest, renderedInvocation, adoptionGeneration),
-    { mode: 0o600 },
-  );
+  writeFileSync(temporary, materializedFile(HOOK_PATH, readFileSync(hookPath), adapterDigest, renderedInvocation), {
+    mode: 0o600,
+  });
   renameSync(temporary, hookPath);
 
   for (const skillPath of normalizedFiles(join(pluginRoot, "skills"))) {
@@ -53,7 +41,6 @@ export function materializeContextPluginPayload(
         readFileSync(skillPath),
         adapterDigest,
         renderedInvocation,
-        adoptionGeneration,
       ),
     );
   }
@@ -69,7 +56,6 @@ export function verifyMaterializedContextPlugin(
   release: ContextIntegrationRelease,
   provider: ContextIntegrationProvider,
   renderedInvocation: string,
-  adoptionGeneration?: string,
 ): string {
   assertLauncherExecutable(pluginRoot);
   const releaseRoot = providerPluginRoot(release.root, provider);
@@ -84,13 +70,7 @@ export function verifyMaterializedContextPlugin(
   const adapterDigest = release.manifest.providers[provider].adapterDigest;
   for (let index = 0; index < releaseFiles.length; index += 1) {
     const name = releaseNames[index] ?? "";
-    const expected = materializedFile(
-      name,
-      readFileSync(releaseFiles[index] ?? ""),
-      adapterDigest,
-      renderedInvocation,
-      adoptionGeneration,
-    );
+    const expected = materializedFile(name, readFileSync(releaseFiles[index] ?? ""), adapterDigest, renderedInvocation);
     const actual = readFileSync(materializedFiles[index] ?? "");
     if (!actual.equals(expected)) {
       throw new Error(`The materialized Context Plugin payload differs from the current release at ${name}.`);
@@ -120,7 +100,6 @@ export function inspectContextPluginPayload(
   release: ContextIntegrationRelease,
   provider: ContextIntegrationProvider,
   renderedInvocation: string | undefined,
-  adoptionGeneration: string | undefined,
 ): string[] {
   if (!probe.installed || !probe.enabled) return [];
   if (!renderedInvocation) {
@@ -128,13 +107,7 @@ export function inspectContextPluginPayload(
   }
   try {
     verifyStableAdapterMarketplace(stablePluginRoot, release, provider);
-    const expectedDigest = verifyMaterializedContextPlugin(
-      stablePluginRoot,
-      release,
-      provider,
-      renderedInvocation,
-      adoptionGeneration,
-    );
+    const expectedDigest = verifyMaterializedContextPlugin(stablePluginRoot, release, provider, renderedInvocation);
     verifyProviderInstalledContextPlugin(probe, expectedDigest);
     return [];
   } catch (error) {
@@ -186,26 +159,14 @@ export function contextPluginTreeDigest(root: string): string {
 function assertLauncherExecutable(pluginRoot: string): void {
   for (const name of LAUNCHER_PATHS) {
     const launcherPath = join(pluginRoot, name);
-    let launcher: ReturnType<typeof lstatSync>;
-    try {
-      launcher = lstatSync(launcherPath);
-    } catch (error) {
-      if (name === "bin/context-observe-loaded" && isMissing(error)) continue;
-      throw error;
-    }
+    const launcher = lstatSync(launcherPath);
     if (!launcher.isFile() || launcher.isSymbolicLink() || (launcher.mode & 0o100) === 0) {
       throw new Error(`Context Plugin launcher is not an executable regular file: ${launcherPath}`);
     }
   }
 }
 
-function materializedFile(
-  name: string,
-  content: Buffer,
-  adapterDigest: string,
-  renderedInvocation: string,
-  adoptionGeneration?: string,
-): Buffer {
+function materializedFile(name: string, content: Buffer, adapterDigest: string, renderedInvocation: string): Buffer {
   if ((LAUNCHER_PATHS as readonly string[]).includes(name)) {
     const rendered = content.toString("utf8").replace("__FIRST_TREE_INVOCATION__", renderedInvocation);
     if (rendered.includes("__FIRST_TREE_INVOCATION__")) {
@@ -214,15 +175,9 @@ function materializedFile(
     return Buffer.from(rendered);
   }
   if (name === HOOK_PATH) {
-    const rendered = content
-      .toString("utf8")
-      .replaceAll("__ADAPTER_DIGEST__", adapterDigest)
-      .replaceAll("__ADOPTION_GENERATION__", adoptionGeneration ?? "");
-    if (rendered.includes("__ADAPTER_DIGEST__") || rendered.includes("__ADOPTION_GENERATION__")) {
+    const rendered = content.toString("utf8").replaceAll("__ADAPTER_DIGEST__", adapterDigest);
+    if (rendered.includes("__ADAPTER_DIGEST__")) {
       throw new Error("Context integration hook contains an unresolved adapter identity placeholder.");
-    }
-    if (rendered.includes("--adoption-generation") && !/^[0-9a-f]{48}$/u.test(adoptionGeneration ?? "")) {
-      throw new Error("Claude Context integration requires an exact adoption generation.");
     }
     return Buffer.from(rendered);
   }
@@ -256,8 +211,4 @@ function normalizedFiles(root: string): string[] {
   };
   visit(root);
   return files;
-}
-
-function isMissing(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "code" in error && Reflect.get(error, "code") === "ENOENT";
 }

--- a/apps/cli/src/core/context-integration/repair-guidance.ts
+++ b/apps/cli/src/core/context-integration/repair-guidance.ts
@@ -12,7 +12,9 @@ export function contextRepairAdditionalContext(provider: ContextIntegrationProvi
     "Ordinary provider work can continue without First Tree Context.",
     "Do not edit provider cache, First Tree config, manifests, receipts, or journals by hand.",
     `Explain the blocker briefly. Only after the user asks to repair this exceptional state, run \`${command}\`.`,
-    `After repair, run \`${channelConfig.binName} context status --provider ${provider}\`; manually activate First Tree Context if the current session still needs it.`,
+    provider === "claude-code"
+      ? `After repair, run \`${channelConfig.binName} context status --provider ${provider}\`, then start a new Claude session.`
+      : `After repair, run \`${channelConfig.binName} context status --provider ${provider}\`; manually activate First Tree Context if the current session still needs it.`,
   ].join("\n");
 }
 

--- a/apps/cli/src/core/context-integration/runtime-health.ts
+++ b/apps/cli/src/core/context-integration/runtime-health.ts
@@ -82,7 +82,6 @@ export function inspectContextIntegrationRuntime(
       release,
       driver.provider,
       install?.materializedInvocation,
-      install?.adoptionGeneration,
     )) {
       if (!issues.includes(issue)) issues.push(issue);
     }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1248,8 +1248,10 @@ available for that location:
 
 `directory` is present only when setup has a stable canonical directory.
 Claude uses `CLAUDE_PROJECT_DIR` unless `--project-root` is explicit; it does
-not fall back to cwd when the variable is missing or invalid. Pathless sessions,
-Codex Documents scratch directories, and default managed worktrees under
+not fall back to cwd when the variable is missing or invalid. Missing or invalid
+Claude project directories become a pathless identity, which can match global
+activation but never directory activation. Pathless sessions, Codex Documents
+scratch directories, and default managed worktrees under
 `$CODEX_HOME/worktrees/<id>/<repo>` return only `global` and `session`. Codex
 temporary paths retain their canonical project identity in those commands.
 Custom Codex App worktree roots remain best-effort because the provider does
@@ -1296,13 +1298,15 @@ For persistent Codex setup, Hook consent remains provider-owned: open
 `/hooks`, enable and Trust **First Tree Context → SessionStart**, return to the
 same conversation, and reply `continue`. The same agent reruns apply and
 adopts the handoff. Session-only installs no Hook, so it needs no Trust.
-Claude Code requires `/reload-plugins` after first thin-Plugin install, legacy
-full-Plugin migration, or adapter repair. Setup remains incomplete until the
-reloaded thin Plugin's `UserPromptSubmit` hook issues a session-bound opaque
-receipt and the same exact apply command consumes it. With no pending adoption
-obligation the hook is a pure no-op; it performs no provider probe, payload
-hash, receipt signing, or context injection. Later Core-only upgrades and
-additional Team grants require no reload or repeated Codex trust.
+Claude Code materializes deterministic thin-Plugin bytes for each
+`adapterVersion`. First install, legacy full-Plugin migration, and adapter repair
+leave a next-session obligation that only an exact repaired SessionStart can
+consume. Repeating repair for the same adapter version does not change the
+provider cache version or payload. The current session need not adopt the repair
+immediately; setup can still return its verified current-session handoff, while
+persistent automatic routing resumes in the next Claude session. Later
+Core-only upgrades and additional Team grants require no provider lifecycle
+action or repeated Codex trust.
 
 `context.yaml` schema v3 stores zero or more global/directory grants keyed by
 provider, Team and exact scope. A legacy v2/v1 file is atomically backed up,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1272,10 +1272,14 @@ the shared Plugin and add one schema-v3 grant. Session-only verifies the
 release bundle, writes no grant, and returns only Read/Write loader entries plus a
 signed opaque candidate receipt.
 
-Successful apply returns `currentSessionHandoff` schema v3. It contains
+Successful session-only apply, and persistent apply when the adapter is already
+usable in the current provider session, returns `currentSessionHandoff` schema
+v3. It contains
 immutable provider/project identity, `consumerKind: byo`, activation scope,
 neutral standing routing context, and versioned exact-release loader commands.
-Persistent scope returns `first-tree`, `first-tree-read`, and
+Claude persistent setup that installs, migrates, or repairs the Plugin returns
+`currentSessionHandoff: null` while its next-session obligation is pending and
+instructs the user to start a new session. Other usable persistent scopes return `first-tree`, `first-tree-read`, and
 `first-tree-write`; session scope returns Read/Write only. Human mode prints
 the full usable JSON handoff.
 
@@ -1303,8 +1307,8 @@ Claude Code materializes deterministic thin-Plugin bytes for each
 leave a next-session obligation that only an exact repaired SessionStart can
 consume. Repeating repair for the same adapter version does not change the
 provider cache version or payload. The current session need not adopt the repair
-immediately; setup can still return its verified current-session handoff, while
-persistent automatic routing resumes in the next Claude session. Later
+immediately; setup returns no current-session handoff, and persistent automatic
+routing starts in the next Claude session. Later
 Core-only upgrades and additional Team grants require no provider lifecycle
 action or repeated Codex trust.
 

--- a/docs/context-integration.md
+++ b/docs/context-integration.md
@@ -34,12 +34,14 @@ identity, and returns the choices that are safe for that session:
 A directory choice is returned only when setup has a stable canonical
 directory. Claude setup uses a valid `CLAUDE_PROJECT_DIR` (or an explicit
 `--project-root`) and never borrows the shell or Hook cwd when that signal is
-missing. Codex Documents scratch directories and managed worktrees under the
-default `$CODEX_HOME/worktrees/<id>/<repo>` layout keep their canonical path
-project identity, but omit the directory choice because another session
-normally receives a different path. Truly pathless sessions also omit it.
-Custom Codex App worktree roots are not classified until the provider exposes
-a stable public setting for them.
+missing. Without a valid Claude project directory, setup and SessionStart use a
+pathless identity so global activation remains available without widening to
+the mutable cwd. Codex Documents scratch directories and managed worktrees
+under the default `$CODEX_HOME/worktrees/<id>/<repo>` layout keep their
+canonical path project identity, but omit the directory choice because another
+session normally receives a different path. Truly pathless sessions also omit
+it. Custom Codex App worktree roots are not classified until the provider
+exposes a stable public setting for them.
 
 The coding agent must show the choices and wait for a new user reply. Every
 available choice carries a complete `applyCommand` built by the same CLI that
@@ -73,10 +75,9 @@ A routine forward adapter update is discovered by the existing SessionStart
 bridge and handed to the coding agent as one exact, session-bound sync action.
 The Hook does not install anything inside its five-second deadline. The agent
 runs the transactional update during the normal turn. A verified protocol-v1
-adapter remains usable for the current task: Claude can optionally run
-`/reload-plugins` to adopt the update immediately, otherwise both providers use
-it next session. Only a missing, damaged, revoked, or incompatible adapter
-pauses First Tree operations.
+adapter remains usable for the current task. Both providers use the updated
+adapter on their next SessionStart. Only a missing, damaged, revoked, or
+incompatible adapter pauses First Tree operations.
 
 Persistent configuration is `config/context.yaml` schema v3. It stores a set
 of `provider + Team + activationScope` grants. A v2/v1 single-Team binding
@@ -210,21 +211,21 @@ writes or bypasses trust:
 5. the same coding agent reruns the exact apply command and adopts the handoff.
 
 A previously trusted Hook skips the consent turn. Session-only never installs a
-Hook and therefore never asks for Trust. Claude Code requires
-`/reload-plugins` after first install, migration from a full legacy Plugin, or
-an adapter repair. Setup remains incomplete until the reloaded thin Plugin's
-lightweight `UserPromptSubmit` Hook receives Claude's session identity and
-returns a per-install adoption generation from the loaded Hook configuration
-plus a signed opaque receipt. The same exact apply consumes that receipt once
-and binds the pending setup plan to the current session. A Hook loaded before a
-same-version repair cannot reuse the new generation. When no install, migration,
-or repair adoption is pending, this Hook is a pure no-op: it does not probe the
-provider, hash Plugin payloads, sign a receipt, or inject additional context.
-Full payload health is checked by setup/status and once at each new task route;
-the exact routed snapshot and Write authority then own the rest of that task.
-The general Skill loader is read-only and never records reload state. Later
-Core-only CLI upgrades and additional Team grants require neither another
-reload nor repeated Codex trust.
+Hook and therefore never asks for Trust. Claude first install, full-Plugin
+migration, and adapter repair materialize deterministic Plugin bytes for the
+target `adapterVersion`. Repeating repair for the same version keeps both the
+provider cache version and payload unchanged. The operation leaves a
+next-session marker; the next valid SessionStart from that exact adapter
+consumes it and enables persistent routing. The current Claude session is not
+required to adopt a repaired adapter immediately, while setup may still return
+its verified current-session handoff. Full payload health is checked by
+setup/status and once at each new task route; the exact routed snapshot and
+Write authority then own the rest of that task. The general Skill loader is
+read-only and never records lifecycle state. Later Core-only CLI upgrades and
+additional Team grants require neither another Claude action nor repeated Codex
+trust. An adapter 1.0.1 command that is already loaded in an old Claude session
+remains as a compatibility no-op only; it issues no receipt and changes no
+state.
 
 ## SCOPE governance and Reviewer authority
 
@@ -258,9 +259,9 @@ future BYO sessions.
 `context status` reports provider compatibility, Plugin payload, Hook state,
 the immutable project identity, every applicable highest-priority grant, and
 each grant's live Team activation separately. After a standalone Claude repair,
-it also reports the pending `/reload-plugins` adoption until the reloaded
-Plugin's `UserPromptSubmit` Hook verifies the session and consumes that repair
-obligation.
+the on-disk Plugin may be healthy while persistent routing remains paused for
+the current session. Status reports that next-session obligation separately;
+the next valid SessionStart from the repaired adapter consumes it.
 
 `context disable --provider ... --team ... --scope ...` removes exactly one
 global or directory grant. Directory removal also requires its exact canonical
@@ -274,17 +275,18 @@ machine-state lock and a durable recovery journal. Do not edit provider caches
 or Context state by hand.
 
 `data/byo` belongs to the active local Client. Account switching parks and
-restores it in the existing entry-level transaction; route, reload-observation,
-write-plan, and repository journals validate `accountClientId`. An active or
-incomplete BYO write blocks switching. `computer reset` and destructive purge
-remove BYO repositories and the new account-scoped receipts/recovery state.
+restores it in the existing entry-level transaction; route, adapter-sync,
+next-session, write-plan, and repository journals validate `accountClientId`.
+An active or incomplete BYO write blocks switching. `computer reset` and
+destructive purge remove BYO repositories and the new account-scoped
+receipts/recovery state.
 
 The Web bootstrap prompt keeps technical envelopes internal. It reports only
 checking, installing/updating, required user action, and completion. The coding
 agent may retry the same exact transient action a bounded number of times and
 may run an exact CLI-provided reversible repair, but scope selection, account
-switching, authentication/permission, Claude reload, Codex trust, destructive
-reset, and changed plans remain explicit human decisions.
+switching, authentication/permission, Codex trust, destructive reset, and
+changed plans remain explicit human decisions.
 
 Activation failure never blocks ordinary Claude/Codex work and never falls back
 to a lower-priority grant, another Team or cached authority. Authentication,
@@ -319,8 +321,9 @@ record evidence for:
 6. single- and multi-Team BYO writes with the mandatory new user confirmation;
 7. SCOPE admin approval, rejection, changed head/digest and manager demotion;
 8. v2 store backup and explicit reauthorization;
-9. legacy full Plugin migration with the Claude reload gate, followed by a
-   Core-only CLI upgrade that leaves adapter bytes and provider trust unchanged;
+9. legacy full Plugin migration with the Claude next-session adoption gate,
+   followed by a Core-only CLI upgrade that leaves adapter bytes and provider
+   trust unchanged;
 10. same-organization cross-provider repo reuse, cross-organization isolation,
     A→B→A Client switching, and active-write switch refusal;
 11. concise bootstrap progress, bounded typed-error recovery, and unchanged

--- a/docs/context-integration.md
+++ b/docs/context-integration.md
@@ -87,7 +87,9 @@ pathless binding to global scope.
 
 ## Current-session handoff
 
-A successful apply returns `currentSessionHandoff` schema v3 with:
+A successful session-only apply, or a persistent apply whose adapter is already
+usable in the current provider session, returns `currentSessionHandoff` schema
+v3 with:
 
 - immutable `provider` and `project` identity;
 - `consumerKind: byo` and the exact activation scope;
@@ -95,7 +97,10 @@ A successful apply returns `currentSessionHandoff` schema v3 with:
 - stable Skill descriptions and versioned loader commands;
 - for session-only, the opaque short-lived Server-signed session candidate receipt.
 
-Persistent handoffs expose `first-tree`, `first-tree-read`, and
+Claude persistent setup that installs, migrates, or repairs the Plugin returns
+no current-session handoff while its next-session obligation is pending; setup
+is complete, but Context activation starts in a new Claude session. Persistent
+handoffs that are safe to use expose `first-tree`, `first-tree-read`, and
 `first-tree-write`; session-only exposes only Read and Write. The coding agent
 adopts the handoff immediately in the same conversation. It must not reconstruct
 a Team from cwd, Git remotes, Web state or remembered context.
@@ -216,9 +221,9 @@ migration, and adapter repair materialize deterministic Plugin bytes for the
 target `adapterVersion`. Repeating repair for the same version keeps both the
 provider cache version and payload unchanged. The operation leaves a
 next-session marker; the next valid SessionStart from that exact adapter
-consumes it and enables persistent routing. The current Claude session is not
-required to adopt a repaired adapter immediately, while setup may still return
-its verified current-session handoff. Full payload health is checked by
+consumes it and enables persistent routing. The current Claude session does not
+adopt a repaired adapter immediately, and setup does not return a handoff that
+persistent routing would reject. Full payload health is checked by
 setup/status and once at each new task route; the exact routed snapshot and
 Write authority then own the rest of that task. The general Skill loader is
 read-only and never records lifecycle state. Later Core-only CLI upgrades and

--- a/packages/qa/cases/cross-surface/external-context-current-session-handoff.md
+++ b/packages/qa/cases/cross-surface/external-context-current-session-handoff.md
@@ -12,7 +12,8 @@ surfaces: [web, server, cli, claude-code, codex, context-tree]
 Confirm that an already-running Claude Code or Codex conversation can install
 the thin First Tree Context Plugin, complete provider-owned consent, and load
 the current CLI release's canonical Core workflow. Prove that a later Core-only
-CLI upgrade needs no Plugin reinstall, Claude reload, or repeated Codex trust.
+CLI upgrade needs no Plugin reinstall, Claude lifecycle action, or repeated
+Codex trust.
 
 ## Preconditions
 
@@ -34,17 +35,16 @@ CLI upgrade needs no Plugin reinstall, Claude reload, or repeated Codex trust.
 2. Inject one retryable timeout and one reversible local Plugin drift. Confirm
    the agent retries the exact transient action no more than twice, or runs only
    the CLI-provided exact repair/retry action, then rechecks the original step.
-3. Exercise scope choice, account-switch consent, login/auth/permission,
-   Claude `/reload-plugins`, Codex Hook trust, destructive reset, and a changed
-   plan. Confirm the agent always stops for the user at these boundaries and
-   never hand-edits provider cache, Context config, receipts, or journals.
-4. Install or migrate Claude. Confirm apply returns `setup.complete: false`
-   and no handoff until `/reload-plugins` is performed. Reply `continue`, verify
-   the reloaded Plugin's `UserPromptSubmit` Hook returns one opaque
-   current-session receipt, and rerun the original exact apply with that receipt.
-   Confirm the general Skill loader creates no observation state. After the
-   obligation is consumed, submit another prompt and confirm the Hook is a pure
-   no-op with no provider probe, receipt, or additional Context injection.
+3. Exercise scope choice, account-switch consent, login/auth/permission, Codex
+   Hook trust, destructive reset, and a changed plan. Confirm the agent always
+   stops for the user at these boundaries and never hand-edits provider cache,
+   Context config, receipts, or journals.
+4. Install or migrate Claude. Confirm apply returns a verified current-session
+   handoff and tells the user that persistent automatic routing begins in the
+   next session. Confirm the Plugin contains only SessionStart lifecycle logic,
+   no same-session adoption hook or receipt path, and the general Skill loader
+   creates no lifecycle state. Start a new session and verify its exact
+   SessionStart consumes the obligation before routing.
 5. Install Codex, complete `/hooks` trust in the same conversation, then rerun
    the same apply command. Repeat with an already trusted Hook.
 6. Inspect the complete schema-v3 handoff. Trigger two Read tasks and then a
@@ -66,14 +66,15 @@ CLI upgrade needs no Plugin reinstall, Claude reload, or repeated Codex trust.
    Confirm typed `CONTEXT_PLUGIN_RELOAD_REQUIRED` and no Tree read. Tamper a
    Core file, symlink a Core path outside the exact release, and remove an old
    exact release; each must fail closed without a HOME Core cache fallback.
-9. Upgrade only the thin adapter to `adapterVersion` 1.0.1 while keeping loader
-   protocol v1 compatible.
+9. Upgrade only the Claude thin adapter to `adapterVersion` 1.0.2 while keeping
+   Codex at 1.0.1 and loader protocol v1 compatible.
    Confirm SessionStart returns one exact sync action within five seconds and
    does not install. The agent syncs in the normal turn while the old adapter
-   continues the current task. Claude reload is optional for immediate adoption;
-   without it, and for Codex, the new adapter is guaranteed next session. Inject
-   one provider-install failure, verify rollback and quiet `update_deferred`, and
-   confirm current First Tree work continues.
+   continues the current task. The new Claude adapter is guaranteed next
+   session. Repair Claude twice and confirm the cache version and payload digest
+   remain identical for 1.0.2. Inject one provider-install failure, verify
+   rollback and quiet `update_deferred`, and confirm current First Tree work
+   continues.
 10. If bounded safe recovery still fails, confirm the agent reports only the
    blocker, attempted recovery, and one concrete next step; raw diagnostics are
    attached only when needed for targeted troubleshooting or a bug report.
@@ -86,14 +87,14 @@ CLI upgrade needs no Plugin reinstall, Claude reload, or repeated Codex trust.
   release root with matching Skill and Policy digests.
 - Provider Plugins contain only discovery stubs, SessionStart adapter, and
   loader calls. They contain no full Read/Write workflow or Policy copy.
-- Legacy full→thin migration and repair without a known-good adapter require Claude reload;
-  successful observation gates `setup.complete`. Core-only upgrades and new
+- Legacy full→thin migration and repair wait for the next Claude SessionStart
+  before automatic persistent routing. Core-only upgrades and new
   Team grants leave adapter bytes/version/digest and install plan unchanged.
 - A routine compatible adapter update is not setup failure: current tasks keep
-  their verified loaded adapter, sync runs outside SessionStart, and reload/trust
-  is requested only for immediate adoption or a provider-reported Hook identity change.
+  their verified loaded adapter, sync runs outside SessionStart, and provider
+  action is requested only for a provider-reported Hook identity change.
 - Session-only loads verified Core without installing Plugin, Hook, grant, or
-  observation state and does not promise future-session activation.
+  lifecycle state and does not promise future-session activation.
 - The current conversation adopts `activationContext`, loader catalog, scope,
   and immutable provider/project receipt. It never reclassifies from changed
   cwd. Every task still runs the loader; reuse requires the exact Skill or
@@ -101,20 +102,22 @@ CLI upgrade needs no Plugin reinstall, Claude reload, or repeated Codex trust.
   current provider context. It never relies on a path or summary, independently
   hashes Core files, or persists a Core cache.
 - Human confirmation boundaries remain unchanged under recovery. No recovery
-  path chooses scope, changes account, authenticates, grants permission,
-  reloads/trusts a provider, resets state, or accepts a changed plan.
+  path chooses scope, changes account, authenticates, grants permission, trusts
+  a provider, resets state, or accepts a changed plan.
 
 ## Expected Result
 
-`PASS`: both providers complete in the original conversation; first migration
-uses the required provider lifecycle; later Core-only releases load on the next
-task with stable adapter identity; unchanged Core content is reused only by
-digest while changed or unavailable content is reread; adapter 1.0.1 is adopted
+`PASS`: both providers return a current-session handoff in the original
+conversation; first Claude migration uses next-session adoption for automatic
+routing; later Core-only releases load on the next task with stable adapter
+identity; unchanged Core content is reused only by
+digest while changed or unavailable content is reread; adapter 1.0.2 is adopted
 through the compatible update path; recovery is bounded, concise, and preserves
 every human boundary; all tamper and legacy paths fail closed.
 
-`FAIL`: a legacy workflow reads Tree data, Claude completes before observation,
-a Core-only release repairs/reloads/retrusts the Plugin, loader escapes or uses
+`FAIL`: a legacy workflow reads Tree data, Claude automatic routing resumes
+before a valid next SessionStart, same-version repair changes the cache payload,
+a Core-only release repairs or retrusts the Plugin, loader escapes or uses
 a mutable path/HOME cache, a task skips the loader, Core reuse relies on a path,
 name, release, or summary, setup leaks internal envelopes by default, or safe
 recovery crosses a human boundary.
@@ -129,6 +132,6 @@ not the same ones used for setup, or adapter/Core byte evidence is missing.
 
 Keep redacted Web prompt and concise transcript, exact apply commands, typed
 failure/recovery evidence, before/after adapter manifests and byte digests,
-Claude reload observation, Codex trust rows, loader envelopes and exact release
+Claude next-session adoption, Codex trust rows, loader envelopes and exact release
 paths, Tree read receipts, and tamper/legacy failure output. Record versions,
 timestamps, task/session ids, and fixture restoration.

--- a/packages/qa/cases/cross-surface/external-context-current-session-handoff.md
+++ b/packages/qa/cases/cross-surface/external-context-current-session-handoff.md
@@ -1,6 +1,6 @@
 ---
 id: external-context-current-session-handoff
-description: Validate thin-Plugin migration, exact-release Core loading, concise setup recovery, and current-session handoff across Claude Code and Codex.
+description: Validate thin-Plugin migration, exact-release Core loading, concise setup recovery, Claude next-session adoption, and safe current-session handoff.
 areas: [cross-surface]
 surfaces: [web, server, cli, claude-code, codex, context-tree]
 ---
@@ -9,9 +9,10 @@ surfaces: [web, server, cli, claude-code, codex, context-tree]
 
 ## Goal
 
-Confirm that an already-running Claude Code or Codex conversation can install
-the thin First Tree Context Plugin, complete provider-owned consent, and load
-the current CLI release's canonical Core workflow. Prove that a later Core-only
+Confirm that Codex can install the thin First Tree Context Plugin, complete
+provider-owned consent, and load the current CLI release's canonical Core
+workflow in the same conversation. Confirm Claude setup accurately waits for a
+new session instead of returning a blocked handoff. Prove that a later Core-only
 CLI upgrade needs no Plugin reinstall, Claude lifecycle action, or repeated
 Codex trust.
 
@@ -39,9 +40,10 @@ Codex trust.
    Hook trust, destructive reset, and a changed plan. Confirm the agent always
    stops for the user at these boundaries and never hand-edits provider cache,
    Context config, receipts, or journals.
-4. Install or migrate Claude. Confirm apply returns a verified current-session
-   handoff and tells the user that persistent automatic routing begins in the
-   next session. Confirm the Plugin contains only SessionStart lifecycle logic,
+4. Install or migrate Claude. Confirm apply completes with
+   `currentSessionHandoff: null`, does not provide a Read loader or claim that
+   Context is active in the current conversation, and tells the user that
+   persistent automatic routing begins in the next session. Confirm the Plugin contains only SessionStart lifecycle logic,
    no same-session adoption hook or receipt path, and the general Skill loader
    creates no lifecycle state. Start a new session and verify its exact
    SessionStart consumes the obligation before routing.
@@ -107,9 +109,9 @@ Codex trust.
 
 ## Expected Result
 
-`PASS`: both providers return a current-session handoff in the original
-conversation; first Claude migration uses next-session adoption for automatic
-routing; later Core-only releases load on the next task with stable adapter
+`PASS`: Codex returns a usable current-session handoff in the original
+conversation; first Claude migration returns no current-session handoff and
+uses next-session adoption for automatic routing; later Core-only releases load on the next task with stable adapter
 identity; unchanged Core content is reused only by
 digest while changed or unavailable content is reread; adapter 1.0.2 is adopted
 through the compatible update path; recovery is bounded, concise, and preserves

--- a/packages/qa/cases/cross-surface/external-context-multi-team-scope-routing.md
+++ b/packages/qa/cases/cross-surface/external-context-multi-team-scope-routing.md
@@ -36,12 +36,14 @@ full Tree is read before one candidate is fixed.
    the exact plan id. Repeat setup for Team B; the shared Plugin is not duplicated,
    its adapter identity is unchanged, Claude does not reload, and Codex does not
    request trust again.
-3. Repeat setup in a pathless session, a Codex projectless scratch directory,
-   and a default Codex managed worktree. Confirm each plan returns only global
-   and session choices: directory is absent and no directory apply command is
-   available. The scratch and managed-worktree plans display their canonical
-   path identity with a temporary-directory warning, and session-only is
-   recommended.
+3. Repeat setup in a pathless session, a Claude App session without
+   `CLAUDE_PROJECT_DIR`, a Codex projectless scratch directory, and a default
+   Codex managed worktree. Confirm each plan returns only global and session
+   choices: directory is absent and no directory apply command is available.
+   Apply global in the Claude App fixture and verify the next SessionStart uses
+   a pathless identity and routes that grant without borrowing Hook cwd. The
+   scratch and managed-worktree plans display their canonical path identity
+   with a temporary-directory warning, and session-only is recommended.
 4. For session-only, inspect filesystem/provider state: no grant, Plugin, Hook,
    marketplace or session receipt file is created. Tamper the opaque candidate
    token and confirm routing fails before authority lookup.
@@ -83,8 +85,10 @@ full Tree is read before one candidate is fixed.
 ## Observe
 
 - Planning is read-only. Stable directories return all three choices, while
-  pathless, Codex scratch, and default managed-worktree locations omit the
-  directory choice entirely. Every returned scope has a complete
+  pathless, Claude without `CLAUDE_PROJECT_DIR`, Codex scratch, and default
+  managed-worktree locations omit the directory choice entirely. Claude's
+  unavailable directory maps to pathless runtime identity for global routing,
+  never to Hook cwd. Every returned scope has a complete
   `applyCommand`. Session-only has `consumerKind: byo`, Read/Write only, an
   opaque signed candidate, and no persistent state.
 - Directory scope includes descendants; all Teams at the deepest matching root

--- a/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
+++ b/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
@@ -44,7 +44,10 @@ together.
   rolls back, confirm `update_deferred` keeps that known-good adapter usable and
   does not surface an internal failure to the user.
 - For Claude, verify the current task may continue on its already loaded adapter
-  while automatic persistent routing waits for the next SessionStart. For Codex,
+  after automatic sync. Trigger resume, clear, and compact on that same session;
+  each must use the session-and-old-digest compatibility record, avoid repair
+  guidance, and leave any next-session obligation untouched. A different
+  session or digest must not reuse that record. For Codex,
   require `/hooks` trust only when the provider reports a changed Hook identity.
   Both providers must use the updated adapter on the next session.
 - Independently tamper one stable stub, one provider-cache file, and one partial

--- a/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
+++ b/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
@@ -56,7 +56,9 @@ together.
   the prewritten compatibility fact must make both retry and the next lifecycle
   event usable without repair guidance. Repeat an already successful Claude
   challenge and confirm its TTL-bound terminal result remains idempotently
-  successful. For Codex,
+  successful. Then issue an old-adapter action before a separate repair creates
+  a next-session obligation; replay and lock-busy fallback must require a new
+  Claude session rather than report `currentAdapterUsable=true`. For Codex,
   require `/hooks` trust only when the provider reports a changed Hook identity.
   Both providers must use the updated adapter on the next session.
 - Independently tamper one stable stub, one provider-cache file, and one partial

--- a/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
+++ b/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
@@ -49,10 +49,14 @@ together.
   guidance, and leave any next-session obligation untouched. A different
   session or digest must not reuse that record. Interleave two old sessions'
   sync actions; the first global Plugin update must preserve both sessions and
-  make the second action idempotent. Inject an exit after the provider update
-  commits but before the sync command returns; the prewritten compatibility
-  fact must make both retry and the next lifecycle event usable without repair
-  guidance. For Codex,
+  make the second action idempotent. Issue a third action after the first sync
+  has scanned existing receipts but before provider mutation; issuance itself
+  must have already persisted its inert fact and recoverable action. Inject an
+  exit after the provider update commits but before the sync command returns;
+  the prewritten compatibility fact must make both retry and the next lifecycle
+  event usable without repair guidance. Repeat an already successful Claude
+  challenge and confirm its TTL-bound terminal result remains idempotently
+  successful. For Codex,
   require `/hooks` trust only when the provider reports a changed Hook identity.
   Both providers must use the updated adapter on the next session.
 - Independently tamper one stable stub, one provider-cache file, and one partial

--- a/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
+++ b/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
@@ -58,7 +58,13 @@ together.
   challenge and confirm its TTL-bound terminal result remains idempotently
   successful. Then issue an old-adapter action before a separate repair creates
   a next-session obligation; replay and lock-busy fallback must require a new
-  Claude session rather than report `currentAdapterUsable=true`. For Codex,
+  Claude session rather than report `currentAdapterUsable=true`. Hold the
+  account-state lock before the repair has written its obligation and confirm
+  that lock acquisition failure alone remains fail closed. Issue another Claude
+  action after an operation snapshot, force the provider
+  update to roll back, and confirm snapshot restoration does not erase the
+  action's fact or TTL backup; its original challenge must still retry safely.
+  For Codex,
   require `/hooks` trust only when the provider reports a changed Hook identity.
   Both providers must use the updated adapter on the next session.
 - Independently tamper one stable stub, one provider-cache file, and one partial

--- a/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
+++ b/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
@@ -43,23 +43,26 @@ together.
   continues on the already loaded adapter; if the provider update fails and
   rolls back, confirm `update_deferred` keeps that known-good adapter usable and
   does not surface an internal failure to the user.
-- For Claude, optionally run `/reload-plugins`, reply `continue`, and verify the
-  new `UserPromptSubmit` Hook returns one current-session opaque receipt. For
-  Codex, require `/hooks` trust only when the provider reports a changed Hook
-  identity. Without either optional current-session action, the new adapter is
-  used on the next session.
+- For Claude, verify the current task may continue on its already loaded adapter
+  while automatic persistent routing waits for the next SessionStart. For Codex,
+  require `/hooks` trust only when the provider reports a changed Hook identity.
+  Both providers must use the updated adapter on the next session.
 - Independently tamper one stable stub, one provider-cache file, and one partial
   cache tree while leaving the embedded digest literal unchanged. SessionStart,
   status/setup and the next persistent task route must reject the unhealthy
-  payload; session-only loading remains independent. With no reload obligation,
-  `UserPromptSubmit` must remain a pure no-op with no provider probe, receipt or
-  injected context. After a route succeeds, snapshot and Write boundaries must
+  payload; session-only loading remains independent. The new Claude Plugin must
+  not contain a same-session adoption hook or receipt path. Invoke the retired
+  command shape from an already-loaded adapter 1.0.1 and confirm it is a pure
+  no-op with no receipt or state mutation. After a route succeeds, snapshot and
+  Write boundaries must
   rely on the routed candidate and their live authority checks rather than
   repeatedly hashing the provider-owned Plugin cache.
-- Run standalone Claude repair, then interrupt before reload. `context status`
-  must show the pending adoption; after `/reload-plugins` and one submitted
-  message, the new Hook consumes that obligation and persistent routing resumes
-  without another Team setup apply.
+- Run standalone Claude repair twice for the same adapter version. Confirm the
+  provider cache version and complete payload digest remain identical. `context
+  status` must report a healthy payload plus a separate next-session obligation;
+  manual persistent routing in the old session remains blocked. Start a new
+  Claude session and verify its exact SessionStart consumes the obligation and
+  persistent routing resumes without another Team setup apply.
 - Repeat in the ungranted path and confirm no Team Context is injected. Choose
   session-only in a projectless session and confirm it works now without
   Plugin/Hook/grant state but does not reactivate after clear/compact/new session.

--- a/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
+++ b/packages/qa/cases/runtime/external-byo-context-activation-resilience.md
@@ -47,7 +47,12 @@ together.
   after automatic sync. Trigger resume, clear, and compact on that same session;
   each must use the session-and-old-digest compatibility record, avoid repair
   guidance, and leave any next-session obligation untouched. A different
-  session or digest must not reuse that record. For Codex,
+  session or digest must not reuse that record. Interleave two old sessions'
+  sync actions; the first global Plugin update must preserve both sessions and
+  make the second action idempotent. Inject an exit after the provider update
+  commits but before the sync command returns; the prewritten compatibility
+  fact must make both retry and the next lifecycle event usable without repair
+  guidance. For Codex,
   require `/hooks` trust only when the provider reports a changed Hook identity.
   Both providers must use the updated adapter on the next session.
 - Independently tamper one stable stub, one provider-cache file, and one partial

--- a/scripts/build-context-integration-bundle.mjs
+++ b/scripts/build-context-integration-bundle.mjs
@@ -15,7 +15,7 @@ if (!Number.isSafeInteger(CONTEXT_INTEGRATION_LIMITS.byoAdditionalContextLimit))
 const EXTERNAL_SKILLS = ["first-tree-read", "first-tree-write"];
 const PLUGIN_NAME = "first-tree-context";
 const PROVIDERS = ["claude-code", "codex"];
-const ADAPTER_VERSION = "1.0.1";
+const ADAPTER_VERSIONS = { "claude-code": "1.0.2", codex: "1.0.1" };
 
 function parseArgs(argv) {
   const args = new Map();
@@ -146,20 +146,6 @@ function writeSessionStartHook(pluginRoot, provider) {
   );
   chmodSync(script, 0o755);
 
-  if (provider === "claude-code") {
-    const observeScript = join(binDir, "context-observe-loaded");
-    writeFileSync(
-      observeScript,
-      [
-        "#!/bin/sh",
-        "set -eu",
-        `exec __FIRST_TREE_INVOCATION__ context observe-loaded --provider ${provider} "$@"`,
-        "",
-      ].join("\n"),
-    );
-    chmodSync(observeScript, 0o755);
-  }
-
   writeJson(join(pluginRoot, "hooks", "hooks.json"), {
     hooks: {
       SessionStart: [
@@ -179,24 +165,6 @@ function writeSessionStartHook(pluginRoot, provider) {
           ],
         },
       ],
-      ...(provider === "claude-code"
-        ? {
-            UserPromptSubmit: [
-              {
-                matcher: "*",
-                hooks: [
-                  {
-                    type: "command",
-                    command: `"\${CLAUDE_PLUGIN_ROOT}/bin/context-observe-loaded" --adapter-digest __ADAPTER_DIGEST__ --adoption-generation __ADOPTION_GENERATION__`,
-                    timeout: 2,
-                    statusMessage: "Checking First Tree Context",
-                    additionalContextLimit: CONTEXT_INTEGRATION_LIMITS.byoAdditionalContextLimit,
-                  },
-                ],
-              },
-            ],
-          }
-        : {}),
     },
   });
 }
@@ -207,7 +175,7 @@ function writeClaudeBundle(providerRoot, marketplaceName) {
   writeSessionStartHook(pluginRoot, "claude-code");
   writeJson(join(pluginRoot, ".claude-plugin", "plugin.json"), {
     name: PLUGIN_NAME,
-    version: ADAPTER_VERSION,
+    version: ADAPTER_VERSIONS["claude-code"],
     description: "Use explicit-Team First Tree Context in Claude Code without joining the First Tree Agent runtime.",
     author: { name: "First Tree" },
     homepage: "https://first-tree.ai",
@@ -223,7 +191,7 @@ function writeClaudeBundle(providerRoot, marketplaceName) {
         name: PLUGIN_NAME,
         source: "./plugins/first-tree-context",
         description: "Read and update explicit-Team First Tree Context from Claude Code.",
-        version: ADAPTER_VERSION,
+        version: ADAPTER_VERSIONS["claude-code"],
       },
     ],
   });
@@ -236,7 +204,7 @@ function writeCodexBundle(providerRoot, marketplaceName) {
   writeSessionStartHook(pluginRoot, "codex");
   writeJson(join(pluginRoot, ".codex-plugin", "plugin.json"), {
     name: PLUGIN_NAME,
-    version: ADAPTER_VERSION,
+    version: ADAPTER_VERSIONS.codex,
     description: "Use explicit-Team First Tree Context in Codex without joining the First Tree Agent runtime.",
     author: { name: "First Tree", url: "https://first-tree.ai" },
     homepage: "https://first-tree.ai",
@@ -321,7 +289,7 @@ export function buildContextIntegrationBundle(rawOptions) {
     PROVIDERS.map((provider) => [
       provider,
       {
-        adapterVersion: ADAPTER_VERSION,
+        adapterVersion: ADAPTER_VERSIONS[provider],
         adapterDigest: treeDigest(join(options.outDir, provider)),
         minimumVersion: provider === "claude-code" ? "2.1.121" : "0.144.0",
       },


### PR DESCRIPTION
## Summary

- make the Claude Plugin payload deterministic for one adapter version and bump only Claude to adapter `1.0.2`; Codex remains at `1.0.1`
- replace same-session reload receipts with a durable next-session obligation consumed only by a fresh Claude `startup`
- omit the persistent current-session handoff while Claude next-session adoption is pending; setup completes with an explicit new-session action instead of returning a handoff that routing would reject
- keep automatically synchronized old Claude sessions usable through account/channel/session/old-digest/exact-target compatibility facts written when each action is issued; concurrent issuance, provider rollback, global Plugin updates, and interrupted syncs remain recoverable
- retain a TTL-bound terminal action backup so replaying the exact Claude sync challenge returns the same successful result after lost output, while pending next-session adoption consistently requires a new Claude session
- fail closed only for a real account-lock conflict (`EEXIST`); non-busy lock I/O errors retain their original classification and known-good adapter fallback
- treat missing or invalid `CLAUDE_PROJECT_DIR` as pathless so global Claude App activation works without falling back to Hook cwd
- update CLI docs and deterministic QA contracts for repair, lifecycle, concurrency, crash recovery, and pathless routing

## Compatibility

- existing global/directory/session grants and schema v3 behavior are unchanged
- legacy install manifests with `adoptionGeneration` remain readable
- legacy reload state is retired during deterministic installation and account cleanup
- compatible-session facts are Claude-only, fail closed unless the exact target payload is healthy and no next-session obligation is pending, and are cleared on provider uninstall, account switch, and purge logout

## Verification

After the request to stop full-suite runs, only targeted verification was run:

- CI-failure regression: `context-activate-command.test.ts`, 11 tests passed with `--maxWorkers=2`
- lock-classification set: 2 files, 9 tests passed with `--maxWorkers=2`
- rollback/lock-contention set: 4 files, 39 tests passed with `--maxWorkers=2`
- obligation/replay set: 3 files, 22 tests passed with `--maxWorkers=2`
- lifecycle/recovery set: 4 files, 67 tests passed with `--maxWorkers=2`
- setup/sync/activation set: 3 files, 38 tests passed with `--maxWorkers=2`
- `apps/cli` typecheck
- affected TypeScript files: Biome check
- `git diff --check`

Earlier, before that request, `pnpm check`, `pnpm typecheck`, the 137-test affected CLI set, and a clean-environment CLI suite (149 files, 1695 passed, 1 skipped) completed successfully.

No model-backed Skill evals were run.

Follow-up to #2209.
