### PR TITLE
fix(web): ignore a fragment on the OpenTag entry instead of dropping the destination

### DIFF
--- a/packages/server/src/__tests__/oauth-bootstrap.test.ts
+++ b/packages/server/src/__tests__/oauth-bootstrap.test.ts
@@ -275,7 +275,13 @@ describe("shouldPreserveSoloSignupNext", () => {
     // Non-canonical spellings of the same destination.
     expect(shouldPreserveSoloSignupNext("/opentag/")).toBe(false);
     expect(shouldPreserveSoloSignupNext("/opentag?")).toBe(false);
-    expect(shouldPreserveSoloSignupNext("/opentag#step")).toBe(false);
+    // A fragment is ignored rather than dropping the destination: the browser
+    // stashes `pathname + search + hash`, so a shared link carrying `#...`
+    // would otherwise land a brand-new member at the workspace root.
+    expect(shouldPreserveSoloSignupNext("/opentag#step")).toBe(true);
+    expect(shouldPreserveSoloSignupNext("/opentag?agent=0198b2c4-1f6a-7c31-9a02-4d5e6f708192#step")).toBe(true);
+    // Still not a hole: the fragment cannot carry anything past the gate.
+    expect(shouldPreserveSoloSignupNext("/opentag?step=runtime#a")).toBe(false);
     // Unknown or malformed parameters.
     expect(shouldPreserveSoloSignupNext("/opentag?agent=not-a-uuid")).toBe(false);
     expect(shouldPreserveSoloSignupNext("/opentag?step=runtime")).toBe(false);

--- a/packages/shared/src/__tests__/opentag-entry.test.ts
+++ b/packages/shared/src/__tests__/opentag-entry.test.ts
@@ -30,7 +30,25 @@ describe("parseOpenTagEntryPath", () => {
     expect(parseOpenTagEntryPath("/opentag/")).toBeNull();
     expect(parseOpenTagEntryPath("/opentag?")).toBeNull();
     expect(parseOpenTagEntryPath(`/opentag?agent=${AGENT_UUID}&`)).toBeNull();
-    expect(parseOpenTagEntryPath(`/opentag?agent=${AGENT_UUID}#step`)).toBeNull();
+  });
+
+  it("ignores a fragment instead of dropping the whole destination", () => {
+    // A link that picked up `#...` is still this entry. Rejecting it used to
+    // strand a brand-new member at the workspace root after solo signup,
+    // which is the one journey this contract exists to protect.
+    expect(parseOpenTagEntryPath("/opentag#step")).toEqual({ agentUuid: null });
+    expect(parseOpenTagEntryPath(`/opentag?agent=${AGENT_UUID}#step`)).toEqual({ agentUuid: AGENT_UUID });
+    expect(parseOpenTagEntryPath(`/opentag?agent=${AGENT_UUID}#`)).toEqual({ agentUuid: AGENT_UUID });
+  });
+
+  it("still requires everything outside the fragment to be canonical", () => {
+    // The fragment is ignored, not a hole: it cannot carry a second path,
+    // an extra parameter, or a non-canonical spelling past the gate.
+    expect(parseOpenTagEntryPath(`/opentag?agent=${AGENT_UUID}&step=1#a`)).toBeNull();
+    expect(parseOpenTagEntryPath(`/opentag?agent=${AGENT_UUID.toUpperCase()}#a`)).toBeNull();
+    expect(parseOpenTagEntryPath("/opentag/#a")).toBeNull();
+    expect(parseOpenTagEntryPath("/opentagged#a")).toBeNull();
+    expect(parseOpenTagEntryPath("https://evil.example/opentag#a")).toBeNull();
   });
 
   it("rejects an unknown or extra query parameter", () => {

--- a/packages/shared/src/opentag-entry.ts
+++ b/packages/shared/src/opentag-entry.ts
@@ -34,11 +34,18 @@ export type OpenTagEntryTarget = {
  * Parse a candidate redirect target into an OpenTag entry, or `null` when it is
  * anything other than this builder's exact output.
  *
- * Same two gates as {@link parseAgentTemplateIntentPath}: a structural check
- * (same-origin relative URL, exact pathname, at most an `agent` UUID query, no
- * fragment) followed by an exact-canonical check against the builder. The
- * strictness is what lets OAuth preserve this destination without widening
+ * A structural check (same-origin relative URL, exact pathname, at most an
+ * `agent` UUID query) followed by an exact-canonical check against the builder.
+ * The strictness is what lets OAuth preserve this destination without widening
  * `next` preservation into a general deep-link or open-redirect channel.
+ *
+ * A fragment is not part of an entry's identity, so it is ignored rather than
+ * rejected: `#anything` never reaches the server, cannot change which page a
+ * same-origin relative redirect lands on, and the only thing rejecting it
+ * achieved was dropping the whole destination. A shared link that picked up a
+ * fragment used to strand a brand-new member at the workspace root after solo
+ * signup — the exact journey this entry exists to protect. Callers that need a
+ * canonical string re-derive it with {@link opentagEntryPath}.
  *
  * Never throws — an unparseable value is simply not an OpenTag entry.
  */
@@ -52,7 +59,6 @@ export function parseOpenTagEntryPath(next: string): OpenTagEntryTarget | null {
   // Anything that resolved against a different origin (absolute or
   // protocol-relative input) is not a same-app relative entry URL.
   if (parsed.origin !== "http://first-tree.local") return null;
-  if (parsed.hash !== "") return null;
   if (parsed.pathname !== OPENTAG_ENTRY_PATH) return null;
 
   const params = [...parsed.searchParams.entries()];
@@ -66,6 +72,13 @@ export function parseOpenTagEntryPath(next: string): OpenTagEntryTarget | null {
     agentUuid = validated.data;
   }
 
-  if (next !== opentagEntryPath(agentUuid)) return null;
+  // Compared as the raw string minus the fragment, not reassembled from the
+  // parsed URL: reassembling would quietly re-admit `/opentag?` and
+  // `/opentag?agent=<uuid>&`, whose empty trailing query the URL parser
+  // normalizes away. Everything outside the fragment stays byte-identical to
+  // this builder's output.
+  const hashIndex = next.indexOf("#");
+  const withoutFragment = hashIndex === -1 ? next : next.slice(0, hashIndex);
+  if (withoutFragment !== opentagEntryPath(agentUuid)) return null;
   return { agentUuid };
 }

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -149,7 +149,8 @@ let root: Root | null = null;
 let lastLocation = "";
 
 function LocationProbe() {
-  lastLocation = `${useLocation().pathname}${useLocation().search}`;
+  const loc = useLocation();
+  lastLocation = `${loc.pathname}${loc.search}${loc.hash}`;
   return null;
 }
 
@@ -467,6 +468,18 @@ describe("OpenTag entry — choosing the Agent", () => {
     expect(lastLocation).toBe("/opentag");
     expect(api.getAgent).not.toHaveBeenCalled();
     expect(container.textContent).toContain("Team Assistant");
+  });
+
+  it("normalizes a fragment out of the entry URL while keeping the Agent", async () => {
+    // A shared link can pick up `#...`. It is not part of this entry, so the
+    // Agent still resolves and the address bar is rewritten to the one
+    // canonical spelling the flow reloads and re-shares.
+    api.getAgent.mockResolvedValue(agentRow());
+
+    await renderAt(`/opentag?agent=${AGENT_UUID}#step`);
+
+    expect(lastLocation).toBe(`/opentag?agent=${AGENT_UUID}`);
+    expect(api.getAgent).toHaveBeenCalledWith(AGENT_UUID);
   });
 
   it("offers a team retry instead of creating against a guessed Team", async () => {

--- a/packages/web/src/pages/opentag/opentag-page.tsx
+++ b/packages/web/src/pages/opentag/opentag-page.tsx
@@ -51,11 +51,18 @@ export function OpenTagPage(): ReactElement | null {
   // would never build is not a URL this page will act on. Anything else is
   // replaced with the bare entry rather than driving a read that can only
   // fail.
-  const target = parseOpenTagEntryPath(`${location.pathname}${location.search}`);
+  const target = parseOpenTagEntryPath(`${location.pathname}${location.search}${location.hash}`);
   const agentUuid = target?.agentUuid ?? null;
   useEffect(() => {
-    if (!target) navigate(opentagEntryPath(), { replace: true });
-  }, [target, navigate]);
+    if (!target) {
+      navigate(opentagEntryPath(), { replace: true });
+      return;
+    }
+    // A fragment is ignored, so drop it from the address bar too. This URL is
+    // the flow's only progress memory and the thing a member reloads or
+    // re-shares, so it should be the one canonical spelling of this entry.
+    if (location.hash !== "") navigate(opentagEntryPath(target.agentUuid), { replace: true });
+  }, [target, location.hash, navigate]);
 
   // Remembered across the URL rewrite below, so the member is told why they are
   // back at the start even though the rejected Agent is no longer in the URL.


### PR DESCRIPTION
## What

Follow-up to #2308. A fragment on the OpenTag entry URL is now ignored rather than rejected, and the page rewrites the address bar to the canonical spelling.

This closes the one reviewer finding from #2308 that was deliberately deferred as non-blocking. Auditing it against merged `main` turned up a second, more costly consequence of the same root fact, so this PR fixes both.

## The visible half

`parseOpenTagEntryPath` rejected any URL with a fragment, but the browser route check built its candidate from `pathname + search` only. So `/opentag?agent=<uuid>#step` worked normally and simply kept the fragment in the address bar — the contract said "no fragment" while the browser quietly accepted one.

## The costly half

`RequireAuth` stashes `pathname + search + hash`, and `SAFE_NEXT_PATH` permits `#`, so the fragment travels to the server inside `next`. `shouldPreserveSoloSignupNext` parses it, gets `null`, and drops the destination.

The result is a brand-new member who follows a shared OpenTag link that picked up a fragment: solo signup creates their personal Team and then lands them at the workspace root instead of the entry they clicked. That is precisely the journey the preservation contract exists to protect. Verified on merged `main` before changing anything:

```
safeRedirectPath("/opentag?agent=<uuid>#step")        -> unchanged (fragment survives)
parseOpenTagEntryPath("/opentag?agent=<uuid>#step")   -> null
shouldPreserveSoloSignupNext("/opentag?agent=<uuid>#step") -> false
shouldPreserveSoloSignupNext("/opentag?agent=<uuid>")      -> true
```

## Why ignoring is the right resolution

A fragment is not part of an entry's identity. It is never sent to the server on a normal navigation, and it cannot change which page a same-origin relative redirect lands on — `safeRedirectPath` has already constrained the target to a relative path. Rejecting it bought no safety and cost the whole destination.

Everything outside the fragment stays exactly as strict as before. The canonical comparison strips the fragment from the **raw string** rather than reassembling from the parsed `URL`; reassembling would have silently re-admitted `/opentag?` and `/opentag?agent=<uuid>&`, whose empty trailing query the URL parser normalizes away. The existing canonical-spelling tests caught that while this was being written, which is why the comparison is shaped this way.

`parseAgentTemplateIntentPath` keeps its own fragment rejection; changing the sibling contract is outside this fix.

## Scope

Nothing else from #2308's review history is still open — the audit is in the PR discussion. No schema, migration, persistence semantics, new state, service layer, or abstraction. No W4 real-first-use behavior.

## Testing

- New regressions at all three layers, each confirmed to fail on current `main` and pass here: shared (fragment ignored and normalized; non-canonical spellings still rejected through a fragment), server (`shouldPreserveSoloSignupNext` preserves a fragment-carrying entry, still refuses `?step=runtime#a`), web DOM (address bar rewritten to canonical, Agent still resolved).
- `pnpm check` clean; shared / server / web typecheck clean including the web design-token guardrail.
- shared 924 and web 2354 passing; the affected server file (`oauth-bootstrap`) passing. The full server suite was not run in this worktree — concurrent server suites corrupt each other's worker databases locally, so CI owns that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
