### PR TITLE
fix(web): hand off first runtime bind to channel setup

### DIFF
--- a/packages/qa/cases/cross-surface/registration-first-run-onboarding.md
+++ b/packages/qa/cases/cross-surface/registration-first-run-onboarding.md
@@ -21,11 +21,14 @@ Confirm the current first-run lifecycle for a genuinely new identity:
 - a campaign action that needs the user's own Agent preserves its handoff and
   routes a Team-less caller through first-Agent selection, never into a hosted
   trial;
+- the exact first Agent continues from its one-shot Runtime bind to the existing
+  channel setup entry, including reload and bind-failure recovery;
 - Account and Sign out remain reachable while the user has no Team.
 
 This case owns the cross-surface behavior that deterministic auth, provisioning,
-rollback, and route tests cannot prove in one real browser journey. Runtime
-binding/readiness after an unbound Team Agent exists is a separate journey.
+rollback, and route tests cannot prove in one real browser journey. It covers
+only the first Runtime bind and handoff to the existing channel entry; provider
+readiness, authentication, and real channel first use remain separate journeys.
 
 ## Preconditions
 
@@ -82,6 +85,29 @@ binding/readiness after an unbound Team Agent exists is a separate journey.
    stored action remains available for the later Runtime/setup continuation.
 3. Re-open the action after the user's Agent is connectable. Verify one task chat
    is created or reused and the handoff clears only after that chat exists.
+
+## Scenario D — first Runtime bind handoff
+
+1. Continue Scenario A with the exact unbound first Team Agent and a connected
+   computer that reports at least one available Runtime artifact. Verify the
+   Runtime page shows that computer and only providers the Client reports as
+   executable; do not treat this capability snapshot as provider authentication.
+2. Assign the computer. Verify the existing member-JWT first-bind path pins the
+   Agent exactly once and the browser replaces the Runtime location with that
+   same Agent's Profile, where the existing Feishu channel setup entry is
+   visible. Verify the onboarding continuation remains pending and no completion
+   stamp is written.
+3. Repeat with the bind request failing before commit. Verify the error remains
+   on Runtime, the selection is retryable, and only a successful bind advances
+   to Profile.
+4. Repeat with the Server committing the pin while the browser loses the
+   response. Reload `/onboarding` and the Agent Runtime URL. Verify both recover
+   from the authoritative bound Agent to the same Profile/channel entry without
+   issuing another bind.
+5. Bind an ordinary unclaimed Agent with no first-Agent continuation. Verify it
+   remains on Runtime after assignment. A provider credential failure, if later
+   encountered in a real task, must remain recoverable from that chat rather
+   than appearing as Runtime readiness here.
 
 ## Legacy Cohort Preservation
 

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -170,6 +170,16 @@ function AgentDetailPageView() {
     onboardingCompletedAt === null ? currentMembership?.firstTeamAgentContinuation : null;
   const continuesFirstTeamAgent =
     firstTeamAgentContinuation?.agentId === uuid && firstTeamAgentContinuation.status === "active";
+  const continueFirstTeamAgentToChannel = useCallback(() => {
+    if (continuesFirstTeamAgent) {
+      navigate(`/agents/${encodeURIComponent(uuid)}/profile`, { replace: true });
+    }
+  }, [continuesFirstTeamAgent, navigate, uuid]);
+  useEffect(() => {
+    if (agentQuery.data?.clientId && location.pathname.endsWith("/runtime")) {
+      continueFirstTeamAgentToChannel();
+    }
+  }, [agentQuery.data?.clientId, continueFirstTeamAgentToChannel, location.pathname]);
   const clientsQuery = useQuery({
     queryKey: ["clients"],
     queryFn: listClients,
@@ -184,9 +194,7 @@ function AgentDetailPageView() {
       setBindClientOpen(false);
       setBindClientSelected("");
       setBindClientError(null);
-      if (continuesFirstTeamAgent) {
-        navigate(`/agents/${encodeURIComponent(uuid)}/profile`, { replace: true });
-      }
+      continueFirstTeamAgentToChannel();
     },
     onError: (err) => setBindClientError(err instanceof Error ? err.message : String(err)),
   });

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -66,7 +66,7 @@ function AgentDetailPageView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const location = useLocation();
-  const { memberId, role } = useAuth();
+  const { memberId, role, onboardingCompletedAt, currentMembership } = useAuth();
   // Narrow web viewports trade the local navigation rail for a section selector.
   const isNarrow = useWorkspaceViewport() === "narrow";
   const agentQuery = useQuery({
@@ -166,6 +166,10 @@ function AgentDetailPageView() {
   const [bindClientOpen, setBindClientOpen] = useState(false);
   const [bindClientSelected, setBindClientSelected] = useState<string>("");
   const [bindClientError, setBindClientError] = useState<string | null>(null);
+  const firstTeamAgentContinuation =
+    onboardingCompletedAt === null ? currentMembership?.firstTeamAgentContinuation : null;
+  const continuesFirstTeamAgent =
+    firstTeamAgentContinuation?.agentId === uuid && firstTeamAgentContinuation.status === "active";
   const clientsQuery = useQuery({
     queryKey: ["clients"],
     queryFn: listClients,
@@ -180,6 +184,9 @@ function AgentDetailPageView() {
       setBindClientOpen(false);
       setBindClientSelected("");
       setBindClientError(null);
+      if (continuesFirstTeamAgent) {
+        navigate(`/agents/${encodeURIComponent(uuid)}/profile`, { replace: true });
+      }
     },
     onError: (err) => setBindClientError(err instanceof Error ? err.message : String(err)),
   });

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -464,6 +464,13 @@ async function chooseSelectOption(trigger: Element | null, optionText: string): 
   await click(buttonByText(document.body, optionText));
 }
 
+async function chooseComputerAndAssign(container: ParentNode, hostname = "gandy-macbook"): Promise<void> {
+  await click(buttonByText(container, "Choose computer"));
+  await waitForText(document.body, hostname);
+  await click(buttonByText(document.body, hostname));
+  await click(exactButtonByText(document.body, "Assign"));
+}
+
 beforeEach(() => {
   installBrowserStubs();
   document.body.innerHTML = "";
@@ -1576,13 +1583,24 @@ describe("AgentDetailPage", () => {
       profile: <LocationEchoWithBack />,
     });
     await waitForText(view.container, "No computer assigned");
-    await click(buttonByText(view.container, "Choose computer"));
-    await waitForText(document.body, "gandy-macbook");
-    await click(buttonByText(document.body, "gandy-macbook"));
-    await click(exactButtonByText(document.body, "Assign"));
+    await chooseComputerAndAssign(view.container);
 
     await waitForText(view.container, "/agents/agent-1/profile");
     expect(agentMocks.updateAgent).toHaveBeenCalledWith("agent-1", { clientId: "client-1" });
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("recovers an already-bound first Team Agent from a Runtime reload to its channel entry", async () => {
+    authMock.value.currentMembership.firstTeamAgentContinuation = { agentId: "agent-1", status: "active" };
+    const { RuntimeTab } = await import("../runtime-tab.js");
+
+    const view = await renderDom("/agents/agent-1/runtime", <RuntimeTab />, undefined, {
+      profile: <LocationEchoWithBack />,
+    });
+
+    await waitForText(view.container, "/agents/agent-1/profile");
+    expect(agentMocks.updateAgent).not.toHaveBeenCalled();
 
     await act(async () => view.root.unmount());
   });
@@ -1604,10 +1622,7 @@ describe("AgentDetailPage", () => {
       profile: <LocationEchoWithBack />,
     });
     await waitForText(view.container, "No computer assigned");
-    await click(buttonByText(view.container, "Choose computer"));
-    await waitForText(document.body, "gandy-macbook");
-    await click(buttonByText(document.body, "gandy-macbook"));
-    await click(exactButtonByText(document.body, "Assign"));
+    await chooseComputerAndAssign(view.container);
 
     await waitForText(document.body, "bind unavailable");
     expect(view.container.textContent).toContain("Execution");

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -343,6 +343,7 @@ async function renderDom(
   child: ReactElement,
   setup?: (queryClient: QueryClient) => void | Promise<void>,
   routeChildren?: {
+    profile?: ReactElement;
     prompt?: ReactElement;
     capabilities?: ReactElement;
     repositories?: ReactElement;
@@ -366,7 +367,7 @@ async function renderDom(
           <ToastProvider>
             <Routes>
               <Route path="/agents/:uuid" element={<AgentDetailPage />}>
-                <Route path="profile" element={child} />
+                <Route path="profile" element={routeChildren?.profile ?? child} />
                 <Route path="responsibilities" element={<Navigate to="../profile" replace />} />
                 <Route path="prompt" element={routeChildren?.prompt ?? child} />
                 <Route path="capabilities" element={routeChildren?.capabilities ?? child} />
@@ -1556,7 +1557,66 @@ describe("AgentDetailPage", () => {
     await click(exactButtonByText(document.body, "Assign"));
     await waitForCondition(() => agentMocks.updateAgent.mock.calls.length > 0, "Expected bind mutation");
     expect(agentMocks.updateAgent).toHaveBeenCalledWith("agent-1", { clientId: "client-1" });
+    expect(first.container.textContent).toContain("Execution");
     await act(async () => first.root.unmount());
+  });
+
+  it("continues the exact first Team Agent from Runtime setup to its channel entry after first bind", async () => {
+    authMock.value.currentMembership.firstTeamAgentContinuation = { agentId: "agent-1", status: "active" };
+    const { RuntimeTab } = await import("../runtime-tab.js");
+    agentConfigMocks.getAgentClientStatus.mockResolvedValueOnce({
+      online: false,
+      clientId: null,
+      offlineSince: null,
+    });
+    agentMocks.getAgent.mockResolvedValueOnce(agent({ clientId: null, runtimeState: null }));
+    agentMocks.updateAgent.mockResolvedValueOnce(agent({ clientId: "client-1", runtimeState: null }));
+
+    const view = await renderDom("/agents/agent-1/runtime", <RuntimeTab />, undefined, {
+      profile: <LocationEchoWithBack />,
+    });
+    await waitForText(view.container, "No computer assigned");
+    await click(buttonByText(view.container, "Choose computer"));
+    await waitForText(document.body, "gandy-macbook");
+    await click(buttonByText(document.body, "gandy-macbook"));
+    await click(exactButtonByText(document.body, "Assign"));
+
+    await waitForText(view.container, "/agents/agent-1/profile");
+    expect(agentMocks.updateAgent).toHaveBeenCalledWith("agent-1", { clientId: "client-1" });
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps a failed first-Team Runtime bind retryable before continuing to the channel entry", async () => {
+    authMock.value.currentMembership.firstTeamAgentContinuation = { agentId: "agent-1", status: "active" };
+    const { RuntimeTab } = await import("../runtime-tab.js");
+    agentConfigMocks.getAgentClientStatus.mockResolvedValueOnce({
+      online: false,
+      clientId: null,
+      offlineSince: null,
+    });
+    agentMocks.getAgent.mockResolvedValueOnce(agent({ clientId: null, runtimeState: null }));
+    agentMocks.updateAgent
+      .mockRejectedValueOnce(new Error("bind unavailable"))
+      .mockResolvedValueOnce(agent({ clientId: "client-1", runtimeState: null }));
+
+    const view = await renderDom("/agents/agent-1/runtime", <RuntimeTab />, undefined, {
+      profile: <LocationEchoWithBack />,
+    });
+    await waitForText(view.container, "No computer assigned");
+    await click(buttonByText(view.container, "Choose computer"));
+    await waitForText(document.body, "gandy-macbook");
+    await click(buttonByText(document.body, "gandy-macbook"));
+    await click(exactButtonByText(document.body, "Assign"));
+
+    await waitForText(document.body, "bind unavailable");
+    expect(view.container.textContent).toContain("Execution");
+
+    await click(exactButtonByText(document.body, "Assign"));
+    await waitForText(view.container, "/agents/agent-1/profile");
+    expect(agentMocks.updateAgent).toHaveBeenCalledTimes(2);
+
+    await act(async () => view.root.unmount());
   });
 
   it("switches an agent runtime from the Runtime tab", async () => {


### PR DESCRIPTION
## Summary

- continue the exact active first-Team-Agent onboarding handoff from a successful one-shot Runtime assignment to that Agent's existing Profile/Feishu channel entry
- recover the same handoff after a committed bind whose response was lost by observing the authoritative bound Agent on Runtime reload
- keep ordinary unclaimed Agents on Runtime and keep failed binds retryable without advancing the onboarding continuation
- add the matching cross-surface QA case for the first Runtime assignment boundary

## Scope boundaries

- no database schema, migration, persistence, onboarding enum, or second onboarding model
- no Feishu contract or transport changes
- no readiness/provider-auth preflight, cache, aggregate read model, or Runtime state machine
- `FIRST_TREE_OPENTAG_AGENT_FIRST_ONBOARDING_ENABLED` remains default-off
- runtime capability remains artifact/platform executability only; provider authentication still recovers in real chat

## Validation

- focused Web regression set: 149/149 passed, including Agent Detail Runtime/Profile and existing Feishu section coverage
- Server bind authorization/immutability/capability suites: 36/36 passed
- QA case lifecycle tests: 5/5 passed
- repository check: passed (existing unrelated diagnostics only)
- repository typecheck: 9/9 tasks passed
- Web production build: passed (existing CSS wildcard-radius and chunk-size warnings only)
- focused Biome check and `git diff --check`: passed
- headed Chromium smoke on the exact Web build: one bind PATCH replaced Runtime with Profile/Feishu; an authoritative already-bound Runtime reload recovered to Profile with no PATCH (deterministic API fixtures; independent cross-surface QA remains separate)
- full repository test run was attempted twice: the first run stopped on a Testcontainers port-bind timeout before Server collection; the one permitted retry stopped on an unrelated CLI build-hook timeout. Neither failure was a product assertion in this change's scope; clean-runner CI covers those suites and independent QA remains required.
- exact-head GitHub CI and CodeQL: passed, including Server, Client/Web, build, check, typecheck, migration guard, and release/portable smoke jobs

## Independent review

- Standards: 0 findings after adding the cross-surface QA case and consolidating the test interaction helper
- Spec: 0 findings after adding authoritative already-bound reload recovery

Exact reviewed head: `d98a8ff8e70d05695aa66d7a1ada339a9f17b244`
