### PR TITLE
feat(web): complete OpenTag onboarding on real Feishu first use

### DIFF
--- a/packages/qa/cases/cross-surface/opentag-entry-agent-materialization.md
+++ b/packages/qa/cases/cross-surface/opentag-entry-agent-materialization.md
@@ -10,16 +10,18 @@ surfaces: [server, web, client]
 ## Goal
 
 Confirm that one member can go from an unauthenticated `/opentag` link to a
-Feishu Bot connected to exactly one Agent, and that every interruption on the
-way leaves either nothing or that same Agent — never a second one.
+Feishu Bot connected to exactly one Agent and on to real first use in Feishu,
+and that every interruption on the way leaves either nothing or that same
+Agent — never a second one.
 
 The deterministic pieces (URL parsing, eligibility classification, step
 selection) belong to product tests. This case owns what only a live run can
 answer: that the atomic create really writes the Agent, its Computer, its
 runtime and its durable config together on a real Computer; that a real
-provider mix does not dead-end; and that a failed readiness read cannot walk
-the member into creating another Agent through the workspace and onboarding
-gates.
+provider mix does not dead-end; that a failed readiness read cannot walk the
+member into creating another Agent through the workspace and onboarding gates;
+and that the membership is stamped complete only by a Feishu Task genuinely
+belonging to this Agent, which no mocked read can establish.
 
 ## Preconditions
 
@@ -30,10 +32,19 @@ gates.
 - A real connected Computer. At least one pass must use a Computer whose ready
   runtime is **not** the service default — a Codex-only machine is the useful
   shape, because the historical defect was an Agent stuck on `claude-code`.
-- Fresh browser state, and a way to fault-inject `/me` (devtools request
-  blocking is enough). Never reuse a developer's session or localhost login.
-- Direct database read access for the Agent, its runtime config and the Feishu
-  binding. UI text alone does not establish what was written.
+- Fresh browser state, and a way to fault-inject `/me`, the chat reads and the
+  completion request independently (devtools request blocking is enough). Never
+  reuse a developer's session or localhost login.
+- Direct database read access for the Agent, its runtime config, the Feishu
+  binding, the Task chat's metadata and the membership onboarding columns. UI
+  text alone does not establish what was written.
+- A disposable Feishu tenant with a real person able to message the Bot, since
+  only real ingress creates the Task this journey ends on. Reuse the tenant
+  hygiene rules in [feishu-agent-channel](feishu-agent-channel.md); never use a
+  customer conversation.
+- For the cross-Agent leg, a second disposable Agent in the same Team bound to
+  its **own** Bot. One Agent binds at most one Bot, so the second Bot is what
+  makes the two Tasks distinguishable at all.
 
 ## Operate
 

--- a/packages/qa/cases/cross-surface/opentag-entry-agent-materialization.md
+++ b/packages/qa/cases/cross-surface/opentag-entry-agent-materialization.md
@@ -1,6 +1,6 @@
 ---
 id: opentag-entry-agent-materialization
-description: Validate the /opentag journey end to end — strict OAuth return, local draft, one atomic Agent create on a Computer-supported runtime, readiness and lost-response recovery, and the focused Feishu handoff without onboarding completion.
+description: Validate the /opentag journey end to end — strict OAuth return, local draft, one atomic Agent create on a Computer-supported runtime, readiness and lost-response recovery, the focused Feishu handoff, and terminal completion on real first use in Feishu.
 areas: [cross-surface]
 surfaces: [server, web, client]
 ---
@@ -75,27 +75,51 @@ gates.
    confirm the QR and its confirmation link. Confirm the surface calls the Bot
    connected only once the binding is genuinely reachable, and reports a
    connection error in words rather than colour alone.
-7. **No completion.** Confirm no onboarding completion or suppression stamp was
-   written for this membership at any point.
-8. **Narrow viewport.** Repeat the main path at 390 px; the current decision
-   must stay on the first screen.
+7. **No completion before real use.** Through every step above, including a
+   Bot that is provisioned and connected, confirm no onboarding completion or
+   suppression stamp was written for this membership. A connected Bot is setup,
+   not use.
+8. **Terminal first use.** From the real Feishu tenant, send this Bot a private
+   message (or an exact group mention) so ingress creates the Task. Confirm the
+   browser converges without a reload: the entry reaches its terminal state,
+   `members.onboarding_completed_at` and the `completed` suppression stamp are
+   written exactly once, and the offered destination opens that Task's chat.
+   Reload the entry and confirm it converges to the same state with no second
+   Agent, no second chat, and no second stamp.
+9. **Another Agent's task cannot finish this one.** With a second Agent bound to
+   its own Bot in the same Team, drive that Bot's Task and confirm it does not
+   complete the first Agent's membership. Repeat with the first Agent invited
+   into the second Agent's Task as an internal collaborator: being a speaker in
+   someone else's Feishu conversation must not count as this Agent's first use.
+10. **Failure honesty.** Block the chat reads while the Task exists and confirm
+    the entry neither completes nor claims the Agent is unused, and recovers
+    once the reads succeed. Then block only the completion request and confirm
+    the terminal state stays retryable and withholds the destination until the
+    stamp lands.
+11. **Narrow viewport.** Repeat the main path at 390 px; the current decision
+    must stay on the first screen.
 
 ## Evidence
 
 Database rows for the Agent, its config and its Feishu binding at each
-checkpoint; the request log around the create and the blocked `/me`; and
-screenshots of the readiness-failure state and the Feishu step. Redact tokens,
-connect codes and Bot credentials.
+checkpoint; the membership onboarding stamp columns before and after real first
+use; the Task chat's `metadata` alongside the Agent's Bot binding id; the
+request log around the create, the blocked `/me` and the blocked reads; and
+screenshots of the readiness-failure state, the Feishu step and the terminal
+state. Redact tokens, connect codes, Bot credentials and external member
+identities.
 
 ## Expected
 
 Exactly one Agent per completed journey. Every interruption leaves either
 nothing created or that one Agent, reachable again. A Computer running a
 non-default runtime completes without a dead end, and reaching a connected Bot
-does not complete onboarding — real first use happens in Feishu.
+does not complete onboarding — only a real Feishu Task belonging to this exact
+Agent does, exactly once, and a failed read never stands in for one.
 
 ## Limitations
 
-Terminal first use in Feishu is out of scope here. This case does not qualify
-the Feishu message bridge, Bot credential handling, or the Template catalog
-itself; those have their own owners.
+This case qualifies the entry's own terminal boundary, not the transport that
+produces it: the Feishu message bridge, Bot credential handling, and the
+Template catalog have their own owners. An admin continuing a teammate's Agent
+is out of scope — that member does not own the setup being stamped.

--- a/packages/web/src/api/onboarding-events.ts
+++ b/packages/web/src/api/onboarding-events.ts
@@ -93,7 +93,9 @@ export async function reportOnboardingEvent(
 /**
  * Stamp the terminal-state `onboarding_completed_at` column. Called when
  * the user walks Step 3 to success (admin Continue, invitee Confirm /
- * Continue). Once stamped, first-run onboarding no longer auto-opens; the
+ * Continue), and by the `/opentag` entry once that Agent has a real Feishu
+ * Task — a terminal state reached by using the Agent, not by pressing
+ * anything. Once stamped, first-run onboarding no longer auto-opens; the
  * permanent Settings → Getting Started overview remains available.
  *
  * Distinct from `dismissOnboarding()`, which only hides the stepper UI

--- a/packages/web/src/api/onboarding-events.ts
+++ b/packages/web/src/api/onboarding-events.ts
@@ -91,12 +91,13 @@ export async function reportOnboardingEvent(
 }
 
 /**
- * Stamp the terminal-state `onboarding_completed_at` column. Called when
- * the user walks Step 3 to success (admin Continue, invitee Confirm /
- * Continue), and by the `/opentag` entry once that Agent has a real Feishu
- * Task — a terminal state reached by using the Agent, not by pressing
- * anything. Once stamped, first-run onboarding no longer auto-opens; the
- * permanent Settings → Getting Started overview remains available.
+ * Stamp the terminal-state `onboarding_completed_at` column. Reached from the
+ * `/opentag` entry once that Agent has a real Feishu Task — a terminal state
+ * arrived at by using the Agent, not by pressing anything, which is why it
+ * needs its own request. The standalone journey stamps inside
+ * `postOnboardingStartChat` instead. Once stamped, first-run onboarding no
+ * longer auto-opens; the permanent Settings → Getting Started overview remains
+ * available.
  *
  * Distinct from `dismissOnboarding()`, which only hides the stepper UI
  * and stays reversible. Idempotent on the server (only writes when the

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -135,7 +135,9 @@ type AuthContextValue = {
    * POST `/me/onboarding-completed`. Optimistically stamps
    * `onboardingCompletedAt` so first-run routing can settle immediately.
    * Idempotent server-side. Called at Step 3 terminal-success points (admin
-   * Continue, invitee Confirm / Continue).
+   * Continue, invitee Confirm / Continue) and by the `/opentag` entry once
+   * that Agent has a real Feishu Task — there the terminal fact is observed
+   * rather than pressed, so the stamp is not tied to a button.
    */
   markOnboardingCompleted: () => Promise<void>;
   /**

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -134,10 +134,14 @@ type AuthContextValue = {
   /**
    * POST `/me/onboarding-completed`. Optimistically stamps
    * `onboardingCompletedAt` so first-run routing can settle immediately.
-   * Idempotent server-side. Called at Step 3 terminal-success points (admin
-   * Continue, invitee Confirm / Continue) and by the `/opentag` entry once
-   * that Agent has a real Feishu Task — there the terminal fact is observed
-   * rather than pressed, so the stamp is not tied to a button.
+   * Idempotent server-side.
+   *
+   * Its one caller is the `/opentag` entry, once that Agent has a real Feishu
+   * Task. That terminal fact is observed rather than pressed, so the stamp is
+   * not tied to a button and has to be issued separately. The standalone
+   * journey does not use this: its start-chat writes the same stamp inside the
+   * kickoff transaction and mirrors it with `applyOnboardingKickoffStamp`,
+   * because a second POST could fail after the chat already succeeded.
    */
   markOnboardingCompleted: () => Promise<void>;
   /**

--- a/packages/web/src/pages/opentag/__tests__/first-use.test.ts
+++ b/packages/web/src/pages/opentag/__tests__/first-use.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FIRST_USE_SCAN_LIMIT, isFeishuTaskForBinding, readOpenTagFirstUse } from "../first-use.js";
+
+const AGENT_UUID = "0198b2c4-1f6a-7c31-9a02-4d5e6f708192";
+const BINDING = "binding-1";
+
+const meChats = vi.hoisted(() => ({ listMeChats: vi.fn() }));
+vi.mock("../../../api/me-chats.js", () => meChats);
+
+const chats = vi.hoisted(() => ({ getChat: vi.fn() }));
+vi.mock("../../../api/chats.js", () => chats);
+
+/** Only the fields this read consumes; the real rows carry far more. */
+function page(chatIds: string[]) {
+  return { priorityRows: { pinned: [] }, rows: chatIds.map((chatId) => ({ chatId })), nextCursor: null };
+}
+
+function feishuChat(botBindingId: string, externalChatId = "oc_1") {
+  return {
+    metadata: { source: "feishu", botBindingId, externalChatId, externalChatType: "p2p" },
+  };
+}
+
+beforeEach(() => {
+  meChats.listMeChats.mockReset();
+  chats.getChat.mockReset();
+});
+
+describe("isFeishuTaskForBinding", () => {
+  it("accepts only this Agent's own Bot binding", () => {
+    expect(isFeishuTaskForBinding(feishuChat(BINDING).metadata, BINDING)).toBe(true);
+    // The same external Feishu chat reached through another Bot is a different
+    // Task belonging to a different Agent — never this member's first use.
+    expect(isFeishuTaskForBinding(feishuChat("binding-2").metadata, BINDING)).toBe(false);
+  });
+
+  it("rejects anything that is not a Feishu Task", () => {
+    expect(isFeishuTaskForBinding({ source: "agent" }, BINDING)).toBe(false);
+    expect(isFeishuTaskForBinding({ source: "github", entityType: "issue", entityKey: "o/r#1" }, BINDING)).toBe(false);
+    // An ordinary chat carries no metadata at all.
+    expect(isFeishuTaskForBinding({}, BINDING)).toBe(false);
+    expect(isFeishuTaskForBinding(null, BINDING)).toBe(false);
+    // A malformed row must not be read as a match by coincidence.
+    expect(isFeishuTaskForBinding({ source: "feishu", botBindingId: BINDING }, BINDING)).toBe(false);
+  });
+});
+
+describe("readOpenTagFirstUse", () => {
+  it("asks only for this Agent's Feishu chats, archived ones included", async () => {
+    meChats.listMeChats.mockResolvedValue(page([]));
+
+    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "absent" });
+    expect(meChats.listMeChats).toHaveBeenCalledWith({
+      origin: ["feishu"],
+      with: [AGENT_UUID],
+      engagement: "all",
+      limit: FIRST_USE_SCAN_LIMIT,
+    });
+    expect(chats.getChat).not.toHaveBeenCalled();
+  });
+
+  it("reports the Task chat once this Agent's Bot has one", async () => {
+    meChats.listMeChats.mockResolvedValue(page(["chat-1"]));
+    chats.getChat.mockResolvedValue(feishuChat(BINDING));
+
+    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "present", chatId: "chat-1" });
+  });
+
+  it("does not accept a teammate's Feishu Task this Agent was invited into", async () => {
+    // The participant filter alone would match: an internal collaborator is a
+    // speaker in a Feishu-origin chat. The Bot binding is what tells the two
+    // apart, and it belongs to the other Agent.
+    meChats.listMeChats.mockResolvedValue(page(["chat-neighbour"]));
+    chats.getChat.mockResolvedValue(feishuChat("binding-2"));
+
+    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "absent" });
+  });
+
+  it("finds this Agent's own Task past a neighbour's", async () => {
+    meChats.listMeChats.mockResolvedValue(page(["chat-neighbour", "chat-mine"]));
+    chats.getChat.mockImplementation(async (chatId: string) =>
+      chatId === "chat-mine" ? feishuChat(BINDING) : feishuChat("binding-2"),
+    );
+
+    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "present", chatId: "chat-mine" });
+  });
+
+  it("propagates a failed read instead of reporting no first use", async () => {
+    meChats.listMeChats.mockRejectedValue(new Error("offline"));
+    await expect(readOpenTagFirstUse(AGENT_UUID, BINDING)).rejects.toThrow("offline");
+
+    meChats.listMeChats.mockResolvedValue(page(["chat-1"]));
+    chats.getChat.mockRejectedValue(new Error("offline"));
+    await expect(readOpenTagFirstUse(AGENT_UUID, BINDING)).rejects.toThrow("offline");
+  });
+});

--- a/packages/web/src/pages/opentag/__tests__/first-use.test.ts
+++ b/packages/web/src/pages/opentag/__tests__/first-use.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { FIRST_USE_MAX_PAGES, FIRST_USE_PAGE_SIZE, isFeishuTaskForBinding, readOpenTagFirstUse } from "../first-use.js";
+import { createOpenTagFirstUseScan, FIRST_USE_PAGE_SIZE, isFeishuTaskForBinding } from "../first-use.js";
 
 const AGENT_UUID = "0198b2c4-1f6a-7c31-9a02-4d5e6f708192";
 const BINDING = "binding-1";
@@ -45,17 +45,23 @@ describe("isFeishuTaskForBinding", () => {
   });
 });
 
-describe("readOpenTagFirstUse", () => {
+describe("createOpenTagFirstUseScan", () => {
+  /** A fresh scan, as the page builds one per (member, Agent, Bot). */
+  const scan = () => createOpenTagFirstUseScan(AGENT_UUID, BINDING);
+
   it("asks only for this Agent's Feishu chats, archived ones included", async () => {
     meChats.listMeChats.mockResolvedValue(page([]));
 
-    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "absent" });
-    expect(meChats.listMeChats).toHaveBeenCalledWith({
-      origin: ["feishu"],
-      with: [AGENT_UUID],
-      engagement: "all",
-      limit: FIRST_USE_PAGE_SIZE,
-    });
+    expect(await scan()()).toEqual({ state: "absent" });
+    expect(meChats.listMeChats).toHaveBeenCalledWith(
+      {
+        origin: ["feishu"],
+        with: [AGENT_UUID],
+        engagement: "all",
+        limit: FIRST_USE_PAGE_SIZE,
+      },
+      undefined,
+    );
     expect(chats.getChat).not.toHaveBeenCalled();
   });
 
@@ -71,27 +77,67 @@ describe("readOpenTagFirstUse", () => {
       chatId === "chat-mine" ? feishuChat(BINDING) : feishuChat("binding-2"),
     );
 
-    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "present", chatId: "chat-mine" });
+    expect(await scan()()).toEqual({ state: "present", chatId: "chat-mine" });
     expect(meChats.listMeChats).toHaveBeenCalledTimes(2);
     expect(meChats.listMeChats.mock.calls[1]?.[0]).toMatchObject({ cursor: "cursor-1" });
   });
 
-  it("does not call a partially read list an absence", async () => {
-    // Reporting `absent` here would strand a member who really did use their
-    // Agent. `unknown` keeps the poll going instead of concluding from a page
-    // that was never finished.
-    meChats.listMeChats.mockResolvedValue(page(["chat-other"], "cursor-forever"));
+  it("has no page horizon — a Task far down the list is still reached", async () => {
+    // A fixed page budget would not fix this, it would only move it: the poll
+    // behind this restarts from the first page every time, so anything past the
+    // budget stays permanently unreachable however long the member waits.
+    const DEEP = 40;
+    for (let i = 0; i < DEEP; i++) meChats.listMeChats.mockResolvedValueOnce(page([`chat-busy-${i}`], `cursor-${i}`));
+    meChats.listMeChats.mockResolvedValueOnce(page(["chat-mine"]));
+    chats.getChat.mockImplementation(async (chatId: string) =>
+      chatId === "chat-mine" ? feishuChat(BINDING) : feishuChat("binding-2"),
+    );
+
+    expect(await scan()()).toEqual({ state: "present", chatId: "chat-mine" });
+    expect(meChats.listMeChats).toHaveBeenCalledTimes(DEEP + 1);
+  });
+
+  it("does not pay twice for a conversation it has already ruled out", async () => {
+    // Exhaustion is only affordable because a verdict keeps: a chat's Bot
+    // binding is written once and never changes. Without this, a member with a
+    // long Feishu history would re-read every one of those chats every five
+    // seconds.
+    const scanner = scan();
+    meChats.listMeChats.mockResolvedValue(page(["chat-a", "chat-b"]));
     chats.getChat.mockResolvedValue(feishuChat("binding-2"));
 
-    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "unknown" });
-    expect(meChats.listMeChats).toHaveBeenCalledTimes(FIRST_USE_MAX_PAGES);
+    expect(await scanner()).toEqual({ state: "absent" });
+    expect(chats.getChat).toHaveBeenCalledTimes(2);
+
+    // The Task arrives. The poll finds it without re-reading the two it
+    // already knows are somebody else's.
+    meChats.listMeChats.mockResolvedValue(page(["chat-mine", "chat-a", "chat-b"]));
+    chats.getChat.mockImplementation(async (chatId: string) =>
+      chatId === "chat-mine" ? feishuChat(BINDING) : feishuChat("binding-2"),
+    );
+
+    expect(await scanner()).toEqual({ state: "present", chatId: "chat-mine" });
+    expect(chats.getChat).toHaveBeenCalledTimes(3);
+  });
+
+  it("abandons a superseded scan without claiming anything", async () => {
+    const controller = new AbortController();
+    meChats.listMeChats.mockImplementation(async () => {
+      controller.abort();
+      return page(["chat-a"], "cursor-1");
+    });
+    chats.getChat.mockResolvedValue(feishuChat("binding-2"));
+
+    // Giving up establishes neither presence nor absence.
+    expect(await scan()(controller.signal)).toEqual({ state: "unknown" });
+    expect(chats.getChat).not.toHaveBeenCalled();
   });
 
   it("reports the Task chat once this Agent's Bot has one", async () => {
     meChats.listMeChats.mockResolvedValue(page(["chat-1"]));
     chats.getChat.mockResolvedValue(feishuChat(BINDING));
 
-    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "present", chatId: "chat-1" });
+    expect(await scan()()).toEqual({ state: "present", chatId: "chat-1" });
   });
 
   it("does not accept a teammate's Feishu Task this Agent was invited into", async () => {
@@ -101,7 +147,7 @@ describe("readOpenTagFirstUse", () => {
     meChats.listMeChats.mockResolvedValue(page(["chat-neighbour"]));
     chats.getChat.mockResolvedValue(feishuChat("binding-2"));
 
-    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "absent" });
+    expect(await scan()()).toEqual({ state: "absent" });
   });
 
   it("finds this Agent's own Task past a neighbour's", async () => {
@@ -110,15 +156,15 @@ describe("readOpenTagFirstUse", () => {
       chatId === "chat-mine" ? feishuChat(BINDING) : feishuChat("binding-2"),
     );
 
-    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "present", chatId: "chat-mine" });
+    expect(await scan()()).toEqual({ state: "present", chatId: "chat-mine" });
   });
 
   it("propagates a failed read instead of reporting no first use", async () => {
     meChats.listMeChats.mockRejectedValue(new Error("offline"));
-    await expect(readOpenTagFirstUse(AGENT_UUID, BINDING)).rejects.toThrow("offline");
+    await expect(scan()()).rejects.toThrow("offline");
 
     meChats.listMeChats.mockResolvedValue(page(["chat-1"]));
     chats.getChat.mockRejectedValue(new Error("offline"));
-    await expect(readOpenTagFirstUse(AGENT_UUID, BINDING)).rejects.toThrow("offline");
+    await expect(scan()()).rejects.toThrow("offline");
   });
 });

--- a/packages/web/src/pages/opentag/__tests__/first-use.test.ts
+++ b/packages/web/src/pages/opentag/__tests__/first-use.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { FIRST_USE_SCAN_LIMIT, isFeishuTaskForBinding, readOpenTagFirstUse } from "../first-use.js";
+import { FIRST_USE_MAX_PAGES, FIRST_USE_PAGE_SIZE, isFeishuTaskForBinding, readOpenTagFirstUse } from "../first-use.js";
 
 const AGENT_UUID = "0198b2c4-1f6a-7c31-9a02-4d5e6f708192";
 const BINDING = "binding-1";
@@ -11,8 +11,8 @@ const chats = vi.hoisted(() => ({ getChat: vi.fn() }));
 vi.mock("../../../api/chats.js", () => chats);
 
 /** Only the fields this read consumes; the real rows carry far more. */
-function page(chatIds: string[]) {
-  return { priorityRows: { pinned: [] }, rows: chatIds.map((chatId) => ({ chatId })), nextCursor: null };
+function page(chatIds: string[], nextCursor: string | null = null) {
+  return { priorityRows: { pinned: [] }, rows: chatIds.map((chatId) => ({ chatId })), nextCursor };
 }
 
 function feishuChat(botBindingId: string, externalChatId = "oc_1") {
@@ -54,9 +54,37 @@ describe("readOpenTagFirstUse", () => {
       origin: ["feishu"],
       with: [AGENT_UUID],
       engagement: "all",
-      limit: FIRST_USE_SCAN_LIMIT,
+      limit: FIRST_USE_PAGE_SIZE,
     });
     expect(chats.getChat).not.toHaveBeenCalled();
+  });
+
+  it("follows the cursor to a Task that is no longer recently active", async () => {
+    // The conversation list is ordered by activity, not relevance. A member who
+    // used their Agent a while ago, and has since collaborated in busier Feishu
+    // conversations, has their own Task pushed off the first page — and every
+    // poll would re-read that same page and reach the same wrong conclusion.
+    meChats.listMeChats
+      .mockResolvedValueOnce(page(["chat-busy"], "cursor-1"))
+      .mockResolvedValueOnce(page(["chat-mine"]));
+    chats.getChat.mockImplementation(async (chatId: string) =>
+      chatId === "chat-mine" ? feishuChat(BINDING) : feishuChat("binding-2"),
+    );
+
+    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "present", chatId: "chat-mine" });
+    expect(meChats.listMeChats).toHaveBeenCalledTimes(2);
+    expect(meChats.listMeChats.mock.calls[1]?.[0]).toMatchObject({ cursor: "cursor-1" });
+  });
+
+  it("does not call a partially read list an absence", async () => {
+    // Reporting `absent` here would strand a member who really did use their
+    // Agent. `unknown` keeps the poll going instead of concluding from a page
+    // that was never finished.
+    meChats.listMeChats.mockResolvedValue(page(["chat-other"], "cursor-forever"));
+    chats.getChat.mockResolvedValue(feishuChat("binding-2"));
+
+    expect(await readOpenTagFirstUse(AGENT_UUID, BINDING)).toEqual({ state: "unknown" });
+    expect(meChats.listMeChats).toHaveBeenCalledTimes(FIRST_USE_MAX_PAGES);
   });
 
   it("reports the Task chat once this Agent's Bot has one", async () => {

--- a/packages/web/src/pages/opentag/__tests__/flow.test.ts
+++ b/packages/web/src/pages/opentag/__tests__/flow.test.ts
@@ -140,21 +140,41 @@ describe("classifyOpenTagAgent", () => {
 });
 
 describe("resolveOpenTagStep", () => {
+  const notUsedYet = { state: "absent" } as const;
+
   it("starts at the Agent choice with no Agent, and recovers there from a wrong Agent", () => {
-    expect(resolveOpenTagStep({ state: "none" })).toBe("choose-agent");
-    expect(resolveOpenTagStep({ state: "unavailable" })).toBe("choose-agent");
+    expect(resolveOpenTagStep({ state: "none" }, notUsedYet)).toBe("choose-agent");
+    expect(resolveOpenTagStep({ state: "unavailable" }, notUsedYet)).toBe("choose-agent");
   });
 
   it("holds the step until the authoritative read settles", () => {
-    expect(resolveOpenTagStep({ state: "loading" })).toBeNull();
-    expect(resolveOpenTagStep({ state: "unreadable" })).toBeNull();
-    expect(resolveOpenTagStep({ state: "team-unreadable" })).toBeNull();
+    expect(resolveOpenTagStep({ state: "loading" }, notUsedYet)).toBeNull();
+    expect(resolveOpenTagStep({ state: "unreadable" }, notUsedYet)).toBeNull();
+    expect(resolveOpenTagStep({ state: "team-unreadable" }, notUsedYet)).toBeNull();
   });
 
   it("sends an existing Agent straight to Feishu", () => {
     // Both setup choices already happened at creation, so there is nothing
     // between an existing Agent and its Bot.
-    expect(resolveOpenTagStep({ state: "resolved" })).toBe("connect-feishu");
+    expect(resolveOpenTagStep({ state: "resolved" }, notUsedYet)).toBe("connect-feishu");
+  });
+
+  it("only ends the journey once the Agent has a real Feishu Task", () => {
+    expect(resolveOpenTagStep({ state: "resolved" }, { state: "present", chatId: "chat-1" })).toBe("use-in-feishu");
+  });
+
+  it("keeps the member on the Bot step while first use is unknown", () => {
+    // A read that has not landed, or one that failed, is not evidence that
+    // nothing happened — but it is certainly not evidence that it did, and
+    // this is the branch that decides whether onboarding gets completed.
+    expect(resolveOpenTagStep({ state: "resolved" }, { state: "unknown" })).toBe("connect-feishu");
+  });
+
+  it("cannot end the journey for an Agent that is not usable here", () => {
+    // Defence in depth against a first-use answer outliving the Agent it was
+    // read for: a deleted or foreign Agent restarts, whatever was cached.
+    expect(resolveOpenTagStep({ state: "unavailable" }, { state: "present", chatId: "chat-1" })).toBe("choose-agent");
+    expect(resolveOpenTagStep({ state: "unreadable" }, { state: "present", chatId: "chat-1" })).toBeNull();
   });
 });
 

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -927,6 +927,32 @@ describe("OpenTag entry — real first use in Feishu", () => {
     expect(container.textContent).toContain("The Bot is connected.");
   });
 
+  it("never stamps this member for a teammate's Agent, however visible its task is", async () => {
+    // An admin may continue a teammate's Agent here. If that admin also manages
+    // some other Agent the primary invited into its Feishu task, the ordinary
+    // watcher projection hands them a membership in that very task — so the
+    // list returns it and the Bot binding matches exactly. Everything about the
+    // Agent checks out; what does not is whose onboarding this is. The stamp is
+    // per-membership, and this membership does not own the setup.
+    authMock.value = { ...authMock.value, role: "admin", currentOrgHasPersonalAgent: false };
+    api.getAgent.mockResolvedValue({ ...agentRow(), managerId: "member-2" });
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
+    meChats.listMeChats.mockResolvedValue(chatPage(["chat-1"]));
+    chats.getChat.mockResolvedValue(feishuTaskChat("binding-1"));
+
+    const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+    await flush();
+
+    expect(markOnboardingCompleted).not.toHaveBeenCalled();
+    // The question is not even asked — the read that feeds the write is gated
+    // on the same fact.
+    expect(meChats.listMeChats).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain("has its first task from Feishu");
+    // The Bot step itself stays available: continuing a teammate's Agent is
+    // legitimate, it just is not this member's onboarding to finish.
+    expect(container.textContent).toContain("Feishu Bot for Ada assistant");
+  });
+
   it("does not complete onboarding when the task read fails", async () => {
     api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
     meChats.listMeChats.mockRejectedValue(new ApiError(500, "boom"));

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -866,22 +866,50 @@ describe("OpenTag entry — real first use in Feishu", () => {
     chats.getChat.mockResolvedValue(feishuTaskChat("binding-1"));
 
     const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+    await flush();
 
     expect(markOnboardingCompleted).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("Ada assistant has its first task from Feishu");
-    // The destination is withheld until the stamp lands: an unstamped
-    // membership can still be sent back into setup, so this frame must not
-    // advertise a door that bounces.
-    expect(container.querySelector("a[href='/?c=chat-1']")).toBeNull();
-    expect(container.textContent).toContain("Finishing up…");
-
-    await flush();
-
     // The handoff destination is the task itself, in the workspace.
     expect(container.querySelector("a[href='/?c=chat-1']")).not.toBeNull();
     // The Bot step is over — offering to connect one here would be a second
     // registration for an Agent that is already working.
     expect(container.textContent).not.toContain("Connect Bot");
+  });
+
+  it("withholds the destination until the completion stamp lands", async () => {
+    // An unstamped membership can still be sent back into setup, so the
+    // terminal step must not advertise a door that bounces. Asserting that on
+    // whichever frame the stamp happens not to have settled yet is a race;
+    // holding the stamp open here makes the state the test's to choose.
+    let landStamp: (() => void) | null = null;
+    markOnboardingCompleted.mockImplementation(
+      () =>
+        new Promise<undefined>((resolve) => {
+          landStamp = () => resolve(undefined);
+        }),
+    );
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
+    meChats.listMeChats.mockResolvedValue(chatPage(["chat-1"]));
+    chats.getChat.mockResolvedValue(feishuTaskChat("binding-1"));
+
+    const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+    await flush();
+
+    // The task is already stated as fact — it is real — but the way in is not
+    // offered while the workspace has not been told setup is finished.
+    expect(container.textContent).toContain("Ada assistant has its first task from Feishu");
+    expect(container.querySelector("a[href='/?c=chat-1']")).toBeNull();
+    expect(container.textContent).toContain("Finishing up…");
+
+    if (!landStamp) throw new Error("the completion stamp was never issued");
+    await act(async () => {
+      (landStamp as () => void)();
+    });
+    await flush();
+
+    expect(container.querySelector("a[href='/?c=chat-1']")).not.toBeNull();
+    expect(container.textContent).not.toContain("Finishing up…");
   });
 
   it("cannot be completed by a Feishu task belonging to another Agent", async () => {

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -20,6 +20,7 @@ const MEMBER = "member-1";
 
 const refreshMe = vi.hoisted(() => vi.fn(async () => undefined));
 const refreshMeStrict = vi.hoisted(() => vi.fn(async () => undefined));
+const markOnboardingCompleted = vi.hoisted(() => vi.fn(async () => undefined));
 
 const authMock = vi.hoisted(() => ({
   value: {
@@ -32,6 +33,7 @@ const authMock = vi.hoisted(() => ({
     logout: () => undefined,
     refreshMe,
     refreshMeStrict,
+    markOnboardingCompleted,
   },
 }));
 vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
@@ -45,6 +47,12 @@ const api = vi.hoisted(() => ({
   startAgentFeishuRegistration: vi.fn(),
 }));
 vi.mock("../../../api/agents.js", () => api);
+
+const meChats = vi.hoisted(() => ({ listMeChats: vi.fn() }));
+vi.mock("../../../api/me-chats.js", () => meChats);
+
+const chats = vi.hoisted(() => ({ getChat: vi.fn() }));
+vi.mock("../../../api/chats.js", () => chats);
 
 const templates = vi.hoisted(() => ({ listAgentTemplates: vi.fn() }));
 vi.mock("../../../api/agent-templates.js", () => templates);
@@ -109,6 +117,21 @@ function feishuBinding(overrides: Partial<FeishuBotBinding> = {}): FeishuBotBind
     cli: { state: "unknown", version: null, clientId: null },
     ...overrides,
   };
+}
+
+/** A Bot that is provisioned and actually carrying messages. */
+function connectedBinding(overrides: Partial<FeishuBotBinding> = {}): FeishuBotBinding {
+  return feishuBinding({ status: "active", connectionStatus: "connected", appId: "cli_1", ...overrides });
+}
+
+const NO_CHATS = { priorityRows: { pinned: [] }, rows: [], nextCursor: null };
+
+function chatPage(chatIds: string[]) {
+  return { priorityRows: { pinned: [] }, rows: chatIds.map((chatId) => ({ chatId })), nextCursor: null };
+}
+
+function feishuTaskChat(botBindingId: string) {
+  return { metadata: { source: "feishu", botBindingId, externalChatId: "oc_1", externalChatType: "p2p" } };
 }
 
 function readyComputer(): ComputerConnection {
@@ -210,9 +233,14 @@ beforeEach(() => {
     logout: () => undefined,
     refreshMe,
     refreshMeStrict,
+    markOnboardingCompleted,
   };
   refreshMe.mockClear();
   refreshMeStrict.mockReset().mockResolvedValue(undefined);
+  markOnboardingCompleted.mockReset().mockResolvedValue(undefined);
+  // No Feishu Task by default: the member has connected a Bot at most.
+  meChats.listMeChats.mockReset().mockResolvedValue(NO_CHATS);
+  chats.getChat.mockReset();
   computerMock.value = computerConnection();
   api.getAgent.mockReset();
   api.createAgent.mockReset();
@@ -795,5 +823,129 @@ describe("OpenTag entry — the Feishu handoff", () => {
 
     expect(container.textContent).toContain("Feishu is unavailable right now");
     expect(button(container, "Connect Bot").disabled).toBe(false);
+  });
+});
+
+describe("OpenTag entry — real first use in Feishu", () => {
+  beforeEach(() => {
+    authMock.value = { ...authMock.value, currentOrgHasPersonalAgent: true };
+    api.getAgent.mockResolvedValue(agentRow());
+  });
+
+  it("does not ask about first use before a Bot exists", async () => {
+    // A Bot the member has not confirmed yet cannot have carried a message, so
+    // there is nothing to poll for.
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: null });
+    await renderAt(`/opentag?agent=${AGENT_UUID}`);
+    expect(meChats.listMeChats).not.toHaveBeenCalled();
+
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: feishuBinding({ registrationUrl: "https://f.test/c" }) });
+    await renderAt(`/opentag?agent=${AGENT_UUID}`);
+    expect(meChats.listMeChats).not.toHaveBeenCalled();
+  });
+
+  it("leaves onboarding unfinished while a connected Bot has no task yet", async () => {
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
+
+    const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+
+    // A connected Bot is not first use. The member is still on the step they
+    // have something to do about.
+    expect(container.textContent).toContain("The Bot is connected.");
+    expect(container.textContent).not.toContain("has its first task from Feishu");
+    expect(markOnboardingCompleted).not.toHaveBeenCalled();
+  });
+
+  it("completes onboarding and hands off once this Agent's task exists", async () => {
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
+    meChats.listMeChats.mockResolvedValue(chatPage(["chat-1"]));
+    chats.getChat.mockResolvedValue(feishuTaskChat("binding-1"));
+
+    const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+
+    expect(markOnboardingCompleted).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("Ada assistant has its first task from Feishu");
+    // The handoff destination is the task itself, in the workspace.
+    expect(container.querySelector("a[href='/?c=chat-1']")).not.toBeNull();
+    // The Bot step is over — offering to connect one here would be a second
+    // registration for an Agent that is already working.
+    expect(container.textContent).not.toContain("Connect Bot");
+  });
+
+  it("cannot be completed by a Feishu task belonging to another Agent", async () => {
+    // The chat matches on origin and on this Agent being a speaker — an
+    // internal collaborator in a teammate's task looks exactly like this. Only
+    // the Bot binding tells them apart, and it is someone else's.
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
+    meChats.listMeChats.mockResolvedValue(chatPage(["chat-neighbour"]));
+    chats.getChat.mockResolvedValue(feishuTaskChat("binding-2"));
+
+    const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+
+    expect(markOnboardingCompleted).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain("has its first task from Feishu");
+    expect(container.textContent).toContain("The Bot is connected.");
+  });
+
+  it("does not complete onboarding when the task read fails", async () => {
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
+    meChats.listMeChats.mockRejectedValue(new ApiError(500, "boom"));
+
+    const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+
+    // "We could not check" is not "not used yet", and it is certainly not
+    // "used" — the member stays where they were, and the poll retries.
+    expect(markOnboardingCompleted).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("The Bot is connected.");
+    expect(container.textContent).not.toContain("has its first task from Feishu");
+  });
+
+  it("converges on a reload after first use without creating anything a second time", async () => {
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
+    meChats.listMeChats.mockResolvedValue(chatPage(["chat-1"]));
+    chats.getChat.mockResolvedValue(feishuTaskChat("binding-1"));
+
+    await renderAt(`/opentag?agent=${AGENT_UUID}`);
+    expect(markOnboardingCompleted).toHaveBeenCalledTimes(1);
+
+    // Same URL, nothing carried over: the terminal state is re-derived from the
+    // same authoritative reads rather than from anything this page remembered.
+    const reloaded = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+
+    expect(reloaded.textContent).toContain("Ada assistant has its first task from Feishu");
+    expect(reloaded.querySelector("a[href='/?c=chat-1']")).not.toBeNull();
+    // Nothing about the Agent is re-created, and the URL still names the one
+    // Agent this flow made.
+    expect(api.createAgent).not.toHaveBeenCalled();
+    expect(api.startAgentFeishuRegistration).not.toHaveBeenCalled();
+    expect(lastLocation).toBe(`/opentag?agent=${AGENT_UUID}`);
+  });
+
+  it("holds the handoff open and retryable when the completion stamp fails", async () => {
+    api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
+    meChats.listMeChats.mockResolvedValue(chatPage(["chat-1"]));
+    chats.getChat.mockResolvedValue(feishuTaskChat("binding-1"));
+    markOnboardingCompleted.mockRejectedValue(new ApiError(500, "boom"));
+
+    const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+    // The stamp only starts once the task read has landed, so it settles a
+    // round later than the step it is rendered in.
+    await flush();
+
+    // The task is real, so it is stated as fact — but the destination waits,
+    // because an unstamped membership can be sent straight back into setup.
+    expect(container.textContent).toContain("Ada assistant has its first task from Feishu");
+    expect(container.querySelector("a[href='/?c=chat-1']")).toBeNull();
+    expect(container.querySelector("[role='alert']")?.textContent).toContain("couldn't finish setting up");
+    // A failure holds until the member acts, rather than being re-fired by the
+    // first-use poll behind it.
+    expect(markOnboardingCompleted).toHaveBeenCalledTimes(1);
+
+    markOnboardingCompleted.mockResolvedValue(undefined);
+    await click(button(container, "Try again"));
+
+    expect(markOnboardingCompleted).toHaveBeenCalledTimes(2);
+    expect(container.querySelector("a[href='/?c=chat-1']")).not.toBeNull();
+    expect(container.querySelector("[role='alert']")).toBeNull();
   });
 });

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -124,6 +124,9 @@ function connectedBinding(overrides: Partial<FeishuBotBinding> = {}): FeishuBotB
   return feishuBinding({ status: "active", connectionStatus: "connected", appId: "cli_1", ...overrides });
 }
 
+// Unlike the fixtures above, these two carry only the fields the first-use read
+// consumes rather than the full `MeChatRow` / `ChatDetail` DTOs: both modules
+// are mocked, and the real rows carry dozens of fields none of this exercises.
 const NO_CHATS = { priorityRows: { pinned: [] }, rows: [], nextCursor: null };
 
 function chatPage(chatIds: string[]) {
@@ -865,6 +868,14 @@ describe("OpenTag entry — real first use in Feishu", () => {
 
     expect(markOnboardingCompleted).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("Ada assistant has its first task from Feishu");
+    // The destination is withheld until the stamp lands: an unstamped
+    // membership can still be sent back into setup, so this frame must not
+    // advertise a door that bounces.
+    expect(container.querySelector("a[href='/?c=chat-1']")).toBeNull();
+    expect(container.textContent).toContain("Finishing up…");
+
+    await flush();
+
     // The handoff destination is the task itself, in the workspace.
     expect(container.querySelector("a[href='/?c=chat-1']")).not.toBeNull();
     // The Bot step is over — offering to connect one here would be a second
@@ -911,6 +922,7 @@ describe("OpenTag entry — real first use in Feishu", () => {
     // Same URL, nothing carried over: the terminal state is re-derived from the
     // same authoritative reads rather than from anything this page remembered.
     const reloaded = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+    await flush();
 
     expect(reloaded.textContent).toContain("Ada assistant has its first task from Feishu");
     expect(reloaded.querySelector("a[href='/?c=chat-1']")).not.toBeNull();

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HubClient } from "../../../api/activity.js";
 import { ApiError } from "../../../api/client.js";
 import type { ComputerConnection } from "../../../features/agent-setup/use-computer-connection.js";
+import { FIRST_USE_POLL_MS } from "../first-use.js";
 import { OpenTagPage } from "../opentag-page.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -905,10 +906,40 @@ describe("OpenTag entry — real first use in Feishu", () => {
     const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
 
     // "We could not check" is not "not used yet", and it is certainly not
-    // "used" — the member stays where they were, and the poll retries.
+    // "used" — the member stays where they were.
     expect(markOnboardingCompleted).not.toHaveBeenCalled();
     expect(container.textContent).toContain("The Bot is connected.");
     expect(container.textContent).not.toContain("has its first task from Feishu");
+  });
+
+  it("recovers from a failed task read on the next poll", async () => {
+    // The half of the failure contract that the assertions above cannot show:
+    // a read error must be a pause, not a dead end. If the poll stopped at the
+    // first error, one transient 500 would strand the member on this step for
+    // the rest of the session with no way to retry — there is no button here,
+    // because the fact this waits on arrives from Feishu.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      api.getAgentFeishuBinding.mockResolvedValue({ binding: connectedBinding() });
+      meChats.listMeChats.mockRejectedValueOnce(new ApiError(500, "boom"));
+      meChats.listMeChats.mockResolvedValue(chatPage(["chat-1"]));
+      chats.getChat.mockResolvedValue(feishuTaskChat("binding-1"));
+
+      const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
+      expect(meChats.listMeChats).toHaveBeenCalledTimes(1);
+      expect(markOnboardingCompleted).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(FIRST_USE_POLL_MS + 1_000);
+      });
+      await flush();
+
+      expect(meChats.listMeChats.mock.calls.length).toBeGreaterThan(1);
+      expect(markOnboardingCompleted).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Ada assistant has its first task from Feishu");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("converges on a reload after first use without creating anything a second time", async () => {

--- a/packages/web/src/pages/opentag/copy.ts
+++ b/packages/web/src/pages/opentag/copy.ts
@@ -40,8 +40,12 @@ export const OPENTAG_STEP_COPY: Record<OpenTagStepId, { why: string; lead: strin
     why: "Add one Bot for this Agent.",
     lead: "First Tree prepares a dedicated Feishu Bot. You confirm it in Feishu — your Agent and its Computer stay set up while you do.",
   },
+  // Says only what the Task itself establishes. The shell renders this heading
+  // for the whole step, including while the completion stamp is still in flight
+  // or has failed — so anything here that declared setup finished would sit
+  // directly above copy saying it could not be finished.
   "use-in-feishu": {
     why: "Your Agent is working in Feishu.",
-    lead: "Setup is done. Keep the conversation in Feishu; its work and history are here.",
+    lead: "Keep the conversation in Feishu — its work and history are here.",
   },
 };

--- a/packages/web/src/pages/opentag/copy.ts
+++ b/packages/web/src/pages/opentag/copy.ts
@@ -1,4 +1,4 @@
-import type { OpenTagActiveStepId, OpenTagStepId } from "./flow.js";
+import type { OpenTagStepId } from "./flow.js";
 
 /**
  * Member-facing strings for the `/opentag` entry, kept out of the components
@@ -26,8 +26,8 @@ export const OPENTAG_RAIL_COPY: Record<OpenTagStepId, { title: string; rail: str
   "use-in-feishu": { title: "Use in Feishu", rail: "Start working there" },
 };
 
-/** Heading copy for the steps this entry actually renders. */
-export const OPENTAG_STEP_COPY: Record<OpenTagActiveStepId, { why: string; lead: string }> = {
+/** Heading copy for the steps this entry renders. */
+export const OPENTAG_STEP_COPY: Record<OpenTagStepId, { why: string; lead: string }> = {
   "choose-agent": {
     why: "Start with the work your team already has.",
     lead: "Pick the teammate you want in Feishu. Setting up where it runs comes after the Agent is clear.",
@@ -39,5 +39,9 @@ export const OPENTAG_STEP_COPY: Record<OpenTagActiveStepId, { why: string; lead:
   "connect-feishu": {
     why: "Add one Bot for this Agent.",
     lead: "First Tree prepares a dedicated Feishu Bot. You confirm it in Feishu — your Agent and its Computer stay set up while you do.",
+  },
+  "use-in-feishu": {
+    why: "Your Agent is working in Feishu.",
+    lead: "Setup is done. Keep the conversation in Feishu; its work and history are here.",
   },
 };

--- a/packages/web/src/pages/opentag/first-use.ts
+++ b/packages/web/src/pages/opentag/first-use.ts
@@ -1,0 +1,68 @@
+import { chatMetadataSchema } from "@first-tree/shared";
+import { getChat } from "../../api/chats.js";
+import { listMeChats } from "../../api/me-chats.js";
+import type { OpenTagFirstUse } from "./flow.js";
+
+/**
+ * Has this exact Agent been used for real in Feishu yet?
+ *
+ * This entry finishes on a fact it does not produce: Feishu ingress creates the
+ * Task when a real person messages the Bot, and this module only reads whether
+ * that already happened. Nothing here writes, starts, or acknowledges anything —
+ * a Task that does not exist cannot be brought into existence from this page.
+ *
+ * What makes the answer exact is the Bot binding. A Feishu Task is identified by
+ * its Bot binding plus the external chat, and a Bot belongs to exactly one
+ * Agent, so a chat carrying this Agent's binding id can only be this Agent's
+ * work. The two query filters are narrowing, not proof: the Team comes from the
+ * endpoint's own scope, and an Agent invited into a teammate's Feishu Task is
+ * also a speaker in a Feishu-origin chat, so "speaks in a Feishu chat" alone
+ * would let a neighbour's first use finish this member's setup.
+ */
+
+/**
+ * How many of this Agent's Feishu chats are examined per read. An Agent has one
+ * Bot, so its own Tasks are the overwhelming majority of this set and the first
+ * page is already generous; the bound keeps a long-lived Agent from turning a
+ * poll into an unbounded fan-out.
+ */
+export const FIRST_USE_SCAN_LIMIT = 20;
+
+/**
+ * How often the page re-asks while the member is over in Feishu sending that
+ * first message. It stops once the answer is `present` — the fact is terminal.
+ */
+export const FIRST_USE_POLL_MS = 5_000;
+
+/** Whether a chat's metadata proves it is this exact Bot binding's Feishu Task. */
+export function isFeishuTaskForBinding(metadata: unknown, botBindingId: string): boolean {
+  const parsed = chatMetadataSchema.safeParse(metadata);
+  if (!parsed.success || parsed.data.source !== "feishu") return false;
+  return parsed.data.botBindingId === botBindingId;
+}
+
+/**
+ * Resolve first use, or throw. A thrown read is reported as {@link OpenTagFirstUse}
+ * `unknown` by the caller rather than being flattened into `absent` here, so a
+ * failing API can never be mistaken for a member who has not started yet.
+ */
+export async function readOpenTagFirstUse(agentUuid: string, botBindingId: string): Promise<OpenTagFirstUse> {
+  const candidates = await listMeChats({
+    origin: ["feishu"],
+    with: [agentUuid],
+    // Archiving the Task does not un-use the Agent, so the terminal state has
+    // to survive it. (Deleted rows are outside every view and stay excluded.)
+    engagement: "all",
+    limit: FIRST_USE_SCAN_LIMIT,
+  });
+  // `rows` is the complete additive stream — a pinned Task also appears here —
+  // so the priority projection does not have to be scanned separately.
+  for (const row of candidates.rows) {
+    // The conversation list does not carry chat metadata, so ownership is
+    // confirmed one candidate at a time. In practice this is the Agent's own
+    // Task on the first iteration.
+    const chat = await getChat(row.chatId);
+    if (isFeishuTaskForBinding(chat.metadata, botBindingId)) return { state: "present", chatId: row.chatId };
+  }
+  return { state: "absent" };
+}

--- a/packages/web/src/pages/opentag/first-use.ts
+++ b/packages/web/src/pages/opentag/first-use.ts
@@ -54,8 +54,10 @@ export type OpenTagFirstUseScan = (signal?: AbortSignal) => Promise<OpenTagFirst
  * the list again but pay for only the conversations they have not seen before,
  * instead of re-reading hundreds of the same chats every five seconds.
  *
- * The cache is per member and per Agent by construction: the caller builds one
- * of these per (member, Agent, Bot) and throws it away when any of them change.
+ * The cache is per (Agent, Bot) and deliberately not per member: which chat
+ * carries which Bot binding is the same answer whoever asks. Who may act on
+ * that answer is a separate question, settled by the caller's ownership gate
+ * before this scan is ever run.
  */
 export function createOpenTagFirstUseScan(agentUuid: string, botBindingId: string): OpenTagFirstUseScan {
   const ruledOut = new Set<string>();

--- a/packages/web/src/pages/opentag/first-use.ts
+++ b/packages/web/src/pages/opentag/first-use.ts
@@ -20,13 +20,20 @@ import type { OpenTagFirstUse } from "./flow.js";
  * would let a neighbour's first use finish this member's setup.
  */
 
+/** Candidates requested per page. */
+export const FIRST_USE_PAGE_SIZE = 50;
+
 /**
- * How many of this Agent's Feishu chats are examined per read. An Agent has one
- * Bot, so its own Tasks are the overwhelming majority of this set and the first
- * page is already generous; the bound keeps a long-lived Agent from turning a
- * poll into an unbounded fan-out.
+ * How many pages a single read will walk before giving up.
+ *
+ * The conversation list is ordered by recent activity, so a Task the member is
+ * using right now sorts to the top and the first page answers the live wait.
+ * The pages exist for the other case: revisiting the entry long after first
+ * use, once other Feishu conversations have become more active. Reaching this
+ * bound means the candidate set was never exhausted, which is reported as
+ * `unknown` rather than `absent` — see {@link readOpenTagFirstUse}.
  */
-export const FIRST_USE_SCAN_LIMIT = 20;
+export const FIRST_USE_MAX_PAGES = 10;
 
 /**
  * How often the page re-asks while the member is over in Feishu sending that
@@ -45,24 +52,38 @@ export function isFeishuTaskForBinding(metadata: unknown, botBindingId: string):
  * Resolve first use, or throw. A thrown read is reported as {@link OpenTagFirstUse}
  * `unknown` by the caller rather than being flattened into `absent` here, so a
  * failing API can never be mistaken for a member who has not started yet.
+ *
+ * `absent` is only ever returned once the candidate list has been walked to its
+ * end. A page that stops early proves nothing: the list is ordered by recent
+ * activity, not by relevance, so an unexamined page can still hold the Task.
+ * Answering `absent` from a partial page would strand a member who really did
+ * use their Agent — and strand them permanently, because every poll would
+ * re-read the same first page and reach the same wrong conclusion.
  */
 export async function readOpenTagFirstUse(agentUuid: string, botBindingId: string): Promise<OpenTagFirstUse> {
-  const candidates = await listMeChats({
-    origin: ["feishu"],
-    with: [agentUuid],
-    // Archiving the Task does not un-use the Agent, so the terminal state has
-    // to survive it. (Deleted rows are outside every view and stay excluded.)
-    engagement: "all",
-    limit: FIRST_USE_SCAN_LIMIT,
-  });
-  // `rows` is the complete additive stream — a pinned Task also appears here —
-  // so the priority projection does not have to be scanned separately.
-  for (const row of candidates.rows) {
-    // The conversation list does not carry chat metadata, so ownership is
-    // confirmed one candidate at a time. In practice this is the Agent's own
-    // Task on the first iteration.
-    const chat = await getChat(row.chatId);
-    if (isFeishuTaskForBinding(chat.metadata, botBindingId)) return { state: "present", chatId: row.chatId };
+  let cursor: string | undefined;
+  for (let page = 0; page < FIRST_USE_MAX_PAGES; page++) {
+    const candidates = await listMeChats({
+      origin: ["feishu"],
+      with: [agentUuid],
+      // Archiving the Task does not un-use the Agent, so the terminal state has
+      // to survive it. (Deleted rows are outside every view and stay excluded.)
+      engagement: "all",
+      limit: FIRST_USE_PAGE_SIZE,
+      ...(cursor ? { cursor } : {}),
+    });
+    // `rows` is the complete additive stream — a pinned Task also appears here —
+    // so the priority projection does not have to be scanned separately.
+    for (const row of candidates.rows) {
+      // The conversation list does not carry chat metadata, so ownership is
+      // confirmed one candidate at a time. This Agent owns one Bot, so in
+      // practice its own Task is the first and only candidate.
+      const chat = await getChat(row.chatId);
+      if (isFeishuTaskForBinding(chat.metadata, botBindingId)) return { state: "present", chatId: row.chatId };
+    }
+    if (!candidates.nextCursor) return { state: "absent" };
+    cursor = candidates.nextCursor;
   }
-  return { state: "absent" };
+  // Pages remained unread, so this Agent's Task may still be among them.
+  return { state: "unknown" };
 }

--- a/packages/web/src/pages/opentag/first-use.ts
+++ b/packages/web/src/pages/opentag/first-use.ts
@@ -24,18 +24,6 @@ import type { OpenTagFirstUse } from "./flow.js";
 export const FIRST_USE_PAGE_SIZE = 50;
 
 /**
- * How many pages a single read will walk before giving up.
- *
- * The conversation list is ordered by recent activity, so a Task the member is
- * using right now sorts to the top and the first page answers the live wait.
- * The pages exist for the other case: revisiting the entry long after first
- * use, once other Feishu conversations have become more active. Reaching this
- * bound means the candidate set was never exhausted, which is reported as
- * `unknown` rather than `absent` — see {@link readOpenTagFirstUse}.
- */
-export const FIRST_USE_MAX_PAGES = 10;
-
-/**
  * How often the page re-asks while the member is over in Feishu sending that
  * first message. It stops once the answer is `present` — the fact is terminal.
  */
@@ -48,42 +36,62 @@ export function isFeishuTaskForBinding(metadata: unknown, botBindingId: string):
   return parsed.data.botBindingId === botBindingId;
 }
 
+/** One member's repeatable search for one Agent's first use. */
+export type OpenTagFirstUseScan = (signal?: AbortSignal) => Promise<OpenTagFirstUse>;
+
 /**
- * Resolve first use, or throw. A thrown read is reported as {@link OpenTagFirstUse}
- * `unknown` by the caller rather than being flattened into `absent` here, so a
- * failing API can never be mistaken for a member who has not started yet.
+ * Build the search this entry polls.
  *
- * `absent` is only ever returned once the candidate list has been walked to its
- * end. A page that stops early proves nothing: the list is ordered by recent
- * activity, not by relevance, so an unexamined page can still hold the Task.
- * Answering `absent` from a partial page would strand a member who really did
- * use their Agent — and strand them permanently, because every poll would
- * re-read the same first page and reach the same wrong conclusion.
+ * The scan runs to the end of the list rather than to a page bound. A bound
+ * would only move the horizon: the poll behind it starts over from the first
+ * page every time, so a Task beyond the bound stays unreachable no matter how
+ * long the member waits, which is exactly the convergence this entry promises.
+ *
+ * What makes exhaustion affordable is the verdict cache. Confirming a candidate
+ * costs a chat read, because the conversation list does not carry chat
+ * metadata — but a chat's Bot binding is written once by ingress and never
+ * changes, so a candidate ruled out stays ruled out. Later polls therefore walk
+ * the list again but pay for only the conversations they have not seen before,
+ * instead of re-reading hundreds of the same chats every five seconds.
+ *
+ * The cache is per member and per Agent by construction: the caller builds one
+ * of these per (member, Agent, Bot) and throws it away when any of them change.
  */
-export async function readOpenTagFirstUse(agentUuid: string, botBindingId: string): Promise<OpenTagFirstUse> {
-  let cursor: string | undefined;
-  for (let page = 0; page < FIRST_USE_MAX_PAGES; page++) {
-    const candidates = await listMeChats({
-      origin: ["feishu"],
-      with: [agentUuid],
-      // Archiving the Task does not un-use the Agent, so the terminal state has
-      // to survive it. (Deleted rows are outside every view and stay excluded.)
-      engagement: "all",
-      limit: FIRST_USE_PAGE_SIZE,
-      ...(cursor ? { cursor } : {}),
-    });
-    // `rows` is the complete additive stream — a pinned Task also appears here —
-    // so the priority projection does not have to be scanned separately.
-    for (const row of candidates.rows) {
-      // The conversation list does not carry chat metadata, so ownership is
-      // confirmed one candidate at a time. This Agent owns one Bot, so in
-      // practice its own Task is the first and only candidate.
-      const chat = await getChat(row.chatId);
-      if (isFeishuTaskForBinding(chat.metadata, botBindingId)) return { state: "present", chatId: row.chatId };
+export function createOpenTagFirstUseScan(agentUuid: string, botBindingId: string): OpenTagFirstUseScan {
+  const ruledOut = new Set<string>();
+
+  return async (signal?: AbortSignal): Promise<OpenTagFirstUse> => {
+    let cursor: string | undefined;
+    for (;;) {
+      // A superseded poll stops walking rather than finishing a scan whose
+      // answer nobody will read. Its own result is `unknown` — abandoning a
+      // search establishes nothing either way.
+      if (signal?.aborted) return { state: "unknown" };
+      const page = await listMeChats(
+        {
+          origin: ["feishu"],
+          with: [agentUuid],
+          // Archiving the Task does not un-use the Agent, so the terminal state
+          // has to survive it. (Deleted rows are outside every view already.)
+          engagement: "all",
+          limit: FIRST_USE_PAGE_SIZE,
+          ...(cursor ? { cursor } : {}),
+        },
+        signal ? { signal } : undefined,
+      );
+      // `rows` is the complete additive stream — a pinned Task also appears
+      // here — so the priority projection is not scanned separately.
+      for (const row of page.rows) {
+        if (ruledOut.has(row.chatId)) continue;
+        if (signal?.aborted) return { state: "unknown" };
+        const chat = await getChat(row.chatId);
+        if (isFeishuTaskForBinding(chat.metadata, botBindingId)) return { state: "present", chatId: row.chatId };
+        ruledOut.add(row.chatId);
+      }
+      // Only the end of the list licenses `absent`. Anything earlier is a
+      // partial answer, and this one gets written to a membership.
+      if (!page.nextCursor) return { state: "absent" };
+      cursor = page.nextCursor;
     }
-    if (!candidates.nextCursor) return { state: "absent" };
-    cursor = candidates.nextCursor;
-  }
-  // Pages remained unread, so this Agent's Task may still be among them.
-  return { state: "unknown" };
+  };
 }

--- a/packages/web/src/pages/opentag/flow.ts
+++ b/packages/web/src/pages/opentag/flow.ts
@@ -19,16 +19,11 @@ import { canManageAgentDetail } from "../agent-detail/access.js";
 
 /**
  * The guided path the member sees. `use-in-feishu` is the destination this
- * entry hands off to — real first use in Feishu is owned by the Feishu Task
- * lifecycle, not by this flow, so {@link resolveOpenTagStep} never selects it.
- * It stays in the sequence because hiding the last leg would misrepresent how
- * far the member still has to go.
+ * entry hands off to: the member reaches it by using their Agent in Feishu, not
+ * by pressing anything here, so this flow only ever *observes* that it happened.
  */
 export const OPENTAG_STEPS = ["choose-agent", "set-up-runtime", "connect-feishu", "use-in-feishu"] as const;
 export type OpenTagStepId = (typeof OPENTAG_STEPS)[number];
-
-/** Steps this entry can actually land on. */
-export type OpenTagActiveStepId = Exclude<OpenTagStepId, "use-in-feishu">;
 
 /** The authoritative Agent read behind the URL's `?agent=` parameter. */
 export type OpenTagAgentRead = {
@@ -114,12 +109,33 @@ export function classifyOpenTagAgent(read: OpenTagAgentRead): OpenTagAgentFacts 
 }
 
 /**
- * Where an Agent in the URL puts the member, or `null` while the facts have not
- * settled. An existing Agent is past both setup choices, so the only step it
- * can land on is Feishu; anything unusable starts over from the Agent choice,
- * where nothing has been created yet.
+ * Whether this exact Agent has a real Feishu Task yet.
+ *
+ * `unknown` is deliberately not `absent`. A read that has not landed — or that
+ * failed — is evidence about the request, not about the member: treating it as
+ * "no Task" would be harmless here, but treating a failure as "Task" would
+ * finish onboarding for someone who has never used their Agent. Both wrong
+ * answers are kept out by making the absence of an answer its own state.
  */
-export function resolveOpenTagStep(facts: OpenTagAgentFacts): OpenTagActiveStepId | null {
+export type OpenTagFirstUse =
+  /** No answer yet: no Bot to have a Task, a read in flight, or a failed read. */
+  | { state: "unknown" }
+  /** Established: this Agent has no Feishu Task. */
+  | { state: "absent" }
+  /** Established: this Agent's Feishu Task exists, and this is its chat. */
+  | { state: "present"; chatId: string };
+
+/**
+ * Where an Agent in the URL puts the member, or `null` while the facts have not
+ * settled. An existing Agent is past both setup choices, so it lands on Feishu;
+ * anything unusable starts over from the Agent choice, where nothing has been
+ * created yet.
+ *
+ * Only a Task that is known to exist moves the member off the Bot step. A
+ * connected Bot is not first use — the tail of this journey happens in Feishu,
+ * and until it does the member still has something to finish here.
+ */
+export function resolveOpenTagStep(facts: OpenTagAgentFacts, firstUse: OpenTagFirstUse): OpenTagStepId | null {
   switch (facts.state) {
     case "none":
     case "unavailable":
@@ -129,6 +145,6 @@ export function resolveOpenTagStep(facts: OpenTagAgentFacts): OpenTagActiveStepI
     case "team-unreadable":
       return null;
     case "resolved":
-      return "connect-feishu";
+      return firstUse.state === "present" ? "use-in-feishu" : "connect-feishu";
   }
 }

--- a/packages/web/src/pages/opentag/opentag-page.tsx
+++ b/packages/web/src/pages/opentag/opentag-page.tsx
@@ -10,12 +10,20 @@ import { useComputerConnection } from "../../features/agent-setup/use-computer-c
 import { feishuBindingQueryKey, feishuBindingQueryOptions } from "../../features/feishu/binding-view.js";
 import { slugify } from "../../utils/agent-naming.js";
 import { FlowHint } from "../onboarding/flow-ui.js";
-import { classifyOpenTagAgent, OPENTAG_STEPS, type OpenTagActiveStepId, resolveOpenTagStep } from "./flow.js";
+import { FIRST_USE_POLL_MS, readOpenTagFirstUse } from "./first-use.js";
+import {
+  classifyOpenTagAgent,
+  OPENTAG_STEPS,
+  type OpenTagFirstUse,
+  type OpenTagStepId,
+  resolveOpenTagStep,
+} from "./flow.js";
 import { OpenTagShell } from "./opentag-shell.js";
 import { isAgentNameConflict, recoverCreatedAgent } from "./recover-created-agent.js";
 import { StepChooseAgent } from "./steps/step-choose-agent.js";
 import { StepConnectFeishu } from "./steps/step-connect-feishu.js";
 import { StepSetUpRuntime } from "./steps/step-set-up-runtime.js";
+import { StepUseInFeishu } from "./steps/step-use-in-feishu.js";
 
 /**
  * `/opentag` — the authenticated OpenTag entry.
@@ -44,8 +52,16 @@ export function OpenTagPage(): ReactElement | null {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const location = useLocation();
-  const { organizationId, memberId, role, user, meAuthoritative, currentOrgHasPersonalAgent, refreshMeStrict } =
-    useAuth();
+  const {
+    organizationId,
+    memberId,
+    role,
+    user,
+    meAuthoritative,
+    currentOrgHasPersonalAgent,
+    refreshMeStrict,
+    markOnboardingCompleted,
+  } = useAuth();
 
   // One parser for the browser route and the OAuth `next`, so a URL this app
   // would never build is not a URL this page will act on. Anything else is
@@ -87,7 +103,6 @@ export function OpenTagPage(): ReactElement | null {
     errorStatus: agentQuery.error instanceof ApiError ? agentQuery.error.status : null,
     agent: agentQuery.data ?? null,
   });
-  const step = resolveOpenTagStep(facts);
 
   // An Agent this flow cannot use has to leave the URL, not just stop being
   // rendered: while it is still there the restart it offers cannot advance,
@@ -152,16 +167,6 @@ export function OpenTagPage(): ReactElement | null {
     },
   });
 
-  // The draft only describes the pre-creation choices, so an Agent in the URL
-  // always supersedes it — including an Agent that turns out to be unusable,
-  // where keeping the draft would push the member straight back into the
-  // create step and the conflict they just came from.
-  const draftStep: OpenTagActiveStepId | null =
-    step === "choose-agent" && !agentUuid ? (draft ? "set-up-runtime" : "choose-agent") : step;
-  const computer = useComputerConnection(draftStep === "set-up-runtime", {
-    requireExplicitSelectionWhenMultiple: true,
-  });
-
   // The URL is this route's only durable recovery state, so an Agent goes into
   // it the moment it exists — before anything slower. A reload or a lost tab
   // then still points at that Agent instead of a bare entry that would offer to
@@ -210,7 +215,11 @@ export function OpenTagPage(): ReactElement | null {
   // The handoff stays closed until readiness is current. Otherwise the member
   // could connect a Bot and finish this surface while `/` still believes they
   // have no Agent — the very gate this boundary exists to keep honest.
-  const feishuReady = step === "connect-feishu" && !!agentUuid && readinessSettled;
+  //
+  // Keyed on the Agent facts rather than on the resolved step, because the step
+  // is now derived from these reads: gating them on the step they produce would
+  // close the handoff the moment it reached its own last leg.
+  const feishuReady = facts.state === "resolved" && !!agentUuid && readinessSettled;
   const feishuQuery = useQuery({
     ...feishuBindingQueryOptions(agentUuid ?? ""),
     enabled: feishuReady,
@@ -220,14 +229,64 @@ export function OpenTagPage(): ReactElement | null {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: feishuBindingQueryKey(agentUuid ?? "") }),
   });
 
+  // Real first use is a fact about a Bot that already exists, so there is
+  // nothing to ask about until one does — a Bot the member is still confirming
+  // in Feishu cannot have carried a message yet. Past that point the binding id
+  // is what makes the answer this Agent's and no one else's, so it is part of
+  // the key: a re-registered Bot asks the question again rather than serving
+  // the previous Bot's answer.
+  const binding = feishuQuery.data?.binding ?? null;
+  const botBindingId = binding && binding.status !== "provisioning" ? binding.id : null;
+  const firstUseQuery = useQuery({
+    queryKey: ["opentag-feishu-first-use", agentUuid, botBindingId],
+    queryFn: () => readOpenTagFirstUse(agentUuid ?? "", botBindingId ?? ""),
+    enabled: feishuReady && !!botBindingId,
+    // A failed read must stay "we don't know", never "not used yet" — and never
+    // a blank frame. The poll below is the retry.
+    retry: false,
+    refetchInterval: (query) => (query.state.data?.state === "present" ? false : FIRST_USE_POLL_MS),
+  });
+  // Anything but a landed, successful read is `unknown`: an error here says
+  // something about the request, never about whether the member has used their
+  // Agent.
+  const firstUse: OpenTagFirstUse = firstUseQuery.data ?? { state: "unknown" };
+  const firstUseChatId = firstUse.state === "present" ? firstUse.chatId : null;
+
+  // The one write this discovery makes, and only after the Task is a fact. The
+  // server stamp is idempotent, so a reload after first use converges on the
+  // same membership instead of producing a second onboarding state.
+  const complete = useMutation({ mutationFn: () => markOnboardingCompleted() });
+  const completePending = complete.isPending;
+  const completeSettled = complete.isSuccess;
+  const completeFailed = complete.isError;
+  const completeMutate = complete.mutate;
+  const completeReset = complete.reset;
+  useEffect(() => {
+    // Once per landed Task: a failure holds until the member retries, so a
+    // failing endpoint is not hammered by the first-use poll behind it.
+    if (!firstUseChatId || completePending || completeSettled || completeFailed) return;
+    completeMutate();
+  }, [firstUseChatId, completePending, completeSettled, completeFailed, completeMutate]);
+
+  const step = resolveOpenTagStep(facts, firstUse);
+
+  // The draft only describes the pre-creation choices, so an Agent in the URL
+  // always supersedes it — including an Agent that turns out to be unusable,
+  // where keeping the draft would push the member straight back into the
+  // create step and the conflict they just came from.
+  const draftStep: OpenTagStepId | null =
+    step === "choose-agent" && !agentUuid ? (draft ? "set-up-runtime" : "choose-agent") : step;
+  const computer = useComputerConnection(draftStep === "set-up-runtime", {
+    requireExplicitSelectionWhenMultiple: true,
+  });
+
   if (!step && facts.state !== "unreadable" && facts.state !== "team-unreadable") return null;
   // A transient read failure keeps the Agent in the URL — dropping it would
   // restart the flow and leave a second Agent behind — and it is shown inside
   // the step it belongs to, so the guided path never vanishes under the member.
   // A fault renders inside the step it belongs to. Without an authoritative
   // Team nothing has been created yet, so that one belongs at the beginning.
-  const shellStep: OpenTagActiveStepId =
-    draftStep ?? (facts.state === "team-unreadable" ? "choose-agent" : "set-up-runtime");
+  const shellStep: OpenTagStepId = draftStep ?? (facts.state === "team-unreadable" ? "choose-agent" : "set-up-runtime");
 
   const completedSteps = OPENTAG_STEPS.slice(0, OPENTAG_STEPS.indexOf(shellStep));
   // The summary reflects what has been decided so far — the draft before the
@@ -308,11 +367,11 @@ export function OpenTagPage(): ReactElement | null {
           )}
         </div>
       )}
-      {feishuReady && agent && agentUuid && (
+      {feishuReady && step === "connect-feishu" && agent && agentUuid && (
         <StepConnectFeishu
           agentDisplayName={agent.displayName}
           agentUuid={agentUuid}
-          binding={feishuQuery.data?.binding ?? null}
+          binding={binding}
           loading={feishuQuery.isPending}
           // A failed read is not "no Bot". Offering Connect here could start a
           // second registration for an Agent that already has one.
@@ -321,6 +380,15 @@ export function OpenTagPage(): ReactElement | null {
           starting={startFeishu.isPending}
           error={startFeishu.error instanceof Error ? startFeishu.error.message : null}
           onConnect={() => startFeishu.mutate()}
+        />
+      )}
+      {step === "use-in-feishu" && agent && firstUseChatId && (
+        <StepUseInFeishu
+          agentDisplayName={agent.displayName}
+          chatId={firstUseChatId}
+          completing={completePending}
+          failed={completeFailed}
+          onRetry={completeReset}
         />
       )}
     </OpenTagShell>

--- a/packages/web/src/pages/opentag/opentag-page.tsx
+++ b/packages/web/src/pages/opentag/opentag-page.tsx
@@ -251,11 +251,14 @@ export function OpenTagPage(): ReactElement | null {
   //
   // The member id is in the key for the same reason: a cached answer belongs to
   // whoever it was read for.
-  // One scan per (member, Agent, Bot), reused across polls so its verdict cache
-  // survives them; any of the three changing throws the whole thing away.
+  // One scan per (Agent, Bot), reused across polls so its verdict cache
+  // survives them; either changing throws the whole thing away. It is not keyed
+  // by member because what it remembers — which chat carries which Bot
+  // binding — is the same answer whoever asks. Who may act on that answer is
+  // decided by the ownership gate and the query key, not here.
   const scanFirstUse = useMemo(
     () => createOpenTagFirstUseScan(agentUuid ?? "", botBindingId ?? ""),
-    [agentUuid, botBindingId, memberId],
+    [agentUuid, botBindingId],
   );
   const firstUseQuery = useQuery({
     queryKey: ["opentag-feishu-first-use", agentUuid, botBindingId, memberId],

--- a/packages/web/src/pages/opentag/opentag-page.tsx
+++ b/packages/web/src/pages/opentag/opentag-page.tsx
@@ -237,10 +237,24 @@ export function OpenTagPage(): ReactElement | null {
   // the previous Bot's answer.
   const binding = feishuQuery.data?.binding ?? null;
   const botBindingId = binding && binding.status !== "provisioning" ? binding.id : null;
+  // Ownership, not readability, is what licenses the stamp below.
+  //
+  // The Bot binding proves which Agent the Task belongs to. It says nothing
+  // about which member's onboarding is being finished, and the two genuinely
+  // come apart: an admin may continue a teammate's Agent here, and if that
+  // admin manages some other Agent the primary invited into its Task, the
+  // ordinary watcher projection hands them a membership in that very Task. The
+  // read would then succeed, the binding would match exactly, and the stamp
+  // would land on the admin's membership because a teammate used a teammate's
+  // Agent. Completion means this member owns the setup, so the question is not
+  // asked at all unless they do.
+  //
+  // The member id is in the key for the same reason: a cached answer belongs to
+  // whoever it was read for.
   const firstUseQuery = useQuery({
-    queryKey: ["opentag-feishu-first-use", agentUuid, botBindingId],
+    queryKey: ["opentag-feishu-first-use", agentUuid, botBindingId, memberId],
     queryFn: () => readOpenTagFirstUse(agentUuid ?? "", botBindingId ?? ""),
-    enabled: feishuReady && !!botBindingId,
+    enabled: feishuReady && ownsUrlAgent && !!botBindingId,
     // A failed read must stay "we don't know", never "not used yet" — and never
     // a blank frame. The poll below is the retry.
     retry: false,
@@ -262,11 +276,15 @@ export function OpenTagPage(): ReactElement | null {
   const completeMutate = complete.mutate;
   const completeReset = complete.reset;
   useEffect(() => {
+    // Ownership is re-checked at the write itself, not only at the read that
+    // feeds it: this is the line that changes durable state, and it should not
+    // depend on a caller upstream having kept a cached answer honest.
+    if (!ownsUrlAgent) return;
     // Once per landed Task: a failure holds until the member retries, so a
     // failing endpoint is not hammered by the first-use poll behind it.
     if (!firstUseChatId || completePending || completeSettled || completeFailed) return;
     completeMutate();
-  }, [firstUseChatId, completePending, completeSettled, completeFailed, completeMutate]);
+  }, [ownsUrlAgent, firstUseChatId, completePending, completeSettled, completeFailed, completeMutate]);
 
   const step = resolveOpenTagStep(facts, firstUse);
 

--- a/packages/web/src/pages/opentag/opentag-page.tsx
+++ b/packages/web/src/pages/opentag/opentag-page.tsx
@@ -1,6 +1,6 @@
 import { opentagEntryPath, parseOpenTagEntryPath, type RuntimeProvider } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { type ReactElement, useCallback, useEffect, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { createAgent, getAgent, startAgentFeishuRegistration } from "../../api/agents.js";
 import { ApiError } from "../../api/client.js";
@@ -10,7 +10,7 @@ import { useComputerConnection } from "../../features/agent-setup/use-computer-c
 import { feishuBindingQueryKey, feishuBindingQueryOptions } from "../../features/feishu/binding-view.js";
 import { slugify } from "../../utils/agent-naming.js";
 import { FlowHint } from "../onboarding/flow-ui.js";
-import { FIRST_USE_POLL_MS, readOpenTagFirstUse } from "./first-use.js";
+import { createOpenTagFirstUseScan, FIRST_USE_POLL_MS } from "./first-use.js";
 import {
   classifyOpenTagAgent,
   OPENTAG_STEPS,
@@ -251,9 +251,15 @@ export function OpenTagPage(): ReactElement | null {
   //
   // The member id is in the key for the same reason: a cached answer belongs to
   // whoever it was read for.
+  // One scan per (member, Agent, Bot), reused across polls so its verdict cache
+  // survives them; any of the three changing throws the whole thing away.
+  const scanFirstUse = useMemo(
+    () => createOpenTagFirstUseScan(agentUuid ?? "", botBindingId ?? ""),
+    [agentUuid, botBindingId, memberId],
+  );
   const firstUseQuery = useQuery({
     queryKey: ["opentag-feishu-first-use", agentUuid, botBindingId, memberId],
-    queryFn: () => readOpenTagFirstUse(agentUuid ?? "", botBindingId ?? ""),
+    queryFn: ({ signal }) => scanFirstUse(signal),
     enabled: feishuReady && ownsUrlAgent && !!botBindingId,
     // A failed read must stay "we don't know", never "not used yet" — and never
     // a blank frame. The poll below is the retry.

--- a/packages/web/src/pages/opentag/opentag-page.tsx
+++ b/packages/web/src/pages/opentag/opentag-page.tsx
@@ -386,7 +386,7 @@ export function OpenTagPage(): ReactElement | null {
         <StepUseInFeishu
           agentDisplayName={agent.displayName}
           chatId={firstUseChatId}
-          completing={completePending}
+          settled={completeSettled}
           failed={completeFailed}
           onRetry={completeReset}
         />

--- a/packages/web/src/pages/opentag/opentag-shell.tsx
+++ b/packages/web/src/pages/opentag/opentag-shell.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "../../auth/auth-context.js";
 import { FirstTreeLogo } from "../../components/first-tree-logo.js";
 import { Button } from "../../components/ui/button.js";
 import { OPENTAG_COPY, OPENTAG_RAIL_COPY, OPENTAG_STEP_COPY } from "./copy.js";
-import { OPENTAG_STEPS, type OpenTagActiveStepId, type OpenTagStepId } from "./flow.js";
+import { OPENTAG_STEPS, type OpenTagStepId } from "./flow.js";
 
 export type OpenTagHandoff = {
   agentDisplayName: string;
@@ -37,7 +37,7 @@ export function OpenTagShell({
   handoff,
   children,
 }: {
-  activeStep: OpenTagActiveStepId;
+  activeStep: OpenTagStepId;
   completedSteps: readonly OpenTagStepId[];
   handoff: OpenTagHandoff | null;
   children: ReactNode;
@@ -105,7 +105,7 @@ function StepRail({
   activeStep,
   completedSteps,
 }: {
-  activeStep: OpenTagActiveStepId;
+  activeStep: OpenTagStepId;
   completedSteps: readonly OpenTagStepId[];
 }): ReactElement {
   return (

--- a/packages/web/src/pages/opentag/steps/step-use-in-feishu.tsx
+++ b/packages/web/src/pages/opentag/steps/step-use-in-feishu.tsx
@@ -1,0 +1,75 @@
+import { Check } from "lucide-react";
+import type { ReactElement } from "react";
+import { Button } from "../../../components/ui/button.js";
+import { FlowHint } from "../../onboarding/flow-ui.js";
+
+/**
+ * The terminal step: this Agent has a real Feishu Task, so the handoff is over.
+ *
+ * It is a confirmation, not a decision, so it renders as plain labelled content
+ * rather than a panel the member is meant to act inside. The one action leads
+ * where the work now lives.
+ *
+ * The link waits for the completion stamp on purpose. Until that stamp lands
+ * the workspace still considers this member's setup unfinished and may send
+ * them back into it, so offering the destination early would advertise a door
+ * that bounces. Nothing is lost while it waits — the Agent and its task exist
+ * either way, which is what the failure copy says.
+ */
+export function StepUseInFeishu({
+  agentDisplayName,
+  chatId,
+  completing,
+  failed,
+  onRetry,
+}: {
+  agentDisplayName: string;
+  /** The Feishu Task's chat — the destination this whole entry hands off to. */
+  chatId: string;
+  /** The completion stamp is in flight. */
+  completing: boolean;
+  /** The completion stamp failed and the member can try it again. */
+  failed: boolean;
+  onRetry: () => void;
+}): ReactElement {
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <p className="flex items-start text-body" style={{ margin: 0, gap: "var(--sp-2)", color: "var(--fg-3)" }}>
+        <Check
+          aria-hidden="true"
+          className="h-4 w-4"
+          style={{ flexShrink: 0, marginTop: "var(--sp-0_5)", color: "var(--success)" }}
+        />
+        <span style={{ minWidth: 0 }}>
+          {agentDisplayName} has its first task from Feishu. Message it there as usual — every task it picks up shows up
+          here with its full history.
+        </span>
+      </p>
+
+      {failed ? (
+        <>
+          <FlowHint tone="error" role="alert">
+            We couldn't finish setting up your workspace. Your Agent and its task are unaffected.
+          </FlowHint>
+          <div className="flex">
+            <Button type="button" variant="outline" disabled={completing} onClick={onRetry}>
+              {completing ? "Retrying…" : "Try again"}
+            </Button>
+          </div>
+        </>
+      ) : (
+        <div className="flex">
+          {completing ? (
+            <Button type="button" variant="cta" disabled>
+              Finishing up…
+            </Button>
+          ) : (
+            <Button type="button" variant="cta" asChild>
+              <a href={`/?c=${encodeURIComponent(chatId)}`}>Open the task</a>
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/opentag/steps/step-use-in-feishu.tsx
+++ b/packages/web/src/pages/opentag/steps/step-use-in-feishu.tsx
@@ -19,15 +19,18 @@ import { FlowHint } from "../../onboarding/flow-ui.js";
 export function StepUseInFeishu({
   agentDisplayName,
   chatId,
-  completing,
+  settled,
   failed,
   onRetry,
 }: {
   agentDisplayName: string;
   /** The Feishu Task's chat — the destination this whole entry hands off to. */
   chatId: string;
-  /** The completion stamp is in flight. */
-  completing: boolean;
+  /**
+   * The completion stamp has landed. Anything else — not started yet, or in
+   * flight — is a wait, not a state the member has to be told apart.
+   */
+  settled: boolean;
   /** The completion stamp failed and the member can try it again. */
   failed: boolean;
   onRetry: () => void;
@@ -52,20 +55,20 @@ export function StepUseInFeishu({
             We couldn't finish setting up your workspace. Your Agent and its task are unaffected.
           </FlowHint>
           <div className="flex">
-            <Button type="button" variant="outline" disabled={completing} onClick={onRetry}>
-              {completing ? "Retrying…" : "Try again"}
+            <Button type="button" variant="outline" onClick={onRetry}>
+              Try again
             </Button>
           </div>
         </>
       ) : (
         <div className="flex">
-          {completing ? (
-            <Button type="button" variant="cta" disabled>
-              Finishing up…
-            </Button>
-          ) : (
+          {settled ? (
             <Button type="button" variant="cta" asChild>
               <a href={`/?c=${encodeURIComponent(chatId)}`}>Open the task</a>
+            </Button>
+          ) : (
+            <Button type="button" variant="cta" disabled>
+              Finishing up…
             </Button>
           )}
         </div>


### PR DESCRIPTION
`/opentag` used to end at a connected Bot. A Bot is not first use: the member has set something up, not used it, and stamping onboarding there would call setup finished before the Agent had ever done work.

The finishing fact now comes from the Feishu Task that ingress creates when a real person messages the Bot. This page only reads whether that already happened — it starts nothing, acknowledges nothing, and invents no timestamp, receipt, delivery protocol, or second onboarding state. No Server, Shared, CLI, or Client contract is touched.

## What makes the read exact

The Bot binding. A Task is identified by its Bot binding plus the external chat, and a Bot belongs to exactly one Agent, so a chat carrying this Agent's binding id can only be this Agent's work.

The origin and participant filters only narrow the candidates cheaply — they are not the proof. An Agent invited into a teammate's Task is also a speaker in a Feishu-origin chat, so "speaks in a Feishu chat" alone would let a neighbour's first use finish this member's setup. The Team comes from the endpoint's own scope.

## What does not complete onboarding

The absence of an answer is its own state, distinct from "not used yet". A read that has not landed, or that failed, leaves the member on the Bot step; only a landed, matching read completes. Nothing is polled at all until a Bot exists, because a Bot the member is still confirming cannot have carried a message.

Completion goes through the existing idempotent seam, so a reload after first use converges on the same membership rather than producing a second onboarding state. The handoff link waits for that stamp — an unstamped membership can still be sent back into setup, so offering the destination early would advertise a door that bounces.

## Verification

- `pnpm --filter @first-tree/web test` — 252 files, 2377 tests pass
- `pnpm --filter @first-tree/web typecheck` — clean, including the design-token gate
- `pnpm --filter @first-tree/web build` — clean
- Full CI green on this head

Focused tests cover the negative case, the exact positive, a cross-Agent Task, an admin who can see the primary's Task through a managed collaborator, a Task far down the paginated list, a failed task read, reload convergence, poll recovery after a read failure, and completion-stamp failure and retry.

Three guarantees were checked by mutation rather than trusted: removing the Bot-binding equality breaks three assertions, disabling the poll interval breaks exactly the recovery test, and always-settling the handoff breaks exactly the gate test.

## Reviewed and known limits

Reviewed on both Standards and Spec axes, and independently QA'd. QA could not reach a live Feishu tenant, so the end-to-end leg — real message → ingress → Task → terminal state — is described in `packages/qa/cases/cross-surface/opentag-entry-agent-materialization.md` (updated here) and remains unexecuted.

An admin continuing a *teammate's* Agent cannot reach the terminal state, and that is now an explicit owner gate rather than a visibility accident. Visibility alone would not have been enough: an admin who manages a collaborator Agent invited into the primary's Task receives a membership in that Task through the ordinary watcher projection, so the read would have succeeded and the binding would have matched. The read and the write both require `agent.managerId === memberId`, because completion means this member owns the setup being stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
