### PR TITLE
ACE-40 feat(web): add an in-app entry to the public template library

### DIFF
--- a/packages/web/src/components/__tests__/new-agent-dialog-templates.test.tsx
+++ b/packages/web/src/components/__tests__/new-agent-dialog-templates.test.tsx
@@ -182,6 +182,10 @@ function buttonByText(text: string): HTMLButtonElement {
   return button;
 }
 
+function templateLibraryLink(): HTMLAnchorElement | null {
+  return document.body.querySelector<HTMLAnchorElement>('a[href="/templates"]');
+}
+
 function optionCardByText(text: string): HTMLElement {
   const label = [...document.body.querySelectorAll("label")].find((el) => el.textContent?.includes(text));
   if (!label) throw new Error(`Missing option card "${text}". Body: ${document.body.textContent ?? ""}`);
@@ -241,6 +245,8 @@ describe("NewAgentDialog template responsibilities", () => {
     await renderDialog(onCreated);
     await flush();
     expect(document.body.textContent).not.toContain("Responsibilities");
+    // No entry to an empty library either — the link is gated on the same catalog.
+    expect(templateLibraryLink()).toBeNull();
 
     await fillNameAndOpenPickerSafe();
     async function fillNameAndOpenPickerSafe() {
@@ -262,6 +268,7 @@ describe("NewAgentDialog template responsibilities", () => {
     await waitForCondition(() => templateMocks.listAgentTemplates.mock.calls.length === 1, "catalog not fetched");
     await flush();
     expect(document.body.textContent).not.toContain("Responsibilities");
+    expect(templateLibraryLink()).toBeNull();
     const input = document.body.querySelector<HTMLInputElement>("#new-agent-display-name");
     if (!input) throw new Error("missing display name input");
     await setValue(input, "Build Bot");
@@ -269,6 +276,36 @@ describe("NewAgentDialog template responsibilities", () => {
     await waitForCondition(() => agentMocks.createAgent.mock.calls.length === 1, "create not called");
     const body = agentMocks.createAgent.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(body.templateIds).toBeUndefined();
+  });
+
+  it("offers an in-app entry to the public template library without disturbing the draft", async () => {
+    templateMocks.listAgentTemplates.mockResolvedValue({ templates: [TEMPLATE_A] });
+    await renderDialog();
+    await waitForText("Responsibilities (optional)");
+
+    const input = document.body.querySelector<HTMLInputElement>("#new-agent-display-name");
+    if (!input) throw new Error("missing display name input");
+    await setValue(input, "Build Bot");
+
+    const link = templateLibraryLink();
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe("Browse the template library");
+    // A new tab, not a route change: the half-filled dialog must survive the detour.
+    expect(link?.target).toBe("_blank");
+    expect(link?.rel).toContain("noopener");
+
+    // happy-dom would otherwise try to follow the href; React's handler still runs.
+    const blockNavigation = (event: Event) => event.preventDefault();
+    document.addEventListener("click", blockNavigation, true);
+    try {
+      await click(link);
+    } finally {
+      document.removeEventListener("click", blockNavigation, true);
+    }
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("agent_template_library_open", { surface: "new_agent" });
+    expect(document.body.querySelector<HTMLInputElement>("#new-agent-display-name")?.value).toBe("Build Bot");
+    expect(agentMocks.createAgent).not.toHaveBeenCalled();
   });
 
   it("submits one selected template and keeps the form draft intact", async () => {

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -947,6 +947,27 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
                   {fieldErrors.templates}
                 </p>
               )}
+              {/* The only in-app entry to the public Template Library. It lives
+                  here — the moment the user is actually choosing a
+                  responsibility — rather than in the sidebar or landing, because
+                  a public Template only pays off when it helps someone reach a
+                  working agent, not as standalone browsing chrome.
+                  Deliberately inside the catalog-gated section, so an empty or
+                  failed catalog never advertises an empty library and the plain
+                  create path stays unchanged. A new tab (not a route change)
+                  keeps the in-progress draft in this dialog alive. */}
+              <p className="text-caption text-muted-foreground">
+                <a
+                  href="/templates"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  aria-label="Browse the template library — opens in a new tab"
+                  onClick={() => trackEvent("agent_template_library_open", { surface: "new_agent" })}
+                  className="rounded-[var(--radius-input)] underline underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  Browse the template library
+                </a>
+              </p>
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- The public Template Library at `/templates` had no link anywhere in the app. Outside `app.tsx`'s route definitions and a few doc comments, nothing in `packages/web/src` pointed at it — landing, sidebar, and the New Agent dialog all had no entry, so users could only reach it by typing the URL or arriving from an off-site placement.
- Adds a "Browse the template library" link to the New Agent dialog's Responsibilities section — the moment a user is actually choosing a starting responsibility, which is the shortest path from discovery to a working agent.

Placement details:

- The link sits **inside** the catalog-gated Responsibilities block, so an empty or failed catalog never advertises an empty library and the plain create path stays unchanged.
- It opens in a **new tab** rather than navigating, so an in-progress draft in the dialog (display name, visibility, computer, runtime, current selection) survives the detour.
- Reports `agent_template_library_open` with `surface: "new_agent"`, matching the existing `agent_template_select` surface convention.

The canonical `/templates/:slug?use=1` intent path and its strict `parseAgentTemplateIntentPath` resolution are untouched.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test`

`packages/web/src/__tests__/app-routes.test.tsx` has 7 failures on this branch, but they reproduce identically on the base commit (`54bcb109c`) with no changes applied — they are pre-existing and unrelated to this PR. Everything else passes, including the 10 tests in `new-agent-dialog-templates.test.tsx`.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: `new-agent-dialog-templates.test.tsx` — a new test covers the link's presence, new-tab behavior, analytics event, and that clicking it leaves the draft intact; the two existing "catalog empty / failed" tests now also assert the link is absent.
- follow-up work: if the product wants additional entry points (landing, sidebar, or Agent Detail → Responsibilities), they can be added on top of this without changing the intent path.
