### PR TITLE
feat(web): give Settings → GitHub a scannable row layout

### DIFF
--- a/packages/qa/cases/cross-surface/github-settings-connection-panel.md
+++ b/packages/qa/cases/cross-surface/github-settings-connection-panel.md
@@ -106,16 +106,20 @@ only touches the webhook where an `installation.created` delivery records the ro
   Reinstall (step 1, when installed) and Disconnect (step 2). The Repositories section hands off to Settings →
   Repositories rather than editing repository URLs here.
 - Admin, not connected: a "Connect GitHub" call-to-action.
-- Connection details, permissions satisfied: every entry under "Required by First Tree" reads as ready, and no
-  GitHub-side call to action appears.
+- Connection details, permissions satisfied: every entry under "Required for automatic replies" reads as ready, and no
+  GitHub-side call to action appears. The heading stays scoped to that capability — it must not claim the installation
+  satisfies First Tree generally, since Context Reviewer and repository coverage gate on their own requirements.
 - Connection details, a required permission missing (downgrade `issues` or `pull_requests` to `read` on the installation
   row): the entry reads as blocked and names what it costs, a "Grant on GitHub" action appears for an admin, and the
   shortfall is also visible on the *collapsed* disclosure. This must agree with the server: the same installation makes
   `team-agent` assignment fail with `github_app_task_reply_permission_required`, so the readout and the gate never
   disagree.
 - Connection details, facts: subscribed events First Tree does not consume are listed as unused rather than blended into
-  the consumed list, and the installation id copies (a non-secure-context copy failure surfaces "Copy failed" instead of
-  looking inert).
+  the consumed list; `installation` / `installation_repositories` are *not* among them, since the webhook route consumes
+  both through `handleInstallationLifecycle` — a normally configured installation must never be described as carrying
+  unused subscriptions. The installation timestamp is labelled "First seen", not "Connected": the row is written unbound
+  by `installation.created` and survives disconnect/rebind, so it does not record when this team connected. The
+  installation id copies (a non-secure-context copy failure surfaces "Copy failed" instead of looking inert).
 - Google/OIDC admin without GitHub identity: after opening Connect, only the inline link-account state appears. After the
   identity is linked and the same Team is restored, the panel shows the linked login and Install remains a separate click.
 - Install preflight mismatch: the current First Tree session and selected Team remain unchanged; the recovery message

--- a/packages/qa/cases/cross-surface/github-settings-connection-panel.md
+++ b/packages/qa/cases/cross-surface/github-settings-connection-panel.md
@@ -101,16 +101,27 @@ only touches the webhook where an `installation.created` delivery records the ro
 
 ### Web UI (Settings → GitHub)
 
-- Admin, connected: the connected account + type, "Connection" and "Source repos" section headings, and the
-  "Manage connection" / "Manage on GitHub" / "Connection details" controls; the connect panel exposes Reinstall (step 1,
-  when installed) and Disconnect (step 2).
+- Admin, connected: the connected account + type, the "Connection" / "Automatic handling" / "Repositories" section
+  headings, and the "Manage connection" / "Manage on GitHub" / "Connection details" controls; the connect panel exposes
+  Reinstall (step 1, when installed) and Disconnect (step 2). The Repositories section hands off to Settings →
+  Repositories rather than editing repository URLs here.
 - Admin, not connected: a "Connect GitHub" call-to-action.
+- Connection details, permissions satisfied: every entry under "Required by First Tree" reads as ready, and no
+  GitHub-side call to action appears.
+- Connection details, a required permission missing (downgrade `issues` or `pull_requests` to `read` on the installation
+  row): the entry reads as blocked and names what it costs, a "Grant on GitHub" action appears for an admin, and the
+  shortfall is also visible on the *collapsed* disclosure. This must agree with the server: the same installation makes
+  `team-agent` assignment fail with `github_app_task_reply_permission_required`, so the readout and the gate never
+  disagree.
+- Connection details, facts: subscribed events First Tree does not consume are listed as unused rather than blended into
+  the consumed list, and the installation id copies (a non-secure-context copy failure surfaces "Copy failed" instead of
+  looking inert).
 - Google/OIDC admin without GitHub identity: after opening Connect, only the inline link-account state appears. After the
   identity is linked and the same Team is restored, the panel shows the linked login and Install remains a separate click.
 - Install preflight mismatch: the current First Tree session and selected Team remain unchanged; the recovery message
   names the expected GitHub login and offers a retry rather than opening the picker.
-- Member: the connection state stays readable, but every admin control (Manage / Disconnect / Connect / Reinstall /
-  Install / Add source repo) is absent.
+- Member: the connection state and the permission diagnosis stay readable, but every admin control (Manage / Disconnect /
+  Connect / Reinstall / Install / Grant on GitHub) is absent.
 - No browser console errors on any state.
 
 ## Expected Result

--- a/packages/server/src/services/team-agent-settings.ts
+++ b/packages/server/src/services/team-agent-settings.ts
@@ -1,4 +1,6 @@
 import {
+  GITHUB_APP_REQUIRED_PERMISSIONS,
+  githubPermissionSatisfies,
   ORG_SETTINGS_NAMESPACES,
   type OrgGithubFeaturesOutput,
   type OrgGithubFeaturesStorage,
@@ -74,7 +76,12 @@ async function readContextReviewerAgentUuid(db: Database, organizationId: string
 function taskReplyInstallationBlocker(installation: InstallationRow | null): SetupBlocker | null {
   if (!installation) return null;
   if (installation.suspendedAt) return blocker("github_app_suspended", "manage_github_installation");
-  if (installation.permissions.issues !== "write" || installation.permissions.pull_requests !== "write") {
+  // Same requirement set the Settings → GitHub readout renders, so an admin is
+  // never shown a healthy connection while this gate refuses the assignment.
+  const unsatisfied = Object.entries(GITHUB_APP_REQUIRED_PERMISSIONS).some(
+    ([permission, level]) => !githubPermissionSatisfies(installation.permissions[permission], level),
+  );
+  if (unsatisfied) {
     return blocker("github_app_task_reply_permission_required", "manage_github_installation");
   }
   return null;

--- a/packages/server/src/services/team-agent-settings.ts
+++ b/packages/server/src/services/team-agent-settings.ts
@@ -1,5 +1,5 @@
 import {
-  GITHUB_APP_REQUIRED_PERMISSIONS,
+  GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS,
   githubPermissionSatisfies,
   ORG_SETTINGS_NAMESPACES,
   type OrgGithubFeaturesOutput,
@@ -78,7 +78,7 @@ function taskReplyInstallationBlocker(installation: InstallationRow | null): Set
   if (installation.suspendedAt) return blocker("github_app_suspended", "manage_github_installation");
   // Same requirement set the Settings → GitHub readout renders, so an admin is
   // never shown a healthy connection while this gate refuses the assignment.
-  const unsatisfied = Object.entries(GITHUB_APP_REQUIRED_PERMISSIONS).some(
+  const unsatisfied = Object.entries(GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS).some(
     ([permission, level]) => !githubPermissionSatisfies(installation.permissions[permission], level),
   );
   if (unsatisfied) {

--- a/packages/shared/src/__tests__/github-app-required-permissions.test.ts
+++ b/packages/shared/src/__tests__/github-app-required-permissions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { GITHUB_APP_REQUIRED_PERMISSIONS, githubPermissionSatisfies } from "../schemas/github-app.js";
+
+describe("GITHUB_APP_REQUIRED_PERMISSIONS", () => {
+  it("is the set the task-reply gate enforces", () => {
+    // Both the server's `taskReplyInstallationBlocker` and the Settings →
+    // GitHub readout derive from this. Changing it changes what an admin is
+    // told AND what the server will publish, so it is pinned here.
+    expect(GITHUB_APP_REQUIRED_PERMISSIONS).toEqual({ issues: "write", pull_requests: "write" });
+  });
+});
+
+describe("githubPermissionSatisfies", () => {
+  it("accepts an exact match", () => {
+    expect(githubPermissionSatisfies("write", "write")).toBe(true);
+    expect(githubPermissionSatisfies("read", "read")).toBe(true);
+  });
+
+  it("accepts a stronger grant — GitHub's write implies read", () => {
+    expect(githubPermissionSatisfies("write", "read")).toBe(true);
+    expect(githubPermissionSatisfies("admin", "write")).toBe(true);
+    expect(githubPermissionSatisfies("admin", "read")).toBe(true);
+  });
+
+  it("rejects a weaker grant", () => {
+    expect(githubPermissionSatisfies("read", "write")).toBe(false);
+    expect(githubPermissionSatisfies("write", "admin")).toBe(false);
+  });
+
+  it("treats an absent permission as unsatisfied", () => {
+    expect(githubPermissionSatisfies(undefined, "read")).toBe(false);
+  });
+});

--- a/packages/shared/src/__tests__/github-app-required-permissions.test.ts
+++ b/packages/shared/src/__tests__/github-app-required-permissions.test.ts
@@ -16,15 +16,17 @@ describe("githubPermissionSatisfies", () => {
     expect(githubPermissionSatisfies("read", "read")).toBe(true);
   });
 
-  it("accepts a stronger grant — GitHub's write implies read", () => {
-    expect(githubPermissionSatisfies("write", "read")).toBe(true);
-    expect(githubPermissionSatisfies("admin", "write")).toBe(true);
-    expect(githubPermissionSatisfies("admin", "read")).toBe(true);
-  });
-
   it("rejects a weaker grant", () => {
     expect(githubPermissionSatisfies("read", "write")).toBe(false);
     expect(githubPermissionSatisfies("write", "admin")).toBe(false);
+  });
+
+  it("does NOT rank levels — a stronger grant is not a substitute", () => {
+    // Every other installation-permission check in the server compares levels
+    // exactly. Ranking here would let this readout and the task-agent gate
+    // accept a grant that `github-audience` / the publishers then reject.
+    expect(githubPermissionSatisfies("admin", "write")).toBe(false);
+    expect(githubPermissionSatisfies("write", "read")).toBe(false);
   });
 
   it("treats an absent permission as unsatisfied", () => {

--- a/packages/shared/src/__tests__/github-task-reply-required-permissions.test.ts
+++ b/packages/shared/src/__tests__/github-task-reply-required-permissions.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { GITHUB_APP_REQUIRED_PERMISSIONS, githubPermissionSatisfies } from "../schemas/github-app.js";
+import { GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS, githubPermissionSatisfies } from "../schemas/github-app.js";
 
-describe("GITHUB_APP_REQUIRED_PERMISSIONS", () => {
+describe("GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS", () => {
   it("is the set the task-reply gate enforces", () => {
     // Both the server's `taskReplyInstallationBlocker` and the Settings →
     // GitHub readout derive from this. Changing it changes what an admin is
     // told AND what the server will publish, so it is pinned here.
-    expect(GITHUB_APP_REQUIRED_PERMISSIONS).toEqual({ issues: "write", pull_requests: "write" });
+    expect(GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS).toEqual({ issues: "write", pull_requests: "write" });
   });
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -780,8 +780,8 @@ export {
 export {
   GITHUB_ACCOUNT_TYPES,
   GITHUB_APP_CONNECT_STATUSES,
-  GITHUB_APP_REQUIRED_PERMISSIONS,
   GITHUB_PERMISSION_LEVELS,
+  GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS,
   type GithubAccountType,
   type GithubAppConnectBody,
   type GithubAppConnectPanelInstallation,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -780,6 +780,7 @@ export {
 export {
   GITHUB_ACCOUNT_TYPES,
   GITHUB_APP_CONNECT_STATUSES,
+  GITHUB_APP_REQUIRED_PERMISSIONS,
   GITHUB_PERMISSION_LEVELS,
   type GithubAccountType,
   type GithubAppConnectBody,
@@ -801,6 +802,7 @@ export {
   githubAppInstallationPermissionsSchema,
   githubAppUserTokenMetadataSchema,
   githubPermissionLevelSchema,
+  githubPermissionSatisfies,
 } from "./schemas/github-app.js";
 export {
   GITHUB_TASK_REPLY_BODY_MAX_BYTES,

--- a/packages/shared/src/schemas/github-app.ts
+++ b/packages/shared/src/schemas/github-app.ts
@@ -71,17 +71,25 @@ export const GITHUB_APP_REQUIRED_PERMISSIONS = {
 } as const satisfies Record<string, GithubPermissionLevel>;
 
 /**
- * True when `permissions` grants at least every level in
- * `GITHUB_APP_REQUIRED_PERMISSIONS`. `write` satisfies a `read` requirement
- * (GitHub's write implies read); `admin` satisfies both.
+ * True when `granted` meets a required level.
+ *
+ * Deliberately an exact match, not a `read < write < admin` ranking. Every
+ * other installation-permission check in the server compares levels exactly
+ * (`github-audience.ts`, `github-task-reply-publisher.ts`,
+ * `context-reviewer-publisher.ts`, `setup-capabilities.ts`, …). A ranking here
+ * would let the Settings readout and the task-agent gate accept an `admin`
+ * grant that routing and publishing then reject — the exact contradiction this
+ * shared definition exists to prevent. GitHub only ever issues `read` / `write`
+ * for `issues` and `pull_requests`, so a ranking would buy nothing anyway.
+ *
+ * If the ranked semantics are ever wanted, change every call site together,
+ * not just this one.
  */
 export function githubPermissionSatisfies(
   granted: GithubPermissionLevel | undefined,
   required: GithubPermissionLevel,
 ): boolean {
-  if (granted === undefined) return false;
-  const rank: Record<GithubPermissionLevel, number> = { read: 0, write: 1, admin: 2 };
-  return rank[granted] >= rank[required];
+  return granted === required;
 }
 
 /**

--- a/packages/shared/src/schemas/github-app.ts
+++ b/packages/shared/src/schemas/github-app.ts
@@ -52,20 +52,27 @@ export const githubAppInstallationPermissionsSchema = z.record(z.string(), githu
 export type GithubAppInstallationPermissions = z.infer<typeof githubAppInstallationPermissionsSchema>;
 
 /**
- * The permission levels an installation must grant before First Tree can act
- * as the App on it — `permission name -> minimum level`.
+ * The permission levels an installation must grant before the GitHub Task
+ * Agent can reply automatically on Issues and pull requests —
+ * `permission name -> required level`.
  *
- * This is the one definition of "is this installation good enough". The server
- * gates the GitHub Task Agent on it (`taskReplyInstallationBlocker`) and the
- * Settings → GitHub readout renders it, so an admin is never told the
- * installation is fine while the server refuses to publish (or the reverse).
+ * Scoped to that one capability, not to the installation as a whole. Other
+ * First Tree capabilities gate on their own permissions, events, and
+ * repository coverage (Context Reviewer, the setup-capability probe, …), so
+ * this set answers "can automatic replies work here", never "is this
+ * installation generally usable".
+ *
+ * Within that scope it is the one definition: the server gates the GitHub Task
+ * Agent on it (`taskReplyInstallationBlocker`) and the Settings → GitHub
+ * readout renders it, so an admin is never told replies are fine while the
+ * server refuses to publish (or the reverse).
  *
  * `metadata: read` is deliberately absent: GitHub grants it to every App
  * install and it cannot be withheld, so listing it would only ever render a
  * tautological ✓. The reply publisher still requests it when minting a scoped
  * token — that is a token scope, not a gate.
  */
-export const GITHUB_APP_REQUIRED_PERMISSIONS = {
+export const GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS = {
   issues: "write",
   pull_requests: "write",
 } as const satisfies Record<string, GithubPermissionLevel>;

--- a/packages/shared/src/schemas/github-app.ts
+++ b/packages/shared/src/schemas/github-app.ts
@@ -52,6 +52,39 @@ export const githubAppInstallationPermissionsSchema = z.record(z.string(), githu
 export type GithubAppInstallationPermissions = z.infer<typeof githubAppInstallationPermissionsSchema>;
 
 /**
+ * The permission levels an installation must grant before First Tree can act
+ * as the App on it — `permission name -> minimum level`.
+ *
+ * This is the one definition of "is this installation good enough". The server
+ * gates the GitHub Task Agent on it (`taskReplyInstallationBlocker`) and the
+ * Settings → GitHub readout renders it, so an admin is never told the
+ * installation is fine while the server refuses to publish (or the reverse).
+ *
+ * `metadata: read` is deliberately absent: GitHub grants it to every App
+ * install and it cannot be withheld, so listing it would only ever render a
+ * tautological ✓. The reply publisher still requests it when minting a scoped
+ * token — that is a token scope, not a gate.
+ */
+export const GITHUB_APP_REQUIRED_PERMISSIONS = {
+  issues: "write",
+  pull_requests: "write",
+} as const satisfies Record<string, GithubPermissionLevel>;
+
+/**
+ * True when `permissions` grants at least every level in
+ * `GITHUB_APP_REQUIRED_PERMISSIONS`. `write` satisfies a `read` requirement
+ * (GitHub's write implies read); `admin` satisfies both.
+ */
+export function githubPermissionSatisfies(
+  granted: GithubPermissionLevel | undefined,
+  required: GithubPermissionLevel,
+): boolean {
+  if (granted === undefined) return false;
+  const rank: Record<GithubPermissionLevel, number> = { read: 0, write: 1, admin: 2 };
+  return rank[granted] >= rank[required];
+}
+
+/**
  * Subscribed event-name list, e.g. `["issues", "pull_request", "push"]`.
  * Free-form for the same forward-compat reason as `permissions`.
  */

--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -308,8 +308,8 @@ const buttonVariants = cva("…base classes…", {
 **Inventory** (representative):
 - **Actions / inputs:** Button, Input, Label, SegmentedControl, FilterPill,
   OptionCard, Command (cmdk), RowActionsMenu
-- **Containers / layout:** Card, Panel, Section, Tile, SettingsField, PageHeader,
-  SectionHeader, FlatSectionHeader, TabBar
+- **Containers / layout:** Card, Panel, Section, SettingRow, Tile, SettingsField,
+  PageHeader, SectionHeader, FlatSectionHeader, TabBar
 - **Data:** Table, DenseTable, Breadcrumb, Markdown
 - **Status / presence:** Badge, DenseBadge, StateChip, StateDot, StatusGlyph,
   PresenceChip, AgentStatusChip

--- a/packages/web/src/components/ui/__tests__/setting-row.test.tsx
+++ b/packages/web/src/components/ui/__tests__/setting-row.test.tsx
@@ -46,7 +46,36 @@ describe("SettingRow", () => {
     expect(control?.parentElement?.className).toContain("sm:justify-end");
     // Extras render below the row line, outside the control cluster.
     const extra = container.querySelector('[data-testid="extra"]');
-    expect(extra?.parentElement?.getAttribute("data-setting-row")).toBe("true");
+    expect(extra?.closest("[data-setting-row]")).not.toBeNull();
+    expect(extra?.parentElement?.contains(control)).toBe(false);
+
+    await act(async () => root.unmount());
+  });
+
+  it("hangs extras off the row's text column when it has a glyph", async () => {
+    const { container, root } = await renderDom(
+      <SettingRow icon={<svg aria-hidden />} title="GitHub App">
+        <span data-testid="extra">Connection details</span>
+      </SettingRow>,
+    );
+
+    // Without this the block resets to the container edge while the title sits
+    // indented past the glyph, leaving two competing left edges.
+    const extraWrapper = container.querySelector('[data-testid="extra"]')?.parentElement;
+    expect(extraWrapper?.style.paddingLeft).toBe("var(--setting-row-indent)");
+
+    await act(async () => root.unmount());
+  });
+
+  it("leaves extras flush when there is no glyph to align to", async () => {
+    const { container, root } = await renderDom(
+      <SettingRow title="Connection">
+        <span data-testid="extra">Detail</span>
+      </SettingRow>,
+    );
+
+    const extraWrapper = container.querySelector('[data-testid="extra"]')?.parentElement;
+    expect(extraWrapper?.style.paddingLeft).toBe("");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/components/ui/__tests__/setting-row.test.tsx
+++ b/packages/web/src/components/ui/__tests__/setting-row.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SettingRow } from "../setting-row.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function renderDom(element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+  return { container, root };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("SettingRow", () => {
+  it("renders name, effect, right-aligned control, and full-width extras", async () => {
+    const { container, root } = await renderDom(
+      <SettingRow
+        title="GitHub Task Agent"
+        description="Dev Agent One handles Issue activity."
+        control={<button type="button">Change</button>}
+      >
+        <span data-testid="extra">Blocker copy</span>
+      </SettingRow>,
+    );
+
+    expect(container.textContent).toContain("GitHub Task Agent");
+    expect(container.textContent).toContain("Dev Agent One handles Issue activity.");
+    const control = container.querySelector("button");
+    expect(control?.textContent).toBe("Change");
+    // The control belongs to the right-hand cluster, not the text column.
+    expect(control?.closest("[data-setting-row]")).not.toBeNull();
+    expect(control?.parentElement?.className).toContain("sm:justify-end");
+    // Extras render below the row line, outside the control cluster.
+    const extra = container.querySelector('[data-testid="extra"]');
+    expect(extra?.parentElement?.getAttribute("data-setting-row")).toBe("true");
+
+    await act(async () => root.unmount());
+  });
+
+  it("draws no chrome of its own — the enclosing Section owns the rule", async () => {
+    const { container, root } = await renderDom(<SettingRow title="Connection" />);
+
+    const row = container.querySelector<HTMLElement>("[data-setting-row]");
+    expect(row).not.toBeNull();
+    expect(row?.style.border).toBe("");
+    expect(row?.style.borderRadius).toBe("");
+    expect(row?.style.background).toBe("");
+
+    await act(async () => root.unmount());
+  });
+
+  it("spreads call-site hooks onto the row element", async () => {
+    const { container, root } = await renderDom(<SettingRow data-github-task-agent-controls="admin" title="Agent" />);
+
+    const row = container.querySelector<HTMLElement>('[data-github-task-agent-controls="admin"]');
+    expect(row?.getAttribute("data-setting-row")).toBe("true");
+
+    await act(async () => root.unmount());
+  });
+
+  it("omits the description and control slots when not supplied", async () => {
+    const { container, root } = await renderDom(<SettingRow title="Connection" />);
+
+    expect(container.querySelector("p")).toBeNull();
+    expect(container.querySelector(".sm\\:justify-end")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/components/ui/setting-row.tsx
+++ b/packages/web/src/components/ui/setting-row.tsx
@@ -1,0 +1,93 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "../../lib/utils.js";
+
+/**
+ * One configurable thing inside a Settings `Section`: an optional leading
+ * glyph, the name of the setting, a one-line explanation of what it does, and
+ * the control that changes it — the control right-aligned on the same line.
+ *
+ * Why a row instead of the previous stack (label → description → full-width
+ * control): a settings section is scanned, not read. Keeping "what it is" on
+ * the left and "change it" on the right lets the eye run down a single control
+ * column, and stops a narrow `Select` from stretching across the whole page.
+ *
+ * The row draws no border, background, or radius of its own. The enclosing
+ * `Section` owns the single rule above the block, and card chrome stays
+ * reserved for genuinely selectable surfaces (DESIGN.md Pillar 5) — the leading
+ * glyph gets a small sunken tile so the row reads as an object, but the row
+ * content itself is never boxed.
+ *
+ * Extra props (`id`, `data-*`, `aria-*`) spread onto the row element so a call
+ * site can keep its own test/scroll hooks on the outermost node.
+ */
+export function SettingRow({
+  icon,
+  title,
+  titleId,
+  description,
+  control,
+  children,
+  className,
+  style,
+  ...rest
+}: {
+  /** Leading line glyph (lucide, `h-4 w-4`), rendered in a sunken tile. */
+  icon?: ReactNode;
+  /** What this row configures. */
+  title: ReactNode;
+  /** Set when a control in this row is named by the title (`aria-labelledby`). */
+  titleId?: string;
+  /** One line on what the setting does / its current effect. */
+  description?: ReactNode;
+  /** Right-aligned control — Switch, Select, Button cluster, or a status line. */
+  control?: ReactNode;
+  /** Full-width content under the row: disclosures, blockers, inline errors. */
+  children?: ReactNode;
+} & Omit<HTMLAttributes<HTMLDivElement>, "title" | "children">): ReactNode {
+  return (
+    <div
+      data-setting-row
+      className={cn("flex flex-col", className)}
+      style={{ gap: "var(--sp-2_5)", padding: "var(--sp-3) 0", ...style }}
+      {...rest}
+    >
+      {/* Stacked on phones so a wide control never overflows; one line with the
+          control right-aligned from sm up. */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex min-w-0 flex-1 items-start" style={{ gap: "var(--sp-2_5)" }}>
+          {icon ? (
+            <span
+              aria-hidden
+              className="inline-flex shrink-0 items-center justify-center"
+              style={{
+                width: "var(--sp-7)",
+                height: "var(--sp-7)",
+                borderRadius: "var(--radius-input)",
+                background: "var(--bg-sunken)",
+                color: "var(--fg-3)",
+              }}
+            >
+              {icon}
+            </span>
+          ) : null}
+          <div className="min-w-0">
+            <div id={titleId} className="text-body font-medium" style={{ color: "var(--fg)" }}>
+              {title}
+            </div>
+            {description ? (
+              <p className="text-label m-0" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
+                {description}
+              </p>
+            ) : null}
+          </div>
+        </div>
+        {control ? (
+          <div className="flex shrink-0 flex-wrap items-center sm:justify-end" style={{ gap: "var(--sp-2)" }}>
+            {control}
+          </div>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/packages/web/src/components/ui/setting-row.tsx
+++ b/packages/web/src/components/ui/setting-row.tsx
@@ -23,7 +23,6 @@ import { cn } from "../../lib/utils.js";
 export function SettingRow({
   icon,
   title,
-  titleId,
   description,
   control,
   children,
@@ -35,8 +34,6 @@ export function SettingRow({
   icon?: ReactNode;
   /** What this row configures. */
   title: ReactNode;
-  /** Set when a control in this row is named by the title (`aria-labelledby`). */
-  titleId?: string;
   /** One line on what the setting does / its current effect. */
   description?: ReactNode;
   /** Right-aligned control — Switch, Select, Button cluster, or a status line. */
@@ -71,7 +68,7 @@ export function SettingRow({
             </span>
           ) : null}
           <div className="min-w-0">
-            <div id={titleId} className="text-body font-medium" style={{ color: "var(--fg)" }}>
+            <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
               {title}
             </div>
             {description ? (

--- a/packages/web/src/components/ui/setting-row.tsx
+++ b/packages/web/src/components/ui/setting-row.tsx
@@ -87,7 +87,20 @@ export function SettingRow({
           </div>
         ) : null}
       </div>
-      {children}
+
+      {/* Extras hang off the row's text column, not the section edge. Without
+          this they reset to the container's left margin while the row's own
+          title sits indented past the glyph, so an expanded block reads as a
+          detached slab with a second, further-left edge. */}
+      {children ? <div style={{ paddingLeft: textColumnOffset(icon) }}>{children}</div> : null}
     </div>
   );
+}
+
+/**
+ * Distance from the row's left edge to where its title starts — the glyph tile
+ * plus the gap after it, or nothing when the row has no glyph.
+ */
+function textColumnOffset(icon: ReactNode): string | undefined {
+  return icon ? "var(--setting-row-indent)" : undefined;
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -554,6 +554,11 @@ video[data-onboarding-orientation-video]::cue {
   /* Shared label column for ConfigRow / IdentityField / DangerActionRow grids. */
   --agent-detail-label-col: 8.25rem;
 
+  /* SettingRow's text column: the glyph tile (--sp-7) plus the gap after it
+     (--sp-2_5). Anything a row renders below its first line indents by this so
+     it hangs off the title instead of resetting to the section edge. */
+  --setting-row-indent: 2.375rem; /* 38px */
+
   /* Default color-scheme so native form controls, scrollbars, and the
      canvas match the light theme (.dark flips this to dark below). */
   color-scheme: light;

--- a/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
@@ -197,7 +197,7 @@ describe("GithubAppInstallationPanel", () => {
     await click(detailsToggle);
 
     expect(detailsToggle?.getAttribute("aria-expanded")).toBe("true");
-    expect(container.textContent).toContain("Required by First Tree");
+    expect(container.textContent).toContain("Required for automatic replies");
     expect(container.textContent).toContain("Also granted");
     expect(container.textContent).toContain("Contents");
     expect(container.textContent).toContain("Issues");

--- a/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
@@ -174,6 +174,8 @@ describe("GithubAppInstallationPanel", () => {
     const { container, root } = await renderDom(<GithubAppInstallationPanel />);
 
     await waitForText(container, "Connected to");
+    // The connection reads as one row: what it is, then who it's bound to.
+    expect(container.textContent).toContain("GitHub App");
     // GitHub accounts render as the full github.com path so a GitHub org is
     // never confusable with a First Tree team name.
     expect(container.textContent).toContain("github.com/octocat");

--- a/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
@@ -192,16 +192,15 @@ describe("GithubAppInstallationPanel", () => {
     // the admin opens it.
     const detailsToggle = buttonByText(container, "Connection details");
     expect(detailsToggle?.getAttribute("aria-expanded")).toBe("false");
-    expect(container.textContent).not.toContain("contents:");
-    expect(container.textContent).not.toContain(`Installation ${"#"}123`);
+    expect(container.textContent).not.toContain("Also granted");
 
     await click(detailsToggle);
 
     expect(detailsToggle?.getAttribute("aria-expanded")).toBe("true");
-    expect(container.textContent).toContain("contents:");
-    expect(container.textContent).toContain("issues:");
-    expect(container.textContent).toContain("pull_request");
-    expect(container.textContent).toContain(`Installation ${"#"}123`);
+    expect(container.textContent).toContain("Required by First Tree");
+    expect(container.textContent).toContain("Also granted");
+    expect(container.textContent).toContain("Contents");
+    expect(container.textContent).toContain("Issues");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/github-connection-details-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-connection-details-dom.test.tsx
@@ -51,17 +51,21 @@ describe("GithubConnectionDetails", () => {
     const { container, root } = await renderDom(<GithubConnectionDetails data={installation()} />);
 
     expect(buttonByText(container, "Connection details")?.getAttribute("aria-expanded")).toBe("false");
-    expect(container.textContent).not.toContain("Required by First Tree");
+    expect(container.textContent).not.toContain("Required for automatic replies");
     expect(container.textContent).not.toContain("131952074");
 
     await act(async () => root.unmount());
   });
 
-  it("answers 'is this installation good enough' before listing raw grants", async () => {
+  it("scopes the requirement list to the capability it actually gates", async () => {
     const { container, root } = await renderDom(<GithubConnectionDetails data={installation()} defaultOpen />);
 
-    // Required set is named in prose and marked satisfied.
-    expect(container.textContent).toContain("Required by First Tree");
+    // `issues: write` / `pull_requests: write` only cover the GitHub Task
+    // Agent's automatic replies. Presenting them as First Tree's blanket
+    // install contract would tell an admin the installation is generally fine
+    // when only this one capability has been checked.
+    expect(container.textContent).toContain("Required for automatic replies");
+    expect(container.textContent).not.toContain("Required by First Tree");
     expect(container.textContent).toContain("Issues");
     expect(container.textContent).toContain("Pull requests");
     // Everything else is secondary, not mixed into the requirement list.
@@ -136,11 +140,31 @@ describe("GithubConnectionDetails", () => {
     await act(async () => root.unmount());
   });
 
+  it("does not call handled lifecycle traffic unused", async () => {
+    // `installation` / `installation_repositories` never reach `buildRule`:
+    // the webhook route hands them to `handleInstallationLifecycle` first, and
+    // they are what keeps this very row and its repository coverage current.
+    // A normally configured installation subscribes to both, so filing them
+    // under "unused" reports a healthy install as misconfigured.
+    const data = installation({ events: ["issues", "installation", "installation_repositories", "push"] });
+    const { container, root } = await renderDom(<GithubConnectionDetails data={data} defaultOpen />);
+
+    expect(container.textContent).toContain("Kept in sync from: Installation lifecycle · Repository access changes");
+    expect(container.textContent).toContain("Subscribed but unused: push");
+    expect(container.textContent).not.toContain("Subscribed but unused: installation");
+
+    await act(async () => root.unmount());
+  });
+
   it("renders the installation id and both timestamps the API already returns", async () => {
     const { container, root } = await renderDom(<GithubConnectionDetails data={installation()} defaultOpen />);
 
     expect(container.textContent).toContain("123");
-    expect(container.textContent).toContain("Connected");
+    // "First seen", not "Connected": the row is written by the
+    // `installation.created` webhook while still unbound and survives a
+    // disconnect/rebind, so it never records when this team connected.
+    expect(container.textContent).toContain("First seen");
+    expect(container.textContent).not.toContain("Connected");
     expect(container.textContent).toContain("Last updated");
     expect(container.textContent).toContain(
       new Date("2026-08-03T09:12:00.000Z").toLocaleDateString(undefined, {

--- a/packages/web/src/pages/__tests__/github-connection-details-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-connection-details-dom.test.tsx
@@ -101,11 +101,14 @@ describe("GithubConnectionDetails", () => {
     await act(async () => root.unmount());
   });
 
-  it("treats a higher granted level as satisfying the requirement", async () => {
+  it("does not accept a level the rest of the server would reject", async () => {
+    // `github-audience` and the publishers compare exactly, so an `admin` grant
+    // must not read as satisfied here — that would promise delivery the routing
+    // path then refuses.
     const data = installation({ permissions: { issues: "admin", pull_requests: "write" } });
     const { container, root } = await renderDom(<GithubConnectionDetails data={data} defaultOpen />);
 
-    expect(container.textContent).not.toContain("Agents can't post replies on issues.");
+    expect(container.textContent).toContain("Agents can't post replies on issues.");
 
     await act(async () => root.unmount());
   });
@@ -146,7 +149,10 @@ describe("GithubConnectionDetails", () => {
         day: "numeric",
       }),
     );
-    expect(container.querySelector('[aria-label="Copy installation id"]')).not.toBeNull();
+    // House convention (inline-command.tsx / invite-link-panel.tsx): the copy
+    // control carries its state in the visible label, so the `failed` case
+    // `useCopyFeedback` returns can't render as an inert button.
+    expect(buttonByText(container, "Copy")).not.toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/github-connection-details-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-connection-details-dom.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment happy-dom
+
+import type { GithubAppInstallationOutput } from "@first-tree/shared";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GithubConnectionDetails } from "../github-connection-details.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function installation(overrides: Partial<GithubAppInstallationOutput> = {}): GithubAppInstallationOutput {
+  return {
+    installationId: 123,
+    accountType: "Organization",
+    accountLogin: "acme",
+    accountGithubId: 456,
+    permissions: { issues: "write", pull_requests: "write", metadata: "read", contents: "write" },
+    events: ["issues", "issue_comment", "pull_request", "push", "member"],
+    suspended: false,
+    manageUrl: "https://github.com/organizations/acme/settings/installations/123",
+    createdAt: "2026-08-03T09:12:00.000Z",
+    updatedAt: "2026-08-06T16:41:00.000Z",
+    ...overrides,
+  };
+}
+
+async function renderDom(element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+  return { container, root };
+}
+
+function buttonByText(container: ParentNode, text: string): HTMLButtonElement | null {
+  return [...container.querySelectorAll("button")].find((button) => button.textContent?.includes(text)) ?? null;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("GithubConnectionDetails", () => {
+  it("keeps the detail behind a collapsed disclosure", async () => {
+    const { container, root } = await renderDom(<GithubConnectionDetails data={installation()} />);
+
+    expect(buttonByText(container, "Connection details")?.getAttribute("aria-expanded")).toBe("false");
+    expect(container.textContent).not.toContain("Required by First Tree");
+    expect(container.textContent).not.toContain("131952074");
+
+    await act(async () => root.unmount());
+  });
+
+  it("answers 'is this installation good enough' before listing raw grants", async () => {
+    const { container, root } = await renderDom(<GithubConnectionDetails data={installation()} defaultOpen />);
+
+    // Required set is named in prose and marked satisfied.
+    expect(container.textContent).toContain("Required by First Tree");
+    expect(container.textContent).toContain("Issues");
+    expect(container.textContent).toContain("Pull requests");
+    // Everything else is secondary, not mixed into the requirement list.
+    expect(container.textContent).toContain("Also granted");
+    expect(container.textContent).toContain("Contents");
+    // Nothing is blocked, so no GitHub-side call to action appears.
+    expect(container.querySelector('a[href*="settings/installations"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("marks a shortfall, says what it costs, and points at the fix", async () => {
+    const data = installation({ permissions: { issues: "write", pull_requests: "read", metadata: "read" } });
+    const { container, root } = await renderDom(<GithubConnectionDetails data={data} defaultOpen />);
+
+    expect(container.textContent).toContain("Agents can't post replies on pull requests.");
+    const grant = container.querySelector<HTMLAnchorElement>(`a[href="${data.manageUrl}"]`);
+    expect(grant?.textContent).toContain("Grant on GitHub");
+
+    await act(async () => root.unmount());
+  });
+
+  it("surfaces the shortfall on the collapsed toggle so it isn't hidden", async () => {
+    const data = installation({ permissions: { issues: "write", pull_requests: "read" } });
+    const { container, root } = await renderDom(<GithubConnectionDetails data={data} />);
+
+    expect(container.textContent).toContain("Pull requests access is missing");
+
+    await act(async () => root.unmount());
+  });
+
+  it("counts multiple shortfalls rather than naming one of them", async () => {
+    const { container, root } = await renderDom(<GithubConnectionDetails data={installation({ permissions: {} })} />);
+
+    expect(container.textContent).toContain("2 required permissions are missing");
+
+    await act(async () => root.unmount());
+  });
+
+  it("treats a higher granted level as satisfying the requirement", async () => {
+    const data = installation({ permissions: { issues: "admin", pull_requests: "write" } });
+    const { container, root } = await renderDom(<GithubConnectionDetails data={data} defaultOpen />);
+
+    expect(container.textContent).not.toContain("Agents can't post replies on issues.");
+
+    await act(async () => root.unmount());
+  });
+
+  it("withholds the GitHub call to action from members who can't act on it", async () => {
+    const data = installation({ permissions: { issues: "write", pull_requests: "read" } });
+    const { container, root } = await renderDom(<GithubConnectionDetails data={data} readOnly defaultOpen />);
+
+    // Members still read the same diagnosis...
+    expect(container.textContent).toContain("Agents can't post replies on pull requests.");
+    // ...without a button they have no standing to use.
+    expect(container.querySelector(`a[href="${data.manageUrl}"]`)).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("names the events it consumes and calls out the ones it drops", async () => {
+    const { container, root } = await renderDom(<GithubConnectionDetails data={installation()} defaultOpen />);
+
+    expect(container.textContent).toContain("Issue comments");
+    // `push` / `member` are subscribed but never normalized into activity —
+    // saying so is the answer when a webhook produced nothing.
+    expect(container.textContent).toContain("Subscribed but unused: push, member");
+
+    await act(async () => root.unmount());
+  });
+
+  it("renders the installation id and both timestamps the API already returns", async () => {
+    const { container, root } = await renderDom(<GithubConnectionDetails data={installation()} defaultOpen />);
+
+    expect(container.textContent).toContain("123");
+    expect(container.textContent).toContain("Connected");
+    expect(container.textContent).toContain("Last updated");
+    expect(container.textContent).toContain(
+      new Date("2026-08-03T09:12:00.000Z").toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      }),
+    );
+    expect(container.querySelector('[aria-label="Copy installation id"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("degrades gracefully on permission and event names it has never seen", async () => {
+    const data = installation({
+      permissions: { issues: "write", pull_requests: "write", dependabot_secrets: "read" },
+      events: ["issues", "some_future_event"],
+    });
+    const { container, root } = await renderDom(<GithubConnectionDetails data={data} defaultOpen />);
+
+    expect(container.textContent).toContain("Dependabot secrets");
+    expect(container.textContent).toContain("Subscribed but unused: some_future_event");
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -363,7 +363,7 @@ describe("extra preview pages", () => {
     await click(detailsButtons[0] ?? detailsButtons[1] ?? buttonByText(rendered.container, "Connection details"));
     expect(detailsButtons[0]?.getAttribute("aria-expanded")).toBe("true");
     expect(text(rendered.container)).toContain("131952074");
-    expect(text(rendered.container)).toContain("Required by First Tree");
+    expect(text(rendered.container)).toContain("Required for automatic replies");
 
     await cleanupRendered(rendered);
   });

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -349,15 +349,21 @@ describe("extra preview pages", () => {
     expect(text(rendered.container)).toContain("waiting");
     expect(text(rendered.container)).toContain("Loading");
     expect(text(rendered.container)).toContain("Waiting for GitHub");
+    // The two states that exist to review the shortfall readout.
+    expect(text(rendered.container)).toContain("a required scope is missing");
+    expect(text(rendered.container)).toContain("Missing scope — collapsed");
+    expect(text(rendered.container)).toContain("Agents can't post replies on pull requests.");
+    expect(text(rendered.container)).toContain("Pull requests access is missing");
 
     const detailsButtons = [...rendered.container.querySelectorAll("button")].filter((button) =>
       button.textContent?.includes("Connection details"),
     );
-    expect(detailsButtons.length).toBe(3);
+    expect(detailsButtons.length).toBe(5);
     expect(detailsButtons[0]?.getAttribute("aria-expanded")).toBe("false");
     await click(detailsButtons[0] ?? detailsButtons[1] ?? buttonByText(rendered.container, "Connection details"));
     expect(detailsButtons[0]?.getAttribute("aria-expanded")).toBe("true");
-    expect(text(rendered.container)).toContain("Installation #131952074");
+    expect(text(rendered.container)).toContain("131952074");
+    expect(text(rendered.container)).toContain("Required by First Tree");
 
     await cleanupRendered(rendered);
   });

--- a/packages/web/src/pages/github-app-installation-panel.tsx
+++ b/packages/web/src/pages/github-app-installation-panel.tsx
@@ -1,6 +1,6 @@
 import type { GithubAppConnectPanelInstallation, GithubAppInstallationOutput } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Building2, ChevronRight, ExternalLink, Github, PauseCircle, User } from "lucide-react";
+import { ArrowLeft, Building2, ExternalLink, Github, PauseCircle, User } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { ApiError } from "../api/client.js";
 import {
@@ -20,6 +20,7 @@ import {
   hasGithubInstallAttemptForOrganization,
   rememberGithubInstallAttempt,
 } from "../lib/github-install-attempt.js";
+import { GithubConnectionDetails } from "./github-connection-details.js";
 
 /**
  * How often the open connect panel refreshes its installation list. Two
@@ -195,7 +196,7 @@ function InstalledState({
       >
         {/* Expandable details sit directly under the connected account they
             describe, not below the action buttons. */}
-        <ConnectionDetails data={data} />
+        <GithubConnectionDetails data={data} readOnly={readOnly} />
       </SettingRow>
     </div>
   );
@@ -717,89 +718,6 @@ function InstallationRow({
         )}
       </div>
       <div className="shrink-0">{children}</div>
-    </div>
-  );
-}
-
-/**
- * Collapsed-by-default disclosure for the developer-facing connection
- * metadata: the granted permission scopes, the subscribed webhook events,
- * and the installation id. Kept off the default view (most admins only need
- * "who's connected" + Manage) but one click away for scope auditing. A plain
- * `aria-expanded` button — there's no shared collapsible primitive in this app,
- * and the controlled toggle keeps the chevron and the mounted content in
- * lockstep.
- */
-function ConnectionDetails({ data }: { data: GithubAppInstallationOutput }) {
-  const [open, setOpen] = useState(false);
-  const permissionEntries = Object.entries(data.permissions);
-  const regionId = "github-connection-details";
-
-  return (
-    <div style={{ borderTop: "var(--hairline) solid var(--border)", paddingTop: "var(--sp-3)" }}>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        onClick={() => setOpen((value) => !value)}
-        aria-expanded={open}
-        aria-controls={open ? regionId : undefined}
-      >
-        <ChevronRight
-          aria-hidden
-          className="h-3 w-3 transition-transform"
-          style={{ transform: open ? "rotate(90deg)" : "none" }}
-        />
-        Connection details
-      </Button>
-
-      {open && (
-        <div
-          id={regionId}
-          style={{ display: "flex", flexDirection: "column", gap: "var(--sp-3)", marginTop: "var(--sp-3)" }}
-        >
-          {permissionEntries.length > 0 && (
-            <div>
-              <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
-                Permissions granted
-              </div>
-              <ul
-                className="text-body"
-                style={{
-                  listStyle: "none",
-                  padding: 0,
-                  margin: 0,
-                  display: "grid",
-                  gridTemplateColumns: "1fr 1fr",
-                  gap: "var(--sp-1)",
-                  color: "var(--fg-2)",
-                }}
-              >
-                {permissionEntries.map(([key, value]) => (
-                  <li key={key} className="mono">
-                    {key}: <strong style={{ color: "var(--fg)" }}>{value}</strong>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-
-          {data.events.length > 0 && (
-            <div>
-              <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
-                Subscribed events
-              </div>
-              <div className="text-body mono" style={{ color: "var(--fg-2)" }}>
-                {data.events.join(", ")}
-              </div>
-            </div>
-          )}
-
-          <span className="text-label" style={{ color: "var(--fg-3)" }}>
-            Installation #{data.installationId}
-          </span>
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/web/src/pages/github-app-installation-panel.tsx
+++ b/packages/web/src/pages/github-app-installation-panel.tsx
@@ -1,6 +1,6 @@
 import type { GithubAppConnectPanelInstallation, GithubAppInstallationOutput } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Building2, ChevronRight, ExternalLink, PauseCircle, User } from "lucide-react";
+import { ArrowLeft, Building2, ChevronRight, ExternalLink, Github, PauseCircle, User } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { ApiError } from "../api/client.js";
 import {
@@ -13,6 +13,7 @@ import {
 import { getAuthProviders, startProviderLink } from "../api/user-settings.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
+import { SettingRow } from "../components/ui/setting-row.js";
 import { clearGithubAccountLinkReturn, rememberGithubAccountLinkReturn } from "../lib/github-account-link-return.js";
 import {
   clearGithubInstallAttemptForOrganization,
@@ -108,7 +109,9 @@ export function GithubAppInstallationPanel({
 
 /**
  * Unbound summary: the team has no GitHub connection yet, so the whole
- * surface is one prominent entry point into the connect panel.
+ * surface is one prominent entry point into the connect panel. Same row shape
+ * as the connected state, so connecting doesn't reflow the section — only the
+ * status line and the right-hand control change.
  */
 function NotConnectedSummary({
   disabled,
@@ -120,17 +123,18 @@ function NotConnectedSummary({
   onOpenPanel: () => void;
 }) {
   return (
-    <div>
-      <p className="text-body" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-3)" }}>
-        This team isn't connected to GitHub yet. Connect a GitHub App installation to start receiving issues, pull
-        requests, and reviews as routed messages.
-      </p>
-      {!readOnly && (
-        <Button type="button" size="sm" onClick={onOpenPanel} disabled={disabled}>
-          Connect GitHub
-        </Button>
-      )}
-    </div>
+    <SettingRow
+      icon={<Github className="h-4 w-4" />}
+      title="GitHub App"
+      description="This team isn't connected to GitHub yet. Connect a GitHub App installation to start receiving issues, pull requests, and reviews as routed messages."
+      control={
+        readOnly ? null : (
+          <Button type="button" size="sm" onClick={onOpenPanel} disabled={disabled}>
+            Connect GitHub
+          </Button>
+        )
+      }
+    />
   );
 }
 
@@ -156,49 +160,43 @@ function InstalledState({
   return (
     // No borderTop of its own: the page's Section frame already draws the
     // rule above this block.
-    <div
-      style={{
-        paddingTop: "var(--sp-1)",
-        display: "flex",
-        flexDirection: "column",
-        gap: "var(--sp-4)",
-      }}
-    >
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-3)" }}>
       {data.suspended && <SuspendedBanner />}
 
-      <div>
-        <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
-          Connected to
-        </div>
-        <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
-          <AccountIcon className="h-4 w-4" style={{ color: "var(--fg-2)" }} />
-          <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
-            {githubAccountPath(data.accountLogin)}
+      <SettingRow
+        icon={<Github className="h-4 w-4" />}
+        title="GitHub App"
+        // Who's connected reads as the row's status line rather than a separate
+        // labelled block — one glance answers "is this wired up, and to what".
+        description={
+          <span className="inline-flex flex-wrap items-center" style={{ gap: "var(--sp-1_5)" }}>
+            <span className="inline-flex items-center" style={{ gap: "var(--sp-1)" }}>
+              <AccountIcon className="h-3 w-3 shrink-0" aria-hidden />
+              <span style={{ overflowWrap: "anywhere" }}>Connected to {githubAccountPath(data.accountLogin)}</span>
+            </span>
+            <span style={{ color: "var(--fg-4)" }}>{data.accountType}</span>
           </span>
-          <span className="text-caption" style={{ color: "var(--fg-3)" }}>
-            {data.accountType}
-          </span>
-        </div>
+        }
+        control={
+          readOnly ? null : (
+            <>
+              <Button type="button" variant="outline" size="sm" onClick={onOpenPanel}>
+                Manage connection
+              </Button>
+              <Button asChild variant="outline" size="sm">
+                <a href={data.manageUrl} target="_blank" rel="noreferrer">
+                  Manage on GitHub
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </Button>
+            </>
+          )
+        }
+      >
         {/* Expandable details sit directly under the connected account they
             describe, not below the action buttons. */}
-        <div style={{ marginTop: "var(--sp-3)" }}>
-          <ConnectionDetails data={data} />
-        </div>
-      </div>
-
-      {!readOnly && (
-        <div className="flex items-center" style={{ gap: "var(--sp-2)", flexWrap: "wrap" }}>
-          <Button type="button" variant="outline" size="sm" onClick={onOpenPanel}>
-            Manage connection
-          </Button>
-          <Button asChild variant="outline" size="sm">
-            <a href={data.manageUrl} target="_blank" rel="noreferrer">
-              Manage on GitHub
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          </Button>
-        </div>
-      )}
+        <ConnectionDetails data={data} />
+      </SettingRow>
     </div>
   );
 }

--- a/packages/web/src/pages/github-connection-details.tsx
+++ b/packages/web/src/pages/github-connection-details.tsx
@@ -1,0 +1,322 @@
+import {
+  GITHUB_APP_REQUIRED_PERMISSIONS,
+  type GithubAppInstallationOutput,
+  type GithubPermissionLevel,
+  githubPermissionSatisfies,
+} from "@first-tree/shared";
+import { Check, ChevronRight, CircleAlert, CircleCheck, Copy, ExternalLink } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { Button } from "../components/ui/button.js";
+import { useCopyFeedback } from "../lib/use-copy-feedback.js";
+
+/**
+ * Human names for the GitHub permission keys an installation is likely to
+ * carry. `permissions` is a free-form record on purpose (GitHub adds keys over
+ * time and we don't want an `app_id` bump just to name one), so an unknown key
+ * falls back to a de-underscored form rather than being dropped.
+ */
+const PERMISSION_LABELS: Record<string, string> = {
+  actions: "Actions",
+  administration: "Administration",
+  checks: "Checks",
+  contents: "Contents",
+  discussions: "Discussions",
+  issues: "Issues",
+  members: "Members",
+  metadata: "Metadata",
+  organization_administration: "Organization administration",
+  pull_requests: "Pull requests",
+  workflows: "Workflows",
+};
+
+/**
+ * Webhook events First Tree actually turns into something — mirrors the
+ * `buildRule` switch in the server's `github-normalize.ts`. Everything else an
+ * installation subscribes to is delivered and dropped, which is exactly what
+ * you want said out loud while working out why an event produced no message.
+ */
+const CONSUMED_EVENT_LABELS: Record<string, string> = {
+  commit_comment: "Commit comments",
+  discussion: "Discussions",
+  discussion_comment: "Discussion comments",
+  issue_comment: "Issue comments",
+  issues: "Issues",
+  pull_request: "Pull requests",
+  pull_request_review: "PR reviews",
+  pull_request_review_comment: "PR review comments",
+};
+
+/** What the team loses while a required permission is missing. */
+const PERMISSION_SHORTFALL: Record<string, string> = {
+  issues: "Agents can't post replies on issues.",
+  pull_requests: "Agents can't post replies on pull requests.",
+};
+
+function humanize(value: string): string {
+  const spaced = value.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function permissionLabel(name: string): string {
+  return PERMISSION_LABELS[name] ?? humanize(name);
+}
+
+function shortfallCopy(name: string, required: GithubPermissionLevel): string {
+  return PERMISSION_SHORTFALL[name] ?? `First Tree needs ${required} access here.`;
+}
+
+type RequiredPermission = {
+  name: string;
+  required: GithubPermissionLevel;
+  granted: GithubPermissionLevel | undefined;
+  satisfied: boolean;
+};
+
+/** Collapsed-state summary: name the single gap, or count several. */
+function blockedSummary(blocked: RequiredPermission[]): string {
+  const [only] = blocked;
+  return blocked.length === 1 && only
+    ? `${permissionLabel(only.name)} access is missing`
+    : `${blocked.length} required permissions are missing`;
+}
+
+function readRequiredPermissions(permissions: GithubAppInstallationOutput["permissions"]): RequiredPermission[] {
+  return Object.entries(GITHUB_APP_REQUIRED_PERMISSIONS).map(([name, required]) => ({
+    name,
+    required,
+    granted: permissions[name],
+    satisfied: githubPermissionSatisfies(permissions[name], required),
+  }));
+}
+
+/**
+ * Collapsed-by-default disclosure for the connection's developer-facing
+ * detail. It used to transcribe GitHub's `permissions` / `events` blobs
+ * verbatim, which left the reader to diff them against a requirement they'd
+ * have to already know. It now answers the question they opened it with —
+ * "is this installation good enough for First Tree?" — before falling back to
+ * the raw grants:
+ *
+ *   - **Required by First Tree** — one row per `GITHUB_APP_REQUIRED_PERMISSIONS`
+ *     entry (the same set the server's task-reply gate gives out), each marked
+ *     ready or blocked.
+ *   - **Also granted** — everything else, secondary.
+ *   - **Events** — the subscriptions First Tree consumes, named in prose, with
+ *     ignored subscriptions called out instead of silently blended in.
+ *   - **Installation** — id (copyable), and the two timestamps the API already
+ *     returns, which are the first thing you want when reconstructing "when
+ *     did this change".
+ *
+ * A shortfall also marks the collapsed toggle, so the one state worth acting
+ * on isn't hidden behind a closed disclosure.
+ *
+ * A plain `aria-expanded` button — there's no shared collapsible primitive in
+ * this app, and the controlled toggle keeps the chevron and the mounted
+ * content in lockstep.
+ */
+export function GithubConnectionDetails({
+  data,
+  readOnly = false,
+  defaultOpen = false,
+}: {
+  data: GithubAppInstallationOutput;
+  /** Members read the same facts but get no GitHub-side call to action. */
+  readOnly?: boolean;
+  /** The DEV `/preview/settings-github` gallery renders the expanded state directly. */
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const regionId = "github-connection-details";
+  const required = readRequiredPermissions(data.permissions);
+  const blocked = required.filter((permission) => !permission.satisfied);
+  const requiredNames = new Set(required.map((permission) => permission.name));
+  const alsoGranted = Object.entries(data.permissions)
+    .filter(([name]) => !requiredNames.has(name))
+    .sort(([a], [b]) => permissionLabel(a).localeCompare(permissionLabel(b)));
+  const consumed = data.events.filter((event) => event in CONSUMED_EVENT_LABELS);
+  const ignored = data.events.filter((event) => !(event in CONSUMED_EVENT_LABELS));
+
+  return (
+    <div style={{ borderTop: "var(--hairline) solid var(--border)", paddingTop: "var(--sp-3)" }}>
+      <div className="flex flex-wrap items-center" style={{ gap: "var(--sp-2)" }}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setOpen((value) => !value)}
+          aria-expanded={open}
+          aria-controls={open ? regionId : undefined}
+        >
+          <ChevronRight
+            aria-hidden
+            className="h-3 w-3 transition-transform"
+            style={{ transform: open ? "rotate(90deg)" : "none" }}
+          />
+          Connection details
+        </Button>
+        {/* Surface the one state worth acting on even while collapsed. */}
+        {blocked.length > 0 && !open ? (
+          <span className="inline-flex items-center text-label" style={{ gap: "var(--sp-1)" }}>
+            <CircleAlert aria-hidden className="h-3.5 w-3.5 shrink-0" style={{ color: "var(--state-blocked)" }} />
+            <span style={{ color: "var(--state-blocked)" }}>{blockedSummary(blocked)}</span>
+          </span>
+        ) : null}
+      </div>
+
+      {open && (
+        <div
+          id={regionId}
+          style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)", marginTop: "var(--sp-3)" }}
+        >
+          <DetailBlock label="Required by First Tree">
+            <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
+              {required.map((permission) => (
+                <RequiredPermissionRow
+                  key={permission.name}
+                  permission={permission}
+                  manageUrl={data.manageUrl}
+                  readOnly={readOnly}
+                />
+              ))}
+            </div>
+          </DetailBlock>
+
+          {alsoGranted.length > 0 && (
+            <DetailBlock label="Also granted">
+              <p className="text-label m-0" style={{ color: "var(--fg-3)" }}>
+                {alsoGranted.map(([name, level], index) => (
+                  <span key={name}>
+                    {index > 0 ? " · " : ""}
+                    {permissionLabel(name)} <span style={{ color: "var(--fg-4)" }}>{level}</span>
+                  </span>
+                ))}
+              </p>
+            </DetailBlock>
+          )}
+
+          <DetailBlock label="Events First Tree listens for">
+            <p className="text-label m-0" style={{ color: "var(--fg-2)" }}>
+              {consumed.length > 0
+                ? consumed.map((event) => CONSUMED_EVENT_LABELS[event]).join(" · ")
+                : "None of this installation's subscriptions produce First Tree activity."}
+            </p>
+            {ignored.length > 0 && (
+              // Named rather than hidden: "you subscribed to it, we drop it" is
+              // the answer when someone is hunting a webhook that changed nothing.
+              <p className="text-caption m-0" style={{ marginTop: "var(--sp-1)", color: "var(--fg-4)" }}>
+                Subscribed but unused: {ignored.join(", ")}
+              </p>
+            )}
+          </DetailBlock>
+
+          <DetailBlock label="Installation">
+            <dl className="m-0 grid" style={{ gap: "var(--sp-1_5) var(--sp-4)", gridTemplateColumns: "auto 1fr" }}>
+              <DetailField term="ID">
+                <span className="inline-flex items-center" style={{ gap: "var(--sp-1)" }}>
+                  <span className="mono">{data.installationId}</span>
+                  <CopyInstallationId installationId={data.installationId} />
+                </span>
+              </DetailField>
+              <DetailField term="Connected">{formatDate(data.createdAt)}</DetailField>
+              <DetailField term="Last updated">{formatDate(data.updatedAt)}</DetailField>
+            </dl>
+          </DetailBlock>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RequiredPermissionRow({
+  permission,
+  manageUrl,
+  readOnly,
+}: {
+  permission: RequiredPermission;
+  manageUrl: string;
+  readOnly: boolean;
+}) {
+  // Blocked, not "needs you": the fix lives on GitHub's side, and a First Tree
+  // admin role alone doesn't establish they can grant it there (DESIGN.md §3).
+  const Glyph = permission.satisfied ? CircleCheck : CircleAlert;
+  const color = permission.satisfied ? "var(--success)" : "var(--state-blocked)";
+  return (
+    <div className="flex flex-col gap-1 sm:flex-row sm:items-center" style={{ gap: "var(--sp-2)" }}>
+      <span className="inline-flex min-w-0 flex-1 items-center" style={{ gap: "var(--sp-2)" }}>
+        <Glyph aria-hidden className="h-4 w-4 shrink-0" style={{ color }} />
+        <span className="text-label" style={{ color: "var(--fg)" }}>
+          {permissionLabel(permission.name)}
+        </span>
+        <span className="text-label" style={{ color: "var(--fg-3)" }}>
+          {permission.granted ?? "not granted"}
+        </span>
+        {!permission.satisfied && (
+          <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+            {shortfallCopy(permission.name, permission.required)}
+          </span>
+        )}
+      </span>
+      {!permission.satisfied && !readOnly && (
+        <Button asChild variant="outline" size="xs" className="shrink-0">
+          <a href={manageUrl} target="_blank" rel="noreferrer">
+            Grant on GitHub
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function CopyInstallationId({ installationId }: { installationId: number }) {
+  const { status, copy } = useCopyFeedback();
+  const copied = status === "copied";
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="xs"
+      aria-label={copied ? "Installation id copied" : "Copy installation id"}
+      title="Copy installation id"
+      onClick={() => void copy(String(installationId))}
+    >
+      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+    </Button>
+  );
+}
+
+function DetailBlock({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1_5)" }}>
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function DetailField({ term, children }: { term: string; children: ReactNode }) {
+  return (
+    <>
+      <dt className="text-label" style={{ color: "var(--fg-3)" }}>
+        {term}
+      </dt>
+      <dd className="text-label m-0" style={{ color: "var(--fg-2)" }}>
+        {children}
+      </dd>
+    </>
+  );
+}
+
+/**
+ * Absolute dates, not "3 days ago": this block is read while reconstructing a
+ * timeline against GitHub's own audit log, where a relative age has to be
+ * converted back before it's usable. Named month over an all-numeric date so
+ * the day/month order can't be misread across locales.
+ */
+function formatDate(iso: string): string {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}

--- a/packages/web/src/pages/github-connection-details.tsx
+++ b/packages/web/src/pages/github-connection-details.tsx
@@ -139,10 +139,13 @@ export function GithubConnectionDetails({
   return (
     <div style={{ borderTop: "var(--hairline) solid var(--border)", paddingTop: "var(--sp-3)" }}>
       <div className="flex flex-wrap items-center" style={{ gap: "var(--sp-2)" }}>
+        {/* `-ml-3` cancels the button's own `px-3` so the chevron lands on this
+            block's left edge instead of floating one padding step inside it. */}
         <Button
           type="button"
           variant="ghost"
           size="sm"
+          className="-ml-3"
           onClick={() => setOpen((value) => !value)}
           aria-expanded={open}
           aria-controls={open ? regionId : undefined}
@@ -166,7 +169,16 @@ export function GithubConnectionDetails({
       {open && (
         <div
           id={regionId}
-          style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)", marginTop: "var(--sp-3)" }}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--sp-4)",
+            marginTop: "var(--sp-3)",
+            // Line the blocks up under the disclosure's label (chevron + its
+            // gap), so opening the section extends one column rather than
+            // starting a new one further left.
+            paddingLeft: "var(--sp-5)",
+          }}
         >
           <DetailBlock label="Required by First Tree">
             <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>

--- a/packages/web/src/pages/github-connection-details.tsx
+++ b/packages/web/src/pages/github-connection-details.tsx
@@ -1,5 +1,5 @@
 import {
-  GITHUB_APP_REQUIRED_PERMISSIONS,
+  GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS,
   type GithubAppInstallationOutput,
   type GithubPermissionLevel,
   githubPermissionSatisfies,
@@ -30,12 +30,12 @@ const PERMISSION_LABELS: Record<string, string> = {
 };
 
 /**
- * Webhook events First Tree actually turns into something — mirrors the
- * `buildRule` switch in the server's `github-normalize.ts`. Everything else an
- * installation subscribes to is delivered and dropped, which is exactly what
- * you want said out loud while working out why an event produced no message.
+ * Webhook events First Tree turns into agent activity — mirrors the `buildRule`
+ * switch in the server's `github-normalize.ts`. These are the ones that can
+ * produce a message, which is what you're checking when an event seems to have
+ * gone nowhere.
  */
-const CONSUMED_EVENT_LABELS: Record<string, string> = {
+const ACTIVITY_EVENT_LABELS: Record<string, string> = {
   commit_comment: "Commit comments",
   discussion: "Discussions",
   discussion_comment: "Discussion comments",
@@ -44,6 +44,21 @@ const CONSUMED_EVENT_LABELS: Record<string, string> = {
   pull_request: "Pull requests",
   pull_request_review: "PR reviews",
   pull_request_review_comment: "PR review comments",
+};
+
+/**
+ * Events the webhook route consumes before it ever reaches `buildRule` — they
+ * create, refresh, suspend/resume and delete the installation record and its
+ * repository coverage (`api/webhooks/github-app.ts`, `handleInstallationLifecycle`).
+ *
+ * Classified apart from both lists on purpose: they produce no agent activity,
+ * so they can't sit under the activity heading, but they are very much handled,
+ * so grouping them with the dropped subscriptions would tell an admin their
+ * normally configured installation is misconfigured.
+ */
+const LIFECYCLE_EVENT_LABELS: Record<string, string> = {
+  installation: "Installation lifecycle",
+  installation_repositories: "Repository access changes",
 };
 
 /** What the team loses while a required permission is missing. */
@@ -81,7 +96,7 @@ function blockedSummary(blocked: RequiredPermission[]): string {
 }
 
 function readRequiredPermissions(permissions: GithubAppInstallationOutput["permissions"]): RequiredPermission[] {
-  return Object.entries(GITHUB_APP_REQUIRED_PERMISSIONS).map(([name, required]) => ({
+  return Object.entries(GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS).map(([name, required]) => ({
     name,
     required,
     granted: permissions[name],
@@ -94,15 +109,18 @@ function readRequiredPermissions(permissions: GithubAppInstallationOutput["permi
  * detail. It used to transcribe GitHub's `permissions` / `events` blobs
  * verbatim, which left the reader to diff them against a requirement they'd
  * have to already know. It now answers the question they opened it with —
- * "is this installation good enough for First Tree?" — before falling back to
- * the raw grants:
+ * "can this installation do the thing I'm waiting on?" — before falling back
+ * to the raw grants:
  *
- *   - **Required by First Tree** — one row per `GITHUB_APP_REQUIRED_PERMISSIONS`
- *     entry (the same set the server's task-reply gate gives out), each marked
- *     ready or blocked.
+ *   - **Required for automatic replies** — one row per
+ *     `GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS` entry (the same set the server's
+ *     task-reply gate reads), each marked ready or blocked. Scoped to that
+ *     capability, not a verdict on the installation: other capabilities gate on
+ *     their own permissions, events, and repository coverage.
  *   - **Also granted** — everything else, secondary.
- *   - **Events** — the subscriptions First Tree consumes, named in prose, with
- *     ignored subscriptions called out instead of silently blended in.
+ *   - **Events** — the subscriptions that produce agent activity, named in
+ *     prose, with lifecycle traffic and genuinely dropped subscriptions each
+ *     called out separately instead of blended together.
  *   - **Installation** — id (copyable), and the two timestamps the API already
  *     returns, which are the first thing you want when reconstructing "when
  *     did this change".
@@ -136,8 +154,11 @@ export function GithubConnectionDetails({
   const alsoGranted = Object.entries(data.permissions)
     .filter(([name]) => !requiredNames.has(name))
     .sort(([a], [b]) => permissionLabel(a).localeCompare(permissionLabel(b)));
-  const consumed = data.events.filter((event) => event in CONSUMED_EVENT_LABELS);
-  const ignored = data.events.filter((event) => !(event in CONSUMED_EVENT_LABELS));
+  const activity = data.events.filter((event) => event in ACTIVITY_EVENT_LABELS);
+  const lifecycle = data.events.filter((event) => event in LIFECYCLE_EVENT_LABELS);
+  const ignored = data.events.filter(
+    (event) => !(event in ACTIVITY_EVENT_LABELS) && !(event in LIFECYCLE_EVENT_LABELS),
+  );
 
   return (
     <div style={{ borderTop: "var(--hairline) solid var(--border)", paddingTop: "var(--sp-3)" }}>
@@ -183,7 +204,7 @@ export function GithubConnectionDetails({
             paddingLeft: "var(--sp-5)",
           }}
         >
-          <DetailBlock label="Required by First Tree">
+          <DetailBlock label="Required for automatic replies">
             <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
               {required.map((permission) => (
                 <RequiredPermissionRow
@@ -211,10 +232,17 @@ export function GithubConnectionDetails({
 
           <DetailBlock label="Events First Tree listens for">
             <p className="text-label m-0" style={{ color: "var(--fg-2)" }}>
-              {consumed.length > 0
-                ? consumed.map((event) => CONSUMED_EVENT_LABELS[event]).join(" · ")
+              {activity.length > 0
+                ? activity.map((event) => ACTIVITY_EVENT_LABELS[event]).join(" · ")
                 : "None of this installation's subscriptions produce First Tree activity."}
             </p>
+            {lifecycle.length > 0 && (
+              // Handled, just not by the activity path — say so, or a normally
+              // configured installation reads as carrying dead subscriptions.
+              <p className="text-caption m-0" style={{ marginTop: "var(--sp-1)", color: "var(--fg-3)" }}>
+                Kept in sync from: {lifecycle.map((event) => LIFECYCLE_EVENT_LABELS[event]).join(" · ")}
+              </p>
+            )}
             {ignored.length > 0 && (
               // Named rather than hidden: "you subscribed to it, we drop it" is
               // the answer when someone is hunting a webhook that changed nothing.
@@ -232,7 +260,13 @@ export function GithubConnectionDetails({
                   <CopyInstallationId installationId={data.installationId} />
                 </span>
               </DetailField>
-              <DetailField term="Connected">{formatDate(data.createdAt)}</DetailField>
+              {/* "First seen", not "Connected": this is when First Tree first
+                  stored the installation. The row is created by the
+                  `installation.created` webhook while still unbound, and it
+                  survives a disconnect/rebind — so it is not the moment this
+                  team connected. Labelling it that way would put a wrong date
+                  into exactly the timeline this block exists to reconstruct. */}
+              <DetailField term="First seen">{formatDate(data.createdAt)}</DetailField>
               <DetailField term="Last updated">{formatDate(data.updatedAt)}</DetailField>
             </dl>
           </DetailBlock>

--- a/packages/web/src/pages/github-connection-details.tsx
+++ b/packages/web/src/pages/github-connection-details.tsx
@@ -5,7 +5,7 @@ import {
   githubPermissionSatisfies,
 } from "@first-tree/shared";
 import { Check, ChevronRight, CircleAlert, CircleCheck, Copy, ExternalLink } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useId, useState } from "react";
 import { Button } from "../components/ui/button.js";
 import { useCopyFeedback } from "../lib/use-copy-feedback.js";
 
@@ -126,7 +126,10 @@ export function GithubConnectionDetails({
   defaultOpen?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
-  const regionId = "github-connection-details";
+  // Per instance, not a module constant: the DEV gallery renders several of
+  // these on one page, and a shared literal would emit duplicate ids and an
+  // ambiguous `aria-controls`.
+  const regionId = useId();
   const required = readRequiredPermissions(data.permissions);
   const blocked = required.filter((permission) => !permission.satisfied);
   const requiredNames = new Set(required.map((permission) => permission.name));
@@ -253,7 +256,7 @@ function RequiredPermissionRow({
   const Glyph = permission.satisfied ? CircleCheck : CircleAlert;
   const color = permission.satisfied ? "var(--success)" : "var(--state-blocked)";
   return (
-    <div className="flex flex-col gap-1 sm:flex-row sm:items-center" style={{ gap: "var(--sp-2)" }}>
+    <div className="flex flex-col sm:flex-row sm:items-center" style={{ gap: "var(--sp-2)" }}>
       <span className="inline-flex min-w-0 flex-1 items-center" style={{ gap: "var(--sp-2)" }}>
         <Glyph aria-hidden className="h-4 w-4 shrink-0" style={{ color }} />
         <span className="text-label" style={{ color: "var(--fg)" }}>
@@ -280,19 +283,19 @@ function RequiredPermissionRow({
   );
 }
 
+/**
+ * Same shape as the other copy affordances in this app (`inline-command.tsx`,
+ * `invite-link-panel.tsx`): the visible label carries the state, including the
+ * `failed` one `useCopyFeedback` returns in a non-secure context or when the
+ * clipboard permission is denied. An icon-only button that ignores `failed`
+ * looks inert exactly when the copy didn't happen.
+ */
 function CopyInstallationId({ installationId }: { installationId: number }) {
   const { status, copy } = useCopyFeedback();
-  const copied = status === "copied";
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="xs"
-      aria-label={copied ? "Installation id copied" : "Copy installation id"}
-      title="Copy installation id"
-      onClick={() => void copy(String(installationId))}
-    >
-      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+    <Button type="button" variant="ghost" size="xs" onClick={() => void copy(String(installationId))}>
+      {status === "copied" ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      {status === "failed" ? "Copy failed" : status === "copied" ? "Copied" : "Copy"}
     </Button>
   );
 }

--- a/packages/web/src/pages/settings-github-preview.tsx
+++ b/packages/web/src/pages/settings-github-preview.tsx
@@ -1,20 +1,12 @@
-import {
-  ArrowRight,
-  Bot,
-  Building2,
-  ChevronRight,
-  ExternalLink,
-  FolderGit2,
-  Github,
-  PauseCircle,
-  User,
-} from "lucide-react";
+import type { GithubAppInstallationOutput } from "@first-tree/shared";
+import { ArrowRight, Bot, Building2, ExternalLink, FolderGit2, Github, PauseCircle, User } from "lucide-react";
 import { useState } from "react";
 import { Button } from "../components/ui/button.js";
 import { PageHeader } from "../components/ui/page-header.js";
 import { Section } from "../components/ui/section.js";
 import { Select } from "../components/ui/select.js";
 import { SettingRow } from "../components/ui/setting-row.js";
+import { GithubConnectionDetails } from "./github-connection-details.js";
 
 /**
  * DEV-only visual review for Settings → GitHub (the connected GitHub App
@@ -38,9 +30,11 @@ import { SettingRow } from "../components/ui/setting-row.js";
  * enough to review their hierarchy without a live GitHub installation.
  */
 
-const MOCK = {
+const MOCK: GithubAppInstallationOutput = {
+  installationId: 131952074,
+  accountType: "Organization",
   accountLogin: "agent-team-foundation",
-  accountType: "Organization" as const,
+  accountGithubId: 987654,
   permissions: {
     issues: "write",
     members: "read",
@@ -49,10 +43,18 @@ const MOCK = {
     contents: "write",
     pull_requests: "write",
     administration: "write",
-  } as Record<string, string>,
+  },
   events: ["issues", "issue_comment", "member", "pull_request", "pull_request_review", "push"],
+  suspended: false,
   manageUrl: "https://github.com/organizations/agent-team-foundation/settings/installations/131952074",
-  installationId: 131952074,
+  createdAt: "2026-08-03T09:12:00.000Z",
+  updatedAt: "2026-08-06T16:41:00.000Z",
+};
+
+/** Same installation with a downgraded scope — the one state worth acting on. */
+const MOCK_MISSING_PERMISSION: GithubAppInstallationOutput = {
+  ...MOCK,
+  permissions: { ...MOCK.permissions, pull_requests: "read" },
 };
 
 const AccountIcon = MOCK.accountType === "Organization" ? Building2 : User;
@@ -74,85 +76,6 @@ function SuspendedBanner() {
         This installation is suspended upstream. GitHub is not delivering webhooks and First Tree can't act as the App
         on this account. Unsuspend it from the GitHub side to restore service.
       </span>
-    </div>
-  );
-}
-
-function ConnectionDetails({ defaultOpen = false }: { defaultOpen?: boolean }) {
-  const [open, setOpen] = useState(defaultOpen);
-  const permissionEntries = Object.entries(MOCK.permissions);
-  const regionId = "github-connection-details";
-
-  return (
-    <div style={{ borderTop: "var(--hairline) solid var(--border)", paddingTop: "var(--sp-3)" }}>
-      <button
-        type="button"
-        onClick={() => setOpen((value) => !value)}
-        aria-expanded={open}
-        aria-controls={open ? regionId : undefined}
-        className="inline-flex items-center text-label"
-        style={{
-          gap: "var(--sp-1)",
-          color: "var(--fg-3)",
-          background: "transparent",
-          border: "none",
-          padding: 0,
-          cursor: "pointer",
-        }}
-      >
-        <ChevronRight
-          aria-hidden
-          className="h-3 w-3 transition-transform"
-          style={{ transform: open ? "rotate(90deg)" : "none" }}
-        />
-        Connection details
-      </button>
-
-      {open && (
-        <div
-          id={regionId}
-          style={{ display: "flex", flexDirection: "column", gap: "var(--sp-3)", marginTop: "var(--sp-3)" }}
-        >
-          {permissionEntries.length > 0 && (
-            <div>
-              <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
-                Permissions granted
-              </div>
-              <ul
-                className="text-body"
-                style={{
-                  listStyle: "none",
-                  padding: 0,
-                  margin: 0,
-                  display: "grid",
-                  gridTemplateColumns: "1fr 1fr",
-                  gap: "var(--sp-1)",
-                  color: "var(--fg-2)",
-                }}
-              >
-                {permissionEntries.map(([key, value]) => (
-                  <li key={key} className="mono">
-                    {key}: <strong style={{ color: "var(--fg)" }}>{value}</strong>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {MOCK.events.length > 0 && (
-            <div>
-              <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
-                Subscribed events
-              </div>
-              <div className="text-body mono" style={{ color: "var(--fg-2)" }}>
-                {MOCK.events.join(", ")}
-              </div>
-            </div>
-          )}
-          <span className="text-label" style={{ color: "var(--fg-3)" }}>
-            Installation #{MOCK.installationId}
-          </span>
-        </div>
-      )}
     </div>
   );
 }
@@ -226,7 +149,15 @@ function PageShell({ children }: { children: React.ReactNode }) {
   );
 }
 
-function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?: boolean; detailsOpen?: boolean }) {
+function InstalledCard({
+  suspended = false,
+  detailsOpen = false,
+  data = MOCK,
+}: {
+  suspended?: boolean;
+  detailsOpen?: boolean;
+  data?: GithubAppInstallationOutput;
+}) {
   return (
     <PageShell>
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-3)" }}>
@@ -238,9 +169,9 @@ function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?:
             <span className="inline-flex flex-wrap items-center" style={{ gap: "var(--sp-1_5)" }}>
               <span className="inline-flex items-center" style={{ gap: "var(--sp-1)" }}>
                 <AccountIcon className="h-3 w-3 shrink-0" aria-hidden />
-                Connected to github.com/{MOCK.accountLogin}
+                Connected to github.com/{data.accountLogin}
               </span>
-              <span style={{ color: "var(--fg-4)" }}>{MOCK.accountType}</span>
+              <span style={{ color: "var(--fg-4)" }}>{data.accountType}</span>
             </span>
           }
           control={
@@ -249,7 +180,7 @@ function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?:
                 Manage connection
               </Button>
               <Button asChild variant="outline" size="sm">
-                <a href={MOCK.manageUrl} target="_blank" rel="noreferrer">
+                <a href={data.manageUrl} target="_blank" rel="noreferrer">
                   Manage on GitHub
                   <ExternalLink className="h-3 w-3" />
                 </a>
@@ -257,7 +188,9 @@ function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?:
             </>
           }
         >
-          <ConnectionDetails defaultOpen={detailsOpen} />
+          {/* The real component, not a copy: the gallery is only useful while it
+              can't drift from what ships. */}
+          <GithubConnectionDetails data={data} defaultOpen={detailsOpen} />
         </SettingRow>
       </div>
     </PageShell>
@@ -366,8 +299,25 @@ export function SettingsGithubPreviewPage() {
         <InstalledCard />
       </Frame>
 
-      <Frame label="Connected — details expanded" note="the disclosure open: scopes, events, installation id">
+      <Frame
+        label="Connected — details expanded"
+        note="required scopes checked off, other grants secondary, events named, installation facts"
+      >
         <InstalledCard detailsOpen />
+      </Frame>
+
+      <Frame
+        label="Connected — a required scope is missing"
+        note="pull_requests downgraded to read: marked blocked, with what it costs and where to fix it"
+      >
+        <InstalledCard detailsOpen data={MOCK_MISSING_PERMISSION} />
+      </Frame>
+
+      <Frame
+        label="Missing scope — collapsed"
+        note="the shortfall still marks the closed disclosure, so it isn't hidden behind a click"
+      >
+        <InstalledCard data={MOCK_MISSING_PERMISSION} />
       </Frame>
 
       <Frame label="Suspended upstream" note="webhook delivery paused on GitHub's side — banner preserved">

--- a/packages/web/src/pages/settings-github-preview.tsx
+++ b/packages/web/src/pages/settings-github-preview.tsx
@@ -44,7 +44,20 @@ const MOCK: GithubAppInstallationOutput = {
     pull_requests: "write",
     administration: "write",
   },
-  events: ["issues", "issue_comment", "member", "pull_request", "pull_request_review", "push"],
+  // `installation` / `installation_repositories` are in here because a real
+  // App subscribes to them — they are the traffic that keeps this installation
+  // row and its repository coverage current. The gallery has to show them so
+  // the three event classes (activity / lifecycle / dropped) can be reviewed.
+  events: [
+    "installation",
+    "installation_repositories",
+    "issues",
+    "issue_comment",
+    "member",
+    "pull_request",
+    "pull_request_review",
+    "push",
+  ],
   suspended: false,
   manageUrl: "https://github.com/organizations/agent-team-foundation/settings/installations/131952074",
   createdAt: "2026-08-03T09:12:00.000Z",

--- a/packages/web/src/pages/settings-github-preview.tsx
+++ b/packages/web/src/pages/settings-github-preview.tsx
@@ -1,8 +1,20 @@
-import { Building2, ChevronRight, ExternalLink, PauseCircle, User } from "lucide-react";
+import {
+  ArrowRight,
+  Bot,
+  Building2,
+  ChevronRight,
+  ExternalLink,
+  FolderGit2,
+  Github,
+  PauseCircle,
+  User,
+} from "lucide-react";
 import { useState } from "react";
+import { Button } from "../components/ui/button.js";
 import { PageHeader } from "../components/ui/page-header.js";
 import { Section } from "../components/ui/section.js";
 import { Select } from "../components/ui/select.js";
+import { SettingRow } from "../components/ui/setting-row.js";
 
 /**
  * DEV-only visual review for Settings → GitHub (the connected GitHub App
@@ -20,9 +32,10 @@ import { Select } from "../components/ui/select.js";
  *   - **Not installed**         — the "Install on GitHub" CTA.
  *   - **Loading**               — the initial fetch state.
  *
- * Connection and automatic handling are separate provider-owned sections. The
- * markup here mirrors the real page closely enough to review their hierarchy
- * without a live GitHub installation.
+ * Connection, automatic handling, and the Repositories hand-off are separate
+ * provider-owned sections, each a `SettingRow` (glyph + name + effect on the
+ * left, control right-aligned). The markup here mirrors the real page closely
+ * enough to review their hierarchy without a live GitHub installation.
  */
 
 const MOCK = {
@@ -149,35 +162,46 @@ function AutomaticHandlingPreview() {
   const agentName = agentUuid === "release-agent" ? "Release Agent" : "Dev Assistant";
 
   return (
-    <div
-      className="flex flex-col"
-      style={{
-        gap: "var(--sp-3)",
-        padding: "var(--sp-3) 0",
-      }}
-    >
-      <div>
-        <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
-          GitHub Task Agent
-        </span>
-        <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
-          {agentName} automatically handles Issue and pull request activity outside the Context Tree repository and
-          posts final replies as the First Tree GitHub App.
+    <SettingRow
+      icon={<Bot className="h-4 w-4" />}
+      title="GitHub Task Agent"
+      description={`${agentName} automatically handles Issue and pull request activity outside the Context Tree repository and posts final replies as the First Tree GitHub App.`}
+      control={
+        <div style={{ minWidth: "var(--sp-45)" }}>
+          <Select
+            aria-label="GitHub Task Agent"
+            value={agentUuid}
+            onChange={setAgentUuid}
+            options={[
+              { value: "dev-agent", label: "Dev Assistant", hint: "Runtime ready" },
+              { value: "release-agent", label: "Release Agent", hint: "Runtime ready" },
+            ]}
+          />
         </div>
-      </div>
-      <Select
-        aria-label="GitHub Task Agent"
-        value={agentUuid}
-        onChange={setAgentUuid}
-        options={[
-          { value: "dev-agent", label: "Dev Assistant", hint: "Runtime ready" },
-          { value: "release-agent", label: "Release Agent", hint: "Runtime ready" },
-        ]}
-      />
+      }
+    >
       <div className="text-caption" style={{ color: "var(--fg-4)" }}>
         Context Tree activity uses Context Reviewer. These roles must use different Agents.
       </div>
-    </div>
+    </SettingRow>
+  );
+}
+
+function RepositoriesPointerPreview() {
+  return (
+    <SettingRow
+      icon={<FolderGit2 className="h-4 w-4" />}
+      title="Team code repositories"
+      description="Repository URLs and the agents that may clone them live in the Repositories tab — they apply to GitLab too, so they aren't tied to this connection."
+      control={
+        <Button asChild variant="outline" size="sm">
+          <a href="/settings/repositories#code-repositories">
+            Manage repositories
+            <ArrowRight className="h-3 w-3" aria-hidden />
+          </a>
+        </Button>
+      }
+    />
   );
 }
 
@@ -194,6 +218,9 @@ function PageShell({ children }: { children: React.ReactNode }) {
         >
           <AutomaticHandlingPreview />
         </Section>
+        <Section title="Repositories">
+          <RepositoriesPointerPreview />
+        </Section>
       </div>
     </div>
   );
@@ -202,56 +229,36 @@ function PageShell({ children }: { children: React.ReactNode }) {
 function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?: boolean; detailsOpen?: boolean }) {
   return (
     <PageShell>
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "var(--sp-4)",
-        }}
-      >
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-3)" }}>
         {suspended && <SuspendedBanner />}
-        <div>
-          <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
-            Connected to
-          </div>
-          <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
-            <AccountIcon className="h-4 w-4" style={{ color: "var(--fg-2)" }} />
-            <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
-              {MOCK.accountLogin}
+        <SettingRow
+          icon={<Github className="h-4 w-4" />}
+          title="GitHub App"
+          description={
+            <span className="inline-flex flex-wrap items-center" style={{ gap: "var(--sp-1_5)" }}>
+              <span className="inline-flex items-center" style={{ gap: "var(--sp-1)" }}>
+                <AccountIcon className="h-3 w-3 shrink-0" aria-hidden />
+                Connected to github.com/{MOCK.accountLogin}
+              </span>
+              <span style={{ color: "var(--fg-4)" }}>{MOCK.accountType}</span>
             </span>
-            <span
-              className="text-label"
-              style={{
-                padding: "var(--sp-0_5) var(--sp-1_5)",
-                background: "var(--bg-sunken)",
-                borderRadius: "var(--radius-input)",
-                color: "var(--fg-3)",
-              }}
-            >
-              {MOCK.accountType}
-            </span>
-          </div>
-        </div>
-        <div>
-          <a
-            href={MOCK.manageUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center text-body"
-            style={{
-              gap: "var(--sp-1)",
-              padding: "var(--sp-1_5) var(--sp-2_5)",
-              border: "var(--hairline) solid var(--border)",
-              borderRadius: "var(--radius-input)",
-              color: "var(--fg)",
-              textDecoration: "none",
-            }}
-          >
-            Manage on GitHub
-            <ExternalLink className="h-3 w-3" />
-          </a>
-        </div>
-        <ConnectionDetails defaultOpen={detailsOpen} />
+          }
+          control={
+            <>
+              <Button type="button" variant="outline" size="sm">
+                Manage connection
+              </Button>
+              <Button asChild variant="outline" size="sm">
+                <a href={MOCK.manageUrl} target="_blank" rel="noreferrer">
+                  Manage on GitHub
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </Button>
+            </>
+          }
+        >
+          <ConnectionDetails defaultOpen={detailsOpen} />
+        </SettingRow>
       </div>
     </PageShell>
   );
@@ -266,53 +273,28 @@ function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?:
 function NotInstalledCard({ waiting = false }: { waiting?: boolean }) {
   return (
     <PageShell>
-      <div>
-        <p className="text-body" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-3)" }}>
-          Install the GitHub App on your personal account or organization to start receiving issues, pull requests, and
-          reviews as routed messages.
-        </p>
-        <button
-          type="button"
-          disabled={waiting}
-          className="inline-flex items-center justify-center font-medium"
-          style={{
-            gap: "var(--sp-1)",
-            padding: "var(--sp-2) var(--sp-3)",
-            background: "var(--primary)",
-            color: "var(--primary-on)",
-            border: "none",
-            borderRadius: "var(--radius-input)",
-            cursor: waiting ? "default" : "pointer",
-            opacity: waiting ? 0.6 : 1,
-          }}
-        >
-          Install on GitHub
-          <ExternalLink className="h-3 w-3" />
-        </button>
+      <SettingRow
+        icon={<Github className="h-4 w-4" />}
+        title="GitHub App"
+        description="This team isn't connected to GitHub yet. Connect a GitHub App installation to start receiving issues, pull requests, and reviews as routed messages."
+        control={
+          <Button type="button" size="sm" disabled={waiting}>
+            Install on GitHub
+            <ExternalLink className="h-3 w-3" />
+          </Button>
+        }
+      >
         {waiting && (
-          <div
-            className="flex items-center"
-            style={{ gap: "var(--sp-2_5)", marginTop: "var(--sp-3)", flexWrap: "wrap" }}
-          >
+          <div className="flex flex-wrap items-center" style={{ gap: "var(--sp-2_5)" }}>
             <span className="text-label" style={{ color: "var(--fg-3)" }}>
               Waiting for GitHub…
             </span>
-            <button
-              type="button"
-              className="text-label underline underline-offset-2"
-              style={{
-                background: "transparent",
-                border: "none",
-                padding: 0,
-                color: "var(--fg-3)",
-                cursor: "pointer",
-              }}
-            >
+            <Button type="button" variant="link" size="sm">
               Didn't work? Start over
-            </button>
+            </Button>
           </div>
         )}
-      </div>
+      </SettingRow>
     </PageShell>
   );
 }
@@ -372,9 +354,11 @@ export function SettingsGithubPreviewPage() {
           Settings → GitHub — shipped layout
         </h1>
         <p className="text-body" style={{ color: "var(--fg-3)" }}>
-          Lean default: who's connected + Manage on GitHub. Permissions, subscribed events, and the installation id sit
-          behind a collapsed "Connection details" disclosure (click to toggle). GitHub Task Agent lives in the adjacent
-          Automatic handling section instead of appearing as a standalone Setup capability.
+          Every section is one row: glyph + what it is + what it currently does on the left, the control that changes it
+          right-aligned. Permissions, subscribed events, and the installation id sit behind a collapsed "Connection
+          details" disclosure (click to toggle). GitHub Task Agent lives in the adjacent Automatic handling section
+          instead of appearing as a standalone Setup capability, and Repositories hands off to the provider-neutral
+          catalog rather than dead-ending here.
         </p>
       </div>
 

--- a/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
@@ -344,6 +344,23 @@ describe("SettingsGithubPage — automatic handling", () => {
     await act(async () => root.unmount());
   });
 
+  it("hands off to the provider-neutral repository catalog below automatic handling", async () => {
+    const { SettingsGithubPage } = await import("../github.js");
+    const { container, root } = await renderAt("/settings/integrations/github", <SettingsGithubPage />);
+    await waitForText(container, "Team code repositories");
+
+    const link = await waitForSelector<HTMLAnchorElement>(
+      container,
+      'a[href="/settings/repositories#code-repositories"]',
+    );
+    expect(link.textContent).toContain("Manage repositories");
+    // The hand-off closes the page — it must not push automatic handling down.
+    const taskRouting = await waitForSelector<HTMLElement>(container, "#task-routing");
+    expect(taskRouting.compareDocumentPosition(link) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+
+    await act(async () => root.unmount());
+  });
+
   it("shows members the configured Agent without exposing assignment controls", async () => {
     authMock.value = {
       role: "member",

--- a/packages/web/src/pages/settings/github-task-agent-controls.tsx
+++ b/packages/web/src/pages/settings/github-task-agent-controls.tsx
@@ -1,6 +1,7 @@
 import type { OrgGithubFeaturesOutput, SetupBlocker, TeamAgentCandidatesOutput } from "@first-tree/shared";
 import { setupBlockerCodeSchema } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Bot } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router";
 import { ApiError } from "../../api/client.js";
@@ -9,6 +10,7 @@ import { setupCapabilitiesQueryKey } from "../../api/setup-capabilities.js";
 import { getTeamAgentCandidates, putTeamAgentAssignment } from "../../api/team-agent-settings.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Select } from "../../components/ui/select.js";
+import { SettingRow } from "../../components/ui/setting-row.js";
 import { setupBlockerCopy } from "./setup-blocker-copy.js";
 
 export function GithubTaskAgentControls({
@@ -62,24 +64,20 @@ export function GithubTaskAgentControls({
   if (!isAdmin) {
     const projectedAgent = settingQuery.data?.teamAgent.agent ?? null;
     return (
-      <div
+      <SettingRow
         data-github-task-agent-controls="read-only"
-        className="flex flex-col"
-        style={{ gap: "var(--sp-1)", paddingTop: "var(--sp-3)" }}
-      >
-        <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
-          GitHub Task Agent
-        </span>
-        <span className="text-label" style={{ color: "var(--fg-3)" }}>
-          {settingQuery.isLoading
+        icon={<Bot className="h-4 w-4" />}
+        title="GitHub Task Agent"
+        description={
+          settingQuery.isLoading
             ? "Loading configured Agent…"
             : settingQuery.error
               ? "First Tree could not load the configured Agent."
               : projectedAgent
                 ? `${projectedAgent.displayName} automatically handles Issue and pull request activity outside the Context Tree repository and posts final replies as the First Tree GitHub App.`
-                : "Not configured. An admin can choose the Agent that automatically handles Issue and pull request activity outside the Context Tree repository and posts final replies as the First Tree GitHub App."}
-        </span>
-      </div>
+                : "Not configured. An admin can choose the Agent that automatically handles Issue and pull request activity outside the Context Tree repository and posts final replies as the First Tree GitHub App."
+        }
+      />
     );
   }
 
@@ -110,32 +108,46 @@ export function GithubTaskAgentControls({
     (item) => item.resolutionOwner === "admin" && item.actionKind === "manage_github_installation",
   );
   const error = settingQuery.error ?? candidatesQuery.error ?? assignmentMutation.error;
+  const loading = settingQuery.isLoading || candidatesQuery.isLoading;
+  const assignable = !loading && candidates.length > 0;
 
   return (
-    <div
+    <SettingRow
       data-github-task-agent-controls="admin"
-      className="flex flex-col"
-      style={{
-        gap: "var(--sp-3)",
-        padding: "var(--sp-3) 0",
-      }}
+      icon={<Bot className="h-4 w-4" />}
+      title="GitHub Task Agent"
+      description={
+        selectedLabel
+          ? `${selectedLabel} automatically handles Issue and pull request activity outside the Context Tree repository and posts final replies as the First Tree GitHub App.`
+          : "Choose the Agent that automatically handles Issue and pull request activity outside the Context Tree repository and posts final replies as the First Tree GitHub App."
+      }
+      control={
+        loading ? (
+          <span className="text-label" style={{ color: "var(--fg-3)" }}>
+            Loading eligible Agents…
+          </span>
+        ) : assignable ? (
+          // The picker keeps a readable minimum instead of stretching the full
+          // page width — it is one control in a column of controls, not a form.
+          <div style={{ minWidth: "var(--sp-45)" }}>
+            <Select
+              aria-label="GitHub Task Agent"
+              value={selectedAgentUuid ?? ""}
+              onChange={(agentUuid) => {
+                const next = agentUuid || null;
+                if (next === selectedAgentUuid) return;
+                assignmentMutation.mutate(next);
+              }}
+              disabled={assignmentMutation.isPending}
+              options={options}
+              placeholder="Select an eligible Agent"
+              searchable={candidates.length > 6}
+            />
+          </div>
+        ) : null
+      }
     >
-      <div>
-        <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
-          GitHub Task Agent
-        </span>
-        <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
-          {selectedLabel
-            ? `${selectedLabel} automatically handles Issue and pull request activity outside the Context Tree repository and posts final replies as the First Tree GitHub App.`
-            : "Choose the Agent that automatically handles Issue and pull request activity outside the Context Tree repository and posts final replies as the First Tree GitHub App."}
-        </div>
-      </div>
-
-      {settingQuery.isLoading || candidatesQuery.isLoading ? (
-        <div className="text-label" style={{ color: "var(--fg-3)" }}>
-          Loading eligible Agents…
-        </div>
-      ) : candidates.length === 0 ? (
+      {!loading && !assignable ? (
         <div className="text-label" style={{ color: "var(--fg-3)" }}>
           {blockerText(blockers)}
           {manageGithubInstallation ? (
@@ -158,33 +170,20 @@ export function GithubTaskAgentControls({
             </>
           ) : null}
         </div>
-      ) : (
-        <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-          <Select
-            aria-label="GitHub Task Agent"
-            value={selectedAgentUuid ?? ""}
-            onChange={(agentUuid) => {
-              const next = agentUuid || null;
-              if (next === selectedAgentUuid) return;
-              assignmentMutation.mutate(next);
-            }}
-            disabled={assignmentMutation.isPending}
-            options={options}
-            placeholder="Select an eligible Agent"
-            searchable={candidates.length > 6}
-          />
-          <div className="text-caption" style={{ color: "var(--fg-4)" }}>
-            Context Tree activity uses Context Reviewer. These roles must use different Agents.
-          </div>
+      ) : null}
+
+      {assignable ? (
+        <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+          Context Tree activity uses Context Reviewer. These roles must use different Agents.
         </div>
-      )}
+      ) : null}
 
       {error ? (
         <div role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
           {teamAgentMutationError(error)}
         </div>
       ) : null}
-    </div>
+    </SettingRow>
   );
 }
 

--- a/packages/web/src/pages/settings/github.tsx
+++ b/packages/web/src/pages/settings/github.tsx
@@ -1,11 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Check } from "lucide-react";
+import { ArrowRight, Check, FolderGit2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Link, useLocation, useSearchParams } from "react-router";
 import { getGithubAppInstallation } from "../../api/github-app.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
+import { SettingRow } from "../../components/ui/setting-row.js";
 import { clearGithubAccountLinkReturn, readGithubAccountLinkReturn } from "../../lib/github-account-link-return.js";
 import { clearGithubInstallAttempt, readGithubInstallAttempt } from "../../lib/github-install-attempt.js";
 import { GithubAppInstallationPanel } from "../github-app-installation-panel.js";
@@ -198,7 +199,34 @@ export function SettingsGithubPage() {
           <GithubTaskAgentControls />
         </Section>
       </section>
+      <RepositoriesPointer />
     </div>
+  );
+}
+
+/**
+ * Connecting GitHub is the moment people go looking for "where do I add my
+ * repos" — but the code catalog is provider-neutral and lives on Settings →
+ * Repositories (this page used to host it under `#code-access`). Close the loop
+ * with an explicit hand-off instead of letting the page dead-end.
+ */
+function RepositoriesPointer() {
+  return (
+    <Section title="Repositories">
+      <SettingRow
+        icon={<FolderGit2 className="h-4 w-4" />}
+        title="Team code repositories"
+        description="Repository URLs and the agents that may clone them live in the Repositories tab — they apply to GitLab too, so they aren't tied to this connection."
+        control={
+          <Button asChild variant="outline" size="sm">
+            <Link to="/settings/repositories#code-repositories">
+              Manage repositories
+              <ArrowRight className="h-3 w-3" aria-hidden />
+            </Link>
+          </Button>
+        }
+      />
+    </Section>
   );
 }
 

--- a/packages/web/src/pages/styleguide-preview.tsx
+++ b/packages/web/src/pages/styleguide-preview.tsx
@@ -1,3 +1,4 @@
+import { Plug } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { AgentStatusChip } from "../components/ui/agent-status-chip.js";
 import { Badge } from "../components/ui/badge.js";
@@ -25,6 +26,7 @@ import { PresenceChip } from "../components/ui/presence-chip.js";
 import { SectionHeader, UppercaseLabel } from "../components/ui/section-header.js";
 import { SegmentedControl } from "../components/ui/segmented-control.js";
 import { Select } from "../components/ui/select.js";
+import { SettingRow } from "../components/ui/setting-row.js";
 import { StateChip } from "../components/ui/state-chip.js";
 import { StateDot } from "../components/ui/state-dot.js";
 import { StatusGlyph } from "../components/ui/status-glyph.js";
@@ -697,7 +699,7 @@ export function StyleguidePreviewPage() {
         </Section>
 
         {/* ─── Containers ────────────────────────────────────────────────── */}
-        <Section title="Containers" subtitle="Card, Panel, Tile.">
+        <Section title="Containers" subtitle="Card, Panel, SettingRow, Tile.">
           <Row>
             <Card style={{ width: "20rem" }}>
               <CardHeader>
@@ -723,6 +725,31 @@ export function StyleguidePreviewPage() {
               </PanelBody>
             </Panel>
           </Row>
+          <Subhead>SettingRow</Subhead>
+          <div style={{ width: "100%", borderTop: "var(--hairline) solid var(--border)" }}>
+            {/* No chrome of its own — an enclosing Section owns the rule above.
+                Extras hang off the row's text column, not the container edge. */}
+            <SettingRow
+              icon={<Plug className="h-4 w-4" />}
+              title="GitHub App"
+              description="Connected to github.com/acme"
+              control={
+                <Button variant="outline" size="sm">
+                  Manage
+                </Button>
+              }
+            >
+              <span className="text-label" style={{ color: "var(--fg-3)" }}>
+                Extras indent to the title, so the block reads as one column.
+              </span>
+            </SettingRow>
+            <SettingRow
+              title="No glyph"
+              description="Without a leading glyph the row and its extras stay flush."
+              control={<Badge variant="secondary">optional</Badge>}
+            />
+          </div>
+
           <Subhead>Tile</Subhead>
           <Row>
             <Tile label="Agents" value="12" />


### PR DESCRIPTION
## Summary

- Rework Settings → Integrations → GitHub around a single row shape — leading glyph, what the setting is, what it currently does, and the control that changes it right-aligned — instead of three differently-shaped stacks of label / description / full-width control. Adds a shared `SettingRow` primitive, moves the connection summary and the GitHub Task Agent picker onto it, and adds a Repositories hand-off.
- The page is scanned, not read. Keeping "what it is" on the left and "change it" in one right-hand column lets the eye run straight down the controls, and stops a narrow `Select` from stretching the full page width. Connecting GitHub is also the moment people go looking for "where do I add my repos" — the catalog is provider-neutral and lives on Settings → Repositories, which this page previously offered no route to, so it dead-ended.
- Connection details then grew past presentation: it now answers whether the installation can actually do the thing the reader is waiting on, deriving its permission readout from the same set the server's task-reply gate enforces (`GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS` in `@first-tree/shared`), so the Settings readout and the assignment gate cannot disagree.

Reference for the visual direction: the Multica GitHub settings page (glyph + name + effect on the left, control on the right, one labelled section per concern).

`SettingRow` deliberately draws **no** border, background, or radius of its own. The enclosing `Section` keeps owning the single rule above the block, so this does not reintroduce the double framing #2197 removed — card chrome stays reserved for genuinely selectable surfaces per DESIGN.md Pillar 5. The one borrowed piece of chrome is the small sunken tile behind each row's glyph.

Visual review: `/preview/settings-github` (DEV-only) mirrors all six states.

## Diagnostics: each claim scoped to what it proves

Review found three readouts asserting more than their data supports; all three are fixed here, and each has a regression test:

- **"Required for automatic replies"**, not "Required by First Tree". `issues: write` + `pull_requests: write` gate the GitHub Task Agent's automatic replies only — Context Reviewer, repository coverage, and the capability probe each gate on their own permissions and events. The constant is named `GITHUB_TASK_REPLY_REQUIRED_PERMISSIONS` to match.
- **Lifecycle events are not "unused".** `installation` / `installation_repositories` are consumed by `handleInstallationLifecycle` before `buildRule` is reached, and are what keeps the installation row and its repository coverage current. They now have their own class ("Kept in sync from"), so a normally configured installation is no longer reported as carrying dead subscriptions.
- **"First seen"**, not "Connected". `github_app_installations.created_at` is written by the `installation.created` webhook while the row is still unbound, and survives a disconnect/rebind — it is not the moment this team connected. This block exists to reconstruct a timeline, which is where a wrong date does the most damage.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test` — `@first-tree/shared` (74 files / 864 tests), `@first-tree/web` (248 files / 2284 tests), and `@first-tree/server` (266 files / 3124 tests) are all green locally, which covers every package this PR touches. Repo-wide `pnpm test` also has failures in `apps/cli` and `packages/skill-evals`; I reproduced both unchanged on the base commit (`54bcb109c`) in a clean worktree, so they are pre-existing and unrelated.
- [x] `/preview/settings-github` re-checked after the diagnostics fixes — the gallery fixture now subscribes to the lifecycle events a real App carries, so all three event classes (activity / lifecycle / dropped) are reviewable.

Change surface: `packages/web/src`, `packages/shared/src` (the task-reply permission set + `githubPermissionSatisfies`), `packages/server/src` (`team-agent-settings.ts` reads the shared set), and `packages/qa/cases/`. No database or migration change.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none.
- docs or tests updated to match: new `SettingRow` DOM test; the GitHub page test covers the Repositories hand-off and its position; the installation-panel test asserts the connection row's name; `github-connection-details-dom.test.tsx` pins the scoped requirement heading, the lifecycle-vs-unused split, and the `First seen` label; `github-task-reply-required-permissions.test.ts` pins the shared set and the exact-match comparison. The `/preview/settings-github` gallery is updated so it keeps mirroring the shipped layout.
- QA risk: this stopped being presentation-only once the connection readout started deriving from the same requirement set as the server's task-agent gate. `packages/qa/cases/cross-surface/github-settings-connection-panel.md` is updated in this PR: its Web-UI expectations now cover the new section headings, the satisfied/blocked permission states, the lifecycle-event classification, the `First seen` label, and the requirement that the readout and the server gate never disagree.
- follow-up work: `SettingRow` is reusable — Settings → GitLab is the obvious next adopter, and a `SettingRowList` (hairline between consecutive rows) is worth adding when a section first needs more than one row. Also happy to drop the glyph tile if it reads as too much chrome for this system; it is one prop.

## Known risks, deliberately not addressed here

- **`ACTIVITY_EVENT_LABELS` mirrors `buildRule` in `github-normalize.ts` with nothing binding them.** Add an event there and this page will label it "Subscribed but unused" — wrong in a way that reads authoritative. The same drift is possible for `LIFECYCLE_EVENT_LABELS` against the webhook route's lifecycle branch. Fixing it properly means moving both lists to `@first-tree/shared` plus a server test asserting the handlers cover exactly those sets; that is its own change.
- **`-ml-3` on the disclosure encodes Button `size="sm"`'s `px-3`.** If that padding changes, the chevron silently drifts off the row's text column. There is no shared token for "cancel a button's own inset".
- **Settings → GitLab still uses the old stacked layout,** so the two provider tabs read differently until it adopts `SettingRow`.
- **`githubPermissionSatisfies` is an exact match on purpose.** GitHub's `write` does imply `read`, so a ranked comparison is arguably more correct — but it has to change all ten call sites at once (`github-audience`, both publishers, `setup-capabilities`, `org-settings`, `context-reviewer-common`) or the UI and the routing/publish paths disagree again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
