### PR TITLE
fix: align OpenTag launch template names

### DIFF
--- a/packages/server/catalog/official-agent-templates.json
+++ b/packages/server/catalog/official-agent-templates.json
@@ -1,10 +1,10 @@
 [
   {
-    "slug": "team-teammate",
-    "name": "Team Teammate",
+    "slug": "team-assistant",
+    "name": "Team Assistant",
     "public": {
-      "tagline": "Recommended for a team's first all-around AI teammate.",
-      "purpose": "Supports everyday team work by synthesizing discussions, using shared materials, researching options, and checking plans against prior decisions.",
+      "tagline": "For team questions, decisions, and follow-through.",
+      "purpose": "The recommended starting point for everyday team work: synthesizing discussions, using shared materials, researching options, and checking plans against prior decisions.",
       "targetUsers": "Teams adopting one broadly useful entry teammate before adding specialized agents.",
       "userValue": "Turn scattered team context into clear answers, recommendations, and next steps without starting from a blank configuration.",
       "instructionsSummary": "Guides the teammate to ground answers in available team context, surface uncertainty, and turn work into accountable next actions.",
@@ -17,21 +17,21 @@
     },
     "components": [
       {
-        "key": "team-teammate-instructions",
+        "key": "team-assistant-instructions",
         "type": "prompt",
-        "name": "Team Teammate Instructions",
+        "name": "Team Assistant Instructions",
         "payload": {
-          "description": "Core responsibilities for the official Team Teammate Template.",
+          "description": "Core responsibilities for the official Team Assistant Template.",
           "body": "You are the team's general-purpose AI teammate. Help the team understand ongoing work, answer questions from the context and materials available to you, research options, and turn discussions into concrete next steps. Ground claims in available evidence, distinguish facts from inference, surface conflicts with existing decisions, and ask for a decision only when the team must choose. Keep outputs concise, actionable, and clear about owners, open questions, and risks."
         }
       }
     ]
   },
   {
-    "slug": "engineering-teammate",
-    "name": "Engineering Teammate",
+    "slug": "software-engineer",
+    "name": "Software Engineer",
     "public": {
-      "tagline": "A software engineering teammate for diagnosis, review, and delivery planning.",
+      "tagline": "A software engineer for diagnosis, review, and delivery planning.",
       "purpose": "Helps engineering teams investigate failures, review changes against architectural constraints, and translate requirements into implementation plans.",
       "targetUsers": "Software teams that want an agent to reason from code, tests, operational evidence, and established technical decisions.",
       "userValue": "Move from an engineering question to an evidence-backed diagnosis or reviewable delivery plan faster.",
@@ -45,21 +45,21 @@
     },
     "components": [
       {
-        "key": "engineering-teammate-instructions",
+        "key": "software-engineer-instructions",
         "type": "prompt",
-        "name": "Engineering Teammate Instructions",
+        "name": "Software Engineer Instructions",
         "payload": {
-          "description": "Core responsibilities for the official Engineering Teammate Template.",
-          "body": "You are the team's software engineering teammate. Investigate code and operational evidence before proposing changes, preserve established product and architecture constraints, and choose the smallest maintainable implementation that satisfies the request. Validate behavior at stable public boundaries, keep diffs focused, and report the commands, results, limitations, and risks that support your conclusion. Escalate only when product scope, security, production data, or an irreversible architecture choice requires a human decision."
+          "description": "Core responsibilities for the official Software Engineer Template.",
+          "body": "You are the team's software engineer. Investigate code and operational evidence before proposing changes, preserve established product and architecture constraints, and choose the smallest maintainable implementation that satisfies the request. Validate behavior at stable public boundaries, keep diffs focused, and report the commands, results, limitations, and risks that support your conclusion. Escalate only when product scope, security, production data, or an irreversible architecture choice requires a human decision."
         }
       }
     ]
   },
   {
-    "slug": "research-teammate",
-    "name": "Research Teammate",
+    "slug": "researcher",
+    "name": "Researcher",
     "public": {
-      "tagline": "A research teammate for evidence gathering, comparison, and decision support.",
+      "tagline": "A researcher for evidence gathering, comparison, and decision support.",
       "purpose": "Investigates markets and technical or operational questions, compares credible alternatives, and turns source material into decision-ready conclusions.",
       "targetUsers": "Teams that need structured research with transparent evidence, tradeoffs, and recommendations.",
       "userValue": "Replace scattered reading with a concise, source-backed view of the decision and the uncertainty that remains.",
@@ -73,12 +73,12 @@
     },
     "components": [
       {
-        "key": "research-teammate-instructions",
+        "key": "researcher-instructions",
         "type": "prompt",
-        "name": "Research Teammate Instructions",
+        "name": "Researcher Instructions",
         "payload": {
-          "description": "Core responsibilities for the official Research Teammate Template.",
-          "body": "You are the team's research teammate. Clarify the decision the research must inform, gather the most authoritative and current evidence available, and compare alternatives against explicit criteria. Cite sources close to the claims they support, separate verified facts from inference, explain material limitations or disagreement, and finish with a concise recommendation and the conditions that could change it. Do not manufacture certainty or hide missing evidence."
+          "description": "Core responsibilities for the official Researcher Template.",
+          "body": "You are the team's researcher. Clarify the decision the research must inform, gather the most authoritative and current evidence available, and compare alternatives against explicit criteria. Cite sources close to the claims they support, separate verified facts from inference, explain material limitations or disagreement, and finish with a concise recommendation and the conditions that could change it. Do not manufacture certainty or hide missing evidence."
         }
       }
     ]

--- a/packages/server/src/__tests__/official-agent-template-catalog.test.ts
+++ b/packages/server/src/__tests__/official-agent-template-catalog.test.ts
@@ -53,17 +53,10 @@ describe("official launch Agent Template catalog", () => {
 
   it("defines the three bounded, importable launch Templates", () => {
     const catalog = loadCatalog();
-    expect(catalog.map((template) => template.slug)).toEqual([
-      "team-teammate",
-      "engineering-teammate",
-      "research-teammate",
-    ]);
-    expect(catalog.map((template) => template.name)).toEqual([
-      "Team Teammate",
-      "Engineering Teammate",
-      "Research Teammate",
-    ]);
-    expect(catalog[0]?.public.tagline).toContain("Recommended");
+    expect(catalog.map((template) => template.slug)).toEqual(["team-assistant", "software-engineer", "researcher"]);
+    expect(catalog.map((template) => template.name)).toEqual(["Team Assistant", "Software Engineer", "Researcher"]);
+    expect(catalog[0]?.public.tagline).toBe("For team questions, decisions, and follow-through.");
+    expect(catalog[0]?.public.purpose).toContain("recommended starting point");
 
     for (const template of catalog) {
       expect(template.public.exampleTasks).toHaveLength(3);
@@ -91,13 +84,14 @@ describe("official launch Agent Template catalog", () => {
 
     const publicList = await app.inject({ method: "GET", url: PUBLIC_URL });
     expect(publicList.statusCode).toBe(200);
+    const officialSlugs = new Set(loadCatalog().map((template) => template.slug));
     const templates = publicList
       .json<{ templates: Array<{ slug: string; public: { exampleTasks?: string[] } }> }>()
-      .templates.filter((template) => template.slug.endsWith("-teammate"));
+      .templates.filter((template) => officialSlugs.has(template.slug));
     expect(templates.map((template) => template.slug).sort()).toEqual([
-      "engineering-teammate",
-      "research-teammate",
-      "team-teammate",
+      "researcher",
+      "software-engineer",
+      "team-assistant",
     ]);
     expect(templates.every((template) => template.public.exampleTasks?.length === 3)).toBe(true);
 

--- a/packages/server/src/__tests__/official-agent-template-publisher.test.ts
+++ b/packages/server/src/__tests__/official-agent-template-publisher.test.ts
@@ -6,8 +6,8 @@ const TOKEN = "2026-08-12T09:00:00.000Z";
 const NEXT_TOKEN = "2026-08-12T09:05:00.000Z";
 
 const DEFINITION: CreateAgentTemplate = {
-  slug: "team-teammate",
-  name: "Team Teammate",
+  slug: "team-assistant",
+  name: "Team Assistant",
   public: {
     tagline: "Recommended for a team's first AI teammate.",
     purpose: "Helps with everyday team work.",
@@ -19,9 +19,9 @@ const DEFINITION: CreateAgentTemplate = {
   },
   components: [
     {
-      key: "team-teammate-instructions",
+      key: "team-assistant-instructions",
       type: "prompt",
-      name: "Team Teammate Instructions",
+      name: "Team Assistant Instructions",
       payload: { body: "Help the team.", description: "Core responsibilities." },
     },
   ],
@@ -116,7 +116,7 @@ describe("official Agent Template catalog publisher", () => {
   });
 
   it("updates a changed active Template with its optimistic-concurrency token", async () => {
-    const stored = detail({ name: "Old Team Teammate" });
+    const stored = detail({ name: "Old Team Assistant" });
     const updated = detail({ updatedAt: NEXT_TOKEN });
     const fetcher = vi
       .fn<typeof fetch>()
@@ -145,7 +145,7 @@ describe("official Agent Template catalog publisher", () => {
   });
 
   it("updates and publishes a changed draft using the refreshed concurrency token", async () => {
-    const stored = detail({ name: "Old Team Teammate", status: "draft" });
+    const stored = detail({ name: "Old Team Assistant", status: "draft" });
     const updatedDraft = detail({ status: "draft", updatedAt: NEXT_TOKEN });
     const active = detail({ updatedAt: "2026-08-12T09:06:00.000Z" });
     const fetcher = vi
@@ -208,7 +208,7 @@ describe("official Agent Template catalog publisher", () => {
         apply: true,
         fetcher,
       }),
-    ).rejects.toThrow('Official Agent Template "team-teammate" is retired');
+    ).rejects.toThrow('Official Agent Template "team-assistant" is retired');
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- rename the official OpenTag launch Templates to role-first names: Team Assistant, Software Engineer, and Researcher
- update their pre-publication slugs to `team-assistant`, `software-engineer`, and `researcher`
- align component identities and catalog tests without changing responsibilities, example tasks, publication governance, or copy-on-adopt semantics

## Context

This is the focused naming follow-up to #2294, which merged before the approved OpenTag product naming adjustment could land. Do not run the official catalog `--apply` command until this follow-up is merged.

The Team Assistant tagline is now exactly `For team questions, decisions, and follow-through.` The existing public-profile model has no structured recommendation flag, so its purpose identifies it as the recommended starting point without expanding the schema.

## Validation

- official catalog and publisher tests: 9 passed
- focused Biome check: passed
- Server typecheck: passed
- `git diff --check origin/main...HEAD`: passed

## Independent review

- Standards: no findings on exact head `9e4dac3980c1ff4ac768479a1c18475f621f54db`
- Spec: no findings on the same exact head; residual UI note is that Recommended remains public copy rather than a structured flag
