### PR TITLE
fix(web): compact agent template provenance

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -641,7 +641,7 @@ describe("AgentDetailPage", () => {
     await act(async () => view.root.unmount());
   });
 
-  it("renders adopted responsibilities between Identity and Agent lifecycle without a dedicated tab", async () => {
+  it("renders adopted Template provenance inside Identity without a dedicated section or tab", async () => {
     const { ProfileTab } = await import("../profile-tab.js");
     agentResourceMocks.getAgentResources.mockResolvedValue(
       agentResources({
@@ -652,11 +652,12 @@ describe("AgentDetailPage", () => {
 
     const profile = await renderDom("/agents/agent-1/profile", <ProfileTab />);
     await waitForText(profile.container, "PR Engineer");
-    expect(profile.container.querySelectorAll('[data-slot="template-responsibility-label"]')).toHaveLength(1);
+    expect(profile.container.querySelectorAll('[data-slot="template-provenance"]')).toHaveLength(1);
+    expect(profile.container.textContent).toContain("Created from");
+    expect(profile.container.textContent).toContain("PR Engineer template");
     const headings = [...profile.container.querySelectorAll("h3")].map((heading) => heading.textContent?.trim());
-    expect(headings).toContain("Responsibilities · 1");
-    expect(headings.indexOf("Identity")).toBeLessThan(headings.indexOf("Responsibilities · 1"));
-    expect(headings.indexOf("Responsibilities · 1")).toBeLessThan(headings.indexOf("Agent lifecycle"));
+    expect(headings).not.toContain("Responsibilities · 1");
+    expect(headings.indexOf("Identity")).toBeLessThan(headings.indexOf("Agent lifecycle"));
     const profileNav = profile.container.querySelector('nav[aria-label="Agent sections"]');
     if (!profileNav) throw new Error("Expected Agent navigation");
     expect([...profileNav.querySelectorAll("a")].map((tab) => tab.textContent?.trim())).toEqual([
@@ -670,7 +671,7 @@ describe("AgentDetailPage", () => {
     await act(async () => profile.root.unmount());
   });
 
-  it("shows adopted responsibilities read-only in Profile for a non-editor", async () => {
+  it("shows adopted Template provenance read-only in Profile for a non-editor", async () => {
     const { ProfileTab } = await import("../profile-tab.js");
     authMock.value = { memberId: "member-other", role: "member", organizationId: "org-1" };
     agentMocks.getAgent.mockResolvedValue(agent({ managerId: "member-owner" }));
@@ -690,25 +691,26 @@ describe("AgentDetailPage", () => {
       "Tools & skills",
       "Usage",
     ]);
-    expect(exactButtonByText(view.container, "Manage")).toBeNull();
+    expect(view.container.textContent).toContain("Created from");
+    expect(view.container.querySelector('button[aria-label="Manage template sources"]')).toBeNull();
     await act(async () => view.root.unmount());
   });
 
-  it("does not query or show responsibilities for a human", async () => {
+  it("does not query or show Template provenance for a human", async () => {
     const { ProfileTab } = await import("../profile-tab.js");
     agentMocks.getAgent.mockResolvedValue(agent({ type: "human", clientId: null }));
 
     const view = await renderDom("/agents/agent-1/profile", <ProfileTab />);
     await waitForText(view.container, "Identity");
     expect(view.container.querySelector('nav[aria-label="Agent sections"]')).toBeNull();
-    expect(view.container.textContent).not.toContain("Responsibilities");
+    expect(view.container.textContent).not.toContain("Created from");
     expect(view.container.textContent).not.toContain("Some profile details couldn’t be loaded.");
     expect(agentResourceMocks.getAgentResources).not.toHaveBeenCalled();
     expect(templateMocks.listAgentTemplates).not.toHaveBeenCalled();
     await act(async () => view.root.unmount());
   });
 
-  it("hides the Profile section when the agent has no adopted templates", async () => {
+  it("hides the provenance row when the agent has no adopted templates", async () => {
     const { ProfileTab } = await import("../profile-tab.js");
     agentResourceMocks.getAgentResources.mockResolvedValue(agentResources({ templateIds: [], adoptedTemplates: [] }));
 
@@ -722,7 +724,7 @@ describe("AgentDetailPage", () => {
       "Repositories",
       "Usage",
     ]);
-    expect(view.container.textContent).not.toContain("Responsibilities");
+    expect(view.container.textContent).not.toContain("Created from");
     expect(templateMocks.listAgentTemplates).not.toHaveBeenCalled();
     await act(async () => view.root.unmount());
   });
@@ -738,30 +740,30 @@ describe("AgentDetailPage", () => {
 
     const loading = await renderDom("/agents/agent-1/profile", <ProfileTab />);
     await waitForText(loading.container, "Identity");
-    expect(loading.container.textContent).not.toContain("Responsibilities");
+    expect(loading.container.textContent).not.toContain("Created from");
     expect(loading.container.textContent).not.toContain("Some profile details couldn’t be loaded.");
 
     await act(async () => resolveResources(agentResources({ templateIds: [], adoptedTemplates: [] })));
     await flush();
-    expect(loading.container.textContent).not.toContain("Responsibilities");
+    expect(loading.container.textContent).not.toContain("Created from");
     await act(async () => loading.root.unmount());
   });
 
-  it("retries an initial resources error without speculating about responsibilities", async () => {
+  it("retries an initial resources error without speculating about Template provenance", async () => {
     const { ProfileTab } = await import("../profile-tab.js");
     agentResourceMocks.getAgentResources
       .mockRejectedValueOnce(new Error("resources down"))
       .mockResolvedValueOnce(agentResources({ templateIds: [], adoptedTemplates: [] }));
     const failed = await renderDom("/agents/agent-1/profile", <ProfileTab />);
     await waitForText(failed.container, "Some profile details couldn’t be loaded.");
-    expect(failed.container.textContent).not.toContain("Responsibilities");
+    expect(failed.container.textContent).not.toContain("Created from");
     expect(failed.container.textContent).not.toContain("resources down");
     await click(exactButtonByText(failed.container, "Retry"));
     await waitForCondition(
       () => !failed.container.textContent?.includes("Some profile details couldn’t be loaded."),
       "Expected the Profile warning to clear after retry",
     );
-    expect(failed.container.textContent).not.toContain("Responsibilities");
+    expect(failed.container.textContent).not.toContain("Created from");
     expect(agentResourceMocks.getAgentResources).toHaveBeenCalledTimes(2);
     await act(async () => failed.root.unmount());
   });
@@ -782,7 +784,7 @@ describe("AgentDetailPage", () => {
     await act(async () => cached.root.unmount());
   });
 
-  it("revalidates cached responsibilities when Profile mounts", async () => {
+  it("revalidates cached Template provenance when Profile mounts", async () => {
     const { ProfileTab } = await import("../profile-tab.js");
     let resolveRefresh!: (value: AgentResourcesOutput) => void;
     agentResourceMocks.getAgentResources.mockReturnValueOnce(
@@ -800,8 +802,8 @@ describe("AgentDetailPage", () => {
     expect(agentResourceMocks.getAgentResources).toHaveBeenCalledTimes(1);
     await act(async () => resolveRefresh(agentResources({ templateIds: [], adoptedTemplates: [] })));
     await waitForCondition(
-      () => !cached.container.textContent?.includes("Responsibilities"),
-      "Expected mount revalidation to remove stale responsibilities",
+      () => !cached.container.textContent?.includes("Created from"),
+      "Expected mount revalidation to remove stale Template provenance",
     );
     await act(async () => cached.root.unmount());
   });

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -288,7 +288,9 @@ describe("IdentitySection (display-only)", () => {
       metadata: { tree: { role: "Maintainer", domains: ["agent-hub", "first_tree"] } },
     });
 
-    const { container, root } = await renderDom(<IdentitySection agent={human} onEdit={onEdit} />);
+    const { container, root } = await renderDom(
+      <IdentitySection agent={human} onEdit={onEdit} createdFrom={<span>QA Engineer template</span>} />,
+    );
     await flush();
     expect(container.textContent).toContain("Manager User");
     expect(container.textContent).toContain("Helper");
@@ -296,6 +298,8 @@ describe("IdentitySection (display-only)", () => {
     expect(container.textContent).toContain("Maintainer");
     expect(container.textContent).toContain("Agent hub");
     expect(container.textContent).toContain("First tree");
+    expect(container.textContent).toContain("Created from");
+    expect(container.textContent).toContain("QA Engineer template");
 
     await click(buttonByText(container, "Edit"));
     expect(onEdit).toHaveBeenCalledTimes(1);

--- a/packages/web/src/pages/agent-detail/__tests__/responsibilities-section.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/responsibilities-section.test.tsx
@@ -8,11 +8,12 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "../../../api/client.js";
 import { ToastProvider } from "../../../components/ui/toast.js";
 import { useAgentResources } from "../capability-section.js";
-import { ResponsibilitiesSection } from "../responsibilities-section.js";
+import { TemplateProvenance } from "../responsibilities-section.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -119,7 +120,9 @@ async function render(element: ReactElement): Promise<HTMLElement> {
   await act(async () => {
     root?.render(
       <QueryClientProvider client={queryClient}>
-        <ToastProvider>{element}</ToastProvider>
+        <MemoryRouter>
+          <ToastProvider>{element}</ToastProvider>
+        </MemoryRouter>
       </QueryClientProvider>,
     );
   });
@@ -135,7 +138,7 @@ function renderSection(props: {
   version?: number;
 }): Promise<HTMLElement> {
   return render(
-    <ResponsibilitiesSection
+    <TemplateProvenance
       agentUuid="agent-1"
       agentStatus={props.agentStatus ?? "active"}
       canManage={props.canManage ?? true}
@@ -158,7 +161,7 @@ function exactButton(text: string): HTMLButtonElement | null {
   return [...document.body.querySelectorAll("button")].find((button) => button.textContent?.trim() === text) ?? null;
 }
 
-describe("ResponsibilitiesSection", () => {
+describe("TemplateProvenance", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -169,13 +172,13 @@ describe("ResponsibilitiesSection", () => {
     document.body.innerHTML = "";
   });
 
-  it("renders nothing when the agent has no adopted responsibilities", async () => {
+  it("renders nothing when the agent has no adopted template sources", async () => {
     const container = await renderSection({ templateIds: [] });
     expect(container.textContent).toBe("");
     expect(container.querySelector("section")).toBeNull();
   });
 
-  it("renders parallel responsibilities in stable visible-name order with missing summaries last", async () => {
+  it("renders one quiet source line in stable visible-name order with missing summaries last", async () => {
     await renderSection({
       templateIds: [TEMPLATE_A_ID, TEMPLATE_C_ID, TEMPLATE_B_ID],
       adoptedTemplates: [
@@ -184,27 +187,25 @@ describe("ResponsibilitiesSection", () => {
       ],
     });
 
-    expect([...document.body.querySelectorAll("h3")].map((heading) => heading.textContent?.trim())).toContain(
-      "Responsibilities · 3",
+    expect(document.body.querySelector("h3")).toBeNull();
+    expect(document.body.querySelector('[data-slot="template-provenance"]')?.textContent).toContain(
+      "Docs Writer template, PR Engineer template, and an unavailable template",
     );
-    expect(document.body.textContent).toContain("One-time starting points imported from Agent Templates.");
-    const labels = [...document.body.querySelectorAll('[data-slot="template-responsibility-label"]')];
-    expect(labels.map((label) => label.textContent)).toEqual([
-      "Docs WriterRetiredShips review-ready pull requests.",
-      "PR EngineerShips review-ready pull requests.",
-      "Unavailable templateUnavailable",
+    expect(document.body.textContent).not.toContain("Retired");
+    expect(document.body.textContent).not.toContain("Ship review-ready PRs");
+    expect([...document.body.querySelectorAll("a")].map((link) => link.getAttribute("href"))).toEqual([
+      "/templates/docs-writer",
+      "/templates/pr-engineer",
     ]);
-    expect(document.body.textContent).not.toContain("Active");
   });
 
-  it("shows row-level management only to managers of active agents", async () => {
+  it("shows one compact source menu only to managers of active agents", async () => {
     await renderSection({
       canManage: true,
       templateIds: [TEMPLATE_A_ID],
       adoptedTemplates: [summary({ id: TEMPLATE_A_ID })],
     });
-    expect(exactButton("Manage")).toBeTruthy();
-    expect(document.body.querySelector('button[aria-label="Manage PR Engineer responsibility"]')).toBeTruthy();
+    expect(document.body.querySelector('button[aria-label="Manage template sources"]')).toBeTruthy();
 
     act(() => root?.unmount());
     root = null;
@@ -214,7 +215,7 @@ describe("ResponsibilitiesSection", () => {
       templateIds: [TEMPLATE_A_ID],
       adoptedTemplates: [summary({ id: TEMPLATE_A_ID })],
     });
-    expect(exactButton("Manage")).toBeNull();
+    expect(document.body.querySelector('button[aria-label="Manage template sources"]')).toBeNull();
 
     act(() => root?.unmount());
     root = null;
@@ -225,24 +226,21 @@ describe("ResponsibilitiesSection", () => {
       templateIds: [TEMPLATE_A_ID],
       adoptedTemplates: [summary({ id: TEMPLATE_A_ID })],
     });
-    expect(exactButton("Manage")).toBeNull();
+    expect(document.body.querySelector('button[aria-label="Manage template sources"]')).toBeNull();
   });
 
-  it("gives every missing responsibility a distinct accessible management name", async () => {
+  it("gives every missing source a distinct accessible removal name", async () => {
     await renderSection({
       templateIds: [TEMPLATE_A_ID, TEMPLATE_B_ID],
       adoptedTemplates: [],
     });
 
-    expect(
-      document.body.querySelector(`button[aria-label="Manage Unavailable template ${TEMPLATE_A_ID} responsibility"]`),
-    ).toBeTruthy();
-    expect(
-      document.body.querySelector(`button[aria-label="Manage Unavailable template ${TEMPLATE_B_ID} responsibility"]`),
-    ).toBeTruthy();
+    await click(document.body.querySelector('button[aria-label="Manage template sources"]'));
+    expect(exactButton(`Remove unavailable template ${TEMPLATE_A_ID}`)).toBeTruthy();
+    expect(exactButton(`Remove unavailable template ${TEMPLATE_B_ID}`)).toBeTruthy();
   });
 
-  it("removes only the selected responsibility without loading the catalog", async () => {
+  it("removes only the selected source without loading the catalog", async () => {
     templateMocks.updateAgentTemplates.mockResolvedValue(
       resources({
         version: 8,
@@ -258,16 +256,14 @@ describe("ResponsibilitiesSection", () => {
       ],
     });
 
-    expect(document.body.querySelector('button[aria-label="Manage Docs Writer responsibility"]')).toBeTruthy();
-    expect(document.body.querySelector('button[aria-label="Manage PR Engineer responsibility"]')).toBeTruthy();
-
-    await click(exactButton("Manage"));
-    expect(document.body.textContent).toContain("Remove responsibility?");
+    await click(document.body.querySelector('button[aria-label="Manage template sources"]'));
+    await click(exactButton("Remove Docs Writer template"));
+    expect(document.body.textContent).toContain("Remove template source?");
     expect(document.body.textContent).toContain(
-      "Only this agent’s bindings created by Docs Writer will be removed. Team Resources will remain available.",
+      "Only this agent’s bindings imported from Docs Writer template will be removed. Team Resources will remain available.",
     );
     expect(templateMocks.listAgentTemplates).not.toHaveBeenCalled();
-    await click(exactButton("Remove responsibility"));
+    await click(exactButton("Remove source"));
 
     await waitForCondition(
       () => templateMocks.updateAgentTemplates.mock.calls.length === 1,
@@ -280,7 +276,7 @@ describe("ResponsibilitiesSection", () => {
     expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("agent_template_replace_set", { result: "success" });
   });
 
-  it("disappears after the last responsibility is removed", async () => {
+  it("disappears after the last template source is removed", async () => {
     resourceMocks.getAgentResources.mockResolvedValue(
       resources({ templateIds: [TEMPLATE_A_ID], adoptedTemplates: [summary({ id: TEMPLATE_A_ID })] }),
     );
@@ -290,7 +286,7 @@ describe("ResponsibilitiesSection", () => {
       const current = useAgentResources("agent-1", { enabled: true });
       if (!current.data) return null;
       return (
-        <ResponsibilitiesSection
+        <TemplateProvenance
           agentUuid="agent-1"
           agentStatus="active"
           canManage
@@ -302,10 +298,11 @@ describe("ResponsibilitiesSection", () => {
     }
 
     const container = await render(<Harness />);
-    await waitForCondition(() => container.textContent?.includes("PR Engineer") ?? false, "Expected responsibility");
-    await click(exactButton("Manage"));
-    await click(exactButton("Remove responsibility"));
-    await waitForCondition(() => container.textContent === "", "Expected section to disappear");
+    await waitForCondition(() => container.textContent?.includes("PR Engineer") ?? false, "Expected template source");
+    await click(document.body.querySelector('button[aria-label="Manage template sources"]'));
+    await click(exactButton("Remove PR Engineer template"));
+    await click(exactButton("Remove source"));
+    await waitForCondition(() => container.textContent === "", "Expected source line to disappear");
   });
 
   it("refreshes and asks for a retry on a version conflict", async () => {
@@ -321,8 +318,9 @@ describe("ResponsibilitiesSection", () => {
       templateIds: [TEMPLATE_A_ID],
       adoptedTemplates: [summary({ id: TEMPLATE_A_ID })],
     });
-    await click(exactButton("Manage"));
-    await click(exactButton("Remove responsibility"));
+    await click(document.body.querySelector('button[aria-label="Manage template sources"]'));
+    await click(exactButton("Remove PR Engineer template"));
+    await click(exactButton("Remove source"));
     await waitForCondition(
       () => document.body.textContent?.includes("refreshed — review and remove again") ?? false,
       "Expected version conflict guidance",

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -31,6 +31,8 @@ export type IdentitySectionProps = {
   title?: string;
   description?: ReactNode;
   aside?: ReactNode;
+  /** Optional one-line creation provenance shown with the other identity metadata. */
+  createdFrom?: ReactNode;
 };
 
 export function IdentitySection({
@@ -41,6 +43,7 @@ export function IdentitySection({
   title = "Identity",
   description,
   aside,
+  createdFrom,
 }: IdentitySectionProps) {
   const resolveAgent = useAgentIdentityMap();
   const resolveMember = useMemberNameMap();
@@ -85,6 +88,11 @@ export function IdentitySection({
             <IdentityField label="Owner">
               <MemberReference memberId={agent.managerId} name={managerName ?? "—"} />
             </IdentityField>
+            {createdFrom && (
+              <IdentityField label="Created from" allowOverflow>
+                {createdFrom}
+              </IdentityField>
+            )}
             {delegateIdentity && (
               <IdentityField label="Delegate">
                 <AgentChip name={delegateIdentity.name} displayName={delegateIdentity.displayName} />
@@ -137,7 +145,15 @@ function VisibilityBadge({ visibility }: { visibility: Agent["visibility"] }) {
   );
 }
 
-function IdentityField({ label, children }: { label: string; children: ReactNode }) {
+function IdentityField({
+  label,
+  children,
+  allowOverflow = false,
+}: {
+  label: string;
+  children: ReactNode;
+  allowOverflow?: boolean;
+}) {
   return (
     <div
       className="grid min-w-0 grid-cols-1 items-baseline gap-1 sm:grid-cols-[var(--agent-detail-label-col)_minmax(0,1fr)] sm:gap-4"
@@ -148,7 +164,12 @@ function IdentityField({ label, children }: { label: string; children: ReactNode
       </div>
       <div
         className="min-w-0 text-body font-medium"
-        style={{ color: "var(--fg)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        style={{
+          color: "var(--fg)",
+          overflow: allowOverflow ? "visible" : "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
       >
         {children}
       </div>

--- a/packages/web/src/pages/agent-detail/profile-tab.tsx
+++ b/packages/web/src/pages/agent-detail/profile-tab.tsx
@@ -7,7 +7,7 @@ import { FeishuSection } from "./feishu-section.js";
 import { IdentitySection } from "./identity-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { ProfileEditDialog } from "./profile-edit-dialog.js";
-import { ResponsibilitiesSection } from "./responsibilities-section.js";
+import { TemplateProvenance } from "./responsibilities-section.js";
 import { useJustSaved } from "./save-semantics.js";
 
 export function ProfileTab() {
@@ -34,6 +34,18 @@ export function ProfileTab() {
         title="Identity"
         description={null}
         aside={<AppearanceSection agent={ctx.agent} canEdit={ctx.canManageAgent} onEdit={onEdit} variant="inline" />}
+        createdFrom={
+          !ctx.isHuman && resources.data && resources.data.templateIds.length > 0 ? (
+            <TemplateProvenance
+              agentUuid={ctx.uuid}
+              agentStatus={ctx.agent.status}
+              canManage={ctx.canEditConfig}
+              templateIds={resources.data.templateIds}
+              adoptedTemplates={resources.data.adoptedTemplates}
+              version={resources.data.version}
+            />
+          ) : undefined
+        }
       />
       {!ctx.isHuman && !resources.data && resources.isError ? (
         <div className="flex flex-wrap items-center gap-2 py-3" role="alert">
@@ -49,16 +61,6 @@ export function ProfileTab() {
             {resources.reloading ? "Retrying…" : "Retry"}
           </Button>
         </div>
-      ) : null}
-      {!ctx.isHuman && resources.data && resources.data.templateIds.length > 0 ? (
-        <ResponsibilitiesSection
-          agentUuid={ctx.uuid}
-          agentStatus={ctx.agent.status}
-          canManage={ctx.canEditConfig}
-          templateIds={resources.data.templateIds}
-          adoptedTemplates={resources.data.adoptedTemplates}
-          version={resources.data.version}
-        />
       ) : null}
       {!ctx.isHuman && <FeishuSection onOpenProfileEdit={onEdit} />}
       {/* Agent lifecycle is identity-level, so destructive controls stay at the

--- a/packages/web/src/pages/agent-detail/responsibilities-section.tsx
+++ b/packages/web/src/pages/agent-detail/responsibilities-section.tsx
@@ -16,7 +16,6 @@ import {
 } from "../../components/ui/dialog.js";
 import { RowActionsMenu } from "../../components/ui/row-actions-menu.js";
 import { agentResourcesMutationHandlers } from "./capability-section.js";
-import { useJustSaved } from "./save-semantics.js";
 
 /**
  * One-line Template provenance inside Profile identity. The source names link
@@ -44,7 +43,6 @@ export function TemplateProvenance({
   version,
 }: TemplateProvenanceProps) {
   const queryClient = useQueryClient();
-  const { markSaved } = useJustSaved();
   const [removeTarget, setRemoveTarget] = useState<AgentTemplateAdoptionSummary | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
   const canEdit = canManage && agentStatus === "active";
@@ -58,7 +56,7 @@ export function TemplateProvenance({
     return templateIds.map((id) => byId.get(id) ?? missingSummary(id)).sort(compareResponsibilitySummaries);
   }, [adoptedTemplates, templateIds]);
 
-  const mutationHandlers = agentResourcesMutationHandlers(queryClient, agentUuid, { onSuccessAfter: markSaved });
+  const mutationHandlers = agentResourcesMutationHandlers(queryClient, agentUuid);
   const removeMutation = useMutation({
     mutationFn: (target: AgentTemplateAdoptionSummary) =>
       updateAgentTemplates(agentUuid, {

--- a/packages/web/src/pages/agent-detail/responsibilities-section.tsx
+++ b/packages/web/src/pages/agent-detail/responsibilities-section.tsx
@@ -1,10 +1,10 @@
 import { AGENT_TEMPLATE_LIFECYCLE_ERROR_CODES, type AgentTemplateAdoptionSummary } from "@first-tree/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
+import { Link } from "react-router";
 import { trackEvent } from "../../analytics.js";
 import { updateAgentTemplates } from "../../api/agent-templates.js";
 import { ApiError } from "../../api/client.js";
-import { TemplateResponsibilityLabel } from "../../components/template-responsibility-label.js";
 import { Button } from "../../components/ui/button.js";
 import {
   Dialog,
@@ -14,16 +14,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../../components/ui/dialog.js";
-import { Section } from "../../components/ui/section.js";
+import { RowActionsMenu } from "../../components/ui/row-actions-menu.js";
 import { agentResourcesMutationHandlers } from "./capability-section.js";
-import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
+import { useJustSaved } from "./save-semantics.js";
 
 /**
- * Compact Template provenance inside Profile. This section explains only the
- * responsibilities already adopted by the agent; discovery and adoption stay
- * in agent creation and the Template Library.
+ * One-line Template provenance inside Profile identity. The source names link
+ * to their public Template pages; the compact overflow preserves the existing
+ * remove-binding action without restoring a dedicated management section.
  */
-export type ResponsibilitiesSectionProps = {
+export type TemplateProvenanceProps = {
   agentUuid: string;
   agentStatus: string;
   canManage: boolean;
@@ -33,18 +33,18 @@ export type ResponsibilitiesSectionProps = {
 };
 
 const VERSION_CAS_FEEDBACK =
-  "This agent changed elsewhere. Its responsibilities were refreshed — review and remove again.";
+  "This agent changed elsewhere. Its template sources were refreshed — review and remove again.";
 
-export function ResponsibilitiesSection({
+export function TemplateProvenance({
   agentUuid,
   agentStatus,
   canManage,
   templateIds,
   adoptedTemplates,
   version,
-}: ResponsibilitiesSectionProps) {
+}: TemplateProvenanceProps) {
   const queryClient = useQueryClient();
-  const { justSaved, markSaved } = useJustSaved();
+  const { markSaved } = useJustSaved();
   const [removeTarget, setRemoveTarget] = useState<AgentTemplateAdoptionSummary | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
   const canEdit = canManage && agentStatus === "active";
@@ -81,49 +81,47 @@ export function ResponsibilitiesSection({
         setFeedback(VERSION_CAS_FEEDBACK);
         return;
       }
-      setFeedback(error instanceof Error ? error.message : "Failed to remove responsibility");
+      setFeedback(error instanceof Error ? error.message : "Failed to remove template source");
     },
   });
 
   if (ordered.length === 0) return null;
 
-  const targetName = removeTarget?.name ?? "this unavailable template";
+  const targetName = removeTarget ? sourceLabel(removeTarget) : "this template source";
 
   return (
     <>
-      <Section
-        headingLevel={3}
-        title={titleWithSemantics("Responsibilities", justSaved)}
-        count={ordered.length}
-        description="One-time starting points imported from Agent Templates. Instructions and tools are managed in their own sections."
-      >
-        <ul className="m-0 list-none p-0">
-          {ordered.map((summary) => (
-            <li
-              key={summary.id}
-              className="flex items-start justify-between gap-3 py-3"
-              style={{ borderBottom: "var(--hairline) solid var(--border-faint)" }}
-            >
-              <TemplateResponsibilityLabel template={summary} variant="assigned" />
-              {canEdit ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="xs"
-                  className="shrink-0"
-                  aria-label={`Manage ${summary.name ?? `Unavailable template ${summary.id}`} responsibility`}
-                  onClick={() => {
-                    setFeedback(null);
-                    setRemoveTarget(summary);
-                  }}
-                >
-                  Manage
-                </Button>
-              ) : null}
-            </li>
+      <span className="inline-flex min-w-0 max-w-full items-center gap-1" data-slot="template-provenance">
+        <span className="min-w-0 truncate">
+          {ordered.map((summary, index) => (
+            <Fragment key={summary.id}>
+              {sourceSeparator(index, ordered.length)}
+              {summary.slug ? (
+                <Link to={`/templates/${summary.slug}`} className="text-primary underline underline-offset-2">
+                  {sourceLabel(summary)}
+                </Link>
+              ) : (
+                <span style={{ color: "var(--fg-3)" }}>{sourceLabel(summary)}</span>
+              )}
+            </Fragment>
           ))}
-        </ul>
-      </Section>
+        </span>
+        {canEdit ? (
+          <RowActionsMenu
+            ariaLabel="Manage template sources"
+            touchTarget
+            actions={ordered.map((summary) => ({
+              key: summary.id,
+              label: summary.name ? `Remove ${sourceLabel(summary)}` : `Remove unavailable template ${summary.id}`,
+              destructive: true,
+              onSelect: () => {
+                setFeedback(null);
+                setRemoveTarget(summary);
+              },
+            }))}
+          />
+        ) : null}
+      </span>
 
       <Dialog
         open={removeTarget !== null}
@@ -135,9 +133,10 @@ export function ResponsibilitiesSection({
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Remove responsibility?</DialogTitle>
+            <DialogTitle>Remove template source?</DialogTitle>
             <DialogDescription>
-              Only this agent’s bindings created by {targetName} will be removed. Team Resources will remain available.
+              Only this agent’s bindings imported from {targetName} will be removed. Team Resources will remain
+              available.
             </DialogDescription>
           </DialogHeader>
           {feedback ? (
@@ -157,13 +156,23 @@ export function ResponsibilitiesSection({
                 if (removeTarget) removeMutation.mutate(removeTarget);
               }}
             >
-              {removeMutation.isPending ? "Removing…" : "Remove responsibility"}
+              {removeMutation.isPending ? "Removing…" : "Remove source"}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
     </>
   );
+}
+
+function sourceLabel(summary: AgentTemplateAdoptionSummary): string {
+  return summary.name ? `${summary.name} template` : "an unavailable template";
+}
+
+function sourceSeparator(index: number, total: number): string {
+  if (index === 0) return "";
+  if (index === total - 1) return total === 2 ? " and " : ", and ";
+  return ", ";
 }
 
 function compareResponsibilitySummaries(


### PR DESCRIPTION
## Summary

- replace the heavy Profile responsibilities section with compact `Created from` identity metadata
- link each available template source to its Template Library detail page
- keep source removal available in an overflow menu while preserving conflict and refresh behavior

## Validation

- `pnpm --filter @first-tree/web typecheck`
- `pnpm check && pnpm typecheck`
- focused Agent Detail tests: 65 passed
- full Web suite: 2,417 passed; one unrelated chat-scroll timing assertion failed and passed on isolated rerun

## Scope

This PR only changes template provenance presentation in the Web Agent Detail Profile. The Feishu channel information architecture is being handled separately.
