### PR TITLE
feat(web): switch agents from the Agent Detail breadcrumb

### DIFF
--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -37,6 +37,7 @@ import { invalidateDisplayNameQueries } from "./../lib/identity-cache.js";
 import { cn } from "./../lib/utils.js";
 import { canManageAgentDetail } from "./agent-detail/access.js";
 import { isBindableClient } from "./agent-detail/action-state.js";
+import { AgentSwitcher } from "./agent-detail/agent-switcher.js";
 import { useAgentResources } from "./agent-detail/capability-section.js";
 import type { AgentDetailContext, RuntimeSwitchClaimView } from "./agent-detail/layout-context.js";
 import {
@@ -453,7 +454,21 @@ function AgentDetailPageView() {
             Team
           </BreadcrumbLink>
           <BreadcrumbSep />
-          <BreadcrumbCurrent>{agent.displayName}</BreadcrumbCurrent>
+          {/* Humans have no switcher: the list is agents only, so their own
+              row would never be in it. */}
+          {isHuman ? (
+            <BreadcrumbCurrent>{agent.displayName}</BreadcrumbCurrent>
+          ) : (
+            <AgentSwitcher
+              currentAgent={agent}
+              onSelect={(nextUuid) =>
+                // Keep the section the user is reading. A pushed entry (not
+                // `replace`, unlike the section links) makes Back return to
+                // the previous agent.
+                navigateAway(`/agents/${encodeURIComponent(nextUuid)}/${currentTab?.path ?? "profile"}`)
+              }
+            />
+          )}
         </Breadcrumb>
 
         <div className={cn("flex gap-4", isNarrow ? "flex-col items-stretch" : "items-center justify-between")}>

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -4,7 +4,7 @@ import type { Agent, AgentResourcesOutput, AgentRuntimeConfig } from "@first-tre
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter, Navigate, Route, Routes, useLocation } from "react-router";
+import { MemoryRouter, Navigate, Route, Routes, useLocation, useNavigate } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HubClient } from "../../../api/activity.js";
 import { ApiError } from "../../../api/client.js";
@@ -390,6 +390,20 @@ async function renderDom(
 function LocationEcho() {
   const location = useLocation();
   return <div>{location.pathname + location.search}</div>;
+}
+
+/** Tab body that reports where it is and can walk the history back. */
+function LocationEchoWithBack() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <div>
+      <div data-testid="here">{location.pathname}</div>
+      <button type="button" onClick={() => navigate(-1)}>
+        Go back
+      </button>
+    </div>
+  );
 }
 
 async function click(element: Element | null): Promise<void> {
@@ -1686,5 +1700,45 @@ describe("AgentDetailPage", () => {
     expect(profile.container.textContent).not.toContain("Reactivate");
     expect(profile.container.textContent).not.toContain("Delete");
     await act(async () => profile.root.unmount());
+  });
+  it("switches agents from the breadcrumb, keeping the section and leaving a history entry", async () => {
+    agentMocks.getAgent.mockImplementation(async (uuid: string) =>
+      uuid === "agent-2" ? agent({ uuid: "agent-2", name: "nova", displayName: "Nova" }) : agent(),
+    );
+
+    const view = await renderDom("/agents/agent-1/runtime", <LocationEchoWithBack />);
+    const breadcrumb = view.container.querySelector('nav[aria-label="Breadcrumb"]');
+    await click(breadcrumb?.querySelector('button[aria-haspopup="menu"]') ?? null);
+
+    const nova = [...document.querySelectorAll<HTMLButtonElement>('button[role="menuitemradio"]')].find(
+      (row) => row.textContent?.trim() === "Nova",
+    );
+    await click(nova ?? null);
+
+    // Same section on the new agent, not a bounce back to Profile.
+    await waitForCondition(
+      () => view.container.querySelector('[data-testid="here"]')?.textContent === "/agents/agent-2/runtime",
+      "Expected the switch to land on the same section of the target agent",
+    );
+    await waitForText(view.container, "Nova");
+
+    // Pushed, not replaced: Back returns to the agent we came from.
+    await click(exactButtonByText(view.container, "Go back"));
+    await waitForCondition(
+      () => view.container.querySelector('[data-testid="here"]')?.textContent === "/agents/agent-1/runtime",
+      "Expected Back to return to the previous agent",
+    );
+    await act(async () => view.root.unmount());
+  });
+
+  it("leaves the breadcrumb plain for a human member, who is never a switch target", async () => {
+    const { ProfileTab } = await import("../profile-tab.js");
+    agentMocks.getAgent.mockResolvedValueOnce(agent({ type: "human", displayName: "Gandy", name: "gandy" }));
+
+    const view = await renderDom("/agents/agent-1/profile", <ProfileTab />);
+    const breadcrumb = view.container.querySelector('nav[aria-label="Breadcrumb"]');
+    expect(breadcrumb?.querySelector('button[aria-haspopup="menu"]')).toBeNull();
+    expect(breadcrumb?.querySelector('[aria-current="page"]')?.textContent).toBe("Gandy");
+    await act(async () => view.root.unmount());
   });
 });

--- a/packages/web/src/pages/agent-detail/__tests__/agent-switcher-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-switcher-dom.test.tsx
@@ -1,0 +1,321 @@
+// @vitest-environment happy-dom
+
+import type { Agent } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const agentMocks = vi.hoisted(() => ({
+  listAgents: vi.fn(),
+  listAllAgents: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => ({
+  value: { memberId: "member-self", role: "member", organizationId: "org-1" } as {
+    memberId: string;
+    role: string;
+    organizationId: string;
+  },
+}));
+
+vi.mock("../../../api/agents.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/agents.js")>()),
+  ...agentMocks,
+}));
+
+vi.mock("../../../auth/auth-context.js", () => ({
+  useAuth: () => authMock.value,
+}));
+
+const NOW = "2026-05-28T12:00:00.000Z";
+
+function agent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    uuid: overrides.uuid ?? "agent-1",
+    name: overrides.name ?? "vega",
+    displayName: overrides.displayName ?? "Vega",
+    type: overrides.type ?? "agent",
+    managerId: overrides.managerId ?? "member-self",
+    visibility: overrides.visibility ?? "organization",
+    avatarColorToken: overrides.avatarColorToken ?? null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+    status: overrides.status ?? "active",
+    organizationId: overrides.organizationId ?? "org-1",
+    delegateMention: overrides.delegateMention ?? null,
+    inboxId: overrides.inboxId ?? "inbox-1",
+    metadata: overrides.metadata ?? {},
+    source: overrides.source ?? "portal",
+    clientId: overrides.clientId === undefined ? "client-1" : overrides.clientId,
+    runtimeProvider: overrides.runtimeProvider ?? "claude-code",
+    runtimeState: overrides.runtimeState === undefined ? "idle" : overrides.runtimeState,
+    createdAt: overrides.createdAt ?? NOW,
+    updatedAt: overrides.updatedAt ?? NOW,
+  };
+}
+
+let root: Root | null = null;
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function renderSwitcher(
+  current: Agent = agent(),
+): Promise<{ onSelect: ReturnType<typeof vi.fn>; container: HTMLElement }> {
+  const { AgentSwitcher } = await import("../agent-switcher.js");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const onSelect = vi.fn();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  });
+  await act(async () => {
+    root?.render(
+      <QueryClientProvider client={queryClient}>
+        <AgentSwitcher currentAgent={current} onSelect={onSelect} />
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  return { onSelect, container };
+}
+
+function trigger(): HTMLButtonElement {
+  const found = document.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]');
+  if (!found) throw new Error("Expected the switcher trigger");
+  return found;
+}
+
+function rows(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>('button[role="menuitemradio"]'));
+}
+
+function rowLabels(): string[] {
+  return rows().map((row) => row.textContent?.trim() ?? "");
+}
+
+async function click(element: Element | null | undefined): Promise<void> {
+  if (!element) throw new Error("Expected an element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function setValue(element: HTMLInputElement, value: string): Promise<void> {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  await act(async () => {
+    setter?.call(element, value);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await flush();
+}
+
+async function press(element: Element, key: string): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function open(): Promise<void> {
+  await click(trigger());
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+  authMock.value = { memberId: "member-self", role: "member", organizationId: "org-1" };
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    callback(0);
+    return 1;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+  agentMocks.listAgents.mockResolvedValue({
+    items: [
+      agent(),
+      agent({ uuid: "agent-2", name: "nova", displayName: "Nova" }),
+      agent({ uuid: "member-mirror", name: "gandy", displayName: "Gandy", type: "human" }),
+    ],
+    nextCursor: null,
+  });
+  agentMocks.listAllAgents.mockResolvedValue({ items: [], nextCursor: null });
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("AgentSwitcher", () => {
+  it("keeps the breadcrumb resting state and only adds a menu affordance", async () => {
+    await renderSwitcher();
+    expect(trigger().textContent).toBe("Vega");
+    expect(trigger().getAttribute("aria-current")).toBe("page");
+    expect(trigger().getAttribute("aria-expanded")).toBe("false");
+    // Nothing is fetched until the user actually asks to switch.
+    expect(agentMocks.listAgents).not.toHaveBeenCalled();
+
+    await open();
+    expect(trigger().getAttribute("aria-expanded")).toBe("true");
+    expect(agentMocks.listAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists agents only, marks the open one, and leaves handles off unique names", async () => {
+    await renderSwitcher();
+    await open();
+
+    expect(rowLabels()).toEqual(["Vega", "Nova"]);
+    expect(rows().map((row) => row.getAttribute("aria-checked"))).toEqual(["true", "false"]);
+  });
+
+  it("adds the handle only where display names collide", async () => {
+    agentMocks.listAgents.mockResolvedValue({
+      items: [
+        agent(),
+        agent({ uuid: "agent-2", name: "vega-2", displayName: "Vega" }),
+        agent({ uuid: "agent-3", name: "nova", displayName: "Nova" }),
+      ],
+      nextCursor: null,
+    });
+    await renderSwitcher();
+    await open();
+
+    expect(rowLabels()).toEqual(["Vega@vega", "Vega@vega-2", "Nova"]);
+  });
+
+  it("keeps the open agent in the list when the roster query cannot see it", async () => {
+    agentMocks.listAgents.mockResolvedValue({
+      items: [agent({ uuid: "agent-2", name: "nova", displayName: "Nova" })],
+      nextCursor: null,
+    });
+    await renderSwitcher(agent({ uuid: "agent-private", name: "orion", displayName: "Orion" }));
+    await open();
+
+    expect(rowLabels()).toEqual(["Orion", "Nova"]);
+    expect(rows()[0]?.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("reads the admin roster when the viewer is an admin", async () => {
+    authMock.value = { memberId: "member-self", role: "admin", organizationId: "org-1" };
+    agentMocks.listAllAgents.mockResolvedValue({
+      items: [agent(), agent({ uuid: "agent-9", name: "private", displayName: "Someone's private agent" })],
+      nextCursor: null,
+    });
+    await renderSwitcher();
+    await open();
+
+    expect(agentMocks.listAgents).not.toHaveBeenCalled();
+    expect(rowLabels()).toEqual(["Vega", "Someone's private agent"]);
+  });
+
+  it("reports the picked agent and closes, but treats the open agent as a no-op", async () => {
+    const { onSelect } = await renderSwitcher();
+    await open();
+    await click(rows()[1]);
+
+    expect(onSelect).toHaveBeenCalledWith("agent-2");
+    expect(document.querySelector('div[role="dialog"]')).toBeNull();
+
+    await open();
+    await click(rows()[0]);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('div[role="dialog"]')).toBeNull();
+  });
+
+  it("opens on the current agent and moves through the list with the arrow keys", async () => {
+    const { onSelect } = await renderSwitcher(agent({ uuid: "agent-2", name: "nova", displayName: "Nova" }));
+    await open();
+
+    // Focus lands on the row already in view, not blindly on the first one.
+    expect(document.activeElement).toBe(rows()[1]);
+
+    await press(rows()[1] as Element, "ArrowUp");
+    expect(document.activeElement).toBe(rows()[0]);
+    await press(rows()[0] as Element, "ArrowUp");
+    expect(document.activeElement).toBe(rows()[1]);
+    await press(rows()[1] as Element, "ArrowDown");
+    expect(document.activeElement).toBe(rows()[0]);
+    await press(rows()[0] as Element, "End");
+    expect(document.activeElement).toBe(rows()[1]);
+    await press(rows()[1] as Element, "Home");
+    expect(document.activeElement).toBe(rows()[0]);
+
+    await click(document.activeElement);
+    expect(onSelect).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("shows a filter only past the small-list threshold and narrows the rows", async () => {
+    const many = Array.from({ length: 9 }, (_, i) =>
+      agent({ uuid: `agent-${i}`, name: `agent-${i}`, displayName: i === 8 ? "Zephyr" : `Agent ${i}` }),
+    );
+    agentMocks.listAgents.mockResolvedValue({ items: many, nextCursor: null });
+    await renderSwitcher(agent({ uuid: "agent-0", name: "agent-0", displayName: "Agent 0" }));
+    await open();
+
+    const filter = document.querySelector<HTMLInputElement>('input[aria-label="Find an agent"]');
+    expect(filter).toBeTruthy();
+    expect(document.activeElement).toBe(filter);
+    expect(rows()).toHaveLength(9);
+
+    if (!filter) throw new Error("Expected the filter input");
+    await setValue(filter, "zep");
+    expect(rowLabels()).toEqual(["Zephyr"]);
+  });
+
+  it("hides the filter for a small roster", async () => {
+    await renderSwitcher();
+    await open();
+    expect(document.querySelector('input[aria-label="Find an agent"]')).toBeNull();
+  });
+
+  it("commits the top match when Enter is pressed in the filter", async () => {
+    const many = Array.from({ length: 9 }, (_, i) =>
+      agent({ uuid: `agent-${i}`, name: `agent-${i}`, displayName: i === 8 ? "Zephyr" : `Agent ${i}` }),
+    );
+    agentMocks.listAgents.mockResolvedValue({ items: many, nextCursor: null });
+    const { onSelect } = await renderSwitcher(agent({ uuid: "agent-0", name: "agent-0", displayName: "Agent 0" }));
+    await open();
+
+    const filter = document.querySelector<HTMLInputElement>('input[aria-label="Find an agent"]');
+    if (!filter) throw new Error("Expected the filter input");
+    await setValue(filter, "zep");
+    await press(filter as Element, "Enter");
+
+    expect(onSelect).toHaveBeenCalledWith("agent-8");
+  });
+
+  it("keeps a failed roster load inside the panel and recovers on retry", async () => {
+    agentMocks.listAgents.mockRejectedValueOnce(new Error("offline"));
+    await renderSwitcher();
+    await open();
+
+    const alert = document.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain("Couldn’t load agents.");
+    expect(rows()).toHaveLength(0);
+    // The page behind the panel is untouched — the trigger still reads the agent.
+    expect(trigger().textContent).toBe("Vega");
+
+    const retry = Array.from(document.querySelectorAll("button")).find((b) => b.textContent === "Retry");
+    await click(retry);
+    expect(rowLabels()).toEqual(["Vega", "Nova"]);
+  });
+
+  it("shows just the open agent when there is nothing to switch to", async () => {
+    agentMocks.listAgents.mockResolvedValue({ items: [agent()], nextCursor: null });
+    await renderSwitcher();
+    await open();
+    expect(rowLabels()).toEqual(["Vega"]);
+    expect(rows()[0]?.getAttribute("aria-checked")).toBe("true");
+  });
+});

--- a/packages/web/src/pages/agent-detail/__tests__/agent-switcher-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-switcher-dom.test.tsx
@@ -307,8 +307,13 @@ describe("AgentSwitcher", () => {
     expect(trigger().textContent).toBe("Vega");
 
     const retry = Array.from(document.querySelectorAll("button")).find((b) => b.textContent === "Retry");
+    expect(document.activeElement).toBe(retry);
+
     await click(retry);
     expect(rowLabels()).toEqual(["Vega", "Nova"]);
+    // The Retry button that held focus is gone; the recovered list takes over
+    // rather than dropping the keyboard on document.body.
+    expect(document.activeElement).toBe(rows()[0]);
   });
 
   it("shows just the open agent when there is nothing to switch to", async () => {

--- a/packages/web/src/pages/agent-detail/__tests__/agent-switcher-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-switcher-dom.test.tsx
@@ -175,8 +175,8 @@ describe("AgentSwitcher", () => {
     await renderSwitcher();
     await open();
 
-    expect(rowLabels()).toEqual(["Vega", "Nova"]);
-    expect(rows().map((row) => row.getAttribute("aria-checked"))).toEqual(["true", "false"]);
+    expect(rowLabels()).toEqual(["Nova", "Vega"]);
+    expect(rows().map((row) => row.getAttribute("aria-checked"))).toEqual(["false", "true"]);
   });
 
   it("adds the handle only where display names collide", async () => {
@@ -191,7 +191,7 @@ describe("AgentSwitcher", () => {
     await renderSwitcher();
     await open();
 
-    expect(rowLabels()).toEqual(["Vega@vega", "Vega@vega-2", "Nova"]);
+    expect(rowLabels()).toEqual(["Nova", "Vega@vega", "Vega@vega-2"]);
   });
 
   it("keeps the open agent in the list when the roster query cannot see it", async () => {
@@ -202,8 +202,8 @@ describe("AgentSwitcher", () => {
     await renderSwitcher(agent({ uuid: "agent-private", name: "orion", displayName: "Orion" }));
     await open();
 
-    expect(rowLabels()).toEqual(["Orion", "Nova"]);
-    expect(rows()[0]?.getAttribute("aria-checked")).toBe("true");
+    expect(rowLabels()).toEqual(["Nova", "Orion"]);
+    expect(rows()[1]?.getAttribute("aria-checked")).toBe("true");
   });
 
   it("reads the admin roster when the viewer is an admin", async () => {
@@ -216,19 +216,20 @@ describe("AgentSwitcher", () => {
     await open();
 
     expect(agentMocks.listAgents).not.toHaveBeenCalled();
-    expect(rowLabels()).toEqual(["Vega", "Someone's private agent"]);
+    expect(rowLabels()).toEqual(["Someone's private agent", "Vega"]);
   });
 
   it("reports the picked agent and closes, but treats the open agent as a no-op", async () => {
     const { onSelect } = await renderSwitcher();
     await open();
-    await click(rows()[1]);
+    // Rows are ["Nova", "Vega"]; the open agent is Vega.
+    await click(rows()[0]);
 
     expect(onSelect).toHaveBeenCalledWith("agent-2");
     expect(document.querySelector('div[role="dialog"]')).toBeNull();
 
     await open();
-    await click(rows()[0]);
+    await click(rows()[1]);
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(document.querySelector('div[role="dialog"]')).toBeNull();
   });
@@ -237,11 +238,10 @@ describe("AgentSwitcher", () => {
     const { onSelect } = await renderSwitcher(agent({ uuid: "agent-2", name: "nova", displayName: "Nova" }));
     await open();
 
-    // Focus lands on the row already in view, not blindly on the first one.
-    expect(document.activeElement).toBe(rows()[1]);
-
-    await press(rows()[1] as Element, "ArrowUp");
+    // Focus lands on the checked row, not blindly on the first one.
+    expect(rowLabels()).toEqual(["Nova", "Vega"]);
     expect(document.activeElement).toBe(rows()[0]);
+
     await press(rows()[0] as Element, "ArrowUp");
     expect(document.activeElement).toBe(rows()[1]);
     await press(rows()[1] as Element, "ArrowDown");
@@ -250,9 +250,36 @@ describe("AgentSwitcher", () => {
     expect(document.activeElement).toBe(rows()[1]);
     await press(rows()[1] as Element, "Home");
     expect(document.activeElement).toBe(rows()[0]);
+    await press(rows()[0] as Element, "ArrowDown");
+    expect(document.activeElement).toBe(rows()[1]);
 
     await click(document.activeElement);
     expect(onSelect).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("reorders the API roster into the Team page's order", async () => {
+    authMock.value = { memberId: "member-self", role: "admin", organizationId: "org-1" };
+    agentMocks.listAllAgents.mockResolvedValue({
+      // As the API returns it: createdAt DESC, mixed visibility and ownership.
+      items: [
+        agent({ uuid: "a1", name: "zeta", displayName: "Zeta", visibility: "private", managerId: "member-other" }),
+        agent({ uuid: "a2", name: "alpha", displayName: "Alpha", managerId: "member-other" }),
+        agent({ uuid: "a3", name: "mine-zulu", displayName: "Mine Zulu", managerId: "member-self" }),
+        agent({
+          uuid: "a4",
+          name: "private-mine",
+          displayName: "Private Mine",
+          visibility: "private",
+          managerId: "member-self",
+        }),
+        agent({ uuid: "a5", name: "beta", displayName: "Beta", managerId: "member-other" }),
+      ],
+      nextCursor: null,
+    });
+    await renderSwitcher(agent({ uuid: "a3", name: "mine-zulu", displayName: "Mine Zulu", managerId: "member-self" }));
+    await open();
+
+    expect(rowLabels()).toEqual(["Mine Zulu", "Alpha", "Beta", "Private Mine", "Zeta"]);
   });
 
   it("shows a filter only past the small-list threshold and narrows the rows", async () => {
@@ -310,10 +337,10 @@ describe("AgentSwitcher", () => {
     expect(document.activeElement).toBe(retry);
 
     await click(retry);
-    expect(rowLabels()).toEqual(["Vega", "Nova"]);
+    expect(rowLabels()).toEqual(["Nova", "Vega"]);
     // The Retry button that held focus is gone; the recovered list takes over
     // rather than dropping the keyboard on document.body.
-    expect(document.activeElement).toBe(rows()[0]);
+    expect(document.activeElement).toBe(rows()[1]);
   });
 
   it("shows just the open agent when there is nothing to switch to", async () => {

--- a/packages/web/src/pages/agent-detail/agent-switcher.tsx
+++ b/packages/web/src/pages/agent-detail/agent-switcher.tsx
@@ -95,7 +95,8 @@ function AgentSwitcherPanel({
   const isAdmin = role === "admin";
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const didAutoFocusRef = useRef(false);
+  const retryRef = useRef<HTMLButtonElement>(null);
+  const autoFocusedForRef = useRef<"none" | "error" | "list">("none");
   const [filter, setFilter] = useState("");
 
   // Same query key, source, and order as the Team page, so the switcher shows
@@ -134,11 +135,19 @@ function AgentSwitcherPanel({
     );
   }, [options, filter]);
 
-  // Land the keyboard on something meaningful once the list resolves: the
-  // filter input when there is one, otherwise the agent already open.
+  // Land the keyboard on something meaningful each time the panel's content
+  // changes shape: Retry while the roster is broken, then the filter input or
+  // the agent already open once a list exists. Tracking which shape we focused
+  // for (rather than a one-shot flag) is what lets a successful retry hand the
+  // keyboard on to the rows it just rendered.
   useEffect(() => {
-    if (didAutoFocusRef.current || agentsQuery.isPending) return;
-    didAutoFocusRef.current = true;
+    if (agentsQuery.isError && autoFocusedForRef.current !== "error") {
+      autoFocusedForRef.current = "error";
+      retryRef.current?.focus();
+      return;
+    }
+    if (!agentsQuery.isSuccess || autoFocusedForRef.current === "list") return;
+    autoFocusedForRef.current = "list";
     if (inputRef.current) {
       inputRef.current.focus();
       return;
@@ -148,7 +157,7 @@ function AgentSwitcherPanel({
       rows?.querySelector<HTMLButtonElement>(`${ROW_SELECTOR}[aria-checked="true"]`) ??
       rows?.querySelector<HTMLButtonElement>(ROW_SELECTOR)
     )?.focus();
-  }, [agentsQuery.isPending]);
+  }, [agentsQuery.isError, agentsQuery.isSuccess]);
 
   function pick(uuid: string) {
     close();
@@ -219,7 +228,7 @@ function AgentSwitcherPanel({
           style={{ padding: "var(--sp-1_5) var(--sp-3)", color: "var(--fg-3)" }}
         >
           <span>Couldn’t load agents.</span>
-          <Button size="xs" variant="outline" onClick={() => void agentsQuery.refetch()}>
+          <Button ref={retryRef} size="xs" variant="outline" onClick={() => void agentsQuery.refetch()}>
             Retry
           </Button>
         </div>

--- a/packages/web/src/pages/agent-detail/agent-switcher.tsx
+++ b/packages/web/src/pages/agent-detail/agent-switcher.tsx
@@ -8,7 +8,7 @@ import { Button } from "../../components/ui/button.js";
 import { Input } from "../../components/ui/input.js";
 import { Popover } from "../../components/ui/popover.js";
 
-import { fetchAllAgents } from "../team/index.js";
+import { fetchAllAgents, orderAgentsLikeTeam } from "../team/index.js";
 
 /** Above this many switch targets the panel gains a filter input. */
 const SEARCH_THRESHOLD = 8;
@@ -91,7 +91,7 @@ function AgentSwitcherPanel({
   onSelect: (uuid: string) => void;
   close: () => void;
 }) {
-  const { role } = useAuth();
+  const { role, memberId } = useAuth();
   const isAdmin = role === "admin";
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -111,8 +111,11 @@ function AgentSwitcherPanel({
     // A member's list is visibility-filtered, so the agent currently open can
     // legitimately be absent from it. Keep it present, or the list would show
     // no checked row at all.
-    return agents.some((a) => a.uuid === currentAgent.uuid) ? agents : [currentAgent, ...agents];
-  }, [agentsQuery.data, currentAgent]);
+    const withCurrent = agents.some((a) => a.uuid === currentAgent.uuid) ? agents : [...agents, currentAgent];
+    // The server returns `createdAt DESC`; Team reorders client-side. Reuse
+    // that rule so the two surfaces can't disagree about where an agent sits.
+    return orderAgentsLikeTeam(withCurrent, memberId);
+  }, [agentsQuery.data, currentAgent, memberId]);
 
   // Display names are not unique. Disambiguate with the handle only where it
   // is actually needed, so the common case stays a bare list of names.

--- a/packages/web/src/pages/agent-detail/agent-switcher.tsx
+++ b/packages/web/src/pages/agent-detail/agent-switcher.tsx
@@ -1,0 +1,265 @@
+import type { Agent } from "@first-tree/shared";
+import { useQuery } from "@tanstack/react-query";
+import { Check, ChevronDown } from "lucide-react";
+import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+import { listAgents, listAllAgents } from "../../api/agents.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { Button } from "../../components/ui/button.js";
+import { Input } from "../../components/ui/input.js";
+import { Popover } from "../../components/ui/popover.js";
+
+import { fetchAllAgents } from "../team/index.js";
+
+/** Above this many switch targets the panel gains a filter input. */
+const SEARCH_THRESHOLD = 8;
+
+// Keyboard navigation moves real DOM focus between rows, so the focused row
+// carries the same background highlight as a hovered one — a menu, not a
+// focus-ringed form control.
+const ROW_CLASS =
+  "flex w-full items-center gap-2 px-3 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)] focus:bg-[var(--bg-hover)] focus:outline-none";
+
+const ROW_SELECTOR = 'button[role="menuitemradio"]';
+
+/**
+ * Breadcrumb-anchored agent switcher.
+ *
+ * The breadcrumb's current segment already answers "which agent am I looking
+ * at"; this makes it answer "and I can change it" without growing the header.
+ * Deliberately plain — no avatar, no presence, no grouping — so the resting
+ * state is the same breadcrumb text plus one chevron, and the Team page stays
+ * the place to browse the roster.
+ */
+export function AgentSwitcher({ currentAgent, onSelect }: { currentAgent: Agent; onSelect: (uuid: string) => void }) {
+  // Hover is tracked in state rather than a `group-hover:` class, matching how
+  // the sibling `BreadcrumbLink` swaps its own hover color.
+  const [hovered, setHovered] = useState(false);
+  return (
+    <Popover
+      align="start"
+      offset={6}
+      panelAriaLabel="Switch agent"
+      panelStyle={{ width: "var(--sp-70)", padding: "var(--sp-1) 0" }}
+      trigger={({ open, toggle }) => (
+        <button
+          type="button"
+          // Still the breadcrumb's current segment — becoming a menu trigger
+          // must not cost it that meaning.
+          aria-current="page"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={`Switch agent, current: ${currentAgent.displayName}`}
+          onClick={toggle}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          onKeyDown={(e) => {
+            if (open || (e.key !== "ArrowDown" && e.key !== "ArrowUp")) return;
+            e.preventDefault();
+            toggle();
+          }}
+          // Borderless by design (it must still read as breadcrumb text), so
+          // focus uses the §13 thin neutral ring rather than a border that
+          // would break the breadcrumb's flat line.
+          className="inline-flex min-h-11 cursor-pointer items-center gap-1 border-0 bg-transparent p-0 text-body font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          style={{ color: "var(--fg)" }}
+        >
+          <span className="truncate">{currentAgent.displayName}</span>
+          {/* The name already sits at full contrast, so the chevron is what
+              deepens on hover and while the menu is open. */}
+          <ChevronDown
+            className="h-3.5 w-3.5 flex-none transition-colors"
+            style={{ color: open || hovered ? "var(--fg)" : "var(--fg-3)" }}
+          />
+        </button>
+      )}
+    >
+      {({ close }) => <AgentSwitcherPanel currentAgent={currentAgent} onSelect={onSelect} close={close} />}
+    </Popover>
+  );
+}
+
+/**
+ * Split out so the filter text and the list query mount with the panel: every
+ * open starts unfiltered, and a closed switcher holds no query observer.
+ */
+function AgentSwitcherPanel({
+  currentAgent,
+  onSelect,
+  close,
+}: {
+  currentAgent: Agent;
+  onSelect: (uuid: string) => void;
+  close: () => void;
+}) {
+  const { role } = useAuth();
+  const isAdmin = role === "admin";
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const didAutoFocusRef = useRef(false);
+  const [filter, setFilter] = useState("");
+
+  // Same query key, source, and order as the Team page, so the switcher shows
+  // the roster the user just came from — and opens against a warm cache.
+  const agentsQuery = useQuery({
+    queryKey: ["agents", "team-page", isAdmin ? "admin" : "member"],
+    queryFn: () => fetchAllAgents((params) => (isAdmin ? listAllAgents(params) : listAgents(params))),
+  });
+
+  const options = useMemo(() => {
+    const agents = (agentsQuery.data ?? []).filter((a) => a.type !== "human");
+    // A member's list is visibility-filtered, so the agent currently open can
+    // legitimately be absent from it. Keep it present, or the list would show
+    // no checked row at all.
+    return agents.some((a) => a.uuid === currentAgent.uuid) ? agents : [currentAgent, ...agents];
+  }, [agentsQuery.data, currentAgent]);
+
+  // Display names are not unique. Disambiguate with the handle only where it
+  // is actually needed, so the common case stays a bare list of names.
+  const ambiguousNames = useMemo(() => {
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const agent of options) {
+      if (seen.has(agent.displayName)) duplicates.add(agent.displayName);
+      else seen.add(agent.displayName);
+    }
+    return duplicates;
+  }, [options]);
+
+  const showFilter = options.length > SEARCH_THRESHOLD;
+  const visible = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return options;
+    return options.filter(
+      (a) => a.displayName.toLowerCase().includes(needle) || (a.name ?? "").toLowerCase().includes(needle),
+    );
+  }, [options, filter]);
+
+  // Land the keyboard on something meaningful once the list resolves: the
+  // filter input when there is one, otherwise the agent already open.
+  useEffect(() => {
+    if (didAutoFocusRef.current || agentsQuery.isPending) return;
+    didAutoFocusRef.current = true;
+    if (inputRef.current) {
+      inputRef.current.focus();
+      return;
+    }
+    const rows = listRef.current;
+    (
+      rows?.querySelector<HTMLButtonElement>(`${ROW_SELECTOR}[aria-checked="true"]`) ??
+      rows?.querySelector<HTMLButtonElement>(ROW_SELECTOR)
+    )?.focus();
+  }, [agentsQuery.isPending]);
+
+  function pick(uuid: string) {
+    close();
+    // Re-selecting the open agent is a no-op rather than a self-navigation
+    // that would push a duplicate history entry.
+    if (uuid === currentAgent.uuid) return;
+    onSelect(uuid);
+  }
+
+  // Bound to the filter input and the menu itself (both already interactive)
+  // rather than to the panel wrapper, so the container stays a plain div.
+  function onPanelKeyDown(e: ReactKeyboardEvent<HTMLElement>) {
+    if (e.key === "Tab") {
+      close();
+      return;
+    }
+    const rows = Array.from(listRef.current?.querySelectorAll<HTMLButtonElement>(ROW_SELECTOR) ?? []);
+    if (rows.length === 0) return;
+    // Enter on a row is the button's own activation; from the filter input it
+    // commits the top match.
+    if (e.key === "Enter") {
+      if ((e.target as HTMLElement).tagName !== "INPUT") return;
+      e.preventDefault();
+      rows[0]?.click();
+      return;
+    }
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+    e.preventDefault();
+    if (e.key === "Home") {
+      rows[0]?.focus();
+      return;
+    }
+    if (e.key === "End") {
+      rows[rows.length - 1]?.focus();
+      return;
+    }
+    const active = rows.indexOf(document.activeElement as HTMLButtonElement);
+    const step = e.key === "ArrowDown" ? 1 : -1;
+    const next = active === -1 ? (step === 1 ? 0 : rows.length - 1) : active + step;
+    rows[(next + rows.length) % rows.length]?.focus();
+  }
+
+  return (
+    <div>
+      {showFilter && (
+        <div style={{ padding: "var(--sp-1) var(--sp-2) var(--sp-1_5)" }}>
+          <Input
+            ref={inputRef}
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            onKeyDown={onPanelKeyDown}
+            placeholder="Find an agent"
+            aria-label="Find an agent"
+            className="h-8"
+          />
+        </div>
+      )}
+
+      {agentsQuery.isPending ? (
+        <div className="text-body" style={{ padding: "var(--sp-1_5) var(--sp-3)", color: "var(--fg-3)" }}>
+          Loading agents…
+        </div>
+      ) : agentsQuery.isError ? (
+        // Scoped to the panel — the detail page behind it stays usable.
+        <div
+          role="alert"
+          className="flex flex-col items-start gap-2 text-body"
+          style={{ padding: "var(--sp-1_5) var(--sp-3)", color: "var(--fg-3)" }}
+        >
+          <span>Couldn’t load agents.</span>
+          <Button size="xs" variant="outline" onClick={() => void agentsQuery.refetch()}>
+            Retry
+          </Button>
+        </div>
+      ) : visible.length === 0 ? (
+        // `options` always carries the open agent, so an empty list can only
+        // mean the filter matched nothing.
+        <div className="text-body" style={{ padding: "var(--sp-1_5) var(--sp-3)", color: "var(--fg-3)" }}>
+          No matching agents
+        </div>
+      ) : (
+        <div ref={listRef} role="menu" aria-label="Agents" aria-orientation="vertical" onKeyDown={onPanelKeyDown}>
+          {visible.map((agent) => {
+            const isCurrent = agent.uuid === currentAgent.uuid;
+            return (
+              <button
+                key={agent.uuid}
+                type="button"
+                role="menuitemradio"
+                aria-checked={isCurrent}
+                tabIndex={-1}
+                onClick={() => pick(agent.uuid)}
+                className={ROW_CLASS}
+                style={{ color: "var(--fg)" }}
+              >
+                <span className="min-w-0 flex-1 truncate" title={agent.displayName}>
+                  <span className={isCurrent ? "font-medium" : undefined}>{agent.displayName}</span>
+                  {ambiguousNames.has(agent.displayName) && agent.name ? (
+                    <span className="mono text-caption" style={{ color: "var(--fg-3)", marginLeft: "var(--sp-1_5)" }}>
+                      @{agent.name}
+                    </span>
+                  ) : null}
+                </span>
+                <span className="inline-flex flex-none justify-center" style={{ width: 14 }}>
+                  {isCurrent ? <Check className="h-3.5 w-3.5" aria-hidden /> : null}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -67,7 +67,11 @@ export function PromptTab() {
     },
     ...agentResourcesMutationHandlers(queryClient, ctx.uuid, { onSuccessAfter: markSaved }),
   });
-  if (ctx.isHuman) return <Navigate to="../profile" replace />;
+  // Instructions is an editor-only tab (`tabKeysFor` gates it on
+  // `canEditConfig`, and the runtime config query is disabled without it).
+  // Non-editors reach this route by deep link or by switching agents while on
+  // it, and would otherwise land on a permanently empty editor.
+  if (ctx.isHuman || !ctx.canEditConfig) return <Navigate to="../profile" replace />;
   if (!ctx.config && ctx.configLoading) return null;
   const prompt = ctx.config?.payload.prompt.append ?? "";
   const promptSections = ctx.config?.payload.prompt.sections;

--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -1,6 +1,6 @@
 import type { Agent } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
-import { buildTeamData, fetchAllAgents, selectDelegateCandidates } from "../index.js";
+import { buildTeamData, fetchAllAgents, orderAgentsLikeTeam, selectDelegateCandidates } from "../index.js";
 
 function agent(input: {
   uuid: string;
@@ -306,5 +306,49 @@ describe("selectDelegateCandidates", () => {
     expect(
       selectDelegateCandidates([mineOrg, theirOrg, minePrivate, suspended, human], "member-1").map((a) => a.uuid),
     ).toEqual(["mine-org", "mine-private"]);
+  });
+});
+
+describe("orderAgentsLikeTeam", () => {
+  // The API returns createdAt DESC; Team reorders client-side. The Agent Detail
+  // switcher shows the same roster without section headings, so its flat order
+  // must stay the concatenation of Team's two groups.
+  const roster = [
+    agent({ uuid: "zeta", type: "agent", displayName: "Zeta", visibility: "private", managerId: "member-2" }),
+    agent({ uuid: "alpha", type: "agent", displayName: "Alpha", managerId: "member-2" }),
+    agent({ uuid: "mine-zulu", type: "agent", displayName: "Mine Zulu", managerId: "member-1" }),
+    agent({
+      uuid: "private-mine",
+      type: "agent",
+      displayName: "Private Mine",
+      visibility: "private",
+      managerId: "member-1",
+    }),
+    agent({ uuid: "beta", type: "agent", displayName: "Beta", managerId: "member-2" }),
+  ];
+
+  it("puts organization agents before private ones, mine first, then by name", () => {
+    expect(orderAgentsLikeTeam(roster, "member-1").map((a) => a.displayName)).toEqual([
+      "Mine Zulu",
+      "Alpha",
+      "Beta",
+      "Private Mine",
+      "Zeta",
+    ]);
+  });
+
+  it("agrees with the order buildTeamData renders for the same viewer", () => {
+    const team = buildTeamData({
+      filter: "all",
+      search: "",
+      isAdmin: true,
+      selfMemberId: "member-1",
+      members: [],
+      agents: roster,
+      agentByUuid: new Map(roster.map((a) => [a.uuid, a])),
+      resolveMember: (id) => id,
+    });
+    const teamOrder = [...team.publicAgents, ...team.privateAgents].map((row) => row.agent.displayName);
+    expect(orderAgentsLikeTeam(roster, "member-1").map((a) => a.displayName)).toEqual(teamOrder);
   });
 });

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -460,6 +460,33 @@ function SearchBar({ query, onQuery }: { query: string; onQuery: (q: string) => 
   );
 }
 
+/**
+ * Order within one roster group: own agents pinned first (fast self-location),
+ * then alphabetical — stable across paginated refetches, unlike the server's
+ * `createdAt DESC`.
+ */
+export function compareRosterAgents(selfMemberId: string | null | undefined): (x: Agent, y: Agent) => number {
+  return (x, y) => {
+    const mineX = x.managerId === selfMemberId ? 0 : 1;
+    const mineY = y.managerId === selfMemberId ? 0 : 1;
+    if (mineX !== mineY) return mineX - mineY;
+    return x.displayName.localeCompare(y.displayName, undefined, { sensitivity: "base" });
+  };
+}
+
+/**
+ * The Team page's roster order as one flat list, for surfaces that show the
+ * same agents without the section headings (the Agent Detail switcher).
+ * Organization-visible agents lead, then private ones, each group ordered by
+ * {@link compareRosterAgents}.
+ */
+export function orderAgentsLikeTeam(agents: Agent[], selfMemberId: string | null | undefined): Agent[] {
+  const compare = compareRosterAgents(selfMemberId);
+  const organization = agents.filter((a) => a.visibility === "organization").sort(compare);
+  const rest = agents.filter((a) => a.visibility !== "organization").sort(compare);
+  return [...organization, ...rest];
+}
+
 export function buildTeamData(args: {
   filter: AgentFilter;
   search: string;
@@ -495,15 +522,8 @@ export function buildTeamData(args: {
     isOwnedBySelf: a.managerId === selfMemberId,
   });
 
-  // Own agents pinned first (fast self-location), then alphabetical — stable
-  // across paginated refetches.
-  const sortRows = (rows: AgentRow[]) =>
-    rows.sort((x, y) => {
-      const mineX = x.isOwnedBySelf ? 0 : 1;
-      const mineY = y.isOwnedBySelf ? 0 : 1;
-      if (mineX !== mineY) return mineX - mineY;
-      return x.agent.displayName.localeCompare(y.agent.displayName, undefined, { sensitivity: "base" });
-    });
+  const compare = compareRosterAgents(selfMemberId);
+  const sortRows = (rows: AgentRow[]) => rows.sort((x, y) => compare(x.agent, y.agent));
 
   const publicAgents = sortRows(agents.filter((a) => a.visibility === "organization" && visible(a)).map(toRow));
   const privateAgents = sortRows(agents.filter((a) => a.visibility === "private" && visible(a)).map(toRow));


### PR DESCRIPTION
## Why

Changing which agent you are configuring meant leaving Agent Detail for Team, finding the target agent, and entering it again — at least two navigations for what is really one action. The breadcrumb's current segment already answers "which agent am I looking at"; this makes it also answer "and I can change it".

## What

`Team / <agent name>` gains a small chevron and becomes a menu trigger. Everything else in the header is unchanged.

The panel is deliberately plain:

- Non-human agents only, name only, in the Team page's order (see below) and off the same query cache, so it opens warm when you arrived from Team.
- The open agent is checked; `@handle` appears only where two display names collide.
- A filter input appears only past eight agents.
- Switching keeps the current section (`/runtime` → `/runtime`) and pushes a history entry, so Back returns to the previous agent. Picking the open agent is a no-op.
- Arrow keys / Home / End move between rows, Enter commits, Escape closes and restores focus to the trigger. Focus opens on the current agent, or on the filter when there is one; while the roster is failing it opens on Retry, and a successful retry hands the keyboard to the rows it just rendered.
- A failed roster load stays inside the panel with a retry; the page behind it is untouched.

Not included, by design: avatars, presence, grouping, recents, a "View all agents" footer, a dedicated shortcut, and a persistent agent rail.

Human members keep the plain breadcrumb — they are never switch targets, so a switcher there would open a list with nothing checked.

## Shared roster order

The switcher must show the roster in the order Team shows it, but the list endpoints return `createdAt DESC` and Team reprojects client-side. Rather than reimplement that, this extracts it:

- `compareRosterAgents(selfMemberId)` — the viewer's own agents first, then `displayName.localeCompare(..., { sensitivity: "base" })`. `buildTeamData`'s `sortRows` now sorts through it, so there is exactly one definition.
- `orderAgentsLikeTeam(agents, selfMemberId)` — organization-visible group then private group, each through that comparator: Team's two sections flattened for this ungrouped menu.

The "current agent is absent from a visibility-filtered roster" case is folded into the same ordering step, so that agent keeps a checked row without gaining a special top position.

## Drive-by fix

`Instructions` now redirects non-editors to Profile, the way `Runtime`, `Repositories`, and `Responsibilities` already do. Without it, switching to an agent you cannot configure while on Instructions left you on a permanently empty editor (its config query is disabled for non-editors).

## Verification

- `pnpm --filter @first-tree/web typecheck` (tsc + design-token guardrails) — clean. `biome check` on the touched paths — clean.
- `pnpm --filter @first-tree/web test` — 2264 passed. The one failing suite, `tests/visual-regression.spec.ts`, is a Playwright spec vitest cannot parse; it fails identically on an untouched tree.
- `agent-switcher-dom.test.tsx` (13 cases): roster source per role, human exclusion, the checked row, handle disambiguation, the open-agent-missing-from-roster case, Team ordering from a divergent API order, filter threshold and filtering, Enter-commits-top-match, keyboard traversal, the no-op re-pick, and the error → retry → focus-recovery path.
- `team-groups.test.ts`: `orderAgentsLikeTeam` on a roster whose API order differs from presentation order, plus a direct equivalence case asserting it equals `[...buildTeamData().publicAgents, ...buildTeamData().privateAgents]` for the same viewer.
- `agent-detail-page-dom.test.tsx`: switching preserves the section and Back returns to the previous agent; a human member keeps the plain breadcrumb.
- Browser pass against a local server + web dev build. Ordering was checked with a deliberately discriminating seed — `Alpha Shared`, `Zeta Shared`, `Beta Shared` (organization) and `A Private Agent` (private), which the API returns as `A Private Agent, Beta Shared, Zeta Shared, Alpha Shared`; the switcher and Team both render `Alpha Shared, Beta Shared, Zeta Shared, A Private Agent`. Also covered: resting breadcrumb and chevron hover, the panel above and below the filter threshold, filter + Enter switching into the same tab, browser Back, keyboard traversal, Escape focus restore, dark theme, and a 390px viewport where the panel stays inside the viewport. No console errors from this change.

## Not verified

The non-editor Profile fallback was exercised through the tab guards and unit tests, not in the browser — the local dev identity is an admin of every agent in its org. The trigger's focus ring was not pixel-checked; it uses the same focus classes as every `Button`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
