### PR TITLE
feat: make attachment object quota configurable

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2137,6 +2137,17 @@ The server applies this as one actor-aware global safety cap per minute. It
 keys by agent id, then user id, then request IP for unauthenticated traffic.
 Old per-route rate-limit env vars are no longer read.
 
+**Attachments:**
+
+| Variable | Default |
+|---|---|
+| `FIRST_TREE_ATTACHMENT_ORG_QUOTA_COUNT` | `10000` |
+
+Maximum number of attachment objects one Team may hold. Chat uploads, Feishu
+inbound resources, Team Skill bundles, and Agent Template adoption copies all
+share the same per-Team pool. The per-file 10 MiB cap and the per-Team 2 GiB
+byte quota are fixed and stay the storage backstop regardless of this value.
+
 **Inbox / WS / archive sweeper:**
 
 | Variable | Default |

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -764,25 +764,29 @@ describe("small API route handlers", () => {
   it("skips malformed org agent pinned frames after create", async () => {
     const sendToClient = vi.fn();
     const createdAt = new Date("2026-07-08T00:00:00.000Z");
+    const createAgent = vi.fn().mockResolvedValue({
+      uuid: "agent_bad_runtime",
+      name: "bad-runtime",
+      displayName: "Bad Runtime",
+      type: "agent",
+      clientId: "client_1",
+      runtimeProvider: "not-a-runtime",
+      metadata: {},
+      createdAt,
+      updatedAt: createdAt,
+    });
     vi.doMock("../services/runtime/connection-manager.js", () => ({ sendToClient }));
     vi.doMock("../services/agents/identity.js", () => ({
-      createAgent: vi.fn().mockResolvedValue({
-        uuid: "agent_bad_runtime",
-        name: "bad-runtime",
-        displayName: "Bad Runtime",
-        type: "agent",
-        clientId: "client_1",
-        runtimeProvider: "not-a-runtime",
-        metadata: {},
-        createdAt,
-        updatedAt: createdAt,
-      }),
+      createAgent,
       resolveAvatarImageUrl: vi.fn(() => null),
       stripReservedAgentMetadata: vi.fn((metadata: unknown) => metadata ?? {}),
     }));
     const warn = vi.fn();
     const { orgAgentRoutes } = await import("../api/orgs/agents.js");
-    const { app, routes } = makeApp({ log: { warn } });
+    const { app, routes } = makeApp({
+      log: { warn },
+      config: { attachments: { organizationObjectQuota: 10_000 } },
+    });
 
     await orgAgentRoutes(app as never);
 
@@ -795,6 +799,11 @@ describe("small API route handlers", () => {
     );
 
     expect(reply.code).toBe(201);
+    expect(createAgent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: "agent", name: "bad-runtime" }),
+      expect.objectContaining({ attachmentObjectQuota: { maxOrganizationAttachments: 10_000 } }),
+    );
     expect(sendToClient).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(expect.any(Object), "agent:pinned frame failed schema validation — not sending");
   });

--- a/packages/server/src/__tests__/attachments-route.test.ts
+++ b/packages/server/src/__tests__/attachments-route.test.ts
@@ -23,6 +23,8 @@ import { createAdminContext, createTestAdmin, useTestApp } from "./helpers.js";
 
 type Admin = Awaited<ReturnType<typeof createTestAdmin>>;
 
+const TEST_ATTACHMENT_QUOTA = { maxOrganizationAttachments: 10_000 };
+
 function postAttachment(
   app: FastifyInstance,
   caller: Admin,
@@ -127,13 +129,17 @@ describe("attachments route — upload + capability download", () => {
   it("database-fences the old PostgreSQL-to-S3 backfill during a rolling deploy", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `storage-fence-${crypto.randomUUID().slice(0, 6)}` });
-    const stored = await createAttachment(app.db, {
-      organizationId: admin.organizationId,
-      mimeType: "application/octet-stream",
-      filename: "postgres.bin",
-      body: Buffer.from("postgres-authoritative"),
-      uploadedBy: admin.humanAgentUuid,
-    });
+    const stored = await createAttachment(
+      app.db,
+      {
+        organizationId: admin.organizationId,
+        mimeType: "application/octet-stream",
+        filename: "postgres.bin",
+        body: Buffer.from("postgres-authoritative"),
+        uploadedBy: admin.humanAgentUuid,
+      },
+      TEST_ATTACHMENT_QUOTA,
+    );
     const legacyObjectKey = `attachments/${admin.organizationId}/${stored.id}`;
 
     // This is the claim UPDATE issued by #2062's old replica before it would
@@ -235,13 +241,13 @@ describe("attachments route — upload + capability download", () => {
       uploadedBy: admin.humanAgentUuid,
     });
     const active = Array.from({ length: MAX_CONCURRENT_ATTACHMENT_UPLOADS_PER_CALLER }, (_, index) =>
-      createAttachment(app.db, input(index)),
+      createAttachment(app.db, input(index), TEST_ATTACHMENT_QUOTA),
     );
 
     await limitReached;
-    await expect(createAttachment(app.db, input(MAX_CONCURRENT_ATTACHMENT_UPLOADS_PER_CALLER))).rejects.toThrow(
-      `already has ${MAX_CONCURRENT_ATTACHMENT_UPLOADS_PER_CALLER}`,
-    );
+    await expect(
+      createAttachment(app.db, input(MAX_CONCURRENT_ATTACHMENT_UPLOADS_PER_CALLER), TEST_ATTACHMENT_QUOTA),
+    ).rejects.toThrow(`already has ${MAX_CONCURRENT_ATTACHMENT_UPLOADS_PER_CALLER}`);
     expect(startedCount).toBe(MAX_CONCURRENT_ATTACHMENT_UPLOADS_PER_CALLER);
 
     releaseUploads();
@@ -257,15 +263,19 @@ describe("attachments route — upload + capability download", () => {
     const id = crypto.randomUUID();
 
     await expect(
-      createAttachment(app.db, {
-        id,
-        organizationId: admin.organizationId,
-        mimeType: "application/octet-stream",
-        filename: "failed-delete.bin",
-        body: Buffer.from("three"),
-        contentLength: 3,
-        uploadedBy: admin.humanAgentUuid,
-      }),
+      createAttachment(
+        app.db,
+        {
+          id,
+          organizationId: admin.organizationId,
+          mimeType: "application/octet-stream",
+          filename: "failed-delete.bin",
+          body: Buffer.from("three"),
+          contentLength: 3,
+          uploadedBy: admin.humanAgentUuid,
+        },
+        TEST_ATTACHMENT_QUOTA,
+      ),
     ).rejects.toThrow("Content-Length does not match");
 
     expect(await app.db.select().from(attachments).where(eq(attachments.id, id))).toHaveLength(0);
@@ -274,13 +284,17 @@ describe("attachments route — upload + capability download", () => {
   it("holds attachment reference locks until the message transaction commits", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `ref-lock-${crypto.randomUUID().slice(0, 6)}` });
-    const stored = await createAttachment(app.db, {
-      organizationId: admin.organizationId,
-      mimeType: "text/markdown",
-      filename: "locked.md",
-      body: Buffer.from("locked"),
-      uploadedBy: admin.humanAgentUuid,
-    });
+    const stored = await createAttachment(
+      app.db,
+      {
+        organizationId: admin.organizationId,
+        mimeType: "text/markdown",
+        filename: "locked.md",
+        body: Buffer.from("locked"),
+        uploadedBy: admin.humanAgentUuid,
+      },
+      TEST_ATTACHMENT_QUOTA,
+    );
     const chatId = uuidv7();
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
     const metadata = {
@@ -335,13 +349,17 @@ describe("attachments route — upload + capability download", () => {
   it("holds single and batch file-content reference locks until message commit", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `file-ref-lock-${crypto.randomUUID().slice(0, 6)}` });
-    const stored = await createAttachment(app.db, {
-      organizationId: admin.organizationId,
-      mimeType: "image/png",
-      filename: "locked.png",
-      body: Buffer.from("locked-image"),
-      uploadedBy: admin.humanAgentUuid,
-    });
+    const stored = await createAttachment(
+      app.db,
+      {
+        organizationId: admin.organizationId,
+        mimeType: "image/png",
+        filename: "locked.png",
+        body: Buffer.from("locked-image"),
+        uploadedBy: admin.humanAgentUuid,
+      },
+      TEST_ATTACHMENT_QUOTA,
+    );
     const chatId = uuidv7();
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
     const ref = {
@@ -413,13 +431,17 @@ describe("attachments route — upload + capability download", () => {
       { allowRecipientlessSend: true },
     );
 
-    const stored = await createAttachment(app.db, {
-      organizationId: admin.organizationId,
-      mimeType: "image/png",
-      filename: "actual.png",
-      body: Buffer.from("actual"),
-      uploadedBy: admin.humanAgentUuid,
-    });
+    const stored = await createAttachment(
+      app.db,
+      {
+        organizationId: admin.organizationId,
+        mimeType: "image/png",
+        filename: "actual.png",
+        body: Buffer.from("actual"),
+        uploadedBy: admin.humanAgentUuid,
+      },
+      TEST_ATTACHMENT_QUOTA,
+    );
     await sendMessage(
       app.db,
       chatId,
@@ -478,20 +500,28 @@ describe("attachments route — upload + capability download", () => {
     const admin = await createTestAdmin(app, { username: `file-ref-edit-${crypto.randomUUID().slice(0, 6)}` });
     const chatId = uuidv7();
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
-    const previous = await createAttachment(app.db, {
-      organizationId: admin.organizationId,
-      mimeType: "image/png",
-      filename: "previous.png",
-      body: Buffer.from("previous"),
-      uploadedBy: admin.humanAgentUuid,
-    });
-    const replacement = await createAttachment(app.db, {
-      organizationId: admin.organizationId,
-      mimeType: "image/png",
-      filename: "replacement.png",
-      body: Buffer.from("replacement"),
-      uploadedBy: admin.humanAgentUuid,
-    });
+    const previous = await createAttachment(
+      app.db,
+      {
+        organizationId: admin.organizationId,
+        mimeType: "image/png",
+        filename: "previous.png",
+        body: Buffer.from("previous"),
+        uploadedBy: admin.humanAgentUuid,
+      },
+      TEST_ATTACHMENT_QUOTA,
+    );
+    const replacement = await createAttachment(
+      app.db,
+      {
+        organizationId: admin.organizationId,
+        mimeType: "image/png",
+        filename: "replacement.png",
+        body: Buffer.from("replacement"),
+        uploadedBy: admin.humanAgentUuid,
+      },
+      TEST_ATTACHMENT_QUOTA,
+    );
     const messageId = uuidv7();
     await app.db.insert(messages).values({
       id: messageId,
@@ -623,13 +653,17 @@ describe("attachments route — upload + capability download", () => {
     expect(blankMime.statusCode).toBe(400);
 
     await expect(
-      createAttachment(app.db, {
-        organizationId: admin.organizationId,
-        mimeType: "image/png",
-        filename: " ",
-        body: Buffer.from("filename"),
-        uploadedBy: admin.humanAgentUuid,
-      }),
+      createAttachment(
+        app.db,
+        {
+          organizationId: admin.organizationId,
+          mimeType: "image/png",
+          filename: " ",
+          body: Buffer.from("filename"),
+          uploadedBy: admin.humanAgentUuid,
+        },
+        TEST_ATTACHMENT_QUOTA,
+      ),
     ).rejects.toThrow("Attachment filename is required");
   });
 
@@ -637,14 +671,18 @@ describe("attachments route — upload + capability download", () => {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `length-${crypto.randomUUID().slice(0, 6)}` });
     await expect(
-      createAttachment(app.db, {
-        organizationId: admin.organizationId,
-        mimeType: "application/octet-stream",
-        filename: "length.bin",
-        body: Buffer.from("three"),
-        contentLength: 3,
-        uploadedBy: admin.humanAgentUuid,
-      }),
+      createAttachment(
+        app.db,
+        {
+          organizationId: admin.organizationId,
+          mimeType: "application/octet-stream",
+          filename: "length.bin",
+          body: Buffer.from("three"),
+          contentLength: 3,
+          uploadedBy: admin.humanAgentUuid,
+        },
+        TEST_ATTACHMENT_QUOTA,
+      ),
     ).rejects.toThrow("Content-Length does not match");
   });
 
@@ -704,5 +742,43 @@ describe("attachments route — upload + capability download", () => {
     const second = await postAttachment(app, admin, Buffer.from("second"), { orgId: otherOrgId });
     expect(second.statusCode).toBe(201);
     expect((second.json() as { uploadedBy: string }).uploadedBy).toBe(otherMember.agentId);
+  });
+});
+
+describe("organization attachment object quota", () => {
+  const getApp = useTestApp();
+
+  it("enforces the caller-supplied object quota at the service layer", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `quota-${crypto.randomUUID().slice(0, 6)}` });
+    const quota = { maxOrganizationAttachments: 2 };
+    const input = (name: string) => ({
+      organizationId: admin.organizationId,
+      mimeType: "application/octet-stream",
+      filename: name,
+      body: Buffer.from(name),
+      uploadedBy: admin.humanAgentUuid,
+    });
+
+    await createAttachment(app.db, input("quota-1.bin"), quota);
+    await createAttachment(app.db, input("quota-2.bin"), quota);
+    await expect(createAttachment(app.db, input("quota-3.bin"), quota)).rejects.toThrow(
+      "Organization attachment quota of 2 objects exceeded",
+    );
+  });
+});
+
+describe("organization attachment object quota — route wiring", () => {
+  const getApp = useTestApp({ attachmentObjectQuota: 2 });
+
+  it("rejects the upload beyond the deployment-configured object quota", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `quota-route-${crypto.randomUUID().slice(0, 6)}` });
+
+    expect((await postAttachment(app, admin, Buffer.from("one"), { filename: "one.bin" })).statusCode).toBe(201);
+    expect((await postAttachment(app, admin, Buffer.from("two"), { filename: "two.bin" })).statusCode).toBe(201);
+    const third = await postAttachment(app, admin, Buffer.from("three"), { filename: "three.bin" });
+    expect(third.statusCode).toBe(400);
+    expect(third.json<{ error: string }>().error).toContain("Organization attachment quota of 2 objects exceeded");
   });
 });

--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -40,6 +40,7 @@ const baseServerConfig: ServerConfig = {
   },
   docs: { enabled: false },
   database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
+  attachments: { organizationObjectQuota: 10_000 },
   server: { port: 0, host: "127.0.0.1", publicUrl: "https://first-tree.example" },
   workspace: { root: "/tmp/first-tree-test-workspaces" },
   secrets: {

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -25,6 +25,7 @@ const baseConfig: Config = {
   },
   docs: { enabled: false },
   database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
+  attachments: { organizationObjectQuota: 10_000 },
   server: { port: 0, host: "127.0.0.1", publicUrl: undefined },
   workspace: { root: "/tmp/first-tree-test-workspaces" },
   secrets: {

--- a/packages/server/src/__tests__/feishu-inbound.test.ts
+++ b/packages/server/src/__tests__/feishu-inbound.test.ts
@@ -80,6 +80,7 @@ describe("Feishu inbound pipeline", () => {
         stream: Readable.from([bytes]),
         headers: { "content-type": "image/png", "content-length": String(bytes.length) },
       }),
+      attachmentObjectQuota: { maxOrganizationAttachments: 10_000 },
     };
   }
 

--- a/packages/server/src/__tests__/feishu-registration.test.ts
+++ b/packages/server/src/__tests__/feishu-registration.test.ts
@@ -215,6 +215,7 @@ describe("official Feishu QR registration", () => {
     sdkMocks.request.mockImplementationOnce(() => new Promise(() => undefined));
     const manager = createFeishuIntegrationManager({
       db: app.db,
+      attachmentObjectQuota: { maxOrganizationAttachments: 10_000 },
       notifier: app.notifier,
       encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       instanceId: "profile-timeout-test",

--- a/packages/server/src/__tests__/feishu-registration.test.ts
+++ b/packages/server/src/__tests__/feishu-registration.test.ts
@@ -177,6 +177,7 @@ describe("official Feishu QR registration", () => {
 
     const replica = createFeishuIntegrationManager({
       db: app.db,
+      attachmentObjectQuota: { maxOrganizationAttachments: 10_000 },
       notifier: app.notifier,
       encryptionKey,
       instanceId: "replacement-replica",
@@ -269,6 +270,7 @@ describe("official Feishu QR registration", () => {
     } as FeishuSdkDependencies;
     const manager = createFeishuIntegrationManager({
       db: app.db,
+      attachmentObjectQuota: { maxOrganizationAttachments: 10_000 },
       notifier: app.notifier,
       encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       instanceId: "registration-stop-test",
@@ -368,6 +370,7 @@ describe("official Feishu QR registration", () => {
     } as FeishuSdkDependencies;
     const manager = createFeishuIntegrationManager({
       db: app.db,
+      attachmentObjectQuota: { maxOrganizationAttachments: 10_000 },
       notifier: app.notifier,
       encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       instanceId: "registration-timeout-test",
@@ -404,6 +407,7 @@ describe("official Feishu QR registration", () => {
     } as FeishuSdkDependencies;
     const manager = createFeishuIntegrationManager({
       db: app.db,
+      attachmentObjectQuota: { maxOrganizationAttachments: 10_000 },
       notifier: app.notifier,
       encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       instanceId: "registration-late-qr-test",

--- a/packages/server/src/__tests__/feishu-resource-hydrator.test.ts
+++ b/packages/server/src/__tests__/feishu-resource-hydrator.test.ts
@@ -23,6 +23,7 @@ describe("Feishu resource hydration", () => {
       messageId: "om_message",
       descriptors: [{ type: "image", fileKey: "img_a", fileName: "picture.png", origin: "message" }],
       download,
+      attachmentObjectQuota: { maxOrganizationAttachments: 10_000 },
     });
 
     expect(download).toHaveBeenCalledWith({ messageId: "om_message", fileKey: "img_a", type: "image" });
@@ -71,6 +72,7 @@ describe("Feishu resource hydration", () => {
         { type: "image", fileKey: "card-image", origin: "interactive" },
       ],
       download,
+      attachmentObjectQuota: { maxOrganizationAttachments: 10_000 },
     });
 
     expect(result.attachments).toEqual([]);
@@ -101,6 +103,7 @@ describe("Feishu resource hydration", () => {
       messageId: "om_message",
       descriptors,
       download,
+      attachmentObjectQuota: { maxOrganizationAttachments: 10_000 },
     });
 
     expect(download).toHaveBeenCalledTimes(MAX_MESSAGE_ATTACHMENT_REFS);

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -101,6 +101,8 @@ export type CreateTestAppOptions = {
   /** Official Agent Template publisher org (FIRST_TREE_AGENT_TEMPLATE_PUBLISHER_ORG_ID). */
   agentTemplatePublisherOrgId?: string;
   gitlabEgressAllowlist?: NonNullable<Config["gitlab"]>["egressAllowlist"];
+  /** Per-organization attachment object quota. Defaults to the production default. */
+  attachmentObjectQuota?: number;
   feishuSdk?: FeishuSdkDependencies;
   /**
    * Drop `oauth.githubApp.slug` from the test config. Used by the
@@ -153,6 +155,9 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
     database: {
       url: process.env.DATABASE_URL ?? "",
       provider: "external",
+    },
+    attachments: {
+      organizationObjectQuota: opts.attachmentObjectQuota ?? 10_000,
     },
     server: {
       port: 0,

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -1088,14 +1088,18 @@ describe("Resources Phase 1", () => {
       body: "# Foreign",
       metadata: {},
     });
-    const foreignAttachment = await createAttachment(app.db, {
-      organizationId: other.organizationId,
-      mimeType: "application/zip",
-      filename: "foreign-bundle.zip",
-      body: bundle,
-      contentLength: bundle.byteLength,
-      uploadedBy: other.humanAgentUuid,
-    });
+    const foreignAttachment = await createAttachment(
+      app.db,
+      {
+        organizationId: other.organizationId,
+        mimeType: "application/zip",
+        filename: "foreign-bundle.zip",
+        body: bundle,
+        contentLength: bundle.byteLength,
+        uploadedBy: other.humanAgentUuid,
+      },
+      { maxOrganizationAttachments: 10_000 },
+    );
     const skillId = uuidv7();
     await app.db.insert(resources).values({
       id: skillId,
@@ -2222,14 +2226,18 @@ async function createTeamSkill(
   payload: SkillResourcePayload,
 ) {
   const bundle = buildLegacySkillBundle(payload);
-  const attachment = await createAttachment(app.db, {
-    organizationId: owner.organizationId,
-    mimeType: "application/zip",
-    filename: `${payload.name}.zip`,
-    body: bundle,
-    contentLength: bundle.byteLength,
-    uploadedBy: owner.humanAgentUuid,
-  });
+  const attachment = await createAttachment(
+    app.db,
+    {
+      organizationId: owner.organizationId,
+      mimeType: "application/zip",
+      filename: `${payload.name}.zip`,
+      body: bundle,
+      contentLength: bundle.byteLength,
+      uploadedBy: owner.humanAgentUuid,
+    },
+    { maxOrganizationAttachments: 10_000 },
+  );
   return app.resourcesService.createTeamResource(
     owner.organizationId,
     {

--- a/packages/server/src/api/agents-resources.ts
+++ b/packages/server/src/api/agents-resources.ts
@@ -43,6 +43,7 @@ export async function agentResourcesRoutes(app: FastifyInstance): Promise<void> 
       scope.memberId,
       scope.humanAgentId,
       body,
+      { maxOrganizationAttachments: app.config.attachments.organizationObjectQuota },
     );
     return app.resourcesService.getAgentResources(request.params.uuid);
   });

--- a/packages/server/src/api/orgs/agents.ts
+++ b/packages/server/src/api/orgs/agents.ts
@@ -162,6 +162,7 @@ export async function orgAgentRoutes(app: FastifyInstance): Promise<void> {
         templatePublisherOrgId: app.config.agentTemplates?.publisherOrgId,
         templateActorMemberId: scope.memberId,
         templateActorHumanAgentId: scope.humanAgentId,
+        attachmentObjectQuota: { maxOrganizationAttachments: app.config.attachments.organizationObjectQuota },
       },
     );
     notifyClientAgentPinned(agent);

--- a/packages/server/src/api/orgs/attachments.ts
+++ b/packages/server/src/api/orgs/attachments.ts
@@ -75,14 +75,18 @@ export async function orgAttachmentRoutes(app: FastifyInstance): Promise<void> {
           ? Number(contentLengthHeader)
           : undefined;
 
-      const row = await createAttachment(app.db, {
-        organizationId: scope.organizationId,
-        mimeType,
-        filename,
-        body,
-        ...(parsedContentLength !== undefined ? { contentLength: parsedContentLength } : {}),
-        uploadedBy: scope.humanAgentId,
-      });
+      const row = await createAttachment(
+        app.db,
+        {
+          organizationId: scope.organizationId,
+          mimeType,
+          filename,
+          body,
+          ...(parsedContentLength !== undefined ? { contentLength: parsedContentLength } : {}),
+          uploadedBy: scope.humanAgentId,
+        },
+        { maxOrganizationAttachments: app.config.attachments.organizationObjectQuota },
+      );
 
       const response: UploadAttachmentResponse = {
         id: row.id,

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -375,6 +375,7 @@ export async function buildApp(config: Config, options: BuildAppOptions = {}) {
     notifier,
     encryptionKey: config.secrets.encryptionKey,
     instanceId: config.instanceId,
+    attachmentObjectQuota: { maxOrganizationAttachments: config.attachments.organizationObjectQuota },
     ...(options.feishuSdk ? { sdk: options.feishuSdk } : {}),
   });
   app.decorate("feishuIntegration", feishuIntegration);
@@ -770,7 +771,9 @@ export async function buildApp(config: Config, options: BuildAppOptions = {}) {
     await backfillExternalAttachmentsToPostgres(db, attachmentBlobStore).catch((err) => {
       app.log.warn({ err }, "legacy S3 attachment reverse backfill failed");
     });
-    await backfillSkillResourceBundles(db, attachmentBlobStore).catch((err) => {
+    await backfillSkillResourceBundles(db, attachmentBlobStore, {
+      maxOrganizationAttachments: config.attachments.organizationObjectQuota,
+    }).catch((err) => {
       app.log.warn({ err }, "legacy Skill bundle backfill failed");
     });
     const gitlabAttentionBackfill = await backfillGitlabAttentionPairs(db);

--- a/packages/server/src/services/agents/identity.ts
+++ b/packages/server/src/services/agents/identity.ts
@@ -32,6 +32,7 @@ import { users } from "../../db/schema/users.js";
 import { BadRequestError, ClientRetiredError, ConflictError, ForbiddenError, NotFoundError } from "../../errors.js";
 import type { OrgScope } from "../../scope/types.js";
 import { uuidv7 } from "../../uuid.js";
+import type { AttachmentObjectQuota } from "../attachment.js";
 import type { AttachmentBlobStore } from "../attachment-blob-store.js";
 import { lockWatcherProjectionMemberMutation } from "../chat/membership/lock.js";
 import { lockWatcherProjectionForAgentChanges, recomputeWatcherChats } from "../chat/membership/watcher.js";
@@ -315,6 +316,7 @@ export async function createAgent(
     templatePublisherOrgId?: string;
     templateActorMemberId?: string;
     templateActorHumanAgentId?: string;
+    attachmentObjectQuota?: AttachmentObjectQuota;
   } = {},
 ) {
   const uuid = uuidv7();
@@ -524,6 +526,7 @@ export async function createAgent(
       // copies, and the bindings are all-or-nothing.
       if (data.templateIds && data.templateIds.length > 0) {
         if (!options.attachmentBlobStore) throw new Error("attachmentBlobStore is required for Template adoption");
+        if (!options.attachmentObjectQuota) throw new Error("attachmentObjectQuota is required for Template adoption");
         if (!options.templateActorMemberId || !options.templateActorHumanAgentId) {
           throw new Error("Template actor identity is required for Template adoption");
         }
@@ -535,6 +538,7 @@ export async function createAgent(
           data.templateIds,
           options.templateActorMemberId,
           options.templateActorHumanAgentId,
+          options.attachmentObjectQuota,
         );
       }
 

--- a/packages/server/src/services/agents/templates/adoption.ts
+++ b/packages/server/src/services/agents/templates/adoption.ts
@@ -17,7 +17,7 @@ import { agents } from "../../../db/schema/agents.js";
 import { resources } from "../../../db/schema/resources.js";
 import { type AppErrorAttrs, BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../../../errors.js";
 import { uuidv7 } from "../../../uuid.js";
-import { copyAttachmentForOrganization } from "../../attachment.js";
+import { type AttachmentObjectQuota, copyAttachmentForOrganization } from "../../attachment.js";
 import type { AttachmentBlobStore } from "../../attachment-blob-store.js";
 import { assertMutableAgentIsNotLandingCampaignTrial } from "../../landing-campaigns/guards.js";
 import type { Notifier } from "../../notifier.js";
@@ -310,6 +310,7 @@ async function adoptTemplatesInTransaction(
   addedTemplateIds: readonly string[],
   actorId: string,
   attachmentUploader: string,
+  attachmentObjectQuota: AttachmentObjectQuota,
 ): Promise<void> {
   if (addedTemplateIds.length === 0) return;
   if (!publisherOrgId) {
@@ -382,7 +383,14 @@ async function adoptTemplatesInTransaction(
   const digestByComponentKey = new Map<string, string>();
   for (const sourceId of sourceBundleIds) {
     const attachment = await withAdoptionConflictCode(() =>
-      copyAttachmentForOrganization(db, blobStore, sourceId, agent.organizationId, attachmentUploader),
+      copyAttachmentForOrganization(
+        db,
+        blobStore,
+        sourceId,
+        agent.organizationId,
+        attachmentUploader,
+        attachmentObjectQuota,
+      ),
     );
     if (!attachment.data) throw new Error("Attachment copy has no PostgreSQL bytes");
     bundleTargetBySourceId.set(sourceId, attachment.id);
@@ -432,11 +440,21 @@ export async function initializeAdoptedTemplates(
   templateIds: readonly string[],
   actorId: string,
   attachmentUploader: string,
+  attachmentObjectQuota: AttachmentObjectQuota,
 ): Promise<void> {
   if (agent.type === AGENT_TYPES.HUMAN) {
     throw new BadRequestError("Human Agents cannot adopt Agent Templates");
   }
-  await adoptTemplatesInTransaction(db, blobStore, publisherOrgId, agent, templateIds, actorId, attachmentUploader);
+  await adoptTemplatesInTransaction(
+    db,
+    blobStore,
+    publisherOrgId,
+    agent,
+    templateIds,
+    actorId,
+    attachmentUploader,
+    attachmentObjectQuota,
+  );
   // The freshly-inserted config stays version 1; only the adopted set is recorded.
   await db
     .update(agentConfigs)
@@ -460,6 +478,7 @@ export async function adoptAgentTemplates(
   actorId: string,
   attachmentUploader: string,
   input: UpdateAgentTemplates,
+  attachmentObjectQuota: AttachmentObjectQuota,
 ): Promise<AdoptAgentTemplatesResult> {
   const result = await db.transaction(async (tx) => {
     const targetDb = tx as unknown as Database;
@@ -542,6 +561,7 @@ export async function adoptAgentTemplates(
       added,
       actorId,
       attachmentUploader,
+      attachmentObjectQuota,
     );
     const [updated] = await targetDb
       .update(agentConfigs)

--- a/packages/server/src/services/attachment.ts
+++ b/packages/server/src/services/attachment.ts
@@ -14,9 +14,20 @@ import type { AttachmentBlobStore } from "./attachment-blob-store.js";
 const log = createLogger("attachment");
 
 export const MAX_ORGANIZATION_ATTACHMENT_BYTES = 2 * 1024 * 1024 * 1024;
-export const MAX_ORGANIZATION_ATTACHMENTS = 1_000;
 export const MAX_CONCURRENT_ATTACHMENT_UPLOADS_PER_CALLER = 3;
 export const ORPHAN_ATTACHMENT_AGE_MS = 24 * 60 * 60 * 1_000;
+
+/**
+ * Deployment-resolved attachment object quota. Every creation path must pass
+ * the value parsed at server startup
+ * (`attachments.organizationObjectQuota`, env
+ * `FIRST_TREE_ATTACHMENT_ORG_QUOTA_COUNT`) so HTTP uploads, Feishu inbound
+ * hydration, Skill bundle backfills, and Template adoption copies all enforce
+ * the same limit.
+ */
+export type AttachmentObjectQuota = {
+  maxOrganizationAttachments: number;
+};
 
 export type AttachmentRow = typeof attachments.$inferSelect;
 
@@ -37,7 +48,11 @@ export type CreateAttachmentInput = {
  * Reserve team quota, read one bounded upload, and publish the immutable
  * bytes together with their metadata in PostgreSQL.
  */
-export async function createAttachment(db: Database, input: CreateAttachmentInput): Promise<AttachmentRow> {
+export async function createAttachment(
+  db: Database,
+  input: CreateAttachmentInput,
+  quota: AttachmentObjectQuota,
+): Promise<AttachmentRow> {
   validateCreateInput(input);
   const id = input.id ?? randomUUID();
   const reservedBytes = input.contentLength ?? MAX_ATTACHMENT_BYTES;
@@ -46,10 +61,15 @@ export async function createAttachment(db: Database, input: CreateAttachmentInpu
     const targetDb = tx as unknown as Database;
     await lockOrganizationAttachmentQuota(targetDb, input.organizationId);
     await assertCallerUploadConcurrency(targetDb, input.organizationId, input.uploadedBy);
-    await assertOrganizationQuota(targetDb, input.organizationId, {
-      additionalObjects: 1,
-      additionalBytes: reservedBytes,
-    });
+    await assertOrganizationQuota(
+      targetDb,
+      input.organizationId,
+      {
+        additionalObjects: 1,
+        additionalBytes: reservedBytes,
+      },
+      quota,
+    );
     await targetDb.insert(attachments).values({
       id,
       organizationId: input.organizationId,
@@ -79,11 +99,16 @@ export async function createAttachment(db: Database, input: CreateAttachmentInpu
     return await db.transaction(async (tx) => {
       const targetDb = tx as unknown as Database;
       await lockOrganizationAttachmentQuota(targetDb, input.organizationId);
-      await assertOrganizationQuota(targetDb, input.organizationId, {
-        excludeId: id,
-        additionalObjects: 1,
-        additionalBytes: bytes.byteLength,
-      });
+      await assertOrganizationQuota(
+        targetDb,
+        input.organizationId,
+        {
+          excludeId: id,
+          additionalObjects: 1,
+          additionalBytes: bytes.byteLength,
+        },
+        quota,
+      );
       const [row] = await targetDb
         .update(attachments)
         .set({
@@ -179,6 +204,7 @@ async function assertOrganizationQuota(
     additionalObjects: number;
     additionalBytes: number;
   },
+  quota: AttachmentObjectQuota,
 ): Promise<void> {
   const conditions = [
     eq(attachments.organizationId, organizationId),
@@ -194,8 +220,8 @@ async function assertOrganizationQuota(
     .where(and(...conditions));
   const objectCount = Number(usage?.objectCount ?? 0);
   const sizeBytes = Number(usage?.sizeBytes ?? 0);
-  if (objectCount + input.additionalObjects > MAX_ORGANIZATION_ATTACHMENTS) {
-    throw new BadRequestError(`Organization attachment quota of ${MAX_ORGANIZATION_ATTACHMENTS} objects exceeded`);
+  if (objectCount + input.additionalObjects > quota.maxOrganizationAttachments) {
+    throw new BadRequestError(`Organization attachment quota of ${quota.maxOrganizationAttachments} objects exceeded`);
   }
   if (sizeBytes + input.additionalBytes > MAX_ORGANIZATION_ATTACHMENT_BYTES) {
     throw new BadRequestError(`Organization attachment quota of ${MAX_ORGANIZATION_ATTACHMENT_BYTES} bytes exceeded`);
@@ -220,6 +246,7 @@ export async function copyAttachmentForOrganization(
   sourceId: string,
   targetOrganizationId: string,
   uploadedBy: string,
+  quota: AttachmentObjectQuota,
 ): Promise<AttachmentRow> {
   // Quota-first, matching the normal upload path: the target Team's advisory
   // lock is always taken before any source row lock, so concurrent
@@ -242,10 +269,15 @@ export async function copyAttachmentForOrganization(
   } else {
     throw new BadRequestError("Source attachment bytes are unavailable");
   }
-  await assertOrganizationQuota(db, targetOrganizationId, {
-    additionalObjects: 1,
-    additionalBytes: bytes.byteLength,
-  });
+  await assertOrganizationQuota(
+    db,
+    targetOrganizationId,
+    {
+      additionalObjects: 1,
+      additionalBytes: bytes.byteLength,
+    },
+    quota,
+  );
   const id = randomUUID();
   const [row] = await db
     .insert(attachments)

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -33,7 +33,9 @@ export function createBackgroundTasks(
 
   async function maintainAttachments(): Promise<void> {
     const legacyAttachments = await backfillExternalAttachmentsToPostgres(app.db, app.attachmentBlobStore);
-    const legacySkills = await backfillSkillResourceBundles(app.db, app.attachmentBlobStore);
+    const legacySkills = await backfillSkillResourceBundles(app.db, app.attachmentBlobStore, {
+      maxOrganizationAttachments: app.config.attachments.organizationObjectQuota,
+    });
     const sweep = await sweepOrphanAttachments(app.db, app.attachmentBlobStore);
     if (legacyAttachments.migrated > 0 || legacySkills.migrated > 0 || sweep.deleted > 0) {
       log.info({ legacyAttachments, legacySkills, sweep }, "attachment maintenance completed");

--- a/packages/server/src/services/integrations/feishu/inbound.ts
+++ b/packages/server/src/services/integrations/feishu/inbound.ts
@@ -14,6 +14,7 @@ import { messages } from "../../../db/schema/messages.js";
 import { processedEvents } from "../../../db/schema/processed-events.js";
 import { createLogger } from "../../../observability/index.js";
 import { uuidv7 } from "../../../uuid.js";
+import type { AttachmentObjectQuota } from "../../attachment.js";
 import { addChatParticipants } from "../../chat/membership/participants.js";
 import { sendMessage } from "../../chat/message.js";
 import { claimEvent, unclaimEvent } from "../../event-dedup.js";
@@ -40,6 +41,7 @@ export async function ingestFeishuMessage(
     senderNames: FeishuSenderNameResolver;
     readMembers: FeishuChatMembersReader;
     downloadResource: FeishuResourceDownloader;
+    attachmentObjectQuota: AttachmentObjectQuota;
   },
 ): Promise<FeishuInboundResult> {
   if (binding.status !== "active") return { state: "ignored", reason: "inactive_binding" };
@@ -85,6 +87,7 @@ export async function ingestFeishuMessage(
       messageId: input.messageId,
       descriptors,
       download: dependencies.downloadResource,
+      attachmentObjectQuota: dependencies.attachmentObjectQuota,
     });
     const content = [converted.content, ...hydrated.unavailableNotes.map((note) => `> ${note}`)]
       .filter(Boolean)

--- a/packages/server/src/services/integrations/feishu/manager.ts
+++ b/packages/server/src/services/integrations/feishu/manager.ts
@@ -8,6 +8,7 @@ import { imChatBindings } from "../../../db/schema/im-chat-bindings.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../../../errors.js";
 import { createLogger } from "../../../observability/index.js";
 import { uuidv7 } from "../../../uuid.js";
+import type { AttachmentObjectQuota } from "../../attachment.js";
 import { decryptCredentials, encryptCredentials } from "../../crypto.js";
 import type { Notifier } from "../../notifier.js";
 import { Client, createLarkChannel, type LarkChannel, LoggerLevel, registerApp } from "./channel-sdk.js";
@@ -53,6 +54,7 @@ export function createFeishuIntegrationManager(input: {
   notifier: Notifier;
   encryptionKey: string;
   instanceId: string;
+  attachmentObjectQuota: AttachmentObjectQuota;
   sdk?: FeishuSdkDependencies;
   timings?: {
     leaseMs?: number;
@@ -61,7 +63,7 @@ export function createFeishuIntegrationManager(input: {
     registrationQrTimeoutMs?: number;
   };
 }): FeishuIntegrationManager {
-  const { db, notifier, encryptionKey, instanceId } = input;
+  const { db, notifier, encryptionKey, instanceId, attachmentObjectQuota } = input;
   const leaseMs = input.timings?.leaseMs ?? LEASE_MS;
   const claimIntervalMs = input.timings?.claimIntervalMs ?? CLAIM_INTERVAL_MS;
   const initialClaimDelayMs = input.timings?.initialClaimDelayMs ?? 2_000;
@@ -417,6 +419,7 @@ export function createFeishuIntegrationManager(input: {
         const current = await requireOwnedBinding(row.id, row.connectionEpoch);
         await ingestFeishuMessage(db, notifier, current, message, {
           senderNames,
+          attachmentObjectQuota,
           readMembers: async ({ chatId, idType, pageToken }) =>
             client.im.v1.chatMembers.get({
               path: { chat_id: chatId },

--- a/packages/server/src/services/integrations/feishu/resource-hydrator.ts
+++ b/packages/server/src/services/integrations/feishu/resource-hydrator.ts
@@ -9,7 +9,7 @@ import {
   SUPPORTED_IMAGE_MIMES,
 } from "@first-tree/shared";
 import type { Database } from "../../../db/connection.js";
-import { createAttachment } from "../../attachment.js";
+import { type AttachmentObjectQuota, createAttachment } from "../../attachment.js";
 import type { FeishuResourceDescriptor } from "./content.js";
 
 const SUPPORTED_IMAGE_MIME_SET = new Set<string>(SUPPORTED_IMAGE_MIMES);
@@ -40,6 +40,7 @@ export async function hydrateFeishuResources(
     messageId: string;
     descriptors: readonly FeishuResourceDescriptor[];
     download: FeishuResourceDownloader;
+    attachmentObjectQuota: AttachmentObjectQuota;
   },
 ): Promise<HydratedFeishuResources> {
   const results = new Array<HydratedOne>(input.descriptors.length);
@@ -100,14 +101,18 @@ async function hydrateOne(
     });
     response.stream.once("error", (error) => hashingStream.destroy(error));
     response.stream.pipe(hashingStream);
-    const row = await createAttachment(db, {
-      organizationId: input.organizationId,
-      mimeType,
-      filename,
-      body: hashingStream,
-      ...(contentLength !== undefined ? { contentLength } : {}),
-      uploadedBy: `integration:feishu:${input.botBindingId}`,
-    });
+    const row = await createAttachment(
+      db,
+      {
+        organizationId: input.organizationId,
+        mimeType,
+        filename,
+        body: hashingStream,
+        ...(contentLength !== undefined ? { contentLength } : {}),
+        uploadedBy: `integration:feishu:${input.botBindingId}`,
+      },
+      input.attachmentObjectQuota,
+    );
     const attachment: AttachmentRef = {
       attachmentId: row.id,
       kind: descriptor.type === "image" && SUPPORTED_IMAGE_MIME_SET.has(mimeType) ? "image" : "file",

--- a/packages/server/src/services/skill-bundle.ts
+++ b/packages/server/src/services/skill-bundle.ts
@@ -24,6 +24,7 @@ import { members } from "../db/schema/members.js";
 import { resources } from "../db/schema/resources.js";
 import { BadRequestError } from "../errors.js";
 import {
+  type AttachmentObjectQuota,
   createAttachment,
   deleteAttachmentIfUnreferenced,
   loadAttachmentMeta,
@@ -335,6 +336,7 @@ export function buildLegacySkillBundle(payload: SkillResourcePayload): Buffer {
 export async function backfillSkillResourceBundles(
   db: Database,
   blobStore: AttachmentBlobStore,
+  quota: AttachmentObjectQuota,
   batchSize = 50,
 ): Promise<{ migrated: number; skipped: number }> {
   const rows = await db
@@ -374,14 +376,18 @@ export async function backfillSkillResourceBundles(
           .limit(1);
         uploaderId = creator?.agentId ?? null;
       }
-      const attachment = await createAttachment(db, {
-        organizationId: row.organizationId,
-        mimeType: "application/zip",
-        filename: `${parsed.data.name}.zip`,
-        body,
-        contentLength: body.byteLength,
-        uploadedBy: uploaderId ?? "system:skill-resource-backfill",
-      });
+      const attachment = await createAttachment(
+        db,
+        {
+          organizationId: row.organizationId,
+          mimeType: "application/zip",
+          filename: `${parsed.data.name}.zip`,
+          body,
+          contentLength: body.byteLength,
+          uploadedBy: uploaderId ?? "system:skill-resource-backfill",
+        },
+        quota,
+      );
       attachmentId = attachment.id;
       const updated = await db
         .update(resources)

--- a/packages/shared/src/config/__tests__/server-config.test.ts
+++ b/packages/shared/src/config/__tests__/server-config.test.ts
@@ -425,6 +425,57 @@ describe("server config", () => {
     expect(config.rateLimit).toBeUndefined();
   });
 
+  it("defaults the organization attachment object quota to 10,000 and accepts env overrides", async () => {
+    const defaultDir = makeTempConfigDir();
+    stubRequiredProductionConfig();
+
+    const defaultConfig = await initConfig({
+      schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+      role: "server",
+      configDir: defaultDir,
+    });
+
+    expect(defaultConfig.attachments.organizationObjectQuota).toBe(10_000);
+
+    resetConfig();
+    const configuredDir = makeTempConfigDir();
+    vi.stubEnv("FIRST_TREE_ATTACHMENT_ORG_QUOTA_COUNT", "25000");
+
+    const configured = await initConfig({
+      schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+      role: "server",
+      configDir: configuredDir,
+    });
+
+    expect(configured.attachments.organizationObjectQuota).toBe(25_000);
+  });
+
+  it("rejects invalid organization attachment object quotas", async () => {
+    const zeroDir = makeTempConfigDir();
+    stubRequiredProductionConfig();
+    vi.stubEnv("FIRST_TREE_ATTACHMENT_ORG_QUOTA_COUNT", "0");
+
+    await expect(
+      initConfig({
+        schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+        role: "server",
+        configDir: zeroDir,
+      }),
+    ).rejects.toThrow(/organizationObjectQuota/);
+
+    resetConfig();
+    const nonNumericDir = makeTempConfigDir();
+    vi.stubEnv("FIRST_TREE_ATTACHMENT_ORG_QUOTA_COUNT", "not-a-number");
+
+    await expect(
+      initConfig({
+        schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+        role: "server",
+        configDir: nonNumericDir,
+      }),
+    ).rejects.toThrow(/organizationObjectQuota/);
+  });
+
   it("accepts operator-provided production server secrets without writing generated YAML", async () => {
     const configDir = makeTempConfigDir();
     const jwtSecret = "operator-jwt-secret";

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -238,6 +238,24 @@ export const serverConfigSchema = defineConfig({
     provider: field(z.enum(["docker", "external"]).default("docker")),
   },
   /**
+   * Attachment quotas. The per-file 10 MiB cap (`MAX_ATTACHMENT_BYTES`) and
+   * the per-organization 2 GiB byte ceiling stay hard-coded; only the object
+   * count is deployment-tunable.
+   */
+  attachments: {
+    /**
+     * Maximum number of attachment objects (rows in `uploading`, `ready`, or
+     * `deleting` state) one organization may hold. The count covers every
+     * creation path — chat uploads, Feishu inbound resources, Team Skill
+     * bundle backfills, and Agent Template adoption copies all share the same
+     * pool. Default 10,000; the 2 GiB byte quota remains the storage
+     * backstop regardless of this value.
+     */
+    organizationObjectQuota: field(z.number().int().min(1).default(10_000), {
+      env: "FIRST_TREE_ATTACHMENT_ORG_QUOTA_COUNT",
+    }),
+  },
+  /**
    * Transitional read/delete compatibility for attachment payloads written
    * to S3 by #2062. New uploads are PostgreSQL-backed. This block can be
    * removed in the contract release after the reverse backfill completes and


### PR DESCRIPTION
## Summary

- replace the hard-coded 1,000-object attachment quota with the deployment setting `FIRST_TREE_ATTACHMENT_ORG_QUOTA_COUNT`
- raise the default per-Team / per-organization object quota to 10,000
- propagate the startup-resolved quota through HTTP uploads, Feishu ingestion, Skill bundle backfill, and Agent Template adoption
- keep the 10 MiB per-file cap and 2 GiB per-organization byte cap unchanged
- document the operator setting

## Why

Teams with many small attachments can hit the row-count ceiling well before the byte quota. A deployment-tunable count keeps the PostgreSQL safety boundary while allowing operators to size the object allowance for their workload.

## Impact

No database schema, migration, backfill, data rewrite, or persistence-semantics change is included. Invalid, zero, and negative configured values fail during startup config parsing.

## Validation

Independent QA: PASS (`test-only`).

- shared server-config tests: 25/25
- server attachment route tests: 24/24
- affected Feishu, Resources/Skill, Template adoption, bootstrap, build-app, and background-task tests: 161/161
- shared and server typechecks
- `pnpm check`
- `git diff --check`

A repository-wide `pnpm test` attempt was interrupted by an unrelated transient skill-evals worker RPC timeout. The affected package then passed independently (36 files, 623 tests), but this PR does not claim a complete repository-wide suite run.

## Context Tree

Companion draft: [first-tree-context#932](https://github.com/agent-team-foundation/first-tree-context/pull/932). It records the durable default/configurability decision and will be reconciled after this source PR lands.
