### PR TITLE
test: isolate Feishu lease renewal timing

### DIFF
--- a/packages/server/src/__tests__/feishu-registration.test.ts
+++ b/packages/server/src/__tests__/feishu-registration.test.ts
@@ -212,6 +212,7 @@ describe("official Feishu QR registration", () => {
       .from(imBotBindings)
       .where(eq(imBotBindings.id, stored?.id ?? "missing"));
     expect(afterStaleEvent?.lastEventAt).toBeNull();
+    await app.feishuIntegration.revoke(a.agent.uuid);
   });
 
   it("keeps the Bot connected when profile metadata cannot be loaded", async () => {
@@ -236,6 +237,7 @@ describe("official Feishu QR registration", () => {
       botName: null,
       botAvatarUrl: null,
     });
+    await app.feishuIntegration.revoke(a.agent.uuid);
   });
 
   it("uses the owned Bot channel to acknowledge an admitted message", async () => {
@@ -288,6 +290,11 @@ describe("official Feishu QR registration", () => {
   it("maintains the provisioning lease while connection and Bot profile enrichment are pending", async () => {
     const app = getApp();
     const a = await createTestAgent(app, { displayName: "Agent A", visibility: "organization" });
+    // This test drives its own manager with accelerated lease timings. Pause
+    // the app-owned manager so its background cleanup cannot satisfy the
+    // shared disconnect spy or compete for the test binding.
+    await app.feishuIntegration.stop();
+    vi.clearAllMocks();
     const connectStarted = deferred<void>();
     const connectCompletion = deferred<void>();
     sdkMocks.connect.mockImplementationOnce(() => {
@@ -355,7 +362,12 @@ describe("official Feishu QR registration", () => {
     } finally {
       connectCompletion.resolve();
       await new Promise((resolve) => setTimeout(resolve, 70));
-      await manager.stop();
+      try {
+        await manager.stop();
+        if (await manager.getBinding(a.agent.uuid)) await manager.revoke(a.agent.uuid);
+      } finally {
+        app.feishuIntegration.start();
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- revoke Feishu bindings left active by earlier registration tests so background maintenance cannot leak into later assertions
- pause the app-owned Feishu manager while the accelerated lease-renewal test runs its dedicated manager
- clean up the dedicated binding and always restore the app-owned manager

This addresses the timing-dependent main-branch failure in [CI run 31691822984](https://github.com/agent-team-foundation/first-tree/actions/runs/31691822984/job/94420655174), where an unrelated shared `disconnect` spy could release the lease wait before its expiry advanced.

## Validation

- [x] `pnpm --filter @first-tree/server exec vitest run src/__tests__/feishu-registration.test.ts --maxWorkers=1` (14 tests)
- [x] repeated the full test file five additional times with one worker; all passed
- [x] `pnpm exec biome check packages/server/src/__tests__/feishu-registration.test.ts`
- [x] `pnpm --filter @first-tree/server typecheck`
- [ ] full repository checks (left to CI per local validation policy)

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: test isolation only; product behavior is unchanged
- follow-up work: none
