### PR TITLE
docs: state BYO Context qualification status and revised release bar

### DIFF
--- a/docs/context-integration.md
+++ b/docs/context-integration.md
@@ -320,7 +320,11 @@ Current coverage comes from three layers, none of which is provider-surface
 evidence:
 
 - deterministic behavior — per-package Vitest;
-- recurring agent behavior — `@first-tree/skill-evals` floors;
+- skill-eval structure — the `@first-tree/skill-evals` no-model floors, which
+  validate the coverage matrix, Skill frontmatter and case schema only. They
+  execute no Codex, Claude Code, or LLM-judge case, so they are not evidence of
+  agent behavior; the model-backed gate, quality and periodic suites are
+  human-requested and have no recorded run for BYO Context;
 - scenario definitions — the prose cases under `packages/qa/cases/`, which are
   prompts for a human-requested QA run, not execution records.
 

--- a/docs/context-integration.md
+++ b/docs/context-integration.md
@@ -308,30 +308,3 @@ Sensitive Teams should use separate provider sessions.
 Session-only means no persistent grant, Plugin or Hook and no automatic future
 activation. It does not promise continuity across clear, compact, resume, exit,
 or a new session.
-
-## Release qualification
-
-Before production qualification, real Claude Code and Codex surfaces must
-record evidence for:
-
-1. global, directory and session-only setup;
-2. dynamic setup choices for pathless, Codex scratch, default managed-worktree,
-   and ordinary-project locations, plus `/hooks` consent and same-conversation
-   continuation;
-3. two or more real Teams with clear, overlapping, missing and non-matching
-   SCOPE bodies;
-4. a non-programming SCOPE and imperative text treated only as routing data;
-5. membership revocation, binding movement, offline authority and scope-commit
-   movement;
-6. single- and multi-Team BYO writes with the mandatory new user confirmation;
-7. SCOPE admin approval, rejection, changed head/digest and manager demotion;
-8. v2 store backup and explicit reauthorization;
-9. legacy full Plugin migration with the Claude next-session adoption gate,
-   followed by a Core-only CLI upgrade that leaves adapter bytes and provider
-   trust unchanged;
-10. same-organization cross-provider repo reuse, cross-organization isolation,
-    A→B→A Client switching, and active-write switch refusal;
-11. concise bootstrap progress, bounded typed-error recovery, and unchanged
-    human confirmation boundaries.
-
-Unit tests and mock QA do not replace these real-provider checks.

--- a/docs/context-integration.md
+++ b/docs/context-integration.md
@@ -308,3 +308,38 @@ Sensitive Teams should use separate provider sessions.
 Session-only means no persistent grant, Plugin or Hook and no automatic future
 activation. It does not promise continuity across clear, compact, resume, exit,
 or a new session.
+
+## Qualification status
+
+BYO Context ships on the public `latest` channel. Its real-provider
+qualification is incomplete: no recorded Claude Code or Codex surface evidence
+exists for any of the scenarios below. #2143 carried this as an explicit
+release risk and it has not since been discharged.
+
+Current coverage comes from three layers, none of which is provider-surface
+evidence:
+
+- deterministic behavior — per-package Vitest;
+- recurring agent behavior — `@first-tree/skill-evals` floors;
+- scenario definitions — the prose cases under `packages/qa/cases/`, which are
+  prompts for a human-requested QA run, not execution records.
+
+The release bar is recorded evidence from real Claude Code and Codex surfaces
+for:
+
+1. global, directory and session-only setup;
+2. two or more real Teams with clear, overlapping, missing and non-matching
+   SCOPE bodies;
+3. single- and multi-Team BYO writes with the mandatory new user confirmation.
+
+Unit tests and mock QA do not replace these real-provider checks.
+
+The remaining scenarios — dynamic setup choices and `/hooks` consent,
+membership revocation and binding movement, SCOPE admin approval, v2 store
+backup, legacy Plugin migration, cross-organization isolation and Client
+switching, and bootstrap error recovery — stay defined in `packages/qa/cases/`
+and are qualified when a change touches them rather than on every release.
+Dynamic directory choice additionally depends on #2208.
+
+#2239 owns the environment these checks need and the current per-scenario
+status.


### PR DESCRIPTION
Replaces the **Release qualification** section in `docs/context-integration.md` with a **Qualification status** section that records the actual gap and sets a narrowed release bar.

## Why

The old section listed 11 checks that "real Claude Code and Codex surfaces must record evidence for" before production qualification, and closed with "Unit tests and mock QA do not replace these real-provider checks."

None of the 11 has ever been executed and no evidence for any of them exists in the repo, while BYO Context has been on npm `latest` since `0.5.18` (2026-07-30). #2143 recorded this at launch as an explicit release risk — "Formal real-surface Claude Code and Codex QA was not run for this PR… therefore remain explicit release risks until that evidence is recorded" — and it has not been discharged since.

This PR originally deleted the section. Review correctly rejected that: deletion turns "we did not meet a declared bar" into "there is no bar," while the document still marks surfaces P0 and describes a complete production contract, leaving a reader unable to tell what is validated.

## What the new section does

1. **States the gap** — real-provider qualification is incomplete, with no recorded evidence for any scenario, and names #2143 as the undischarged risk.
2. **States real coverage** — per-package Vitest, `@first-tree/skill-evals` floors, and the prose cases under `packages/qa/cases/`, with the cases identified as prompts for a human-requested run, not execution records.
3. **Sets a revised bar** — three real-provider checks rather than 11: global/directory/session-only setup; two or more Teams with clear, overlapping, missing and non-matching SCOPE bodies; and single- and multi-Team BYO writes with the mandatory new user confirmation. The remaining scenarios stay defined in `packages/qa/cases/` and are qualified when a change touches them rather than on every release.

The bar was narrowed to those three because they are the paths a first-time user hits first. Dynamic directory choice is excluded while #2208 is open, noted inline. #2239 is referenced as the owner of the environment and the per-scenario status.

## Scope

Docs-only, one file, one section. The generic `release qualification` QA-tier vocabulary in `packages/qa/` and `skills/first-tree-qa/` is unrelated and untouched.

## Open decision

The narrowed bar is a policy call, not a documentation one. Three checks is a proposal; if the line belongs elsewhere, say where and it moves.

## Follow-up

- **#2239** stays open. Closing it was only on the table while this PR removed the requirement outright; the revised bar still needs that environment.
- **#2240** is independent of this change and stands on its own.
