### PR TITLE
release: bump apps/cli to v0.5.19

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- bump `apps/cli/package.json` from `0.5.18` to `0.5.19`
- keep the source package identity as `first-tree-dev`; the lockfile and publish metadata are unchanged
- prepare the source version required by the future `v0.5.19` stable tag

## Draft GitHub Release

**Title:** `v0.5.19 — Agent Templates, more runtimes, visible Context impact`

## Highlights

- Discover and adopt official Agent Templates that bring curated instructions, Skills, MCP integrations, and starter responsibilities into new or existing agents.
- Choose from three additional agent runtimes—OpenCode, Grok Build, and Pi—with provider-aware setup, session handling, and recovery.
- Use BYO Context in the current session and across multiple Teams, with scoped routing, exact apply commands, and visible notes showing how Context Tree decisions influenced an answer.
- Let repository-scoped task agents automatically handle supported GitHub Issue and pull-request activity without requiring mentions or assignments.
- Move through a smoother first-chat Orientation, clearer Agent Details, and a Need you queue that resolves requests inside their original chats.

## Notable fixes

- Preserved portable-install identity and tightened managed/BYO Context handoffs so sessions stay on the intended Team and channel.
- Kept Kimi background work alive through turn completion and fixed bundled SDK paths in npm packages.
- Avoided automatic provider discovery in macOS protected folders and hardened runtime session recovery and cleanup.
- Improved Chat Summary hierarchy and reading width, composer mentions, working-turn timers, and chat token-usage performance.

## Validation

- `npx --yes pnpm@10.12.1 install --frozen-lockfile`
- `npx --yes pnpm@10.12.1 check` (passed with existing non-blocking warnings)
- `npx --yes pnpm@10.12.1 typecheck` (11/11 tasks passed)
- `git diff --check`
- full `pnpm test` not run for this one-line version-only change; PR CI will run the repository test matrix

## Post-merge

1. Confirm the squash commit on `main` contains `apps/cli/package.json` version `0.5.19`.
2. Wait for the commit's `CI`, `npm Publish`, and `Docker` workflows.
3. After maintainer confirmation of the version, target SHA, release title, and release notes, create GitHub Release/tag `v0.5.19` at the exact merge commit.
4. Verify the tag-triggered production npm, portable, and Docker publication.
