### PR TITLE
test(server): stabilize context receipt tampering

### DIFF
--- a/packages/server/src/__tests__/org-context-activation.test.ts
+++ b/packages/server/src/__tests__/org-context-activation.test.ts
@@ -250,7 +250,10 @@ describe("org-scoped member Context activation", () => {
     });
     expect((await validate({ kind: "path", root: "/tmp/changed" })).statusCode).toBe(403);
 
-    const tampered = `${receipt.slice(0, -1)}${receipt.endsWith("a") ? "b" : "a"}`;
+    // Mutate a fully significant Base64URL character rather than trailing pad bits.
+    const signatureStart = receipt.lastIndexOf(".") + 1;
+    const signatureHead = receipt.charAt(signatureStart);
+    const tampered = `${receipt.slice(0, signatureStart)}${signatureHead === "A" ? "B" : "A"}${receipt.slice(signatureStart + 1)}`;
     const rejected = await app.inject({
       method: "POST",
       url: "/api/v1/me/context-activation/session-candidate/validate",


### PR DESCRIPTION
## Summary

- tamper the first Base64URL character of the JWT signature instead of its final character
- guarantee that the negative-path receipt differs at the decoded-byte level, eliminating the roughly 1/16 padding-bit alias

## Validation

- [x] `pnpm exec biome check packages/server/src/__tests__/org-context-activation.test.ts`
- [x] `pnpm --filter @first-tree/server typecheck`
- [x] `pnpm --filter @first-tree/server exec vitest run src/__tests__/org-context-activation.test.ts --maxWorkers=2` (exact commit: 7 tests passed)
- [x] `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2` (275 files / 3202 tests passed)

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: test-only fix
- follow-up work: none
