### PR TITLE
feat(web): add public OpenTag entry

### DIFF
--- a/packages/web/src/pages/landing/__tests__/hero.test.tsx
+++ b/packages/web/src/pages/landing/__tests__/hero.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment happy-dom
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+import { Hero } from "../hero.js";
+
+describe("Landing hero", () => {
+  it("offers OpenTag without changing the existing signup destination", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Hero />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain('href="/opentag"');
+    expect(html).toContain("Start with OpenTag");
+    expect(html).toContain("OpenTag brings one AI agent into your Feishu team");
+    expect(html).toContain('href="/login"');
+    expect(html).toContain("Get Started");
+  });
+});

--- a/packages/web/src/pages/landing/__tests__/hero.test.tsx
+++ b/packages/web/src/pages/landing/__tests__/hero.test.tsx
@@ -18,5 +18,12 @@ describe("Landing hero", () => {
     expect(html).toContain("OpenTag brings one AI agent into your Feishu team");
     expect(html).toContain('href="/login"');
     expect(html).toContain("Get Started");
+
+    document.body.innerHTML = html;
+    const generalSignup = document.querySelector<HTMLAnchorElement>('a[href="/login"]');
+    const openTag = document.querySelector<HTMLAnchorElement>('a[href="/opentag"]');
+    expect(generalSignup?.className).toContain("border-input");
+    expect(generalSignup?.className).not.toContain("bg-brand");
+    expect(openTag?.className).toContain("bg-brand");
   });
 });

--- a/packages/web/src/pages/landing/hero.tsx
+++ b/packages/web/src/pages/landing/hero.tsx
@@ -1,10 +1,12 @@
 import { ArrowRight } from "lucide-react";
 import { Link } from "react-router";
+import { Button } from "../../components/ui/button.js";
 
 /**
  * Hero section.
  *
- * Single column, large display headline, short subtitle, one primary CTA.
+ * Single column, large display headline, short subtitle, and two focused CTAs:
+ * the existing general signup plus the OpenTag guided entry.
  * No illustration — typography carries the page per the first-tree.ai
  * reference style. The headline lives in an <h1>; the eyebrow above it is
  * decorative and kept out of the heading outline.
@@ -17,7 +19,7 @@ export function Hero() {
       <p className="mb-6 text-eyebrow uppercase text-fg-3">First Tree</p>
       <h1 className="text-display text-foreground">Communication infrastructure for AI-native teams</h1>
       <p className="mt-6 max-w-2xl text-lead text-fg-2">Where agents and humans work as one team</p>
-      <div className="mt-10">
+      <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row">
         <Link
           to="/login"
           className="group inline-flex items-center gap-2 rounded-[var(--radius-input)] bg-primary px-6 py-3 text-body font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
@@ -25,7 +27,16 @@ export function Hero() {
           Get Started
           <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
         </Link>
+        <Button asChild variant="cta" size="lg">
+          <Link to="/opentag">
+            Start with OpenTag
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </Button>
       </div>
+      <p className="mt-4 max-w-xl text-body text-fg-3">
+        OpenTag brings one AI agent into your Feishu team, where a real message starts its first Task.
+      </p>
     </section>
   );
 }

--- a/packages/web/src/pages/landing/hero.tsx
+++ b/packages/web/src/pages/landing/hero.tsx
@@ -20,13 +20,12 @@ export function Hero() {
       <h1 className="text-display text-foreground">Communication infrastructure for AI-native teams</h1>
       <p className="mt-6 max-w-2xl text-lead text-fg-2">Where agents and humans work as one team</p>
       <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row">
-        <Link
-          to="/login"
-          className="group inline-flex items-center gap-2 rounded-[var(--radius-input)] bg-primary px-6 py-3 text-body font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-        >
-          Get Started
-          <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-        </Link>
+        <Button asChild variant="outline" size="lg">
+          <Link to="/login">
+            Get Started
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </Button>
         <Button asChild variant="cta" size="lg">
           <Link to="/opentag">
             Start with OpenTag


### PR DESCRIPTION
## Summary

- add one public OpenTag CTA to the source-owned unauthenticated landing hero
- keep the existing general `Get Started` sign-in destination unchanged
- explain the OpenTag Feishu/Task value in one factual sentence
- cover both landing destinations with a focused DOM regression test

The CTA uses the existing `/opentag` route. The current auth guard, login `next` handoff, callback navigation, and strict solo-signup preservation continue to return a new OAuth user to that exact destination.

## Verification

- `pnpm --filter @first-tree/web test` (253 files, 2397 tests)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/oauth-bootstrap.test.ts` (13 tests)
- `pnpm check` (exit 0; existing repository warnings only)
- local Playwright check: unauthenticated `/` showed both CTAs; selecting OpenTag navigated to `/login`

## Scope

No navigation redesign, signup protocol, campaign, analytics, rollout, onboarding, or broader rebrand changes.
