### PR TITLE
feat(web): redesign agent instructions tab

### DIFF
--- a/packages/web/src/components/ui/row-actions-menu.tsx
+++ b/packages/web/src/components/ui/row-actions-menu.tsx
@@ -26,11 +26,14 @@ export function RowActionsMenu({
   actions,
   ariaLabel,
   triggerClassName,
+  touchTarget,
   icon: Icon = MoreHorizontal,
 }: {
   actions: RowAction[];
   ariaLabel: string;
   triggerClassName?: string;
+  /** Preserve the compact icon inside the minimum interactive target. */
+  touchTarget?: boolean;
   icon?: LucideIcon;
 }) {
   const [open, setOpen] = useState(false);
@@ -84,8 +87,8 @@ export function RowActionsMenu({
         }}
         className={cn("inline-flex items-center justify-center", triggerClassName)}
         style={{
-          width: 28,
-          height: 28,
+          width: touchTarget ? "var(--sp-11)" : 28,
+          height: touchTarget ? "var(--sp-11)" : 28,
           borderRadius: 4,
           background: "transparent",
           color: "var(--fg-3)",

--- a/packages/web/src/components/ui/switch.tsx
+++ b/packages/web/src/components/ui/switch.tsx
@@ -24,8 +24,32 @@ export function Switch(props: {
   "aria-labelledby"?: string;
   id?: string;
   className?: string;
+  /** Preserve the compact visual track inside the minimum interactive target. */
+  touchTarget?: boolean;
 }): ReactNode {
-  const { checked, onCheckedChange, disabled, className } = props;
+  const { checked, onCheckedChange, disabled, className, touchTarget } = props;
+  if (touchTarget) {
+    return (
+      <button
+        type="button"
+        role="switch"
+        id={props.id}
+        aria-checked={checked}
+        aria-label={props["aria-label"]}
+        aria-labelledby={props["aria-labelledby"]}
+        disabled={disabled}
+        onClick={() => onCheckedChange(!checked)}
+        className={cn(
+          "inline-flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-[var(--radius-input)] border-0 bg-transparent p-0",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+      >
+        <SwitchTrack checked={checked} />
+      </button>
+    );
+  }
   return (
     <button
       type="button"
@@ -47,12 +71,31 @@ export function Switch(props: {
         className,
       )}
     >
-      <span
-        className={cn(
-          "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm transition-transform",
-          checked ? "translate-x-4" : "translate-x-0.5",
-        )}
-      />
+      <SwitchThumb checked={checked} />
     </button>
+  );
+}
+
+function SwitchTrack({ checked }: { checked: boolean }): ReactNode {
+  return (
+    <span
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-transparent p-0 transition-colors",
+        checked ? "bg-primary" : "bg-secondary dark:border-[var(--border-strong)]",
+      )}
+    >
+      <SwitchThumb checked={checked} />
+    </span>
+  );
+}
+
+function SwitchThumb({ checked }: { checked: boolean }): ReactNode {
+  return (
+    <span
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm transition-transform",
+        checked ? "translate-x-4" : "translate-x-0.5",
+      )}
+    />
   );
 }

--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -523,8 +523,8 @@ export function AgentDetailPreviewPage() {
             Instructions section
           </h2>
           <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-            Result-first: the top block shows the merged runtime instructions (clamp + Show all), without extra label
-            copy. Source rows are de-crowded — Switch + ⋯ only, click a row to read its full body.
+            Result-first: the top block shows a compact merged-instructions preview with a full reader dialog. Applied
+            rows explain ownership and editability without exposing the internal source stack.
           </p>
           <div style={{ marginTop: "var(--sp-4)" }}>
             <TabHost element={<PromptTab />} />

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -804,6 +804,66 @@ describe("PromptTab extra DOM states", () => {
     await click(dialog?.querySelector("button") ?? null);
     await waitForCondition(() => document.activeElement === trigger, "Expected focus to return to Read full");
   });
+
+  it("reserves Editable here for standalone inline instructions", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    contextMock.value = createContext({
+      config: config({
+        payload: {
+          kind: "claude-code",
+          prompt: {
+            append: "Customized team instructions.",
+            sections: [{ scope: "agent", name: "Customized instructions", body: "Customized team instructions." }],
+          },
+          model: "sonnet",
+          reasoningEffort: "medium",
+          mcpServers: [],
+          env: [],
+          gitRepos: [],
+          resourceSkills: [],
+        },
+      }),
+    });
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        effective: {
+          version: 9,
+          repos: [],
+          prompts: [
+            promptRow({
+              id: "binding:override-1:enabled",
+              bindingId: "override-1",
+              source: "inline_prompt",
+              scope: "agent",
+              resourceId: null,
+              replacesResourceId: "team-prompt",
+              name: "Customized instructions",
+              promptBody: "Customized team instructions.",
+            }),
+          ],
+          skills: [],
+          mcp: [],
+          unavailable: [],
+        },
+        bindings: [
+          {
+            id: "override-1",
+            type: "prompt",
+            mode: "replace",
+            resourceId: null,
+            replacesResourceId: "team-prompt",
+            inlinePromptBody: "Customized team instructions.",
+            order: 1,
+          },
+        ],
+      }),
+    );
+
+    const container = await renderWithProviders(<PromptTab />);
+    await waitForText(container, "For this agent · Customized from team");
+    expect(container.textContent).not.toContain("For this agent · Editable here");
+    expect(container.querySelector('button[aria-label="More actions for Custom instructions"]')).toBeTruthy();
+  });
 });
 
 describe("ProfileEditDialog extra DOM states", () => {

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -662,8 +662,17 @@ describe("PromptTab extra DOM states", () => {
               name: "Unavailable prompt",
               mode: "unavailable",
               promptBody: "Unavailable content must not be merged.",
-              unavailableReason: "Prompt budget exceeded.",
+              unavailableReason: "prompt_budget_exceeded",
               order: 3,
+            }),
+            promptRow({
+              id: "resource:unknown-unavailable-prompt",
+              resourceId: "unknown-unavailable-prompt",
+              name: "Unknown unavailable prompt",
+              mode: "unavailable",
+              promptBody: "Unknown unavailable content must not be merged.",
+              unavailableReason: "unexpected_prompt_failure",
+              order: 4,
             }),
           ],
           skills: [],
@@ -696,13 +705,17 @@ describe("PromptTab extra DOM states", () => {
     const container = await renderWithProviders(<PromptTab />);
     await waitForText(container, "Active prompt");
     expect(container.textContent).toContain("1 instruction applied");
-    expect(container.textContent).toContain("Not applied · 3");
+    expect(container.textContent).toContain("Not applied · 4");
     expect(container.textContent).toContain("Replaced");
     expect(container.textContent).toContain("Can't load");
-    expect(container.textContent).toContain("Prompt budget exceeded.");
+    expect(container.textContent).toContain("These instructions exceed the agent's instruction limit.");
+    expect(container.textContent).not.toContain("prompt_budget_exceeded");
+    expect(container.textContent).toContain("Unexpected prompt failure.");
+    expect(container.textContent).not.toContain("unexpected_prompt_failure");
     const preview = container.querySelector("[data-instruction-result-preview]");
     expect(preview?.textContent).not.toContain("Original body is hidden until expanded.");
     expect(preview?.textContent).not.toContain("Unavailable content must not be merged.");
+    expect(preview?.textContent).not.toContain("Unknown unavailable content must not be merged.");
     expect((container.textContent?.match(/Active body is hidden until expanded\./g) ?? []).length).toBe(1);
 
     await click(container.querySelector('button[aria-label="Expand Active prompt"]'));
@@ -803,6 +816,54 @@ describe("PromptTab extra DOM states", () => {
     expect(dialog?.textContent).not.toContain("Legacy merged fallback must not replace sections.");
     await click(dialog?.querySelector("button") ?? null);
     await waitForCondition(() => document.activeElement === trigger, "Expected focus to return to Read full");
+  });
+
+  it("keeps an enabled empty Team Prompt manageable without counting it as applied", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    contextMock.value = createContext({
+      config: config({
+        payload: {
+          kind: "claude-code",
+          prompt: { append: "", sections: [] },
+          model: "sonnet",
+          reasoningEffort: "medium",
+          mcpServers: [],
+          env: [],
+          gitRepos: [],
+          resourceSkills: [],
+        },
+      }),
+    });
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        effective: {
+          version: 9,
+          repos: [],
+          prompts: [
+            promptRow({
+              id: "resource:empty-team-prompt",
+              resourceId: "empty-team-prompt",
+              name: "Empty team prompt",
+              mode: "enabled",
+              promptBody: "",
+            }),
+          ],
+          skills: [],
+          mcp: [],
+          unavailable: [],
+        },
+      }),
+    );
+
+    const container = await renderWithProviders(<PromptTab />);
+    await waitForText(container, "Empty team prompt");
+    expect(container.textContent).toContain("0 instructions applied");
+    expect(container.textContent).toContain("No additional instructions are active.");
+    expect(container.textContent).toContain("No instructions are applied.");
+    expect(container.textContent).toContain("Not applied · 1");
+    expect(container.querySelector('button[aria-label="Read full"]')).toBeNull();
+    expect(container.querySelector('button[role="switch"][aria-label="Enable Empty team prompt"]')).toBeTruthy();
+    expect(container.querySelector('button[aria-label="More actions for Empty team prompt"]')).toBeTruthy();
   });
 
   it("reserves Editable here for standalone inline instructions", async () => {

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -454,7 +454,7 @@ describe("PromptTab extra DOM states", () => {
     await waitForText(container, "resources offline");
 
     expect(container.textContent).toContain("Fallback instructions from config.");
-    expect(container.querySelector('button[aria-label="Add instructions"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Add instruction"]')).toBeNull();
   });
 
   it("enables optional team prompts and routes the settings escape through navigateAway", async () => {
@@ -483,13 +483,14 @@ describe("PromptTab extra DOM states", () => {
     );
 
     const container = await renderWithProviders(<PromptTab />);
-    await waitForText(container, "No instructions yet.");
+    await waitForText(container, "No additional instructions are active.");
+    await waitForText(container, "No instructions are applied.");
 
-    await click(container.querySelector('button[aria-label="Add instructions"]'));
+    await click(container.querySelector('button[aria-label="Add instruction"]'));
     await click(buttonByText(document.body, "Manage in Settings"));
     expect(navigateAway).toHaveBeenCalledWith("/settings/resources");
 
-    await click(container.querySelector('button[aria-label="Add instructions"]'));
+    await click(container.querySelector('button[aria-label="Add instruction"]'));
     await waitForText(document.body, "Optional safety prompt");
     await click(buttonByText(document.body, "Optional safety prompt"));
     await waitForCondition(
@@ -655,6 +656,15 @@ describe("PromptTab extra DOM states", () => {
               promptBody: "Original body is hidden until expanded.",
               order: 2,
             }),
+            promptRow({
+              id: "resource:unavailable-prompt",
+              resourceId: "unavailable-prompt",
+              name: "Unavailable prompt",
+              mode: "unavailable",
+              promptBody: "Unavailable content must not be merged.",
+              unavailableReason: "Prompt budget exceeded.",
+              order: 3,
+            }),
           ],
           skills: [],
           mcp: [],
@@ -685,12 +695,24 @@ describe("PromptTab extra DOM states", () => {
 
     const container = await renderWithProviders(<PromptTab />);
     await waitForText(container, "Active prompt");
-    expect(container.textContent).not.toContain("Active body is hidden until expanded.");
+    expect(container.textContent).toContain("1 instruction applied");
+    expect(container.textContent).toContain("Not applied · 3");
+    expect(container.textContent).toContain("Replaced");
+    expect(container.textContent).toContain("Can't load");
+    expect(container.textContent).toContain("Prompt budget exceeded.");
+    const preview = container.querySelector("[data-instruction-result-preview]");
+    expect(preview?.textContent).not.toContain("Original body is hidden until expanded.");
+    expect(preview?.textContent).not.toContain("Unavailable content must not be merged.");
+    expect((container.textContent?.match(/Active body is hidden until expanded\./g) ?? []).length).toBe(1);
 
     await click(container.querySelector('button[aria-label="Expand Active prompt"]'));
-    expect(container.textContent).toContain("Active body is hidden until expanded.");
+    expect(container.querySelector('button[aria-label="Collapse Active prompt"]')).toBeTruthy();
+    const activeRow = container
+      .querySelector('button[aria-label="Collapse Active prompt"]')
+      ?.closest("[data-resource-row]");
+    expect(activeRow?.querySelector<HTMLElement>(".max-w-2xl")?.parentElement?.style.background).toBe("transparent");
     await click(container.querySelector('button[aria-label="Collapse Active prompt"]'));
-    expect(container.textContent).not.toContain("Active body is hidden until expanded.");
+    expect((container.textContent?.match(/Active body is hidden until expanded\./g) ?? []).length).toBe(1);
 
     await click(container.querySelector('button[aria-label="Expand Overridden prompt"]'));
     expect(container.textContent).toContain("Original body is hidden until expanded.");
@@ -716,73 +738,71 @@ describe("PromptTab extra DOM states", () => {
     });
   });
 
-  it("toggles the clamped effective instructions block", async () => {
+  it("opens the ordered read-only result in a dialog and restores trigger focus", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
-    const scrollDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight");
-    const clientDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientHeight");
-    Object.defineProperty(HTMLElement.prototype, "scrollHeight", { configurable: true, get: () => 600 });
-    Object.defineProperty(HTMLElement.prototype, "clientHeight", { configurable: true, get: () => 80 });
-    try {
-      contextMock.value = createContext({
-        config: config({
-          payload: {
-            kind: "claude-code",
-            prompt: {
-              append: "Team section.\n\nCustom section.",
-              sections: [
-                { scope: "team", name: "Team guide", body: "Team section." },
-                { scope: "agent", name: "", body: "Custom section." },
-              ],
-            },
-            model: "sonnet",
-            reasoningEffort: "medium",
-            mcpServers: [],
-            env: [],
-            gitRepos: [],
-            resourceSkills: [],
-          },
-        }),
-      });
-      agentResourceMocks.getAgentResources.mockResolvedValue(
-        agentResources({
-          effective: {
-            version: 9,
-            repos: [],
-            prompts: [
-              promptRow({ id: "team-guide", name: "Team guide", promptBody: "Team section.", order: 1 }),
-              promptRow({
-                id: "binding:inline-1:enabled",
-                bindingId: "inline-1",
-                source: "inline_prompt",
-                scope: "agent",
-                resourceId: null,
-                name: "Custom instructions",
-                promptBody: "Custom section.",
-                order: 2,
-              }),
+    contextMock.value = createContext({
+      config: config({
+        payload: {
+          kind: "claude-code",
+          prompt: {
+            append: "Legacy merged fallback must not replace sections.",
+            sections: [
+              { scope: "team", name: "Team guide", body: "Team section." },
+              { scope: "agent", name: "", body: "Custom section.", editable: true },
             ],
-            skills: [],
-            mcp: [],
-            unavailable: [],
           },
-        }),
-      );
+          model: "sonnet",
+          reasoningEffort: "medium",
+          mcpServers: [],
+          env: [],
+          gitRepos: [],
+          resourceSkills: [],
+        },
+      }),
+    });
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        effective: {
+          version: 9,
+          repos: [],
+          prompts: [
+            promptRow({ id: "team-guide", name: "Team guide", promptBody: "Team section.", order: 1 }),
+            promptRow({
+              id: "binding:inline-1:enabled",
+              bindingId: "inline-1",
+              source: "inline_prompt",
+              scope: "agent",
+              resourceId: null,
+              name: "Custom instructions",
+              promptBody: "Custom section.",
+              order: 2,
+            }),
+          ],
+          skills: [],
+          mcp: [],
+          unavailable: [],
+        },
+      }),
+    );
 
-      const container = await renderWithProviders(<PromptTab />);
-      await waitForText(container, "All instructions");
-      await waitForText(container, "Show all");
-      const toggle = buttonByText(container, "Show all");
-      expect(toggle?.getAttribute("aria-expanded")).toBe("false");
-      await click(toggle);
-      expect(buttonByText(container, "Collapse")?.getAttribute("aria-expanded")).toBe("true");
-      await click(buttonByText(container, "Collapse"));
-      expect(buttonByText(container, "Show all")?.getAttribute("aria-expanded")).toBe("false");
-    } finally {
-      if (scrollDescriptor) Object.defineProperty(HTMLElement.prototype, "scrollHeight", scrollDescriptor);
-      else Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
-      if (clientDescriptor) Object.defineProperty(HTMLElement.prototype, "clientHeight", clientDescriptor);
-      else Reflect.deleteProperty(HTMLElement.prototype, "clientHeight");
-    }
+    const container = await renderWithProviders(<PromptTab />);
+    await waitForText(container, "Read-only preview");
+    const preview = container.querySelector<HTMLElement>("[data-instruction-result-preview] p:last-child");
+    expect(preview?.textContent).toBe("Team section. Custom section.");
+    expect(preview?.dataset.lineClamp).toBe("4");
+
+    const trigger = buttonByText(container, "Read full");
+    trigger?.focus();
+    await click(trigger);
+    const dialog = document.body.querySelector('[role="dialog"]');
+    expect(dialog?.textContent).toContain("Team guide · Team instruction");
+    expect(dialog?.textContent).toContain("Custom instructions · Editable for this agent");
+    expect(dialog?.textContent?.indexOf("Team section.")).toBeLessThan(
+      dialog?.textContent?.indexOf("Custom section.") ?? 0,
+    );
+    expect(dialog?.textContent).not.toContain("Legacy merged fallback must not replace sections.");
+    await click(dialog?.querySelector("button") ?? null);
+    await waitForCondition(() => document.activeElement === trigger, "Expected focus to return to Read full");
   });
 });
 

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -867,21 +867,29 @@ describe("AgentDetailPage", () => {
       "Usage",
     ]);
     expect(container.textContent).toContain("Always explain tradeoffs.");
-    expect(container.textContent).toContain("All instructions");
+    expect(container.textContent).toContain("What this agent follows");
+    expect(container.textContent).toContain("2 instructions applied");
+    expect(container.textContent).toContain("Applied instructions");
     await waitForText(container, "Team style guide");
     expect(container.textContent).toContain("Team style guide");
-    expect(container.textContent).toContain("Custom for this agent");
-    // The merged block renders each contributed instruction as its own labelled
-    // segment (not one blob): the team segment + the agent's own "Custom" segment.
-    const effBlock = container.querySelector('[aria-label="All instructions"]');
-    expect(effBlock).toBeTruthy();
-    const segLabels = [...(effBlock?.querySelectorAll(".text-eyebrow") ?? [])].map((n) => n.textContent?.trim());
-    // Each segment label is "<name> · <source>", aligned with the source rows.
-    expect(segLabels.some((l) => l?.includes("Team style guide") && l?.includes("Team default"))).toBe(true);
-    expect(segLabels.some((l) => l?.includes("Custom instructions") && l?.includes("Custom for this agent"))).toBe(
+    expect(container.textContent).toContain("Team instruction · Managed by your team");
+    expect(container.textContent).toContain("For this agent · Editable here");
+    const preview = container.querySelector("[data-instruction-result-preview]");
+    expect(preview?.textContent).toContain("Use the team house style. Always explain tradeoffs.");
+
+    const readFull = exactButtonByText(container, "Read full");
+    readFull?.focus();
+    await click(readFull);
+    const dialog = document.body.querySelector('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+    const segLabels = [...(dialog?.querySelectorAll(".text-eyebrow") ?? [])].map((n) => n.textContent?.trim());
+    expect(segLabels.some((l) => l?.includes("Team style guide") && l?.includes("Team instruction"))).toBe(true);
+    expect(segLabels.some((l) => l?.includes("Custom instructions") && l?.includes("Editable for this agent"))).toBe(
       true,
     );
-    expect(effBlock?.textContent).toContain("Use the team house style.");
+    expect(dialog?.textContent).toContain("Use the team house style.");
+    await click(dialog?.querySelector("button span.sr-only")?.parentElement ?? null);
+    await waitForCondition(() => document.activeElement === readFull, "Expected dialog focus to return to Read full");
 
     // The custom prompt's edit action now lives in the row's ⋯ overflow menu.
     await clickRowMenuItem(container, "More actions for Custom instructions", "Edit custom instructions");
@@ -963,7 +971,7 @@ describe("AgentDetailPage", () => {
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "Team style guide");
-    await waitForText(container, "Custom for this agent");
+    await waitForText(container, "For this agent · Editable here");
     expect(container.textContent).toContain("No instructions yet.");
 
     await clickRowMenuItem(container, "More actions for Custom instructions", "Edit custom instructions");
@@ -1193,8 +1201,9 @@ describe("AgentDetailPage", () => {
     );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "No instructions yet.");
-    await click(container.querySelector('button[aria-label="Add instructions"]'));
+    await waitForText(container, "No additional instructions are active.");
+    await waitForText(container, "No instructions are applied.");
+    await click(container.querySelector('button[aria-label="Add instruction"]'));
     await click(buttonByText(document.body, "Add custom instructions"));
     await waitForText(container, "Save instructions");
     await click(exactButtonByText(container, "Save instructions"));
@@ -1205,7 +1214,7 @@ describe("AgentDetailPage", () => {
       "Expected prompt body validation error to clear",
     );
 
-    await click(container.querySelector('button[aria-label="Add instructions"]'));
+    await click(container.querySelector('button[aria-label="Add instruction"]'));
     await click(buttonByText(document.body, "Add custom instructions"));
     await waitForText(container, "Save instructions");
     expect(container.textContent).not.toContain("Instructions are required.");

--- a/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
@@ -154,6 +154,9 @@ describe("ResourceRowView — converged action slots", () => {
     expect(container.querySelector('button[aria-label="More actions for Default resource"]')?.className).not.toContain(
       "min-h-11",
     );
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="More actions for Default resource"]')?.style.width,
+    ).toBe(`${28}px`);
 
     render(
       <ResourceRowView
@@ -167,9 +170,14 @@ describe("ResourceRowView — converged action slots", () => {
     );
     const instructionHeader = container.querySelector("[data-resource-row] > div");
     expect(instructionHeader?.className).toContain("grid-cols-[minmax(0,1fr)_auto]");
-    expect(container.querySelector('button[aria-label="More actions for Custom instructions"]')?.className).toContain(
-      "min-h-11",
-    );
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="More actions for Custom instructions"]')?.style
+        .width,
+    ).toBe("var(--sp-11)");
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="More actions for Custom instructions"]')?.style
+        .height,
+    ).toBe("var(--sp-11)");
     expect(container.querySelector('button[aria-label="Enable Custom instructions"]')?.className).toContain("h-11");
     expect(container.querySelector('button[aria-label="Enable Custom instructions"]')?.className).toContain("w-11");
     expect(container.querySelector<HTMLElement>("[data-resource-row] > p")?.dataset.lineClamp).toBe("3");

--- a/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
@@ -137,4 +137,42 @@ describe("ResourceRowView — converged action slots", () => {
     // The expand control is the heading (aria-label), not a duplicate chevron button.
     expect(buttons.filter((b) => b.getAttribute("aria-label") === "Expand Style guide")).toHaveLength(1);
   });
+
+  it("opts Instructions into a two-column mobile row without changing the default presentation", () => {
+    const actions = [{ key: "edit", label: "Edit", onSelect: () => {} }];
+    render(
+      <ResourceRowView
+        name="Default resource"
+        source="From your team"
+        toggle={{ checked: true, ariaLabel: "Enable Default resource", onChange: () => {} }}
+        menu={{ ariaLabel: "More actions for Default resource", actions }}
+      />,
+    );
+    const defaultHeader = container.querySelector("[data-resource-row] > div");
+    expect(defaultHeader?.className).toContain("flex-col");
+    expect(defaultHeader?.className).not.toContain("grid-cols-[minmax(0,1fr)_auto]");
+    expect(container.querySelector('button[aria-label="More actions for Default resource"]')?.className).not.toContain(
+      "min-h-11",
+    );
+
+    render(
+      <ResourceRowView
+        name="Custom instructions"
+        source="For this agent · Editable here"
+        peek="A readable three-line prompt excerpt."
+        presentation="instruction"
+        toggle={{ checked: true, ariaLabel: "Enable Custom instructions", onChange: () => {} }}
+        menu={{ ariaLabel: "More actions for Custom instructions", actions }}
+      />,
+    );
+    const instructionHeader = container.querySelector("[data-resource-row] > div");
+    expect(instructionHeader?.className).toContain("grid-cols-[minmax(0,1fr)_auto]");
+    expect(container.querySelector('button[aria-label="More actions for Custom instructions"]')?.className).toContain(
+      "min-h-11",
+    );
+    expect(container.querySelector('button[aria-label="Enable Custom instructions"]')?.className).toContain("h-11");
+    expect(container.querySelector('button[aria-label="Enable Custom instructions"]')?.className).toContain("w-11");
+    expect(container.querySelector<HTMLElement>("[data-resource-row] > p")?.dataset.lineClamp).toBe("3");
+    expect(container.textContent).toContain("For this agent · Editable here");
+  });
 });

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -10,15 +10,23 @@ import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "rea
 import { Navigate } from "react-router";
 import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
 import { Button } from "../../components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../../components/ui/dialog.js";
 import { Markdown } from "../../components/ui/markdown.js";
 import { Popover } from "../../components/ui/popover.js";
 import type { RowAction as RowMenuAction } from "../../components/ui/row-actions-menu.js";
 import { Section } from "../../components/ui/section.js";
 import { Textarea } from "../../components/ui/textarea.js";
-import { agentResourcesMutationHandlers, resourceTypeIcon, statusMarker } from "./capability-section.js";
+import { agentResourcesMutationHandlers, resourceTypeIcon } from "./capability-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { ResourceRowView, type RowMenu, type RowStatusMarker, type RowToggle } from "./resource-row.js";
-import { sourceLabel, templateSourceLabel } from "./resource-source.js";
+import { templateSourceLabel } from "./resource-source.js";
 import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
 
 type AvailablePrompt = { id: string; name: string };
@@ -78,7 +86,9 @@ export function PromptTab() {
   const canEditPrompt = ctx.canManageAgent && ctx.agent.status === "active";
   const resourceError = resourcesQuery.error instanceof Error ? resourcesQuery.error.message : null;
   const resources = resourcesQuery.data;
-  const showEffectiveInstructions = resources ? shouldShowEffectiveInstructions(resources, prompt) : false;
+  const appliedCount = resources
+    ? appliedPromptRows(resources).length
+    : (promptSections?.filter((section) => section.body.trim()).length ?? (prompt.trim() ? 1 : 0));
   const editorError = savePromptMut.error instanceof Error ? savePromptMut.error.message : null;
   const bindingError = bindingMut.error instanceof Error ? bindingMut.error.message : null;
   const bindings = resources?.bindings ?? [];
@@ -134,9 +144,12 @@ export function PromptTab() {
 
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
+      <EffectiveInstructionsBlock prompt={prompt} sections={promptSections} appliedCount={appliedCount} />
       <Section
         headingLevel={3}
-        title={titleWithSemantics("Instructions", justSaved)}
+        title={titleWithSemantics("Applied instructions", justSaved)}
+        count={appliedCount}
+        className="[&>div:first-child]:flex-row [&>div:first-child]:items-center"
         action={
           canEditPrompt && !resourceError && !editor && resources ? (
             <AddInstructionsMenu
@@ -149,7 +162,6 @@ export function PromptTab() {
           ) : null
         }
       >
-        {showEffectiveInstructions ? <EffectiveInstructionsBlock prompt={prompt} sections={promptSections} /> : null}
         <div>
           {resources ? (
             <PromptResourceBlocks
@@ -168,7 +180,7 @@ export function PromptTab() {
               onEditBinding={editBinding}
             />
           ) : (
-            <PromptFallbackPanel prompt={prompt} />
+            <PromptFallbackPanel loading={resourcesQuery.isPending} />
           )}
         </div>
         {resourceError ? (
@@ -186,90 +198,109 @@ export function PromptTab() {
   );
 }
 
-// Result-first: the merged runtime instructions (`ctx.config.payload.prompt.append`,
-// after every team prompt + override) are surfaced at the TOP of the tab as the
-// thing the agent actually runs with — replacing the old on-demand 👁 modal. Long
-// bodies clamp to ~8 lines with a Show all toggle; the source list below is for
-// management (toggle / customize / add).
-function EffectiveInstructionsBlock({ prompt, sections }: { prompt: string; sections?: PromptSection[] }) {
-  const [showAll, setShowAll] = useState(false);
-  const [clamped, setClamped] = useState(false);
-  const bodyRef = useRef<HTMLElement | null>(null);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure when the merged text changes.
-  useEffect(() => {
-    const el = bodyRef.current;
-    if (el) setClamped(el.scrollHeight > el.clientHeight + 2);
-  }, [prompt]);
-
-  // Prefer the structured per-source sections (resolved server-side from the
-  // same effective stack as `append`, in the same order) so each contributed
-  // instruction reads as its own segment split by a dashed rule. Fall back to
-  // the merged `append` string for older payloads that carry no sections.
+// Result-first: the resolved prompt is always visible before its management
+// rows. The compact preview answers "what does this agent follow?" without
+// turning the tab into a long document; the full ordered result remains a
+// read-only Dialog.
+function EffectiveInstructionsBlock({
+  prompt,
+  sections,
+  appliedCount,
+}: {
+  prompt: string;
+  sections?: PromptSection[];
+  appliedCount: number;
+}) {
   const segments = sections?.filter((s) => s.body.trim()) ?? [];
+  const effectiveBody = segments.length > 0 ? segments.map((segment) => segment.body).join("\n\n") : prompt;
+  const hasInstructions = effectiveBody.trim().length > 0;
+  const countLabel = `${appliedCount} ${appliedCount === 1 ? "instruction" : "instructions"} applied`;
 
   return (
-    <div style={{ marginBottom: "var(--sp-4)" }}>
-      {prompt.trim() ? (
-        <>
-          <p className="text-eyebrow" style={{ color: "var(--fg-4)", margin: "0 0 var(--sp-1_5)" }}>
-            All instructions
-          </p>
-          <section
-            ref={bodyRef}
-            aria-label="All instructions"
-            className="text-body"
+    <Dialog>
+      <Section
+        headingLevel={3}
+        title="What this agent follows"
+        count={countLabel}
+        className="[&>div:first-child]:flex-row [&>div:first-child]:items-center"
+        action={
+          hasInstructions ? (
+            <DialogTrigger asChild>
+              <Button type="button" size="xs" variant="ghost">
+                Read full
+              </Button>
+            </DialogTrigger>
+          ) : null
+        }
+      >
+        {hasInstructions ? (
+          <div
+            data-instruction-result-preview
             style={{
-              background: "var(--bg-sunken)",
-              border: "var(--hairline) solid var(--border-faint)",
-              borderRadius: "var(--radius-panel)",
-              padding: "var(--sp-3)",
-              maxHeight: showAll ? undefined : "var(--sp-35)",
-              overflow: showAll ? undefined : "hidden",
+              borderLeft: "var(--hairline-bold) solid var(--border)",
+              margin: "var(--sp-3) 0",
+              paddingLeft: "var(--sp-3)",
             }}
           >
+            <p className="text-eyebrow" style={{ color: "var(--fg-4)", margin: "0 0 var(--sp-1)" }}>
+              Read-only preview
+            </p>
+            <p
+              className="m-0 text-body"
+              data-line-clamp="4"
+              style={{
+                color: "var(--fg-2)",
+                display: "-webkit-box",
+                WebkitBoxOrient: "vertical",
+                WebkitLineClamp: 4,
+                overflow: "hidden",
+              }}
+            >
+              {promptExcerpt(effectiveBody)}
+            </p>
+          </div>
+        ) : (
+          <p className="m-0 text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0" }}>
+            No additional instructions are active.
+          </p>
+        )}
+      </Section>
+      {hasInstructions ? (
+        <DialogContent className="max-h-[calc(100vh-var(--sp-8))] w-[calc(100%-var(--sp-4))] max-w-2xl grid-rows-[auto_minmax(0,1fr)]">
+          <DialogHeader>
+            <DialogTitle>What this agent follows</DialogTitle>
+            <DialogDescription className="sr-only">
+              Read-only instructions applied to this agent, shown in their effective order.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="min-h-0 overflow-y-auto" style={{ paddingRight: "var(--sp-2)" }}>
             {segments.length > 0 ? (
-              segments.map((section, i) => (
-                <div
+              segments.map((section, index) => (
+                <section
                   key={`${section.scope}:${section.name}:${section.body.length}`}
                   style={
-                    i > 0
+                    index > 0
                       ? {
-                          marginTop: "var(--sp-3)",
-                          paddingTop: "var(--sp-3)",
-                          borderTop: "var(--hairline) dashed var(--border)",
+                          marginTop: "var(--sp-4)",
+                          paddingTop: "var(--sp-4)",
+                          borderTop: "var(--hairline) solid var(--border-faint)",
                         }
                       : undefined
                   }
                 >
-                  <p className="text-eyebrow" style={{ color: "var(--fg-4)", margin: "0 0 var(--sp-1)" }}>
+                  <p className="text-eyebrow" style={{ color: "var(--fg-4)", margin: "0 0 var(--sp-2)" }}>
                     {segmentLabel(section)}
                   </p>
                   <Markdown className={PROSE_COMPACT_HEADINGS}>{section.body}</Markdown>
-                </div>
+                </section>
               ))
             ) : (
               <Markdown className={PROSE_COMPACT_HEADINGS}>{prompt}</Markdown>
             )}
-          </section>
-          {clamped || showAll ? (
-            <Button
-              type="button"
-              size="xs"
-              variant="ghost"
-              aria-expanded={showAll}
-              onClick={() => setShowAll((v) => !v)}
-              style={{ marginTop: "var(--sp-1)" }}
-            >
-              {showAll ? "Collapse" : "Show all"}
-            </Button>
-          ) : null}
-        </>
-      ) : (
-        <p className="text-body" style={{ color: "var(--fg-4)", margin: 0 }}>
-          No extra instructions — this agent runs on its base profile only.
-        </p>
-      )}
-    </div>
+          </div>
+        </DialogContent>
+      ) : null}
+    </Dialog>
   );
 }
 
@@ -280,7 +311,12 @@ function EffectiveInstructionsBlock({ prompt, sections }: { prompt: string; sect
 // exactly like its row does.
 function segmentLabel(section: PromptSection): string {
   const name = section.name.trim() || "Custom instructions";
-  const source = section.scope === "team" ? "Team default" : "Custom for this agent";
+  const source =
+    section.scope === "team"
+      ? "Team instruction"
+      : section.editable
+        ? "Editable for this agent"
+        : "Customized for this agent";
   return `${name} · ${source}`;
 }
 
@@ -385,13 +421,6 @@ function nextOrder(bindings: readonly AgentResourceBindingInput[]): number {
   return bindings.reduce((max, binding) => Math.max(max, binding.order ?? 0), 0) + 1;
 }
 
-function shouldShowEffectiveInstructions(data: AgentResourcesOutput, prompt: string): boolean {
-  if (!prompt.trim()) return false;
-  const activeRows = enabledPromptRows(data);
-  if (activeRows.length > 1) return true;
-  return data.effective.prompts.some((row) => row.mode === "replaced" || !!row.replacesResourceId);
-}
-
 function PromptResourceBlocks(props: {
   data: AgentResourcesOutput;
   editor: PromptEditorState | null;
@@ -407,10 +436,10 @@ function PromptResourceBlocks(props: {
   onRemoveBinding: (bindingId: string) => void;
   onEditBinding: (bindingId: string) => void;
 }) {
-  // Every instruction block collapses to a short summary by default and expands
-  // to its full body on demand — same affordance whether the block is enabled or
-  // inactive (disabled / overridden). This keeps the list scannable while the
-  // bottom "Effective instructions" panel stays the single full merged preview.
+  // Each row exposes a short readable summary by default and expands in place.
+  // Only rows that contribute to the effective prompt live in Applied;
+  // disabled, replaced, unavailable, and empty orphan bindings stay explainable
+  // under Not applied without inflating the count above.
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
   const toggleExpand = (id: string) => {
     setExpandedIds((prev) => {
@@ -420,11 +449,11 @@ function PromptResourceBlocks(props: {
       return next;
     });
   };
-  const rows = enabledPromptRows(props.data);
+  const rows = appliedPromptRows(props.data);
   const templateNameById = new Map(props.data.adoptedTemplates.map((summary) => [summary.id, summary.name]));
   // Disabled / overridden prompts are hidden from the active list, but the user
   // must still be able to re-enable or revert them — render them below.
-  const inactiveRows = props.data.effective.prompts.filter((row) => row.mode === "disabled" || row.mode === "replaced");
+  const inactiveRows = props.data.effective.prompts.filter((row) => row.mode !== "enabled");
   // Inline prompt bindings the backend produced no effective row for (e.g. an
   // empty body it drops): keep them visible so they can be edited or removed —
   // an unremovable empty include binding otherwise makes every save fail.
@@ -454,7 +483,7 @@ function PromptResourceBlocks(props: {
     />
   ) : null;
 
-  const blocks: ReactNode[] = rows.map((row) => {
+  const appliedBlocks: ReactNode[] = rows.map((row) => {
     const isEditingRow = !!props.editor && editorIsInline && props.editor.rowId === row.id;
     const controls = props.editor || !props.canEdit ? {} : promptRowControls(row, props);
     return (
@@ -462,11 +491,13 @@ function PromptResourceBlocks(props: {
         key={row.id}
         name={promptBlockName(row)}
         source={row.source}
+        customizedFromTeam={!!row.replacesResourceId}
         templateName={row.originTemplateId ? (templateNameById.get(row.originTemplateId) ?? null) : undefined}
-        marker={statusMarker(row.mode)}
+        marker={promptStatusMarker(row.mode)}
         toggle={controls.toggle}
         menu={controls.menu}
         body={row.promptBody ?? ""}
+        unavailableReason={row.unavailableReason}
         expanded={expandedIds.has(row.id)}
         onToggle={() => toggleExpand(row.id)}
         editor={isEditingRow ? editorNode : null}
@@ -475,7 +506,7 @@ function PromptResourceBlocks(props: {
   });
 
   if (editorNeedsAgentBlock) {
-    blocks.push(
+    appliedBlocks.push(
       <PromptResourceBlock
         key="agent-custom-editor"
         name={null}
@@ -488,6 +519,7 @@ function PromptResourceBlocks(props: {
     );
   }
 
+  const inactiveBlocks: ReactNode[] = [];
   for (const row of inactiveRows) {
     // Disabled team prompt → Switch off (toggling on removes the disable binding).
     // Overridden prompt with no live replacement row (e.g. an empty inline
@@ -500,7 +532,11 @@ function PromptResourceBlocks(props: {
     const name = promptBlockName(row) ?? "instructions";
     let toggle: RowToggle | undefined;
     let menu: RowMenu | undefined;
-    if (manageable && row.bindingId) {
+    if (row.mode === "unavailable" && props.canEdit && !props.editor) {
+      const controls = promptRowControls(row, props);
+      toggle = controls.toggle;
+      menu = controls.menu;
+    } else if (manageable && row.bindingId) {
       if (row.mode === "disabled") {
         toggle = {
           checked: false,
@@ -523,17 +559,19 @@ function PromptResourceBlocks(props: {
         };
       }
     }
-    blocks.push(
+    inactiveBlocks.push(
       <PromptResourceBlock
         key={row.id}
         name={promptBlockName(row)}
         source={row.source}
+        customizedFromTeam={!!row.replacesResourceId}
         templateName={row.originTemplateId ? (templateNameById.get(row.originTemplateId) ?? null) : undefined}
-        marker={statusMarker(row.mode)}
+        marker={promptStatusMarker(row.mode)}
         toggle={toggle}
         menu={menu}
-        dimmed={row.mode === "disabled"}
+        dimmed
         body={row.promptBody ?? ""}
+        unavailableReason={row.unavailableReason}
         expanded={expandedIds.has(row.id)}
         onToggle={() => toggleExpand(row.id)}
       />,
@@ -561,7 +599,7 @@ function PromptResourceBlocks(props: {
               },
             ],
           };
-    blocks.push(
+    inactiveBlocks.push(
       <PromptResourceBlock
         key={orphanId}
         name={null}
@@ -575,12 +613,35 @@ function PromptResourceBlocks(props: {
     );
   }
 
-  return blocks.length > 0 ? (
-    <div className="ad-tail-trim">{blocks}</div>
-  ) : (
-    <p className="text-body text-muted-foreground" style={{ margin: 0, padding: "var(--sp-3) 0" }}>
-      No instructions yet.
-    </p>
+  return (
+    <>
+      <div className="ad-tail-trim">
+        {appliedBlocks.length > 0 ? (
+          appliedBlocks
+        ) : (
+          <p className="m-0 text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0" }}>
+            No instructions are applied. Add custom instructions or enable one from your team.
+          </p>
+        )}
+      </div>
+      {inactiveBlocks.length > 0 ? (
+        <section style={{ marginTop: "var(--sp-5)" }}>
+          <h4 className="m-0 text-subtitle font-semibold" style={{ color: "var(--fg-3)" }}>
+            Not applied
+            <span className="font-normal" style={{ color: "var(--fg-4)" }}>
+              {" · "}
+              {inactiveBlocks.length}
+            </span>
+          </h4>
+          <div
+            className="ad-tail-trim"
+            style={{ borderTop: "var(--hairline) solid var(--border)", marginTop: "var(--sp-3)" }}
+          >
+            {inactiveBlocks}
+          </div>
+        </section>
+      ) : null}
+    </>
   );
 }
 
@@ -646,43 +707,23 @@ function promptRowControls(
   return {};
 }
 
-function PromptFallbackPanel(props: { prompt: string }) {
+function PromptFallbackPanel(props: { loading: boolean }) {
   return (
-    <PromptPanel minHeight={props.prompt ? "10rem" : undefined} sunken={!props.prompt}>
-      {props.prompt ? (
-        <Markdown>{props.prompt}</Markdown>
-      ) : (
-        <span className="text-muted-foreground">No instructions yet.</span>
-      )}
-    </PromptPanel>
-  );
-}
-
-function PromptPanel(props: { children: ReactNode; minHeight?: string; sunken?: boolean }) {
-  return (
-    <div
-      className="text-body"
-      style={{
-        minHeight: props.minHeight,
-        border: "var(--hairline) solid var(--border-faint)",
-        borderRadius: "var(--radius-panel)",
-        background: props.sunken ? "var(--bg-sunken)" : "var(--bg)",
-        padding: "var(--sp-3)",
-      }}
-    >
-      {props.children}
-    </div>
+    <p className="m-0 text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0" }}>
+      {props.loading ? "Loading instruction details…" : "Instruction details are unavailable."}
+    </p>
   );
 }
 
 // One instruction row — a thin wrapper over the shared `ResourceRowView`
 // primitive (the same flat skeleton the Tools & skills / Repositories rows use):
-// name → source → status, plus Switch / ⋯. De-crowded: no per-row body peek —
-// click the row to read the full Markdown in the sunken block (the merged net
-// result lives in the top Effective block).
+// name → ownership → status, plus Switch / ⋯. A short plain-text excerpt keeps
+// the default state informative; click the row to read the full Markdown while
+// the merged result remains in the result-first block above.
 function PromptResourceBlock(props: {
   name: string | null;
   source: EffectivePromptRow["source"];
+  customizedFromTeam?: boolean;
   /** Resolved Template name when the row was imported from one; undefined otherwise. */
   templateName?: string | null;
   marker?: RowStatusMarker;
@@ -690,6 +731,7 @@ function PromptResourceBlock(props: {
   menu?: RowMenu;
   dimmed?: boolean;
   body: string;
+  unavailableReason?: string | null;
   expanded: boolean;
   onToggle: () => void;
   /** When present (editor active), the sunken area shows this instead of Markdown. */
@@ -704,13 +746,14 @@ function PromptResourceBlock(props: {
       name={props.name}
       source={
         <span title={props.templateName !== undefined ? templateSourceLabel(props.templateName) : undefined}>
-          {sourceLabel(props.source)}
+          {instructionOwnershipLabel(props.source, !!props.customizedFromTeam)}
         </span>
       }
       status={props.marker}
       toggle={props.toggle}
       menu={props.menu}
       dimmed={props.dimmed}
+      peek={props.unavailableReason ?? (hasBody ? promptExcerpt(props.body) : undefined)}
       emptyPeek={hasBody ? undefined : "No instructions yet."}
       expandLabel="instructions"
       leadingIcon={resourceTypeIcon("prompt")}
@@ -726,6 +769,7 @@ function PromptResourceBlock(props: {
         ) : null,
       }}
       editor={props.editor ?? undefined}
+      presentation="instruction"
     />
   );
 }
@@ -748,13 +792,14 @@ function AddInstructionsMenu(props: {
       trigger={({ open, toggle }) => (
         <Button
           size="xs"
-          variant="ghost"
+          variant="outline"
           aria-expanded={open}
-          aria-label="Add instructions"
-          title="Add instructions"
+          aria-label="Add instruction"
+          title="Add instruction"
           onClick={toggle}
         >
           <Plus className="h-4 w-4" />
+          Add instruction
         </Button>
       )}
     >
@@ -830,12 +875,34 @@ function InstructionsMenuButton(props: {
   );
 }
 
-function enabledPromptRows(data: AgentResourcesOutput): EffectivePromptRow[] {
-  // Active list = enabled + unavailable (e.g. budget-exceeded). Include blank-body
-  // rows too: a team prompt can legitimately have an empty body and still needs its
-  // management controls. (The backend only drops blank *inline* bindings, which the
-  // orphan-binding path below recovers — those never produce a row here.)
-  return data.effective.prompts.filter((row) => row.mode === "enabled" || row.mode === "unavailable");
+function appliedPromptRows(data: AgentResourcesOutput): EffectivePromptRow[] {
+  return data.effective.prompts.filter((row) => row.mode === "enabled");
+}
+
+function instructionOwnershipLabel(source: EffectivePromptRow["source"], customizedFromTeam: boolean): string {
+  if (source === "inline_prompt") {
+    return customizedFromTeam ? "For this agent · Customized from team" : "For this agent · Editable here";
+  }
+  if (source.startsWith("team_")) return "Team instruction · Managed by your team";
+  return "For this agent · Managed here";
+}
+
+function promptStatusMarker(mode: EffectivePromptRow["mode"]): RowStatusMarker {
+  if (mode === "replaced") return { label: "Replaced", tone: "neutral" };
+  if (mode === "unavailable") return { label: "Can't load", tone: "error" };
+  return null;
+}
+
+function promptExcerpt(body: string): string {
+  return body
+    .replace(/```[^\n]*\n?/g, "")
+    .replace(/```/g, "")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/^\s{0,3}(?:#{1,6}|>|[-+*])\s+/gm, "")
+    .replace(/[*_~`]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function promptBlockName(row: EffectivePromptRow): string | null {

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -453,7 +453,7 @@ function PromptResourceBlocks(props: {
   const templateNameById = new Map(props.data.adoptedTemplates.map((summary) => [summary.id, summary.name]));
   // Disabled / overridden prompts are hidden from the active list, but the user
   // must still be able to re-enable or revert them — render them below.
-  const inactiveRows = props.data.effective.prompts.filter((row) => row.mode !== "enabled");
+  const inactiveRows = props.data.effective.prompts.filter((row) => !isAppliedPromptRow(row));
   // Inline prompt bindings the backend produced no effective row for (e.g. an
   // empty body it drops): keep them visible so they can be edited or removed —
   // an unremovable empty include binding otherwise makes every save fail.
@@ -521,6 +521,7 @@ function PromptResourceBlocks(props: {
 
   const inactiveBlocks: ReactNode[] = [];
   for (const row of inactiveRows) {
+    const isEditingRow = !!props.editor && editorIsInline && props.editor.rowId === row.id;
     // Disabled team prompt → Switch off (toggling on removes the disable binding).
     // Overridden prompt with no live replacement row (e.g. an empty inline
     // replacement) → ⋯ Remove, so it never gets stuck.
@@ -532,7 +533,11 @@ function PromptResourceBlocks(props: {
     const name = promptBlockName(row) ?? "instructions";
     let toggle: RowToggle | undefined;
     let menu: RowMenu | undefined;
-    if (row.mode === "unavailable" && props.canEdit && !props.editor) {
+    if (row.mode === "enabled" && props.canEdit && !props.editor) {
+      const controls = promptRowControls(row, props);
+      toggle = controls.toggle;
+      menu = controls.menu;
+    } else if (row.mode === "unavailable" && props.canEdit && !props.editor) {
       const controls = promptRowControls(row, props);
       toggle = controls.toggle;
       menu = controls.menu;
@@ -574,6 +579,7 @@ function PromptResourceBlocks(props: {
         unavailableReason={row.unavailableReason}
         expanded={expandedIds.has(row.id)}
         onToggle={() => toggleExpand(row.id)}
+        editor={isEditingRow ? editorNode : null}
       />,
     );
   }
@@ -753,7 +759,7 @@ function PromptResourceBlock(props: {
       toggle={props.toggle}
       menu={props.menu}
       dimmed={props.dimmed}
-      peek={props.unavailableReason ?? (hasBody ? promptExcerpt(props.body) : undefined)}
+      peek={instructionUnavailableReason(props.unavailableReason) ?? (hasBody ? promptExcerpt(props.body) : undefined)}
       emptyPeek={hasBody ? undefined : "No instructions yet."}
       expandLabel="instructions"
       leadingIcon={resourceTypeIcon("prompt")}
@@ -876,7 +882,14 @@ function InstructionsMenuButton(props: {
 }
 
 function appliedPromptRows(data: AgentResourcesOutput): EffectivePromptRow[] {
-  return data.effective.prompts.filter((row) => row.mode === "enabled");
+  return data.effective.prompts.filter(isAppliedPromptRow);
+}
+
+// Match the server's runtime projection: an enabled row contributes only when
+// it carries a body. Empty Team Prompt resources remain manageable below, but
+// do not inflate the applied count or contradict the read-only result.
+function isAppliedPromptRow(row: EffectivePromptRow): boolean {
+  return row.mode === "enabled" && !!row.promptBody;
 }
 
 function instructionOwnershipLabel(source: EffectivePromptRow["source"], customizedFromTeam: boolean): string {
@@ -891,6 +904,19 @@ function promptStatusMarker(mode: EffectivePromptRow["mode"]): RowStatusMarker {
   if (mode === "replaced") return { label: "Replaced", tone: "neutral" };
   if (mode === "unavailable") return { label: "Can't load", tone: "error" };
   return null;
+}
+
+function instructionUnavailableReason(reason: string | null | undefined): string | undefined {
+  const normalized = reason?.trim();
+  if (!normalized) return undefined;
+  if (normalized === "prompt_budget_exceeded") {
+    return "These instructions exceed the agent's instruction limit.";
+  }
+  // Preserve already-readable server copy. Unknown machine codes still get a
+  // safe sentence rather than leaking snake_case into the UI.
+  if (/\s|[.!?]/.test(normalized)) return normalized;
+  const words = normalized.replace(/[_-]+/g, " ");
+  return `${words.charAt(0).toUpperCase()}${words.slice(1)}.`;
 }
 
 function promptExcerpt(body: string): string {

--- a/packages/web/src/pages/agent-detail/resource-row.tsx
+++ b/packages/web/src/pages/agent-detail/resource-row.tsx
@@ -153,7 +153,7 @@ export function ResourceRowView(props: {
               <RowActionsMenu
                 actions={props.menu.actions}
                 ariaLabel={props.menu.ariaLabel}
-                triggerClassName={instructionPresentation ? "min-h-11 min-w-11" : undefined}
+                touchTarget={instructionPresentation}
               />
             ) : null}
           </div>

--- a/packages/web/src/pages/agent-detail/resource-row.tsx
+++ b/packages/web/src/pages/agent-detail/resource-row.tsx
@@ -68,7 +68,11 @@ export function ResourceRowView(props: {
   /** Leading type glyph (repo / skill / MCP / instruction) so the four resource
    *  kinds are distinguishable at a glance. A small line icon, tinted --fg-4. */
   leadingIcon?: ReactNode;
+  /** Prompt-only presentation used by Instructions. The default keeps every
+   *  other Agent Detail resource row byte-for-byte on its existing layout. */
+  presentation?: "default" | "instruction";
 }): ReactNode {
+  const instructionPresentation = props.presentation === "instruction";
   const expanded = !!props.expand?.expanded;
   const canExpand = !props.editor && !!props.expand?.canExpand;
   const showSunken = props.editor ? true : expanded && !!props.expand?.body;
@@ -91,7 +95,13 @@ export function ResourceRowView(props: {
       {/* Title + action cluster. On mobile they stack (title, then the controls
           wrap below) so a long control group never overflows a phone width; on
           sm+ they sit on one row with the controls right-aligned. */}
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
+      <div
+        className={cn(
+          instructionPresentation
+            ? "grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2"
+            : "flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3",
+        )}
+      >
         <div className="min-w-0 flex-1">
           {canExpand ? (
             <button
@@ -114,6 +124,7 @@ export function ResourceRowView(props: {
                 dimmed={props.dimmed}
                 expandable
                 expanded={expanded}
+                instructionPresentation={instructionPresentation}
               />
             </button>
           ) : (
@@ -123,20 +134,28 @@ export function ResourceRowView(props: {
               status={props.status}
               leadingIcon={props.leadingIcon}
               dimmed={props.dimmed}
+              instructionPresentation={instructionPresentation}
             />
           )}
         </div>
         {showCluster ? (
-          <div className="flex flex-wrap items-center gap-1 shrink-0">
+          <div className={cn("flex shrink-0 items-center", instructionPresentation ? "gap-2" : "flex-wrap gap-1")}>
             {props.toggle ? (
               <Switch
                 checked={props.toggle.checked}
                 onCheckedChange={props.toggle.onChange}
                 disabled={props.toggle.disabled}
                 aria-label={props.toggle.ariaLabel}
+                touchTarget={instructionPresentation}
               />
             ) : null}
-            {props.menu ? <RowActionsMenu actions={props.menu.actions} ariaLabel={props.menu.ariaLabel} /> : null}
+            {props.menu ? (
+              <RowActionsMenu
+                actions={props.menu.actions}
+                ariaLabel={props.menu.ariaLabel}
+                triggerClassName={instructionPresentation ? "min-h-11 min-w-11" : undefined}
+              />
+            ) : null}
           </div>
         ) : null}
       </div>
@@ -145,10 +164,10 @@ export function ResourceRowView(props: {
           className="text-body"
           style={{
             marginTop: "var(--sp-2)",
-            background: "var(--bg-sunken)",
-            border: "var(--hairline) solid var(--border-faint)",
-            borderRadius: "var(--radius-panel)",
-            padding: "var(--sp-3)",
+            background: instructionPresentation && !props.editor ? "transparent" : "var(--bg-sunken)",
+            border: instructionPresentation && !props.editor ? "none" : "var(--hairline) solid var(--border-faint)",
+            borderRadius: instructionPresentation && !props.editor ? undefined : "var(--radius-panel)",
+            padding: instructionPresentation && !props.editor ? "0 0 0 var(--sp-6)" : "var(--sp-3)",
           }}
         >
           {props.editor ? props.editor : props.expand?.body}
@@ -156,19 +175,27 @@ export function ResourceRowView(props: {
       ) : props.peek ? (
         <p
           className={cn("m-0 text-caption", props.monoPeek && "mono")}
+          data-line-clamp={instructionPresentation ? "3" : undefined}
           style={{
             color: "var(--fg-3)",
             marginTop: "var(--sp-0_5)",
             display: "-webkit-box",
             WebkitBoxOrient: "vertical",
-            WebkitLineClamp: 2,
+            WebkitLineClamp: instructionPresentation ? 3 : 2,
             overflow: "hidden",
+            paddingLeft: instructionPresentation ? "var(--sp-6)" : undefined,
           }}
         >
           {props.peek}
         </p>
       ) : props.emptyPeek ? (
-        <p className="m-0 text-caption text-muted-foreground" style={{ marginTop: "var(--sp-0_5)" }}>
+        <p
+          className="m-0 text-caption text-muted-foreground"
+          style={{
+            marginTop: "var(--sp-0_5)",
+            paddingLeft: instructionPresentation ? "var(--sp-6)" : undefined,
+          }}
+        >
           {props.emptyPeek}
         </p>
       ) : null}
@@ -184,6 +211,7 @@ function RowHeading({
   dimmed,
   expandable,
   expanded,
+  instructionPresentation,
 }: {
   name: ReactNode | null;
   source: ReactNode;
@@ -193,7 +221,45 @@ function RowHeading({
   /** When the heading itself is the expand trigger, show a subtle affordance. */
   expandable?: boolean;
   expanded?: boolean;
+  instructionPresentation?: boolean;
 }) {
+  if (instructionPresentation) {
+    return (
+      <span className="flex min-w-0 items-start gap-2">
+        {leadingIcon ? (
+          <span className="inline-flex shrink-0 items-center" style={{ color: "var(--fg-3)" }} aria-hidden>
+            {leadingIcon}
+          </span>
+        ) : null}
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 items-center gap-2">
+            {name ? (
+              <span
+                className="min-w-0 truncate text-body font-medium"
+                style={{ color: dimmed ? "var(--fg-4)" : "var(--fg)" }}
+              >
+                {name}
+              </span>
+            ) : null}
+            {status ? (
+              <DenseBadge tone={status.tone} className="shrink-0">
+                {status.label}
+              </DenseBadge>
+            ) : null}
+            {expandable ? (
+              <span className="inline-flex shrink-0 items-center" style={{ color: "var(--fg-4)" }} aria-hidden>
+                {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+              </span>
+            ) : null}
+          </span>
+          <span className="block text-caption font-normal" style={{ color: "var(--fg-4)", marginTop: "var(--sp-0_5)" }}>
+            {source}
+          </span>
+        </span>
+      </span>
+    );
+  }
+
   return (
     <span className="inline-flex items-center gap-2">
       {leadingIcon ? (


### PR DESCRIPTION
## Summary

- lead the Instructions tab with an always-visible, read-only `What this agent follows` preview and an ordered full-result dialog
- organize prompt rows into `Applied instructions` and `Not applied`, with plain-language ownership, editability, and concise excerpts
- keep existing prompt mutation semantics while opting Instructions into mobile-safe rows and real 44px switch/menu targets without changing other Agent Detail tabs

## Test plan

- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/web exec vitest run --passWithNoTests --reporter=dot` (251 files, 2,354 tests)
- focused Agent Detail suites (56 tests)
- `pnpm --filter @first-tree/web build`
- Playwright visual and interaction checks at 1440px and 390px, including zero horizontal overflow, 44px action targets, ordered full-result dialog, and focus restoration

## Scope

This PR changes only the Instructions presentation and an explicit opt-in presentation path on shared row/switch primitives. Default shared component rendering and the other Agent Detail tabs remain unchanged.
