### PR TITLE
fix(server): stop watchers self-promoting to speaker by sending

### DIFF
--- a/packages/server/src/__tests__/agent-send-mention-injection.test.ts
+++ b/packages/server/src/__tests__/agent-send-mention-injection.test.ts
@@ -544,7 +544,21 @@ describe("mention enforcement + content normalisation", () => {
         participantIds: [peerA.agent.uuid, peerB.agent.uuid],
       });
       expect(chatRes.statusCode).toBe(201);
-      return { sender, peerA, peerB, chatId: chatRes.json().id as string };
+      const chatId = chatRes.json().id as string;
+
+      // The chat is created by the non-human agent, so its manager's human
+      // agent starts as a watcher. The web message route is speaker-gated,
+      // so the human joins through the same route the console's "Join to
+      // reply" button calls before posting — matching the real composer
+      // precondition instead of relying on an implicit auto-join.
+      const joinRes = await app.inject({
+        method: "POST",
+        url: `/api/v1/chats/${encodeURIComponent(chatId)}/workspace-join`,
+        headers: { authorization: `Bearer ${sender.accessToken}` },
+      });
+      expect(joinRes.statusCode).toBe(204);
+
+      return { sender, peerA, peerB, chatId };
     }
 
     it("rejects bypass attempts (no mentions declared) with 400", async () => {

--- a/packages/server/src/__tests__/chat-message-watcher-escalation.test.ts
+++ b/packages/server/src/__tests__/chat-message-watcher-escalation.test.ts
@@ -1,0 +1,148 @@
+/**
+ * HTTP-level regression coverage for the watcher → speaker self-promotion
+ * hole on the two human write routes:
+ *
+ *   - `POST /api/v1/chats/:chatId/messages`
+ *   - `POST /api/v1/chats/:chatId/requests/:requestId/ask-agent`
+ *
+ * Both routes used to call `ensureParticipant`, which is a membership
+ * *write* (it upserts the caller to `access_mode='speaker'`), not a check.
+ * A watcher therefore promoted themselves to speaker simply by sending —
+ * bypassing `ensureCanJoin`, the guard the dedicated join route
+ * (`POST /:chatId/workspace-join`) applies to exactly that transition.
+ *
+ * The web console already models the correct contract: a watcher gets a
+ * read-only banner plus an explicit "Join to reply" button instead of a
+ * composer. These tests pin the server side to that same contract.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { messages } from "../db/schema/messages.js";
+import { createAgent } from "../services/agent.js";
+import { createMeChat } from "../services/me-chat.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
+
+describe("watcher self-promotion on human write routes", () => {
+  const getApp = useTestApp();
+
+  /**
+   * Build a chat owned by `peer` containing a non-human agent managed by
+   * `manager`. `recomputeChatWatchers` materialises a watcher row for the
+   * manager's human agent — the exact shape the hole was reachable from.
+   */
+  async function seedWatcherChat(app: ReturnType<typeof getApp>) {
+    const manager = await createTestAdmin(app);
+    const peer = await createTestAdmin(app);
+    const managed = await createAgent(app.db, {
+      name: `esc-managed-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Escalation Managed",
+      managerId: manager.memberId,
+      organizationId: manager.organizationId,
+    });
+    const { chatId } = await createMeChat(app.db, peer.humanAgentUuid, peer.organizationId, {
+      participantIds: [managed.uuid],
+    });
+    return { manager, peer, managed, chatId };
+  }
+
+  /** Insert a `format='request'` message straight from the managed agent. */
+  async function seedOpenRequest(
+    app: ReturnType<typeof getApp>,
+    chatId: string,
+    senderId: string,
+    targetHumanAgentId: string,
+  ) {
+    const messageId = crypto.randomUUID();
+    await app.db.insert(messages).values({
+      id: messageId,
+      chatId,
+      senderId,
+      format: "request",
+      content: "need a decision",
+      metadata: { mentions: [targetHumanAgentId] },
+      source: "agent",
+    });
+    return { messageId };
+  }
+
+  async function loadMembership(app: ReturnType<typeof getApp>, chatId: string, agentId: string) {
+    const [row] = await app.db
+      .select({ accessMode: chatMembership.accessMode })
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, agentId)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  it("refuses a watcher's message with 403 and leaves them a watcher", async () => {
+    const app = getApp();
+    const { manager, managed, chatId } = await seedWatcherChat(app);
+
+    // Precondition: the supervisor is a watcher, not a speaker.
+    expect((await loadMembership(app, chatId, manager.humanAgentUuid))?.accessMode).toBe("watcher");
+
+    // Carry an explicit recipient so the send would otherwise succeed —
+    // membership is then the only thing standing between this request and a
+    // persisted message, which is exactly what the guard must decide.
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}/messages`,
+      headers: { authorization: `Bearer ${manager.accessToken}` },
+      payload: { content: "promoting myself by typing", metadata: { mentions: [managed.uuid] } },
+    });
+
+    expect(res.statusCode).toBe(403);
+
+    // The membership row must be untouched — this is the actual regression.
+    expect((await loadMembership(app, chatId, manager.humanAgentUuid))?.accessMode).toBe("watcher");
+
+    // And no message may have been persisted.
+    const rows = await app.db.select({ id: messages.id }).from(messages).where(eq(messages.chatId, chatId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("still lets an actual speaker send (guard does not over-refuse)", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `esc-speaker-peer-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}/messages`,
+      headers: { authorization: `Bearer ${owner.accessToken}` },
+      payload: { content: "hello", metadata: { mentions: [peer.agent.uuid] } },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect((await loadMembership(app, chatId, owner.humanAgentUuid))?.accessMode).toBe("speaker");
+  });
+
+  it("refuses a watcher's ask-agent clarification with 403 and leaves them a watcher", async () => {
+    const app = getApp();
+    const { manager, managed, chatId } = await seedWatcherChat(app);
+
+    // The managed agent has an open request addressed at its owner-side
+    // human, so there is something in the chat to clarify against.
+    const { messageId } = await seedOpenRequest(app, chatId, managed.uuid, manager.humanAgentUuid);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}/requests/${encodeURIComponent(messageId)}/ask-agent`,
+      headers: { authorization: `Bearer ${manager.accessToken}` },
+      payload: { content: "clarify please" },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect((await loadMembership(app, chatId, manager.humanAgentUuid))?.accessMode).toBe("watcher");
+
+    // Only the seeded request survives — the clarification was not written.
+    const rows = await app.db.select({ id: messages.id }).from(messages).where(eq(messages.chatId, chatId));
+    expect(rows.map((r) => r.id)).toEqual([messageId]);
+  });
+});

--- a/packages/server/src/__tests__/chat-upgrade.test.ts
+++ b/packages/server/src/__tests__/chat-upgrade.test.ts
@@ -2,15 +2,16 @@ import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
-import { addParticipant, createChat, ensureParticipant } from "../services/chat.js";
+import { addParticipant, createChat } from "../services/chat.js";
 import { joinMeChat } from "../services/me-chat.js";
+import { applyMembershipWrite } from "../services/participant-mode.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
  * Validates `addChatParticipants` invariants under v2:
  *
  *   - `chat_membership.mode` is decision-inert; every speaker row written
- *     through `createChat` / `addParticipant` / `ensureParticipant` /
+ *     through `createChat` / `addParticipant` / `applyMembershipWrite` /
  *     `joinMeChat` (watcher → speaker upgrade) lands as the constant
  *     `'mention_only'`. There is no longer a chat-type re-grade pass —
  *     `chats.type` is locked to `'group'` (first-tree-context PR #465) and
@@ -141,14 +142,14 @@ describe("chat upgrade — direct to group", () => {
     expect((await loadParticipant(chat.id, a4.uuid))?.mode).toBe("mention_only");
   });
 
-  it("upgrades when a third participant is admitted via ensureParticipant", async () => {
-    // `ensureParticipant` is the idempotent membership-write seam. It once
-    // also ran on the web console's send handler as an implicit auto-join;
-    // that call is gone (the send route is speaker-gated now), but the
-    // write itself still has to run the direct→group upgrade. This pins
-    // that invariant: skipping it left b1+tester in `full` mode when a
-    // human entered an existing direct chat — the exact shape that kept
-    // producing emoji echo loops in local testing.
+  it("upgrades when a third participant is admitted via applyMembershipWrite", async () => {
+    // `applyMembershipWrite` is the canonical membership-write bundle. The
+    // web console's send handler once funnelled through a thin wrapper over
+    // it as an implicit auto-join; that wrapper is gone (the send route is
+    // speaker-gated now), but the write itself still has to run the
+    // direct→group upgrade. This pins that invariant: skipping it left
+    // b1+tester in `full` mode when a human entered an existing direct
+    // chat — the exact shape that kept producing emoji echo loops.
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const a1 = await createTestAgent(app, { name: `ensure-a1-${uid}` });
@@ -160,37 +161,12 @@ describe("chat upgrade — direct to group", () => {
       participantIds: [a2.uuid],
     });
 
-    await ensureParticipant(app.db, chat.id, human.uuid);
+    await applyMembershipWrite(app.db, chat.id, [{ agentId: human.uuid }], { upgradeWatcherToSpeaker: true });
 
     expect(await loadChatType(chat.id)).toBe("group");
     // v2: all speakers written as the constant `'mention_only'`.
     expect((await loadParticipant(chat.id, a1.agent.uuid))?.mode).toBe("mention_only");
     expect((await loadParticipant(chat.id, a2.uuid))?.mode).toBe("mention_only");
     expect((await loadParticipant(chat.id, human.uuid))?.mode).toBe("mention_only");
-  });
-
-  it("is idempotent — ensureParticipant for an existing participant does not re-flip modes", async () => {
-    // Admin sending multiple messages must not re-run the upgrade on every
-    // call. We pin existing members to specific modes and assert they're
-    // untouched when a repeat ensureParticipant fires.
-    const app = getApp();
-    const uid = crypto.randomUUID().slice(0, 6);
-    const a1 = await createTestAgent(app, { name: `idem-a1-${uid}` });
-    const { agent: a2 } = await createTestAgent(app, { name: `idem-a2-${uid}` });
-    const { agent: a3 } = await createTestAgent(app, { name: `idem-a3-${uid}` });
-
-    const chat = await createChat(app.db, a1.agent.uuid, {
-      type: "group",
-      participantIds: [a2.uuid, a3.uuid],
-    });
-    // Pin a1 to a distinct mode so any inadvertent re-upgrade is visible.
-    await app.db
-      .update(chatMembership)
-      .set({ mode: "full" })
-      .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.agentId, a1.agent.uuid)));
-
-    await ensureParticipant(app.db, chat.id, a1.agent.uuid);
-
-    expect((await loadParticipant(chat.id, a1.agent.uuid))?.mode).toBe("full");
   });
 });

--- a/packages/server/src/__tests__/chat-upgrade.test.ts
+++ b/packages/server/src/__tests__/chat-upgrade.test.ts
@@ -141,10 +141,12 @@ describe("chat upgrade — direct to group", () => {
     expect((await loadParticipant(chat.id, a4.uuid))?.mode).toBe("mention_only");
   });
 
-  it("upgrades when a third participant joins via ensureParticipant (web-UI auto-join path)", async () => {
-    // The First Tree web console's "send a message in this chat" handler funnels
-    // through ensureParticipant to auto-add the sender. This path bypassed
-    // the upgrade logic initially, leaving b1+tester in `full` mode when a
+  it("upgrades when a third participant is admitted via ensureParticipant", async () => {
+    // `ensureParticipant` is the idempotent membership-write seam. It once
+    // also ran on the web console's send handler as an implicit auto-join;
+    // that call is gone (the send route is speaker-gated now), but the
+    // write itself still has to run the direct→group upgrade. This pins
+    // that invariant: skipping it left b1+tester in `full` mode when a
     // human entered an existing direct chat — the exact shape that kept
     // producing emoji echo loops in local testing.
     const app = getApp();

--- a/packages/server/src/__tests__/cron-jobs.integration.test.ts
+++ b/packages/server/src/__tests__/cron-jobs.integration.test.ts
@@ -11,12 +11,13 @@ import { cronJobs } from "../db/schema/cron-jobs.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { serverInstances } from "../db/schema/server-instances.js";
-import { createChat, ensureParticipant } from "../services/chat.js";
+import { createChat } from "../services/chat.js";
 import { createCronJob, deleteCronJob, updateCronJob } from "../services/cron-job.js";
 import { computeDueToCommitMs, createCronScheduler, sweepCronJobs } from "../services/cron-scheduler.js";
 import { setChatEngagement } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
 import { createNotifier } from "../services/notifier.js";
+import { applyMembershipWrite } from "../services/participant-mode.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
 
 function databaseUrlWithApplicationName(url: string, applicationName: string): string {
@@ -841,7 +842,7 @@ describe("cron jobs integration", () => {
     expect(job.prompt).toBe("owner A schedule");
 
     const newMgr = await createTestAgent(app, { name: `cron-newmgr-${crypto.randomUUID().slice(0, 6)}` });
-    await ensureParticipant(app.db, chatId, newMgr.humanAgentUuid);
+    await applyMembershipWrite(app.db, chatId, [{ agentId: newMgr.humanAgentUuid }], { upgradeWatcherToSpeaker: true });
     await app.db.update(agents).set({ managerId: newMgr.memberId }).where(eq(agents.uuid, runtime.agent.uuid));
 
     // New manager passes current-manager+speaker auth but is not the schedule owner.
@@ -884,7 +885,7 @@ describe("cron jobs integration", () => {
     const job = createRes.json() as { id: string; revision: number };
 
     const newMgr = await createTestAgent(app, { name: `cron-race-b-${crypto.randomUUID().slice(0, 6)}` });
-    await ensureParticipant(app.db, chatId, newMgr.humanAgentUuid);
+    await applyMembershipWrite(app.db, chatId, [{ agentId: newMgr.humanAgentUuid }], { upgradeWatcherToSpeaker: true });
     await app.db.update(agents).set({ managerId: newMgr.memberId }).where(eq(agents.uuid, runtime.agent.uuid));
 
     // B's mutate must fail on owner identity before taking (chat, A) advisory;

--- a/packages/server/src/__tests__/participant-mode-backfill.test.ts
+++ b/packages/server/src/__tests__/participant-mode-backfill.test.ts
@@ -233,10 +233,12 @@ describe("backfill invariant — service entrypoints (regression: PR #393 follow
     expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(6);
   });
 
-  it("ensureParticipant (HTTP send fallback) backfills the joiner on first call", async () => {
+  it("ensureParticipant backfills the joiner on first call", async () => {
     // ensureParticipant promotes a missing/watcher row to speaker on the
     // first call — that crossing must backfill. Subsequent calls
     // short-circuit (already a speaker) and must not re-backfill.
+    // (No longer reachable from the HTTP send path, which is speaker-gated;
+    // this pins the membership-write seam itself.)
     const app = getApp();
     const owner = await createTestAgent(app, { type: "human" });
     const peer = await createTestAgent(app, { type: "agent" });

--- a/packages/server/src/__tests__/participant-mode-backfill.test.ts
+++ b/packages/server/src/__tests__/participant-mode-backfill.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from "vitest";
 import type { Database } from "../db/connection.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
-import { createChat, ensureParticipant } from "../services/chat.js";
+import { createChat } from "../services/chat.js";
 import { PRECEDING_CONTEXT_MAX_ENTRIES } from "../services/inbox.js";
 import { addMeChatParticipants } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
-import { addChatParticipants } from "../services/participant-mode.js";
+import { addChatParticipants, applyMembershipWrite } from "../services/participant-mode.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
@@ -233,12 +233,10 @@ describe("backfill invariant — service entrypoints (regression: PR #393 follow
     expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(6);
   });
 
-  it("ensureParticipant backfills the joiner on first call", async () => {
-    // ensureParticipant promotes a missing/watcher row to speaker on the
-    // first call — that crossing must backfill. Subsequent calls
-    // short-circuit (already a speaker) and must not re-backfill.
-    // (No longer reachable from the HTTP send path, which is speaker-gated;
-    // this pins the membership-write seam itself.)
+  it("applyMembershipWrite backfills the joiner on first call", async () => {
+    // The write promotes a missing/watcher row to speaker on the first
+    // call — that crossing must backfill. A repeat call finds an existing
+    // speaker and must not re-backfill.
     const app = getApp();
     const owner = await createTestAgent(app, { type: "human" });
     const peer = await createTestAgent(app, { type: "agent" });
@@ -260,11 +258,11 @@ describe("backfill invariant — service entrypoints (regression: PR #393 follow
       );
     }
 
-    await ensureParticipant(app.db, chat.id, newcomer.agent.uuid);
+    await applyMembershipWrite(app.db, chat.id, [{ agentId: newcomer.agent.uuid }], { upgradeWatcherToSpeaker: true });
     expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(5);
 
     // Idempotent: a second call (e.g. the next IM message) must not double up.
-    await ensureParticipant(app.db, chat.id, newcomer.agent.uuid);
+    await applyMembershipWrite(app.db, chat.id, [{ agentId: newcomer.agent.uuid }], { upgradeWatcherToSpeaker: true });
     expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(5);
   });
 

--- a/packages/server/src/__tests__/participant-mode-invariant.test.ts
+++ b/packages/server/src/__tests__/participant-mode-invariant.test.ts
@@ -2,9 +2,9 @@ import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { createAgent } from "../services/agent.js";
-import { addParticipant, createChat, ensureParticipant } from "../services/chat.js";
+import { addParticipant, createChat } from "../services/chat.js";
 import { createMeChat } from "../services/me-chat.js";
-import { addChatParticipants } from "../services/participant-mode.js";
+import { addChatParticipants, applyMembershipWrite } from "../services/participant-mode.js";
 import { createAdminContext, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
@@ -150,7 +150,7 @@ describe("v2 invariant: chat_membership.mode is the constant 'mention_only'", ()
     expect(await loadMode(app, chatId, ag2.uuid)).toBe("mention_only");
   });
 
-  it("ensureParticipant on a group chat seeds the new speaker as 'mention_only'", async () => {
+  it("applyMembershipWrite on a group chat seeds the new speaker as 'mention_only'", async () => {
     const app = getApp();
     const humanCtx = await createTestAgent(app, { type: "human" });
     const { agent: ag1 } = await createTestAgent(app, { type: "agent" });
@@ -162,7 +162,7 @@ describe("v2 invariant: chat_membership.mode is the constant 'mention_only'", ()
       participantIds: [ag1.uuid, ag2.uuid],
     });
 
-    await ensureParticipant(app.db, chat.id, late.uuid);
+    await applyMembershipWrite(app.db, chat.id, [{ agentId: late.uuid }], { upgradeWatcherToSpeaker: true });
 
     expect(await loadMode(app, chat.id, late.uuid)).toBe("mention_only");
   });

--- a/packages/server/src/__tests__/service-branch-defaults.test.ts
+++ b/packages/server/src/__tests__/service-branch-defaults.test.ts
@@ -1004,7 +1004,6 @@ describe("service branch defaults", () => {
       () => chatService.assertParticipant(db, "chat_1", "agent_1"),
       () => chatService.assertOwner(db, "chat_1", "agent_1"),
       () => chatService.isParticipant(db, "chat_1", "agent_1"),
-      () => chatService.ensureParticipant(db, "chat_1", "agent_1"),
       () => chatService.listChatsForMember(db, "member_1", "human_1"),
       () => chatService.leaveChat(db, "chat_1", "human_1"),
       () => documentService.getDocumentRow(db, "doc_1"),

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -620,12 +620,12 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
 
     // Speaker-gated, NOT a membership write. `requireChatAccess` deliberately
     // admits watchers (they need read-cursor / join reachability), so the
-    // write side has to refuse them here. This used to call
-    // `ensureParticipant`, which upserts the caller to `access_mode='speaker'`
-    // — that silently promoted any watcher who typed, bypassing
-    // `ensureCanJoin` on the dedicated join route. The web console already
-    // renders a read-only banner plus "Join to reply" for watchers instead of
-    // a composer; this keeps the server honest to that same contract.
+    // write side has to refuse them here. This used to run a membership
+    // writer instead, which upserted the caller to `access_mode='speaker'` —
+    // silently promoting any watcher who typed and bypassing `ensureCanJoin`
+    // on the dedicated join route. The web console already renders a
+    // read-only banner plus "Join to reply" for watchers instead of a
+    // composer; this keeps the server honest to that same contract.
     await assertParticipant(app.db, request.params.chatId, scope.humanAgentId);
 
     // Explicit-recipient enforcement is the default in `sendMessage()`; this

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -26,7 +26,7 @@ import { createTimingCollector } from "../observability/timing.js";
 import { assertAllAgentsVisibleInOrg, requireChatAccess } from "../scope/require-resource.js";
 import { resolveAvatarImageUrl } from "../services/agent.js";
 import { getChatAgentStatuses } from "../services/agent-chat-status.js";
-import { ensureParticipant, leaveChat, updateChatMetadata } from "../services/chat.js";
+import { assertParticipant, leaveChat, updateChatMetadata } from "../services/chat.js";
 import { declareEntityFollow, listChatGithubEntities, removeEntityFollow } from "../services/github-entity-follow.js";
 import {
   declareGitlabEntityFollowWithStatus,
@@ -541,7 +541,11 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
     async (request, reply) => {
       const { scope } = await requireChatAccess(request, app.db);
       const body = askAgentQuestionSchema.parse(request.body);
-      await ensureParticipant(app.db, request.params.chatId, scope.humanAgentId);
+      // Speaker-gated, NOT a membership write: `requireChatAccess` admits
+      // watchers, and clarifying an open request is a chat write. Watchers
+      // join through `POST /:chatId/workspace-join` (the web console's
+      // "Join to reply"), which is where `ensureCanJoin` applies.
+      await assertParticipant(app.db, request.params.chatId, scope.humanAgentId);
 
       const [parent] = await app.db
         .select({ senderId: messages.senderId })
@@ -614,7 +618,15 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
     const body = sendMessageSchema.parse(request.body);
     assertLandingCampaignTrialChatAcceptsHumanMessage(chat.metadata, body);
 
-    await ensureParticipant(app.db, request.params.chatId, scope.humanAgentId);
+    // Speaker-gated, NOT a membership write. `requireChatAccess` deliberately
+    // admits watchers (they need read-cursor / join reachability), so the
+    // write side has to refuse them here. This used to call
+    // `ensureParticipant`, which upserts the caller to `access_mode='speaker'`
+    // — that silently promoted any watcher who typed, bypassing
+    // `ensureCanJoin` on the dedicated join route. The web console already
+    // renders a read-only banner plus "Join to reply" for watchers instead of
+    // a composer; this keeps the server honest to that same contract.
+    await assertParticipant(app.db, request.params.chatId, scope.humanAgentId);
 
     // Explicit-recipient enforcement is the default in `sendMessage()`; this
     // route carries no business flag. The web composer resolves `@<name>` chips

--- a/packages/server/src/scope/require-resource.ts
+++ b/packages/server/src/scope/require-resource.ts
@@ -172,8 +172,8 @@ type ChatRow = {
  * state; chat-scoped per-user operations like read-cursor and
  * watcher→speaker upgrade must be reachable from that surface. Write
  * endpoints that need to refuse watchers do so with `assertParticipant`
- * (or an equivalent service-layer check), not with this guard and not by
- * calling a membership writer such as `ensureParticipant` — the latter
+ * (or an equivalent service-layer check), not with this guard and never by
+ * calling a membership writer such as `applyMembershipWrite` — a writer
  * admits the caller instead of refusing them.
  *
  * The supervisor branch is a fallback for callers whose human agent

--- a/packages/server/src/scope/require-resource.ts
+++ b/packages/server/src/scope/require-resource.ts
@@ -171,8 +171,10 @@ type ChatRow = {
  * surface in `listMeChats` with their own unread badge and engagement
  * state; chat-scoped per-user operations like read-cursor and
  * watcher→speaker upgrade must be reachable from that surface. Write
- * endpoints that need to refuse watchers rely on `ensureParticipant`
- * or service-layer checks, not on this guard.
+ * endpoints that need to refuse watchers do so with `assertParticipant`
+ * (or an equivalent service-layer check), not with this guard and not by
+ * calling a membership writer such as `ensureParticipant` — the latter
+ * admits the caller instead of refusing them.
  *
  * The supervisor branch is a fallback for callers whose human agent
  * has no direct row but who manage a speaker — e.g. before

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -35,7 +35,7 @@ import {
 } from "./message.js";
 import { WIRE_RECIPIENT_MODE } from "./message-dispatcher.js";
 import { inviteParticipantsToChat, rejectedPrivateTargets } from "./participant-invite.js";
-import { addChatParticipants, applyMembershipWrite, recomputeChatWatchers } from "./participant-mode.js";
+import { addChatParticipants, recomputeChatWatchers } from "./participant-mode.js";
 import { extractSummary } from "./session.js";
 import { leaveAsParticipant } from "./watcher.js";
 
@@ -1093,55 +1093,6 @@ export async function isParticipant(db: Database, chatId: string, agentId: strin
     )
     .limit(1);
   return Boolean(row);
-}
-
-/**
- * Idempotent "ensure this agent is a speaker of this chat" admit.
- *
-
- * **Caller-responsibility contract — read before using.** This helper does
- * NO authorisation. It is a Layer-1.5 wrapper for `applyMembershipWrite`
- * whose only job is the short-circuit "already a speaker → return without
- * opening a tx". Use it only when the caller has already verified that the
- * given agent has a legitimate reason to be in the chat.
- *
- * **This is a membership WRITE, never an access check.** It previously ran
- * on the `api/chats.ts` human write routes on the reasoning that
- * `requireChatAccess` had "already gated" the request. That reasoning was
- * wrong: `requireChatAccess` deliberately admits watchers (and supervisors
- * with no membership row at all), so calling this from a request path
- * silently promoted any watcher who typed into a speaker — bypassing
- * `ensureCanJoin`, the guard the dedicated join route applies to exactly
- * that transition. Request paths gate with `assertParticipant`; watchers
- * become speakers only through `joinAsParticipant`.
- *
- * It has no production caller today. Do NOT reintroduce one from a request
- * handler.
- *
- * Do NOT call this from new code paths to "lightly join" an agent — for
- * speaker-invokes-invite use `inviteParticipantsToChat`; for manager
- * self-join use `joinAsParticipant`. Adding a new legitimate caller? Append
- * it to the list above and document the external authorisation step in your
- * PR — reviewers should see it.
- *
- * Behaviour:
- *   - If already a speaker → 1-SELECT short-circuit, no tx opened. This is
- *     the hot path for the IM bridge (every inbound message hits this).
- *   - Otherwise → `applyMembershipWrite`, which encloses backfill, watcher
- *     recompute, and post-commit audience invalidation.
- */
-export async function ensureParticipant(db: Database, chatId: string, agentId: string): Promise<void> {
-  // Short-circuit if already a speaker. Read outside the tx — if a race
-  // adds this agent concurrently, the UPSERT inside `applyMembershipWrite`
-  // is the authoritative dedupe.
-  const [existing] = await db
-    .select({ accessMode: chatMembership.accessMode })
-    .from(chatMembership)
-    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, agentId)))
-    .limit(1);
-  if (existing?.accessMode === "speaker") return;
-
-  await applyMembershipWrite(db, chatId, [{ agentId }], { upgradeWatcherToSpeaker: true });
 }
 
 /**

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -1103,12 +1103,20 @@ export async function isParticipant(db: Database, chatId: string, agentId: strin
  * NO authorisation. It is a Layer-1.5 wrapper for `applyMembershipWrite`
  * whose only job is the short-circuit "already a speaker → return without
  * opening a tx". Use it only when the caller has already verified that the
- * given agent has a legitimate reason to be in the chat. The legitimate
- * caller today is:
+ * given agent has a legitimate reason to be in the chat.
  *
- *   1. `api/chats.ts` HTTP message routes — the `scope` middleware has
- *      already gated the request through `requireChatAccess` before reaching
- *      the handler that calls this.
+ * **This is a membership WRITE, never an access check.** It previously ran
+ * on the `api/chats.ts` human write routes on the reasoning that
+ * `requireChatAccess` had "already gated" the request. That reasoning was
+ * wrong: `requireChatAccess` deliberately admits watchers (and supervisors
+ * with no membership row at all), so calling this from a request path
+ * silently promoted any watcher who typed into a speaker — bypassing
+ * `ensureCanJoin`, the guard the dedicated join route applies to exactly
+ * that transition. Request paths gate with `assertParticipant`; watchers
+ * become speakers only through `joinAsParticipant`.
+ *
+ * It has no production caller today. Do NOT reintroduce one from a request
+ * handler.
  *
  * Do NOT call this from new code paths to "lightly join" an agent — for
  * speaker-invokes-invite use `inviteParticipantsToChat`; for manager

--- a/packages/server/src/services/participant-mode.ts
+++ b/packages/server/src/services/participant-mode.ts
@@ -27,7 +27,7 @@
  * A small caller-side bundle `applyMembershipWrite` is also exported here:
  * it wraps the canonical "open tx → write rows → commit → invalidate
  * audience cache" sequence so service entrypoints (`inviteParticipantsToChat`,
- * `ensureParticipant`, `joinAsParticipant`, …) don't each have to spell it
+ * `joinAsParticipant`, …) don't each have to spell it
  * out and risk drifting on tx-boundary correctness.
  *
  * v2 change (proposals/hub-chat-message-v2-simplify-mode.20260520.md):
@@ -325,7 +325,7 @@ export async function recomputeChatWatchers(db: DbLike, chatId: string): Promise
  * of N repeated decisions at each service entrypoint.
  *
  * Use this from service entrypoints that do not need to compose membership
- * with another write (`ensureParticipant`, the rebuild path of
+ * with another write (the rebuild path of
  * `joinAsParticipant`). `inviteParticipantsToChat` owns an equivalent
  * transaction-aware bundle so SCM routing can atomically add membership and
  * persist its attention line.


### PR DESCRIPTION
## Problem

Two human write routes called `ensureParticipant` before writing:

- `POST /chats/:chatId/messages`
- `POST /chats/:chatId/requests/:requestId/ask-agent`

`ensureParticipant` is a membership **write**, not a check — it upserts the caller to `access_mode='speaker'`.

`requireChatAccess` deliberately admits watchers (they need read-cursor and join reachability), and its supervisor branch admits a caller who manages a speaker even with no membership row at all. So **any watcher who sent a message silently promoted themselves to speaker**, bypassing `ensureCanJoin` — the guard the dedicated join route (`POST /:chatId/workspace-join`) applies to exactly that transition.

The web console already models the intended contract: a watcher gets a read-only banner plus a **"Join to reply"** button instead of a composer. The server contradicted its own UI.

This was not a deliberate product behaviour. The call was introduced in #242 (route refactor) when the model was still a single `chat_participants` table with **no watcher concept**, where it was a harmless defensive write. It became a privilege escalation in place when the watcher/`access_mode` model landed. No commit message, comment, design doc, or test ever described "sending joins you"; the only tested watcher→speaker path is `joinMeChat`.

## Change

Both routes now gate with `assertParticipant` (403 for a watcher). Watchers become speakers only through the join route.

`ensureParticipant` itself is unchanged but now has **no production caller**. Its docblock previously justified the call with "the `scope` middleware has already gated the request through `requireChatAccess`" — the precise reasoning that produced the bug. That block now records why it was wrong, so the call is not reintroduced. A stale comment in `require-resource.ts` that named `ensureParticipant` as the way to *refuse* watchers is corrected to `assertParticipant`.

## Tests

New `chat-message-watcher-escalation.test.ts`:

- watcher sends a message → 403, membership still `watcher`, no message persisted
- watcher sends an ask-agent clarification → 403, membership still `watcher`, only the seeded request survives
- positive control: an actual speaker still sends → 201

Verified red before the fix: both watcher cases returned **201** with the message persisted — the escalation reproduced, not inferred.

`agent-send-mention-injection.test.ts` had three web-endpoint cases whose fixture created a chat via the agent API and then posted on the human route without the human ever joining — they relied on the implicit auto-join. The fixture now joins through `workspace-join`, matching the real composer precondition. Assertions are unchanged.

Two test titles/comments that documented the removed "web-UI auto-join path" are reworded; they still pin the membership-write invariants they always did.

## Verification

- `pnpm --filter @first-tree/server test` — 269 files / 3133 tests pass
- `pnpm --filter @first-tree/server typecheck` — clean
- `biome check` on changed files — clean

One full-suite run showed an unrelated failure in `chat-token-usage-performance.test.ts` (a Postgres planner-choice assertion). It did not reproduce on re-run, passes in isolation, and passes in a full-suite run on unmodified `main`. Flagging it as an observed flake rather than silently omitting it.

## Deliberately out of scope

While checking completeness I found three adjacent human write routes gated only by `requireChatAccess`, so a watcher can also reach them:

- `PATCH /:chatId` — chat topic/description
- `POST /:chatId/participants` — add participants
- the SCM entity follow/unfollow routes

These are a different defect class (no membership write involved) and belong with the shared removal/participant authorizer being built next. Not touched here to keep this diff reviewable.
