### PR TITLE
fix: stop bolding the Chat Summary lead line

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -911,6 +911,19 @@ video[data-onboarding-orientation-video]::cue {
   }
 }
 
+/* Chat summary lead line: the promoted first physical line of a current-state
+   brief. It is separated from supporting copy by a gap, but a lead with nothing
+   after it is the whole summary — the `:last-child` reset keeps that case from
+   reserving space for copy that does not exist. In the blank-line form the lead
+   is also its paragraph's last child, and the following paragraph carries its
+   own top margin, so the separation survives there. */
+[data-summary-part="lead"] {
+  margin-bottom: var(--sp-3);
+}
+[data-summary-part="lead"]:last-child {
+  margin-bottom: 0;
+}
+
 /* Chat summary floating card: drops in from the bar's lower edge. */
 @keyframes chat-summary-card-in {
   from {

--- a/packages/web/src/pages/chat-summary-preview.tsx
+++ b/packages/web/src/pages/chat-summary-preview.tsx
@@ -22,6 +22,12 @@ const CURRENT_STATE = [
   "**Next:** Validate the same hierarchy in the live Workspace.",
 ].join("\n");
 
+// The most common real shape: one physical line, no supporting copy. The lead is
+// the whole summary here, so it must read as ordinary prose and must not reserve
+// separation below itself.
+const SINGLE_LINE =
+  "正在核验团队的成员规模、First Tree 安装完成情况与实际使用情况。口径按 Asia/Taipei T+1 截止，并将安装状态与使用行为分开统计。";
+
 const PLAIN = "Reviewing PR 1207 — server-side freshness fields landed; wiring the collapsed-bar first line next.";
 
 const HEADING_FIRST = [
@@ -137,6 +143,18 @@ export function ChatSummaryPreviewPage() {
           <Demo
             chatId="preview-unread"
             description={CURRENT_STATE}
+            descriptionUpdatedAt={hoursAgo(2)}
+            lastReadAt={null}
+          />
+        </Col>
+
+        <Col
+          label="Single-line brief (the common shape)"
+          note="lead is the whole summary — ordinary weight, no reserved gap below it"
+        >
+          <Demo
+            chatId="preview-single-line"
+            description={SINGLE_LINE}
             descriptionUpdatedAt={hoursAgo(2)}
             lastReadAt={null}
           />

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -195,6 +195,14 @@ describe("ChatSummary", () => {
     expect(lead?.textContent).toContain("The current result is ready for readers.");
     expect(lead?.className).toContain("text-subtitle");
     expect(lead?.style.fontSize).toBe("var(--text-subtitle)");
+    // The lead reads as the lead through size and colour only — never weight. A
+    // majority of descriptions are a single line, where a bolded lead is the
+    // whole summary and the emphasis carries no information.
+    expect(lead?.style.fontWeight).toBe("var(--text-body--font-weight)");
+    // Spacing below the lead is CSS-driven so it can collapse when the lead is
+    // the last thing in the summary; an inline margin could not.
+    expect(lead?.style.marginBottom).toBe("");
+    // Authored emphasis is untouched — only the promotion styling drops weight.
     expect(lead?.querySelector("strong")?.textContent).toBe("current result");
     expect(paragraphs?.[1]?.textContent).toContain("Supporting context is secondary.");
     expect(paragraphs?.[2]?.textContent).toContain("Next: Observe usage.");
@@ -272,6 +280,33 @@ describe("ChatSummary", () => {
     expect(leads[0]?.textContent).toBe("首行是唯一 headline。");
     expect(leads[0]?.textContent).not.toContain("第二行");
     expect(overlayEl.querySelector("p")?.getAttribute("data-summary-part")).toBeNull();
+
+    await act(async () => root.unmount());
+    container.remove();
+    overlayEl.remove();
+  });
+
+  // Most descriptions are a single physical line. There the lead IS the whole
+  // summary, so it must not be emphasised against itself and must not reserve
+  // separation for supporting copy that does not exist.
+  it("does not emphasise or pad a single-line summary against itself", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const { container, overlayEl, root } = await renderSummary(scrollEl, {
+      description: "正在核验成员规模、安装完成情况与实际使用情况，口径按 T+1 截止。",
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    });
+
+    const summaryDocument = overlayEl.querySelector<HTMLElement>('[data-summary-part="document"]');
+    const lead = summaryDocument?.querySelector<HTMLElement>('[data-summary-part="lead"]');
+    expect(summaryDocument?.querySelectorAll("p")).toHaveLength(1);
+    expect(lead?.textContent).toBe("正在核验成员规模、安装完成情况与实际使用情况，口径按 T+1 截止。");
+    expect(lead?.style.fontWeight).toBe("var(--text-body--font-weight)");
+    // The lead is its paragraph's last child here, which is what lets the CSS
+    // `:last-child` rule collapse the separation below it.
+    expect(lead?.nextSibling).toBeNull();
+    expect(lead?.style.marginBottom).toBe("");
 
     await act(async () => root.unmount());
     container.remove();

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -254,12 +254,19 @@ function joinSoftBreakSegments(segments: ReactNode[][]): ReactNode {
 const LEAD_SPAN_STYLE: CSSProperties = {
   display: "block",
   color: "var(--fg)",
-  marginBottom: "var(--sp-3)",
   // Inline measure beats parent `[&_p]:text-body` inheritance/specificity on <p>.
   fontSize: "var(--text-subtitle)",
-  fontWeight: "var(--text-subtitle--font-weight)" as CSSProperties["fontWeight"],
+  // Body weight, deliberately: the lead separates itself through size and colour,
+  // not emphasis. Most descriptions are a single physical line, where the lead is
+  // the entire summary — bolding it emphasises the text against nothing and just
+  // reads as a heavy block. Authored `**bold**` inside the description is
+  // untouched.
+  fontWeight: "var(--text-body--font-weight)" as CSSProperties["fontWeight"],
   lineHeight: "var(--text-subtitle--line-height)",
   letterSpacing: "var(--text-subtitle--letter-spacing)",
+  // Separation below the lead lives in index.css so it can collapse when the lead
+  // is the last thing in the summary; an inline margin would outrank that rule
+  // and leave dead space under a single-line brief.
 };
 
 function LeadSpan({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Problem

Two issues in the expanded **Current state** card, both from promoting the first physical line.

**The lead was bold against nothing.** The promotion styles the lead at `--text-subtitle` weight 600. But most descriptions are a single physical line — sampling 26 real chats with a description, **15 (58%)** were one line, 108–232 characters. There the lead *is* the whole summary, so the emphasis separates the text from nothing and the entire brief renders as a heavy block.

**A single-line card was too tall.** The lead reserved `margin-bottom: var(--sp-3)` to separate itself from supporting copy. With no supporting copy that became dead space: measured on a one-line brief, **13px of slack** below the text and a **69px** card for a 19px line.

## Change

- the lead reads as the lead through **size and colour only** — `--text-subtitle` size, `--fg`, body weight. Authored `**bold**` inside a description is untouched.
- move the lead's separation out of the inline style and into `index.css`, and collapse it with `:last-child` so a lead with nothing after it reserves no gap. The blank-line form is unaffected: the lead is its paragraph's last child there too, and the following paragraph carries its own top margin.
- add the single-line shape to the DEV preview gallery and to deterministic coverage — it was the majority real shape with no fixture.

## Validation

- `pnpm check`
- `pnpm typecheck` — 11/11 tasks, including the web `lint:tokens` guard
- `pnpm --filter @first-tree/web test` — 245 files / 2,247 tests passed
- real browser measurement of the rendered component:

  | shape | lead weight | lead size | lead margin-bottom | card height | slack below text |
  | --- | --- | --- | --- | --- | --- |
  | single line | 400 | 14px | 0px | **57px** (was 69) | **1px** (was 13) |
  | soft-break, 3 lines | 400 | 14px | 12px | 108px | 1px |

  Authored `<strong>` still computes to 600 in the multi-line fixtures, confirming only the promotion styling lost weight.

## Note

Hierarchy is now carried by a 14px/13px step plus `--fg` vs `--fg-2`, which is deliberately subtler than before. That was the agreed direction; worth a look in the live Workspace to confirm the result line still reads as the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
