### PR TITLE
fix(server): defer GitHub Issue Task Agent until first comment

### DIFF
--- a/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
+++ b/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
@@ -1,6 +1,6 @@
 ---
 id: github-webhook-routing-regression
-description: Verify signed GitHub App webhooks reach followed chats and automatically route supported Issue and pull request activity to the repository-scoped Agent role.
+description: Verify signed GitHub App webhooks reach followed chats and automatically route pull-request activity plus Issue first-comment activation to the repository-scoped Agent role.
 areas: [cross-surface]
 surfaces: [server, github, client, web]
 ---
@@ -11,9 +11,11 @@ surfaces: [server, github, client, web]
 
 Verify the live GitHub App ingress-to-chat path across its real boundaries: HMAC authentication, installation-to-Team
 resolution, normalized event processing, followed-chat routing, automatic repository-role task creation, card
-persistence, Agent wake delivery, and terminal App publication. Product tests own deterministic payload and failure
-matrices; this case checks that the assembled deployment still wires those parts together without string-matching the
-App login or adding a GitHub-specific post-delivery branch.
+persistence, Agent wake delivery, and terminal App publication. For ordinary (non-Context) repositories, pull-request
+activity still auto-routes the GitHub Task Agent on supported events, while Issue owner-line creation waits for a
+qualifying first comment unless an exact Task Agent owner line already exists. Product tests own deterministic payload
+and failure matrices; this case checks that the assembled deployment still wires those parts together without
+string-matching the App login or adding a GitHub-specific post-delivery branch.
 
 ## Preconditions
 
@@ -49,27 +51,47 @@ App login or adding a GitHub-specific post-delivery branch.
   baseline rather than an exactly-once promise.
 - Send a request with an invalid signature and confirm it is rejected before installation lookup, claim, card, task run,
   or wake.
-- In the non-Context repository, deliver representative normalized Issue and pull-request events with no App mention,
-  App assignment, or other personnel target. Include an external public contributor and vary `author_association`.
-  Confirm every supported event creates or reuses one entity chat for the selected GitHub Task Agent, wakes that exact
-  Agent, and persists `teamAgentTask: { agentUuid: "<selected UUID>", runId: "<server run>" }` on both the card and
-  message metadata. The card must retain the real event kind, use reason `subscribed`, and omit `mentionedUser`.
+- In the non-Context repository, deliver a fresh `issues.opened` and other supported Issue activity before any qualifying
+  comment, with no App mention, App assignment, or other personnel target when proving the delay path. Include an
+  external public contributor and vary `author_association`. Confirm none of those events creates a GitHub Task Agent
+  owner chat, owner mapping, task run, or Task Agent wake.
+- On the same fresh Issue, deliver real human assignee and mention targets (and, separately, an independent follow).
+  Confirm those personnel / follow routes still create or reuse their own lines immediately, without minting the Task
+  Agent owner line and without suppressing later first-comment activation.
+- Deliver a real Issue `issue_comment.created` that is not verified terminal App self-output. Confirm this first
+  qualifying comment creates or reuses exactly one GitHub Task Agent owner line, wakes that exact Agent, and persists
+  `teamAgentTask: { agentUuid: "<selected UUID>", runId: "<server run>" }` on both the card and message metadata. The
+  card must retain the real event kind, use reason `subscribed`, and omit `mentionedUser`. Do not expect a backfilled
+  `opened` card.
+- After that exact owner line exists, deliver further supported Issue events for the same entity. Confirm they reuse the
+  existing Task Agent chat / mapping rather than creating another owner line.
+- Deliver `issue_comment.edited` / deleted and a verified terminal App self-output comment on a fresh Issue that has no
+  owner line. Confirm none of those first-activates the Task Agent owner line. Existing independent subscription cards
+  for self-output may still arrive without minting another task run.
+- In the same non-Context repository, deliver representative normalized pull-request events with no App mention, App
+  assignment, or other personnel target. Confirm every supported pull-request event still creates or reuses one entity
+  chat for the selected GitHub Task Agent, wakes that exact Agent, and persists the same `teamAgentTask` shape. PR
+  automatic routing must remain unchanged by the Issue first-comment gate.
 - Repeat with real human mention, assignee, and review-request targets and with an independent followed line. Confirm
   those routes remain intact, the task and follow/personnel wakes union into one card per chat, and only real personnel
   evidence can set a directed reason or `mentionedUser`.
-- Repeat a non-Context event where the GitHub actor already maps the entity to a different delegate. Confirm the selected
-  GitHub Task Agent is added as a chat participant and is woken, while actor-echo suppression still applies only to the
-  pre-existing human attention line. Repeat with unrelated attention lines in the same chat and confirm task identity
-  remains recipient-scoped.
+- Repeat a non-Context event where the GitHub actor already maps the entity to a different delegate. For a pull request,
+  or for an Issue that already has an exact Task Agent owner line / is activated by a qualifying first comment, confirm
+  the selected GitHub Task Agent is added as a chat participant and is woken, while actor-echo suppression still applies
+  only to the pre-existing human attention line. Repeat with unrelated attention lines in the same chat and confirm task
+  identity remains recipient-scoped.
 - In the bound GitHub Context Tree repository, deliver the same supported activity and confirm its automatic task uses
   Context Reviewer rather than GitHub Task Agent. Confirm repository matching tolerates canonical URL spelling, case,
   and `.git` differences. Verify the second GitHub repository still targets GitHub Task Agent, and that a GitLab Context
-  Tree binding does not classify any GitHub repository as the Context repository.
+  Tree binding does not classify any GitHub repository as the Context repository. Bound Context Tree role behavior must
+  remain unchanged by the ordinary-repo Issue first-comment gate.
 - Remove or invalidate each role selection in turn and confirm only that automatic task is skipped; existing human
   targets and subscriptions still receive ordinary cards. Remove the verified App slug/login and confirm Settings →
   Integrations → GitHub → Automatic handling exposes a readiness blocker and runtime routing fails closed. Remove an
-  accepted Issue or pull-request write grant and confirm the corresponding event reports
-  `GITHUB_TASK_REPLY_APP_PERMISSION_REQUIRED` without a run while independent routes remain delivered.
+  accepted Issue or pull-request write grant and confirm an otherwise eligible automatic event (Issue first-comment
+  activation or a supported pull-request event) reports `GITHUB_TASK_REPLY_APP_PERMISSION_REQUIRED` without a run while
+  independent routes remain delivered. Non-activating fresh Issue events must not invent that blocker merely because
+  write permission is missing.
 - Let the GitHub Task Agent finish one automatically routed task. Confirm it treats the webhook actor/body as untrusted
   context, inspects the live entity through the normal host GitHub identity, limits work to that identity's permissions,
   then uses `first-tree github reply --run <runId> --body-file <path>` for the terminal outcome. A First Tree chat-only
@@ -91,8 +113,8 @@ App login or adding a GitHub-specific post-delivery branch.
 - Deliver normalized Discussion and commit activity, plus installation lifecycle, observation-only, and currently
   filtered/noise events. Confirm none creates a provider task or task run. Existing applicable subscription or projection
   behavior remains unchanged.
-- Redeliver a supported event with a fresh delivery id on the same entity. Confirm the existing repository-role chat and
-  attention line are reused rather than creating another chat.
+- Redeliver a supported event with a fresh delivery id on an entity that already has the repository-role attention line.
+  Confirm the existing repository-role chat and attention line are reused rather than creating another chat.
 - Enable Context Reviewer and include one supported Context Tree PR trigger. Confirm it reuses its dedicated reviewer
   chat and retains trusted review publication authority only for that path. The ordinary automatic task card must not
   gain trusted App review or merge authority.
@@ -101,16 +123,19 @@ App login or adding a GitHub-specific post-delivery branch.
 
 `PASS`: signed events resolve through the bound installation, reach the expected chat and wake path, stable delivery ids
 deduplicate the whole request, missing delivery ids do not claim, invalid signatures have no side effects, and optional
-Context Reviewer behavior remains dedicated and claim-covered. Supported Issue and pull-request activity automatically
-wakes exactly the repository-scoped role Agent without App mention or assignment matching, receives its terminal outcome
-on GitHub, and does not loop. Human targeting and followed-chat routes remain independent. The two roles remain
+Context Reviewer behavior remains dedicated and claim-covered. In non-Context repositories, fresh Issue activity before
+a qualifying comment does not mint a GitHub Task Agent owner line, while assignee / mention / follow routes remain
+immediate and independent; the first real Issue `issue_comment.created` (excluding verified terminal App self-output)
+activates exactly one Task Agent owner line; later supported Issue events reuse that line; pull-request automatic
+routing and bound Context Tree role selection remain unchanged. Activated repository-role work receives its terminal
+outcome on GitHub and does not loop. Human targeting and followed-chat routes remain independent. The two roles remain
 independently configured and cannot select the same Agent. Agent-visible webhook attribution is GitHub/system, task-only
 cards do not invent personnel context, and webhook content is never treated as authorization beyond the recipient-scoped
 task capability and host GitHub permissions.
 
-`FAIL`: a reproducible regression in authentication, tenant resolution, followed-chat/card delivery, automatic task or
-wake routing, recipient-bound publication, self-output suppression, whole-request deduplication, or Context Reviewer
-claim coverage.
+`FAIL`: a reproducible regression in authentication, tenant resolution, followed-chat/card delivery, Issue first-comment
+activation or premature Issue owner-line creation, pull-request automatic task or wake routing, recipient-bound
+publication, self-output suppression, whole-request deduplication, or Context Reviewer claim coverage.
 
 `BLOCKED`: the isolated run cell cannot provision a disposable App/installation, webhook credential, bound entity, or
 connected runtime needed by the selected observations.

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -1926,6 +1926,63 @@ describe("POST /webhooks/github-app", () => {
     ).toBe(true);
   });
 
+  it("still creates a Context Reviewer provider task on issues.opened in the bound Context Tree repo", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100051;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+    await configureTeamAgent(app, admin);
+    const reviewer = await configureContextReviewer(app, admin);
+
+    const response = await postWebhook(app, "issues", {
+      action: "opened",
+      issue: {
+        number: 77,
+        title: "Context Tree Issue stays automatic",
+        html_url: "https://github.com/owner/context-tree/issues/77",
+        body: "Please review",
+        assignees: [],
+        author_association: "NONE",
+      },
+      repository: { full_name: "owner/context-tree" },
+      sender: { login: "external-contributor", type: "User" },
+      installation: { id: installationId },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ ok: true, delivered: 1, newChats: 1, failed: 0 });
+    const [mapping] = await app.db.select().from(githubEntityChatMappings).limit(1);
+    expect(mapping).toMatchObject({
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: reviewer,
+      entityType: "issue",
+      entityKey: "owner/context-tree#77",
+    });
+    const [message] = await app.db
+      .select()
+      .from(messages)
+      .where(eq(messages.chatId, mapping?.chatId ?? ""))
+      .limit(1);
+    expect(message?.content).toMatchObject({
+      type: "github_event",
+      reason: "subscribed",
+      kind: "opened",
+      teamAgentTask: { agentUuid: reviewer, runId: expect.any(String) },
+    });
+    expect(message?.metadata).toMatchObject({
+      mentions: [reviewer],
+      teamAgentTask: { agentUuid: reviewer, runId: expect.any(String) },
+      githubTaskRun: true,
+      githubTaskAgentUuid: reviewer,
+    });
+    const [entry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.messageId, message?.id ?? ""), eq(inboxEntries.inboxId, `inbox_${reviewer}`)))
+      .limit(1);
+    expect(entry?.notify).toBe(true);
+  });
+
   it("returns a stable permission blocker and creates no task run after an installation permission downgrade", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -1713,18 +1713,25 @@ describe("POST /webhooks/github-app", () => {
 
   it.each([
     {
-      label: "Issue",
-      eventType: "issues",
+      label: "Issue first comment",
+      eventType: "issue_comment",
       entityType: "issue",
       number: 12,
+      kind: "commented",
       payload: {
-        action: "opened",
+        action: "created",
         issue: {
           number: 12,
           title: "Automatic Issue handling",
           html_url: "https://github.com/owner/repo/issues/12",
           body: "Please investigate this issue.",
           assignees: [],
+          author_association: "CONTRIBUTOR",
+        },
+        comment: {
+          body: "Please investigate this issue.",
+          html_url: "https://github.com/owner/repo/issues/12#issuecomment-12",
+          user: { login: "external-contributor", type: "User" },
           author_association: "CONTRIBUTOR",
         },
       },
@@ -1734,6 +1741,7 @@ describe("POST /webhooks/github-app", () => {
       eventType: "pull_request",
       entityType: "pull_request",
       number: 13,
+      kind: "opened",
       payload: {
         action: "opened",
         pull_request: {
@@ -1781,7 +1789,7 @@ describe("POST /webhooks/github-app", () => {
     expect(message?.content).toMatchObject({
       type: "github_event",
       reason: "subscribed",
-      kind: "opened",
+      kind: scenario.kind,
       teamAgentTask: { agentUuid: teamAgent, runId: expect.any(String) },
     });
     expect(message?.content).not.toHaveProperty("mentionedUser");
@@ -1830,6 +1838,94 @@ describe("POST /webhooks/github-app", () => {
     ).toBe(true);
   });
 
+  it("does not create a Task Agent chat on issues.opened, but still creates an assignee line", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100050;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+    const teamAgent = await configureTeamAgent(app, admin);
+    const assigneeDelegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `assignee-dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const assigneeName = `assignee-${randomUUID().slice(0, 6)}`;
+    await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: assigneeName,
+      delegateMention: assigneeDelegate,
+      type: "human",
+    });
+
+    const opened = await postWebhook(app, "issues", {
+      action: "opened",
+      issue: {
+        number: 40,
+        title: "Deferred owner activation",
+        html_url: "https://github.com/owner/repo/issues/40",
+        body: "body",
+        assignees: [{ login: assigneeName, type: "User" }],
+        author_association: "NONE",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "external-contributor", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(opened.statusCode).toBe(200);
+    expect(opened.json()).toMatchObject({ ok: true, delivered: 1, newChats: 1, failed: 0 });
+    expect(opened.json()).not.toHaveProperty("appTaskBlocker");
+
+    const mappingsAfterOpen = await app.db.select().from(githubEntityChatMappings);
+    expect(mappingsAfterOpen).toHaveLength(1);
+    expect(mappingsAfterOpen[0]).toMatchObject({
+      delegateAgentId: assigneeDelegate,
+      entityType: "issue",
+      entityKey: "owner/repo#40",
+    });
+    expect(mappingsAfterOpen.some((row) => row.delegateAgentId === teamAgent)).toBe(false);
+    const openedMessages = await app.db.select().from(messages);
+    expect(openedMessages).toHaveLength(1);
+    expect(openedMessages[0]?.metadata).not.toHaveProperty("teamAgentTask");
+
+    const firstComment = await postWebhook(app, "issue_comment", {
+      action: "created",
+      issue: {
+        number: 40,
+        title: "Deferred owner activation",
+        html_url: "https://github.com/owner/repo/issues/40",
+        author_association: "NONE",
+      },
+      comment: {
+        body: "First qualifying comment",
+        html_url: "https://github.com/owner/repo/issues/40#issuecomment-40",
+        user: { login: "external-contributor", type: "User" },
+        author_association: "NONE",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "external-contributor", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(firstComment.statusCode).toBe(200);
+    expect(firstComment.json()).toMatchObject({ ok: true, failed: 0 });
+    expect(firstComment.json().delivered).toBeGreaterThanOrEqual(1);
+
+    const mappingsAfterComment = await app.db.select().from(githubEntityChatMappings);
+    expect(mappingsAfterComment.some((row) => row.delegateAgentId === teamAgent)).toBe(true);
+    expect(mappingsAfterComment.some((row) => row.delegateAgentId === assigneeDelegate)).toBe(true);
+    const taskChatId = mappingsAfterComment.find((row) => row.delegateAgentId === teamAgent)?.chatId ?? "";
+    const taskMessages = await app.db.select().from(messages).where(eq(messages.chatId, taskChatId));
+    expect(
+      taskMessages.some(
+        (row) =>
+          typeof row.metadata.teamAgentTask === "object" &&
+          row.metadata.teamAgentTask !== null &&
+          "agentUuid" in row.metadata.teamAgentTask &&
+          row.metadata.teamAgentTask.agentUuid === teamAgent,
+      ),
+    ).toBe(true);
+  });
+
   it("returns a stable permission blocker and creates no task run after an installation permission downgrade", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -1841,14 +1937,18 @@ describe("POST /webhooks/github-app", () => {
       .set({ permissions: { metadata: "read", issues: "read", pull_requests: "write" } })
       .where(eq(githubAppInstallations.installationId, installationId));
 
-    const response = await postWebhook(app, "issues", {
-      action: "opened",
+    const response = await postWebhook(app, "issue_comment", {
+      action: "created",
       issue: {
         number: 16,
         title: "Permission downgraded",
         html_url: "https://github.com/owner/repo/issues/16",
+        author_association: "CONTRIBUTOR",
+      },
+      comment: {
         body: "Please investigate",
-        assignees: [],
+        html_url: "https://github.com/owner/repo/issues/16#issuecomment-16",
+        user: { login: "authorized-member", type: "User" },
         author_association: "CONTRIBUTOR",
       },
       repository: { full_name: "owner/repo" },
@@ -2161,17 +2261,20 @@ describe("POST /webhooks/github-app", () => {
       boundVia: "human_declared",
     });
 
-    const response = await postWebhook(app, "issues", {
-      action: "assigned",
+    const response = await postWebhook(app, "issue_comment", {
+      action: "created",
       issue: {
         number: 14,
         title: "Existing mapping",
         html_url: "https://github.com/owner/repo/issues/14",
-        body: "",
-        assignees: [{ login: "test-app-slug[bot]", type: "Bot" }],
         author_association: "NONE",
       },
-      assignee: { login: "test-app-slug[bot]", type: "Bot" },
+      comment: {
+        body: "Activating comment",
+        html_url: "https://github.com/owner/repo/issues/14#issuecomment-14",
+        user: { login: "external", type: "User" },
+        author_association: "NONE",
+      },
       repository: { full_name: "owner/repo" },
       sender: { login: "external", type: "User" },
       installation: { id: installationId },
@@ -2199,7 +2302,7 @@ describe("POST /webhooks/github-app", () => {
     expect(message?.metadata).toMatchObject({
       teamAgentTask: { agentUuid: teamAgent },
     });
-    expect(message?.content).toMatchObject({ reason: "subscribed", kind: "assigned" });
+    expect(message?.content).toMatchObject({ reason: "subscribed", kind: "commented" });
     expect(message?.content).not.toHaveProperty("mentionedUser");
     expect(message?.metadata).not.toHaveProperty("mentionedUser");
     expect(message?.metadata.mentions).toEqual(expect.arrayContaining([teamAgent, otherDelegate]));
@@ -2271,17 +2374,20 @@ describe("POST /webhooks/github-app", () => {
       },
     ]);
 
-    const response = await postWebhook(app, "issues", {
-      action: "assigned",
+    const response = await postWebhook(app, "issue_comment", {
+      action: "created",
       issue: {
         number: 15,
         title: "Mixed App task and subscription",
         html_url: "https://github.com/owner/repo/issues/15",
-        body: "",
-        assignees: [{ login: "test-app-slug[bot]", type: "Bot" }],
         author_association: "NONE",
       },
-      assignee: { login: "test-app-slug[bot]", type: "Bot" },
+      comment: {
+        body: "Activating comment",
+        html_url: "https://github.com/owner/repo/issues/15#issuecomment-15",
+        user: { login: managerHuman.name, type: "User" },
+        author_association: "NONE",
+      },
       repository: { full_name: "owner/repo" },
       // Prune only the manager's historical line. The automatic task remains
       // eligible, as does the other human's explicit subscription.
@@ -2297,7 +2403,7 @@ describe("POST /webhooks/github-app", () => {
     expect(message?.metadata).toMatchObject({
       teamAgentTask: { agentUuid: teamAgent },
     });
-    expect(message?.content).toMatchObject({ reason: "subscribed", kind: "assigned" });
+    expect(message?.content).toMatchObject({ reason: "subscribed", kind: "commented" });
     expect(message?.content).not.toHaveProperty("mentionedUser");
     expect(message?.metadata.mentions).toEqual(expect.arrayContaining([teamAgent, subscribedDelegate]));
     expect(message?.metadata.mentions).toHaveLength(2);

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { NormalizedScmEvent } from "@first-tree/shared";
+import type { NormalizedScmEvent, ScmAudienceEntry } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
@@ -10,6 +10,9 @@ import { putContextReviewerAssignment } from "../services/context-tree/reviewer/
 import { isGithubAppTargetLogin } from "../services/scm/github/app-self-output.js";
 import {
   type GithubProviderTaskContext,
+  hasExactGithubProviderTaskOwnerLine,
+  isGithubIssueProviderTaskActivationEvent,
+  isGithubProviderTaskEventEligible,
   resolveGithubAudience as resolveAudienceResolution,
   resolveGithubActorHumanId,
 } from "../services/scm/github/audience.js";
@@ -295,13 +298,129 @@ describe("isGithubAppTargetLogin", () => {
   });
 });
 
+describe("isGithubIssueProviderTaskActivationEvent", () => {
+  it("accepts only a real Issue issue_comment.created", () => {
+    expect(
+      isGithubIssueProviderTaskActivationEvent(
+        makeEvent({
+          orgId: "org",
+          entityType: "issue",
+          entityKey: "owner/repo#1",
+          actorLogin: "alice",
+          eventType: "issue_comment",
+          action: "created",
+          kind: "commented",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["issues.opened", { eventType: "issues", action: "opened", kind: "opened" as const }],
+    ["issue_comment.edited", { eventType: "issue_comment", action: "edited", kind: "commented" as const }],
+    [
+      "PR-shaped issue_comment.created",
+      {
+        entityType: "pull_request" as const,
+        eventType: "issue_comment",
+        action: "created",
+        kind: "commented" as const,
+      },
+    ],
+  ])("rejects %s", (_label, override) => {
+    expect(
+      isGithubIssueProviderTaskActivationEvent(
+        makeEvent({
+          orgId: "org",
+          entityType: "issue",
+          entityKey: "owner/repo#1",
+          actorLogin: "alice",
+          ...override,
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("hasExactGithubProviderTaskOwnerLine", () => {
+  it("requires the exact manager-human + task-agent pair", () => {
+    const entries: Array<Extract<ScmAudienceEntry, { kind: "existing_line" }>> = [
+      {
+        kind: "existing_line",
+        line: {
+          kind: "attention_line",
+          humanAgentId: "manager",
+          wakeAgentId: "task-agent",
+          chatId: "chat-1",
+          provenance: "identity_target",
+        },
+      },
+    ];
+    expect(hasExactGithubProviderTaskOwnerLine(entries, "manager", "task-agent")).toBe(true);
+    expect(hasExactGithubProviderTaskOwnerLine(entries, "manager", "other-agent")).toBe(false);
+    expect(hasExactGithubProviderTaskOwnerLine(entries, "other-human", "task-agent")).toBe(false);
+  });
+});
+
+describe("isGithubProviderTaskEventEligible", () => {
+  const ownerLine: Extract<ScmAudienceEntry, { kind: "existing_line" }> = {
+    kind: "existing_line",
+    line: {
+      kind: "attention_line",
+      humanAgentId: "manager",
+      wakeAgentId: "task-agent",
+      chatId: "chat-1",
+      provenance: "identity_target",
+    },
+  };
+  const taskAgent = { uuid: "task-agent", managerHumanAgentId: "manager" };
+
+  it("keeps every pull_request semantic event eligible", () => {
+    expect(
+      isGithubProviderTaskEventEligible(
+        makeEvent({
+          orgId: "org",
+          entityType: "pull_request",
+          entityKey: "owner/repo#2",
+          actorLogin: "alice",
+          kind: "opened",
+        }),
+        [],
+        taskAgent,
+      ),
+    ).toBe(true);
+  });
+
+  it("requires an exact owner line or issue_comment.created for issues", () => {
+    const opened = makeEvent({
+      orgId: "org",
+      entityType: "issue",
+      entityKey: "owner/repo#1",
+      actorLogin: "alice",
+      kind: "opened",
+    });
+    const commented = makeEvent({
+      orgId: "org",
+      entityType: "issue",
+      entityKey: "owner/repo#1",
+      actorLogin: "alice",
+      eventType: "issue_comment",
+      action: "created",
+      kind: "commented",
+    });
+    expect(isGithubProviderTaskEventEligible(opened, [], taskAgent)).toBe(false);
+    expect(isGithubProviderTaskEventEligible(opened, [ownerLine], taskAgent)).toBe(true);
+    expect(isGithubProviderTaskEventEligible(commented, [], taskAgent)).toBe(true);
+  });
+});
+
 describe("resolveAudience", () => {
   const getApp = useTestApp();
 
   it.each([
-    ["issue", "owner/repo#41", { issues: "write" }, "commented"],
-    ["pull_request", "owner/repo#42", { pull_requests: "write" }, "reviewed"],
-  ] as const)("automatically routes a normalized %s event without App mention or assignment evidence", async (entityType, entityKey, appPermissions, kind) => {
+    ["issue", "owner/repo#41", { issues: "write" }, "commented", "issue_comment"],
+    ["pull_request", "owner/repo#42", { pull_requests: "write" }, "reviewed", "pull_request_review"],
+  ] as const)("automatically routes a normalized %s event without App mention or assignment evidence", async (entityType, entityKey, appPermissions, kind, eventType) => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const teamAgentUuid = await configureTeamAgent(app, admin);
@@ -316,6 +435,8 @@ describe("resolveAudience", () => {
         actorAuthorAssociation: "CONTRIBUTOR",
         targets: [],
         kind,
+        eventType,
+        action: kind === "commented" ? "created" : "submitted",
       }),
       { appSlug: "test-app-slug", appPermissions },
     );
@@ -334,6 +455,211 @@ describe("resolveAudience", () => {
     expect(resolution.appTaskBlocker).toBeNull();
   });
 
+  it.each([
+    ["opened", "issues", "opened"],
+    ["assigned", "issues", "assigned"],
+    ["edited", "issues", "edited"],
+    ["closed", "issues", "closed"],
+  ] as const)("does not mint a provider task for a fresh issue %s event", async (kind, eventType, action) => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await configureTeamAgent(app, admin);
+
+    const resolution = await resolveAudienceResolution(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "issue",
+        entityKey: "owner/repo#delay-1",
+        actorLogin: "external-contributor",
+        targets: [],
+        kind,
+        eventType,
+        action,
+      }),
+      { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
+    );
+
+    expect(projectAudienceTargets(resolution.targets)).toEqual([]);
+    expect(resolution.appTaskBlocker).toBeNull();
+  });
+
+  it("still creates an assignee personnel target on issue opened without a provider task", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await configureTeamAgent(app, admin);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `assignee-dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `assignee-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+      type: "human",
+    });
+
+    const resolution = await resolveAudienceResolution(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "issue",
+        entityKey: "owner/repo#delay-assignee",
+        actorLogin: "external",
+        targets: [{ externalUsername: humanName, reason: "assigned" }],
+        kind: "opened",
+      }),
+      { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
+    );
+
+    expect(projectAudienceTargets(resolution.targets)).toEqual([
+      {
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        kind: "new",
+        chatId: null,
+        involveReason: "assigned",
+        involveLogin: humanName.toLowerCase(),
+      },
+    ]);
+    expect(resolution.appTaskBlocker).toBeNull();
+  });
+
+  it("does not treat an assignee-only or same-human different-agent mapping as the owner line", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const teamAgentUuid = await configureTeamAgent(app, admin);
+    const otherDelegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `other-dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const chatId = await seedChat(app, admin.organizationId, admin.humanAgentUuid);
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: admin.humanAgentUuid,
+      delegateId: otherDelegate,
+      entityType: "issue",
+      entityKey: "owner/repo#not-owner",
+      chatId,
+    });
+
+    const resolution = await resolveAudienceResolution(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "issue",
+        entityKey: "owner/repo#not-owner",
+        actorLogin: "external",
+        kind: "assigned",
+      }),
+      { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
+    );
+
+    expect(projectAudienceTargets(resolution.targets)).toEqual([
+      expect.objectContaining({ kind: "existing", chatId, delegateAgentId: otherDelegate }),
+    ]);
+    expect(projectAudienceTargets(resolution.targets)).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ teamAgentTask: { agentUuid: teamAgentUuid } })]),
+    );
+    expect(resolution.appTaskBlocker).toBeNull();
+  });
+
+  it("continues provider-task routing for non-comment issue events once the exact owner line exists", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const teamAgentUuid = await configureTeamAgent(app, admin);
+    const chatId = await seedChat(app, admin.organizationId, admin.humanAgentUuid);
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: admin.humanAgentUuid,
+      delegateId: teamAgentUuid,
+      entityType: "issue",
+      entityKey: "owner/repo#901",
+      chatId,
+    });
+
+    const resolution = await resolveAudienceResolution(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "issue",
+        entityKey: "owner/repo#901",
+        actorLogin: "external",
+        kind: "closed",
+      }),
+      { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
+    );
+
+    expect(projectAudienceTargets(resolution.targets)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "existing",
+          chatId,
+          delegateAgentId: teamAgentUuid,
+        }),
+        expect.objectContaining({
+          kind: "new",
+          delegateAgentId: teamAgentUuid,
+          teamAgentTask: { agentUuid: teamAgentUuid },
+        }),
+      ]),
+    );
+    expect(resolution.appTaskBlocker).toBeNull();
+  });
+
+  it("does not activate an issue owner line from issue_comment.edited", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await configureTeamAgent(app, admin);
+
+    const resolution = await resolveAudienceResolution(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "issue",
+        entityKey: "owner/repo#edit-comment",
+        actorLogin: "external",
+        eventType: "issue_comment",
+        action: "edited",
+        kind: "commented",
+      }),
+      { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
+    );
+
+    expect(projectAudienceTargets(resolution.targets)).toEqual([]);
+    expect(resolution.appTaskBlocker).toBeNull();
+  });
+
+  it("does not treat a PR-shaped issue_comment as Issue first-comment activation", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const teamAgentUuid = await configureTeamAgent(app, admin);
+
+    const resolution = await resolveAudienceResolution(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#902",
+        actorLogin: "external",
+        eventType: "issue_comment",
+        action: "created",
+        kind: "commented",
+      }),
+      { appSlug: "test-app-slug", appPermissions: { pull_requests: "write" } },
+    );
+
+    expect(projectAudienceTargets(resolution.targets)).toEqual([
+      expect.objectContaining({
+        teamAgentTask: { agentUuid: teamAgentUuid },
+      }),
+    ]);
+  });
+
   it("does not treat the App login as a human target when no GitHub Task Agent is selected", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -347,6 +673,8 @@ describe("resolveAudience", () => {
         actorLogin: "outsider",
         targets: [{ externalUsername: "test-app-slug", reason: "mentioned" }],
         kind: "commented",
+        eventType: "issue_comment",
+        action: "created",
       }),
       { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
     );
@@ -369,6 +697,8 @@ describe("resolveAudience", () => {
         actorAuthorAssociation: "CONTRIBUTOR",
         targets: [{ externalUsername: "test-app-slug", reason: "mentioned" }],
         kind: "commented",
+        eventType: "issue_comment",
+        action: "created",
       }),
       { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
     );
@@ -400,11 +730,32 @@ describe("resolveAudience", () => {
         actorAuthorAssociation: "NONE",
         targets: [],
         kind: "commented",
+        eventType: entityType === "issue" ? "issue_comment" : "pull_request_review_comment",
+        action: "created",
       }),
       { appSlug: "test-app-slug", appPermissions: permissions },
     );
     expect(projectAudienceTargets(resolution.targets)).toEqual([]);
     expect(resolution.appTaskBlocker).toBe(blocker);
+  });
+
+  it("does not raise an App task blocker for a non-activating fresh issue event", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await configureTeamAgent(app, admin);
+    const resolution = await resolveAudienceResolution(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "issue",
+        entityKey: "owner/repo#19-opened",
+        actorLogin: "external",
+        kind: "opened",
+      }),
+      { appSlug: "test-app-slug", appPermissions: { issues: "read" } },
+    );
+    expect(projectAudienceTargets(resolution.targets)).toEqual([]);
+    expect(resolution.appTaskBlocker).toBeNull();
   });
 
   it.each([
@@ -424,6 +775,8 @@ describe("resolveAudience", () => {
         entityUrl,
         actorLogin: "external",
         kind: "commented",
+        eventType: "issue_comment",
+        action: "created",
       }),
       { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
     );
@@ -486,6 +839,8 @@ describe("resolveAudience", () => {
         entityKey: "owner/repo#20",
         actorLogin: "external",
         kind: "commented",
+        eventType: "issue_comment",
+        action: "created",
       }),
       { appSlug: null, appPermissions: { issues: "write" } },
     );
@@ -523,6 +878,8 @@ describe("resolveAudience", () => {
         entityKey: "owner/repo#22",
         actorLogin: "external",
         kind: "commented",
+        eventType: "issue_comment",
+        action: "created",
       }),
       { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
     );
@@ -561,6 +918,8 @@ describe("resolveAudience", () => {
         entityKey: "owner/repo#21",
         actorLogin: "external",
         kind: "commented",
+        eventType: "issue_comment",
+        action: "created",
       }),
       { appSlug: "test-app-slug", appPermissions: { issues: "read" } },
     );
@@ -600,6 +959,8 @@ describe("resolveAudience", () => {
         actorLogin: "test-app-slug[bot]",
         actorIsBot: true,
         kind: "commented",
+        eventType: "issue_comment",
+        action: "created",
       }),
       { appSlug: "test-app-slug", appPermissions: { issues: "write" }, appSelfOutput: true },
     );
@@ -639,6 +1000,8 @@ describe("resolveAudience", () => {
           actorAuthorAssociation: "NONE",
           targets: [],
           kind: "commented",
+          eventType: "issue_comment",
+          action: "created",
         }),
         { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
       );
@@ -690,6 +1053,8 @@ describe("resolveAudience", () => {
         actorLogin: "external",
         targets: [],
         kind: "commented",
+        eventType: "issue_comment",
+        action: "created",
       }),
       { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
     );

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -373,7 +373,16 @@ describe("isGithubProviderTaskEventEligible", () => {
       provenance: "identity_target",
     },
   };
-  const taskAgent = { uuid: "task-agent", managerHumanAgentId: "manager" };
+  const taskAgent = {
+    uuid: "task-agent",
+    managerHumanAgentId: "manager",
+    role: "github_task_agent" as const,
+  };
+  const contextReviewer = {
+    uuid: "reviewer",
+    managerHumanAgentId: "manager",
+    role: "context_reviewer" as const,
+  };
 
   it("keeps every pull_request semantic event eligible", () => {
     expect(
@@ -391,7 +400,7 @@ describe("isGithubProviderTaskEventEligible", () => {
     ).toBe(true);
   });
 
-  it("requires an exact owner line or issue_comment.created for issues", () => {
+  it("requires an exact owner line or issue_comment.created for ordinary Task Agent issues", () => {
     const opened = makeEvent({
       orgId: "org",
       entityType: "issue",
@@ -411,6 +420,17 @@ describe("isGithubProviderTaskEventEligible", () => {
     expect(isGithubProviderTaskEventEligible(opened, [], taskAgent)).toBe(false);
     expect(isGithubProviderTaskEventEligible(opened, [ownerLine], taskAgent)).toBe(true);
     expect(isGithubProviderTaskEventEligible(commented, [], taskAgent)).toBe(true);
+  });
+
+  it("keeps every supported Issue semantic event eligible for Context Reviewer", () => {
+    const opened = makeEvent({
+      orgId: "org",
+      entityType: "issue",
+      entityKey: "owner/context-tree#1",
+      actorLogin: "alice",
+      kind: "opened",
+    });
+    expect(isGithubProviderTaskEventEligible(opened, [], contextReviewer)).toBe(true);
   });
 });
 
@@ -1024,6 +1044,50 @@ describe("resolveAudience", () => {
         }),
       ],
     });
+  });
+
+  it("still routes bound Context Tree issues.opened to Context Reviewer while ordinary issues.opened waits for first comment", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const teamAgentUuid = await configureTeamAgent(app, admin);
+    const reviewerUuid = await configureContextReviewer(app, admin);
+    await putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      {
+        provider: "github",
+        repo: "git@github.com:Owner/Context-Tree.git",
+        branch: "main",
+      },
+      { updatedBy: admin.userId },
+    );
+
+    const resolveOpened = async (projectKey: string) => {
+      const resolution = await resolveAudienceResolution(
+        app.db,
+        makeEvent({
+          orgId: admin.organizationId,
+          entityType: "issue",
+          entityKey: `${projectKey}#77`,
+          projectKey,
+          actorLogin: "external",
+          targets: [],
+          kind: "opened",
+        }),
+        { appSlug: "test-app-slug", appPermissions: { issues: "write" } },
+      );
+      return projectAudienceTargets(resolution.targets);
+    };
+
+    await expect(resolveOpened("OWNER/CONTEXT-TREE")).resolves.toEqual([
+      expect.objectContaining({
+        delegateAgentId: reviewerUuid,
+        teamAgentTask: { agentUuid: reviewerUuid },
+      }),
+    ]);
+    await expect(resolveOpened("owner/code")).resolves.toEqual([]);
+    expect(teamAgentUuid).not.toBe(reviewerUuid);
   });
 
   it("does not treat a GitLab Context Tree binding as a GitHub context repo", async () => {

--- a/packages/server/src/services/scm/github/audience.ts
+++ b/packages/server/src/services/scm/github/audience.ts
@@ -122,12 +122,14 @@ function isGithubTaskEntityType(event: NormalizedScmEvent): boolean {
 }
 
 /**
- * First-activation event for an Issue owner (GitHub Task Agent) line.
+ * First-activation event for an ordinary-repo GitHub Task Agent Issue owner
+ * line.
  *
- * Real Issues stay dormant for automatic provider-task routing until a
- * non-self-output `issue_comment.created` arrives. Pull-request-shaped
- * `issue_comment` payloads normalize to `entity.type === "pull_request"` and
- * never match. Comment edits/deletes are not activation events.
+ * Real Issues on non-Context repositories stay dormant for automatic Task
+ * Agent routing until a non-self-output `issue_comment.created` arrives.
+ * Pull-request-shaped `issue_comment` payloads normalize to
+ * `entity.type === "pull_request"` and never match. Comment edits/deletes are
+ * not activation events. Bound Context Tree repositories do not use this gate.
  */
 export function isGithubIssueProviderTaskActivationEvent(event: NormalizedScmEvent): boolean {
   return event.entity.type === "issue" && event.eventType === "issue_comment" && event.action === "created";
@@ -148,21 +150,33 @@ export function hasExactGithubProviderTaskOwnerLine(
   );
 }
 
+/** Repository-scoped automatic provider-task role selected for this event. */
+export type GithubProviderTaskRole = "github_task_agent" | "context_reviewer";
+
+export type GithubResolvedProviderTaskAgent = {
+  uuid: string;
+  managerHumanAgentId: string;
+  role: GithubProviderTaskRole;
+};
+
 /**
  * Whether this event may mint or continue an automatic provider-task target.
  *
- * Pull requests keep the historical "every supported semantic event" rule.
- * Issues require either an exact Task Agent owner mapping or a qualifying
- * first comment; non-activating Issue events skip quietly (no App task
- * blocker) so assignee / mention / follow routes stay independent.
+ * Pull requests keep the historical "every supported semantic event" rule for
+ * every repository role. Bound Context Tree Context Reviewer Issue events also
+ * keep that rule. Only ordinary-repo GitHub Task Agent Issue routing requires
+ * either an exact owner mapping or a qualifying first comment; non-activating
+ * Issue events skip quietly (no App task blocker) so assignee / mention /
+ * follow routes stay independent.
  */
 export function isGithubProviderTaskEventEligible(
   event: NormalizedScmEvent,
   existingEntries: Array<Extract<ScmAudienceEntry, { kind: "existing_line" }>>,
-  taskAgent: { uuid: string; managerHumanAgentId: string },
+  taskAgent: GithubResolvedProviderTaskAgent,
 ): boolean {
   if (event.entity.type === "pull_request") return true;
   if (event.entity.type !== "issue") return false;
+  if (taskAgent.role === "context_reviewer") return true;
   return (
     hasExactGithubProviderTaskOwnerLine(existingEntries, taskAgent.managerHumanAgentId, taskAgent.uuid) ||
     isGithubIssueProviderTaskActivationEvent(event)
@@ -188,21 +202,28 @@ function hasGithubTaskEntityIdentity(event: NormalizedScmEvent): boolean {
 async function resolveGithubAppTaskAgent(
   db: Database,
   event: NormalizedScmEvent,
-): Promise<Awaited<ReturnType<typeof loadValidContextReviewerAgent>>> {
+): Promise<GithubResolvedProviderTaskAgent | null> {
   const runtime = await getOrgContextReviewRuntime(db, event.source.organizationId);
   const contextRepo =
     runtime.bindingState === "bound" &&
     runtime.provider === "github" &&
     runtime.providerMatchesRepository &&
     normalizeGithubRepo(runtime.repo) === normalizeGithubRepo(event.entity.projectKey);
+  const role: GithubProviderTaskRole = contextRepo ? "context_reviewer" : "github_task_agent";
   const agentUuid = contextRepo
     ? runtime.contextReviewer.agentUuid
     : await getTeamAgentUuid(db, event.source.organizationId);
   if (!agentUuid) return null;
-  return loadValidContextReviewerAgent(db, {
+  const agent = await loadValidContextReviewerAgent(db, {
     organizationId: event.source.organizationId,
     reviewerAgentUuid: agentUuid,
   });
+  if (!agent) return null;
+  return {
+    uuid: agent.uuid,
+    managerHumanAgentId: agent.managerHumanAgentId,
+    role,
+  };
 }
 
 /**
@@ -391,15 +412,16 @@ export async function resolveGithubAudience(
     }
   }
 
-  // Automatic event routing. Pull-request semantic events and already-active
-  // Issue owner lines remain repository-scoped work for that repository's
-  // task role. Fresh Issues wait for a qualifying `issue_comment.created`
-  // before minting the GitHub Task Agent / Context Reviewer owner line — no
+  // Automatic event routing. Pull-request semantic events remain
+  // repository-scoped work for every role. Bound Context Tree Issue events
+  // keep the same "every supported semantic event" rule for Context Reviewer.
+  // Ordinary-repo GitHub Task Agent Issue lines wait for a qualifying
+  // `issue_comment.created` (or an exact existing owner mapping) — no
   // `@app-slug` text, assignee, or `author_association` is consulted. The
   // skip conditions below drop only the automatic task and never touch
-  // independent personnel targets or subscriptions. Non-activating Issue
-  // events exit before permission / identity blockers so they do not surface
-  // an App task failure for work that was never eligible.
+  // independent personnel targets or subscriptions. Non-activating ordinary
+  // Issue events exit before permission / identity blockers so they do not
+  // surface an App task failure for work that was never eligible.
   const providerTaskTargets: ScmProviderTaskTarget<GithubProviderTaskContext>[] = [];
   if (options.appSlug?.trim() && !options.appSelfOutput && isGithubTaskEntityType(event)) {
     const taskAgent = await resolveGithubAppTaskAgent(db, event);

--- a/packages/server/src/services/scm/github/audience.ts
+++ b/packages/server/src/services/scm/github/audience.ts
@@ -121,6 +121,54 @@ function isGithubTaskEntityType(event: NormalizedScmEvent): boolean {
   return event.entity.type === "issue" || event.entity.type === "pull_request";
 }
 
+/**
+ * First-activation event for an Issue owner (GitHub Task Agent) line.
+ *
+ * Real Issues stay dormant for automatic provider-task routing until a
+ * non-self-output `issue_comment.created` arrives. Pull-request-shaped
+ * `issue_comment` payloads normalize to `entity.type === "pull_request"` and
+ * never match. Comment edits/deletes are not activation events.
+ */
+export function isGithubIssueProviderTaskActivationEvent(event: NormalizedScmEvent): boolean {
+  return event.entity.type === "issue" && event.eventType === "issue_comment" && event.action === "created";
+}
+
+/**
+ * Exact owner-line evidence for the repository task role: the manager-human /
+ * wake-agent pair already follows this entity. Assignee, mention, or
+ * same-human/different-agent rows are not owner evidence.
+ */
+export function hasExactGithubProviderTaskOwnerLine(
+  existingEntries: Array<Extract<ScmAudienceEntry, { kind: "existing_line" }>>,
+  humanAgentId: string,
+  wakeAgentId: string,
+): boolean {
+  return existingEntries.some(
+    (entry) => entry.line.humanAgentId === humanAgentId && entry.line.wakeAgentId === wakeAgentId,
+  );
+}
+
+/**
+ * Whether this event may mint or continue an automatic provider-task target.
+ *
+ * Pull requests keep the historical "every supported semantic event" rule.
+ * Issues require either an exact Task Agent owner mapping or a qualifying
+ * first comment; non-activating Issue events skip quietly (no App task
+ * blocker) so assignee / mention / follow routes stay independent.
+ */
+export function isGithubProviderTaskEventEligible(
+  event: NormalizedScmEvent,
+  existingEntries: Array<Extract<ScmAudienceEntry, { kind: "existing_line" }>>,
+  taskAgent: { uuid: string; managerHumanAgentId: string },
+): boolean {
+  if (event.entity.type === "pull_request") return true;
+  if (event.entity.type !== "issue") return false;
+  return (
+    hasExactGithubProviderTaskOwnerLine(existingEntries, taskAgent.managerHumanAgentId, taskAgent.uuid) ||
+    isGithubIssueProviderTaskActivationEvent(event)
+  );
+}
+
 /** The immutable Issue / PR identity the App reply publisher is bound to. */
 function hasGithubTaskEntityIdentity(event: NormalizedScmEvent): boolean {
   const match = /#([1-9]\d*)$/u.exec(event.entity.key);
@@ -343,16 +391,19 @@ export async function resolveGithubAudience(
     }
   }
 
-  // Automatic event routing. Every normalizer-accepted Issue / pull request
-  // event is repository-scoped work for that repository's task role — no
-  // `@app-slug` text, assignee, or `author_association` is consulted, because
-  // an ordinary App bot isn't even selectable in GitHub's mention/assignee
-  // pickers. The three skip conditions below drop only the automatic task and
-  // never touch independent personnel targets or subscriptions.
+  // Automatic event routing. Pull-request semantic events and already-active
+  // Issue owner lines remain repository-scoped work for that repository's
+  // task role. Fresh Issues wait for a qualifying `issue_comment.created`
+  // before minting the GitHub Task Agent / Context Reviewer owner line — no
+  // `@app-slug` text, assignee, or `author_association` is consulted. The
+  // skip conditions below drop only the automatic task and never touch
+  // independent personnel targets or subscriptions. Non-activating Issue
+  // events exit before permission / identity blockers so they do not surface
+  // an App task failure for work that was never eligible.
   const providerTaskTargets: ScmProviderTaskTarget<GithubProviderTaskContext>[] = [];
   if (options.appSlug?.trim() && !options.appSelfOutput && isGithubTaskEntityType(event)) {
     const taskAgent = await resolveGithubAppTaskAgent(db, event);
-    if (taskAgent) {
+    if (taskAgent && isGithubProviderTaskEventEligible(event, existingEntries, taskAgent)) {
       if (!hasGithubTaskEntityIdentity(event)) {
         appTaskBlocker = "GITHUB_TASK_REPLY_ENTITY_UNSUPPORTED";
       } else if (!isGithubTaskReplySupported(event.entity.type, options.appPermissions)) {


### PR DESCRIPTION
## Summary

- defer the ordinary-repository GitHub Task Agent owner line for Issues until the first qualifying `issue_comment.created`, unless the exact manager-human + Task-Agent line already exists
- keep assignee, mention, follow, and existing-subscription routes immediate and independent
- preserve pull-request automatic routing and the bound Context Tree repository's Context Reviewer behavior
- align the durable cross-surface QA case with the new activation contract

## Why

Issue ownership and execution are usually carried by the GitHub assignee, while the repository-level Task Agent owner often does not need to act at `issues.opened`. Waiting for a real new comment avoids creating an unused Task Agent Chat while preserving immediate assignee attention.

The previous provider-task eligibility treated every supported Issue event alike. This change adds an exact, role-aware activation boundary without inferring owner state from Chat topics, membership, metadata, or human-only mappings.

## Validation

- [ ] `pnpm check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`

Targeted evidence:

- `pnpm exec vitest run src/__tests__/github-audience.test.ts src/__tests__/github-app-webhook-route.test.ts src/__tests__/github-delivery.test.ts src/__tests__/github-delivery-unit.test.ts` — 4 files, 152 tests passed
- `pnpm --filter @first-tree/server typecheck` — passed
- `pnpm --filter @first-tree/qa test` — 1 file, 4 tests passed
- Biome on changed TypeScript files — passed
- independent focused-local QA exercised valid-HMAC HTTP ingress, PostgreSQL state, Inbox notifications, and real Web rendering for delayed ordinary Issue activation, first-comment activation, preserved assignee routing, unchanged Context Reviewer Issue routing, and unchanged PR routing
- independent QA found no product defect in that slice, but its overall status is **INCONCLUSIVE** because Momentic returned a plan-limit error before the first saved step, so no shared Momentic run URL/ID exists; the full disposable-github.com regression case was not run

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [x] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Persistence And Rollout

This changes write timing for `github_entity_chat_mappings`, Chats, messages/task-run metadata, and Inbox entries. It adds no schema, migration, index, backfill, data rewrite, or assignee-line cleanup.

During a rolling deployment, an older instance may still create a Task Agent line from `issues.opened`. Rolling back does not remove lines already created, and neither direction backfills a delayed `opened` card.

## Notes

- package or install behavior changes: none
- docs or tests updated to match: deterministic server tests plus `packages/qa/cases/cross-surface/github-webhook-routing-regression.md`
- follow-up work: companion Context Tree draft PR https://github.com/agent-team-foundation/first-tree-context/pull/916; source should merge before that decision PR is marked ready
