### PR TITLE
ACE-40 fix(web): revert the New Agent dialog template library entry

### DIFF
--- a/packages/web/src/components/__tests__/new-agent-dialog-templates.test.tsx
+++ b/packages/web/src/components/__tests__/new-agent-dialog-templates.test.tsx
@@ -182,10 +182,6 @@ function buttonByText(text: string): HTMLButtonElement {
   return button;
 }
 
-function templateLibraryLink(): HTMLAnchorElement | null {
-  return document.body.querySelector<HTMLAnchorElement>('a[href="/templates"]');
-}
-
 function optionCardByText(text: string): HTMLElement {
   const label = [...document.body.querySelectorAll("label")].find((el) => el.textContent?.includes(text));
   if (!label) throw new Error(`Missing option card "${text}". Body: ${document.body.textContent ?? ""}`);
@@ -245,8 +241,6 @@ describe("NewAgentDialog template responsibilities", () => {
     await renderDialog(onCreated);
     await flush();
     expect(document.body.textContent).not.toContain("Responsibilities");
-    // No entry to an empty library either — the link is gated on the same catalog.
-    expect(templateLibraryLink()).toBeNull();
 
     await fillNameAndOpenPickerSafe();
     async function fillNameAndOpenPickerSafe() {
@@ -268,7 +262,6 @@ describe("NewAgentDialog template responsibilities", () => {
     await waitForCondition(() => templateMocks.listAgentTemplates.mock.calls.length === 1, "catalog not fetched");
     await flush();
     expect(document.body.textContent).not.toContain("Responsibilities");
-    expect(templateLibraryLink()).toBeNull();
     const input = document.body.querySelector<HTMLInputElement>("#new-agent-display-name");
     if (!input) throw new Error("missing display name input");
     await setValue(input, "Build Bot");
@@ -276,36 +269,6 @@ describe("NewAgentDialog template responsibilities", () => {
     await waitForCondition(() => agentMocks.createAgent.mock.calls.length === 1, "create not called");
     const body = agentMocks.createAgent.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(body.templateIds).toBeUndefined();
-  });
-
-  it("offers an in-app entry to the public template library without disturbing the draft", async () => {
-    templateMocks.listAgentTemplates.mockResolvedValue({ templates: [TEMPLATE_A] });
-    await renderDialog();
-    await waitForText("Responsibilities (optional)");
-
-    const input = document.body.querySelector<HTMLInputElement>("#new-agent-display-name");
-    if (!input) throw new Error("missing display name input");
-    await setValue(input, "Build Bot");
-
-    const link = templateLibraryLink();
-    expect(link).not.toBeNull();
-    expect(link?.textContent).toBe("Browse the template library");
-    // A new tab, not a route change: the half-filled dialog must survive the detour.
-    expect(link?.target).toBe("_blank");
-    expect(link?.rel).toContain("noopener");
-
-    // happy-dom would otherwise try to follow the href; React's handler still runs.
-    const blockNavigation = (event: Event) => event.preventDefault();
-    document.addEventListener("click", blockNavigation, true);
-    try {
-      await click(link);
-    } finally {
-      document.removeEventListener("click", blockNavigation, true);
-    }
-
-    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("agent_template_library_open", { surface: "new_agent" });
-    expect(document.body.querySelector<HTMLInputElement>("#new-agent-display-name")?.value).toBe("Build Bot");
-    expect(agentMocks.createAgent).not.toHaveBeenCalled();
   });
 
   it("submits one selected template and keeps the form draft intact", async () => {

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -943,27 +943,6 @@ export function NewAgentDialog({ open, onOpenChange, onCreated, initialTemplateS
                   {fieldErrors.templates}
                 </p>
               )}
-              {/* The only in-app entry to the public Template Library. It lives
-                  here — the moment the user is actually choosing a
-                  responsibility — rather than in the sidebar or landing, because
-                  a public Template only pays off when it helps someone reach a
-                  working agent, not as standalone browsing chrome.
-                  Deliberately inside the catalog-gated section, so an empty or
-                  failed catalog never advertises an empty library and the plain
-                  create path stays unchanged. A new tab (not a route change)
-                  keeps the in-progress draft in this dialog alive. */}
-              <p className="text-caption text-muted-foreground">
-                <a
-                  href="/templates"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  aria-label="Browse the template library — opens in a new tab"
-                  onClick={() => trackEvent("agent_template_library_open", { surface: "new_agent" })}
-                  className="rounded-[var(--radius-input)] underline underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                >
-                  Browse the template library
-                </a>
-              </p>
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- Reverts #2247 (`7d9d05538`), which added a "Browse the template library" link to the New Agent dialog's Responsibilities section.
- The New Agent dialog already carries the intended in-app template entry: the **"Choose a template" picker** added in #2130. It reads the same public catalog and lets the user adopt a Template without leaving the dialog. A second, outbound link to `/templates` at the same decision point is redundant — it competes with the picker instead of serving it.
- Reverting restores the dialog to its pre-#2247 shape: `-58` lines, exactly the two files #2247 touched.

The public `/templates` route and the canonical `/templates/:slug?use=1` intent path are unaffected — neither was introduced or modified by #2247.

Requested by the issue owner on ACE-40 after reviewing the placement.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test`

`@first-tree/web` is fully green (248 files / 2326 tests), including `new-agent-dialog-templates.test.tsx` (9 tests) which returns to its pre-#2247 assertions.

Two unrelated packages flaked under the full parallel `pnpm test` on this machine, and both pass when run on their own — neither can be affected by a `packages/web`-only revert:

- `@first-tree/skill-evals` — all 621 tests passed; the run failed on a `[vitest-worker]: Timeout calling "onTaskUpdate"` RPC timeout under load.
- `@first-tree/client` — `capability-probes.test.ts` hit the 5s timeout while launch-verifying a real runtime binary; passes standalone (53 tests).

`@first-tree/server` also passes standalone (275 files / 3211 tests).

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: the test file is reverted alongside the component, so the "link is absent" assertions and the link-behavior test go away together
- follow-up work: the onboarding "create your first agent" step (`step-create-agent.tsx`) still has no template picker at all — a Template only appears there when arriving via `?use=1`. Users on the normal signup path never see Templates while creating their first agent. Out of scope here; worth its own issue if we want to close that gap.
