### PR TITLE
docs: document FIRST_TREE_AGENT_TEMPLATE_PUBLISHER_ORG_ID in .env.example (ACE-38)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,15 @@ FIRST_TREE_HOST=0.0.0.0
 # Team admins cannot extend this policy from Settings.
 # FIRST_TREE_GITLAB_EGRESS_ALLOWLIST=[{"origin":"https://gitlab.example.com","addressPolicy":{"kind":"public"}}]
 
+# Team whose current active admins act as the official Agent Template
+# publisher. Membership is re-read on every request, so granting or revoking
+# publisher access takes effect immediately without reissuing tokens.
+# Leaving it unset fails closed in two visible ways: the publisher API
+# (`/api/v1/internal/agent-templates`) answers 403 for everyone, and every
+# already-adopted Template degrades to an "Unavailable" badge on Agent
+# Detail. The public read-only catalog keeps working either way.
+# FIRST_TREE_AGENT_TEMPLATE_PUBLISHER_ORG_ID=00000000-0000-0000-0000-000000000000
+
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │ Web Sentry (SaaS internal) — Optional                                    │
 # └───────────────────────────────────────────────────────────────────────────┘

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2039,6 +2039,32 @@ server secrets even if `FIRST_TREE_CHANNEL` is omitted or defaults to `dev`.
 | `FIRST_TREE_GITHUB_APP_WEBHOOK_SECRET` | Webhook HMAC secret. |
 | `FIRST_TREE_GITHUB_APP_SLUG` | Optional explicit slug override. |
 
+**Agent Template publishing:**
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `FIRST_TREE_AGENT_TEMPLATE_PUBLISHER_ORG_ID` | Team whose current active admins act as the official Agent Template publisher. | — (publisher API disabled) |
+
+This is deployment authority, not a Team setting. Membership is re-read from
+the members table on every request rather than trusted from the caller's JWT,
+so granting or revoking publisher access takes effect immediately without
+reissuing tokens. Official Skill bundles must be attachments owned by the same
+Team.
+
+Leaving it unset fails closed in two places:
+
+- every `/api/v1/internal/agent-templates` request answers `403 "Agent Template
+  publishing is not configured on this deployment."`, for all callers
+- adopted-Template summaries cannot be proven public-safe, so all of them
+  degrade to `missing`, which Agent Detail renders as an `Unavailable` badge —
+  a deployment that merely forgot the variable shows broken-looking state on
+  otherwise healthy agents
+
+The public read-only catalog (`/api/v1/agent-templates`, `/templates`) stays
+available either way; this variable gates publishing, not discovery. Setting it
+publishes nothing on its own — the catalog stays empty until a publisher admin
+creates and publishes a Template.
+
 **GitLab Context Tree snapshot egress:**
 
 | Variable | Purpose | Default |


### PR DESCRIPTION
## Why

`FIRST_TREE_AGENT_TEMPLATE_PUBLISHER_ORG_ID` decides which Team may maintain
the official Agent Template catalog, but it was absent from `.env.example`.
An operator bringing up a deployment had no way to discover it short of
reading `packages/shared/src/config/server-config.ts` — or hitting a 403.

Leaving it unset fails closed in two places, and only one of them is obvious:

- `requireAgentTemplatePublisher` rejects every publisher-API request with
  403 `"Agent Template publishing is not configured on this deployment."`
- `buildAdoptedTemplateSummaries` cannot prove any adopted Template is
  public-safe without a publisher Team, so it degrades **all** of them to
  `missing` — which Agent Detail renders as an `Unavailable` badge. Users of
  a deployment that simply forgot the variable see broken-looking state on
  agents that are in fact fine.

The public read-only catalog keeps working either way; that is worth stating
too, so nobody sets the variable expecting it to gate `/templates`.

## What

One commented entry in the `Server (SaaS internal) — Optional` block of
`.env.example` covering what the variable selects, that membership is
re-read per request (so grants and revocations take effect immediately), and
both failure modes above.

Config-example only — no source, schema, or behavior change.

Refs ACE-38.
