### PR TITLE
fix(client): keep automatic provider discovery out of macOS protected folders

### DIFF
--- a/apps/cli/src/__tests__/context-project-resolver.test.ts
+++ b/apps/cli/src/__tests__/context-project-resolver.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   classifyCodexManagedWorktreePath,
   classifyCodexProjectlessPath,
@@ -10,6 +10,15 @@ import {
   resolveProviderProject,
   resolveSessionContextProject,
 } from "../core/context-integration/client-preflight.js";
+
+/**
+ * A recording canonicalization seam, so a test can assert exactly which paths
+ * the classifier touches. Resolving each path to itself keeps the synthetic
+ * (non-existent) roots below comparable without going near the filesystem.
+ */
+function recordingRealpath() {
+  return vi.fn((path: string) => path);
+}
 
 describe("Context project resolver", () => {
   it.each([
@@ -137,6 +146,40 @@ describe("Context project resolver", () => {
         },
       ),
     ).toMatchObject({ kind: "pathless", source: "codex_documents_v1" });
+  });
+
+  // On macOS `~/Documents` sits behind a TCC prompt, so classifying an ordinary
+  // project must not touch it. The base is only canonicalized when the caller's
+  // original cwd is already lexically inside it (a redirected base, above).
+  it("never canonicalizes the Documents base for a cwd outside it", () => {
+    const realpath = recordingRealpath();
+    const home = "/Users/alice";
+
+    expect(
+      classifyCodexProjectlessPath(
+        "/Users/alice/code/app",
+        {},
+        { platform: "darwin", home, realpath, rawCwd: "/Users/alice/code/app" },
+      ),
+    ).toBe(false);
+    expect(realpath).not.toHaveBeenCalled();
+
+    expect(
+      classifyCodexProjectlessPath(
+        "/Users/alice/Documents/Codex/2026-07-30/scratch",
+        {},
+        { platform: "darwin", home, realpath, rawCwd: "/Users/alice/Documents/Codex/2026-07-30/scratch" },
+      ),
+    ).toBe(true);
+    expect(realpath).toHaveBeenCalledWith("/Users/alice/Documents/Codex");
+  });
+
+  it("still canonicalizes the base when the original cwd is unknown", () => {
+    const realpath = recordingRealpath();
+    expect(
+      classifyCodexProjectlessPath("/Users/alice/code/app", {}, { platform: "darwin", home: "/Users/alice", realpath }),
+    ).toBe(false);
+    expect(realpath).toHaveBeenCalledWith("/Users/alice/Documents/Codex");
   });
 
   it("accepts only readable directories as path projects", () => {

--- a/apps/cli/src/core/context-integration/client-preflight.ts
+++ b/apps/cli/src/core/context-integration/client-preflight.ts
@@ -5,8 +5,15 @@ import type { ContextIntegrationProject, ContextIntegrationProvider } from "@fir
 import { loadCredentials } from "../bootstrap.js";
 import { channelConfig } from "../channel.js";
 
-const CODEX_PROJECTLESS_CLASSIFIER_VERSION = 1;
+const CODEX_PROJECTLESS_CLASSIFIER_VERSION = 2;
 const SESSION_CACHE_TTL_MS = 30 * 24 * 60 * 60_000;
+
+/**
+ * The one `realpathSync` form this module uses: canonicalize a single path to a
+ * string. Naming it keeps the injected test seams to that shape rather than
+ * Node's full Buffer-returning overload set.
+ */
+type RealpathFn = (path: string) => string;
 
 export type ContextProjectResolution =
   | {
@@ -80,7 +87,7 @@ export function inspectContextSetupLocation(
   }
   const temporaryDirectory =
     provider === "codex" &&
-    (classifyCodexProjectlessPath(resolved.project.root, env, input.classifierOptions) ||
+    (classifyCodexProjectlessPath(resolved.project.root, env, { ...input.classifierOptions, rawCwd: candidate }) ||
       classifyCodexManagedWorktreePath(resolved.project.root, env, input.classifierOptions));
   return {
     project: resolved.project,
@@ -175,7 +182,7 @@ export function resolveProviderProject(
   classifierOptions: {
     platform?: NodeJS.Platform;
     home?: string;
-    realpath?: typeof realpathSync;
+    realpath?: RealpathFn;
     stat?: typeof statSync;
   } = {},
 ): ContextProjectResolution {
@@ -199,7 +206,10 @@ export function resolveProviderProject(
   }
   const canonical = resolvePathProject(input.cwd, "codex_cwd_best_effort", classifierOptions);
   if (canonical.kind !== "path") return canonical;
-  const pathless = classifyCodexProjectlessPath(canonical.project.root, env, classifierOptions);
+  const pathless = classifyCodexProjectlessPath(canonical.project.root, env, {
+    ...classifierOptions,
+    rawCwd: input.cwd,
+  });
   if (pathless) return { kind: "pathless", project: { kind: "pathless" }, source: "codex_documents_v1" };
   return canonical;
 }
@@ -207,7 +217,17 @@ export function resolveProviderProject(
 export function classifyCodexProjectlessPath(
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
-  options: { platform?: NodeJS.Platform; home?: string; realpath?: typeof realpathSync } = {},
+  options: {
+    platform?: NodeJS.Platform;
+    home?: string;
+    realpath?: RealpathFn;
+    /**
+     * The caller's ORIGINAL, pre-`realpath` form of `cwd`. Supplying it keeps this
+     * classification off the filesystem for every path that is not already
+     * lexically inside a Codex scratch base — see {@link shouldCanonicalizeBase}.
+     */
+    rawCwd?: string;
+  } = {},
 ): boolean {
   const platform = options.platform ?? process.platform;
   const pathApi = platform === "win32" ? win32 : posix;
@@ -222,6 +242,7 @@ export function classifyCodexProjectlessPath(
   const normalizedCwd = normalizeForComparison(cwd, platform);
   const comparableBases = new Set(bases);
   for (const base of bases) {
+    if (!shouldCanonicalizeBase(base, options.rawCwd, platform)) continue;
     try {
       comparableBases.add((options.realpath ?? realpathSync)(base));
     } catch {
@@ -231,25 +252,55 @@ export function classifyCodexProjectlessPath(
     }
   }
   for (const base of comparableBases) {
-    const relativePath = pathApi.relative(normalizeForComparison(base, platform), normalizedCwd);
-    if (
-      !relativePath ||
-      relativePath === ".." ||
-      relativePath.startsWith(`..${pathApi.sep}`) ||
-      pathApi.isAbsolute(relativePath)
-    ) {
-      continue;
-    }
+    const relativePath = relativeInside(base, normalizedCwd, platform);
+    if (relativePath === null) continue;
     const [date, slug] = relativePath.split(pathApi.sep);
     if (date && slug && validIsoDate(date)) return true;
   }
   return false;
 }
 
+/**
+ * Should `base` be canonicalized before comparison?
+ *
+ * Canonicalizing means touching the path, and on macOS `~/Documents` sits behind
+ * a TCC "Files & Folders" consent prompt — so an ordinary project cwd must not
+ * cause it. The canonical form only ever matters when the base itself is
+ * redirected (macOS iCloud "Desktop & Documents Folders" makes `~/Documents` a
+ * symlink), and in that case the caller's original cwd is still lexically inside
+ * the logical base. So gate on that, and fall back to canonicalizing whenever
+ * the original cwd is unknown or relative, which preserves the prior behavior
+ * for callers that cannot supply it.
+ */
+function shouldCanonicalizeBase(base: string, rawCwd: string | undefined, platform: NodeJS.Platform): boolean {
+  const pathApi = platform === "win32" ? win32 : posix;
+  if (rawCwd === undefined || !pathApi.isAbsolute(rawCwd)) return true;
+  return relativeInside(base, normalizeForComparison(rawCwd, platform), platform) !== null;
+}
+
+/**
+ * The path of `candidate` relative to `root` when it is strictly inside it,
+ * otherwise `null`. `root` is normalized here; `candidate` is expected to be
+ * normalized already.
+ */
+function relativeInside(root: string, candidate: string, platform: NodeJS.Platform): string | null {
+  const pathApi = platform === "win32" ? win32 : posix;
+  const relativePath = pathApi.relative(normalizeForComparison(root, platform), candidate);
+  if (
+    !relativePath ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${pathApi.sep}`) ||
+    pathApi.isAbsolute(relativePath)
+  ) {
+    return null;
+  }
+  return relativePath;
+}
+
 export function classifyCodexManagedWorktreePath(
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
-  options: { platform?: NodeJS.Platform; home?: string; realpath?: typeof realpathSync } = {},
+  options: { platform?: NodeJS.Platform; home?: string; realpath?: RealpathFn } = {},
 ): boolean {
   const platform = options.platform ?? process.platform;
   const pathApi = platform === "win32" ? win32 : posix;
@@ -269,15 +320,8 @@ export function classifyCodexManagedWorktreePath(
 
   const normalizedCwd = normalizeForComparison(cwd, platform);
   for (const root of comparableRoots) {
-    const relativePath = pathApi.relative(normalizeForComparison(root, platform), normalizedCwd);
-    if (
-      !relativePath ||
-      relativePath === ".." ||
-      relativePath.startsWith(`..${pathApi.sep}`) ||
-      pathApi.isAbsolute(relativePath)
-    ) {
-      continue;
-    }
+    const relativePath = relativeInside(root, normalizedCwd, platform);
+    if (relativePath === null) continue;
     const [worktreeId, repository] = relativePath.split(pathApi.sep);
     if (worktreeId && repository) return true;
   }
@@ -312,7 +356,7 @@ function resolvePathProject(
   path: string,
   source: Extract<ContextProjectResolution, { kind: "path" }>["source"],
   dependencies: {
-    realpath?: typeof realpathSync;
+    realpath?: RealpathFn;
     stat?: typeof statSync;
   } = {},
 ): ContextProjectResolution {

--- a/packages/client/src/__tests__/install-locations.test.ts
+++ b/packages/client/src/__tests__/install-locations.test.ts
@@ -1,12 +1,26 @@
 import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findCodexExecutableOnPath } from "../runtime/codex-binary.js";
 import { versionManagerBinDirs, wellKnownBinDirs } from "../runtime/install-locations.js";
 
+const NEVER_LISTED = (path: string): string[] => {
+  throw new Error(`unexpected readdir: ${path}`);
+};
+
 describe("versionManagerBinDirs", () => {
-  afterEach(() => vi.unstubAllEnvs());
+  // Pin a non-macOS baseline: on macOS these synthetic roots go through
+  // protected-root resolution, which follows real symlinks (`/home` is a
+  // firmlink there) and would rewrite them. The macOS cases opt in below.
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(process, "platform", { value: "linux" });
+  });
 
   it("lists nvm and fnm version bins, newest version first", () => {
     const home = "/home/u";
@@ -16,7 +30,7 @@ describe("versionManagerBinDirs", () => {
       throw new Error("ENOENT");
     };
 
-    expect(versionManagerBinDirs(home, readDir)).toEqual([
+    expect(versionManagerBinDirs(home, { readDir, env: {} })).toEqual([
       // Numeric-aware, so v22 sorts above v9 rather than below it.
       join(home, ".nvm", "versions", "node", "v22.2.0", "bin"),
       join(home, ".nvm", "versions", "node", "v20.11.0", "bin"),
@@ -28,7 +42,6 @@ describe("versionManagerBinDirs", () => {
 
   it("covers the Homebrew and pre-XDG fnm layouts and honours $FNM_DIR", () => {
     const home = "/home/u";
-    vi.stubEnv("FNM_DIR", "/opt/fnm");
     const readDir = (path: string): string[] => {
       if (path === join("/opt/fnm", "node-versions")) return ["v22.0.0"];
       if (path === join(home, "Library", "Application Support", "fnm", "node-versions")) return ["v21.0.0"];
@@ -36,7 +49,7 @@ describe("versionManagerBinDirs", () => {
       throw new Error("ENOENT");
     };
 
-    expect(versionManagerBinDirs(home, readDir)).toEqual([
+    expect(versionManagerBinDirs(home, { readDir, env: { FNM_DIR: "/opt/fnm" } })).toEqual([
       join("/opt/fnm", "node-versions", "v22.0.0", "installation", "bin"),
       join(home, "Library", "Application Support", "fnm", "node-versions", "v21.0.0", "installation", "bin"),
       join(home, ".fnm", "node-versions", "v20.0.0", "installation", "bin"),
@@ -45,23 +58,70 @@ describe("versionManagerBinDirs", () => {
 
   it("returns nothing when no version manager is installed", () => {
     expect(
-      versionManagerBinDirs("/home/u", () => {
-        throw new Error("ENOENT");
+      versionManagerBinDirs("/home/u", {
+        readDir: () => {
+          throw new Error("ENOENT");
+        },
+        env: {},
       }),
     ).toEqual([]);
   });
 
-  it("appends version dirs after every fixed location, leaving precedence intact", () => {
-    const home = "/home/u";
-    const fixed = wellKnownBinDirs(home, () => {
-      throw new Error("ENOENT");
-    });
-    const withVersions = wellKnownBinDirs(home, (path) =>
-      path === join(home, ".nvm", "versions", "node") ? ["v22.0.0"] : [],
-    );
+  it("keeps version dirs out of wellKnownBinDirs, whose precedence is above the login shell", () => {
+    // Well-known dirs are searched BEFORE the login-shell PATH, so a newest-first
+    // version list there would outrank the version the shell actually selected.
+    // The fallback belongs after the login shell instead.
+    const dirs = wellKnownBinDirs("/home/u");
+    expect(dirs.some((dir) => dir.includes(".nvm"))).toBe(false);
+    expect(dirs.some((dir) => dir.includes("fnm"))).toBe(false);
+  });
+});
 
-    expect(withVersions.slice(0, fixed.length)).toEqual(fixed);
-    expect(withVersions).toContain(join(home, ".nvm", "versions", "node", "v22.0.0", "bin"));
+// A version-manager root is not trusted for being spelled like one. `$FNM_DIR`
+// is user-controlled, and `~/.nvm`, a fnm data dir, or one version entry can be
+// a symlink — or sit under one — pointing into a protected folder. Listing such
+// a root, or handing its `bin` dirs to an executable check, is the same TCC
+// access this change exists to remove.
+describe("versionManagerBinDirs protected-root vetting (macOS)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(process, "platform", { value: "linux" });
+  });
+
+  function macHome(): string {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-vm-")));
+    const home = join(root, "home");
+    mkdirSync(join(home, "Documents"), { recursive: true });
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    vi.stubEnv("HOME", home);
+    return home;
+  }
+
+  it("never lists a $FNM_DIR pointing into a protected folder", () => {
+    const home = macHome();
+    expect(
+      versionManagerBinDirs(home, { readDir: NEVER_LISTED, env: { FNM_DIR: join(home, "Documents", "fnm") } }),
+    ).toEqual([]);
+  });
+
+  it("never lists a default root symlinked into a protected folder", () => {
+    const home = macHome();
+    mkdirSync(join(home, "Documents", "nvm", "versions", "node"), { recursive: true });
+    symlinkSync(join(home, "Documents", "nvm"), join(home, ".nvm"));
+
+    expect(versionManagerBinDirs(home, { readDir: NEVER_LISTED, env: {} })).toEqual([]);
+  });
+
+  it("drops a version entry symlinked into a protected folder, keeping its siblings", () => {
+    const home = macHome();
+    const versions = join(home, ".nvm", "versions", "node");
+    mkdirSync(join(versions, "v22.0.0", "bin"), { recursive: true });
+    mkdirSync(join(home, "Documents", "sneaky", "bin"), { recursive: true });
+    symlinkSync(join(home, "Documents", "sneaky"), join(versions, "v23.0.0"));
+
+    expect(
+      versionManagerBinDirs(home, { readDir: (path) => (path === versions ? ["v23.0.0", "v22.0.0"] : []), env: {} }),
+    ).toEqual([join(versions, "v22.0.0", "bin")]);
   });
 });
 
@@ -84,10 +144,11 @@ describe("version-manager discovery after a multishell teardown", () => {
     symlinkSync(installBin, multishell);
 
     // The login-shell seam models the probe shell's lifetime: by the time it has
-    // answered, its per-session dir no longer exists.
+    // answered, its per-session dir no longer exists — so only the stable
+    // version dir, appended after it, can still answer.
     const loginShellPathDirs = (): string[] => {
       rmSync(multishell, { force: true });
-      return [multishell];
+      return [multishell, ...versionManagerBinDirs(home, { env: {} })];
     };
 
     expect(
@@ -98,12 +159,48 @@ describe("version-manager discovery after a multishell teardown", () => {
           pathDelimiter: ":",
           loginShellPathDirs,
           // Only the version dirs, so a real binary on this host's `/usr/local`
-          // or Homebrew path cannot answer for the mechanism under test. That
-          // `wellKnownBinDirs` appends these is covered above.
-          wellKnownDirs: () => versionManagerBinDirs(home),
+          // or Homebrew path cannot answer for the mechanism under test.
+          wellKnownDirs: () => [],
           desktopAppDirs: () => [],
         },
       ),
     ).toBe(codex);
+  });
+
+  // The precedence the fallback must not disturb: an intentionally selected
+  // older version keeps its binary (and credential context) while a newer
+  // inactive version is also installed.
+  it("prefers the shell's active version over a newer installed one", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-active-")));
+    const home = join(root, "home");
+    const versions = join(home, ".nvm", "versions", "node");
+    const activeBin = join(versions, "v20.11.0", "bin");
+    const newerBin = join(versions, "v22.2.0", "bin");
+    mkdirSync(activeBin, { recursive: true });
+    mkdirSync(newerBin, { recursive: true });
+    for (const bin of [activeBin, newerBin]) {
+      const codex = join(bin, "codex");
+      writeFileSync(codex, "#!/bin/sh\n");
+      chmodSync(codex, 0o755);
+    }
+
+    const fallback = versionManagerBinDirs(home, { env: {} });
+    // Newest-first, so the fallback alone would pick v22.
+    expect(fallback[0]).toBe(newerBin);
+
+    expect(
+      findCodexExecutableOnPath(
+        { HOME: home, PATH: "" },
+        {
+          platform: "linux",
+          pathDelimiter: ":",
+          // What `getLoginShellPathDirs` composes: the live selection first,
+          // the stable roots appended behind it.
+          loginShellPathDirs: () => [activeBin, ...fallback],
+          wellKnownDirs: () => [],
+          desktopAppDirs: () => [],
+        },
+      ),
+    ).toBe(join(activeBin, "codex"));
   });
 });

--- a/packages/client/src/__tests__/install-locations.test.ts
+++ b/packages/client/src/__tests__/install-locations.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findCodexExecutableOnPath } from "../runtime/codex-binary.js";
 import { versionManagerBinDirs, wellKnownBinDirs } from "../runtime/install-locations.js";
+import { getLoginShellPathDirs, resetLoginShellPathDirsCache } from "../runtime/login-shell-path.js";
 
 const NEVER_LISTED = (path: string): string[] => {
   throw new Error(`unexpected readdir: ${path}`);
@@ -327,6 +328,48 @@ describe("version-manager discovery after a multishell teardown", () => {
         },
       ),
     ).toBe(codex);
+  });
+
+  // End to end, through the real `getLoginShellPathDirs` composition: two
+  // manager variables reported, the fnm per-session entry already gone, and a
+  // runnable binary sitting under `$NVM_BIN`. Withholding nvm only from the
+  // appended fallback would prove nothing here — the raw `$PATH` lists it, so
+  // the resolver would skip the dead entry and launch nvm. Missing is the
+  // correct answer: the live shell had selected fnm.
+  it("resolves nothing rather than nvm when both managers were reported", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-dual-")));
+    const home = join(root, "home");
+    const nvmBin = join(home, ".nvm", "versions", "node", "v22.2.0", "bin");
+    const fnmDir = join(root, "custom-fnm");
+    const multishell = join(root, "fnm_multishells", "88_2", "bin");
+    mkdirSync(nvmBin, { recursive: true });
+    mkdirSync(join(fnmDir, "node-versions", "v20.11.0", "installation", "bin"), { recursive: true });
+    mkdirSync(home, { recursive: true });
+    const nvmCodex = join(nvmBin, "codex");
+    writeFileSync(nvmCodex, "#!/bin/sh\n");
+    chmodSync(nvmCodex, 0o755);
+
+    vi.stubEnv("HOME", home);
+    resetLoginShellPathDirsCache();
+    const dirs = getLoginShellPathDirs(
+      () =>
+        `__FT_SHELL_PATH__${multishell}\n${nvmBin}__FT_SHELL_PATH__${"__FT_SHELL_ENV__"}${fnmDir}\n${nvmBin}${"__FT_SHELL_ENV__"}`,
+    );
+    resetLoginShellPathDirsCache();
+
+    expect(dirs).not.toContain(nvmBin);
+    expect(
+      findCodexExecutableOnPath(
+        { HOME: home, PATH: "" },
+        {
+          platform: "linux",
+          pathDelimiter: ":",
+          loginShellPathDirs: () => dirs,
+          wellKnownDirs: () => [],
+          desktopAppDirs: () => [],
+        },
+      ),
+    ).toBeNull();
   });
 
   // The precedence the fallback must not disturb. With two versions installed

--- a/packages/client/src/__tests__/install-locations.test.ts
+++ b/packages/client/src/__tests__/install-locations.test.ts
@@ -336,7 +336,7 @@ describe("version-manager discovery after a multishell teardown", () => {
   // appended fallback would prove nothing here — the raw `$PATH` lists it, so
   // the resolver would skip the dead entry and launch nvm. Missing is the
   // correct answer: the live shell had selected fnm.
-  it("resolves nothing rather than nvm when both managers were reported", () => {
+  it("resolves nothing rather than nvm when both managers were reported (macOS)", () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-dual-")));
     const home = join(root, "home");
     const nvmBin = join(home, ".nvm", "versions", "node", "v22.2.0", "bin");
@@ -349,15 +349,62 @@ describe("version-manager discovery after a multishell teardown", () => {
     writeFileSync(nvmCodex, "#!/bin/sh\n");
     chmodSync(nvmCodex, 0o755);
 
+    // macOS is the platform that resolves after the shell exits, so this is the
+    // only one where the capture can arrive with a dead first entry.
+    Object.defineProperty(process, "platform", { value: "darwin" });
     vi.stubEnv("HOME", home);
     resetLoginShellPathDirsCache();
     const dirs = getLoginShellPathDirs(
       () =>
-        `__FT_SHELL_PATH__${multishell}\n${nvmBin}__FT_SHELL_PATH__${"__FT_SHELL_ENV__"}${fnmDir}\n${nvmBin}${"__FT_SHELL_ENV__"}`,
+        `__FT_SHELL_PATH__${multishell}\n${nvmBin}__FT_SHELL_PATH____FT_SHELL_ENV__${fnmDir}\n${nvmBin}__FT_SHELL_ENV__`,
     );
     resetLoginShellPathDirsCache();
 
     expect(dirs).not.toContain(nvmBin);
+    expect(
+      findCodexExecutableOnPath(
+        { HOME: home, PATH: "" },
+        {
+          platform: "darwin",
+          pathDelimiter: ":",
+          loginShellPathDirs: () => dirs,
+          wellKnownDirs: () => [],
+          desktopAppDirs: () => [],
+        },
+      ),
+    ).toBeNull();
+  });
+
+  // Off macOS the shell canonicalizes while it is still alive, so the returned
+  // order already establishes which manager `$PATH` had selected. Dropping both
+  // trees there would discard a correctly discovered provider for no reason.
+  it("keeps a dual-manager PATH intact where the shell already canonicalized it", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-dual-linux-")));
+    const home = join(root, "home");
+    const fnmDir = join(root, "custom-fnm");
+    const fnmTarget = join(fnmDir, "node-versions", "v20.11.0", "installation", "bin");
+    const nvmBin = join(home, ".nvm", "versions", "node", "v22.2.0", "bin");
+    mkdirSync(fnmTarget, { recursive: true });
+    mkdirSync(nvmBin, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    for (const bin of [fnmTarget, nvmBin]) {
+      const codex = join(bin, "codex");
+      writeFileSync(codex, "#!/bin/sh\n");
+      chmodSync(codex, 0o755);
+    }
+
+    Object.defineProperty(process, "platform", { value: "linux" });
+    vi.stubEnv("HOME", home);
+    resetLoginShellPathDirsCache();
+    // What a live `cd`/`pwd -P` yields: the multishell entry already resolved to
+    // its stable target, still ahead of nvm.
+    const dirs = getLoginShellPathDirs(
+      () =>
+        `__FT_SHELL_PATH__${fnmTarget}\n${nvmBin}__FT_SHELL_PATH____FT_SHELL_ENV__${fnmDir}\n${nvmBin}__FT_SHELL_ENV__`,
+    );
+    resetLoginShellPathDirsCache();
+
+    expect(dirs.slice(0, 2)).toEqual([fnmTarget, nvmBin]);
     expect(
       findCodexExecutableOnPath(
         { HOME: home, PATH: "" },
@@ -369,7 +416,7 @@ describe("version-manager discovery after a multishell teardown", () => {
           desktopAppDirs: () => [],
         },
       ),
-    ).toBeNull();
+    ).toBe(join(fnmTarget, "codex"));
   });
 
   // The precedence the fallback must not disturb. With two versions installed

--- a/packages/client/src/__tests__/install-locations.test.ts
+++ b/packages/client/src/__tests__/install-locations.test.ts
@@ -22,22 +22,32 @@ describe("versionManagerBinDirs", () => {
     Object.defineProperty(process, "platform", { value: "linux" });
   });
 
-  it("lists nvm and fnm version bins, newest version first", () => {
+  it("returns the single installed version under each root", () => {
     const home = "/home/u";
     const readDir = (path: string): string[] => {
-      if (path === join(home, ".nvm", "versions", "node")) return ["v20.11.0", "v22.2.0", "v9.0.0"];
-      if (path === join(home, ".local", "share", "fnm", "node-versions")) return ["v18.0.0", "v22.2.0"];
+      if (path === join(home, ".nvm", "versions", "node")) return ["v22.2.0"];
+      if (path === join(home, ".local", "share", "fnm", "node-versions")) return ["v18.0.0"];
       throw new Error("ENOENT");
     };
 
     expect(versionManagerBinDirs(home, { readDir, env: {} })).toEqual([
-      // Numeric-aware, so v22 sorts above v9 rather than below it.
       join(home, ".nvm", "versions", "node", "v22.2.0", "bin"),
-      join(home, ".nvm", "versions", "node", "v20.11.0", "bin"),
-      join(home, ".nvm", "versions", "node", "v9.0.0", "bin"),
-      join(home, ".local", "share", "fnm", "node-versions", "v22.2.0", "installation", "bin"),
       join(home, ".local", "share", "fnm", "node-versions", "v18.0.0", "installation", "bin"),
     ]);
+  });
+
+  // Which version the shell selected is not recoverable from disk. Answering
+  // with the newest would silently swap the executable the user pinned, so an
+  // ambiguous root contributes nothing and the provider reports as not found.
+  it("contributes nothing from a root holding more than one version", () => {
+    const home = "/home/u";
+    const versions = join(home, ".local", "share", "fnm", "node-versions");
+    expect(
+      versionManagerBinDirs(home, {
+        readDir: (path) => (path === versions ? ["v20.11.0", "v22.2.0"] : []),
+        env: {},
+      }),
+    ).toEqual([]);
   });
 
   it("covers the Homebrew and pre-XDG fnm layouts and honours $FNM_DIR", () => {
@@ -112,16 +122,18 @@ describe("versionManagerBinDirs protected-root vetting (macOS)", () => {
     expect(versionManagerBinDirs(home, { readDir: NEVER_LISTED, env: {} })).toEqual([]);
   });
 
-  it("drops a version entry symlinked into a protected folder, keeping its siblings", () => {
+  it("drops a version entry symlinked into a protected folder", () => {
     const home = macHome();
     const versions = join(home, ".nvm", "versions", "node");
-    mkdirSync(join(versions, "v22.0.0", "bin"), { recursive: true });
+    mkdirSync(versions, { recursive: true });
     mkdirSync(join(home, "Documents", "sneaky", "bin"), { recursive: true });
     symlinkSync(join(home, "Documents", "sneaky"), join(versions, "v23.0.0"));
 
-    expect(
-      versionManagerBinDirs(home, { readDir: (path) => (path === versions ? ["v23.0.0", "v22.0.0"] : []), env: {} }),
-    ).toEqual([join(versions, "v22.0.0", "bin")]);
+    // The root itself is fine and holds exactly one version, so only the
+    // per-candidate vetting can reject it.
+    expect(versionManagerBinDirs(home, { readDir: (path) => (path === versions ? ["v23.0.0"] : []), env: {} })).toEqual(
+      [],
+    );
   });
 });
 
@@ -263,10 +275,12 @@ describe("version-manager discovery after a multishell teardown", () => {
     ).toBe(codex);
   });
 
-  // The precedence the fallback must not disturb: an intentionally selected
-  // older version keeps its binary (and credential context) while a newer
-  // inactive version is also installed.
-  it("prefers the shell's active version over a newer installed one", () => {
+  // The precedence the fallback must not disturb. With two versions installed
+  // the shell's selection is unrecoverable from disk, so the fallback fails
+  // closed: a live selection still wins, and once it is gone the provider
+  // reports missing rather than silently running the version the user did not
+  // pick.
+  it("keeps the shell's active version, and refuses to guess once it is gone", () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-active-")));
     const home = join(root, "home");
     const versions = join(home, ".nvm", "versions", "node");
@@ -280,23 +294,25 @@ describe("version-manager discovery after a multishell teardown", () => {
       chmodSync(codex, 0o755);
     }
 
+    // Ambiguous root: it contributes nothing rather than answering v22.
     const fallback = versionManagerBinDirs(home, { env: {} });
-    // Newest-first, so the fallback alone would pick v22.
-    expect(fallback[0]).toBe(newerBin);
+    expect(fallback).toEqual([]);
 
-    expect(
+    const resolveWith = (dirs: string[]): string | null =>
       findCodexExecutableOnPath(
         { HOME: home, PATH: "" },
         {
           platform: "linux",
           pathDelimiter: ":",
-          // What `getLoginShellPathDirs` composes: the live selection first,
-          // the stable roots appended behind it.
-          loginShellPathDirs: () => [activeBin, ...fallback],
+          loginShellPathDirs: () => dirs,
           wellKnownDirs: () => [],
           desktopAppDirs: () => [],
         },
-      ),
-    ).toBe(join(activeBin, "codex"));
+      );
+
+    // Live selection present: it wins, exactly as before this change.
+    expect(resolveWith([activeBin, ...fallback])).toBe(join(activeBin, "codex"));
+    // Selection gone: missing, not silently v22.
+    expect(resolveWith([join(root, "dead-multishell", "bin"), ...fallback])).toBeNull();
   });
 });

--- a/packages/client/src/__tests__/install-locations.test.ts
+++ b/packages/client/src/__tests__/install-locations.test.ts
@@ -22,23 +22,17 @@ describe("versionManagerBinDirs", () => {
     Object.defineProperty(process, "platform", { value: "linux" });
   });
 
-  it("returns the single installed version under each root", () => {
+  it("returns the sole candidate when exactly one root holds exactly one version", () => {
     const home = "/home/u";
-    const readDir = (path: string): string[] => {
-      if (path === join(home, ".nvm", "versions", "node")) return ["v22.2.0"];
-      if (path === join(home, ".local", "share", "fnm", "node-versions")) return ["v18.0.0"];
-      throw new Error("ENOENT");
-    };
-
-    expect(versionManagerBinDirs(home, { readDir, env: {} })).toEqual([
-      join(home, ".nvm", "versions", "node", "v22.2.0", "bin"),
-      join(home, ".local", "share", "fnm", "node-versions", "v18.0.0", "installation", "bin"),
-    ]);
+    const versions = join(home, ".nvm", "versions", "node");
+    expect(versionManagerBinDirs(home, { readDir: (path) => (path === versions ? ["v22.2.0"] : []), env: {} })).toEqual(
+      [join(versions, "v22.2.0", "bin")],
+    );
   });
 
-  // Which version the shell selected is not recoverable from disk. Answering
-  // with the newest would silently swap the executable the user pinned, so an
-  // ambiguous root contributes nothing and the provider reports as not found.
+  // Which version the shell selected is not recoverable from disk, and
+  // answering with the wrong one silently swaps the executable the user pinned.
+  // Ambiguity is judged across the WHOLE state, not per root.
   it("contributes nothing from a root holding more than one version", () => {
     const home = "/home/u";
     const versions = join(home, ".local", "share", "fnm", "node-versions");
@@ -50,20 +44,52 @@ describe("versionManagerBinDirs", () => {
     ).toEqual([]);
   });
 
-  it("covers the Homebrew and pre-XDG fnm layouts and honours $FNM_DIR", () => {
+  it("contributes nothing when two roots each hold one version", () => {
     const home = "/home/u";
-    const readDir = (path: string): string[] => {
-      if (path === join("/opt/fnm", "node-versions")) return ["v22.0.0"];
-      if (path === join(home, "Library", "Application Support", "fnm", "node-versions")) return ["v21.0.0"];
-      if (path === join(home, ".fnm", "node-versions")) return ["v20.0.0"];
-      throw new Error("ENOENT");
-    };
+    const nvm = join(home, ".nvm", "versions", "node");
+    const fnm = join(home, ".local", "share", "fnm", "node-versions");
+    expect(
+      versionManagerBinDirs(home, {
+        readDir: (path) => (path === nvm ? ["v22.2.0"] : path === fnm ? ["v18.0.0"] : []),
+        env: {},
+      }),
+    ).toEqual([]);
+  });
 
-    expect(versionManagerBinDirs(home, { readDir, env: { FNM_DIR: "/opt/fnm" } })).toEqual([
-      join("/opt/fnm", "node-versions", "v22.0.0", "installation", "bin"),
-      join(home, "Library", "Application Support", "fnm", "node-versions", "v21.0.0", "installation", "bin"),
-      join(home, ".fnm", "node-versions", "v20.0.0", "installation", "bin"),
-    ]);
+  it("uses only the active $FNM_DIR the shell reported, and only when it is unambiguous", () => {
+    const home = "/home/u";
+    const activeVersions = join("/opt/fnm", "node-versions");
+    const staleNvm = join(home, ".nvm", "versions", "node");
+    const readDir = (path: string): string[] =>
+      path === activeVersions ? ["v20.11.0", "v22.2.0"] : path === staleNvm ? ["v18.0.0"] : [];
+
+    // Active root is ambiguous — a stale single-version root elsewhere is NOT a
+    // better answer, it is a different installation.
+    expect(versionManagerBinDirs(home, { readDir, active: { fnmDir: "/opt/fnm" }, env: {} })).toEqual([]);
+
+    // Same active root, now unambiguous: it answers, and the stale root still
+    // plays no part.
+    expect(
+      versionManagerBinDirs(home, {
+        readDir: (path) => (path === activeVersions ? ["v20.11.0"] : path === staleNvm ? ["v18.0.0"] : []),
+        active: { fnmDir: "/opt/fnm" },
+        env: {},
+      }),
+    ).toEqual([join(activeVersions, "v20.11.0", "installation", "bin")]);
+  });
+
+  it("takes $NVM_BIN as authoritative instead of enumerating nvm", () => {
+    const home = "/home/u";
+    const active = join(home, ".nvm", "versions", "node", "v20.11.0", "bin");
+    expect(
+      versionManagerBinDirs(home, {
+        // Two installed versions would be ambiguous on their own; the shell
+        // named the selected one, so there is nothing to guess.
+        readDir: () => ["v20.11.0", "v22.2.0"],
+        active: { nvmBin: active },
+        env: {},
+      }),
+    ).toEqual([active]);
   });
 
   it("returns nothing when no version manager is installed", () => {

--- a/packages/client/src/__tests__/install-locations.test.ts
+++ b/packages/client/src/__tests__/install-locations.test.ts
@@ -125,6 +125,102 @@ describe("versionManagerBinDirs protected-root vetting (macOS)", () => {
   });
 });
 
+// Vetting the directory a candidate came from is not enough, and neither is
+// trusting the source that produced it. The check has to happen on the complete
+// candidate, at the last moment before `stat` / `access` follows it.
+describe("executable candidates are vetted, whatever produced them (macOS)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(process, "platform", { value: "linux" });
+  });
+
+  function macRoot(): { root: string; home: string } {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-cand-")));
+    const home = join(root, "home");
+    mkdirSync(join(home, "Documents"), { recursive: true });
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    vi.stubEnv("HOME", home);
+    return { root, home };
+  }
+
+  function executable(path: string): string {
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, "#!/bin/sh\n");
+    chmodSync(path, 0o755);
+    return path;
+  }
+
+  it("rejects a well-known dir whose ancestor is symlinked into a protected folder", () => {
+    const { home } = macRoot();
+    // `~/.local` -> `~/Documents/hidden`, so `~/.local/bin/codex` resolves inside
+    // Documents even though the spelling of the well-known dir looks ordinary.
+    mkdirSync(join(home, "Documents", "hidden", "bin"), { recursive: true });
+    executable(join(home, "Documents", "hidden", "bin", "codex"));
+    symlinkSync(join(home, "Documents", "hidden"), join(home, ".local"));
+
+    expect(
+      findCodexExecutableOnPath(
+        { HOME: home, PATH: "" },
+        {
+          platform: "darwin",
+          pathDelimiter: ":",
+          loginShellPathDirs: () => [],
+          wellKnownDirs: () => [join(home, ".local", "bin")],
+          desktopAppDirs: () => [],
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects an executable that is itself a symlink into a protected folder", () => {
+    const { home } = macRoot();
+    // The directory is entirely ordinary; only the leaf points into Documents.
+    const safeBin = join(home, "tools", "bin");
+    mkdirSync(safeBin, { recursive: true });
+    executable(join(home, "Documents", "codex"));
+    symlinkSync(join(home, "Documents", "codex"), join(safeBin, "codex"));
+
+    expect(
+      findCodexExecutableOnPath(
+        { HOME: home, PATH: "" },
+        {
+          platform: "darwin",
+          pathDelimiter: ":",
+          loginShellPathDirs: () => [safeBin],
+          wellKnownDirs: () => [],
+          desktopAppDirs: () => [],
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("still resolves an ordinary executable, and one symlinked outside protected roots", () => {
+    const { root, home } = macRoot();
+    const plainBin = join(home, "tools", "bin");
+    const linkedBin = join(home, "linked", "bin");
+    mkdirSync(plainBin, { recursive: true });
+    mkdirSync(linkedBin, { recursive: true });
+    const real = executable(join(root, "elsewhere", "codex"));
+    symlinkSync(real, join(linkedBin, "codex"));
+    executable(join(plainBin, "codex"));
+
+    for (const dir of [plainBin, linkedBin]) {
+      expect(
+        findCodexExecutableOnPath(
+          { HOME: home, PATH: "" },
+          {
+            platform: "darwin",
+            pathDelimiter: ":",
+            loginShellPathDirs: () => [dir],
+            wellKnownDirs: () => [],
+            desktopAppDirs: () => [],
+          },
+        ),
+      ).toBe(join(dir, "codex"));
+    }
+  });
+});
+
 describe("version-manager discovery after a multishell teardown", () => {
   // The exact regression #1314 fixed, re-checked against the mechanism that
   // replaced it. fnm puts a per-session SYMLINK on `$PATH`; it is gone once the

--- a/packages/client/src/__tests__/install-locations.test.ts
+++ b/packages/client/src/__tests__/install-locations.test.ts
@@ -92,6 +92,34 @@ describe("versionManagerBinDirs", () => {
     ).toEqual([active]);
   });
 
+  // Both variables set says two managers initialised, not which one `$PATH`
+  // had put first — and that ordering is precisely what is gone. Neither form
+  // may quietly resolve to nvm just because it is cheaper to answer.
+  it("fails closed when the shell reported both managers", () => {
+    const home = "/home/u";
+    const nvmBin = join(home, ".nvm", "versions", "node", "v20.11.0", "bin");
+    const fnmVersions = join("/opt/fnm", "node-versions");
+
+    // …with an unambiguous fnm root.
+    expect(
+      versionManagerBinDirs(home, {
+        readDir: (path) => (path === fnmVersions ? ["v18.0.0"] : []),
+        active: { nvmBin, fnmDir: "/opt/fnm" },
+        env: {},
+      }),
+    ).toEqual([]);
+
+    // …and with an ambiguous one, where falling through to nvm would look
+    // harmless but is the same guess.
+    expect(
+      versionManagerBinDirs(home, {
+        readDir: (path) => (path === fnmVersions ? ["v18.0.0", "v22.2.0"] : []),
+        active: { nvmBin, fnmDir: "/opt/fnm" },
+        env: {},
+      }),
+    ).toEqual([]);
+  });
+
   it("returns nothing when no version manager is installed", () => {
     expect(
       versionManagerBinDirs("/home/u", {

--- a/packages/client/src/__tests__/install-locations.test.ts
+++ b/packages/client/src/__tests__/install-locations.test.ts
@@ -1,0 +1,109 @@
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { findCodexExecutableOnPath } from "../runtime/codex-binary.js";
+import { versionManagerBinDirs, wellKnownBinDirs } from "../runtime/install-locations.js";
+
+describe("versionManagerBinDirs", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("lists nvm and fnm version bins, newest version first", () => {
+    const home = "/home/u";
+    const readDir = (path: string): string[] => {
+      if (path === join(home, ".nvm", "versions", "node")) return ["v20.11.0", "v22.2.0", "v9.0.0"];
+      if (path === join(home, ".local", "share", "fnm", "node-versions")) return ["v18.0.0", "v22.2.0"];
+      throw new Error("ENOENT");
+    };
+
+    expect(versionManagerBinDirs(home, readDir)).toEqual([
+      // Numeric-aware, so v22 sorts above v9 rather than below it.
+      join(home, ".nvm", "versions", "node", "v22.2.0", "bin"),
+      join(home, ".nvm", "versions", "node", "v20.11.0", "bin"),
+      join(home, ".nvm", "versions", "node", "v9.0.0", "bin"),
+      join(home, ".local", "share", "fnm", "node-versions", "v22.2.0", "installation", "bin"),
+      join(home, ".local", "share", "fnm", "node-versions", "v18.0.0", "installation", "bin"),
+    ]);
+  });
+
+  it("covers the Homebrew and pre-XDG fnm layouts and honours $FNM_DIR", () => {
+    const home = "/home/u";
+    vi.stubEnv("FNM_DIR", "/opt/fnm");
+    const readDir = (path: string): string[] => {
+      if (path === join("/opt/fnm", "node-versions")) return ["v22.0.0"];
+      if (path === join(home, "Library", "Application Support", "fnm", "node-versions")) return ["v21.0.0"];
+      if (path === join(home, ".fnm", "node-versions")) return ["v20.0.0"];
+      throw new Error("ENOENT");
+    };
+
+    expect(versionManagerBinDirs(home, readDir)).toEqual([
+      join("/opt/fnm", "node-versions", "v22.0.0", "installation", "bin"),
+      join(home, "Library", "Application Support", "fnm", "node-versions", "v21.0.0", "installation", "bin"),
+      join(home, ".fnm", "node-versions", "v20.0.0", "installation", "bin"),
+    ]);
+  });
+
+  it("returns nothing when no version manager is installed", () => {
+    expect(
+      versionManagerBinDirs("/home/u", () => {
+        throw new Error("ENOENT");
+      }),
+    ).toEqual([]);
+  });
+
+  it("appends version dirs after every fixed location, leaving precedence intact", () => {
+    const home = "/home/u";
+    const fixed = wellKnownBinDirs(home, () => {
+      throw new Error("ENOENT");
+    });
+    const withVersions = wellKnownBinDirs(home, (path) =>
+      path === join(home, ".nvm", "versions", "node") ? ["v22.0.0"] : [],
+    );
+
+    expect(withVersions.slice(0, fixed.length)).toEqual(fixed);
+    expect(withVersions).toContain(join(home, ".nvm", "versions", "node", "v22.0.0", "bin"));
+  });
+});
+
+describe("version-manager discovery after a multishell teardown", () => {
+  // The exact regression #1314 fixed, re-checked against the mechanism that
+  // replaced it. fnm puts a per-session SYMLINK on `$PATH`; it is gone once the
+  // probe shell exits, so nothing can follow it afterwards. The binary itself
+  // never moved — it lives in the stable version dir — and that is what must
+  // keep the provider discoverable.
+  it("still finds a codex installed under fnm once the session symlink is gone", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-fnm-")));
+    const home = join(root, "home");
+    const installBin = join(home, ".local", "share", "fnm", "node-versions", "v22.2.0", "installation", "bin");
+    const multishell = join(root, "fnm_multishells", "4321_9");
+    mkdirSync(installBin, { recursive: true });
+    mkdirSync(join(root, "fnm_multishells"), { recursive: true });
+    const codex = join(installBin, "codex");
+    writeFileSync(codex, "#!/bin/sh\n");
+    chmodSync(codex, 0o755);
+    symlinkSync(installBin, multishell);
+
+    // The login-shell seam models the probe shell's lifetime: by the time it has
+    // answered, its per-session dir no longer exists.
+    const loginShellPathDirs = (): string[] => {
+      rmSync(multishell, { force: true });
+      return [multishell];
+    };
+
+    expect(
+      findCodexExecutableOnPath(
+        { HOME: home, PATH: "" },
+        {
+          platform: "linux",
+          pathDelimiter: ":",
+          loginShellPathDirs,
+          // Only the version dirs, so a real binary on this host's `/usr/local`
+          // or Homebrew path cannot answer for the mechanism under test. That
+          // `wellKnownBinDirs` appends these is covered above.
+          wellKnownDirs: () => versionManagerBinDirs(home),
+          desktopAppDirs: () => [],
+        },
+      ),
+    ).toBe(codex);
+  });
+});

--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -1,4 +1,7 @@
 import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildProbeScript,
@@ -8,6 +11,16 @@ import {
 } from "../runtime/login-shell-path.js";
 
 const DELIM = "__FT_SHELL_PATH__";
+
+/** Extract the delimited dir list from raw probe stdout. */
+function parseDirs(stdout: string): string[] {
+  const start = stdout.indexOf(DELIM);
+  const end = stdout.indexOf(DELIM, start + DELIM.length);
+  return stdout
+    .slice(start + DELIM.length, end)
+    .split("\n")
+    .filter((line) => line.length > 0);
+}
 
 /**
  * Simulate the probe stdout: the canonical dirs the login shell prints (one per
@@ -20,6 +33,7 @@ function wrap(dirs: string[]): string {
 describe("getLoginShellPathDirs", () => {
   afterEach(() => {
     resetLoginShellPathDirsCache();
+    vi.unstubAllEnvs();
     Object.defineProperty(process, "platform", { value: "linux" });
   });
 
@@ -119,6 +133,42 @@ describe("getLoginShellPathDirs", () => {
     expect(getLoginShellPathDirs(runShell)).toEqual([]);
     expect(runShell).not.toHaveBeenCalled();
   });
+
+  // A dir the shell canonicalized INTO a protected root (e.g. `~/bin` symlinked
+  // to `~/Documents/bin`) survives the script's `case` guard, so the parsed
+  // result is filtered too — otherwise each provider resolver would go on to
+  // `existsSync` inside Documents.
+  it("drops macOS TCC-protected dirs from a successful probe", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    vi.stubEnv("HOME", "/Users/tester");
+    const dirs = getLoginShellPathDirs(() =>
+      wrap([
+        "/opt/homebrew/bin",
+        "/Users/tester/Documents/bin",
+        "/Users/tester/Desktop",
+        "/Users/tester/Downloads/tools/bin",
+        "/Users/tester/Library/Mobile Documents/com~apple~CloudDocs/bin",
+        "/Users/tester/Library/CloudStorage/OneDrive/bin",
+        "/Users/tester/.nvm/versions/node/v22.0.0/bin",
+        // Not protected: a sibling whose name merely starts with a protected one.
+        "/Users/tester/Documents-archive/bin",
+      ]),
+    );
+    expect(dirs).toEqual([
+      "/opt/homebrew/bin",
+      "/Users/tester/.nvm/versions/node/v22.0.0/bin",
+      "/Users/tester/Documents-archive/bin",
+    ]);
+  });
+
+  it("keeps protected-looking dirs on non-macOS hosts", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    vi.stubEnv("HOME", "/home/tester");
+    expect(getLoginShellPathDirs(() => wrap(["/home/tester/Documents/bin", "/usr/local/bin"]))).toEqual([
+      "/home/tester/Documents/bin",
+      "/usr/local/bin",
+    ]);
+  });
 });
 
 /**
@@ -164,5 +214,54 @@ describe("probe script (real execution)", () => {
     const dirs = getLoginShellPathDirs();
     expect(Array.isArray(dirs)).toBe(true);
     for (const dir of dirs) expect(dir.startsWith("/")).toBe(true);
+  });
+
+  // The macOS guard must drop TCC-protected `$PATH` entries WITHOUT weakening
+  // the canonicalization the fnm / nvm multishell dirs depend on — that pairing
+  // is the whole point of the change, so it is asserted in one real shell run.
+  it.skipIf(process.platform === "win32")("skips macOS protected roots while still canonicalizing the rest", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-probe-")));
+    const home = join(root, "home");
+    const multishellTarget = join(root, "multishell-target", "bin");
+    const multishellLink = join(root, "multishell-link");
+    mkdirSync(join(home, "Documents", "bin"), { recursive: true });
+    mkdirSync(join(home, "Library", "Mobile Documents", "bin"), { recursive: true });
+    mkdirSync(join(root, "tools", "bin"), { recursive: true });
+    mkdirSync(multishellTarget, { recursive: true });
+    symlinkSync(multishellTarget, multishellLink);
+
+    const r = spawnSync("/bin/sh", ["-c", buildProbeScript("darwin")], {
+      encoding: "utf-8",
+      timeout: 4_000,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: [
+          join(home, "Documents", "bin"),
+          join(home, "Library", "Mobile Documents", "bin"),
+          join(root, "tools", "bin"),
+          multishellLink,
+        ].join(":"),
+      },
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.status).toBe(0);
+
+    const dirs = parseDirs(typeof r.stdout === "string" ? r.stdout : "");
+    // Protected roots never reached — not even a `cd`.
+    expect(dirs).not.toContain(join(home, "Documents", "bin"));
+    expect(dirs).not.toContain(join(home, "Library", "Mobile Documents", "bin"));
+    // Everything else keeps today's behavior, symlink canonicalization included.
+    expect(dirs).toContain(join(root, "tools", "bin"));
+    expect(dirs).toContain(multishellTarget);
+    expect(dirs).not.toContain(multishellLink);
+  });
+
+  it("emits the unguarded script on non-macOS platforms", () => {
+    const linux = buildProbeScript("linux");
+    expect(linux).not.toContain("case ");
+    expect(linux).not.toContain("$HOME");
+    expect(buildProbeScript("win32")).toBe(linux);
   });
 });

--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { join, sep } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildProbeScript,
   getLoginShellPathDirs,
@@ -31,6 +31,14 @@ function wrap(dirs: string[]): string {
 }
 
 describe("getLoginShellPathDirs", () => {
+  // Pin a non-macOS baseline so the parsing tests never depend on the host: on
+  // macOS the result goes through protected-root resolution, which follows real
+  // symlinks (`/home` is a firmlink there) and would rewrite synthetic paths.
+  // The macOS tests opt in explicitly.
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+  });
+
   afterEach(() => {
     resetLoginShellPathDirsCache();
     vi.unstubAllEnvs();
@@ -134,10 +142,6 @@ describe("getLoginShellPathDirs", () => {
     expect(runShell).not.toHaveBeenCalled();
   });
 
-  // A dir the shell canonicalized INTO a protected root (e.g. `~/bin` symlinked
-  // to `~/Documents/bin`) survives the script's `case` guard, so the parsed
-  // result is filtered too — otherwise each provider resolver would go on to
-  // `existsSync` inside Documents.
   it("drops macOS TCC-protected dirs from a successful probe", () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
     vi.stubEnv("HOME", "/Users/tester");
@@ -159,6 +163,43 @@ describe("getLoginShellPathDirs", () => {
       "/Users/tester/.nvm/versions/node/v22.0.0/bin",
       "/Users/tester/Documents-archive/bin",
     ]);
+  });
+
+  // The spelling of a `$PATH` entry says nothing about where it lands: `~/bin`
+  // can be a symlink to `~/Documents/bin`, and `~/deep/mid/bin` can reach the
+  // same place through a symlinked ANCESTOR. Resolution therefore has to reject
+  // these without entering them — `readlink` reads the link itself, `cd` /
+  // `realpath` / `existsSync` would already be the protected access.
+  it.skipIf(process.platform === "win32")("rejects symlinks into a protected root without entering them", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-symlink-")));
+    const home = join(root, "home");
+    mkdirSync(join(home, "Documents", "real", "bin"), { recursive: true });
+    mkdirSync(join(home, "deep"), { recursive: true });
+    mkdirSync(join(home, "safe", "bin"), { recursive: true });
+    // `~/bin` -> `~/Documents/real`, so `~/bin/bin` is a protected target.
+    symlinkSync(join(home, "Documents", "real"), join(home, "bin"));
+    // `~/deep/mid` -> `~/Documents`, so the protected root is an ANCESTOR.
+    symlinkSync(join(home, "Documents"), join(home, "deep", "mid"));
+    // A symlink that stays outside must still resolve, and to its target.
+    symlinkSync(join(home, "safe", "bin"), join(home, "safe-link"));
+
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    vi.stubEnv("HOME", home);
+    const dirs = getLoginShellPathDirs(() =>
+      wrap([join(home, "bin", "bin"), join(home, "deep", "mid", "real", "bin"), join(home, "safe-link")]),
+    );
+
+    expect(dirs).toEqual([join(home, "safe", "bin")]);
+  });
+
+  it.skipIf(process.platform === "win32")("does not loop forever on a symlink cycle", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-cycle-")));
+    symlinkSync(join(root, "b"), join(root, "a"));
+    symlinkSync(join(root, "a"), join(root, "b"));
+
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    vi.stubEnv("HOME", root);
+    expect(getLoginShellPathDirs(() => wrap([join(root, "a")]))).toEqual([]);
   });
 
   it("keeps protected-looking dirs on non-macOS hosts", () => {
@@ -216,20 +257,33 @@ describe("probe script (real execution)", () => {
     for (const dir of dirs) expect(dir.startsWith("/")).toBe(true);
   });
 
-  // The macOS guard must drop TCC-protected `$PATH` entries WITHOUT weakening
-  // the canonicalization the fnm / nvm multishell dirs depend on — that pairing
-  // is the whole point of the change, so it is asserted in one real shell run.
-  it.skipIf(process.platform === "win32")("skips macOS protected roots while still canonicalizing the rest", () => {
+  // End-to-end over the real shell AND the real parse: a `$PATH` whose entries
+  // reach a protected root by spelling, by symlinked entry, and by symlinked
+  // ANCESTOR must produce no protected dir — while the fnm / nvm multishell
+  // case (a symlink under a temp root) still gets canonicalized in-shell,
+  // because that symlink is gone by the time the parse runs.
+  it.skipIf(process.platform === "win32")("never yields a protected dir, however the entry reaches one", () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-probe-")));
     const home = join(root, "home");
-    const multishellTarget = join(root, "multishell-target", "bin");
-    const multishellLink = join(root, "multishell-link");
-    mkdirSync(join(home, "Documents", "bin"), { recursive: true });
-    mkdirSync(join(home, "Library", "Mobile Documents", "bin"), { recursive: true });
+    const multishellTarget = join(root, "fnm-install", "bin");
+    // The real fnm shape: a per-session symlink under a `fnm_multishells` dir.
+    const multishellLink = join(root, "fnm_multishells", "1234_567", "bin");
+    mkdirSync(join(home, "Documents", "real", "bin"), { recursive: true });
+    mkdirSync(join(home, "deep"), { recursive: true });
     mkdirSync(join(root, "tools", "bin"), { recursive: true });
     mkdirSync(multishellTarget, { recursive: true });
+    mkdirSync(join(root, "fnm_multishells", "1234_567"), { recursive: true });
+    // Lexically innocent, resolves into Documents: as the entry, and via ancestor.
+    symlinkSync(join(home, "Documents", "real"), join(home, "bin"));
+    symlinkSync(join(home, "Documents"), join(home, "deep", "mid"));
+    // The multishell shape: a symlink under a temp root, torn down with the shell.
     symlinkSync(multishellTarget, multishellLink);
 
+    const protectedEntries = [
+      join(home, "Documents", "bin"),
+      join(home, "bin", "bin"),
+      join(home, "deep", "mid", "real", "bin"),
+    ];
     const r = spawnSync("/bin/sh", ["-c", buildProbeScript("darwin")], {
       encoding: "utf-8",
       timeout: 4_000,
@@ -237,25 +291,28 @@ describe("probe script (real execution)", () => {
       env: {
         ...process.env,
         HOME: home,
-        PATH: [
-          join(home, "Documents", "bin"),
-          join(home, "Library", "Mobile Documents", "bin"),
-          join(root, "tools", "bin"),
-          multishellLink,
-        ].join(":"),
+        PATH: [...protectedEntries, join(root, "tools", "bin"), multishellLink].join(":"),
       },
     });
     expect(r.error).toBeUndefined();
     expect(r.status).toBe(0);
 
-    const dirs = parseDirs(typeof r.stdout === "string" ? r.stdout : "");
-    // Protected roots never reached — not even a `cd`.
-    expect(dirs).not.toContain(join(home, "Documents", "bin"));
-    expect(dirs).not.toContain(join(home, "Library", "Mobile Documents", "bin"));
-    // Everything else keeps today's behavior, symlink canonicalization included.
+    // The shell never entered any of them: had `cd` resolved one, its RESOLVED
+    // path would be here, and every resolved path passes through Documents.
+    const raw = parseDirs(typeof r.stdout === "string" ? r.stdout : "");
+    expect(raw.filter((dir) => dir.includes(`${sep}Documents${sep}`))).toEqual([]);
+    // The multishell entry is canonicalized while its symlink is still alive.
+    expect(raw).toContain(multishellTarget);
+    expect(raw).not.toContain(multishellLink);
+
+    // And the parse drops the ones the shell could only pass through verbatim.
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    vi.stubEnv("HOME", home);
+    const dirs = getLoginShellPathDirs(() => (typeof r.stdout === "string" ? r.stdout : null));
+    for (const entry of protectedEntries) expect(dirs).not.toContain(entry);
+    expect(dirs.filter((dir) => dir.includes(`${sep}Documents${sep}`))).toEqual([]);
     expect(dirs).toContain(join(root, "tools", "bin"));
     expect(dirs).toContain(multishellTarget);
-    expect(dirs).not.toContain(multishellLink);
   });
 
   it("emits the unguarded script on non-macOS platforms", () => {

--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -254,6 +254,37 @@ describe("getLoginShellPathDirs", () => {
     expect(getLoginShellPathDirs(() => wrap([join(root, "a")]))).toEqual([]);
   });
 
+  // The teardown case as it actually happens on macOS: the shell emits the raw
+  // multishell path, the link is gone by the time resolution runs, and the
+  // custom `$FNM_DIR` that produced it exists ONLY in the login shell — the
+  // daemon's own environment never saw `fnm env` run. Both the active selection
+  // and the custom root have to survive the shell for the provider to be found.
+  it.skipIf(process.platform === "win32")("recovers a shell-only FNM_DIR after the multishell link is gone", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-shellenv-")));
+    const home = join(root, "home");
+    const fnmDir = join(root, "custom-fnm");
+    const activeBin = join(fnmDir, "node-versions", "v20.11.0", "installation", "bin");
+    const newerBin = join(fnmDir, "node-versions", "v22.2.0", "installation", "bin");
+    const multishell = join(root, "fnm_multishells", "77_1", "bin");
+    mkdirSync(activeBin, { recursive: true });
+    mkdirSync(newerBin, { recursive: true });
+    mkdirSync(home, { recursive: true });
+
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    vi.stubEnv("HOME", home);
+    // The daemon environment has no FNM_DIR at all — only the shell reports it.
+    vi.stubEnv("FNM_DIR", "");
+
+    const dirs = getLoginShellPathDirs(
+      () => `${DELIM}${multishell}${DELIM}${"__FT_SHELL_ENV__"}${fnmDir}\n${"__FT_SHELL_ENV__"}`,
+    );
+
+    // The dead per-session entry is kept lexically (it simply fails later
+    // existence checks), and the custom root's versions follow it.
+    expect(dirs).toContain(newerBin);
+    expect(dirs).toContain(activeBin);
+  });
+
   it("keeps protected-looking dirs on non-macOS hosts", () => {
     Object.defineProperty(process, "platform", { value: "linux" });
     vi.stubEnv("HOME", "/home/tester");

--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -263,11 +263,9 @@ describe("getLoginShellPathDirs", () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-shellenv-")));
     const home = join(root, "home");
     const fnmDir = join(root, "custom-fnm");
-    const activeBin = join(fnmDir, "node-versions", "v20.11.0", "installation", "bin");
-    const newerBin = join(fnmDir, "node-versions", "v22.2.0", "installation", "bin");
+    const onlyBin = join(fnmDir, "node-versions", "v20.11.0", "installation", "bin");
     const multishell = join(root, "fnm_multishells", "77_1", "bin");
-    mkdirSync(activeBin, { recursive: true });
-    mkdirSync(newerBin, { recursive: true });
+    mkdirSync(onlyBin, { recursive: true });
     mkdirSync(home, { recursive: true });
 
     Object.defineProperty(process, "platform", { value: "darwin" });
@@ -280,9 +278,9 @@ describe("getLoginShellPathDirs", () => {
     );
 
     // The dead per-session entry is kept lexically (it simply fails later
-    // existence checks), and the custom root's versions follow it.
-    expect(dirs).toContain(newerBin);
-    expect(dirs).toContain(activeBin);
+    // existence checks), and the custom root — visible only because the shell
+    // reported it — follows.
+    expect(dirs).toContain(onlyBin);
   });
 
   it("keeps protected-looking dirs on non-macOS hosts", () => {

--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -366,6 +366,35 @@ describe("probe script (real execution)", () => {
     expect(dirs).toEqual([join(root, "tools", "bin"), safeTarget]);
   });
 
+  // Unquoted `$PATH` also undergoes PATHNAME expansion, so a wildcard entry
+  // makes the shell enumerate that directory — a protected-folder read, and one
+  // that leaks its entry names into the result — with no `cd` in sight. Both
+  // platforms split the same way, so both are covered.
+  it.skipIf(process.platform === "win32").each(["darwin", "linux"] as const)(
+    "echoes a wildcard PATH entry literally instead of expanding it (%s)",
+    (platform) => {
+      const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-glob-")));
+      mkdirSync(join(root, "Documents", "secret-a"), { recursive: true });
+      mkdirSync(join(root, "Documents", "secret-b"), { recursive: true });
+      const wildcard = join(root, "Documents", "*");
+
+      const r = spawnSync("/bin/sh", ["-c", buildProbeScript(platform)], {
+        encoding: "utf-8",
+        timeout: 4_000,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env, PATH: wildcard },
+      });
+      expect(r.error).toBeUndefined();
+
+      const raw = parseDirs(typeof r.stdout === "string" ? r.stdout : "");
+      expect(raw).not.toContain(join(root, "Documents", "secret-a"));
+      expect(raw).not.toContain(join(root, "Documents", "secret-b"));
+      // On darwin the literal entry is echoed; on linux `cd` fails on it and
+      // drops it. Either way the directory is never enumerated.
+      expect(raw).toEqual(platform === "darwin" ? [wildcard] : []);
+    },
+  );
+
   it("emits a script with no filesystem access on macOS", () => {
     const darwin = buildProbeScript("darwin");
     expect(darwin).not.toContain("cd ");

--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readlinkSync, realpathSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, sep } from "node:path";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildProbeScript,
@@ -192,6 +192,58 @@ describe("getLoginShellPathDirs", () => {
     expect(dirs).toEqual([join(home, "safe", "bin")]);
   });
 
+  // The macOS filesystem is case-insensitive by default, so `~/documents/bin`
+  // IS `~/Documents/bin`. A case-sensitive guard would wave it through and the
+  // walk would go on to read the protected path.
+  it("matches protected roots regardless of case", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    vi.stubEnv("HOME", "/Users/tester");
+    expect(
+      getLoginShellPathDirs(() =>
+        wrap([
+          "/Users/tester/documents/bin",
+          "/Users/tester/DOWNLOADS/bin",
+          "/Users/tester/Library/mobile documents/bin",
+          "/opt/homebrew/bin",
+        ]),
+      ),
+    ).toEqual(["/opt/homebrew/bin"]);
+  });
+
+  // The ordering guarantee — check a component against the protected roots
+  // BEFORE touching it — is what makes the whole thing work, so assert it
+  // directly on the only syscall resolution is allowed to make.
+  it.skipIf(process.platform === "win32")("never passes a protected path to readlink", () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-touch-")));
+    const home = join(root, "home");
+    mkdirSync(join(home, "Documents", "real", "bin"), { recursive: true });
+    mkdirSync(join(home, "deep"), { recursive: true });
+    symlinkSync(join(home, "Documents", "real"), join(home, "bin"));
+    symlinkSync(join(home, "Documents"), join(home, "deep", "mid"));
+
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    vi.stubEnv("HOME", home);
+    const touched: string[] = [];
+    const readLink = (path: string): string => {
+      touched.push(path);
+      return readlinkSync(path);
+    };
+
+    getLoginShellPathDirs(
+      () =>
+        wrap([
+          join(home, "Documents", "bin"),
+          join(home, "documents", "bin"),
+          join(home, "bin", "bin"),
+          join(home, "deep", "mid", "real", "bin"),
+        ]),
+      readLink,
+    );
+
+    expect(touched.length).toBeGreaterThan(0);
+    expect(touched.filter((path) => path.toLowerCase().startsWith(join(home, "documents")))).toEqual([]);
+  });
+
   it.skipIf(process.platform === "win32")("does not loop forever on a symlink cycle", () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-cycle-")));
     symlinkSync(join(root, "b"), join(root, "a"));
@@ -257,32 +309,35 @@ describe("probe script (real execution)", () => {
     for (const dir of dirs) expect(dir.startsWith("/")).toBe(true);
   });
 
-  // End-to-end over the real shell AND the real parse: a `$PATH` whose entries
-  // reach a protected root by spelling, by symlinked entry, and by symlinked
-  // ANCESTOR must produce no protected dir — while the fnm / nvm multishell
-  // case (a symlink under a temp root) still gets canonicalized in-shell,
-  // because that symlink is gone by the time the parse runs.
+  // End-to-end over the real shell AND the real parse. A `$PATH` entry can reach
+  // a protected root four ways — by spelling, as a symlink, through a symlinked
+  // ANCESTOR, and while wearing a spelling an earlier revision trusted (the fnm
+  // multishell name) — and none of them may be entered or returned.
   it.skipIf(process.platform === "win32")("never yields a protected dir, however the entry reaches one", () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-probe-")));
     const home = join(root, "home");
-    const multishellTarget = join(root, "fnm-install", "bin");
-    // The real fnm shape: a per-session symlink under a `fnm_multishells` dir.
-    const multishellLink = join(root, "fnm_multishells", "1234_567", "bin");
+    const safeTarget = join(root, "fnm-install", "bin");
+    // A link carrying the fnm multishell NAME but pointing at Documents — the
+    // spelling that an earlier revision treated as inherently safe.
+    const multishellIntoProtected = join(root, "fnm_multishells", "9999_000", "bin");
+    const multishellSafe = join(root, "fnm_multishells", "1234_567", "bin");
     mkdirSync(join(home, "Documents", "real", "bin"), { recursive: true });
     mkdirSync(join(home, "deep"), { recursive: true });
     mkdirSync(join(root, "tools", "bin"), { recursive: true });
-    mkdirSync(multishellTarget, { recursive: true });
+    mkdirSync(safeTarget, { recursive: true });
     mkdirSync(join(root, "fnm_multishells", "1234_567"), { recursive: true });
+    mkdirSync(join(root, "fnm_multishells", "9999_000"), { recursive: true });
     // Lexically innocent, resolves into Documents: as the entry, and via ancestor.
     symlinkSync(join(home, "Documents", "real"), join(home, "bin"));
     symlinkSync(join(home, "Documents"), join(home, "deep", "mid"));
-    // The multishell shape: a symlink under a temp root, torn down with the shell.
-    symlinkSync(multishellTarget, multishellLink);
+    symlinkSync(join(home, "Documents", "real", "bin"), multishellIntoProtected);
+    symlinkSync(safeTarget, multishellSafe);
 
-    const protectedEntries = [
+    const mustNotLeak = [
       join(home, "Documents", "bin"),
       join(home, "bin", "bin"),
       join(home, "deep", "mid", "real", "bin"),
+      multishellIntoProtected,
     ];
     const r = spawnSync("/bin/sh", ["-c", buildProbeScript("darwin")], {
       encoding: "utf-8",
@@ -291,34 +346,36 @@ describe("probe script (real execution)", () => {
       env: {
         ...process.env,
         HOME: home,
-        PATH: [...protectedEntries, join(root, "tools", "bin"), multishellLink].join(":"),
+        PATH: [...mustNotLeak, join(root, "tools", "bin"), multishellSafe].join(":"),
       },
     });
     expect(r.error).toBeUndefined();
     expect(r.status).toBe(0);
 
-    // The shell never entered any of them: had `cd` resolved one, its RESOLVED
-    // path would be here, and every resolved path passes through Documents.
+    // The shell resolved nothing. Byte-identical echo is the proof: four of
+    // these entries are symlinks whose resolved spelling differs from what was
+    // written, so any `cd` — and therefore any traversal into the protected
+    // target — would show up as a changed line here.
     const raw = parseDirs(typeof r.stdout === "string" ? r.stdout : "");
-    expect(raw.filter((dir) => dir.includes(`${sep}Documents${sep}`))).toEqual([]);
-    // The multishell entry is canonicalized while its symlink is still alive.
-    expect(raw).toContain(multishellTarget);
-    expect(raw).not.toContain(multishellLink);
+    expect(raw).toEqual([...mustNotLeak, join(root, "tools", "bin"), multishellSafe]);
 
-    // And the parse drops the ones the shell could only pass through verbatim.
+    // The parse then drops every route into a protected root and resolves the rest.
     Object.defineProperty(process, "platform", { value: "darwin" });
     vi.stubEnv("HOME", home);
     const dirs = getLoginShellPathDirs(() => (typeof r.stdout === "string" ? r.stdout : null));
-    for (const entry of protectedEntries) expect(dirs).not.toContain(entry);
-    expect(dirs.filter((dir) => dir.includes(`${sep}Documents${sep}`))).toEqual([]);
-    expect(dirs).toContain(join(root, "tools", "bin"));
-    expect(dirs).toContain(multishellTarget);
+    expect(dirs).toEqual([join(root, "tools", "bin"), safeTarget]);
   });
 
-  it("emits the unguarded script on non-macOS platforms", () => {
+  it("emits a script with no filesystem access on macOS", () => {
+    const darwin = buildProbeScript("darwin");
+    expect(darwin).not.toContain("cd ");
+    expect(darwin).not.toContain("pwd");
+    expect(darwin).not.toContain("readlink");
+  });
+
+  it("keeps the shell canonicalization on non-macOS platforms", () => {
     const linux = buildProbeScript("linux");
-    expect(linux).not.toContain("case ");
-    expect(linux).not.toContain("$HOME");
+    expect(linux).toContain('(cd "$d" 2>/dev/null && pwd -P)');
     expect(buildProbeScript("win32")).toBe(linux);
   });
 });

--- a/packages/client/src/handlers/claude-executable.ts
+++ b/packages/client/src/handlers/claude-executable.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { delimiter, join } from "node:path";
 import { wellKnownBinDirs } from "../runtime/install-locations.js";
 import { getLoginShellPathDirs } from "../runtime/login-shell-path.js";
+import { automaticCandidateAllowed } from "../runtime/protected-paths.js";
 
 /**
  * A resolved `claude` candidate is usable only if it is a regular file that is
@@ -10,8 +11,14 @@ import { getLoginShellPathDirs } from "../runtime/login-shell-path.js";
  * non-executable shim, which would yield a false `ok` the runtime then can't
  * spawn (mirrors codex's executability gate, plus a regular-file check so a
  * directory entry named `claude` doesn't pass via the dir search bit).
+ *
+ * Automatic candidates are vetted first: `statSync` follows a symlink, so a
+ * `claude` that points into a TCC-protected folder would be read there before
+ * anything could reject it, no matter how safe the directory it sat in looked.
+ * Pass `automatic: false` only for a path the operator named explicitly.
  */
-export function isExecutableFile(filePath: string): boolean {
+export function isExecutableFile(filePath: string, options: { automatic?: boolean } = {}): boolean {
+  if (options.automatic !== false && !automaticCandidateAllowed(filePath)) return false;
   try {
     if (!statSync(filePath).isFile()) return false;
     accessSync(filePath, process.platform === "win32" ? constants.F_OK : constants.X_OK);
@@ -110,7 +117,7 @@ export function resolveClaudeCodeExecutable(
   const override = env.CLAUDE_CODE_EXECUTABLE;
   let overrideError: string | undefined;
   if (override && override.length > 0) {
-    if (isExecutableFile(override)) return { path: override, source: "env" };
+    if (isExecutableFile(override, { automatic: false })) return { path: override, source: "env" };
     overrideError = `CLAUDE_CODE_EXECUTABLE is set to "${override}" but is not an executable file; searching PATH and well-known install dirs instead`;
   }
 

--- a/packages/client/src/runtime/codex-binary.ts
+++ b/packages/client/src/runtime/codex-binary.ts
@@ -6,6 +6,7 @@ import { delimiter, dirname, extname, isAbsolute, join, resolve } from "node:pat
 import { runtimeProviderInstallCommand, runtimeProviderLoginCommand } from "@first-tree/shared";
 import { codexDesktopAppBinDirs, wellKnownBinDirs } from "./install-locations.js";
 import { getLoginShellPathDirs } from "./login-shell-path.js";
+import { automaticCandidateAllowed } from "./protected-paths.js";
 
 export type CodexRuntimeSource = "bundled" | "path";
 
@@ -352,6 +353,10 @@ function resolveWindowsNativeCodexFromNpmShim(
 }
 
 function isExecutable(filePath: string): boolean {
+  // Vet the complete candidate before `access` follows it — the directory it
+  // came from having been vetted says nothing about the leaf, which can itself
+  // be a symlink into a protected folder. See `automaticCandidateAllowed`.
+  if (!automaticCandidateAllowed(filePath)) return false;
   try {
     accessSync(filePath, process.platform === "win32" ? constants.F_OK : constants.X_OK);
     return true;
@@ -361,6 +366,7 @@ function isExecutable(filePath: string): boolean {
 }
 
 function fileExists(filePath: string): boolean {
+  if (!automaticCandidateAllowed(filePath)) return false;
   try {
     accessSync(filePath, constants.F_OK);
     return true;

--- a/packages/client/src/runtime/cursor-binary.ts
+++ b/packages/client/src/runtime/cursor-binary.ts
@@ -5,6 +5,7 @@ import { delimiter, isAbsolute, join, resolve } from "node:path";
 import { CURSOR_INSTALL_COMMAND, runtimeProviderLoginCommand } from "@first-tree/shared";
 import { wellKnownBinDirs } from "./install-locations.js";
 import { getLoginShellPathDirs } from "./login-shell-path.js";
+import { automaticCandidateAllowed } from "./protected-paths.js";
 
 /**
  * Cursor Agent CLI binary resolution. Cursor is EXTERNAL-ONLY: First Tree never
@@ -261,6 +262,10 @@ function cursorExecutableNames(platform: NodeJS.Platform): string[] {
 }
 
 function isExecutableFile(filePath: string, platform: NodeJS.Platform): boolean {
+  // Every automatic source funnels through here, so this is the one place a
+  // candidate can be vetted before `stat` / `access` follows it into a
+  // TCC-protected folder. See `automaticCandidateAllowed`.
+  if (!automaticCandidateAllowed(filePath)) return false;
   try {
     if (!statSync(filePath).isFile()) return false;
     accessSync(filePath, platform === "win32" ? constants.F_OK : constants.X_OK);

--- a/packages/client/src/runtime/grok-binary.ts
+++ b/packages/client/src/runtime/grok-binary.ts
@@ -5,6 +5,7 @@ import { delimiter, isAbsolute, join, resolve } from "node:path";
 import { GROK_INSTALL_COMMAND, runtimeProviderLoginCommand } from "@first-tree/shared";
 import { wellKnownBinDirs } from "./install-locations.js";
 import { getLoginShellPathDirs } from "./login-shell-path.js";
+import { automaticCandidateAllowed } from "./protected-paths.js";
 
 /**
  * Grok Build CLI binary resolution. Grok Build is EXTERNAL-ONLY: First Tree
@@ -317,6 +318,10 @@ function grokExecutableName(platform: NodeJS.Platform): string {
 }
 
 function isExecutableFile(filePath: string, platform: NodeJS.Platform): boolean {
+  // Every automatic source funnels through here, so this is the one place a
+  // candidate can be vetted before `stat` / `access` follows it into a
+  // TCC-protected folder. See `automaticCandidateAllowed`.
+  if (!automaticCandidateAllowed(filePath)) return false;
   try {
     if (!statSync(filePath).isFile()) return false;
     accessSync(filePath, platform === "win32" ? constants.F_OK : constants.X_OK);

--- a/packages/client/src/runtime/install-locations.ts
+++ b/packages/client/src/runtime/install-locations.ts
@@ -1,4 +1,60 @@
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
+
+/** Injectable directory listing so tests need no real version-manager install. */
+export type ReadDirNames = (path: string) => string[];
+
+function listNames(path: string, readDir: ReadDirNames): string[] {
+  try {
+    return readDir(path);
+  } catch {
+    // No such version manager on this host, or the root is unreadable.
+    return [];
+  }
+}
+
+/** Newest-looking version first, so the chosen dir is stable across runs. */
+const VERSION_COLLATOR = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
+
+/**
+ * `bin` dirs of every Node version installed by nvm or fnm.
+ *
+ * These are the STABLE homes of a `claude` / `codex` installed under a Node
+ * version manager. The per-session dir such a shell actually puts on `$PATH`
+ * (`fnm_multishells/<pid>_<ts>/bin`) is a symlink that disappears with the
+ * shell, so it cannot be searched later — but its target lives here and does
+ * not move. Enumerating these keeps version-manager installs discoverable
+ * without following anything the user may have pointed somewhere unexpected.
+ *
+ * Every root read here belongs to the version manager itself, never to a
+ * macOS TCC-protected folder, so this is safe to run during automatic probing.
+ */
+export function versionManagerBinDirs(home: string, readDir: ReadDirNames = readdirSync): string[] {
+  const nvm = listNames(join(home, ".nvm", "versions", "node"), readDir)
+    .sort((a, b) => VERSION_COLLATOR.compare(b, a))
+    .map((version) => join(home, ".nvm", "versions", "node", version, "bin"));
+
+  // fnm's data dir varies by installer: XDG default, Homebrew on macOS, and the
+  // pre-XDG layout. `$FNM_DIR` wins when the operator set one.
+  const fnmRoots = [
+    process.env.FNM_DIR,
+    join(home, ".local", "share", "fnm"),
+    join(home, "Library", "Application Support", "fnm"),
+    join(home, ".fnm"),
+  ].filter((root): root is string => typeof root === "string" && root.length > 0);
+
+  const seen = new Set<string>();
+  const fnm = fnmRoots.flatMap((root) => {
+    if (seen.has(root)) return [];
+    seen.add(root);
+    const versionsRoot = join(root, "node-versions");
+    return listNames(versionsRoot, readDir)
+      .sort((a, b) => VERSION_COLLATOR.compare(b, a))
+      .map((version) => join(versionsRoot, version, "installation", "bin"));
+  });
+
+  return [...nvm, ...fnm];
+}
 
 /**
  * Curated, stable install directories where a globally-installed `claude` /
@@ -10,8 +66,12 @@ import { join } from "node:path";
  * Covers node-version-manager shims, global-npm prefixes, and the pnpm / bun
  * global bins. macOS-only Homebrew / pnpm dirs are gated on `darwin`. Returns
  * absolute dir paths (binary name is appended by the caller, per provider).
+ *
+ * The nvm / fnm version dirs come LAST, after every fixed location, so they
+ * only decide the outcome when nothing else matched and the existing precedence
+ * is untouched.
  */
-export function wellKnownBinDirs(home: string): string[] {
+export function wellKnownBinDirs(home: string, readDir?: ReadDirNames): string[] {
   const isMac = process.platform === "darwin";
   const dirs = [
     join(home, ".local", "bin"), // official native installer default
@@ -25,6 +85,7 @@ export function wellKnownBinDirs(home: string): string[] {
     join(home, ".bun", "bin"), // bun global
     ...(isMac ? ["/opt/homebrew/bin"] : []), // Apple-silicon Homebrew
     "/usr/local/bin", // Intel Homebrew / common manual installs
+    ...versionManagerBinDirs(home, readDir),
   ];
   return dirs;
 }

--- a/packages/client/src/runtime/install-locations.ts
+++ b/packages/client/src/runtime/install-locations.ts
@@ -34,53 +34,68 @@ export function wellKnownBinDirs(home: string): string[] {
   return dirs;
 }
 
+/**
+ * What the login shell reported about the version manager it had active.
+ * `nvmBin` names the selected version outright; `fnmDir` names only the root it
+ * was selected from, leaving the version still to be determined.
+ */
+export type ActiveVersionManager = { fnmDir?: string; nvmBin?: string };
+
 /** Injectable seams so tests need neither a real install nor a real filesystem. */
 export type VersionManagerDirDeps = {
+  active?: ActiveVersionManager;
   readDir?: ReadDirNames;
   readLink?: ReadLink;
   env?: NodeJS.ProcessEnv;
 };
 
 /**
- * `bin` dir of the **unambiguously** installed Node version under nvm or fnm.
+ * The `bin` dir to fall back to when a version manager's per-session `$PATH`
+ * entry is gone, or nothing when the selected version cannot be established.
  *
- * This is the STABLE home of a `claude` / `codex` installed under a Node version
- * manager. The dir such a shell actually puts on `$PATH`
- * (`fnm_multishells/<pid>_<ts>/bin`) is a per-session symlink that disappears
- * with the shell, so it cannot be searched afterwards — but its target lives
- * here and does not move.
+ * The dir such a shell puts on `$PATH` (`fnm_multishells/<pid>_<ts>/bin`) is a
+ * symlink that disappears with the shell, so it cannot be searched afterwards.
+ * The binary itself lives in a stable version dir that does not move — the
+ * problem is knowing WHICH one the shell had selected.
+ *
+ * The answer must never be a guess. Resolving a version the user did not select
+ * silently swaps the executable and its context, which is worse than reporting
+ * the provider as not found, so the decision is made across the complete state
+ * rather than per root:
+ *
+ *   - The login shell reported something. Only that is used. `$NVM_BIN` names
+ *     the selected version outright and is authoritative, replacing any nvm
+ *     enumeration. `$FNM_DIR` names only the active root, so that root — and no
+ *     other — is consulted, and it answers only if it holds exactly one version.
+ *     Default roots are not scanned at all: if we know which manager is active
+ *     and it cannot answer, an unrelated installation is not a better answer.
+ *   - The login shell reported nothing. The default roots are scanned and the
+ *     result is used only when there is exactly ONE safe candidate in total.
+ *     Two single-version roots are just as ambiguous as one two-version root.
  *
  * It is a FALLBACK, not a preference: callers search it only after the
  * login-shell dirs, so a live selection always wins.
  *
- * **A root with more than one installed version contributes nothing.** Which one
- * the shell selected is not recoverable from disk, and answering with the newest
- * would silently run a different version than the user pinned — a quiet swap of
- * the executable and its context, which is worse than reporting the provider as
- * not found. nvm avoids the ambiguity entirely by exporting `$NVM_BIN` (handled
- * by the caller); fnm exports no equivalent, so a multi-version fnm root fails
- * closed.
- *
- * Every root and every returned dir is vetted with
- * {@link resolveOutsideProtectedRootsOnThisHost} BEFORE it is listed or handed
- * back. Nothing here is trusted for being spelled like a version manager:
- * `$FNM_DIR` is user-controlled, and `~/.nvm`, a fnm data dir, or a single
- * version entry can each be a symlink — or sit under one — pointing into a
- * protected folder.
+ * Every root is vetted with {@link resolveOutsideProtectedRootsOnThisHost}
+ * before it is listed, and every candidate before it is returned. Nothing is
+ * trusted for being spelled like a version manager: `$FNM_DIR` is
+ * user-controlled, and `~/.nvm`, a fnm data dir, or a single version entry can
+ * each be a symlink — or sit under one — pointing into a protected folder.
  */
 export function versionManagerBinDirs(home: string, deps: VersionManagerDirDeps = {}): string[] {
   const readDir = deps.readDir ?? readdirSync;
   const readLink = deps.readLink;
   const env = deps.env ?? process.env;
+  const active = deps.active ?? {};
 
   const safe = (path: string): string | null => resolveOutsideProtectedRootsOnThisHost(path, readLink);
 
   /**
    * The single installed version under `root`, or nothing when the root is
-   * unsafe, absent, empty, or ambiguous. Listing happens only after the root
-   * itself is known to be safe.
+   * unsafe, absent, empty, or holds more than one. Listing happens only after
+   * the root itself is known to be safe.
    */
-  const versionsUnder = (root: string): Array<{ version: string; root: string }> => {
+  const soleVersionUnder = (root: string, layout: (versionsRoot: string, version: string) => string): string[] => {
     const vetted = safe(root);
     if (vetted === null) return [];
     let entries: string[];
@@ -92,35 +107,50 @@ export function versionManagerBinDirs(home: string, deps: VersionManagerDirDeps 
     }
     const [only] = entries;
     if (entries.length !== 1 || only === undefined) return [];
-    return [{ version: only, root: vetted }];
+    return [layout(vetted, only)];
   };
 
-  const nvm = versionsUnder(join(home, ".nvm", "versions", "node")).map(({ version, root }) =>
-    join(root, version, "bin"),
-  );
+  const nvmLayout = (versionsRoot: string, version: string): string => join(versionsRoot, version, "bin");
+  const fnmLayout = (versionsRoot: string, version: string): string =>
+    join(versionsRoot, version, "installation", "bin");
+
+  if (active.nvmBin !== undefined || active.fnmDir !== undefined) {
+    const fromActive = [
+      ...(active.nvmBin !== undefined ? [active.nvmBin] : []),
+      ...(active.fnmDir !== undefined ? soleVersionUnder(join(active.fnmDir, "node-versions"), fnmLayout) : []),
+    ];
+    return fromActive.map(safe).filter((dir): dir is string => dir !== null);
+  }
 
   // fnm's data dir varies by installer: XDG default, Homebrew on macOS, and the
-  // pre-XDG layout. `$FNM_DIR` wins when the operator set one — and is exactly
-  // why the vetting above is not optional.
-  const fnmRoots = [
-    env.FNM_DIR,
-    join(home, ".local", "share", "fnm"),
-    join(home, "Library", "Application Support", "fnm"),
-    join(home, ".fnm"),
-  ].filter((root): root is string => typeof root === "string" && root.length > 0);
+  // pre-XDG layout. `$FNM_DIR` from the daemon's own environment is included for
+  // a host that exports it outside the login shell.
+  const defaultRoots: Array<[string, (versionsRoot: string, version: string) => string]> = [
+    [join(home, ".nvm", "versions", "node"), nvmLayout],
+    ...[
+      env.FNM_DIR,
+      join(home, ".local", "share", "fnm"),
+      join(home, "Library", "Application Support", "fnm"),
+      join(home, ".fnm"),
+    ]
+      .filter((root): root is string => typeof root === "string" && root.length > 0)
+      .map((root): [string, (versionsRoot: string, version: string) => string] => [
+        join(root, "node-versions"),
+        fnmLayout,
+      ]),
+  ];
 
   const seen = new Set<string>();
-  const fnm = fnmRoots.flatMap((root) => {
+  const candidates = defaultRoots.flatMap(([root, layout]) => {
     if (seen.has(root)) return [];
     seen.add(root);
-    return versionsUnder(join(root, "node-versions")).map(({ version, root: versionsRoot }) =>
-      join(versionsRoot, version, "installation", "bin"),
-    );
+    return soleVersionUnder(root, layout);
   });
 
-  // A vetted root can still hold a version entry that is itself a symlink into a
-  // protected folder, so re-vet each candidate before returning it.
-  return [...nvm, ...fnm].map(safe).filter((dir): dir is string => dir !== null);
+  const vetted = candidates.map(safe).filter((dir): dir is string => dir !== null);
+  // Globally ambiguous: two roots each holding one version say no more about the
+  // user's selection than one root holding two.
+  return vetted.length === 1 ? vetted : [];
 }
 
 /**

--- a/packages/client/src/runtime/install-locations.ts
+++ b/packages/client/src/runtime/install-locations.ts
@@ -1,60 +1,9 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
+import { type ReadLink, resolveOutsideProtectedRootsOnThisHost } from "./protected-paths.js";
 
 /** Injectable directory listing so tests need no real version-manager install. */
 export type ReadDirNames = (path: string) => string[];
-
-function listNames(path: string, readDir: ReadDirNames): string[] {
-  try {
-    return readDir(path);
-  } catch {
-    // No such version manager on this host, or the root is unreadable.
-    return [];
-  }
-}
-
-/** Newest-looking version first, so the chosen dir is stable across runs. */
-const VERSION_COLLATOR = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
-
-/**
- * `bin` dirs of every Node version installed by nvm or fnm.
- *
- * These are the STABLE homes of a `claude` / `codex` installed under a Node
- * version manager. The per-session dir such a shell actually puts on `$PATH`
- * (`fnm_multishells/<pid>_<ts>/bin`) is a symlink that disappears with the
- * shell, so it cannot be searched later — but its target lives here and does
- * not move. Enumerating these keeps version-manager installs discoverable
- * without following anything the user may have pointed somewhere unexpected.
- *
- * Every root read here belongs to the version manager itself, never to a
- * macOS TCC-protected folder, so this is safe to run during automatic probing.
- */
-export function versionManagerBinDirs(home: string, readDir: ReadDirNames = readdirSync): string[] {
-  const nvm = listNames(join(home, ".nvm", "versions", "node"), readDir)
-    .sort((a, b) => VERSION_COLLATOR.compare(b, a))
-    .map((version) => join(home, ".nvm", "versions", "node", version, "bin"));
-
-  // fnm's data dir varies by installer: XDG default, Homebrew on macOS, and the
-  // pre-XDG layout. `$FNM_DIR` wins when the operator set one.
-  const fnmRoots = [
-    process.env.FNM_DIR,
-    join(home, ".local", "share", "fnm"),
-    join(home, "Library", "Application Support", "fnm"),
-    join(home, ".fnm"),
-  ].filter((root): root is string => typeof root === "string" && root.length > 0);
-
-  const seen = new Set<string>();
-  const fnm = fnmRoots.flatMap((root) => {
-    if (seen.has(root)) return [];
-    seen.add(root);
-    const versionsRoot = join(root, "node-versions");
-    return listNames(versionsRoot, readDir)
-      .sort((a, b) => VERSION_COLLATOR.compare(b, a))
-      .map((version) => join(versionsRoot, version, "installation", "bin"));
-  });
-
-  return [...nvm, ...fnm];
-}
 
 /**
  * Curated, stable install directories where a globally-installed `claude` /
@@ -66,12 +15,8 @@ export function versionManagerBinDirs(home: string, readDir: ReadDirNames = read
  * Covers node-version-manager shims, global-npm prefixes, and the pnpm / bun
  * global bins. macOS-only Homebrew / pnpm dirs are gated on `darwin`. Returns
  * absolute dir paths (binary name is appended by the caller, per provider).
- *
- * The nvm / fnm version dirs come LAST, after every fixed location, so they
- * only decide the outcome when nothing else matched and the existing precedence
- * is untouched.
  */
-export function wellKnownBinDirs(home: string, readDir?: ReadDirNames): string[] {
+export function wellKnownBinDirs(home: string): string[] {
   const isMac = process.platform === "darwin";
   const dirs = [
     join(home, ".local", "bin"), // official native installer default
@@ -85,10 +30,90 @@ export function wellKnownBinDirs(home: string, readDir?: ReadDirNames): string[]
     join(home, ".bun", "bin"), // bun global
     ...(isMac ? ["/opt/homebrew/bin"] : []), // Apple-silicon Homebrew
     "/usr/local/bin", // Intel Homebrew / common manual installs
-    ...versionManagerBinDirs(home, readDir),
   ];
   return dirs;
 }
+
+/** Injectable seams so tests need neither a real install nor a real filesystem. */
+export type VersionManagerDirDeps = {
+  readDir?: ReadDirNames;
+  readLink?: ReadLink;
+  env?: NodeJS.ProcessEnv;
+};
+
+/**
+ * `bin` dirs of every Node version installed by nvm or fnm, **newest first**.
+ *
+ * These are the STABLE homes of a `claude` / `codex` installed under a Node
+ * version manager. The dir such a shell actually puts on `$PATH`
+ * (`fnm_multishells/<pid>_<ts>/bin`) is a per-session symlink that disappears
+ * with the shell, so it cannot be searched afterwards — but its target lives
+ * here and does not move.
+ *
+ * This is a FALLBACK, not a preference: callers must search it only after the
+ * login-shell dirs, so a shell that intentionally selected an older version
+ * keeps that version (and its credential context) whenever the live dir is
+ * still resolvable. Newest-first only decides between versions once the active
+ * one is already gone.
+ *
+ * Every root and every returned dir is vetted with
+ * {@link resolveOutsideProtectedRootsOnThisHost} BEFORE it is listed or handed
+ * back. Nothing here is trusted for being spelled like a version manager:
+ * `$FNM_DIR` is user-controlled, and `~/.nvm`, a fnm data dir, or a single
+ * version entry can each be a symlink — or sit under one — pointing into a
+ * protected folder.
+ */
+export function versionManagerBinDirs(home: string, deps: VersionManagerDirDeps = {}): string[] {
+  const readDir = deps.readDir ?? readdirSync;
+  const readLink = deps.readLink;
+  const env = deps.env ?? process.env;
+
+  const safe = (path: string): string | null => resolveOutsideProtectedRootsOnThisHost(path, readLink);
+
+  /** List `root`'s entries only once the root itself is known to be safe. */
+  const versionsUnder = (root: string): Array<{ version: string; root: string }> => {
+    const vetted = safe(root);
+    if (vetted === null) return [];
+    try {
+      return readDir(vetted)
+        .sort((a, b) => VERSION_COLLATOR.compare(b, a))
+        .map((version) => ({ version, root: vetted }));
+    } catch {
+      // No such version manager on this host, or the root is unreadable.
+      return [];
+    }
+  };
+
+  const nvm = versionsUnder(join(home, ".nvm", "versions", "node")).map(({ version, root }) =>
+    join(root, version, "bin"),
+  );
+
+  // fnm's data dir varies by installer: XDG default, Homebrew on macOS, and the
+  // pre-XDG layout. `$FNM_DIR` wins when the operator set one — and is exactly
+  // why the vetting above is not optional.
+  const fnmRoots = [
+    env.FNM_DIR,
+    join(home, ".local", "share", "fnm"),
+    join(home, "Library", "Application Support", "fnm"),
+    join(home, ".fnm"),
+  ].filter((root): root is string => typeof root === "string" && root.length > 0);
+
+  const seen = new Set<string>();
+  const fnm = fnmRoots.flatMap((root) => {
+    if (seen.has(root)) return [];
+    seen.add(root);
+    return versionsUnder(join(root, "node-versions")).map(({ version, root: versionsRoot }) =>
+      join(versionsRoot, version, "installation", "bin"),
+    );
+  });
+
+  // A vetted root can still hold a version entry that is itself a symlink into a
+  // protected folder, so re-vet each candidate before returning it.
+  return [...nvm, ...fnm].map(safe).filter((dir): dir is string => dir !== null);
+}
+
+/** Newest-looking version first, so the chosen dir is stable across runs. */
+const VERSION_COLLATOR = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
 
 /**
  * macOS desktop-app resource directories that can carry the Codex CLI.

--- a/packages/client/src/runtime/install-locations.ts
+++ b/packages/client/src/runtime/install-locations.ts
@@ -63,12 +63,16 @@ export type VersionManagerDirDeps = {
  * the provider as not found, so the decision is made across the complete state
  * rather than per root:
  *
- *   - The login shell reported something. Only that is used. `$NVM_BIN` names
- *     the selected version outright and is authoritative, replacing any nvm
- *     enumeration. `$FNM_DIR` names only the active root, so that root — and no
- *     other — is consulted, and it answers only if it holds exactly one version.
- *     Default roots are not scanned at all: if we know which manager is active
- *     and it cannot answer, an unrelated installation is not a better answer.
+ *   - The login shell reported exactly one manager. Only that is used.
+ *     `$NVM_BIN` names the selected version outright and is authoritative,
+ *     replacing any nvm enumeration. `$FNM_DIR` names only the active root, so
+ *     that root — and no other — is consulted, and it answers only if it holds
+ *     exactly one version. Default roots are not scanned at all: if we know
+ *     which manager is active and it cannot answer, an unrelated installation
+ *     is not a better answer.
+ *   - The login shell reported BOTH managers. Which one was active was decided
+ *     by the live `$PATH` order, which is exactly what is no longer available,
+ *     so neither answers.
  *   - The login shell reported nothing. The default roots are scanned and the
  *     result is used only when there is exactly ONE safe candidate in total.
  *     Two single-version roots are just as ambiguous as one two-version root.
@@ -115,11 +119,17 @@ export function versionManagerBinDirs(home: string, deps: VersionManagerDirDeps 
     join(versionsRoot, version, "installation", "bin");
 
   if (active.nvmBin !== undefined || active.fnmDir !== undefined) {
-    const fromActive = [
-      ...(active.nvmBin !== undefined ? [active.nvmBin] : []),
-      ...(active.fnmDir !== undefined ? soleVersionUnder(join(active.fnmDir, "node-versions"), fnmLayout) : []),
-    ];
-    return fromActive.map(safe).filter((dir): dir is string => dir !== null);
+    // Two managers reported: which one was actually active was decided by the
+    // live `$PATH` order, and once that entry is gone the variables alone do
+    // not say. Both can be set when both init scripts ran, or when one survived
+    // a later PATH change. Answering with either is a guess, so answer neither.
+    if (active.nvmBin !== undefined && active.fnmDir !== undefined) return [];
+    const fromActive =
+      active.nvmBin !== undefined
+        ? [active.nvmBin]
+        : soleVersionUnder(join(active.fnmDir ?? "", "node-versions"), fnmLayout);
+    const vettedActive = fromActive.map(safe).filter((dir): dir is string => dir !== null);
+    return vettedActive.length === 1 ? vettedActive : [];
   }
 
   // fnm's data dir varies by installer: XDG default, Homebrew on macOS, and the

--- a/packages/client/src/runtime/install-locations.ts
+++ b/packages/client/src/runtime/install-locations.ts
@@ -42,19 +42,24 @@ export type VersionManagerDirDeps = {
 };
 
 /**
- * `bin` dirs of every Node version installed by nvm or fnm, **newest first**.
+ * `bin` dir of the **unambiguously** installed Node version under nvm or fnm.
  *
- * These are the STABLE homes of a `claude` / `codex` installed under a Node
- * version manager. The dir such a shell actually puts on `$PATH`
+ * This is the STABLE home of a `claude` / `codex` installed under a Node version
+ * manager. The dir such a shell actually puts on `$PATH`
  * (`fnm_multishells/<pid>_<ts>/bin`) is a per-session symlink that disappears
  * with the shell, so it cannot be searched afterwards — but its target lives
  * here and does not move.
  *
- * This is a FALLBACK, not a preference: callers must search it only after the
- * login-shell dirs, so a shell that intentionally selected an older version
- * keeps that version (and its credential context) whenever the live dir is
- * still resolvable. Newest-first only decides between versions once the active
- * one is already gone.
+ * It is a FALLBACK, not a preference: callers search it only after the
+ * login-shell dirs, so a live selection always wins.
+ *
+ * **A root with more than one installed version contributes nothing.** Which one
+ * the shell selected is not recoverable from disk, and answering with the newest
+ * would silently run a different version than the user pinned — a quiet swap of
+ * the executable and its context, which is worse than reporting the provider as
+ * not found. nvm avoids the ambiguity entirely by exporting `$NVM_BIN` (handled
+ * by the caller); fnm exports no equivalent, so a multi-version fnm root fails
+ * closed.
  *
  * Every root and every returned dir is vetted with
  * {@link resolveOutsideProtectedRootsOnThisHost} BEFORE it is listed or handed
@@ -70,18 +75,24 @@ export function versionManagerBinDirs(home: string, deps: VersionManagerDirDeps 
 
   const safe = (path: string): string | null => resolveOutsideProtectedRootsOnThisHost(path, readLink);
 
-  /** List `root`'s entries only once the root itself is known to be safe. */
+  /**
+   * The single installed version under `root`, or nothing when the root is
+   * unsafe, absent, empty, or ambiguous. Listing happens only after the root
+   * itself is known to be safe.
+   */
   const versionsUnder = (root: string): Array<{ version: string; root: string }> => {
     const vetted = safe(root);
     if (vetted === null) return [];
+    let entries: string[];
     try {
-      return readDir(vetted)
-        .sort((a, b) => VERSION_COLLATOR.compare(b, a))
-        .map((version) => ({ version, root: vetted }));
+      entries = readDir(vetted);
     } catch {
       // No such version manager on this host, or the root is unreadable.
       return [];
     }
+    const [only] = entries;
+    if (entries.length !== 1 || only === undefined) return [];
+    return [{ version: only, root: vetted }];
   };
 
   const nvm = versionsUnder(join(home, ".nvm", "versions", "node")).map(({ version, root }) =>
@@ -111,9 +122,6 @@ export function versionManagerBinDirs(home: string, deps: VersionManagerDirDeps 
   // protected folder, so re-vet each candidate before returning it.
   return [...nvm, ...fnm].map(safe).filter((dir): dir is string => dir !== null);
 }
-
-/** Newest-looking version first, so the chosen dir is stable across runs. */
-const VERSION_COLLATOR = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
 
 /**
  * macOS desktop-app resource directories that can carry the Codex CLI.

--- a/packages/client/src/runtime/kimi-binary.ts
+++ b/packages/client/src/runtime/kimi-binary.ts
@@ -8,6 +8,7 @@ import {
 } from "@first-tree/shared";
 import { wellKnownBinDirs } from "./install-locations.js";
 import { getLoginShellPathDirs } from "./login-shell-path.js";
+import { automaticCandidateAllowed } from "./protected-paths.js";
 
 /**
  * Official Kimi Code CLI binary resolution for Computer capability detection.
@@ -126,6 +127,10 @@ function readPathValue(env: Record<string, string | undefined>, platform = proce
 }
 
 function isExecutableFile(filePath: string, platform: NodeJS.Platform): boolean {
+  // Every automatic source funnels through here, so this is the one place a
+  // candidate can be vetted before `stat` / `access` follows it into a
+  // TCC-protected folder. See `automaticCandidateAllowed`.
+  if (!automaticCandidateAllowed(filePath)) return false;
   try {
     if (!statSync(filePath).isFile()) return false;
     accessSync(filePath, platform === "win32" ? constants.F_OK : constants.X_OK);

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
+import { readlinkSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, resolve, sep } from "node:path";
 
 /**
  * Unique marker that brackets the canonical dir list in the probe output so we
@@ -68,9 +69,11 @@ let failedAttempts = 0;
  * be gone. Resolving the symlink to the stable underlying install dir while the
  * shell lives hands back a path that still exists at search time.
  *
- * On macOS, entries under a TCC-protected root are skipped rather than
- * canonicalized, and any that survive canonicalization are dropped from the
- * result — see {@link MACOS_PROTECTED_HOME_SUBPATHS}.
+ * On macOS the shell canonicalizes only the per-session multishell dirs;
+ * everything else is
+ * canonicalized here by {@link resolveOutsideProtectedRoots}, which walks the
+ * path with `readlink` so a dir that resolves into a TCC-protected root is
+ * dropped WITHOUT ever being entered — see {@link MACOS_PROTECTED_HOME_SUBPATHS}.
  *
  * Properties:
  *   - **Memoized on success**: a probe that ran the shell, exited 0, and parsed a
@@ -97,7 +100,13 @@ export function getLoginShellPathDirs(runShell: RunShell = defaultRunShell): str
   }
   const dirs = probe(runShell);
   if (dirs) {
-    memo = { dirs: dirs.filter((dir) => !protectedOnThisHost(dir)) };
+    const roots = protectedRootsOnThisHost();
+    memo = {
+      dirs:
+        roots.length === 0
+          ? dirs
+          : dirs.map((dir) => resolveOutsideProtectedRoots(dir, roots)).filter((dir): dir is string => dir !== null),
+    };
     return memo.dirs;
   }
   // Probe failed (spawn error / timeout / non-zero exit / parse miss). Don't
@@ -163,12 +172,18 @@ function probe(runShell: RunShell): string[] | null {
  * Verified end to end under bash, zsh, and sh; fish is covered by the
  * runtime-env-qa `DW7_fish_frozen` scenario.
  *
- * On macOS a `case` guard skips entries under a TCC-protected root
- * ({@link MACOS_PROTECTED_HOME_SUBPATHS}) instead of `cd`-ing into them, so this
- * automatic probe never triggers a Files & Folders consent prompt. `$HOME` is
- * read inside the shell rather than interpolated from Node so a home path
- * containing a quote can never break out of the `'…'` wrapper. On every other
- * platform the emitted script is byte-for-byte what it has always been.
+ * On macOS `cd` is NOT safe to run over arbitrary entries: `cd` resolves the
+ * whole path, so an entry that is a symlink into a protected root — or that has
+ * a symlinked ancestor — enters that root even though its spelling looks
+ * harmless. A lexical guard alone cannot see through either. So on macOS the
+ * shell canonicalizes ONLY the per-session multishell dirs that genuinely
+ * require in-shell resolution ({@link multishellCasePatterns}); every other
+ * entry is emitted verbatim, with no filesystem access at all, and
+ * {@link getLoginShellPathDirs} resolves it with `readlink` instead — see
+ * {@link resolveOutsideProtectedRoots}. `$HOME` is read
+ * inside the shell rather than interpolated from Node so a home path containing
+ * a quote can never break out of the `'…'` wrapper. On every other platform the
+ * emitted script is byte-for-byte what it has always been.
  *
  * @param platform test seam / platform selector for the protected-root guard.
  */
@@ -176,10 +191,15 @@ export function buildProbeScript(platform: NodeJS.Platform = process.platform): 
   // POSIX body run by the nested `sh`; uses only double quotes so the whole
   // string can be wrapped in single quotes for `/bin/sh -c '…'`. DELIM is a bare
   // word (letters + underscores), safe unquoted.
-  const skipProtected = platform === "darwin" ? `case "$d" in ${protectedCasePatterns()}) continue;; esac; ` : "";
+  const canonicalize = '(cd "$d" 2>/dev/null && pwd -P)';
+  const body =
+    platform === "darwin"
+      ? `case "$d" in ${protectedCasePatterns()}) continue;; ${multishellCasePatterns()}) ${canonicalize};; ` +
+        `*) printf "%s\\n" "$d";; esac`
+      : canonicalize;
   const posix =
     `printf %s ${DELIM}; ` +
-    `IFS=:; for d in $PATH; do [ -n "$d" ] || continue; ${skipProtected}(cd "$d" 2>/dev/null && pwd -P); done; ` +
+    `IFS=:; for d in $PATH; do [ -n "$d" ] || continue; ${body}; done; ` +
     `printf %s ${DELIM}`;
   return `/bin/sh -c '${posix}'`;
 }
@@ -196,6 +216,25 @@ function protectedCasePatterns(): string {
 }
 
 /**
+ * `case` alternatives for the per-session multishell dirs — the ONLY entries
+ * that must be canonicalized while the probe shell is alive, because their
+ * symlink is torn down when it exits and Node could no longer follow it.
+ *
+ * Matched by the tool-specific directory name rather than by "somewhere under a
+ * temp root". A temp root is not a safety guarantee: `$HOME` itself can sit
+ * under one, and then a broad temp pattern would re-admit exactly the symlink
+ * traversal this guard exists to close. These names are created by fnm / nvm,
+ * never by a user pointing at their own folders.
+ *
+ * A per-session symlink dir from some other tool is not canonicalized in-shell
+ * and will simply not resolve after the probe exits — the deliberate trade for
+ * not entering paths we cannot vet first.
+ */
+function multishellCasePatterns(): string {
+  return ["*/fnm_multishells/*", "*/nvm_multishells/*"].join("|");
+}
+
+/**
  * Escape a literal path fragment for use inside a `case` pattern: whitespace
  * would end the pattern word ("Library/Mobile Documents"), and glob
  * metacharacters would make it match more than the literal path.
@@ -204,14 +243,66 @@ function escapeCasePattern(literal: string): string {
   return literal.replace(/[\s\\*?[\]]/gu, (char) => `\\${char}`);
 }
 
-/** Is `dir` inside a TCC-protected root of this host's home? Non-macOS: never. */
-function protectedOnThisHost(dir: string): boolean {
-  if (process.platform !== "darwin") return false;
+/** This host's absolute TCC-protected roots. Empty off macOS, where none apply. */
+function protectedRootsOnThisHost(): string[] {
+  if (process.platform !== "darwin") return [];
   const home = process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir();
-  return MACOS_PROTECTED_HOME_SUBPATHS.some((sub) => {
-    const root = join(home, sub);
-    return dir === root || dir.startsWith(`${root}/`);
-  });
+  return MACOS_PROTECTED_HOME_SUBPATHS.map((sub) => join(home, sub));
+}
+
+function insideAny(path: string, roots: readonly string[]): boolean {
+  return roots.some((root) => path === root || path.startsWith(`${root}${sep}`));
+}
+
+/** Give up rather than loop forever on a symlink cycle. */
+const MAX_SYMLINK_HOPS = 32;
+
+/**
+ * Canonicalize `dir`, or return `null` if doing so would mean reaching into a
+ * protected root.
+ *
+ * This exists because neither a lexical check nor `cd` can do the job alone. A
+ * lexical check cannot see that `~/bin` is a symlink to `~/Documents/bin`, and
+ * `cd` (or `realpath`, or `existsSync`) finds that out only by entering the
+ * protected directory — which is the access we are trying to avoid, not a way
+ * to detect it.
+ *
+ * So the path is walked one component at a time from the root. Each component
+ * is checked against the protected roots BEFORE it is touched, and the only
+ * syscall performed on it is `readlink`, which reads the link's own target and
+ * never follows it. A component that is not a symlink is simply appended.
+ * Because a symlink's target is re-walked from the root, an expansion that
+ * lands in a protected root is caught on the next iteration, before anything
+ * inside it is read — which covers the symlinked-ancestor case as well as a
+ * symlinked entry.
+ */
+function resolveOutsideProtectedRoots(dir: string, roots: readonly string[]): string | null {
+  let pending = resolve(dir).split(sep).filter(Boolean);
+  let resolved: string = sep;
+  let hops = 0;
+  while (pending.length > 0) {
+    const [head = "", ...rest] = pending;
+    const candidate = join(resolved, head);
+    if (insideAny(candidate, roots)) return null;
+    let target: string | null = null;
+    try {
+      target = readlinkSync(candidate);
+    } catch {
+      // Not a symlink, missing, or unreadable — nothing to follow either way.
+      // A missing dir stays in the result and simply fails the caller's
+      // existence check, exactly as an uncanonicalized entry did before.
+    }
+    if (target === null) {
+      resolved = candidate;
+      pending = rest;
+      continue;
+    }
+    if (++hops > MAX_SYMLINK_HOPS) return null;
+    const expanded = isAbsolute(target) ? target : join(resolved, target);
+    pending = [...resolve(expanded).split(sep).filter(Boolean), ...rest];
+    resolved = sep;
+  }
+  return resolved;
 }
 
 /** Spawn the user's interactive login shell to run the probe; raw stdout or null. */

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -10,6 +10,22 @@ import { protectedRootsOnThisHost, type ReadLink, resolveOutsideProtectedRoots }
  */
 const DELIM = "__FT_SHELL_PATH__";
 
+/**
+ * Brackets a second section carrying the version-manager variables the login
+ * shell exported. Reading an environment variable costs no filesystem access at
+ * all, which is why these can be captured here while a symlink target cannot.
+ *
+ * They matter because the daemon's own environment never sees them: `fnm env` /
+ * `nvm.sh` run inside the user's rc files. `$NVM_BIN` is nvm's ACTIVE version's
+ * bin dir and is a real directory, so it survives the probe shell and keeps the
+ * selected version winning after its per-session entry is gone. `$FNM_DIR` is a
+ * custom fnm data root the hard-coded defaults would otherwise miss entirely.
+ */
+const ENV_DELIM = "__FT_SHELL_ENV__";
+
+/** The version-manager environment the login shell reported, if it reported any. */
+type ProbedShellEnv = { fnmDir?: string; nvmBin?: string };
+
 /** Injectable seam for hermetic tests — returns the raw shell stdout, or null on failure. */
 export type RunShell = () => string | null;
 
@@ -84,17 +100,31 @@ export function getLoginShellPathDirs(runShell: RunShell = defaultRunShell, read
     memo = { dirs: [] };
     return memo.dirs;
   }
-  const dirs = probe(runShell);
-  if (dirs) {
+  const probed = probe(runShell);
+  if (probed) {
     const roots = protectedRootsOnThisHost();
-    const live =
-      roots.length === 0
-        ? dirs
-        : dirs
-            .map((dir) => resolveOutsideProtectedRoots(dir, roots, readLink))
-            .filter((dir): dir is string => dir !== null);
+    const vet = (dir: string): string | null =>
+      roots.length === 0 ? dir : resolveOutsideProtectedRoots(dir, roots, readLink);
+    const live = probed.dirs.map(vet).filter((dir): dir is string => dir !== null);
+
+    // Stable fallback, in precedence order: the version the shell actually
+    // selected (nvm reports it as a real directory that outlives the probe),
+    // then every installed version newest-first. `$FNM_DIR` comes from the
+    // shell too — the daemon's own environment never sees a root exported by
+    // `fnm env` inside an rc file.
     const home = process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir();
-    const fallback = versionManagerBinDirs(home, { readLink }).filter((dir) => !live.includes(dir));
+    const env = probed.env.fnmDir ? { ...process.env, FNM_DIR: probed.env.fnmDir } : process.env;
+    const seen = new Set(live);
+    const fallback: string[] = [];
+    for (const dir of [
+      ...(probed.env.nvmBin ? [probed.env.nvmBin] : []),
+      ...versionManagerBinDirs(home, { readLink, env }),
+    ]) {
+      const vetted = vet(dir);
+      if (vetted === null || seen.has(vetted)) continue;
+      seen.add(vetted);
+      fallback.push(vetted);
+    }
     memo = { dirs: [...live, ...fallback] };
     return memo.dirs;
   }
@@ -121,7 +151,7 @@ export function resetLoginShellPathDirsCache(): void {
  * `null` on any failure (spawn error / timeout / non-zero exit / missing stdout /
  * parse miss) so the caller can distinguish "ran ok" from "must retry".
  */
-function probe(runShell: RunShell): string[] | null {
+function probe(runShell: RunShell): { dirs: string[]; env: ProbedShellEnv } | null {
   let output: string | null;
   try {
     output = runShell();
@@ -129,7 +159,9 @@ function probe(runShell: RunShell): string[] | null {
     return null;
   }
   if (!output) return null;
-  return parsePathFromShellOutput(output);
+  const dirs = parsePathFromShellOutput(output);
+  if (dirs === null) return null;
+  return { dirs, env: parseShellEnv(output) };
 }
 
 /**
@@ -192,7 +224,10 @@ export function buildProbeScript(platform: NodeJS.Platform = process.platform): 
   const posix =
     `printf %s ${DELIM}; ` +
     `set -f; IFS=:; for d in $PATH; do [ -n "$d" ] || continue; ${body}; done; ` +
-    `printf %s ${DELIM}`;
+    `printf %s ${DELIM}; ` +
+    // Pure variable expansion — no path is touched, so this is safe on every
+    // platform and needs no vetting until the values are used.
+    `printf %s ${ENV_DELIM}; printf "%s\n%s\n" "$FNM_DIR" "$NVM_BIN"; printf %s ${ENV_DELIM}`;
   return `/bin/sh -c '${posix}'`;
 }
 
@@ -226,6 +261,18 @@ function pickShell(): string {
  * (delimiters absent) so the caller treats it as a retryable failure rather than
  * a genuine empty PATH.
  */
+function parseShellEnv(output: string): ProbedShellEnv {
+  const start = output.indexOf(ENV_DELIM);
+  if (start < 0) return {};
+  const end = output.indexOf(ENV_DELIM, start + ENV_DELIM.length);
+  if (end < 0) return {};
+  const [fnmDir, nvmBin] = output.slice(start + ENV_DELIM.length, end).split("\n");
+  return {
+    ...(fnmDir ? { fnmDir } : {}),
+    ...(nvmBin ? { nvmBin } : {}),
+  };
+}
+
 function parsePathFromShellOutput(output: string): string[] | null {
   const start = output.indexOf(DELIM);
   if (start < 0) return null;

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -106,15 +106,21 @@ export function getLoginShellPathDirs(runShell: RunShell = defaultRunShell, read
     const roots = protectedRootsOnThisHost();
     const vet = (dir: string): string | null =>
       roots.length === 0 ? dir : resolveOutsideProtectedRoots(dir, roots, readLink);
-    // When the shell reported two version managers, neither one's tree can be
-    // trusted to hold the selection — and withholding it only from the appended
-    // fallback would achieve nothing, because the raw `$PATH` already lists it.
-    // A capture ordered `[dead fnm multishell, $NVM_BIN]` would otherwise skip
-    // the dead entry and launch nvm, which is precisely the substitution the
-    // ambiguity rule exists to prevent. So the decision applies to the whole
-    // returned list, not just the part this function appends.
+    // The ambiguity is a consequence of resolving AFTER the shell exits, which
+    // only macOS does. Elsewhere `buildProbeScript` still canonicalizes while
+    // the shell is alive, so a `$PATH` ordered `[fnm multishell, $NVM_BIN]`
+    // comes back as the stable fnm target followed by nvm — that ordering IS
+    // the selection, and dropping both trees there would turn a correctly
+    // discovered provider into a miss.
+    //
+    // On macOS the same capture arrives raw, and its first entry may already be
+    // gone. Withholding the answer only from the appended fallback achieves
+    // nothing then, because the raw `$PATH` still lists `$NVM_BIN` and every
+    // resolver would skip the dead entry and launch it. So there — and only
+    // there — the decision applies to the whole returned list.
+    const resolutionDeferredPastShellExit = process.platform === "darwin";
     const untrusted =
-      probed.env.nvmBin !== undefined && probed.env.fnmDir !== undefined
+      resolutionDeferredPastShellExit && probed.env.nvmBin !== undefined && probed.env.fnmDir !== undefined
         ? [probed.env.nvmBin, probed.env.fnmDir].map(vet).filter((dir): dir is string => dir !== null)
         : [];
     const trusted = (dir: string): boolean =>

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { readlinkSync } from "node:fs";
 import { homedir } from "node:os";
-import { isAbsolute, join, resolve, sep } from "node:path";
+import { versionManagerBinDirs } from "./install-locations.js";
+import { protectedRootsOnThisHost, type ReadLink, resolveOutsideProtectedRoots } from "./protected-paths.js";
 
 /**
  * Unique marker that brackets the canonical dir list in the probe output so we
@@ -10,40 +10,8 @@ import { isAbsolute, join, resolve, sep } from "node:path";
  */
 const DELIM = "__FT_SHELL_PATH__";
 
-/**
- * Home-relative roots macOS puts behind a TCC "Files & Folders" consent prompt.
- *
- * The daemon runs this probe automatically at startup / reconnect, before the
- * user has chosen anything, so it must never be the reason macOS asks for
- * Desktop / Documents / Downloads / iCloud access. Both the shell script (which
- * would otherwise `cd` into every `$PATH` entry) and the parsed result (whose
- * dirs are later `existsSync`-checked by each provider resolver) skip these.
- *
- * The cost is bounded and deliberate: a provider binary whose `$PATH` entry
- * lives inside one of these roots is not auto-discovered. Every ordinary
- * install location — Homebrew, `~/.local/bin`, npm-global, pnpm, bun, and the
- * nvm / fnm / volta / mise / asdf shims this probe exists for — is unaffected.
- */
-const MACOS_PROTECTED_HOME_SUBPATHS = [
-  "Desktop",
-  "Documents",
-  "Downloads",
-  // iCloud Drive, including the "Desktop & Documents Folders" sync target.
-  "Library/Mobile Documents",
-  // File Provider mounts: OneDrive, Dropbox, Google Drive, Box, …
-  "Library/CloudStorage",
-] as const;
-
 /** Injectable seam for hermetic tests — returns the raw shell stdout, or null on failure. */
 export type RunShell = () => string | null;
-
-/**
- * Injectable seam for the ONE syscall path resolution is allowed to make. Tests
- * use it to assert what was touched, which is the property that matters here:
- * a reviewer can check the ordering by reading the code, but only this can show
- * that no protected path was ever passed to it.
- */
-export type ReadLink = (path: string) => string;
 
 /**
  * Cap on the number of probe spawns per process. The first probe may run during
@@ -80,12 +48,17 @@ let failedAttempts = 0;
  * On macOS the shell does no filesystem access at all and the same
  * canonicalization happens here, via {@link resolveOutsideProtectedRoots}: it
  * walks each path with `readlink`, so a dir that resolves into a TCC-protected
- * root is dropped WITHOUT ever being entered — see
- * {@link MACOS_PROTECTED_HOME_SUBPATHS}. That runs immediately after the probe
- * returns, so a multishell dir still present then resolves exactly as before;
- * one already torn down does not. Relative `$PATH` entries also resolve against
- * this process's cwd rather than the probe shell's, which only matters for a
- * shape that cannot hold a reliably spawnable binary anyway.
+ * root is dropped WITHOUT ever being entered. That runs immediately after the
+ * probe returns, so a multishell dir still present then resolves exactly as
+ * before; one already torn down does not. Relative `$PATH` entries also resolve
+ * against this process's cwd rather than the probe shell's, which only matters
+ * for a shape that cannot hold a reliably spawnable binary anyway.
+ *
+ * The nvm / fnm stable version dirs are appended AFTER whatever the probe
+ * returned, so a torn-down multishell entry still has somewhere to resolve from
+ * while an intentionally selected version — which the live probe reports first —
+ * keeps winning. Callers search this list in order, so the fallback only decides
+ * the outcome once the active dir is gone.
  *
  * Properties:
  *   - **Memoized on success**: a probe that ran the shell, exited 0, and parsed a
@@ -104,10 +77,7 @@ let failedAttempts = 0;
  * @param runShell test-only seam to supply the raw shell stdout without spawning.
  * @param readLink test-only seam to observe every path resolution touches.
  */
-export function getLoginShellPathDirs(
-  runShell: RunShell = defaultRunShell,
-  readLink: ReadLink = readlinkSync,
-): string[] {
+export function getLoginShellPathDirs(runShell: RunShell = defaultRunShell, readLink?: ReadLink): string[] {
   if (memo) return memo.dirs;
   // Deterministic skip — cache immediately, this is not a transient failure.
   if (process.platform === "win32") {
@@ -117,14 +87,15 @@ export function getLoginShellPathDirs(
   const dirs = probe(runShell);
   if (dirs) {
     const roots = protectedRootsOnThisHost();
-    memo = {
-      dirs:
-        roots.length === 0
-          ? dirs
-          : dirs
-              .map((dir) => resolveOutsideProtectedRoots(dir, roots, readLink))
-              .filter((dir): dir is string => dir !== null),
-    };
+    const live =
+      roots.length === 0
+        ? dirs
+        : dirs
+            .map((dir) => resolveOutsideProtectedRoots(dir, roots, readLink))
+            .filter((dir): dir is string => dir !== null);
+    const home = process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir();
+    const fallback = versionManagerBinDirs(home, { readLink }).filter((dir) => !live.includes(dir));
+    memo = { dirs: [...live, ...fallback] };
     return memo.dirs;
   }
   // Probe failed (spawn error / timeout / non-zero exit / parse miss). Don't
@@ -223,83 +194,6 @@ export function buildProbeScript(platform: NodeJS.Platform = process.platform): 
     `set -f; IFS=:; for d in $PATH; do [ -n "$d" ] || continue; ${body}; done; ` +
     `printf %s ${DELIM}`;
   return `/bin/sh -c '${posix}'`;
-}
-
-/** This host's absolute TCC-protected roots. Empty off macOS, where none apply. */
-function protectedRootsOnThisHost(): string[] {
-  if (process.platform !== "darwin") return [];
-  const home = process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir();
-  return MACOS_PROTECTED_HOME_SUBPATHS.map((sub) => join(home, sub));
-}
-
-/**
- * Case-fold for path comparison. The default macOS filesystem is
- * case-INSENSITIVE, so `~/documents/bin` and `~/Documents/bin` are the same
- * directory and a case-sensitive guard would wave one of them through. Folding
- * both sides is also the conservative answer on a case-sensitive volume, where
- * it can only over-reject — never enter a protected folder by accident.
- */
-function fold(value: string): string {
-  return value.toLocaleLowerCase("en-US");
-}
-
-function insideAny(path: string, roots: readonly string[]): boolean {
-  const candidate = fold(path);
-  return roots.some((root) => {
-    const folded = fold(root);
-    return candidate === folded || candidate.startsWith(`${folded}${sep}`);
-  });
-}
-
-/** Give up rather than loop forever on a symlink cycle. */
-const MAX_SYMLINK_HOPS = 32;
-
-/**
- * Canonicalize `dir`, or return `null` if doing so would mean reaching into a
- * protected root.
- *
- * This exists because neither a lexical check nor `cd` can do the job alone. A
- * lexical check cannot see that `~/bin` is a symlink to `~/Documents/bin`, and
- * `cd` (or `realpath`, or `existsSync`) finds that out only by entering the
- * protected directory — which is the access we are trying to avoid, not a way
- * to detect it.
- *
- * So the path is walked one component at a time from the root. Each component
- * is checked against the protected roots BEFORE it is touched, and the only
- * syscall performed on it is `readlink`, which reads the link's own target and
- * never follows it. A component that is not a symlink is simply appended.
- * Because a symlink's target is re-walked from the root, an expansion that
- * lands in a protected root is caught on the next iteration, before anything
- * inside it is read — which covers the symlinked-ancestor case as well as a
- * symlinked entry.
- */
-function resolveOutsideProtectedRoots(dir: string, roots: readonly string[], readLink: ReadLink): string | null {
-  let pending = resolve(dir).split(sep).filter(Boolean);
-  let resolved: string = sep;
-  let hops = 0;
-  while (pending.length > 0) {
-    const [head = "", ...rest] = pending;
-    const candidate = join(resolved, head);
-    if (insideAny(candidate, roots)) return null;
-    let target: string | null = null;
-    try {
-      target = readLink(candidate);
-    } catch {
-      // Not a symlink, missing, or unreadable — nothing to follow either way.
-      // A missing dir stays in the result and simply fails the caller's
-      // existence check, exactly as an uncanonicalized entry did before.
-    }
-    if (target === null) {
-      resolved = candidate;
-      pending = rest;
-      continue;
-    }
-    if (++hops > MAX_SYMLINK_HOPS) return null;
-    const expanded = isAbsolute(target) ? target : join(resolved, target);
-    pending = [...resolve(expanded).split(sep).filter(Boolean), ...rest];
-    resolved = sep;
-  }
-  return resolved;
 }
 
 /** Spawn the user's interactive login shell to run the probe; raw stdout or null. */

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
+import { sep } from "node:path";
 import { versionManagerBinDirs } from "./install-locations.js";
 import { protectedRootsOnThisHost, type ReadLink, resolveOutsideProtectedRoots } from "./protected-paths.js";
 
@@ -105,7 +106,24 @@ export function getLoginShellPathDirs(runShell: RunShell = defaultRunShell, read
     const roots = protectedRootsOnThisHost();
     const vet = (dir: string): string | null =>
       roots.length === 0 ? dir : resolveOutsideProtectedRoots(dir, roots, readLink);
-    const live = probed.dirs.map(vet).filter((dir): dir is string => dir !== null);
+    // When the shell reported two version managers, neither one's tree can be
+    // trusted to hold the selection — and withholding it only from the appended
+    // fallback would achieve nothing, because the raw `$PATH` already lists it.
+    // A capture ordered `[dead fnm multishell, $NVM_BIN]` would otherwise skip
+    // the dead entry and launch nvm, which is precisely the substitution the
+    // ambiguity rule exists to prevent. So the decision applies to the whole
+    // returned list, not just the part this function appends.
+    const untrusted =
+      probed.env.nvmBin !== undefined && probed.env.fnmDir !== undefined
+        ? [probed.env.nvmBin, probed.env.fnmDir].map(vet).filter((dir): dir is string => dir !== null)
+        : [];
+    const trusted = (dir: string): boolean =>
+      !untrusted.some((root) => dir === root || dir.startsWith(`${root}${sep}`));
+
+    const live = probed.dirs
+      .map(vet)
+      .filter((dir): dir is string => dir !== null)
+      .filter(trusted);
 
     // Stable fallback for a per-session dir that is already gone. What the shell
     // reported about its version manager decides it — and decides it globally,

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -107,23 +107,17 @@ export function getLoginShellPathDirs(runShell: RunShell = defaultRunShell, read
       roots.length === 0 ? dir : resolveOutsideProtectedRoots(dir, roots, readLink);
     const live = probed.dirs.map(vet).filter((dir): dir is string => dir !== null);
 
-    // Stable fallback, in precedence order: the version the shell actually
-    // selected (nvm reports it as a real directory that outlives the probe),
-    // then every installed version newest-first. `$FNM_DIR` comes from the
-    // shell too — the daemon's own environment never sees a root exported by
-    // `fnm env` inside an rc file.
+    // Stable fallback for a per-session dir that is already gone. What the shell
+    // reported about its version manager decides it — and decides it globally,
+    // so an unrelated installation is never substituted for a selection we
+    // could not recover. See `versionManagerBinDirs`.
     const home = process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir();
-    const env = probed.env.fnmDir ? { ...process.env, FNM_DIR: probed.env.fnmDir } : process.env;
     const seen = new Set(live);
     const fallback: string[] = [];
-    for (const dir of [
-      ...(probed.env.nvmBin ? [probed.env.nvmBin] : []),
-      ...versionManagerBinDirs(home, { readLink, env }),
-    ]) {
-      const vetted = vet(dir);
-      if (vetted === null || seen.has(vetted)) continue;
-      seen.add(vetted);
-      fallback.push(vetted);
+    for (const dir of versionManagerBinDirs(home, { readLink, active: probed.env })) {
+      if (seen.has(dir)) continue;
+      seen.add(dir);
+      fallback.push(dir);
     }
     memo = { dirs: [...live, ...fallback] };
     return memo.dirs;

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 /**
  * Unique marker that brackets the canonical dir list in the probe output so we
@@ -6,6 +8,30 @@ import { spawnSync } from "node:child_process";
  * prints. Chosen to be vanishingly unlikely to appear in a real PATH entry.
  */
 const DELIM = "__FT_SHELL_PATH__";
+
+/**
+ * Home-relative roots macOS puts behind a TCC "Files & Folders" consent prompt.
+ *
+ * The daemon runs this probe automatically at startup / reconnect, before the
+ * user has chosen anything, so it must never be the reason macOS asks for
+ * Desktop / Documents / Downloads / iCloud access. Both the shell script (which
+ * would otherwise `cd` into every `$PATH` entry) and the parsed result (whose
+ * dirs are later `existsSync`-checked by each provider resolver) skip these.
+ *
+ * The cost is bounded and deliberate: a provider binary whose `$PATH` entry
+ * lives inside one of these roots is not auto-discovered. Every ordinary
+ * install location — Homebrew, `~/.local/bin`, npm-global, pnpm, bun, and the
+ * nvm / fnm / volta / mise / asdf shims this probe exists for — is unaffected.
+ */
+const MACOS_PROTECTED_HOME_SUBPATHS = [
+  "Desktop",
+  "Documents",
+  "Downloads",
+  // iCloud Drive, including the "Desktop & Documents Folders" sync target.
+  "Library/Mobile Documents",
+  // File Provider mounts: OneDrive, Dropbox, Google Drive, Box, …
+  "Library/CloudStorage",
+] as const;
 
 /** Injectable seam for hermetic tests — returns the raw shell stdout, or null on failure. */
 export type RunShell = () => string | null;
@@ -42,6 +68,10 @@ let failedAttempts = 0;
  * be gone. Resolving the symlink to the stable underlying install dir while the
  * shell lives hands back a path that still exists at search time.
  *
+ * On macOS, entries under a TCC-protected root are skipped rather than
+ * canonicalized, and any that survive canonicalization are dropped from the
+ * result — see {@link MACOS_PROTECTED_HOME_SUBPATHS}.
+ *
  * Properties:
  *   - **Memoized on success**: a probe that ran the shell, exited 0, and parsed a
  *     PATH is cached for the process — detection runs on a background poll, so we
@@ -67,8 +97,8 @@ export function getLoginShellPathDirs(runShell: RunShell = defaultRunShell): str
   }
   const dirs = probe(runShell);
   if (dirs) {
-    memo = { dirs };
-    return dirs;
+    memo = { dirs: dirs.filter((dir) => !protectedOnThisHost(dir)) };
+    return memo.dirs;
   }
   // Probe failed (spawn error / timeout / non-zero exit / parse miss). Don't
   // cache a transient failure — allow a later call to re-probe — but stop once
@@ -132,16 +162,56 @@ function probe(runShell: RunShell): string[] | null {
  * `$PATH`, which is colon-delimited regardless of how the outer shell stores it.
  * Verified end to end under bash, zsh, and sh; fish is covered by the
  * runtime-env-qa `DW7_fish_frozen` scenario.
+ *
+ * On macOS a `case` guard skips entries under a TCC-protected root
+ * ({@link MACOS_PROTECTED_HOME_SUBPATHS}) instead of `cd`-ing into them, so this
+ * automatic probe never triggers a Files & Folders consent prompt. `$HOME` is
+ * read inside the shell rather than interpolated from Node so a home path
+ * containing a quote can never break out of the `'…'` wrapper. On every other
+ * platform the emitted script is byte-for-byte what it has always been.
+ *
+ * @param platform test seam / platform selector for the protected-root guard.
  */
-export function buildProbeScript(): string {
+export function buildProbeScript(platform: NodeJS.Platform = process.platform): string {
   // POSIX body run by the nested `sh`; uses only double quotes so the whole
   // string can be wrapped in single quotes for `/bin/sh -c '…'`. DELIM is a bare
   // word (letters + underscores), safe unquoted.
+  const skipProtected = platform === "darwin" ? `case "$d" in ${protectedCasePatterns()}) continue;; esac; ` : "";
   const posix =
     `printf %s ${DELIM}; ` +
-    `IFS=:; for d in $PATH; do [ -n "$d" ] && (cd "$d" 2>/dev/null && pwd -P); done; ` +
+    `IFS=:; for d in $PATH; do [ -n "$d" ] || continue; ${skipProtected}(cd "$d" 2>/dev/null && pwd -P); done; ` +
     `printf %s ${DELIM}`;
   return `/bin/sh -c '${posix}'`;
+}
+
+/**
+ * `case` alternatives matching each protected root and everything beneath it.
+ * Only double quotes are used so the result stays embeddable in `sh -c '…'`.
+ */
+function protectedCasePatterns(): string {
+  return MACOS_PROTECTED_HOME_SUBPATHS.flatMap((sub) => {
+    const root = `"$HOME"/${escapeCasePattern(sub)}`;
+    return [root, `${root}/*`];
+  }).join("|");
+}
+
+/**
+ * Escape a literal path fragment for use inside a `case` pattern: whitespace
+ * would end the pattern word ("Library/Mobile Documents"), and glob
+ * metacharacters would make it match more than the literal path.
+ */
+function escapeCasePattern(literal: string): string {
+  return literal.replace(/[\s\\*?[\]]/gu, (char) => `\\${char}`);
+}
+
+/** Is `dir` inside a TCC-protected root of this host's home? Non-macOS: never. */
+function protectedOnThisHost(dir: string): boolean {
+  if (process.platform !== "darwin") return false;
+  const home = process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir();
+  return MACOS_PROTECTED_HOME_SUBPATHS.some((sub) => {
+    const root = join(home, sub);
+    return dir === root || dir.startsWith(`${root}/`);
+  });
 }
 
 /** Spawn the user's interactive login shell to run the probe; raw stdout or null. */

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -211,10 +211,16 @@ export function buildProbeScript(platform: NodeJS.Platform = process.platform): 
   // POSIX body run by the nested `sh`; uses only double quotes so the whole
   // string can be wrapped in single quotes for `/bin/sh -c '…'`. DELIM is a bare
   // word (letters + underscores), safe unquoted.
+  //
+  // `set -f` is load-bearing, not hygiene. Unquoted `$PATH` undergoes field
+  // splitting AND pathname expansion, so an entry spelled `$HOME/Documents/*`
+  // makes the shell ENUMERATE that directory — reading a protected folder and
+  // pulling its entry names into the result — before any of the code below
+  // runs. Disabling globbing keeps the split while leaving each entry literal.
   const body = platform === "darwin" ? 'printf "%s\\n" "$d"' : '(cd "$d" 2>/dev/null && pwd -P)';
   const posix =
     `printf %s ${DELIM}; ` +
-    `IFS=:; for d in $PATH; do [ -n "$d" ] || continue; ${body}; done; ` +
+    `set -f; IFS=:; for d in $PATH; do [ -n "$d" ] || continue; ${body}; done; ` +
     `printf %s ${DELIM}`;
   return `/bin/sh -c '${posix}'`;
 }

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -38,6 +38,14 @@ const MACOS_PROTECTED_HOME_SUBPATHS = [
 export type RunShell = () => string | null;
 
 /**
+ * Injectable seam for the ONE syscall path resolution is allowed to make. Tests
+ * use it to assert what was touched, which is the property that matters here:
+ * a reviewer can check the ordering by reading the code, but only this can show
+ * that no protected path was ever passed to it.
+ */
+export type ReadLink = (path: string) => string;
+
+/**
  * Cap on the number of probe spawns per process. The first probe may run during
  * daemon startup under heavy load and time out; a transient failure must be
  * retryable so discovery is not permanently dead. But a persistently-failing
@@ -62,18 +70,22 @@ let failedAttempts = 0;
  * the daemon's `env.PATH`. This probes the login shell and returns the extra
  * dirs so install-only capability detection can find those binaries.
  *
- * Each dir is **canonicalized inside the still-alive shell** (`cd "$d" && pwd -P`)
- * before being returned. fnm / nvm "multishell" PATH entries are per-session
+ * Off macOS each dir is **canonicalized inside the still-alive shell**
+ * (`cd "$d" && pwd -P`). fnm / nvm "multishell" PATH entries are per-session
  * symlink dirs (e.g. `/tmp/fnm_multishells/xxx/bin`) that are torn down when the
  * probe shell exits — by the time the caller `existsSync`-checks them they would
  * be gone. Resolving the symlink to the stable underlying install dir while the
  * shell lives hands back a path that still exists at search time.
  *
- * On macOS the shell canonicalizes only the per-session multishell dirs;
- * everything else is
- * canonicalized here by {@link resolveOutsideProtectedRoots}, which walks the
- * path with `readlink` so a dir that resolves into a TCC-protected root is
- * dropped WITHOUT ever being entered — see {@link MACOS_PROTECTED_HOME_SUBPATHS}.
+ * On macOS the shell does no filesystem access at all and the same
+ * canonicalization happens here, via {@link resolveOutsideProtectedRoots}: it
+ * walks each path with `readlink`, so a dir that resolves into a TCC-protected
+ * root is dropped WITHOUT ever being entered — see
+ * {@link MACOS_PROTECTED_HOME_SUBPATHS}. That runs immediately after the probe
+ * returns, so a multishell dir still present then resolves exactly as before;
+ * one already torn down does not. Relative `$PATH` entries also resolve against
+ * this process's cwd rather than the probe shell's, which only matters for a
+ * shape that cannot hold a reliably spawnable binary anyway.
  *
  * Properties:
  *   - **Memoized on success**: a probe that ran the shell, exited 0, and parsed a
@@ -90,8 +102,12 @@ let failedAttempts = 0;
  *     stdout, or a parse miss — never throws.
  *
  * @param runShell test-only seam to supply the raw shell stdout without spawning.
+ * @param readLink test-only seam to observe every path resolution touches.
  */
-export function getLoginShellPathDirs(runShell: RunShell = defaultRunShell): string[] {
+export function getLoginShellPathDirs(
+  runShell: RunShell = defaultRunShell,
+  readLink: ReadLink = readlinkSync,
+): string[] {
   if (memo) return memo.dirs;
   // Deterministic skip — cache immediately, this is not a transient failure.
   if (process.platform === "win32") {
@@ -105,7 +121,9 @@ export function getLoginShellPathDirs(runShell: RunShell = defaultRunShell): str
       dirs:
         roots.length === 0
           ? dirs
-          : dirs.map((dir) => resolveOutsideProtectedRoots(dir, roots)).filter((dir): dir is string => dir !== null),
+          : dirs
+              .map((dir) => resolveOutsideProtectedRoots(dir, roots, readLink))
+              .filter((dir): dir is string => dir !== null),
     };
     return memo.dirs;
   }
@@ -172,75 +190,33 @@ function probe(runShell: RunShell): string[] | null {
  * Verified end to end under bash, zsh, and sh; fish is covered by the
  * runtime-env-qa `DW7_fish_frozen` scenario.
  *
- * On macOS `cd` is NOT safe to run over arbitrary entries: `cd` resolves the
- * whole path, so an entry that is a symlink into a protected root — or that has
- * a symlinked ancestor — enters that root even though its spelling looks
- * harmless. A lexical guard alone cannot see through either. So on macOS the
- * shell canonicalizes ONLY the per-session multishell dirs that genuinely
- * require in-shell resolution ({@link multishellCasePatterns}); every other
- * entry is emitted verbatim, with no filesystem access at all, and
- * {@link getLoginShellPathDirs} resolves it with `readlink` instead — see
- * {@link resolveOutsideProtectedRoots}. `$HOME` is read
- * inside the shell rather than interpolated from Node so a home path containing
- * a quote can never break out of the `'…'` wrapper. On every other platform the
- * emitted script is byte-for-byte what it has always been.
+ * On macOS this script performs **no filesystem access at all**: it only prints
+ * `$PATH`, one entry per line, and {@link getLoginShellPathDirs} does the
+ * resolving. `cd` resolves a whole path at once, so it enters a protected root
+ * whenever an entry is a symlink into one or has a symlinked ancestor — and no
+ * lexical test on the spelling can predict that. Carving out "safe" spellings
+ * was tried twice (a temp-root prefix, then the fnm/nvm multishell directory
+ * name) and neither is a boundary: `$HOME` can live under a temp root, and a
+ * multishell-named link can point at Documents. Emitting the raw entries makes
+ * the guarantee structural rather than argued, and leaves it in one place that
+ * unit tests can reach: {@link resolveOutsideProtectedRoots}.
  *
- * @param platform test seam / platform selector for the protected-root guard.
+ * The cost is that a per-session symlink dir already torn down by the time the
+ * probe returns can no longer be followed. On every other platform the emitted
+ * script is byte-for-byte what it has always been.
+ *
+ * @param platform test seam / platform selector for the macOS behavior.
  */
 export function buildProbeScript(platform: NodeJS.Platform = process.platform): string {
   // POSIX body run by the nested `sh`; uses only double quotes so the whole
   // string can be wrapped in single quotes for `/bin/sh -c '…'`. DELIM is a bare
   // word (letters + underscores), safe unquoted.
-  const canonicalize = '(cd "$d" 2>/dev/null && pwd -P)';
-  const body =
-    platform === "darwin"
-      ? `case "$d" in ${protectedCasePatterns()}) continue;; ${multishellCasePatterns()}) ${canonicalize};; ` +
-        `*) printf "%s\\n" "$d";; esac`
-      : canonicalize;
+  const body = platform === "darwin" ? 'printf "%s\\n" "$d"' : '(cd "$d" 2>/dev/null && pwd -P)';
   const posix =
     `printf %s ${DELIM}; ` +
     `IFS=:; for d in $PATH; do [ -n "$d" ] || continue; ${body}; done; ` +
     `printf %s ${DELIM}`;
   return `/bin/sh -c '${posix}'`;
-}
-
-/**
- * `case` alternatives matching each protected root and everything beneath it.
- * Only double quotes are used so the result stays embeddable in `sh -c '…'`.
- */
-function protectedCasePatterns(): string {
-  return MACOS_PROTECTED_HOME_SUBPATHS.flatMap((sub) => {
-    const root = `"$HOME"/${escapeCasePattern(sub)}`;
-    return [root, `${root}/*`];
-  }).join("|");
-}
-
-/**
- * `case` alternatives for the per-session multishell dirs — the ONLY entries
- * that must be canonicalized while the probe shell is alive, because their
- * symlink is torn down when it exits and Node could no longer follow it.
- *
- * Matched by the tool-specific directory name rather than by "somewhere under a
- * temp root". A temp root is not a safety guarantee: `$HOME` itself can sit
- * under one, and then a broad temp pattern would re-admit exactly the symlink
- * traversal this guard exists to close. These names are created by fnm / nvm,
- * never by a user pointing at their own folders.
- *
- * A per-session symlink dir from some other tool is not canonicalized in-shell
- * and will simply not resolve after the probe exits — the deliberate trade for
- * not entering paths we cannot vet first.
- */
-function multishellCasePatterns(): string {
-  return ["*/fnm_multishells/*", "*/nvm_multishells/*"].join("|");
-}
-
-/**
- * Escape a literal path fragment for use inside a `case` pattern: whitespace
- * would end the pattern word ("Library/Mobile Documents"), and glob
- * metacharacters would make it match more than the literal path.
- */
-function escapeCasePattern(literal: string): string {
-  return literal.replace(/[\s\\*?[\]]/gu, (char) => `\\${char}`);
 }
 
 /** This host's absolute TCC-protected roots. Empty off macOS, where none apply. */
@@ -250,8 +226,23 @@ function protectedRootsOnThisHost(): string[] {
   return MACOS_PROTECTED_HOME_SUBPATHS.map((sub) => join(home, sub));
 }
 
+/**
+ * Case-fold for path comparison. The default macOS filesystem is
+ * case-INSENSITIVE, so `~/documents/bin` and `~/Documents/bin` are the same
+ * directory and a case-sensitive guard would wave one of them through. Folding
+ * both sides is also the conservative answer on a case-sensitive volume, where
+ * it can only over-reject — never enter a protected folder by accident.
+ */
+function fold(value: string): string {
+  return value.toLocaleLowerCase("en-US");
+}
+
 function insideAny(path: string, roots: readonly string[]): boolean {
-  return roots.some((root) => path === root || path.startsWith(`${root}${sep}`));
+  const candidate = fold(path);
+  return roots.some((root) => {
+    const folded = fold(root);
+    return candidate === folded || candidate.startsWith(`${folded}${sep}`);
+  });
 }
 
 /** Give up rather than loop forever on a symlink cycle. */
@@ -276,7 +267,7 @@ const MAX_SYMLINK_HOPS = 32;
  * inside it is read — which covers the symlinked-ancestor case as well as a
  * symlinked entry.
  */
-function resolveOutsideProtectedRoots(dir: string, roots: readonly string[]): string | null {
+function resolveOutsideProtectedRoots(dir: string, roots: readonly string[], readLink: ReadLink): string | null {
   let pending = resolve(dir).split(sep).filter(Boolean);
   let resolved: string = sep;
   let hops = 0;
@@ -286,7 +277,7 @@ function resolveOutsideProtectedRoots(dir: string, roots: readonly string[]): st
     if (insideAny(candidate, roots)) return null;
     let target: string | null = null;
     try {
-      target = readlinkSync(candidate);
+      target = readLink(candidate);
     } catch {
       // Not a symlink, missing, or unreadable — nothing to follow either way.
       // A missing dir stays in the result and simply fails the caller's

--- a/packages/client/src/runtime/opencode-binary.ts
+++ b/packages/client/src/runtime/opencode-binary.ts
@@ -9,6 +9,7 @@ import {
 import { prerelease, satisfies, valid } from "semver";
 import { wellKnownBinDirs } from "./install-locations.js";
 import { getLoginShellPathDirs } from "./login-shell-path.js";
+import { automaticCandidateAllowed } from "./protected-paths.js";
 
 /** Lowest compatible CLI — shared with catalog npm package metadata. */
 export { OPENCODE_MINIMUM_VERSION };
@@ -153,6 +154,10 @@ function whitespaceTokens(value: string): string[] {
 }
 
 function isExecutableFile(filePath: string, platform: NodeJS.Platform): boolean {
+  // Every automatic source funnels through here, so this is the one place a
+  // candidate can be vetted before `stat` / `access` follows it into a
+  // TCC-protected folder. See `automaticCandidateAllowed`.
+  if (!automaticCandidateAllowed(filePath)) return false;
   try {
     if (!statSync(filePath).isFile()) return false;
     accessSync(filePath, platform === "win32" ? constants.F_OK : constants.X_OK);

--- a/packages/client/src/runtime/pi-binary.ts
+++ b/packages/client/src/runtime/pi-binary.ts
@@ -9,6 +9,7 @@ import {
 import { prerelease, satisfies, valid } from "semver";
 import { wellKnownBinDirs } from "./install-locations.js";
 import { getLoginShellPathDirs } from "./login-shell-path.js";
+import { automaticCandidateAllowed } from "./protected-paths.js";
 
 /** Lowest published compatible CLI validated by the runtime contract. */
 export const PI_MINIMUM_VERSION = "0.80.5";
@@ -161,6 +162,10 @@ function whitespaceTokens(value: string): string[] {
 }
 
 function isExecutableFile(filePath: string, platform: NodeJS.Platform): boolean {
+  // Every automatic source funnels through here, so this is the one place a
+  // candidate can be vetted before `stat` / `access` follows it into a
+  // TCC-protected folder. See `automaticCandidateAllowed`.
+  if (!automaticCandidateAllowed(filePath)) return false;
   try {
     if (!statSync(filePath).isFile()) return false;
     accessSync(filePath, platform === "win32" ? constants.F_OK : constants.X_OK);

--- a/packages/client/src/runtime/protected-paths.ts
+++ b/packages/client/src/runtime/protected-paths.ts
@@ -1,0 +1,130 @@
+import { readlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve, sep } from "node:path";
+
+/**
+ * Home-relative roots macOS puts behind a TCC "Files & Folders" consent prompt.
+ *
+ * The daemon probes for installed providers automatically at startup, on
+ * reconnect, and on the degraded-capability poll — before the user has chosen
+ * anything — so none of that may be the reason macOS asks for Desktop /
+ * Documents / Downloads / iCloud access.
+ *
+ * The cost is bounded and deliberate: a provider binary reachable only through
+ * one of these roots is not auto-discovered. Every ordinary install location —
+ * Homebrew, `~/.local/bin`, npm-global, pnpm, bun, and the nvm / fnm / volta /
+ * mise / asdf trees — is unaffected.
+ */
+const MACOS_PROTECTED_HOME_SUBPATHS = [
+  "Desktop",
+  "Documents",
+  "Downloads",
+  // iCloud Drive, including the "Desktop & Documents Folders" sync target.
+  "Library/Mobile Documents",
+  // File Provider mounts: OneDrive, Dropbox, Google Drive, Box, …
+  "Library/CloudStorage",
+] as const;
+
+/**
+ * Injectable seam for the ONE syscall this module is allowed to make. Tests use
+ * it to assert what was touched, which is the property that matters here: a
+ * reviewer can check the ordering by reading the code, but only this can show
+ * that no protected path was ever passed to it.
+ */
+export type ReadLink = (path: string) => string;
+
+/** Give up rather than loop forever on a symlink cycle. */
+const MAX_SYMLINK_HOPS = 32;
+
+/** This host's absolute TCC-protected roots. Empty off macOS, where none apply. */
+export function protectedRootsOnThisHost(): string[] {
+  if (process.platform !== "darwin") return [];
+  const home = process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir();
+  return MACOS_PROTECTED_HOME_SUBPATHS.map((sub) => join(home, sub));
+}
+
+/**
+ * Case-fold for path comparison. The default macOS filesystem is
+ * case-INSENSITIVE, so `~/documents/bin` and `~/Documents/bin` are the same
+ * directory and a case-sensitive guard would wave one of them through. Folding
+ * both sides is also the conservative answer on a case-sensitive volume, where
+ * it can only over-reject — never enter a protected folder by accident.
+ */
+function fold(value: string): string {
+  return value.toLocaleLowerCase("en-US");
+}
+
+function insideAny(path: string, roots: readonly string[]): boolean {
+  const candidate = fold(path);
+  return roots.some((root) => {
+    const folded = fold(root);
+    return candidate === folded || candidate.startsWith(`${folded}${sep}`);
+  });
+}
+
+/**
+ * Canonicalize `dir`, or return `null` if doing so would mean reaching into a
+ * protected root.
+ *
+ * This exists because neither a lexical check nor an ordinary resolve can do the
+ * job alone. A lexical check cannot see that `~/bin` is a symlink to
+ * `~/Documents/bin`; `cd`, `realpath`, `readdir` and `existsSync` find that out
+ * only by entering the protected directory — which is the access we are trying
+ * to avoid, not a way to detect it.
+ *
+ * So the path is walked one component at a time from the root. Each component is
+ * checked against the protected roots BEFORE it is touched, and the only syscall
+ * performed on it is `readlink`, which reads the link's own target and never
+ * follows it. A component that is not a symlink is simply appended. Because a
+ * symlink's target is re-walked from the root, an expansion that lands in a
+ * protected root is caught on the next iteration, before anything inside it is
+ * read — which covers a symlinked ancestor as well as a symlinked leaf.
+ *
+ * EVERY automatic filesystem source must pass a path through here before
+ * listing, stat-ing, or searching it. Judging a source safe by where it is
+ * *spelled* does not hold: a version-manager root, a temp dir, or a
+ * tool-specific directory name can each be a symlink into a protected folder.
+ */
+export function resolveOutsideProtectedRoots(
+  dir: string,
+  roots: readonly string[],
+  readLink: ReadLink = readlinkSync,
+): string | null {
+  let pending = resolve(dir).split(sep).filter(Boolean);
+  let resolved: string = sep;
+  let hops = 0;
+  while (pending.length > 0) {
+    const [head = "", ...rest] = pending;
+    const candidate = join(resolved, head);
+    if (insideAny(candidate, roots)) return null;
+    let target: string | null = null;
+    try {
+      target = readLink(candidate);
+    } catch {
+      // Not a symlink, missing, or unreadable — nothing to follow either way.
+      // A missing dir stays in the result and simply fails the caller's
+      // existence check, exactly as an unresolved entry did before.
+    }
+    if (target === null) {
+      resolved = candidate;
+      pending = rest;
+      continue;
+    }
+    if (++hops > MAX_SYMLINK_HOPS) return null;
+    const expanded = isAbsolute(target) ? target : join(resolved, target);
+    pending = [...resolve(expanded).split(sep).filter(Boolean), ...rest];
+    resolved = sep;
+  }
+  return resolved;
+}
+
+/**
+ * {@link resolveOutsideProtectedRoots} against this host's roots. Off macOS
+ * there are no protected roots, so the path is returned untouched rather than
+ * spending syscalls to reach the same answer.
+ */
+export function resolveOutsideProtectedRootsOnThisHost(dir: string, readLink: ReadLink = readlinkSync): string | null {
+  const roots = protectedRootsOnThisHost();
+  if (roots.length === 0) return dir;
+  return resolveOutsideProtectedRoots(dir, roots, readLink);
+}

--- a/packages/client/src/runtime/protected-paths.ts
+++ b/packages/client/src/runtime/protected-paths.ts
@@ -128,3 +128,24 @@ export function resolveOutsideProtectedRootsOnThisHost(dir: string, readLink: Re
   if (roots.length === 0) return dir;
   return resolveOutsideProtectedRoots(dir, roots, readLink);
 }
+
+/**
+ * The gate every AUTOMATIC executable check must pass before it calls `stat` or
+ * `access` on a candidate.
+ *
+ * Vetting the containing directory is not enough, and neither is vetting the
+ * source it came from. `~/.local/bin` is no safer a spelling than a
+ * version-manager root — `~/.local`, or `bin`, or the `codex` entry inside it
+ * can each be a symlink into `~/Documents` — and `statSync` / `accessSync`
+ * follow that link, which IS the protected access. So the check happens on the
+ * complete candidate path, at the last moment before the syscall, and applies
+ * uniformly to every source: daemon `PATH`, fixed well-known dirs,
+ * provider-specific dirs, login-shell dirs, version roots, and desktop-app
+ * candidates.
+ *
+ * An explicit operator override (`CLAUDE_CODE_EXECUTABLE`) is user-directed
+ * rather than automatic and is deliberately not gated here.
+ */
+export function automaticCandidateAllowed(candidate: string, readLink?: ReadLink): boolean {
+  return resolveOutsideProtectedRootsOnThisHost(candidate, readLink) !== null;
+}

--- a/packages/qa/cases/runtime/macos-automatic-probe-file-access.md
+++ b/packages/qa/cases/runtime/macos-automatic-probe-file-access.md
@@ -25,8 +25,12 @@ Codex external-Context project classifier.
 
 - Run on macOS, in the isolated QA run cell selected by the plan, under a user account whose TCC decisions for the
   runtime binary have not already been granted. A machine that previously approved these folders cannot answer property 1.
-- Install one provider so that it is reachable ONLY from the interactive login shell — e.g. `npm i -g` under nvm, with the
-  nvm init line in `~/.zshrc` and not in the daemon's service `PATH`.
+- Install one provider so that it is reachable ONLY from the interactive login shell — e.g. `npm i -g` under nvm or fnm,
+  with the version-manager init line in `~/.zshrc` and not in the daemon's service `PATH`. Prefer fnm with
+  `--use-on-cd`, because that puts a per-session symlink on `$PATH` that disappears with the shell: discovery must come
+  from the version manager's stable install dir, not from that link.
+- Put a wildcard entry on the login-shell `PATH` too (for example `$HOME/Documents/*`), since an unquoted expansion can
+  enumerate a protected folder without any explicit directory access.
 - Add protected directories to the login-shell `PATH` in all three ways they can be reached, because a guard can close
   one and leave the others open:
   - by spelling — `$HOME/Documents/bin`;

--- a/packages/qa/cases/runtime/macos-automatic-probe-file-access.md
+++ b/packages/qa/cases/runtime/macos-automatic-probe-file-access.md
@@ -27,8 +27,11 @@ Codex external-Context project classifier.
   runtime binary have not already been granted. A machine that previously approved these folders cannot answer property 1.
 - Install one provider so that it is reachable ONLY from the interactive login shell — e.g. `npm i -g` under nvm, with the
   nvm init line in `~/.zshrc` and not in the daemon's service `PATH`.
-- Add at least one protected directory to the login-shell `PATH` (for example `$HOME/Documents/bin`) so the probe has a
-  reason to touch it if the guard regresses.
+- Add protected directories to the login-shell `PATH` in all three ways they can be reached, because a guard can close
+  one and leave the others open:
+  - by spelling — `$HOME/Documents/bin`;
+  - as a symlinked entry — `$HOME/bin` symlinked to `$HOME/Documents/bin`;
+  - through a symlinked ancestor — `$HOME/deep/mid/bin`, where `$HOME/deep/mid` is symlinked to `$HOME/Documents`.
 
 ## Operate
 

--- a/packages/qa/cases/runtime/macos-automatic-probe-file-access.md
+++ b/packages/qa/cases/runtime/macos-automatic-probe-file-access.md
@@ -55,6 +55,9 @@ Record the exact commands, the daemon version under test, and the shell used.
   filtered to the runtime process) or the TCC decision log for the run window, not by prompt appearance alone, since a
   prompt is suppressed once a decision exists.
 - The capability entry for the login-shell-only provider in the probe output: state, `runtimeSource`, and `runtimePath`.
+- When the provider is under a version manager, whether `runtimePath` points at the version the shell actually selected.
+  It must never silently be a different installed version: with several fnm versions installed and the per-session link
+  already gone, "not found" is the correct answer, not the newest one.
 - For step 4, whether the process touched `~/Documents` at all.
 
 ## Expected Result
@@ -63,7 +66,9 @@ Record the exact commands, the daemon version under test, and the shell used.
 and on-demand probe, AND the login-shell-only provider was still reported installed with a usable path.
 
 `FAIL` means either half broke: a protected folder was read (or consent requested) without the user selecting anything,
-or the login-shell-only provider was reported missing. Report which half failed — they have different fixes.
+or the login-shell-only provider was reported missing while its selected version was still resolvable. Report which half
+failed — they have different fixes. A resolved path pointing at a version the shell did NOT select is also a `FAIL`,
+and a more serious one than a miss.
 
 `BLOCKED` means the run cell is not macOS, the account already carries TCC decisions for the runtime binary, or no
 filesystem tracing is available, so property 1 cannot be observed.

--- a/packages/qa/cases/runtime/macos-automatic-probe-file-access.md
+++ b/packages/qa/cases/runtime/macos-automatic-probe-file-access.md
@@ -1,0 +1,71 @@
+---
+id: macos-automatic-probe-file-access
+description: Validate that automatic provider discovery on macOS reaches no TCC-protected folder while still finding login-shell-only installs.
+areas: [runtime]
+surfaces: [cli]
+---
+
+# macOS Automatic Probe File Access
+
+## Goal
+
+Verify two properties of automatic provider discovery on macOS at the same time, because either one alone can be
+satisfied by breaking the other:
+
+1. Startup, reconnect, and background capability refresh never read inside a TCC-protected folder — Desktop, Documents,
+   Downloads, iCloud Drive, or a cloud File Provider mount — so a user who has chosen nothing yet is never asked for
+   Files & Folders consent, and is never told to grant Full Disk Access.
+2. A provider installed only on the user's interactive login-shell `PATH` (nvm, fnm, volta, mise, asdf, a custom
+   `export PATH=`) is still discovered.
+
+Use this case when a task changes provider discovery, the login-shell `PATH` probe, daemon startup/reconnect, or the
+Codex external-Context project classifier.
+
+## Preconditions
+
+- Run on macOS, in the isolated QA run cell selected by the plan, under a user account whose TCC decisions for the
+  runtime binary have not already been granted. A machine that previously approved these folders cannot answer property 1.
+- Install one provider so that it is reachable ONLY from the interactive login shell — e.g. `npm i -g` under nvm, with the
+  nvm init line in `~/.zshrc` and not in the daemon's service `PATH`.
+- Add at least one protected directory to the login-shell `PATH` (for example `$HOME/Documents/bin`) so the probe has a
+  reason to touch it if the guard regresses.
+
+## Operate
+
+1. Install and start the daemon, then leave it connected and idle long enough for the degraded-capability refresh to run
+   several times.
+2. Disconnect the network, reconnect, and let the reconnect re-probe run.
+3. Run the on-demand probe: `first-tree daemon probe --json --no-upload`.
+4. If external Codex Context is enabled in the run cell, start a Codex session from an ordinary project directory that is
+   NOT under `~/Documents`.
+
+Record the exact commands, the daemon version under test, and the shell used.
+
+## Observe
+
+- Whether macOS presented any Files & Folders consent prompt at any point in steps 1-4.
+- Whether the runtime process read inside a protected folder — observe with a filesystem trace (for example `fs_usage`
+  filtered to the runtime process) or the TCC decision log for the run window, not by prompt appearance alone, since a
+  prompt is suppressed once a decision exists.
+- The capability entry for the login-shell-only provider in the probe output: state, `runtimeSource`, and `runtimePath`.
+- For step 4, whether the process touched `~/Documents` at all.
+
+## Expected Result
+
+`PASS` means no consent prompt appeared and the trace shows zero reads inside a protected folder across idle, reconnect,
+and on-demand probe, AND the login-shell-only provider was still reported installed with a usable path.
+
+`FAIL` means either half broke: a protected folder was read (or consent requested) without the user selecting anything,
+or the login-shell-only provider was reported missing. Report which half failed — they have different fixes.
+
+`BLOCKED` means the run cell is not macOS, the account already carries TCC decisions for the runtime binary, or no
+filesystem tracing is available, so property 1 cannot be observed.
+
+`INCONCLUSIVE` means tracing was partial, the protected `PATH` entry was never actually on the login-shell `PATH`, or the
+observation cannot be attributed to the target ref.
+
+## Evidence
+
+Keep the trace excerpt for the run window, the probe JSON entry for the login-shell-only provider, the login-shell `PATH`
+as the shell reports it, and the macOS version. Redact home-directory contents and any provider credentials; record
+directory paths only, never file listings.


### PR DESCRIPTION
## Problem

The daemon probes provider installs at startup, on reconnect, and on the degraded-capability poll — before the user has selected anything. Paths in that automatic flow reached into folders macOS guards behind a TCC **Files & Folders** consent prompt, so a fresh install could ask for Desktop / Documents / Downloads / iCloud access for reasons the user could not connect to any action of their own.

None of them needed that access to do their job.

## Changes

### 1. The login-shell `PATH` probe does no filesystem access on macOS

`packages/client/src/runtime/login-shell-path.ts`

The script used to run `cd "$d" && pwd -P` over every `$PATH` entry. `cd` resolves a whole path at once, so it enters a protected root whenever an entry is a symlink into one or has a symlinked ancestor — and no lexical test on the spelling can predict that. Review of this PR killed two attempts to carve out "safe" spellings (a temp-root prefix, then the fnm/nvm multishell directory name); neither is a boundary, since `$HOME` can live under a temp root and a multishell-named link can point at Documents.

So on macOS the script now prints `$PATH`, one entry per line, and nothing else — no `cd`, no `pwd`, no `readlink`. It also runs `set -f`: unquoted `$PATH` undergoes pathname expansion as well as field splitting, so an entry spelled `$HOME/Documents/*` made the shell *enumerate* that directory and pull its entry names into the result, with no explicit filesystem command in sight. That bug predates this PR; the no-access claim made here is what puts it in scope.

All resolution moved to `resolveOutsideProtectedRoots`, which walks a path one component at a time from the root, checks each component against the protected roots **before** touching it, and only ever calls `readlink` — which reads a link's own target without following it. A symlink target is re-walked from the root, so an expansion landing in a protected root is caught on the next iteration; that covers symlinked ancestors without a special case. Comparison is case-folded, because the default macOS filesystem is case-insensitive and `$HOME/documents/bin` *is* `$HOME/Documents/bin`. Cycles are bounded.

The guarantee is now structural — no branch remains that could enter an unvetted path — and it lives in one function that unit tests reach directly, rather than in a shell string. Off macOS the emitted script is unchanged apart from `set -f`.

### 2. Version-manager discovery no longer depends on a per-session symlink

`packages/client/src/runtime/install-locations.ts`

Moving canonicalization out of the shell would otherwise reintroduce the fnm/nvm false negative fixed by #1314: the `$PATH` entry such a shell contributes is a per-session symlink torn down when the shell exits, so nothing can follow it afterwards. The binary itself lives in a stable version dir that does not move — the problem is knowing *which* one the shell had selected.

The probe protocol now carries `$FNM_DIR` and `$NVM_BIN`. Reading an environment variable costs no filesystem access at all, which is precisely why these are capturable while a symlink target is not.

The fallback then answers **only when the selection can be established**, judged across the complete state rather than per root — because resolving a version the user did not select silently swaps the executable and its context, which is worse than reporting the provider as not found:

- **One manager reported.** Only it is used. `$NVM_BIN` names the selected version outright and replaces nvm enumeration. `$FNM_DIR` names only the active root, so that root and no other is consulted, and answers only if it holds exactly one version. Default roots are not scanned: if we know which manager is active and it cannot answer, an unrelated installation is not a better answer.
- **Both managers reported.** Nothing. Which one was active was decided by the live `$PATH` order, and that is exactly what is gone; two variables say two init scripts ran, not which owned precedence.
- **Nothing reported.** Default roots are scanned, and the result is used only when exactly one safe candidate exists in total. Two roots holding one version each are as ambiguous as one root holding two.

Every root is vetted before it is listed and every candidate before it is returned — `$FNM_DIR` is user-controlled, and `~/.nvm` or a fnm data dir can be a symlink, or sit under one, into a protected folder.

### 3. The Codex external-Context classifier stops probing Documents

`apps/cli/src/core/context-integration/client-preflight.ts`

`classifyCodexProjectlessPath` called `realpathSync` on `~/Documents/Codex` for every session, including sessions whose cwd was nowhere near Documents. The caller already canonicalizes the cwd, so canonicalizing the base is only meaningful when the base itself is redirected — which macOS iCloud "Desktop & Documents Folders" does by making `~/Documents` a symlink. The base is now canonicalized only when the caller's original, pre-`realpath` cwd is already lexically inside it. Ordinary project cwds no longer touch Documents at all. `CODEX_PROJECTLESS_CLASSIFIER_VERSION` is bumped so cached classifications recompute once.

## What is deliberately unchanged

Discovery order (daemon `PATH` → well-known install dirs → login-shell `PATH` → Codex desktop app), the provider list, the capability wire schema, the background refresher and its backoff, the Web provider picker, and the launchd plist. The daemon's own service `PATH` is composed by First Tree and never inherited from the user, so the login-shell probe was the only user-derived directory source in automatic discovery.

## Cost

A provider whose `$PATH` entry lives inside Desktop, Documents, Downloads, iCloud Drive, or a cloud File Provider mount is no longer auto-discovered. Those locations essentially never hold a CLI on `PATH`, and the alternative is asking every user for consent to folders the product has no reason to read.

On macOS, once a per-session version-manager link is gone, the fallback answers only when the selected version can be established from what the shell reported. Otherwise the provider reports as not found rather than silently resolving a version the user did not select. In practice the live link is still resolvable, since resolution runs immediately after the probe returns.

Still open, deliberately: whether `/Volumes` and `/Network` should join the protected list. That removes the removable- and network-volume prompt categories too, but a toolchain on an external volume would then need a way to be named explicitly, and no such escape hatch exists today (`CLAUDE_CODE_EXECUTABLE` is the only override, and it covers one provider). Worth deciding separately.

## Verification

- `pnpm check`, `pnpm typecheck` — clean.
- `packages/client` full suite: 2445 passed, 7 skipped.
- `apps/cli` full suite (batch runner): green except 3 pre-existing `daemon-refresh-unit` failures that reproduce identically on an unmodified tree (this host has no dev portable shim at `~/.local/bin/first-tree-dev`).

Tests added for each property that can otherwise regress silently:

- **No protected access, however an entry reaches one** — end-to-end over the real shell *and* the real parse, with four routes in one `$PATH`: by spelling, symlinked entry, symlinked ancestor, and a `fnm_multishells`-named link pointing at Documents. It asserts the shell echoes every entry **byte for byte**; four are symlinks whose resolved spelling differs, so any `cd` would show as a changed line.
- **Nothing protected is ever touched** — resolution takes an injectable `readlink` seam and a test asserts no protected path is ever passed to it. That observes what was touched instead of arguing about control flow.
- **The complete candidate is vetted, not just its directory** — a well-known dir whose *ancestor* is symlinked into Documents, and an executable that is *itself* such a symlink, are both rejected; an ordinary binary and one symlinked to a safe target still resolve, so the gate is not simply refusing everything.
- **Version-manager roots are vetted before listing** — a protected `$FNM_DIR`, a symlinked default root, and a symlinked version entry, with a `readDir` seam that throws if a rejected root is ever listed.
- **Wildcard entries are not expanded** — a `$HOME/Documents/*` entry is echoed literally and its directory never enumerated, on both platforms.
- **Case-insensitive spellings are caught** — mixed-case `documents` / `DOWNLOADS` / `mobile documents`.
- **The macOS script contains no `cd` / `pwd` / `readlink`**, and non-macOS keeps its canonicalization.
- **Teardown behaviour** — a login-shell seam that deletes the per-session symlink before returning still resolves from the stable dir; a shell-only custom `$FNM_DIR` is reachable; a live selection wins while a dead one yields missing rather than the newest.
- **The fallback never guesses** — a multi-version root, two single-version roots, an ambiguous active `$FNM_DIR` beside an unrelated single-version root, and both manager signals present (with the fnm root both unambiguous and ambiguous) all yield nothing; `$NVM_BIN` answers where enumeration alone would have been ambiguous.
- **Ambiguity is decided on the whole search list, and only where it exists** — under `darwin`, a capture of `[dead fnm multishell, $NVM_BIN]` with a runnable binary under `$NVM_BIN` resolves to nothing rather than substituting nvm; off macOS, where the shell canonicalized while alive, the same dual-manager PATH keeps its order and still resolves to the selected fnm binary. Both were mutation-checked — removing the filter fails the first, applying it unconditionally fails the second.
- **The classifier makes zero canonicalization calls** for a cwd outside the base, and still canonicalizes when the original cwd is unknown. The two existing symlink regression tests pass unchanged; the redirected-base one is the iCloud case and is why the `realpath` could not simply be deleted.

## QA

Adds `packages/qa/cases/runtime/macos-automatic-probe-file-access.md`. It asserts both halves together — no protected-folder read across idle / reconnect / on-demand probe, *and* a login-shell-only provider still discovered — because either property alone is trivially satisfiable by breaking the other. It needs a macOS account with no prior TCC decision for the runtime binary plus filesystem tracing, so it is a human-requested case, not a CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



