### PR TITLE
fix(server): ACE-39 reject publishing an Agent Template with no components

### DIFF
--- a/packages/server/src/__tests__/agent-templates.test.ts
+++ b/packages/server/src/__tests__/agent-templates.test.ts
@@ -341,6 +341,36 @@ describe("Agent Template catalog", () => {
       expect(reactivate.statusCode).toBe(409);
     });
 
+    // A component-less Template can never be adopted, so publish must reject
+    // it at the source instead of letting it reach the public catalog and
+    // fail only once a real user clicks Use.
+    it("rejects publishing a Template with no components and leaves it draft", async () => {
+      const app = getApp();
+      const publisher = await createPublisherAdmin(app);
+      const draft = await createDraft(app, publisher, []);
+
+      const rejected = await call(app, publisher, "POST", `${INTERNAL_URL}/${draft.id}/publish`, {
+        expectedUpdatedAt: draft.updatedAt,
+      });
+      expect(rejected.statusCode).toBe(409);
+      expect(rejected.json<{ error: string }>().error).toContain("has no components");
+
+      const detail = await call(app, publisher, "GET", `${INTERNAL_URL}/${draft.id}`);
+      expect(detail.statusCode).toBe(200);
+      const unchanged = detail.json<{ status: string; updatedAt: string }>();
+      expect(unchanged.status).toBe("draft");
+      expect(unchanged.updatedAt).toBe(draft.updatedAt);
+
+      // The draft is still publishable once it actually carries a component.
+      const filled = await call(app, publisher, "PATCH", `${INTERNAL_URL}/${draft.id}`, {
+        expectedUpdatedAt: draft.updatedAt,
+        components: [promptComponent()],
+      });
+      expect(filled.statusCode).toBe(200);
+      const active = await publish(app, publisher, filled.json<{ id: string; updatedAt: string }>());
+      expect(active.status).toBe("active");
+    });
+
     it("allows slug edits only while draft", async () => {
       const app = getApp();
       const publisher = await createPublisherAdmin(app);

--- a/packages/server/src/services/agent-templates.ts
+++ b/packages/server/src/services/agent-templates.ts
@@ -407,6 +407,12 @@ export async function publishAgentTemplate(
     // projection still matches its real bundle before the Template becomes
     // adoptable.
     const payload = agentTemplatePayloadSchema.parse(row.payload);
+    // A component-less draft is legal while drafting but can never be
+    // adopted, so publish rejects it here instead of letting it reach the
+    // public catalog and fail in adoption (see lockAndVerifyTemplate).
+    if (payload.components.length === 0) {
+      throw new ConflictError(`Agent Template "${templateId}" has no components and cannot be published.`);
+    }
     await lockBundleAttachments(targetDb, skillBundleIds(payload.components));
     for (const component of payload.components) {
       if (component.type !== "skill") continue;


### PR DESCRIPTION
## Summary

- `publishAgentTemplate` re-parsed the stored payload and verified every Skill bundle projection, but never checked the component count. `agentTemplatePayloadSchema` intentionally allows an empty `components` array (drafts start empty), so a component-less draft published cleanly and showed up in the public catalog like any other Template.
- The only check lived downstream in `lockAndVerifyTemplate` (`agent-template-adoption.ts`), which throws `has no components and cannot be adopted`. That pushed the error to the worst possible place: the publisher saw a successful publish, the catalog looked fine, and the failure only surfaced once a real user clicked **Use**.
- Publish now rejects an empty payload inside the transaction with a `ConflictError` (409) worded to match the adoption-side check, so the publisher gets the feedback at publish time and the Template stays `draft`. Non-empty publishes are unchanged.

Fixes ACE-39.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test`

`packages/server`: 3125 tests pass, including the new case. Full-suite runs on this machine also surfaced timeout-only failures in `@first-tree/client`, `@first-tree/web`, and `@first-tree/skill-evals`; each passes in isolation. The one exception is `client/src/__tests__/pi-handler.test.ts > exhausts active version-gate timeout...`, which fails identically on the unmodified base commit (`54bcb109c`) because it needs a working `pi` binary on the host — pre-existing, unrelated to this change.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none.
- docs or tests updated to match: added `rejects publishing a Template with no components and leaves it draft` to `packages/server/src/__tests__/agent-templates.test.ts` — asserts the 409, that the row stays `draft` with an unchanged `updatedAt` token, and that the same draft publishes fine once it carries a component. No docs reference publish preconditions.
- follow-up work: the shared schema still allows `components: []` by design so drafts can be created empty; publish is the right gate. If empty drafts turn out to have no use, `.min(1)` on the write-source schema would be a separate, larger contract change.
