### PR TITLE
refactor(server): extract agent runtime binding boundary

### DIFF
--- a/packages/server/src/__tests__/agent-service-extra.test.ts
+++ b/packages/server/src/__tests__/agent-service-extra.test.ts
@@ -13,7 +13,6 @@ import {
   clearAgentAvatarImage,
   createAgent,
   deleteAgent,
-  ensureClientSupportsRuntimeProvider,
   getAgentAvatarImage,
   getAgentSkills,
   listAgentsForAdmin,
@@ -25,6 +24,7 @@ import {
   updateAgent,
   updateAgentSkills,
 } from "../services/agent.js";
+import { ensureClientSupportsRuntimeProvider } from "../services/agent-runtime-binding.js";
 import { createMember } from "../services/member.js";
 import { createOrganization } from "../services/organization.js";
 import { createAdminContext, useTestApp } from "./helpers.js";

--- a/packages/server/src/__tests__/service-branch-defaults.test.ts
+++ b/packages/server/src/__tests__/service-branch-defaults.test.ts
@@ -5,7 +5,6 @@ import {
   agentAvatarImageUrl,
   assertUserAgentMetadataHasNoReservedKeys,
   deleteAgent,
-  ensureClientSupportsRuntimeProvider,
   fetchUserAvatarForHumanAgent,
   listAgents,
   reactivateAgent,
@@ -13,6 +12,7 @@ import {
   stripReservedAgentMetadata,
   suspendAgent,
 } from "../services/agent.js";
+import { ensureClientSupportsRuntimeProvider } from "../services/agent-runtime-binding.js";
 import { assertNoRuntimeSwitchInProgress, getRuntimeSwitchClaim } from "../services/agent-runtime-switch.js";
 import { createChat, resolveAgentIdsByNameInOrg, updateChatMetadata } from "../services/chat/conversation.js";
 import { maybeUnwrapDoubleEncoded, preflightMessageSendIntent } from "../services/chat/message.js";

--- a/packages/server/src/scope/require-resource.ts
+++ b/packages/server/src/scope/require-resource.ts
@@ -10,7 +10,7 @@ import { gitlabIdentityLinks } from "../db/schema/gitlab-identity-links.js";
 import { members } from "../db/schema/members.js";
 import { NotFoundError } from "../errors.js";
 import { stampAgentResource, stampChatResource, stampOrgScope } from "../observability/request-context.js";
-import { selectAgentRowWithRuntime } from "../services/agent.js";
+import { selectAgentRowWithRuntime } from "../services/agent-runtime-binding.js";
 import { requireUser } from "./require-user.js";
 import type { OrgScope } from "./types.js";
 
@@ -46,7 +46,7 @@ type AgentRow = {
    * the agent has no presence row yet (never bound a runtime client). Used
    * by management surfaces to derive reachability (online/offline) without
    * relying on the legacy `presenceStatus` column. Loaded via the shared
-   * `selectAgentRowWithRuntime` projection (services/agent.ts).
+   * `selectAgentRowWithRuntime` projection (services/agent-runtime-binding.ts).
    */
   runtimeState: string | null;
   createdAt: Date;

--- a/packages/server/src/services/agent-runtime-binding.ts
+++ b/packages/server/src/services/agent-runtime-binding.ts
@@ -1,0 +1,128 @@
+import type { RuntimeProvider } from "@first-tree/shared";
+import { eq, getTableColumns } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+import { BadRequestError, ClientRetiredError } from "../errors.js";
+
+type SelectDbLike = Pick<PostgresJsDatabase<Record<string, never>>, "select">;
+
+/**
+ * True iff `clients.metadata.capabilities` is a non-empty object — i.e. the
+ * client has reported at least one runtime probe result. Used to distinguish
+ * "we don't know what's installed yet" (empty / never reported) from
+ * "client explicitly reports this provider is missing".
+ */
+function clientCapabilitiesReported(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== "object") return false;
+  const meta = metadata as Record<string, unknown>;
+  const caps = meta.capabilities;
+  if (!caps || typeof caps !== "object") return false;
+  return Object.keys(caps as Record<string, unknown>).length > 0;
+}
+
+/**
+ * Inspect a `clients.metadata.capabilities` blob (jsonb) for a specific
+ * runtime provider entry. Capabilities live under the `metadata.capabilities`
+ * subkey (Option C); the column is unstructured at the DB layer, so we
+ * defensively narrow before key access.
+ *
+ * "Supports" requires the entry to be **available** — i.e. `available === true`,
+ * which under install-only detection means `state: "ok"` (the binary is
+ * installed). A `missing` or `error` entry is *reported* but not installed, so
+ * we explicitly reject those rather than treating mere key presence as support.
+ * Authentication is no longer probed; a logged-out provider is still `available`
+ * (installed) and the login is resolved at session run time via the in-chat
+ * needs-login entry, not gated here.
+ */
+function clientSupportsRuntimeProvider(metadata: unknown, provider: RuntimeProvider): boolean {
+  if (!metadata || typeof metadata !== "object") return false;
+  const meta = metadata as Record<string, unknown>;
+  const caps = meta.capabilities;
+  if (!caps || typeof caps !== "object") return false;
+  const entry = (caps as Record<string, unknown>)[provider];
+  if (!entry || typeof entry !== "object") return false;
+  const available = (entry as { available?: unknown }).available;
+  return available === true;
+}
+
+/**
+ * Check that a client's reported capabilities show the given runtime provider
+ * as **available** (SDK installed, regardless of auth state).
+ *
+ * Tri-state semantics by `clients.metadata.capabilities` shape:
+ *   - empty / absent — client hasn't probed yet (newly registered or pre-P2
+ *     install). Treat as "unknown" and allow; the in-band repair path
+ *     (RUNTIME_PROVIDER_MISMATCH on bind) catches actual incompatibility.
+ *   - reported, entry shows `available: true` (install-only `state: ok`) — allow.
+ *   - reported, entry missing OR `state: missing | error` — block unless
+ *     `force` is set. We deliberately do NOT treat mere key presence as
+ *     support: probeCapabilities() always emits an entry per built-in
+ *     provider, including `{ state: "missing" }` for absent SDKs.
+ *
+ * Skipped entirely for human agents (no clientId) and when `force` is set
+ * (e.g. operator overrides for an offline client).
+ */
+export async function ensureClientSupportsRuntimeProvider(
+  db: SelectDbLike,
+  clientId: string | null,
+  runtimeProvider: RuntimeProvider,
+  options: { force?: boolean } = {},
+): Promise<void> {
+  if (clientId === null) return;
+  if (options.force) return;
+
+  const [client] = await db
+    .select({ metadata: clients.metadata, retiredAt: clients.retiredAt })
+    .from(clients)
+    .where(eq(clients.id, clientId))
+    .limit(1);
+  if (!client) return; // resolveAgentClient validates existence elsewhere
+  if (client.retiredAt) {
+    throw new ClientRetiredError(`Client "${clientId}" has been retired`);
+  }
+
+  // Best-effort: if the client never reported capabilities, allow and let
+  // the runtime path catch real mismatches at bind time.
+  if (!clientCapabilitiesReported(client.metadata)) return;
+
+  if (!clientSupportsRuntimeProvider(client.metadata, runtimeProvider)) {
+    throw new BadRequestError(
+      `Client "${clientId}" does not have runtime provider "${runtimeProvider}" available. ` +
+        "Install the matching SDK on that machine and re-run capability detection, " +
+        "or retry with `force: true` if the client is offline / capabilities are stale.",
+    );
+  }
+}
+
+/**
+ * Reusable projection for single-agent reads + mutation responses: every
+ * column on `agents` plus `agent_presence.runtimeState` (the M1+ authority
+ * for "is this agent running"; NULL when the agent has no presence row
+ * yet, i.e. never bound a runtime client).
+ *
+ * Threading this through `getAgent`, `requireAgentAccess`, and every
+ * mutation service is what keeps `runtimeState` on the wire across all
+ * single-agent endpoints — see PR #571 review: the previous shape lost
+ * the field on `GET /:uuid` and every PATCH/suspend/reactivate
+ * response, which made management surfaces (Team / Settings) read a
+ * fictitious "offline" state.
+ *
+ * Returns `null` when no row exists (the caller decides whether that's a
+ * 404 or an internal invariant violation post-update).
+ */
+export async function selectAgentRowWithRuntime(db: SelectDbLike, uuid: string): Promise<AgentRowWithRuntime | null> {
+  const [row] = await db
+    .select({
+      ...getTableColumns(agents),
+      runtimeState: agentPresence.runtimeState,
+    })
+    .from(agents)
+    .leftJoin(agentPresence, eq(agents.uuid, agentPresence.agentId))
+    .where(eq(agents.uuid, uuid))
+    .limit(1);
+  return row ?? null;
+}
+
+export type AgentRowWithRuntime = typeof agents.$inferSelect & { runtimeState: string | null };

--- a/packages/server/src/services/agent-runtime-switch.ts
+++ b/packages/server/src/services/agent-runtime-switch.ts
@@ -16,7 +16,7 @@ import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { BadRequestError, ClientRetiredError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
-import { ensureClientSupportsRuntimeProvider, selectAgentRowWithRuntime } from "./agent.js";
+import { ensureClientSupportsRuntimeProvider, selectAgentRowWithRuntime } from "./agent-runtime-binding.js";
 import { revokeAgentRuntimeSession } from "./agent-runtime-session.js";
 import { archiveAllSessionsForAgent } from "./chat/sessions/lifecycle.js";
 import { forceDisconnect } from "./connection-manager.js";

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -20,8 +20,7 @@ import {
   runtimeProviderSchema,
 } from "@first-tree/shared";
 import { getServerCliBinding } from "@first-tree/shared/channel";
-import { and, asc, count, desc, eq, getTableColumns, ilike, isNull, lt, ne, or, sql } from "drizzle-orm";
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { and, asc, count, desc, eq, ilike, isNull, lt, ne, or, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
@@ -38,6 +37,11 @@ import {
   agentNotLandingCampaignTrialCondition,
   agentVisibilityCondition,
 } from "./access-control.js";
+import {
+  type AgentRowWithRuntime,
+  ensureClientSupportsRuntimeProvider,
+  selectAgentRowWithRuntime,
+} from "./agent-runtime-binding.js";
 import { initializeAdoptedTemplates } from "./agent-template-adoption.js";
 import type { AttachmentBlobStore } from "./attachment-blob-store.js";
 import { recomputeWatchersForAgent } from "./chat/membership/watcher.js";
@@ -49,7 +53,6 @@ import { resolveDefaultOrgId } from "./organization.js";
  * internal traffic could be routed through a real account.
  */
 const RESERVED_AGENT_NAME_PREFIX = "__";
-type SelectDbLike = Pick<PostgresJsDatabase<Record<string, never>>, "select">;
 export type NewChatDefaultCandidateAgent = {
   uuid: string;
   name: string | null;
@@ -145,45 +148,6 @@ export async function fetchUserAvatarForHumanAgent(
 }
 
 /**
- * True iff `clients.metadata.capabilities` is a non-empty object — i.e. the
- * client has reported at least one runtime probe result. Used to distinguish
- * "we don't know what's installed yet" (empty / never reported) from
- * "client explicitly reports this provider is missing".
- */
-function clientCapabilitiesReported(metadata: unknown): boolean {
-  if (!metadata || typeof metadata !== "object") return false;
-  const meta = metadata as Record<string, unknown>;
-  const caps = meta.capabilities;
-  if (!caps || typeof caps !== "object") return false;
-  return Object.keys(caps as Record<string, unknown>).length > 0;
-}
-
-/**
- * Inspect a `clients.metadata.capabilities` blob (jsonb) for a specific
- * runtime provider entry. Capabilities live under the `metadata.capabilities`
- * subkey (Option C); the column is unstructured at the DB layer, so we
- * defensively narrow before key access.
- *
- * "Supports" requires the entry to be **available** — i.e. `available === true`,
- * which under install-only detection means `state: "ok"` (the binary is
- * installed). A `missing` or `error` entry is *reported* but not installed, so
- * we explicitly reject those rather than treating mere key presence as support.
- * Authentication is no longer probed; a logged-out provider is still `available`
- * (installed) and the login is resolved at session run time via the in-chat
- * needs-login entry, not gated here.
- */
-function clientSupportsRuntimeProvider(metadata: unknown, provider: RuntimeProvider): boolean {
-  if (!metadata || typeof metadata !== "object") return false;
-  const meta = metadata as Record<string, unknown>;
-  const caps = meta.capabilities;
-  if (!caps || typeof caps !== "object") return false;
-  const entry = (caps as Record<string, unknown>)[provider];
-  if (!entry || typeof entry !== "object") return false;
-  const available = (entry as { available?: unknown }).available;
-  return available === true;
-}
-
-/**
  * Default visibility per agent type. Both `human` and `agent` default to
  * "organization" — the bot-style default that pre-merge `autonomous_agent`
  * carried. The "personal assistant" framing (private to the manager) is now
@@ -211,57 +175,8 @@ function defaultVisibility(type: AgentType): AgentVisibility {
  *   - When a non-human agent IS created with a `clientId`, the pinned client
  *     must already be owned by the manager's user (Rule R-RUN).
  */
-/**
- * Check that a client's reported capabilities show the given runtime provider
- * as **available** (SDK installed, regardless of auth state).
- *
- * Tri-state semantics by `clients.metadata.capabilities` shape:
- *   - empty / absent — client hasn't probed yet (newly registered or pre-P2
- *     install). Treat as "unknown" and allow; the in-band repair path
- *     (RUNTIME_PROVIDER_MISMATCH on bind) catches actual incompatibility.
- *   - reported, entry shows `available: true` (install-only `state: ok`) — allow.
- *   - reported, entry missing OR `state: missing | error` — block unless
- *     `force` is set. We deliberately do NOT treat mere key presence as
- *     support: probeCapabilities() always emits an entry per built-in
- *     provider, including `{ state: "missing" }` for absent SDKs.
- *
- * Skipped entirely for human agents (no clientId) and when `force` is set
- * (e.g. operator overrides for an offline client).
- */
-export async function ensureClientSupportsRuntimeProvider(
-  db: SelectDbLike,
-  clientId: string | null,
-  runtimeProvider: RuntimeProvider,
-  options: { force?: boolean } = {},
-): Promise<void> {
-  if (clientId === null) return;
-  if (options.force) return;
-
-  const [client] = await db
-    .select({ metadata: clients.metadata, retiredAt: clients.retiredAt })
-    .from(clients)
-    .where(eq(clients.id, clientId))
-    .limit(1);
-  if (!client) return; // resolveAgentClient validates existence elsewhere
-  if (client.retiredAt) {
-    throw new ClientRetiredError(`Client "${clientId}" has been retired`);
-  }
-
-  // Best-effort: if the client never reported capabilities, allow and let
-  // the runtime path catch real mismatches at bind time.
-  if (!clientCapabilitiesReported(client.metadata)) return;
-
-  if (!clientSupportsRuntimeProvider(client.metadata, runtimeProvider)) {
-    throw new BadRequestError(
-      `Client "${clientId}" does not have runtime provider "${runtimeProvider}" available. ` +
-        "Install the matching SDK on that machine and re-run capability detection, " +
-        "or retry with `force: true` if the client is offline / capabilities are stale.",
-    );
-  }
-}
-
 async function resolveAgentClient(
-  db: SelectDbLike,
+  db: Pick<Database, "select">,
   data: { clientId?: string; managerId: string; type: string },
 ): Promise<string | null> {
   if (data.type === "human") {
@@ -736,37 +651,6 @@ export async function checkAgentNameAvailability(
     .limit(1);
   return existing ? { available: false, reason: "taken" } : { available: true };
 }
-
-/**
- * Reusable projection for single-agent reads + mutation responses: every
- * column on `agents` plus `agent_presence.runtimeState` (the M1+ authority
- * for "is this agent running"; NULL when the agent has no presence row
- * yet, i.e. never bound a runtime client).
- *
- * Threading this through `getAgent`, `requireAgentAccess`, and every
- * mutation service is what keeps `runtimeState` on the wire across all
- * single-agent endpoints — see PR #571 review: the previous shape lost
- * the field on `GET /:uuid` and every PATCH/suspend/reactivate
- * response, which made management surfaces (Team / Settings) read a
- * fictitious "offline" state.
- *
- * Returns `null` when no row exists (the caller decides whether that's a
- * 404 or an internal invariant violation post-update).
- */
-export async function selectAgentRowWithRuntime(db: SelectDbLike, uuid: string): Promise<AgentRowWithRuntime | null> {
-  const [row] = await db
-    .select({
-      ...getTableColumns(agents),
-      runtimeState: agentPresence.runtimeState,
-    })
-    .from(agents)
-    .leftJoin(agentPresence, eq(agents.uuid, agentPresence.agentId))
-    .where(eq(agents.uuid, uuid))
-    .limit(1);
-  return row ?? null;
-}
-
-export type AgentRowWithRuntime = typeof agents.$inferSelect & { runtimeState: string | null };
 
 export async function getAgent(db: Database, uuid: string): Promise<AgentRowWithRuntime> {
   const agent = await selectAgentRowWithRuntime(db, uuid);


### PR DESCRIPTION
## Summary

- extract the runtime-aware agent projection and client runtime-provider capability guard into `agent-runtime-binding.ts`
- migrate agent, runtime-switch, scope, and test callers to the new canonical module
- remove the old `agent.ts` exports so runtime switching no longer closes the `agent -> agent-template-adoption -> agent-runtime-switch -> agent` dependency cycle

## Testing

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/agent-service-extra.test.ts src/__tests__/service-branch-defaults.test.ts src/__tests__/agent-runtime-switch.test.ts src/__tests__/agent-template-adoption.test.ts src/__tests__/admin-agents.test.ts --maxWorkers=1 --minWorkers=1`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/agent-runtime-binding.ts packages/server/src/services/agent.ts packages/server/src/services/agent-runtime-switch.ts packages/server/src/scope/require-resource.ts packages/server/src/__tests__/agent-service-extra.test.ts packages/server/src/__tests__/service-branch-defaults.test.ts`
- `git diff --check`

## Scope

This is a dependency-boundary-only refactor. It does not change APIs, database schema, shared or WebSocket protocols, runtime-switch behavior, template adoption, permissions, or user-visible behavior.
