### PR TITLE
fix: use Get for Feishu acknowledgements

### DIFF
--- a/packages/server/src/__tests__/feishu-inbound.test.ts
+++ b/packages/server/src/__tests__/feishu-inbound.test.ts
@@ -110,7 +110,7 @@ describe("Feishu inbound pipeline", () => {
     expect(deps.downloadResource).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => {
       expect(deps.addReaction).toHaveBeenCalledOnce();
-      expect(deps.addReaction).toHaveBeenCalledWith({ messageId: input.messageId, emojiType: "THUMBSUP" });
+      expect(deps.addReaction).toHaveBeenCalledWith({ messageId: input.messageId, emojiType: "Get" });
     });
 
     const stored = await app.db.select().from(messages);

--- a/packages/server/src/__tests__/feishu-registration.test.ts
+++ b/packages/server/src/__tests__/feishu-registration.test.ts
@@ -255,7 +255,7 @@ describe("official Feishu QR registration", () => {
     expect(messageHandler).toBeTypeOf("function");
     await messageHandler?.(receivedMessage("acknowledge"));
 
-    await vi.waitFor(() => expect(sdkMocks.addReaction).toHaveBeenCalledWith("om_acknowledge", "THUMBSUP"));
+    await vi.waitFor(() => expect(sdkMocks.addReaction).toHaveBeenCalledWith("om_acknowledge", "Get"));
     expect(await app.db.select().from(messages)).toHaveLength(1);
     await app.feishuIntegration.revoke(a.agent.uuid);
   });

--- a/packages/server/src/services/integrations/feishu/inbound.ts
+++ b/packages/server/src/services/integrations/feishu/inbound.ts
@@ -25,7 +25,7 @@ import { safeFeishuErrorContext } from "./safe-error.js";
 import { externalAuthorIdentity, type FeishuChatMembersReader, type FeishuSenderNameResolver } from "./sender-name.js";
 
 const log = createLogger("feishu-inbound");
-const ACKNOWLEDGEMENT_EMOJI = "THUMBSUP";
+const ACKNOWLEDGEMENT_EMOJI = "Get";
 
 type Binding = typeof imBotBindings.$inferSelect;
 


### PR DESCRIPTION
## Summary

- change the automatic Feishu message acknowledgement reaction from `THUMBSUP` to the provider-defined `Get` emoji
- update the inbound and owned-channel tests to lock the exact case-sensitive emoji type

## Validation

- [x] `pnpm exec biome check packages/server/src/services/integrations/feishu/inbound.ts packages/server/src/__tests__/feishu-inbound.test.ts packages/server/src/__tests__/feishu-registration.test.ts`
- [x] `pnpm --filter @first-tree/server typecheck`
- [x] `pnpm --filter @first-tree/server exec vitest run src/__tests__/feishu-inbound.test.ts src/__tests__/feishu-registration.test.ts --maxWorkers=2` (19 tests)
- [ ] full repository checks (left to CI per local validation policy)

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: focused Feishu acknowledgement expectations updated
- follow-up work: none
