### PR TITLE
feat(server): shared authorizer for chat participant removal

### DIFF
--- a/packages/server/src/__tests__/chat-remove-participant-route.test.ts
+++ b/packages/server/src/__tests__/chat-remove-participant-route.test.ts
@@ -1,0 +1,171 @@
+/**
+ * HTTP-level tests for `DELETE /api/v1/chats/:chatId/participants/:agentId`
+ * — the web-side removal surface. Chat details previously had no removal
+ * action at all ("deferred alongside the missing backend routes for
+ * member-side removal"); this is that route.
+ *
+ * Class C route — `docs/development/http-path-conventions.md` requires
+ * multi-org / access coverage. The authorization matrix itself lives in
+ * `participant-removal.test.ts`; this file pins the wire contract and the
+ * access boundary, plus one case proving the route really does route
+ * through the shared authorizer rather than re-implementing it.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chats } from "../db/schema/chats.js";
+import { organizations } from "../db/schema/organizations.js";
+import { createAgent } from "../services/agent.js";
+import { createMeChat } from "../services/me-chat.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+describe("DELETE /chats/:chatId/participants/:agentId", () => {
+  const getApp = useTestApp();
+
+  async function ownedAgent(app: ReturnType<typeof getApp>, memberId: string, orgId: string, label: string) {
+    return createAgent(app.db, {
+      name: `route-${label}-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: `Route ${label}`,
+      managerId: memberId,
+      organizationId: orgId,
+    });
+  }
+
+  function removeUrl(chatId: string, agentId: string) {
+    return `/api/v1/chats/${encodeURIComponent(chatId)}/participants/${encodeURIComponent(agentId)}`;
+  }
+
+  it("removes a participant and returns 204", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "ok");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: removeUrl(chatId, helper.uuid),
+      headers: { authorization: `Bearer ${owner.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(204);
+    const [row] = await app.db
+      .select({ agentId: chatMembership.agentId })
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, helper.uuid)));
+    expect(row).toBeUndefined();
+  });
+
+  it("404s for a same-org caller with no access to the chat (anti-enumeration)", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const outsider = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "iso");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: removeUrl(chatId, helper.uuid),
+      headers: { authorization: `Bearer ${outsider.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+    const [row] = await app.db
+      .select({ agentId: chatMembership.agentId })
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, helper.uuid)));
+    expect(row).toBeDefined();
+  });
+
+  it("404s for a caller in a different organization (cross-org boundary)", async () => {
+    const app = getApp();
+    const caller = await createTestAdmin(app);
+
+    const orgB = `org-rm-${crypto.randomUUID().slice(0, 6)}`;
+    await app.db.insert(organizations).values({ id: orgB, name: orgB.slice(0, 30), displayName: "Org B" });
+    const botUuid = crypto.randomUUID();
+    await app.db.insert(agents).values({
+      uuid: botUuid,
+      name: `bot-rm-${crypto.randomUUID().slice(0, 6)}`,
+      organizationId: orgB,
+      type: "agent",
+      displayName: "Bot B",
+      inboxId: `inbox_${botUuid}`,
+      // FK is unconstrained across orgs; mirrors the cross-org convention
+      // used by the pin-route suite for building a side-org agent cheaply.
+      managerId: caller.memberId,
+    });
+    const chatIdB = crypto.randomUUID();
+    await app.db.insert(chats).values({ id: chatIdB, organizationId: orgB, type: "group" });
+    await app.db
+      .insert(chatMembership)
+      .values({ chatId: chatIdB, agentId: botUuid, role: "member", accessMode: "speaker" });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: removeUrl(chatIdB, botUuid),
+      headers: { authorization: `Bearer ${caller.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("applies the shared authorizer — a bystander speaker gets 403", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const bystander = await createTestAdmin(app);
+    const victimOwner = await createTestAdmin(app);
+    const victim = await ownedAgent(app, victimOwner.memberId, victimOwner.organizationId, "victim");
+    const bystanderAgent = await ownedAgent(app, bystander.memberId, bystander.organizationId, "bystander");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [victim.uuid, bystanderAgent.uuid],
+    });
+    // The bystander speaks in the chat but owns neither it nor the target.
+    await app.db
+      .insert(chatMembership)
+      .values({
+        chatId,
+        agentId: bystander.humanAgentUuid,
+        role: "member",
+        accessMode: "speaker",
+        mode: "mention_only",
+        source: "manual",
+      })
+      .onConflictDoUpdate({
+        target: [chatMembership.chatId, chatMembership.agentId],
+        set: { accessMode: "speaker" },
+      });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: removeUrl(chatId, victim.uuid),
+      headers: { authorization: `Bearer ${bystander.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("refuses removing yourself — that is workspace-leave", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "selfroute");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: removeUrl(chatId, owner.humanAgentUuid),
+      headers: { authorization: `Bearer ${owner.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/packages/server/src/__tests__/participant-removal.test.ts
+++ b/packages/server/src/__tests__/participant-removal.test.ts
@@ -14,6 +14,7 @@ import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { messages } from "../db/schema/messages.js";
 import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import { createMeChat } from "../services/me-chat.js";
@@ -423,6 +424,128 @@ describe("removeParticipantFromChat", () => {
         targetAgentId: helper.uuid,
       }),
     ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("also clears delivered inbox rows, which rebind would otherwise revive", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "delivered");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+    await sendMessage(
+      app.db,
+      chatId,
+      owner.humanAgentUuid,
+      { source: "api", format: "text", content: "ping" },
+      { allowRecipientlessSend: true },
+    );
+    // Simulate a claim that already handed the row to the runtime.
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "delivered" })
+      .where(and(eq(inboxEntries.inboxId, helper.inboxId), eq(inboxEntries.chatId, chatId)));
+
+    await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: owner.humanAgentUuid,
+      targetAgentId: helper.uuid,
+    });
+
+    // `resetDeliveredForInboxes` flips delivered → pending on the next bind
+    // without consulting membership, so a surviving delivered row would wake
+    // an agent that is no longer in the chat.
+    const rows = await app.db
+      .select({ id: inboxEntries.id })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, helper.inboxId), eq(inboxEntries.chatId, chatId)));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("refuses to strand an unanswered request when removal detaches the target entirely", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const other = await createTestAdmin(app);
+    const ownerAgent = await ownedAgent(app, owner.memberId, owner.organizationId, "asker");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [ownerAgent.uuid],
+    });
+    // `other` speaks here but manages nothing in the chat, so removal would
+    // delete their row outright.
+    await app.db.insert(chatMembership).values({
+      chatId,
+      agentId: other.humanAgentUuid,
+      role: "member",
+      accessMode: "speaker",
+      mode: "mention_only",
+      source: "manual",
+    });
+    await app.db.insert(messages).values({
+      id: crypto.randomUUID(),
+      chatId,
+      senderId: ownerAgent.uuid,
+      format: "request",
+      content: "need a decision",
+      metadata: { mentions: [other.humanAgentUuid] },
+      source: "agent",
+    });
+
+    // Detaching them would drop the request out of their Need-You queue,
+    // deny them the chat, and leave open_request_count blocking archive.
+    await expect(
+      removeParticipantFromChat(app.db, {
+        chatId,
+        callerAgentId: owner.humanAgentUuid,
+        targetAgentId: other.humanAgentUuid,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    expect((await membershipOf(app, chatId, other.humanAgentUuid))?.accessMode).toBe("speaker");
+  });
+
+  it("allows removal with an open request when the target keeps a watcher row", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const other = await createTestAdmin(app);
+    const theirAgent = await ownedAgent(app, other.memberId, other.organizationId, "theirs");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [theirAgent.uuid],
+    });
+    await app.db
+      .insert(chatMembership)
+      .values({
+        chatId,
+        agentId: other.humanAgentUuid,
+        role: "member",
+        accessMode: "speaker",
+        mode: "mention_only",
+        source: "manual",
+      })
+      .onConflictDoUpdate({
+        target: [chatMembership.chatId, chatMembership.agentId],
+        set: { accessMode: "speaker" },
+      });
+    await app.db.insert(messages).values({
+      id: crypto.randomUUID(),
+      chatId,
+      senderId: theirAgent.uuid,
+      format: "request",
+      content: "need a decision",
+      metadata: { mentions: [other.humanAgentUuid] },
+      source: "agent",
+    });
+
+    // Their own agent stays, so the watcher row survives — they can still
+    // see the request and join to answer it. No reason to block.
+    await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: owner.humanAgentUuid,
+      targetAgentId: other.humanAgentUuid,
+    });
+
+    expect((await membershipOf(app, chatId, other.humanAgentUuid))?.accessMode).toBe("watcher");
   });
 
   it("does not resurrect the removed agent through the watcher recompute", async () => {

--- a/packages/server/src/__tests__/participant-removal.test.ts
+++ b/packages/server/src/__tests__/participant-removal.test.ts
@@ -560,9 +560,12 @@ describe("removeParticipantFromChat", () => {
     });
 
     // `workspace-leave` downgrades a departing owner to watcher and keeps
-    // `role='owner'`, so the owner row is not necessarily a speaker. The
-    // authority snapshot has to lock that agent row anyway — it is still the
-    // row the owner-side decision is read from.
+    // `role='owner'`, so the owner row is not necessarily a speaker. This
+    // pins the FUNCTIONAL rule for that shape only. It says nothing about
+    // whether the owner's agent row is locked: locking is a concurrency
+    // property, and a sequential assertion passes either way. The
+    // deterministic manager-reassignment race belongs with the ordering
+    // work — see the PR discussion.
     await leaveMeChat(app.db, chatId, owner.humanAgentUuid);
     expect(await membershipOf(app, chatId, owner.humanAgentUuid)).toEqual({
       accessMode: "watcher",

--- a/packages/server/src/__tests__/participant-removal.test.ts
+++ b/packages/server/src/__tests__/participant-removal.test.ts
@@ -17,7 +17,7 @@ import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
-import { createMeChat } from "../services/me-chat.js";
+import { createMeChat, leaveMeChat } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
 import { removeParticipantFromChat } from "../services/participant-removal.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -546,6 +546,38 @@ describe("removeParticipantFromChat", () => {
     });
 
     expect((await membershipOf(app, chatId, other.humanAgentUuid))?.accessMode).toBe("watcher");
+  });
+
+  it("still resolves owner-side when the chat owner is a watcher, not a speaker", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const ownerAgent = await ownedAgent(app, owner.memberId, owner.organizationId, "ownerbot");
+    const guestOwner = await createTestAdmin(app);
+    const guest = await ownedAgent(app, guestOwner.memberId, guestOwner.organizationId, "guestbot");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [ownerAgent.uuid, guest.uuid],
+    });
+
+    // `workspace-leave` downgrades a departing owner to watcher and keeps
+    // `role='owner'`, so the owner row is not necessarily a speaker. The
+    // authority snapshot has to lock that agent row anyway — it is still the
+    // row the owner-side decision is read from.
+    await leaveMeChat(app.db, chatId, owner.humanAgentUuid);
+    expect(await membershipOf(app, chatId, owner.humanAgentUuid)).toEqual({
+      accessMode: "watcher",
+      role: "owner",
+    });
+
+    // The owner's own agent is still a speaker and shares their owning
+    // member, so it counts as owner-side and may remove the guest.
+    await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: ownerAgent.uuid,
+      targetAgentId: guest.uuid,
+    });
+
+    expect(await membershipOf(app, chatId, guest.uuid)).toBeNull();
   });
 
   it("does not resurrect the removed agent through the watcher recompute", async () => {

--- a/packages/server/src/__tests__/participant-removal.test.ts
+++ b/packages/server/src/__tests__/participant-removal.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Removal authorization + writer — the mirror of `participant-invite`.
+ *
+ * Before this, removal existed only as the agent-JWT route and its whole
+ * authorization was "is the caller a speaker of this chat", so any speaker
+ * could remove any other speaker — including the chat owner, and including
+ * agents belonging to a different member. These cases pin the shared rules
+ * that both entrypoints now route through.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chats } from "../db/schema/chats.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { createAgent } from "../services/agent.js";
+import { createChat } from "../services/chat.js";
+import { createMeChat } from "../services/me-chat.js";
+import { sendMessage } from "../services/message.js";
+import { removeParticipantFromChat } from "../services/participant-removal.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+describe("removeParticipantFromChat", () => {
+  const getApp = useTestApp();
+
+  async function ownedAgent(app: ReturnType<typeof getApp>, memberId: string, orgId: string, label: string) {
+    return createAgent(app.db, {
+      name: `rm-${label}-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: `Removal ${label}`,
+      managerId: memberId,
+      organizationId: orgId,
+    });
+  }
+
+  async function membershipOf(app: ReturnType<typeof getApp>, chatId: string, agentId: string) {
+    const [row] = await app.db
+      .select({ accessMode: chatMembership.accessMode, role: chatMembership.role })
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, agentId)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  it("lets the chat owner remove an ordinary participant", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await createTestAdmin(app);
+    const helper = await ownedAgent(app, peer.memberId, peer.organizationId, "helper");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+    expect((await membershipOf(app, chatId, helper.uuid))?.accessMode).toBe("speaker");
+
+    await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: owner.humanAgentUuid,
+      targetAgentId: helper.uuid,
+    });
+
+    expect(await membershipOf(app, chatId, helper.uuid)).toBeNull();
+  });
+
+  it("refuses to remove the chat owner, so the owner record survives", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const other = await createTestAdmin(app);
+    const otherAgent = await ownedAgent(app, other.memberId, other.organizationId, "other");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [otherAgent.uuid],
+    });
+    // The other member joins as a speaker so they are a legitimate caller.
+    await app.db
+      .insert(chatMembership)
+      .values({
+        chatId,
+        agentId: other.humanAgentUuid,
+        role: "member",
+        accessMode: "speaker",
+        mode: "mention_only",
+        source: "manual",
+      })
+      .onConflictDoUpdate({
+        target: [chatMembership.chatId, chatMembership.agentId],
+        set: { accessMode: "speaker" },
+      });
+
+    expect((await membershipOf(app, chatId, owner.humanAgentUuid))?.role).toBe("owner");
+
+    await expect(
+      removeParticipantFromChat(app.db, {
+        chatId,
+        callerAgentId: other.humanAgentUuid,
+        targetAgentId: owner.humanAgentUuid,
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+
+    // `chats` has no creator column — this row is the only record that the
+    // chat has an owner, so losing it would be irrecoverable.
+    expect(await membershipOf(app, chatId, owner.humanAgentUuid)).toEqual({
+      accessMode: "speaker",
+      role: "owner",
+    });
+  });
+
+  it("refuses a bystander speaker removing someone else's agent", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const bystander = await createTestAdmin(app);
+    const victimOwner = await createTestAdmin(app);
+    const victim = await ownedAgent(app, victimOwner.memberId, victimOwner.organizationId, "victim");
+    const bystanderAgent = await ownedAgent(app, bystander.memberId, bystander.organizationId, "bystander");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [victim.uuid, bystanderAgent.uuid],
+    });
+
+    // The bystander's own agent is a speaker, which was the entire previous
+    // authorization requirement.
+    await expect(
+      removeParticipantFromChat(app.db, {
+        chatId,
+        callerAgentId: bystanderAgent.uuid,
+        targetAgentId: victim.uuid,
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+
+    expect((await membershipOf(app, chatId, victim.uuid))?.accessMode).toBe("speaker");
+  });
+
+  it("lets a manager recall their own agent from someone else's chat", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const manager = await createTestAdmin(app);
+    const mine = await ownedAgent(app, manager.memberId, manager.organizationId, "mine");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [mine.uuid],
+    });
+    // The manager is a watcher via supervision; promote to speaker so they
+    // are a legitimate caller without being the chat owner.
+    await app.db
+      .insert(chatMembership)
+      .values({
+        chatId,
+        agentId: manager.humanAgentUuid,
+        role: "member",
+        accessMode: "speaker",
+        mode: "mention_only",
+        source: "manual",
+      })
+      .onConflictDoUpdate({
+        target: [chatMembership.chatId, chatMembership.agentId],
+        set: { accessMode: "speaker" },
+      });
+
+    await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: manager.humanAgentUuid,
+      targetAgentId: mine.uuid,
+    });
+
+    expect(await membershipOf(app, chatId, mine.uuid)).toBeNull();
+  });
+
+  it("refuses self-removal and points at leave", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "self");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+
+    await expect(
+      removeParticipantFromChat(app.db, {
+        chatId,
+        callerAgentId: owner.humanAgentUuid,
+        targetAgentId: owner.humanAgentUuid,
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("refuses a caller who is not a speaker of the chat", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const outsider = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "outside");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+
+    await expect(
+      removeParticipantFromChat(app.db, {
+        chatId,
+        callerAgentId: outsider.humanAgentUuid,
+        targetAgentId: helper.uuid,
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("404s when the target is not a speaker", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "present");
+    const absent = await ownedAgent(app, owner.memberId, owner.organizationId, "absent");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+
+    await expect(
+      removeParticipantFromChat(app.db, {
+        chatId,
+        callerAgentId: owner.humanAgentUuid,
+        targetAgentId: absent.uuid,
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("drops the removed agent's pending inbox rows for that chat only", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "inbox");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+    // A second chat the agent stays in — its queue must be untouched.
+    const otherChat = await createChat(app.db, owner.humanAgentUuid, {
+      type: "group",
+      participantIds: [helper.uuid],
+    });
+
+    for (const target of [chatId, otherChat.id]) {
+      await sendMessage(
+        app.db,
+        target,
+        owner.humanAgentUuid,
+        { source: "api", format: "text", content: "ping" },
+        { allowRecipientlessSend: true },
+      );
+    }
+
+    const pendingIn = async (chat: string) => {
+      const rows = await app.db
+        .select({ id: inboxEntries.id })
+        .from(inboxEntries)
+        .where(
+          and(
+            eq(inboxEntries.inboxId, helper.inboxId),
+            eq(inboxEntries.chatId, chat),
+            eq(inboxEntries.status, "pending"),
+          ),
+        );
+      return rows.length;
+    };
+
+    expect(await pendingIn(chatId)).toBeGreaterThan(0);
+    const otherBefore = await pendingIn(otherChat.id);
+    expect(otherBefore).toBeGreaterThan(0);
+
+    await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: owner.humanAgentUuid,
+      targetAgentId: helper.uuid,
+    });
+
+    // Without this the agent keeps being woken for a chat it can no longer
+    // write to — it burns a turn and then takes a 403 on reply.
+    expect(await pendingIn(chatId)).toBe(0);
+    expect(await pendingIn(otherChat.id)).toBe(otherBefore);
+  });
+
+  it("keeps a removed human readable while they still manage a speaker", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const other = await createTestAdmin(app);
+    const theirAgent = await ownedAgent(app, other.memberId, other.organizationId, "supervised");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [theirAgent.uuid],
+    });
+    await app.db
+      .insert(chatMembership)
+      .values({
+        chatId,
+        agentId: other.humanAgentUuid,
+        role: "member",
+        accessMode: "speaker",
+        mode: "mention_only",
+        source: "manual",
+      })
+      .onConflictDoUpdate({
+        target: [chatMembership.chatId, chatMembership.agentId],
+        set: { accessMode: "speaker" },
+      });
+
+    await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: owner.humanAgentUuid,
+      targetAgentId: other.humanAgentUuid,
+    });
+
+    // Removal takes away speaking, not sight: their own agent is still in
+    // the chat producing work that belongs to them, so `recomputeChatWatchers`
+    // re-materialises the watcher row.
+    expect((await membershipOf(app, chatId, other.humanAgentUuid))?.accessMode).toBe("watcher");
+  });
+
+  it("fully detaches a removed human who manages no remaining speaker", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const other = await createTestAdmin(app);
+    const ownerAgent = await ownedAgent(app, owner.memberId, owner.organizationId, "ownerside");
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [ownerAgent.uuid],
+    });
+    await app.db.insert(chatMembership).values({
+      chatId,
+      agentId: other.humanAgentUuid,
+      role: "member",
+      accessMode: "speaker",
+      mode: "mention_only",
+      source: "manual",
+    });
+
+    await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: owner.humanAgentUuid,
+      targetAgentId: other.humanAgentUuid,
+    });
+
+    expect(await membershipOf(app, chatId, other.humanAgentUuid)).toBeNull();
+  });
+
+  it("leaves agents in the chat untouched apart from the removed one", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const keep = await ownedAgent(app, owner.memberId, owner.organizationId, "keep");
+    const drop = await ownedAgent(app, owner.memberId, owner.organizationId, "drop");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [keep.uuid, drop.uuid],
+    });
+
+    const remaining = await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: owner.humanAgentUuid,
+      targetAgentId: drop.uuid,
+    });
+
+    const ids = remaining.map((r) => r.agentId).sort();
+    expect(ids).toEqual([keep.uuid, owner.humanAgentUuid].sort());
+  });
+
+  it("still resolves the owning member when the chat owner is an agent", async () => {
+    const app = getApp();
+    // Agent-created chats are the common shape: the `owner` row belongs to a
+    // non-human agent, and its manager must still count as owner-side.
+    const boss = await createTestAdmin(app);
+    const creator = await ownedAgent(app, boss.memberId, boss.organizationId, "creator");
+    const guestOwner = await createTestAdmin(app);
+    const guest = await ownedAgent(app, guestOwner.memberId, guestOwner.organizationId, "guest");
+
+    const chat = await createChat(app.db, creator.uuid, {
+      type: "group",
+      participantIds: [guest.uuid],
+    });
+    await app.db
+      .insert(chatMembership)
+      .values({
+        chatId: chat.id,
+        agentId: boss.humanAgentUuid,
+        role: "member",
+        accessMode: "speaker",
+        mode: "mention_only",
+        source: "manual",
+      })
+      .onConflictDoUpdate({
+        target: [chatMembership.chatId, chatMembership.agentId],
+        set: { accessMode: "speaker" },
+      });
+
+    await removeParticipantFromChat(app.db, {
+      chatId: chat.id,
+      callerAgentId: boss.humanAgentUuid,
+      targetAgentId: guest.uuid,
+    });
+
+    expect(await membershipOf(app, chat.id, guest.uuid)).toBeNull();
+  });
+
+  it("refuses to touch a landing campaign trial chat", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "trial");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+    await app.db
+      .update(chats)
+      .set({
+        metadata: {
+          landingCampaignTrial: {
+            campaign: "production-scan",
+            agentId: helper.uuid,
+            skillSetId: "production-scan",
+            skillSetVersion: "test",
+            repo: { url: "https://github.com/acme/backend", canonicalKey: "github.com/acme/backend" },
+            state: "running",
+            inputLocked: false,
+          },
+        },
+      })
+      .where(eq(chats.id, chatId));
+
+    await expect(
+      removeParticipantFromChat(app.db, {
+        chatId,
+        callerAgentId: owner.humanAgentUuid,
+        targetAgentId: helper.uuid,
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("does not resurrect the removed agent through the watcher recompute", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const helper = await ownedAgent(app, owner.memberId, owner.organizationId, "norevive");
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [helper.uuid],
+    });
+
+    await removeParticipantFromChat(app.db, {
+      chatId,
+      callerAgentId: owner.humanAgentUuid,
+      targetAgentId: helper.uuid,
+    });
+
+    const [row] = await app.db
+      .select({ agentId: agents.uuid })
+      .from(chatMembership)
+      .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, helper.uuid)));
+    expect(row).toBeUndefined();
+  });
+});

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -61,6 +61,7 @@ import {
 import { WIRE_RECIPIENT_MODE } from "../services/message-dispatcher.js";
 import { listRequestThread } from "../services/need-you.js";
 import { notifyRecipients } from "../services/notifier.js";
+import { removeParticipantFromChat } from "../services/participant-removal.js";
 import { resolveHumanScmBindingPair } from "../services/scm-attention-line.js";
 import { extractSummary } from "../services/session.js";
 import { listChatSpeakerEvents, summarizeChatTokenUsage } from "../services/session-event.js";
@@ -684,6 +685,27 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
     await addMeChatParticipants(app.db, request.params.chatId, scope.humanAgentId, scope.organizationId, body);
     return reply.status(204).send();
   });
+
+  /**
+   * DELETE /chats/:chatId/participants/:agentId — remove one speaker.
+   *
+   * The caller acts as their HUMAN agent, so the shared authorizer sees the
+   * same shape it sees on the agent route and applies one set of rules to
+   * both. Removing yourself is refused here on purpose: that is
+   * `POST /:chatId/workspace-leave`.
+   */
+  app.delete<{ Params: { chatId: string; agentId: string } }>(
+    "/:chatId/participants/:agentId",
+    async (request, reply) => {
+      const { scope } = await requireChatAccess(request, app.db);
+      await removeParticipantFromChat(app.db, {
+        chatId: request.params.chatId,
+        callerAgentId: scope.humanAgentId,
+        targetAgentId: request.params.agentId,
+      });
+      return reply.status(204).send();
+    },
+  );
 
   /** Watcher → speaking participant. State-carry. */
   app.post<{ Params: { chatId: string } }>("/:chatId/workspace-join", async (request, reply) => {

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -7,7 +7,6 @@ import {
   FIRST_CHAT_ORIENTATION_CHAT_STATES,
   type LegacyCreateChat,
   parseLandingCampaignTrialAgentMetadata,
-  parseLandingCampaignTrialChatMetadata,
   type SendMessage,
   withFirstChatOrientationChatState,
 } from "@first-tree/shared";
@@ -23,7 +22,6 @@ import { users } from "../db/schema/users.js";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
 import { resolveAvatarImageUrl } from "./agent.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
-import { lockChatMembershipMutation } from "./chat-membership-lock.js";
 import { resolveChatTitle } from "./me-chat.js";
 import {
   type DeferredSendMessagePostCommitEffects,
@@ -35,7 +33,8 @@ import {
 } from "./message.js";
 import { WIRE_RECIPIENT_MODE } from "./message-dispatcher.js";
 import { inviteParticipantsToChat, rejectedPrivateTargets } from "./participant-invite.js";
-import { addChatParticipants, applyMembershipWrite, recomputeChatWatchers } from "./participant-mode.js";
+import { addChatParticipants, applyMembershipWrite } from "./participant-mode.js";
+import { removeParticipantFromChat } from "./participant-removal.js";
 import { extractSummary } from "./session.js";
 import { leaveAsParticipant } from "./watcher.js";
 
@@ -1175,41 +1174,16 @@ export async function addParticipant(db: Database, chatId: string, requesterId: 
     .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
 }
 
+/**
+ * Agent-JWT entrypoint: `DELETE /agent/.../chats/:id/participants/:agentId`.
+ *
+ * Thin shell over the shared removal authorizer so this route and the web
+ * route `DELETE /chats/:id/participants/:agentId` cannot drift apart. The
+ * rules — owner protection, owner-side-or-own-agent, self-removal is
+ * `leave` — live in `participant-removal.ts`.
+ */
 export async function removeParticipant(db: Database, chatId: string, requesterId: string, targetAgentId: string) {
-  const speakers = await db.transaction(async (rawTx) => {
-    const tx = rawTx as unknown as Database;
-    await lockChatMembershipMutation(tx, [chatId]);
-    const chat = await getChat(tx, chatId);
-    if (parseLandingCampaignTrialChatMetadata(chat.metadata)) {
-      throw new ForbiddenError("Landing campaign trial chats are managed by First Tree.");
-    }
-
-    await assertParticipant(tx, chatId, requesterId);
-    if (requesterId === targetAgentId) {
-      throw new BadRequestError("Cannot remove yourself from a chat");
-    }
-
-    const [removed] = await tx
-      .delete(chatMembership)
-      .where(
-        and(
-          eq(chatMembership.chatId, chatId),
-          eq(chatMembership.agentId, targetAgentId),
-          eq(chatMembership.accessMode, "speaker"),
-        ),
-      )
-      .returning();
-    if (!removed) {
-      throw new NotFoundError(`Agent "${targetAgentId}" is not a participant of this chat`);
-    }
-    await recomputeChatWatchers(tx, chatId);
-    return tx
-      .select()
-      .from(chatMembership)
-      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
-  });
-  invalidateChatAudience(chatId);
-  return speakers;
+  return removeParticipantFromChat(db, { chatId, callerAgentId: requesterId, targetAgentId });
 }
 
 /**

--- a/packages/server/src/services/need-you.ts
+++ b/packages/server/src/services/need-you.ts
@@ -38,7 +38,7 @@ function parseNeedYouCursor(cursor: string): { createdAt: Date; id: string } {
   return { createdAt, id };
 }
 
-function openRequestPredicate(viewerAgentId: string) {
+export function openRequestPredicate(viewerAgentId: string) {
   return and(
     eq(messages.format, MESSAGE_FORMATS.REQUEST),
     sql`${messages.metadata} -> 'mentions' @> jsonb_build_array(${viewerAgentId}::text)`,

--- a/packages/server/src/services/participant-removal.ts
+++ b/packages/server/src/services/participant-removal.ts
@@ -42,15 +42,16 @@
  */
 
 import { parseLandingCampaignTrialChatMetadata } from "@first-tree/shared";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
-import { BadRequestError, CallerNotSpeakerError, ForbiddenError, NotFoundError } from "../errors.js";
+import { messages } from "../db/schema/messages.js";
+import { BadRequestError, CallerNotSpeakerError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
-import { lockChatMembershipMutation } from "./chat-membership-lock.js";
+import { lockChatSpeakerAndAgentSnapshot } from "./chat-membership-lock.js";
 import { recomputeChatWatchers } from "./participant-mode.js";
 
 export type RemoveParticipantArgs = {
@@ -89,6 +90,55 @@ async function loadSpeaker(db: Database, chatId: string, agentId: string): Promi
   return row ?? null;
 }
 
+/**
+ * Would the target still hold a `chat_membership` row after their speaker row
+ * goes away? Mirrors `recomputeChatWatchers`' anchoring condition: a human
+ * keeps a watcher row while they still manage an active non-human speaker in
+ * the chat. Non-human agents have no watcher representation, so removing one
+ * always detaches it.
+ */
+async function keepsMembershipAfterRemoval(
+  db: Database,
+  chatId: string,
+  target: { type: string; agentId: string },
+): Promise<boolean> {
+  if (target.type !== "human") return false;
+  const rows = (await db.execute(sql`
+    SELECT EXISTS (
+      SELECT 1
+        FROM chat_membership cm
+        JOIN agents  a ON a.uuid = cm.agent_id
+        JOIN members m ON m.id   = a.manager_id
+       WHERE cm.chat_id = ${chatId}
+         AND cm.access_mode = 'speaker'
+         AND cm.agent_id <> ${target.agentId}
+         AND m.agent_id = ${target.agentId}
+         AND m.status   = 'active'
+         AND a.type    <> 'human'
+    ) AS anchored
+  `)) as unknown as Array<{ anchored: boolean }>;
+  return Boolean(rows[0]?.anchored);
+}
+
+/**
+ * An unresolved `format='request'` message addressed to `agentId`. Mirrors
+ * `need-you.ts::openRequestPredicate` — same request/resolution authority the
+ * review queue and `open_request_count` derive from.
+ */
+function openRequestForTarget(agentId: string) {
+  return and(
+    eq(messages.format, "request"),
+    sql`${messages.metadata} -> 'mentions' @> jsonb_build_array(${agentId}::text)`,
+    sql`NOT EXISTS (
+      SELECT 1 FROM ${messages} AS resolver
+      WHERE resolver.chat_id = ${messages.chatId}
+        AND resolver.metadata -> 'resolves' ->> 'request' = ${messages.id}::text
+        AND resolver.metadata -> 'resolves' ->> 'kind' IN ('answered', 'closed')
+        AND resolver.sender_id IN (${messages.senderId}, ${agentId})
+    )`,
+  );
+}
+
 /** The owning member behind the chat's `role='owner'` row, if the chat still has one. */
 async function loadChatOwnerMemberId(db: Database, chatId: string): Promise<string | null> {
   const [row] = await db
@@ -112,7 +162,15 @@ export async function removeParticipantFromChat(
 
   const speakers = await db.transaction(async (rawTx) => {
     const tx = rawTx as unknown as Database;
-    await lockChatMembershipMutation(tx, [chatId]);
+    // Authorization below is derived from `agents.manager_id` (who owns the
+    // caller, the target, and the chat owner). Taking only the membership
+    // fence would leave those rows free to move: a manager reassignment
+    // committing between the reads and this commit would let the decision
+    // stand on ownership that no longer holds. `lockChatSpeakerAndAgentSnapshot`
+    // exists for exactly that — it locks the chat, its speaker rows, and the
+    // named agent rows FOR UPDATE in one UUID-sorted set, so manager
+    // transfers cannot invalidate owner authority mid-transaction.
+    await lockChatSpeakerAndAgentSnapshot(tx, [chatId], [callerAgentId, targetAgentId]);
 
     const [chat] = await tx
       .select({ id: chats.id, metadata: chats.metadata })
@@ -156,6 +214,28 @@ export async function removeParticipantFromChat(
       );
     }
 
+    // An unresolved request addressed to the target, when removal would
+    // leave them no membership row at all, is a trap with no exit:
+    // `listNeedYouRequests` joins `chat_membership` so the request drops out
+    // of their queue, `requireChatAccess` then refuses the chat so "Join to
+    // reply" is unreachable, and `chat_user_state.open_request_count` stays
+    // positive — which `chat-archive` treats as never-archivable. Refuse
+    // instead of manufacturing that state. Callers who still hold a watcher
+    // row are unaffected: they can see the request and join to answer it.
+    if (!(await keepsMembershipAfterRemoval(tx, chatId, { type: target.type, agentId: targetAgentId }))) {
+      const [openRequest] = await tx
+        .select({ id: messages.id })
+        .from(messages)
+        .where(and(eq(messages.chatId, chatId), openRequestForTarget(targetAgentId)))
+        .limit(1);
+      if (openRequest) {
+        throw new ConflictError(
+          `Agent "${targetAgentId}" has an unanswered request in this chat and would lose all access to it. ` +
+            "Resolve the request first, then remove them.",
+        );
+      }
+    }
+
     await tx
       .delete(chatMembership)
       .where(
@@ -166,18 +246,27 @@ export async function removeParticipantFromChat(
         ),
       );
 
-    // Drop anything still queued for the removed agent in this chat.
-    // Inbox delivery is inbox-scoped and never re-checks membership, so
-    // without this the agent keeps being woken for a chat it can no longer
-    // write to — it would burn a turn and then take a 403 on reply.
-    // Deleting undeliverable rows matches `pruneStaleSilentEntries`.
+    // Drop what is still queued or in flight for the removed agent in this
+    // chat. Delivery is inbox-scoped and never re-checks membership, so
+    // leaving rows behind keeps waking an agent that can no longer write —
+    // it burns a turn and then takes a 403 on reply. `delivered` rows matter
+    // as much as `pending` ones: `resetDeliveredForInboxes` flips them back
+    // to `pending` on the next bind without consulting membership, which
+    // would resurrect exactly what this clears. Deleting undeliverable rows
+    // matches `pruneStaleSilentEntries`.
+    //
+    // This is a mitigation, not a fence: `sendMessage` snapshots the speaker
+    // set without taking the membership lock, so a send that started before
+    // this transaction can still insert a row afterwards. Closing that
+    // properly means making the delivery path membership-aware rather than
+    // cleaning up behind it — tracked separately, see the PR discussion.
     await tx
       .delete(inboxEntries)
       .where(
         and(
           eq(inboxEntries.inboxId, target.inboxId),
           eq(inboxEntries.chatId, chatId),
-          eq(inboxEntries.status, "pending"),
+          inArray(inboxEntries.status, ["pending", "delivered"]),
         ),
       );
 

--- a/packages/server/src/services/participant-removal.ts
+++ b/packages/server/src/services/participant-removal.ts
@@ -1,0 +1,194 @@
+/**
+ * Canonical "remove a participant from a chat" authorization + writer.
+ *
+ * This is the mirror of `participant-invite.ts`. Admission has always had a
+ * single shared consent boundary that every entrypoint routes through;
+ * removal did not — the agent-JWT `DELETE /agent/chats/:id/participants/:id`
+ * route checked only "is the caller a speaker of this chat", which let any
+ * speaker remove any other speaker, including the chat owner and agents
+ * belonging to someone else. Web had no removal surface at all.
+ *
+ * Both entrypoints now come through here, so the rules live in one place:
+ *
+ *   1. Chat exists and is not a managed landing-campaign trial chat.
+ *   2. Caller MUST be a speaker (`CallerNotSpeakerError`).
+ *   3. Removing yourself is not a removal — `POST /:chatId/leave` and
+ *      `POST /:chatId/workspace-leave` own that transition.
+ *   4. Target MUST currently be a speaker.
+ *   5. **The chat owner can never be removed.** `chats` carries no creator
+ *      column, so `chat_membership.role = 'owner'` is the only record that
+ *      the chat has an owner at all. Deleting that row would erase the fact
+ *      irrecoverably and, via `assertOwner`'s "no agent owner is present"
+ *      fallback, hand topic/description writes to every agent speaker.
+ *      Protecting the row is also what lets the writer below stay a plain
+ *      DELETE: the row it deletes is never the owner row, so `role` cannot
+ *      be lost.
+ *   6. Otherwise the caller must be **owner-side** for this removal:
+ *        - the caller holds the chat's `owner` membership row, or
+ *        - the caller's owning member is the chat owner's owning member
+ *          (a manager and the agents they own share roster rights — the
+ *          same "worker agents count as the owner" rule `assertOwner`
+ *          already applies to chat metadata), or
+ *        - the target is a non-human agent owned by the caller's owning
+ *          member (recall your own agent from someone else's chat).
+ *
+ * Removing a human is deliberately NOT a hard eviction: their
+ * `chat_membership` speaker row goes away, but `recomputeChatWatchers` will
+ * re-materialise a watcher row while they still manage a speaker in the
+ * chat, so they keep read access to work their own agents are doing. What
+ * removal takes away is the ability to speak and to be addressed. Making
+ * that durable against a self-service re-join is a separate, explicit
+ * product decision and is not implemented here.
+ */
+
+import { parseLandingCampaignTrialChatMetadata } from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chats } from "../db/schema/chats.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { BadRequestError, CallerNotSpeakerError, ForbiddenError, NotFoundError } from "../errors.js";
+import { invalidateChatAudience } from "./chat-audience-cache.js";
+import { lockChatMembershipMutation } from "./chat-membership-lock.js";
+import { recomputeChatWatchers } from "./participant-mode.js";
+
+export type RemoveParticipantArgs = {
+  chatId: string;
+  /** The agent acting — a human agent for the web route, the agent itself for the agent route. */
+  callerAgentId: string;
+  targetAgentId: string;
+};
+
+type MembershipRow = {
+  role: string;
+  /** `agents.manager_id` — the member who owns this agent. */
+  ownerMemberId: string;
+  type: string;
+  inboxId: string;
+};
+
+async function loadSpeaker(db: Database, chatId: string, agentId: string): Promise<MembershipRow | null> {
+  const [row] = await db
+    .select({
+      role: chatMembership.role,
+      ownerMemberId: agents.managerId,
+      type: agents.type,
+      inboxId: agents.inboxId,
+    })
+    .from(chatMembership)
+    .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
+    .where(
+      and(
+        eq(chatMembership.chatId, chatId),
+        eq(chatMembership.agentId, agentId),
+        eq(chatMembership.accessMode, "speaker"),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+/** The owning member behind the chat's `role='owner'` row, if the chat still has one. */
+async function loadChatOwnerMemberId(db: Database, chatId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ ownerMemberId: agents.managerId })
+    .from(chatMembership)
+    .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
+    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.role, "owner")))
+    .limit(1);
+  return row?.ownerMemberId ?? null;
+}
+
+/**
+ * Remove one speaker from a chat. Returns the chat's remaining speaker rows,
+ * matching the wire shape both entrypoints already return.
+ */
+export async function removeParticipantFromChat(
+  db: Database,
+  args: RemoveParticipantArgs,
+): Promise<(typeof chatMembership.$inferSelect)[]> {
+  const { chatId, callerAgentId, targetAgentId } = args;
+
+  const speakers = await db.transaction(async (rawTx) => {
+    const tx = rawTx as unknown as Database;
+    await lockChatMembershipMutation(tx, [chatId]);
+
+    const [chat] = await tx
+      .select({ id: chats.id, metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, chatId))
+      .limit(1);
+    if (!chat) {
+      throw new NotFoundError(`Chat "${chatId}" not found`);
+    }
+    if (parseLandingCampaignTrialChatMetadata(chat.metadata)) {
+      throw new ForbiddenError("Landing campaign trial chats are managed by First Tree.");
+    }
+
+    // Self-removal is `leave`, not `remove`. Checked before the membership
+    // lookups so the caller gets the actionable error even when they are not
+    // a speaker at all.
+    if (callerAgentId === targetAgentId) {
+      throw new BadRequestError("Cannot remove yourself from a chat — leave the chat instead");
+    }
+
+    const caller = await loadSpeaker(tx, chatId, callerAgentId);
+    if (!caller) {
+      throw new CallerNotSpeakerError(callerAgentId, chatId);
+    }
+
+    const target = await loadSpeaker(tx, chatId, targetAgentId);
+    if (!target) {
+      throw new NotFoundError(`Agent "${targetAgentId}" is not a participant of this chat`);
+    }
+    if (target.role === "owner") {
+      throw new ForbiddenError("The chat owner cannot be removed from their own chat");
+    }
+
+    const chatOwnerMemberId = await loadChatOwnerMemberId(tx, chatId);
+    const callerIsOwnerSide =
+      caller.role === "owner" || (chatOwnerMemberId !== null && chatOwnerMemberId === caller.ownerMemberId);
+    const targetIsCallersOwnAgent = target.type !== "human" && target.ownerMemberId === caller.ownerMemberId;
+    if (!callerIsOwnerSide && !targetIsCallersOwnAgent) {
+      throw new ForbiddenError(
+        "Only the chat owner's side can remove a participant, or the agent's own manager can recall it",
+      );
+    }
+
+    await tx
+      .delete(chatMembership)
+      .where(
+        and(
+          eq(chatMembership.chatId, chatId),
+          eq(chatMembership.agentId, targetAgentId),
+          eq(chatMembership.accessMode, "speaker"),
+        ),
+      );
+
+    // Drop anything still queued for the removed agent in this chat.
+    // Inbox delivery is inbox-scoped and never re-checks membership, so
+    // without this the agent keeps being woken for a chat it can no longer
+    // write to — it would burn a turn and then take a 403 on reply.
+    // Deleting undeliverable rows matches `pruneStaleSilentEntries`.
+    await tx
+      .delete(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.inboxId, target.inboxId),
+          eq(inboxEntries.chatId, chatId),
+          eq(inboxEntries.status, "pending"),
+        ),
+      );
+
+    await recomputeChatWatchers(tx, chatId);
+
+    return tx
+      .select()
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
+  });
+
+  invalidateChatAudience(chatId);
+  return speakers;
+}

--- a/packages/server/src/services/participant-removal.ts
+++ b/packages/server/src/services/participant-removal.ts
@@ -51,7 +51,8 @@ import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { BadRequestError, CallerNotSpeakerError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
-import { lockChatSpeakerAndAgentSnapshot } from "./chat-membership-lock.js";
+import { lockChatMembershipMutation, lockChatSpeakerAndAgentSnapshot } from "./chat-membership-lock.js";
+import { openRequestPredicate } from "./need-you.js";
 import { recomputeChatWatchers } from "./participant-mode.js";
 
 export type RemoveParticipantArgs = {
@@ -120,34 +121,22 @@ async function keepsMembershipAfterRemoval(
   return Boolean(rows[0]?.anchored);
 }
 
-/**
- * An unresolved `format='request'` message addressed to `agentId`. Mirrors
- * `need-you.ts::openRequestPredicate` — same request/resolution authority the
- * review queue and `open_request_count` derive from.
- */
-function openRequestForTarget(agentId: string) {
-  return and(
-    eq(messages.format, "request"),
-    sql`${messages.metadata} -> 'mentions' @> jsonb_build_array(${agentId}::text)`,
-    sql`NOT EXISTS (
-      SELECT 1 FROM ${messages} AS resolver
-      WHERE resolver.chat_id = ${messages.chatId}
-        AND resolver.metadata -> 'resolves' ->> 'request' = ${messages.id}::text
-        AND resolver.metadata -> 'resolves' ->> 'kind' IN ('answered', 'closed')
-        AND resolver.sender_id IN (${messages.senderId}, ${agentId})
-    )`,
-  );
-}
-
 /** The owning member behind the chat's `role='owner'` row, if the chat still has one. */
-async function loadChatOwnerMemberId(db: Database, chatId: string): Promise<string | null> {
+async function loadChatOwnerAgentId(db: Database, chatId: string): Promise<string | null> {
+  // Deliberately unfiltered on access_mode: `leaveAsParticipant` flips a
+  // departing owner to `watcher` while preserving `role`, so the owner row
+  // is not necessarily a speaker.
   const [row] = await db
-    .select({ ownerMemberId: agents.managerId })
+    .select({ agentId: chatMembership.agentId })
     .from(chatMembership)
-    .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
     .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.role, "owner")))
     .limit(1);
-  return row?.ownerMemberId ?? null;
+  return row?.agentId ?? null;
+}
+
+async function loadOwningMember(db: Database, agentId: string): Promise<string | null> {
+  const [row] = await db.select({ managerId: agents.managerId }).from(agents).where(eq(agents.uuid, agentId)).limit(1);
+  return row?.managerId ?? null;
 }
 
 /**
@@ -170,7 +159,20 @@ export async function removeParticipantFromChat(
     // exists for exactly that — it locks the chat, its speaker rows, and the
     // named agent rows FOR UPDATE in one UUID-sorted set, so manager
     // transfers cannot invalidate owner authority mid-transaction.
-    await lockChatSpeakerAndAgentSnapshot(tx, [chatId], [callerAgentId, targetAgentId]);
+    // Take the membership fence first so the owner row cannot move, read who
+    // the owner is, then lock the full authority set — caller, target AND the
+    // owner's agent row. The snapshot helper only locks `access_mode='speaker'`
+    // memberships plus the ids handed to it, and a `role='owner'` row is not
+    // necessarily a speaker (`workspace-leave` downgrades an owner to watcher
+    // while preserving the role), so the owner id has to be passed explicitly
+    // or its `manager_id` stays free to change under the decision below.
+    await lockChatMembershipMutation(tx, [chatId]);
+    const chatOwnerAgentId = await loadChatOwnerAgentId(tx, chatId);
+    await lockChatSpeakerAndAgentSnapshot(
+      tx,
+      [chatId],
+      chatOwnerAgentId ? [callerAgentId, targetAgentId, chatOwnerAgentId] : [callerAgentId, targetAgentId],
+    );
 
     const [chat] = await tx
       .select({ id: chats.id, metadata: chats.metadata })
@@ -204,7 +206,7 @@ export async function removeParticipantFromChat(
       throw new ForbiddenError("The chat owner cannot be removed from their own chat");
     }
 
-    const chatOwnerMemberId = await loadChatOwnerMemberId(tx, chatId);
+    const chatOwnerMemberId = chatOwnerAgentId ? await loadOwningMember(tx, chatOwnerAgentId) : null;
     const callerIsOwnerSide =
       caller.role === "owner" || (chatOwnerMemberId !== null && chatOwnerMemberId === caller.ownerMemberId);
     const targetIsCallersOwnAgent = target.type !== "human" && target.ownerMemberId === caller.ownerMemberId;
@@ -226,7 +228,7 @@ export async function removeParticipantFromChat(
       const [openRequest] = await tx
         .select({ id: messages.id })
         .from(messages)
-        .where(and(eq(messages.chatId, chatId), openRequestForTarget(targetAgentId)))
+        .where(and(eq(messages.chatId, chatId), openRequestPredicate(targetAgentId)))
         .limit(1);
       if (openRequest) {
         throw new ConflictError(


### PR DESCRIPTION
Second slice of "remove a member from a group chat". Slice 1 is #2222 (watcher self-promotion); this one is the removal semantics and its authorization. The web UI is a separate follow-up.

## Problem

Admission has one shared consent boundary — `participant-invite.ts` — and every entrypoint routes through it. Removal had none.

The only removal surface was the agent-JWT `DELETE /agent/chats/:id/participants/:agentId`, and its entire authorization was `assertParticipant`: *is the caller a speaker of this chat*. Consequences:

- any speaker could remove any other speaker, including agents owned by a different member
- **the chat owner could be removed** — and since `chats` has no creator column, `chat_membership.role = 'owner'` is the only record that the chat has an owner. Deleting it erased the fact irrecoverably and, via `assertOwner`'s "no agent owner is present" fallback, handed topic/description writes to every agent speaker.
- Web had no removal action at all (`participants-section.tsx`: *"no actions in v1 — Remove / Change role are deferred alongside the missing backend routes for member-side removal"*)

## Change

`services/participant-removal.ts` is the mirror of the invite service. Both entrypoints now route through it, so the rules cannot drift:

1. caller must be a speaker
2. self-removal refused — `leave` / `workspace-leave` own that transition
3. target must be a speaker
4. **the chat owner can never be removed**
5. otherwise the caller must be owner-side (holds the `owner` row, or shares the chat owner's owning member — the same "worker agents count as the owner" rule `assertOwner` already applies to metadata), **or** the target is a non-human agent owned by the caller's owning member (recall your own agent)

Rule 4 is what lets the writer stay a plain `DELETE`: the deleted row can never be the owner row, so `role` cannot be lost and removal needs no speaker→watcher transition of its own.

The transaction takes `lockChatSpeakerAndAgentSnapshot`, not just the membership fence. Authorization is derived from `agents.manager_id` for the caller, the target, and the chat owner, so those agent rows must be locked `FOR UPDATE` too — otherwise a manager reassignment committing mid-transaction leaves the decision standing on ownership that no longer holds.

**Stranded-request guard.** Removing a human who would keep no membership row at all, while an unanswered request is addressed to them, is refused with 409. That state has no exit: `listNeedYouRequests` joins `chat_membership`, so the request leaves their queue; `requireChatAccess` then denies the chat, so "Join to reply" is unreachable; and `open_request_count` stays positive, which `chat-archive` treats as never-archivable. A target who keeps a watcher row is still removable — they can see the request and join to answer it.

**Inbox cleanup (mitigation, not a fence — see Known gaps).** Removal deletes the target's `pending` **and** `delivered` inbox rows for that chat. Delivery is inbox-scoped and never re-checks membership, so leftover rows keep waking an agent that can no longer write — it burns a turn and then takes a 403 on reply. `delivered` matters as much as `pending`: `resetDeliveredForInboxes` flips them back to `pending` on the next bind without consulting membership.

Adds `DELETE /chats/:chatId/participants/:agentId` (Class C) as the web surface.

## Semantics worth stating explicitly

Removing a **human** is deliberately not an eviction. Their speaker row goes away, but `recomputeChatWatchers` re-materialises a watcher row while they still manage a speaker in the chat — they keep read access to work their own agents are doing there. What removal takes away is speaking and being addressed.

A removed human can also re-enter through "Join to reply", by product decision. Making removal durable against self-service re-entry would need persisted state and was explicitly declined for this version. A removed **agent** has no equivalent path: `inviteParticipantsToChat` requires the caller to be a speaker, so it cannot re-add itself.

## Known gaps — this PR does not establish a delivery/runtime cutoff

Raised in review and confirmed. Both are real, and neither is fixed here:

- **Send-vs-remove race.** `sendMessage` snapshots the speaker set and inserts inbox rows in its own transaction without taking the membership lock, so a send that started before this transaction can insert a fresh row after the cleanup.
- **No session fence.** An already-running turn continues, and remove → re-add can reuse the pre-removal provider-session mapping, because no durable session generation or tombstone is advanced.

So removal currently revokes *authority* (the target cannot write, cannot be addressed, cannot be re-added by itself) but does not guarantee a *delivery* cutoff. The row cleanup narrows the window; it does not close it.

I believe the durable fix is to make the delivery path membership-aware — check membership at claim/push rather than sweeping rows behind it — which subsumes the race, the delivered-row revival, and re-add reuse, and does not depend on removal having swept correctly. That is being prepared as a stacked change, and per review this PR stays blocked on it.

## Tests

`participant-removal.test.ts` — 17 cases: owner removes participant; owner cannot be removed (and the owner row survives); bystander speaker refused; manager recalls their own agent; self-removal 400; non-speaker caller 403; absent target 404; pending inbox dropped for that chat only; delivered rows dropped too; removed human keeps a watcher row when they still manage a speaker; removed human fully detaches when they do not; open request + full detachment refused with 409; open request + retained watcher row still allowed; agent-owned chat resolves owner-side through the owning member; landing-campaign trial chat refused; remaining speaker list returned; removed agent is not resurrected by the watcher recompute.

`chat-remove-participant-route.test.ts` — 5 cases for the new Class C route: 204 + row gone; same-org non-member 404 (anti-enumeration); cross-org 404; bystander 403 (proves the route uses the shared authorizer rather than re-implementing it); self-removal 400.

## Verification

- `pnpm --filter @first-tree/server test` — 270 files / 3152 tests pass
- `pnpm --filter @first-tree/server typecheck` — clean
- `biome check` on changed files — clean

No schema or migration change.

## Follow-ups

In #2222 I listed three routes as watcher-reachable write gaps. Following each into its service — and after review pushback on my first correction — the accurate picture is:

| Route | Status |
|---|---|
| `POST /:chatId/participants` | speaker-gated inside `inviteParticipantsToChat` (`CallerNotSpeakerError`, remapped to 404) — my original claim was wrong |
| SCM follow — GitHub `POST`, GitLab `POST` | speaker/delegate-gated via `resolveHumanScmBindingPair` — also wrong |
| SCM unfollow — GitHub `DELETE`, GitLab `DELETE` | **watcher-accessible.** GitHub's has no membership check past `requireChatAccess`; GitLab's `requireDirectHumanChatMembership` selects on `(chat_id, agent_id)` with no `access_mode` predicate, so a watcher row passes. Neither deletion service re-checks. |
| `PATCH /:chatId` | **watcher-accessible.** `updateChatMetadata` performs no authorization; contradicts `assertOwner`'s documented "human/web route stays participation-gated". |

Those two are the same class as #2222 — a write route that admits watchers — not participant-roster rules, so they are deliberately not folded in here.
