### PR TITLE
test(server): isolate cron scheduler in test apps

### DIFF
--- a/packages/server/src/__tests__/background-tasks-extra.test.ts
+++ b/packages/server/src/__tests__/background-tasks-extra.test.ts
@@ -158,4 +158,17 @@ describe("createBackgroundTasks", () => {
 
     await tasks.stop();
   });
+
+  it("allows tests to disable the periodic cron scheduler", async () => {
+    const { createBackgroundTasks } = await import("../services/background-tasks.js");
+    const tasks = createBackgroundTasks(makeApp(), "srv_3", { cronSchedulerEnabled: false });
+
+    tasks.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+    await tasks.stop();
+
+    expect(serviceMocks.cronStart).not.toHaveBeenCalled();
+    expect(serviceMocks.cronStop).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -94,6 +94,8 @@ export type CreateTestAppOptions = {
   connectBootstrap?: Config["connectBootstrap"];
   inbox?: Partial<NonNullable<Config["inbox"]>>;
   runtimeSwitchFaultInjection?: boolean;
+  /** Enable the periodic cron scheduler. Disabled by default so tests that drive sweeps explicitly cannot race it. */
+  cronSchedulerEnabled?: boolean;
   allowedOrganizationId?: string;
   /** Official Agent Template publisher org (FIRST_TREE_AGENT_TEMPLATE_PUBLISHER_ORG_ID). */
   agentTemplatePublisherOrgId?: string;
@@ -272,7 +274,10 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
   // test scaffolding bypasses it and builds the Config object manually, so
   // we set the singleton ourselves here.
   setConfig(config);
-  const app = await buildApp(config, { attachmentBlobStore: new MemoryAttachmentBlobStore() });
+  const app = await buildApp(config, {
+    attachmentBlobStore: new MemoryAttachmentBlobStore(),
+    backgroundTasks: { cronSchedulerEnabled: opts.cronSchedulerEnabled ?? false },
+  });
   await app.ready();
   return app;
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -108,7 +108,11 @@ import {
   createUnavailableAttachmentBlobStore,
 } from "./services/attachment-blob-store.js";
 import { expiryToSeconds } from "./services/auth.js";
-import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
+import {
+  type BackgroundTaskOptions,
+  type BackgroundTasks,
+  createBackgroundTasks,
+} from "./services/background-tasks.js";
 import {
   invalidateChatAudienceLocal,
   registerChatAudienceDispatcher,
@@ -176,6 +180,7 @@ function namePlugin<T extends FastifyPluginAsync>(name: string, fn: T): T {
 
 export type BuildAppOptions = {
   attachmentBlobStore?: AttachmentBlobStore;
+  backgroundTasks?: BackgroundTaskOptions;
 };
 
 export async function buildApp(config: Config, options: BuildAppOptions = {}) {
@@ -707,7 +712,7 @@ export async function buildApp(config: Config, options: BuildAppOptions = {}) {
   app.decorate("notifier", notifier);
 
   // Background tasks
-  const backgroundTasks = createBackgroundTasks(app, config.instanceId);
+  const backgroundTasks = createBackgroundTasks(app, config.instanceId, options.backgroundTasks);
 
   // NC1 pulse aggregator — 32-bucket rolling window over runtime state
   // transitions. Broadcasts a per-org `pulse:tick` frame every 5s to admin

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -16,12 +16,20 @@ export type BackgroundTasks = {
   stop(): Promise<void>;
 };
 
-export function createBackgroundTasks(app: FastifyInstance, instanceId: string): BackgroundTasks {
+export type BackgroundTaskOptions = {
+  cronSchedulerEnabled?: boolean;
+};
+
+export function createBackgroundTasks(
+  app: FastifyInstance,
+  instanceId: string,
+  options: BackgroundTaskOptions = {},
+): BackgroundTasks {
   let inboxTimer: ReturnType<typeof setInterval> | null = null;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let archiveSweepTimer: ReturnType<typeof setInterval> | null = null;
   let attachmentSweepTimer: ReturnType<typeof setInterval> | null = null;
-  const cronScheduler = createCronScheduler(app);
+  const cronScheduler = options.cronSchedulerEnabled === false ? null : createCronScheduler(app);
 
   async function maintainAttachments(): Promise<void> {
     const legacyAttachments = await backfillExternalAttachmentsToPostgres(app.db, app.attachmentBlobStore);
@@ -93,7 +101,7 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
         60 * 60 * 1000,
       );
 
-      cronScheduler.start();
+      cronScheduler?.start();
 
       presenceService.heartbeatInstance(app.db, instanceId).catch((err) => {
         log.error({ err }, "failed initial heartbeat");
@@ -104,7 +112,7 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
     },
 
     async stop() {
-      await cronScheduler.stop();
+      await cronScheduler?.stop();
       if (inboxTimer) {
         clearInterval(inboxTimer);
         inboxTimer = null;


### PR DESCRIPTION
## Summary

- keep the production cron scheduler enabled by default while adding an internal background-task assembly option for deterministic tests
- disable the periodic cron scheduler in `createTestApp` by default so explicit cron sweeps cannot race the next test's database reset
- cover both the production-default start/stop path and the test-only disabled path

## Root cause

After #2262 merged, the Server CI run exposed an existing timing race in `cron-jobs.integration.test.ts`: the test App's periodic scheduler could claim a due job before the test's explicit `sweepCronJobs` call. The explicit sweep then returned no work because of `SKIP LOCKED`, and the still-running background transaction raced the next test's full-table `TRUNCATE`, producing a PostgreSQL deadlock.

This change keeps production startup and shutdown semantics unchanged. Tests that need scheduler lifecycle behavior can still opt in or instantiate `createCronScheduler` directly.

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/background-tasks-extra.test.ts src/__tests__/cron-jobs.integration.test.ts` (37 tests passed)
- `pnpm --filter @first-tree/server typecheck`
- Biome check for all 4 changed files
- `git diff --check`

Follow-up to [main CI run #31362118653](https://github.com/agent-team-foundation/first-tree/actions/runs/31362118653).
