### PR TITLE
refactor(server): organize document services

### DIFF
--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -59,7 +59,7 @@ const mockedModules = [
   "../services/scm/github/entity-follow.js",
   "../services/team/invitation.js",
   "../services/landing-campaigns/guards.js",
-  "../services/me-doc.js",
+  "../services/chat/workspace/document-preview.js",
   "../services/team/membership.js",
   "../services/onboarding-kickoff.js",
   "../services/context-tree/settings.js",
@@ -105,7 +105,7 @@ function mockRouteDependencies(): void {
     assertMetadataDoesNotClaimLandingCampaignTrial: vi.fn(),
     assertMutableAgentIsNotLandingCampaignTrial: routeMocks.assertMutableAgentIsNotLandingCampaignTrial,
   }));
-  vi.doMock("../services/me-doc.js", () => ({
+  vi.doMock("../services/chat/workspace/document-preview.js", () => ({
     getMeDocPreview: routeMocks.getMeDocPreview,
   }));
   vi.doMock("../services/team/membership.js", () => ({

--- a/packages/server/src/__tests__/attachments-route.test.ts
+++ b/packages/server/src/__tests__/attachments-route.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../services/attachment.js";
 import { MemoryAttachmentBlobStore } from "../services/attachment-blob-store.js";
 import { editMessage, lockFileAttachmentRefsIfPresent, sendMessage } from "../services/chat/message.js";
-import { validateMessageAttachmentRefs } from "../services/doc-snapshots.js";
+import { validateMessageAttachmentRefs } from "../services/chat/message-attachment-validation.js";
 import { ensureMembership } from "../services/team/membership.js";
 import { uuidv7 } from "../uuid.js";
 import { createAdminContext, createTestAdmin, useTestApp } from "./helpers.js";

--- a/packages/server/src/__tests__/doc-snapshots.test.ts
+++ b/packages/server/src/__tests__/doc-snapshots.test.ts
@@ -3,7 +3,10 @@ import { MAX_MESSAGE_ATTACHMENT_REFS } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
 import { BadRequestError } from "../errors.js";
 import type { AttachmentReader } from "../services/attachment.js";
-import { validateDocumentContext, validateMessageAttachmentRefs } from "../services/doc-snapshots.js";
+import {
+  validateDocumentContext,
+  validateMessageAttachmentRefs,
+} from "../services/chat/message-attachment-validation.js";
 
 describe("validateDocumentContext", () => {
   it("accepts metadata without documentContext", () => {

--- a/packages/server/src/__tests__/documents.test.ts
+++ b/packages/server/src/__tests__/documents.test.ts
@@ -8,8 +8,8 @@ import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agents/identity.js";
-import { docAuthorForAgentUuid } from "../services/doc-author.js";
-import { createComment } from "../services/document.js";
+import { docAuthorForAgentUuid } from "../services/document-review/author.js";
+import { createComment } from "../services/document-review/document.js";
 import { uuidv7 } from "../uuid.js";
 import { createAdminContext, createTestAgent, INVALID_BCRYPT_PLACEHOLDER, useTestApp } from "./helpers.js";
 

--- a/packages/server/src/__tests__/me-doc.test.ts
+++ b/packages/server/src/__tests__/me-doc.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { ForbiddenError, NotFoundError } from "../errors.js";
-import { getMeDocPreview } from "../services/me-doc.js";
+import { getMeDocPreview } from "../services/chat/workspace/document-preview.js";
 
 const baseInput = {
   chatId: "chat-1",

--- a/packages/server/src/__tests__/service-branch-defaults.test.ts
+++ b/packages/server/src/__tests__/service-branch-defaults.test.ts
@@ -942,7 +942,7 @@ describe("service branch defaults", () => {
     ] = await Promise.all([
       import("../services/agents/identity.js"),
       import("../services/chat/conversation.js"),
-      import("../services/document.js"),
+      import("../services/document-review/document.js"),
       import("../services/chat/inbox.js"),
       import("../services/team/member.js"),
       import("../services/team/membership.js"),

--- a/packages/server/src/api/agent/documents.ts
+++ b/packages/server/src/api/agent/documents.ts
@@ -13,8 +13,8 @@ import { z } from "zod";
 import type { Database } from "../../db/connection.js";
 import { NotFoundError } from "../../errors.js";
 import { requireAgent } from "../../middleware/require-identity.js";
-import { docAuthorForAgentUuid } from "../../services/doc-author.js";
-import type { DocCommentRow, DocDocumentRow } from "../../services/document.js";
+import { docAuthorForAgentUuid } from "../../services/document-review/author.js";
+import type { DocCommentRow, DocDocumentRow } from "../../services/document-review/document.js";
 import {
   createComment,
   getCommentRow,
@@ -25,7 +25,7 @@ import {
   publishDocument,
   setCommentStatus,
   setDocumentStatus,
-} from "../../services/document.js";
+} from "../../services/document-review/document.js";
 
 const getDocQuerySchema = z.object({
   version: z.coerce.number().int().positive().optional(),
@@ -48,7 +48,7 @@ const getDocQuerySchema = z.object({
  * Scope: the agent's own org (from the agent selector). Cross-org ids 404 so
  * existence never leaks. Authorship is the agent itself — a human member
  * driving the CLI comes through here as their identity-mirror agent and is
- * recorded with kind "human" (see services/doc-author.ts).
+ * recorded with kind "human" (see services/document-review/author.ts).
  */
 export async function agentDocumentRoutes(app: FastifyInstance): Promise<void> {
   async function requireOrgDocument(db: Database, organizationId: string, docId: string): Promise<DocDocumentRow> {

--- a/packages/server/src/api/documents.ts
+++ b/packages/server/src/api/documents.ts
@@ -8,14 +8,14 @@ import {
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { requireDocumentAccess, requireDocumentCommentAccess } from "../scope/require-document-access.js";
-import { docAuthorForAgentUuid } from "../services/doc-author.js";
+import { docAuthorForAgentUuid } from "../services/document-review/author.js";
 import {
   createComment,
   getDocumentWithVersion,
   listComments,
   setCommentStatus,
   setDocumentStatus,
-} from "../services/document.js";
+} from "../services/document-review/document.js";
 
 const getDocQuerySchema = z.object({
   version: z.coerce.number().int().positive().optional(),

--- a/packages/server/src/api/me-docs.ts
+++ b/packages/server/src/api/me-docs.ts
@@ -5,7 +5,7 @@ import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { NotFoundError } from "../errors.js";
 import { requireChatAccess } from "../scope/require-resource.js";
-import { getMeDocPreview } from "../services/me-doc.js";
+import { getMeDocPreview } from "../services/chat/workspace/document-preview.js";
 
 export type MeDocsRouteOptions = {
   /**

--- a/packages/server/src/api/orgs/documents.ts
+++ b/packages/server/src/api/orgs/documents.ts
@@ -1,8 +1,8 @@
 import { DOC_PUBLISH_BODY_LIMIT, listDocsQuerySchema, publishDocRequestSchema } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
 import { requireOrgMembership } from "../../scope/require-org.js";
-import { docAuthorForAgentUuid } from "../../services/doc-author.js";
-import { listDocuments, publishDocument } from "../../services/document.js";
+import { docAuthorForAgentUuid } from "../../services/document-review/author.js";
+import { listDocuments, publishDocument } from "../../services/document-review/document.js";
 
 /**
  * Document review (docloop) — org surface (Class B).

--- a/packages/server/src/scope/require-document-access.ts
+++ b/packages/server/src/scope/require-document-access.ts
@@ -3,8 +3,8 @@ import type { FastifyRequest } from "fastify";
 import type { Database } from "../db/connection.js";
 import { members } from "../db/schema/members.js";
 import { NotFoundError } from "../errors.js";
-import type { DocCommentRow, DocDocumentRow } from "../services/document.js";
-import { getCommentRow, getDocumentRow } from "../services/document.js";
+import type { DocCommentRow, DocDocumentRow } from "../services/document-review/document.js";
+import { getCommentRow, getDocumentRow } from "../services/document-review/document.js";
 import { requireUser } from "./require-user.js";
 import type { OrgScope } from "./types.js";
 

--- a/packages/server/src/services/chat/message-attachment-validation.ts
+++ b/packages/server/src/services/chat/message-attachment-validation.ts
@@ -4,8 +4,8 @@ import {
   documentContextSchema,
   MAX_MESSAGE_ATTACHMENT_REFS,
 } from "@first-tree/shared";
-import { BadRequestError } from "../errors.js";
-import { type AttachmentReader, loadAttachmentMetaForReference } from "./attachment.js";
+import { BadRequestError } from "../../errors.js";
+import { type AttachmentReader, loadAttachmentMetaForReference } from "../attachment.js";
 
 /**
  * Server-side shape validation for `metadata.documentContext`.

--- a/packages/server/src/services/chat/message.ts
+++ b/packages/server/src/services/chat/message.ts
@@ -41,9 +41,9 @@ import {
   loadAttachmentMetaForReference,
 } from "../attachment.js";
 import type { AttachmentBlobStore } from "../attachment-blob-store.js";
-import { validateDocumentContext, validateMessageAttachmentRefs } from "../doc-snapshots.js";
 import { hasRemainingLandingCampaignTrialBudget } from "../landing-campaigns/chat-state.js";
 import { getLandingCampaignTrialChat, withLandingCampaignChatState } from "../landing-campaigns/metadata.js";
+import { validateDocumentContext, validateMessageAttachmentRefs } from "./message-attachment-validation.js";
 import { upsertSessionState } from "./sessions/activity.js";
 import { applyAfterFanOut, fireChatMessageKick } from "./workspace/projection.js";
 

--- a/packages/server/src/services/chat/workspace/document-preview.ts
+++ b/packages/server/src/services/chat/workspace/document-preview.ts
@@ -1,7 +1,7 @@
 import { readFile, realpath, stat } from "node:fs/promises";
 import { extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { defaultDataDir } from "@first-tree/shared/config";
-import { AppError, ForbiddenError, NotFoundError } from "../errors.js";
+import { AppError, ForbiddenError, NotFoundError } from "../../../errors.js";
 
 const MAX_DOC_BYTES = 5 * 1024 * 1024;
 

--- a/packages/server/src/services/document-review/author.ts
+++ b/packages/server/src/services/document-review/author.ts
@@ -1,8 +1,8 @@
 import type { DocAuthor } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
-import type { Database } from "../db/connection.js";
-import { agents } from "../db/schema/agents.js";
-import { UnauthorizedError } from "../errors.js";
+import type { Database } from "../../db/connection.js";
+import { agents } from "../../db/schema/agents.js";
+import { UnauthorizedError } from "../../errors.js";
 
 /**
  * Host-identity adapter for the document review (docloop) domain.
@@ -13,7 +13,8 @@ import { UnauthorizedError } from "../errors.js";
  * `DocAuthor` principal the domain service consumes. `kind` comes from
  * `agents.type`, so a human driving the CLI through their mirror agent is
  * still recorded as a human author. Extracting docloop into a standalone
- * product means replacing this file, nothing in `services/document.ts`.
+ * product means replacing this file, nothing in
+ * `services/document-review/document.ts`.
  */
 export async function docAuthorForAgentUuid(db: Database, agentUuid: string): Promise<DocAuthor> {
   const [row] = await db

--- a/packages/server/src/services/document-review/document.ts
+++ b/packages/server/src/services/document-review/document.ts
@@ -12,10 +12,10 @@ import type {
 } from "@first-tree/shared";
 import { docCommentStatusSchema, docStatusSchema, locateDocAnchors } from "@first-tree/shared";
 import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
-import type { Database } from "../db/connection.js";
-import { docComments, docDocuments, docVersions } from "../db/schema/index.js";
-import { BadRequestError, NotFoundError } from "../errors.js";
-import { uuidv7 } from "../uuid.js";
+import type { Database } from "../../db/connection.js";
+import { docComments, docDocuments, docVersions } from "../../db/schema/index.js";
+import { BadRequestError, NotFoundError } from "../../errors.js";
+import { uuidv7 } from "../../uuid.js";
 
 /**
  * Document review (docloop) domain service.


### PR DESCRIPTION
## Summary

- move the DocLoop domain service and host identity adapter under `services/document-review`
- move workspace Markdown preview and message attachment-reference validation under their Chat-owned service paths
- update production imports, test imports/mocks, dynamic imports, and path comments without adding compatibility shims
- keep the generic attachment storage and lifecycle primitives at the top-level service boundary

No API, shared schema, database, protocol, or behavior changes are included.

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/documents.test.ts src/__tests__/me-doc.test.ts src/__tests__/doc-snapshots.test.ts src/__tests__/attachments-route.test.ts src/__tests__/api-small-routes-extra.test.ts src/__tests__/service-branch-defaults.test.ts --maxWorkers=2` (102 tests passed)
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src` (passed with 14 pre-existing warnings)
- full Server suite with `--maxWorkers=2`: 274/275 files and 3210/3211 tests passed; the unrelated 501-row inbox backlog test exceeded its default 30-second timeout
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/inbox-bind-recovery.test.ts --maxWorkers=1 --testTimeout=60000` (12 tests passed; slow test completed in 48.829 seconds)
