### PR TITLE
release: bump apps/cli to v0.5.20

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- bump `apps/cli/package.json` from `0.5.19` to the stable release version `0.5.20`
- keep the source package identity as `first-tree-dev`; production identity rewrites remain CI-only
- prepare the matching `v0.5.20` GitHub Release and trusted-publishing workflow after merge

## Draft GitHub Release

**Title:** `v0.5.20 — Context influence, easier agent control, private-deployment SSO`

### Highlights

- See where Context Tree guidance changed agent work: the Context tab now surfaces agent-reported influence, ranks cited nodes, and lets you filter the activity feed to influence events.
- Create and manage agents with less navigation: choose an online computer and runtime in one flow, switch agents from the Agent Detail breadcrumb, and remove other speakers from a chat from their identity card.
- Private deployments can require OpenID Connect SSO with PKCE, discovery/JWKS validation, and provider-aware login UI.

### Notable fixes

- BYO Context workflows now preserve the exact installed CLI channel and pass the local GitHub identity through write-worktree setup, avoiding channel mismatch and authorization failures.
- Client recovery quarantines timed-out suspend handlers instead of letting stuck provider callbacks block future work, while SCM follow authority is more stable.
- Markdown rendering keeps a stable default renderer, and Chat Summary lead lines no longer receive unintended bold styling.

### Compatibility

- Clients older than `v0.5.12` are no longer supported. Upgrade older computers before using this release.
- Web and Server now assume same-version deployment; deploy them from the same Docker image.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] all applicable exact-head GitHub CI and CodeQL checks
- [x] independent `full-isolated` release QA on exact head `181b05054b3ad324c7c4b8fd52c02086e8fbada6`: **PASS**
- [ ] root concurrent `pnpm test` was not fully clean locally: Skill-evals hit a provider-shim fixture race, while its isolated suite passed 621/621 and exact-head CI passed; Client cleanup failed only on host Node 24.7.0 and passed in shipped Node 24.18.0

The maintainer explicitly waived execution of two Momentic files for this release after the provider's organization limit blocked both uploaded and non-uploaded runs. They remain **Human-waived / NOT RUN**, not passed:

- `e2e/registration-new-user.test.yaml`
- `e2e/agent-detail-configuration.test.yaml`

Residual risk is limited to the assertions and locator/model drift those two unattended runs would have covered. Exact-head production image/migrations, npm-shaped CLI, four portable platforms, daemon/runtime handshakes, controlled OIDC/PKCE, docs, real Web/API/DB journeys, high-risk targeted suites, and GitHub CI passed. No backfill was run.

## Post-merge

1. Wait for `CI`, `npm Publish` staging jobs, and `Docker` on the merge SHA.
2. Ask the maintainer to confirm version, tag, exact target SHA, release title, and release body.
3. Create `v0.5.20` from the exact merge SHA and let GitHub Actions publish `first-tree@0.5.20` plus portable artifacts.
4. Verify npm, GitHub Release, Docker, and the versioned GHCR image.

Made with [Cursor](https://cursor.com)
