### PR TITLE
ACE-35: speed up CLI CI with scoped shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      cli: ${{ steps.filter.outputs.cli }}
       skills: ${{ steps.filter.outputs.skills }}
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +58,20 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'tsconfig.json'
               - 'biome.json'
+              - 'turbo.json'
+              - '.github/**'
+            cli:
+              - 'apps/cli/**'
+              - 'packages/client/**'
+              - 'packages/shared/**'
+              - 'skills/**'
+              - 'scripts/**'
+              - 'patches/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig.json'
+              - 'tsconfig.base.json'
               - 'turbo.json'
               - '.github/**'
             skills:
@@ -185,15 +200,21 @@ jobs:
         run: pnpm exec turbo run test --filter='!@first-tree/server' --filter='!first-tree-dev' --concurrency=2
 
   test_cli:
-    name: Test CLI
+    name: Test CLI (${{ matrix.shard }}/2)
     needs: changes
-    if: needs.changes.outputs.code == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.cli == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     env:
       # The CLI suite previously exhausted a single worker's ~4GB V8 heap.
-      # Keep its bounded batches serial and isolate them from every other
-      # package on a dedicated runner.
+      # Each shard keeps bounded batches serial on its own runner. The two
+      # independent heaps halve wall time without returning to a monolithic
+      # Vitest process or stacking both shards inside one ~7GB runner.
       VITEST_MAX_FORKS: "1"
+      FIRST_TREE_CLI_TEST_SHARD: ${{ matrix.shard }}/2
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -205,9 +226,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-test-cli-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-test-cli-${{ matrix.shard }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-test-cli-
+            ${{ runner.os }}-turbo-test-cli-${{ matrix.shard }}-
       - run: pnpm install --frozen-lockfile
       # `post-bundle-channel-home.test.ts` spawns the built CLI dist
       # binary to verify channel-home resolution. Without an explicit
@@ -218,7 +239,34 @@ jobs:
       # Timeout calling "onTaskUpdate"`), failing the job even though
       # all 233 tests passed. Building before vitest starts keeps the
       # heavy work outside the worker IPC window.
-      - run: pnpm build
+      - run: pnpm exec turbo run build --filter=first-tree-dev...
+      # Keep the CLI behind Turbo so each unchanged shard can use its own
+      # cache while the package script releases heap between bounded batches.
+      - run: pnpm exec turbo run test --filter=first-tree-dev --concurrency=1
+
+  test_cli_release_smoke:
+    name: Test CLI Release Smoke
+    needs: changes
+    # Keep the exact pre-sharding cadence: every code-affecting PR and every
+    # main push. This job is intentionally broader than changes.cli.
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+      - name: Restore Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-test-cli-release-smoke-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-test-cli-release-smoke-
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec turbo run build --filter=first-tree-dev...
       # The npm release surface packs with a bundled Kimi SDK; npm's
       # trusted-publishing client is pinned to the exact version QA qualifies
       # (a floated range already broke this boundary upstream). Smoke the real
@@ -233,17 +281,15 @@ jobs:
         run: npm install -g npm@11.5.1
       - name: Release pack smoke (bundled Kimi SDK + turbo context-integration cache)
         run: node scripts/release-pack-smoke.mjs selftest-turbo-context-integration-cache
-      # Keep the CLI behind Turbo so an unchanged first-tree-dev#test task can
-      # use cache while its package script releases heap between batches.
-      - run: pnpm exec turbo run test --filter=first-tree-dev --concurrency=1
 
   test:
     name: Test
-    needs: [changes, test_server, test_client_web, test_cli]
+    needs: [changes, test_server, test_client_web, test_cli, test_cli_release_smoke]
     if: >-
       always() &&
       (needs.changes.result != 'success' ||
        needs.changes.outputs.code == 'true' ||
+       needs.changes.outputs.cli == 'true' ||
        github.event_name == 'push')
     runs-on: ubuntu-latest
     steps:
@@ -255,14 +301,32 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           SERVER_RESULT: ${{ needs.test_server.result }}
           CLIENT_WEB_RESULT: ${{ needs.test_client_web.result }}
+          CODE_REQUIRED: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
           CLI_RESULT: ${{ needs.test_cli.result }}
+          CLI_REQUIRED: ${{ needs.changes.outputs.cli }}
+          CLI_RELEASE_SMOKE_RESULT: ${{ needs.test_cli_release_smoke.result }}
         run: |
-          for result in "$CHANGES_RESULT" "$SERVER_RESULT" "$CLIENT_WEB_RESULT" "$CLI_RESULT"; do
-            if [ "$result" != "success" ]; then
-              echo "::error::A required test job finished with result: $result"
+          require_result() {
+            name="$1"
+            result="$2"
+            required="$3"
+            expected="skipped"
+            if [ "$required" = "true" ]; then
+              expected="success"
+            fi
+            if [ "$result" != "$expected" ]; then
+              echo "::error::$name result was $result; expected $expected"
               exit 1
             fi
-          done
+          }
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::Detect Changes result was $CHANGES_RESULT; expected success"
+            exit 1
+          fi
+          require_result "Test Server" "$SERVER_RESULT" "$CODE_REQUIRED"
+          require_result "Test Client & Web" "$CLIENT_WEB_RESULT" "$CODE_REQUIRED"
+          require_result "Test CLI" "$CLI_RESULT" "$CLI_REQUIRED"
+          require_result "Test CLI Release Smoke" "$CLI_RELEASE_SMOKE_RESULT" "$CODE_REQUIRED"
 
   portable-smoke:
     name: Portable CLI Smoke

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -81,9 +81,7 @@
   },
   "devDependencies": {
     "@first-tree/client": "workspace:*",
-    "@first-tree/server": "workspace:*",
     "@first-tree/shared": "workspace:*",
-    "@first-tree/web": "workspace:*",
     "@types/ejs": "^3.1.5",
     "@types/node": "^22.16.0",
     "@types/semver": "^7.5.8",

--- a/apps/cli/scripts/run-vitest-batches.mjs
+++ b/apps/cli/scripts/run-vitest-batches.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const testRoots = ["src/__tests__", "tests"];
-const singletonFiles = new Set([
+export const singletonFiles = new Set([
   "src/__tests__/client-runtime-context-tree.test.ts",
   "src/__tests__/login-command.test.ts",
   "src/__tests__/service-install-core.test.ts",
@@ -54,7 +56,7 @@ function resolveTempRoot() {
   return tmpdir();
 }
 
-function listTestFiles(root) {
+export function listTestFiles(root) {
   if (!existsSync(root)) {
     return [];
   }
@@ -63,7 +65,7 @@ function listTestFiles(root) {
     .map((entry) => join(root, entry.name).replaceAll("\\", "/"));
 }
 
-function chunk(files, size) {
+export function chunk(files, size) {
   const chunks = [];
   for (let index = 0; index < files.length; index += size) {
     chunks.push(files.slice(index, index + size));
@@ -71,35 +73,105 @@ function chunk(files, size) {
   return chunks;
 }
 
-const discoveredFiles = testRoots.flatMap(listTestFiles).sort();
-const singletonBatches = discoveredFiles.filter((file) => singletonFiles.has(file)).map((file) => [file]);
-const remainingBatches = chunk(
-  discoveredFiles.filter((file) => !singletonFiles.has(file)),
-  maxBatchSize,
-);
-const batches = [...singletonBatches, ...remainingBatches];
-const tempRoot = resolveTempRoot();
+export function parseShard(value) {
+  if (value === undefined || value.trim() === "") {
+    return { index: 1, total: 1 };
+  }
+  const match = /^(\d+)\/(\d+)$/.exec(value.trim());
+  if (!match) {
+    throw new Error(`FIRST_TREE_CLI_TEST_SHARD must use <index>/<total>, received: ${value}`);
+  }
+  const index = Number.parseInt(match[1], 10);
+  const total = Number.parseInt(match[2], 10);
+  if (index < 1 || total < 1 || index > total) {
+    throw new Error(`FIRST_TREE_CLI_TEST_SHARD must satisfy 1 <= index <= total, received: ${value}`);
+  }
+  return { index, total };
+}
 
-for (const [index, files] of batches.entries()) {
-  console.error(
-    `[first-tree-dev test] batch ${index + 1}/${batches.length}: ${files.length} file${files.length === 1 ? "" : "s"}`,
-  );
-  const result = spawnSync(vitestBin, ["run", "--passWithNoTests", ...passthroughArgs, ...files], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      TEMP: tempRoot,
-      TMP: tempRoot,
-      TMPDIR: tempRoot,
-      VITEST_MAX_FORKS: process.env.VITEST_MAX_FORKS ?? "1",
-    },
-    stdio: "inherit",
+function stableFileRank(file) {
+  return createHash("sha256").update(file).digest("hex");
+}
+
+function compareText(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+export function partitionTestFiles(files, total) {
+  if (!Number.isInteger(total) || total < 1) {
+    throw new Error(`shard total must be a positive integer, received: ${total}`);
+  }
+  const partitions = Array.from({ length: total }, () => []);
+  const ranked = [...files].sort((left, right) => {
+    const rankOrder = compareText(stableFileRank(left), stableFileRank(right));
+    return rankOrder === 0 ? compareText(left, right) : rankOrder;
   });
-  if (result.error) {
-    console.error(result.error.message);
-    process.exit(1);
+  for (const [index, file] of ranked.entries()) {
+    partitions[index % total].push(file);
   }
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+  return partitions.map((partition) => partition.sort(compareText));
+}
+
+export function selectTestFilesForShard(files, shard) {
+  return partitionTestFiles(files, shard.total)[shard.index - 1];
+}
+
+export function createBatches(files, size) {
+  const singletonBatches = files.filter((file) => singletonFiles.has(file)).map((file) => [file]);
+  const remainingBatches = chunk(
+    files.filter((file) => !singletonFiles.has(file)),
+    size,
+  );
+  return [...singletonBatches, ...remainingBatches];
+}
+
+export function createTestPlan(files, size, shardValue) {
+  const shard = parseShard(shardValue);
+  const selectedFiles = selectTestFilesForShard(files, shard);
+  return {
+    shard,
+    files: selectedFiles,
+    batches: createBatches(selectedFiles, size),
+  };
+}
+
+export function main() {
+  const discoveredFiles = testRoots.flatMap(listTestFiles).sort();
+  const plan = createTestPlan(discoveredFiles, maxBatchSize, process.env.FIRST_TREE_CLI_TEST_SHARD);
+  const baseTempRoot = resolveTempRoot();
+  const tempRoot = join(baseTempRoot, `shard-${plan.shard.index}-of-${plan.shard.total}`);
+  mkdirSync(tempRoot, { recursive: true });
+
+  for (const [index, files] of plan.batches.entries()) {
+    console.error(
+      `[first-tree-dev test] shard ${plan.shard.index}/${plan.shard.total} batch ${index + 1}/${plan.batches.length}: ${files.length} file${files.length === 1 ? "" : "s"}`,
+    );
+    const result = spawnSync(vitestBin, ["run", "--passWithNoTests", ...passthroughArgs, ...files], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        TEMP: tempRoot,
+        TMP: tempRoot,
+        TMPDIR: tempRoot,
+        VITEST_MAX_FORKS: process.env.VITEST_MAX_FORKS ?? "1",
+      },
+      stdio: "inherit",
+    });
+    if (result.error) {
+      console.error(result.error.message);
+      process.exitCode = 1;
+      return;
+    }
+    if (result.status !== 0) {
+      process.exitCode = result.status ?? 1;
+      return;
+    }
   }
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(resolve(invokedPath)).href) {
+  main();
 }

--- a/apps/cli/tests/ci-cli-workflow.test.mjs
+++ b/apps/cli/tests/ci-cli-workflow.test.mjs
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "../../..");
+const CI_PATH = resolve(REPO_ROOT, ".github/workflows/ci.yml");
+const ciText = readFileSync(CI_PATH, "utf8");
+const workflow = parse(ciText);
+
+function matchesPath(path, pattern) {
+  if (pattern.endsWith("/**")) {
+    const prefix = pattern.slice(0, -3);
+    return path === prefix || path.startsWith(`${prefix}/`);
+  }
+  return path === pattern;
+}
+
+function cliPatterns() {
+  const filterStep = workflow.jobs.changes.steps.find((step) => step.id === "filter");
+  const filters = parse(filterStep.with.filters);
+  return filters.cli;
+}
+
+describe("CLI CI trigger contract", () => {
+  it("runs CLI shards for the conservative dependency matrix and skips unrelated packages", () => {
+    const patterns = cliPatterns();
+    const matrix = [
+      ["apps/cli/src/index.ts", true],
+      ["packages/client/src/index.ts", true],
+      ["packages/shared/src/index.ts", true],
+      ["skills/first-tree-read/SKILL.md", true],
+      ["scripts/vitest-max-forks.ts", true],
+      ["patches/@botiverse__kimi.patch", true],
+      ["package.json", true],
+      ["pnpm-lock.yaml", true],
+      ["pnpm-workspace.yaml", true],
+      ["tsconfig.json", true],
+      ["tsconfig.base.json", true],
+      ["turbo.json", true],
+      [".github/workflows/ci.yml", true],
+      ["packages/server/src/app.ts", false],
+      ["packages/web/src/main.tsx", false],
+      ["packages/skill-evals/src/index.ts", false],
+      ["docs/cli-reference.md", false],
+    ];
+
+    expect(patterns).not.toContain("apps/**");
+    expect(patterns).not.toContain("packages/**");
+    for (const [path, expected] of matrix) {
+      expect(
+        patterns.some((pattern) => matchesPath(path, pattern)),
+        path,
+      ).toBe(expected);
+    }
+  });
+
+  it("uses exactly two deterministic shards whose value participates in the Turbo test hash", () => {
+    const cliJob = workflow.jobs.test_cli;
+    const shardExpression = "$" + "{{ matrix.shard }}/2";
+    expect(cliJob.if).toBe("needs.changes.outputs.cli == 'true'");
+    expect(cliJob.strategy.matrix.shard).toEqual([1, 2]);
+    expect(cliJob.env.FIRST_TREE_CLI_TEST_SHARD).toBe(shardExpression);
+    expect(cliJob.env.VITEST_MAX_FORKS).toBe("1");
+    expect(ciText).toContain("pnpm exec turbo run test --filter=first-tree-dev --concurrency=1");
+    expect(ciText).not.toMatch(/FIRST_TREE_CLI_TEST_BATCH_SIZE:\s*(9|[1-9]\d+)/);
+
+    const turbo = JSON.parse(readFileSync(resolve(REPO_ROOT, "apps/cli/turbo.json"), "utf8"));
+    expect(turbo.tasks.test.env).toContain("FIRST_TREE_CLI_TEST_SHARD");
+  });
+
+  it("keeps release smoke at its original cadence and gates intentional shard skips", () => {
+    const smoke = workflow.jobs.test_cli_release_smoke;
+    expect(smoke.if).toBe("needs.changes.outputs.code == 'true' || github.event_name == 'push'");
+    expect(smoke.steps.some((step) => step.name?.startsWith("Release pack smoke"))).toBe(true);
+    expect(
+      smoke.steps.some(
+        (step) => step.run === "node scripts/release-pack-smoke.mjs selftest-turbo-context-integration-cache",
+      ),
+    ).toBe(true);
+    expect(
+      ciText.match(/node scripts\/release-pack-smoke\.mjs selftest-turbo-context-integration-cache/g),
+    ).toHaveLength(1);
+
+    const gate = workflow.jobs.test;
+    expect(gate.if).toContain("needs.changes.outputs.cli == 'true'");
+    expect(gate.needs).toEqual(
+      expect.arrayContaining(["changes", "test_server", "test_client_web", "test_cli", "test_cli_release_smoke"]),
+    );
+    const gateScript = gate.steps.find((step) => step.name === "Verify parallel test jobs").run;
+    expect(gateScript).toContain('require_result "Test Server" "$SERVER_RESULT" "$CODE_REQUIRED"');
+    expect(gateScript).toContain('require_result "Test Client & Web" "$CLIENT_WEB_RESULT" "$CODE_REQUIRED"');
+    expect(gateScript).toContain('require_result "Test CLI" "$CLI_RESULT" "$CLI_REQUIRED"');
+    expect(gateScript).toContain(
+      'require_result "Test CLI Release Smoke" "$CLI_RELEASE_SMOKE_RESULT" "$CODE_REQUIRED"',
+    );
+  });
+});

--- a/apps/cli/tests/run-vitest-batches.test.mjs
+++ b/apps/cli/tests/run-vitest-batches.test.mjs
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  createTestPlan,
+  parseShard,
+  partitionTestFiles,
+  selectTestFilesForShard,
+  singletonFiles,
+} from "../scripts/run-vitest-batches.mjs";
+
+describe("CLI Vitest shard planning", () => {
+  it("defaults to one shard and rejects malformed shard selectors", () => {
+    expect(parseShard(undefined)).toEqual({ index: 1, total: 1 });
+    expect(parseShard(" 2/3 ")).toEqual({ index: 2, total: 3 });
+    for (const invalid of ["", "1", "0/2", "3/2", "1/0", "left/right"]) {
+      if (invalid === "") {
+        expect(parseShard(invalid)).toEqual({ index: 1, total: 1 });
+      } else {
+        expect(() => parseShard(invalid)).toThrow(/FIRST_TREE_CLI_TEST_SHARD/);
+      }
+    }
+  });
+
+  it("partitions every file exactly once, independent of discovery order", () => {
+    const files = Array.from({ length: 31 }, (_, index) => `src/__tests__/fixture-${index}.test.ts`);
+    const partitions = partitionTestFiles(files, 2);
+
+    expect(partitions).toEqual(partitionTestFiles([...files].reverse(), 2));
+    expect(Math.abs(partitions[0].length - partitions[1].length)).toBeLessThanOrEqual(1);
+    expect(partitions.flat().sort()).toEqual([...files].sort());
+    expect(new Set(partitions.flat()).size).toBe(files.length);
+    expect(() => partitionTestFiles(files, 0)).toThrow(/positive integer/);
+  });
+
+  it("builds two deterministic, disjoint plans while preserving bounded and singleton batches", () => {
+    const heavy = [...singletonFiles];
+    const ordinary = Array.from({ length: 41 }, (_, index) => `src/__tests__/ordinary-${index}.test.ts`);
+    const files = [...heavy, ...ordinary].sort();
+    const first = createTestPlan(files, 8, "1/2");
+    const second = createTestPlan(files, 8, "2/2");
+
+    expect(first.files).toEqual(selectTestFilesForShard(files, { index: 1, total: 2 }));
+    expect(second.files).toEqual(selectTestFilesForShard(files, { index: 2, total: 2 }));
+    expect([...first.files, ...second.files].sort()).toEqual(files);
+    expect(first.files.filter((file) => second.files.includes(file))).toEqual([]);
+
+    for (const plan of [first, second]) {
+      expect(plan.batches.every((batch) => batch.length >= 1 && batch.length <= 8)).toBe(true);
+      for (const singleton of plan.files.filter((file) => singletonFiles.has(file))) {
+        expect(plan.batches).toContainEqual([singleton]);
+      }
+    }
+  });
+});

--- a/apps/cli/turbo.json
+++ b/apps/cli/turbo.json
@@ -8,7 +8,8 @@
       "inputs": ["$TURBO_DEFAULT$", "../../skills/**"]
     },
     "test": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "env": ["FIRST_TREE_CLI_TEST_SHARD"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,15 +83,9 @@ importers:
       '@first-tree/client':
         specifier: workspace:*
         version: link:../../packages/client
-      '@first-tree/server':
-        specifier: workspace:*
-        version: link:../../packages/server
       '@first-tree/shared':
         specifier: workspace:*
         version: link:../../packages/shared
-      '@first-tree/web':
-        specifier: workspace:*
-        version: link:../../packages/web
       '@types/ejs':
         specifier: ^3.1.5
         version: 3.1.5


### PR DESCRIPTION
## Summary

- scope CLI test runs to CLI, client, shared, skill, tooling, and root dependency changes while excluding unrelated server/web changes
- split the memory-bounded CLI Vitest batches into two deterministic GitHub runner shards with shard-specific Turbo hashes and caches
- keep release-pack smoke on its existing `code || push` cadence in a parallel job
- remove unused CLI workspace dependencies on server/web and add trigger-matrix plus sharding contract tests

## Local verification

- `pnpm exec turbo run build --filter=first-tree-dev... --concurrency=2`
- `CI=true VITEST_MAX_FORKS=1 FIRST_TREE_CLI_TEST_SHARD=1/2 pnpm exec turbo run test --filter=first-tree-dev --concurrency=1` (77 files, 13 batches, 2m09s)
- `CI=true VITEST_MAX_FORKS=1 FIRST_TREE_CLI_TEST_SHARD=2/2 pnpm exec turbo run test --filter=first-tree-dev --concurrency=1` (76 files, 13 batches, 2m24s)
- `VITEST_MAX_FORKS=2 pnpm --filter first-tree-dev exec vitest run tests/run-vitest-batches.test.mjs tests/ci-cli-workflow.test.mjs src/__tests__/package-metadata.test.ts` (21 tests)
- `pnpm --filter first-tree-dev typecheck`
- Biome checks for all changed JS/JSON files

The two local shards cover all 153 CLI test files exactly once. Release smoke implementation and invocation frequency are unchanged; only its job placement is parallelized.
