### PR TITLE
fix(web): stabilize Markdown default renderer identity

### DIFF
--- a/packages/web/src/components/__tests__/markdown-renderer-identity.test.tsx
+++ b/packages/web/src/components/__tests__/markdown-renderer-identity.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Markdown } from "../ui/markdown.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/**
+ * Parent re-renders of Markdown must keep the same DOM anchor node when the
+ * markdown source is unchanged. Inline default `components.a` factories used
+ * to remount the link and drop focus into surrounding surfaces.
+ */
+describe("Markdown default renderer identity", () => {
+  it("keeps DOM identity and focus on an unchanged link across parent re-renders", async () => {
+    let bump: (() => void) | undefined;
+
+    function Harness() {
+      const [, setTick] = useState(0);
+      bump = () => setTick((value) => value + 1);
+      return <Markdown>See [notes](https://example.com/notes) for detail.</Markdown>;
+    }
+
+    act(() => {
+      root.render((<Harness />) as ReactElement);
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>('a[href="https://example.com/notes"]');
+    if (!link) throw new Error("Expected Markdown link");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    link.focus();
+    expect(document.activeElement).toBe(link);
+
+    act(() => {
+      bump?.();
+    });
+    for (let i = 0; i < 5; i += 1) {
+      await act(async () => {
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        });
+      });
+    }
+
+    const after = container.querySelector<HTMLAnchorElement>('a[href="https://example.com/notes"]');
+    expect(after).toBe(link);
+    expect(document.activeElement).toBe(link);
+  });
+
+  it("still lets caller-supplied components override the defaults", () => {
+    act(() => {
+      root.render(
+        (
+          <Markdown
+            components={{
+              a: ({ href, children }) => (
+                <a href={href} data-custom-anchor="true">
+                  {children}
+                </a>
+              ),
+            }}
+          >
+            [custom](https://example.com/custom)
+          </Markdown>
+        ) as ReactElement,
+      );
+    });
+
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("data-custom-anchor")).toBe("true");
+    expect(link?.getAttribute("href")).toBe("https://example.com/custom");
+    // Caller override wins; default target/rel are not forced on.
+    expect(link?.getAttribute("target")).toBeNull();
+  });
+});

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -119,6 +119,17 @@ async function waitForSettled(h: DomHarness, assertion: () => void): Promise<voi
   throw lastErr;
 }
 
+/** Drain pending animation frames inside act (ComposeStatusBar focus RAF). */
+async function drainAnimationFrames(count = 5): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+  }
+}
+
 async function click(h: DomHarness, element: Element | null): Promise<void> {
   if (!element) throw new Error("Expected element to click");
   await act(async () => {
@@ -1111,6 +1122,10 @@ describe("ComposeStatusBar extra DOM coverage", () => {
       );
     });
     await h.flush();
+    // Drain ComposeStatusBar's focus-restoration RAF(s). Stable Markdown
+    // default renderer identity keeps the focused link mounted so this does
+    // not steal focus onto the disclosure.
+    await drainAnimationFrames();
 
     expect(document.activeElement).toBe(link);
   });

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -134,6 +134,43 @@ export type MarkdownProps = {
 };
 
 /**
+ * Module-scoped defaults so ReactMarkdown sees a stable element type across
+ * parent re-renders. Inline `a`/`table` factories would remount unchanged
+ * anchors (dropping focus) when a surrounding status surface re-renders.
+ */
+const defaultMarkdownLink: NonNullable<Components["a"]> = ({ node, href, children, ...props }) => {
+  void node;
+  // issue 831: never render a local filesystem path / unknown-scheme href
+  // as a live anchor — it has no route on the cloud origin and 404s
+  // when clicked. Show the link text instead of a dead link.
+  if (!isNavigableWebHref(href)) {
+    return <>{children}</>;
+  }
+  return (
+    <a {...props} href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  );
+};
+
+const defaultMarkdownTable: NonNullable<Components["table"]> = ({ node, className: tableClassName, ...props }) => {
+  void node;
+  // Keep a wide GFM table's intrinsic column width behind a local
+  // scroll boundary. Otherwise its overflow reaches the timeline's
+  // vertical scroller and widens the entire chat on phone screens.
+  return (
+    <div className="my-2 min-w-0 max-w-full overflow-x-auto overscroll-x-contain">
+      <table {...props} className={cn("my-0 min-w-full", tableClassName)} />
+    </div>
+  );
+};
+
+const defaultMarkdownComponents: Components = {
+  a: defaultMarkdownLink,
+  table: defaultMarkdownTable,
+};
+
+/**
  * Renders a markdown string with GFM (tables, task lists, strikethrough,
  * autolinks) and treats single newlines as hard line breaks, matching the
  * way people type messages in a chat box.
@@ -171,31 +208,7 @@ export function Markdown({ children, className, components, rehypePlugins }: Mar
         rehypePlugins={rehypePlugins}
         urlTransform={previewSafeUrlTransform}
         components={{
-          a: ({ node, href, children, ...props }) => {
-            void node;
-            // issue 831: never render a local filesystem path / unknown-scheme href
-            // as a live anchor — it has no route on the cloud origin and 404s
-            // when clicked. Show the link text instead of a dead link.
-            if (!isNavigableWebHref(href)) {
-              return <>{children}</>;
-            }
-            return (
-              <a {...props} href={href} target="_blank" rel="noopener noreferrer">
-                {children}
-              </a>
-            );
-          },
-          table: ({ node, className: tableClassName, ...props }) => {
-            void node;
-            // Keep a wide GFM table's intrinsic column width behind a local
-            // scroll boundary. Otherwise its overflow reaches the timeline's
-            // vertical scroller and widens the entire chat on phone screens.
-            return (
-              <div className="my-2 min-w-0 max-w-full overflow-x-auto overscroll-x-contain">
-                <table {...props} className={cn("my-0 min-w-full", tableClassName)} />
-              </div>
-            );
-          },
+          ...defaultMarkdownComponents,
           ...components,
         }}
       >


### PR DESCRIPTION
## Summary
- Stabilize Markdown default `a` / `table` renderer **component identity** at module scope so `ReactMarkdown` does not remount an unchanged link when a parent (ComposeStatusBar) re-renders.
- Harden the compose-status focus regression by draining focus-restoration RAF after the status update, so the remount→disclosure race fails closed without this fix (matches the CI Linux/full-suite failure mode).
- Add a direct Markdown DOM-identity + focus characterization, plus a caller-override coverage check.

This is the **diff-external** blocker for S1d [#2219](https://github.com/agent-team-foundation/first-tree/pull/2219) (zero `packages/web/**` in that PR). Observed on Actions [run 31100366695](https://github.com/agent-team-foundation/first-tree/actions/runs/31100366695) at `chat-components-extra.test.tsx:1115` (`keeps focus on a surviving Markdown link…`).

## Root cause
ComposeStatusBar keeps `focusWithinRef` and, when the previously focused control is no longer in the surface, schedules `requestAnimationFrame(() => triggerRef.focus())`. Inline `components.a` / `components.table` factories inside `Markdown` created a new element type every render, so an unchanged narration link remounted on status refresh; focus left the surface and the RAF fallback stole it onto the disclosure.

`react-markdown` 10.1.0 passes `options.components` through to hast-util-to-jsx-runtime as JSX element types, so a new function identity each render remounts the anchor.

## Behavior preserved
- Safe-href downgrade for non-navigable schemes
- External links still `target="_blank"` + `rel="noopener noreferrer"`
- Table overflow wrapper unchanged
- Caller-supplied `components` still override defaults
- Disclosure focus fallback when a jump truly disappears unchanged

## Test plan
- [x] Pre-fix: with RAF drain only, target compose-status test **failed** (focus → disclosure)
- [x] Post-fix: target test **passed** 5/5 isolated repeats (author)
- [x] `chat-components-extra.test.tsx` full file 26/26
- [x] New `markdown-renderer-identity` + existing Markdown suites
- [x] `@first-tree/web` full: **2248 passed**
- [x] `@first-tree/web` typecheck (+ design-token lint)
- [x] Root `pnpm check`, `git diff --check`
- [x] GitHub Actions `Test Client & Web` + fan-in `Test` on frozen head `f849bfb191de529aa36d2f69a1649ed701c63840` (Ubuntu; compose-status 26/26, identity 2/2, Web 2248/2248)
- [x] Independent exact-head QA **PASS** at `f849bfb191de529aa36d2f69a1649ed701c63840`: RAF-drained compose-status target 10/10; renderer identity/override 20/20 across 10 runs; full Web 2248/2248; typecheck / `pnpm check` / `git diff --check` green; base-checkout causality reproduced the CI failure shape

## Scope / non-goals
Independent Web stability PR only. Does **not** modify #2219 / S1d. No assertion weakening, no sleep/retry/timeout expansion, no ComposeStatusBar focus policy change beyond what stable Markdown identity prevents.