### PR TITLE
fix(client): accept Grok Build 1.x

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -261,7 +261,7 @@ available until the Client has the required pre-admission Job Object
 supervisor.
 
 The `grok` runtime drives an operator-installed Grok Build CLI
-(`>=0.2.117 <0.3.0`) over ACP on macOS or Linux. Install it with the official
+(`>=0.2.117 <2.0.0`) over ACP on macOS or Linux. Install it with the official
 script (`curl -fsSL https://x.ai/cli/install.sh | bash`), complete
 provider-owned authentication with `grok login`, and run
 `first-tree daemon probe` after installation to force immediate

--- a/packages/client/src/__tests__/discover-models.test.ts
+++ b/packages/client/src/__tests__/discover-models.test.ts
@@ -49,7 +49,7 @@ describe("discoverProviderModels — grok", () => {
     const catalog = await discoverProviderModels("grok", {
       resolveGrokBinary: () => ({
         ok: false as const,
-        error: "resolved grok failed validation: grok 0.1.0 is outside the supported range >=0.2.117 <0.3.0",
+        error: "resolved grok failed validation: grok 0.1.0 is outside the supported range >=0.2.117 <2.0.0",
         transient: false,
       }),
       fetchGrokModelMeta: async () => {

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -588,7 +588,7 @@ describe("classifyProviderFailure", () => {
     const c = classifyProviderFailure(
       new Error(
         "Grok Build CLI at /home/op/.local/bin/grok is not a supported Grok Build version: `grok --version` " +
-          "reported 0.2.89 (supported range >=0.2.117 <0.3.0).",
+          "reported 2.0.0 (supported range >=0.2.117 <2.0.0).",
       ),
       { provider: "grok", scope: "provider_turn" },
     );

--- a/packages/client/src/providers/grok/__tests__/binary.test.ts
+++ b/packages/client/src/providers/grok/__tests__/binary.test.ts
@@ -122,8 +122,22 @@ describe("verifyGrokExecutable — version parse + supported-range gate", () => 
     expect(verification.reason).toContain("outside the supported range");
   });
 
-  it("rejects 0.3.0 (the exclusive ceiling) as deterministic, NOT transient", () => {
-    const verification = verifyGrokExecutable(fakeGrok("grok 0.3.0 (abcd1234)"));
+  it("accepts the current 1.x line (official 1.0.3) inside the range", () => {
+    const verification = verifyGrokExecutable(fakeGrok("grok 1.0.3 (abcd1234)"));
+    expect(verification).toMatchObject({ ok: true, version: "1.0.3" });
+  });
+
+  it("rejects 0.2.116 (below the floor) as deterministic, NOT transient", () => {
+    const verification = verifyGrokExecutable(fakeGrok("grok 0.2.116 (abcd1234)"));
+    expect(verification.ok).toBe(false);
+    if (verification.ok) throw new Error("unreachable");
+    expect(verification.transient).toBe(false);
+    expect(verification.reason).toContain("0.2.116");
+    expect(verification.reason).toContain("outside the supported range");
+  });
+
+  it("rejects 2.0.0 (the exclusive ceiling) as deterministic, NOT transient", () => {
+    const verification = verifyGrokExecutable(fakeGrok("grok 2.0.0 (abcd1234)"));
     expect(verification.ok).toBe(false);
     if (verification.ok) throw new Error("unreachable");
     expect(verification.transient).toBe(false);
@@ -134,8 +148,10 @@ describe("verifyGrokExecutable — version parse + supported-range gate", () => 
     expect(isGrokVersionSupported("0.2.116")).toBe(false);
     expect(isGrokVersionSupported("0.2.117")).toBe(true);
     expect(isGrokVersionSupported("0.2.999")).toBe(true);
-    expect(isGrokVersionSupported("0.3.0")).toBe(false);
-    expect(isGrokVersionSupported("1.0.0")).toBe(false);
+    expect(isGrokVersionSupported("0.3.0")).toBe(true);
+    expect(isGrokVersionSupported("1.0.3")).toBe(true);
+    expect(isGrokVersionSupported("1.9.9")).toBe(true);
+    expect(isGrokVersionSupported("2.0.0")).toBe(false);
   });
 
   it("a clean exit with unparseable output is deterministic, NOT transient", () => {
@@ -218,7 +234,7 @@ describe("resolveGrokRuntimeBinary — spawn-time smoke split", () => {
         verifyPath: () => ({
           ok: false,
           transient: false,
-          reason: "grok 0.2.89 is outside the supported range >=0.2.117 <0.3.0",
+          reason: "grok 2.0.0 is outside the supported range >=0.2.117 <2.0.0",
         }),
       },
     );

--- a/packages/client/src/providers/grok/binary.ts
+++ b/packages/client/src/providers/grok/binary.ts
@@ -23,12 +23,15 @@ import {
 export { GROK_INSTALL_COMMAND };
 
 /**
- * Supported Grok Build CLI range for this integration. Verified against
- * `grok 0.2.117 (f1c06093089f)`; a resolved binary outside the range is a
- * deterministic configuration failure, never a transient one.
+ * Supported Grok Build CLI range for this integration. Live-verified against
+ * `grok 0.2.117 (f1c06093089f)`; the 1.x line is accepted because the official
+ * 1.0.0–1.0.3 changelog carries no ACP breaking changes. The exclusive 2.0.0
+ * ceiling keeps future unverified majors fail closed: a resolved binary
+ * outside the range is a deterministic configuration failure, never a
+ * transient one.
  */
 export const GROK_MIN_SUPPORTED_VERSION = "0.2.117";
-export const GROK_MAX_EXCLUSIVE_VERSION = "0.3.0";
+export const GROK_MAX_EXCLUSIVE_VERSION = "2.0.0";
 
 /**
  * `grok --version` smoke-check ceiling. Mirrors the cursor bound: a cold

--- a/packages/qa/cases/runtime/grok-provider.md
+++ b/packages/qa/cases/runtime/grok-provider.md
@@ -84,7 +84,7 @@ that case and the run-local plan, not this one.
   like any other failure: redelivery only when the turn is replay-safe, consumed-terminal when user-visible output
   or tool side effects already happened — never an unconditional abort/redelivery.
 - Discovery version gate: host-local model discovery resolves the binary through the launch-verified supported range
-  (`>=0.2.117 <0.3.0`), never the existence-only probe path; an out-of-range `grok` degrades the catalog to
+  (`>=0.2.117 <2.0.0`), never the existence-only probe path; an out-of-range `grok` degrades the catalog to
   `unavailable` instead of spawning the ACP handshake.
 - Context Tree I/O: in a chat whose agent has a bound Context Tree, have the agent read a tree node and edit a tree
   file; the Context tab must record repo-qualified read/write evidence for the native Grok file tools


### PR DESCRIPTION
## Summary

- widen the launch-verified Grok Build range from `>=0.2.117 <0.3.0` to `>=0.2.117 <2.0.0`, so the official 1.0.3 CLI can start
- keep future 2.x releases fail-closed as an explicit unsupported capability
- add version-boundary regressions and update the CLI reference and Grok QA case

## Why

First Tree rejected Grok Build 1.0.3 before ACP initialization because its pre-1.0 compatibility ceiling was stale. xAI's [1.0.0–1.0.3 changelog](https://github.com/xai-org/grok-build/blob/e5fd4816d43260c15ba785f103990c1ed6cea230/crates/codegen/xai-grok-shell/CHANGELOG.md) contains no ACP-breaking change, and the current [Agent mode documentation](https://github.com/xai-org/grok-build/blob/e5fd4816d43260c15ba785f103990c1ed6cea230/crates/codegen/xai-grok-pager/docs/user-guide/15-agent-mode.md) retains the existing stdio launch contract. Current upstream source also continues to advertise ACP protocol v1.

The upper bound remains exclusive so an unverified future major release is still reported as `grok_binary_unsupported`, never as a missing binary or a transient retry.

## Validation

- independent `focused-local` QA passed against exact commit `4885705ba34892ac94ed8cd3546c8c70ac71ec5a`
  - installed the official macOS arm64 `grok 1.0.3 (1a29d5bc12d4)` binary into an empty task-owned HOME with no credentials
  - the built public `resolveGrokRuntimeBinary` accepted 1.0.3
  - the built public `discoverProviderModels("grok")` completed a real ACP v1 initialize and returned a provider-CLI catalog with `agentVersion: 1.0.3`
  - the same built resolver accepted 0.2.117 and rejected 0.2.116 / 2.0.0 as explicit non-transient unsupported binaries
- 69 focused Grok binary, model-discovery, and provider retry-policy tests passed independently
- `pnpm --filter @first-tree/client test`: 197 files / 2508 tests passed / 7 skipped in the implementation run
- `pnpm check` and `pnpm typecheck` passed
- GitHub CI: 17 checks passed, 2 skipped, 0 failed

The live QA scope was initialize-only: it did not log in, send a prompt, create a paid turn, or claim full `grok-provider` release qualification.

## Scope

- no database, schema, migration, persistence, or backfill changes
- no Web UI changes
- no Context Tree update: the durable fail-closed constraint is unchanged; this range is implementation compatibility detail
