### PR TITLE
Add Agent Channels tab for Feishu

### DIFF
--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -163,6 +163,7 @@ vi.mock("../pages/agent-detail.js", async () => {
   };
 });
 vi.mock("../pages/agent-detail/profile-tab.js", () => ({ ProfileTab: () => <div>profile tab</div> }));
+vi.mock("../pages/agent-detail/channels-tab.js", () => ({ ChannelsTab: () => <div>channels tab</div> }));
 vi.mock("../pages/agent-detail/runtime-tab.js", () => ({ RuntimeTab: () => <div>runtime tab</div> }));
 vi.mock("../pages/agent-detail/prompt-tab.js", () => ({ PromptTab: () => <div>prompt tab</div> }));
 vi.mock("../pages/agent-detail/resources-tab.js", () => ({ ResourcesTab: () => <div>resources tab</div> }));
@@ -348,6 +349,9 @@ describe("App routes", () => {
     await resetRenderedApp();
 
     expect(await renderAppAt("/agents/agent-1/usage")).toContain("usage tab");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/agents/agent-1/channels")).toContain("channels tab");
     await resetRenderedApp();
 
     expect(await renderAppAt("/agents/agent-1/responsibilities")).toContain("profile tab");

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -11,6 +11,7 @@ import { ToastProvider } from "./components/ui/toast.js";
 import { PulseProvider } from "./hooks/pulse-context.js";
 import { useMobileExperienceState } from "./hooks/use-mobile-experience.js";
 import { useContextTreeSetupPreviewBootstrapState } from "./hooks/use-server-channel.js";
+import { ChannelsTab } from "./pages/agent-detail/channels-tab.js";
 import { ProfileTab } from "./pages/agent-detail/profile-tab.js";
 import { PromptTab } from "./pages/agent-detail/prompt-tab.js";
 import { RepositoriesTab } from "./pages/agent-detail/repositories-tab.js";
@@ -512,6 +513,7 @@ export function App() {
                   <Route path="agents/:uuid" element={<AgentDetailPage />}>
                     <Route index element={<Navigate to="profile" replace />} />
                     <Route path="profile" element={<ProfileTab />} />
+                    <Route path="channels" element={<ChannelsTab />} />
                     <Route path="responsibilities" element={<Navigate to="../profile" replace />} />
                     <Route path="runtime" element={<RuntimeTab />} />
                     <Route path="prompt" element={<PromptTab />} />

--- a/packages/web/src/features/feishu/binding-view.tsx
+++ b/packages/web/src/features/feishu/binding-view.tsx
@@ -57,6 +57,15 @@ export function isFeishuBotReachable(binding: FeishuBotBinding): boolean {
 }
 
 /**
+ * Whether the Agent's Feishu handoff is configured to carry work. Both halves
+ * have to hold: the Bot must receive messages and the CLI must be ready to
+ * answer them. Agent lifecycle is a separate caller-owned constraint.
+ */
+export function isFeishuHandoffUsable(binding: FeishuBotBinding | null): boolean {
+  return !!binding && isFeishuBotReachable(binding) && binding.cli.state === "ready";
+}
+
+/**
  * The registration QR the member scans in Feishu, plus the same destination as
  * a link for anyone who is already signed in on this device.
  */

--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -2,6 +2,7 @@ import type {
   Agent,
   AgentResourcesOutput,
   AgentRuntimeConfig,
+  FeishuBotBinding,
   UsageAgentSummary,
   UsageTurnsResponse,
 } from "@first-tree/shared";
@@ -9,6 +10,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { Outlet, Route, Routes } from "react-router";
 import { ResourceTypeSection } from "./agent-detail/capability-section.js";
+import { FeishuSection } from "./agent-detail/feishu-section.js";
 import type { AgentDetailContext } from "./agent-detail/layout-context.js";
 import { PromptTab } from "./agent-detail/prompt-tab.js";
 import { ResourcesTab } from "./agent-detail/resources-tab.js";
@@ -380,6 +382,26 @@ const CONFIG: AgentRuntimeConfig = {
   updatedBy: "member-self",
 };
 
+const FEISHU_BINDING: FeishuBotBinding = {
+  id: "binding-preview",
+  agentId: UUID,
+  appId: "cli_preview",
+  botOpenId: "ou_preview",
+  botName: "Vega · First Tree",
+  botAvatarUrl: null,
+  tenantKey: "tenant-preview",
+  status: "active",
+  connectionStatus: "connected",
+  grantedScopes: [],
+  registrationUrl: null,
+  registrationExpiresAt: null,
+  lastConnectedAt: NOW,
+  lastEventAt: NOW,
+  lastErrorCode: null,
+  lastErrorMessage: null,
+  cli: { state: "ready", version: "1.2.3", clientId: "client-preview" },
+};
+
 // Usage tab sample data — crafted to exercise the slimmed Recent turns table:
 // a long chat title (truncates), a non-default model (claude-haiku) next to the
 // dominant one, and big token counts (compact in-cell, exact on hover).
@@ -465,6 +487,7 @@ function buildClient(): QueryClient {
     },
   });
   client.setQueryData(["agent-resources", UUID], RESOURCES);
+  client.setQueryData(["agent-feishu-binding", UUID], { binding: FEISHU_BINDING });
   client.setQueryData(["usage-summary", UUID, "30d"], USAGE_SUMMARY);
   client.setQueryData(["usage-turns", UUID, "30d", 10], USAGE_TURNS);
   return client;
@@ -496,6 +519,17 @@ export function AgentDetailPreviewPage() {
             Seeded resource and runtime content for visual QA. Validate the shared shell, responsive navigation, and
             keyboard behavior on the real Agent Detail route rather than duplicating them here.
           </p>
+
+          <h2 className="text-title m-0" style={{ color: "var(--fg)", marginTop: "var(--sp-8)" }}>
+            Channels section
+          </h2>
+          <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
+            The aggregate state answers whether teammates can reach this Agent and receive a reply before technical Bot
+            and CLI details.
+          </p>
+          <div style={{ marginTop: "var(--sp-4)", marginBottom: "var(--sp-8)" }}>
+            <TabHost element={<FeishuSection poll={false} />} />
+          </div>
 
           <h2 className="text-title m-0" style={{ color: "var(--fg)", marginTop: "var(--sp-8)" }}>
             Repositories section

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -1123,7 +1123,7 @@ describe("agent detail pure helpers", () => {
     expect(canManageAgentDetail({ managerId: "member-self" }, null, "member")).toBe(false);
     expect(canManageAgentDetail({ managerId: "member-other" }, null, "admin")).toBe(true);
 
-    expect(buildTabs(false, false).map((tab) => tab.path)).toEqual(["profile", "capabilities", "usage"]);
+    expect(buildTabs(false, false).map((tab) => tab.path)).toEqual(["profile", "channels", "capabilities", "usage"]);
 
     expect(isBindableClient({ status: "connected" })).toBe(true);
     expect(isBindableClient({ status: "retired" })).toBe(false);

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -661,6 +661,7 @@ describe("AgentDetailPage", () => {
     if (!profileNav) throw new Error("Expected Agent navigation");
     expect([...profileNav.querySelectorAll("a")].map((tab) => tab.textContent?.trim())).toEqual([
       "Profile",
+      "Channels",
       "Runtime",
       "Instructions",
       "Tools & skills",
@@ -687,6 +688,7 @@ describe("AgentDetailPage", () => {
     if (!viewerNav) throw new Error("Expected Agent navigation");
     expect([...viewerNav.querySelectorAll("a")].map((tab) => tab.textContent?.trim())).toEqual([
       "Profile",
+      "Channels",
       "Tools & skills",
       "Usage",
     ]);
@@ -702,6 +704,7 @@ describe("AgentDetailPage", () => {
     await waitForText(view.container, "Identity");
     expect(view.container.querySelector('nav[aria-label="Agent sections"]')).toBeNull();
     expect(view.container.textContent).not.toContain("Responsibilities");
+    expect(view.container.textContent).not.toContain("Feishu");
     expect(view.container.textContent).not.toContain("Some profile details couldn’t be loaded.");
     expect(agentResourceMocks.getAgentResources).not.toHaveBeenCalled();
     expect(templateMocks.listAgentTemplates).not.toHaveBeenCalled();
@@ -716,6 +719,7 @@ describe("AgentDetailPage", () => {
     await waitForText(view.container, "Identity");
     expect(agentSectionLabels(view.container)).toEqual([
       "Profile",
+      "Channels",
       "Runtime",
       "Instructions",
       "Tools & skills",
@@ -724,6 +728,7 @@ describe("AgentDetailPage", () => {
     ]);
     expect(view.container.textContent).not.toContain("Responsibilities");
     expect(templateMocks.listAgentTemplates).not.toHaveBeenCalled();
+    expect(view.container.textContent).not.toContain("Feishu");
     await act(async () => view.root.unmount());
   });
 
@@ -860,6 +865,7 @@ describe("AgentDetailPage", () => {
     if (!nav) throw new Error("Expected Agent navigation");
     expect([...nav.querySelectorAll("a")].map((tab) => tab.textContent?.trim())).toEqual([
       "Profile",
+      "Channels",
       "Runtime",
       "Instructions",
       "Tools & skills",

--- a/packages/web/src/pages/agent-detail/__tests__/channels-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/channels-tab-dom.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentDetailContext } from "../layout-context.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../feishu-section.js", () => ({
+  FeishuSection: () => <div>Feishu channel surface</div>,
+}));
+
+let root: Root | null = null;
+
+function context(isHuman: boolean): AgentDetailContext {
+  return {
+    uuid: "agent-a",
+    agent: { uuid: "agent-a", type: isHuman ? "human" : "agent" },
+    isHuman,
+    canManageAgent: true,
+    navigateAway: vi.fn(),
+  } as unknown as AgentDetailContext;
+}
+
+async function renderChannels(isHuman: boolean): Promise<HTMLElement> {
+  const { ChannelsTab } = await import("../channels-tab.js");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <MemoryRouter initialEntries={["/agents/agent-a/channels"]}>
+        <Routes>
+          <Route path="/agents/:uuid" element={<Outlet context={context(isHuman)} />}>
+            <Route path="profile" element={<div>Profile destination</div>} />
+            <Route path="channels" element={<ChannelsTab />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+  });
+  return container;
+}
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  root = null;
+  document.body.innerHTML = "";
+});
+
+describe("Channels tab visibility", () => {
+  it("renders the channel surface for a non-human read-only-capable route", async () => {
+    const container = await renderChannels(false);
+    expect(container.textContent).toContain("Feishu channel surface");
+  });
+
+  it("redirects a human-agent deep link back to Profile", async () => {
+    const container = await renderChannels(true);
+    expect(container.textContent).toContain("Profile destination");
+    expect(container.textContent).not.toContain("Feishu channel surface");
+  });
+});

--- a/packages/web/src/pages/agent-detail/__tests__/feishu-section-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/feishu-section-dom.test.tsx
@@ -76,7 +76,7 @@ async function flush(): Promise<void> {
   });
 }
 
-async function renderSection(props: { onOpenProfileEdit?: () => void } = {}): Promise<HTMLElement> {
+async function renderSection(props: { onOpenProfile?: () => void } = {}): Promise<HTMLElement> {
   const { FeishuSection } = await import("../feishu-section.js");
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -130,13 +130,14 @@ afterEach(async () => {
 describe("Feishu Agent Detail section", () => {
   it("starts the QR registration from the Agent Detail surface", async () => {
     const container = await renderSection();
-    expect(container.textContent).toContain("No Feishu Bot is connected");
+    expect(container.textContent).toContain("Not connected");
+    expect(container.textContent).toContain("Teammates can't reach this Agent in Feishu yet");
     await click(buttonByText(container, "Connect Bot"));
     expect(apiMocks.startAgentFeishuRegistration).toHaveBeenCalledWith("agent-a", "Agent A · First Tree");
   });
 
   it("explains the visibility requirement before a private Agent can connect", async () => {
-    const onOpenProfileEdit = vi.fn();
+    const onOpenProfile = vi.fn();
     const privateContext = context();
     contextMock.value = context({
       agent: {
@@ -144,13 +145,13 @@ describe("Feishu Agent Detail section", () => {
         visibility: "private",
       } as AgentDetailContext["agent"],
     });
-    const container = await renderSection({ onOpenProfileEdit });
+    const container = await renderSection({ onOpenProfile });
 
     expect(container.textContent).toContain("Organization visibility is required");
     expect(container.textContent).not.toContain("One Bot and Feishu chat map");
     expect(buttonByText(container, "Connect Bot")?.disabled).toBe(true);
-    await click(buttonByText(container, "Change visibility"));
-    expect(onOpenProfileEdit).toHaveBeenCalledOnce();
+    await click(buttonByText(container, "Manage in Profile"));
+    expect(onOpenProfile).toHaveBeenCalledOnce();
     expect(apiMocks.startAgentFeishuRegistration).not.toHaveBeenCalled();
   });
 
@@ -168,8 +169,36 @@ describe("Feishu Agent Detail section", () => {
     expect(container.querySelector('img[src="https://example.com/bot.png"]')).not.toBeNull();
   });
 
+  it("only reports Ready when both the Bot is reachable and the CLI is ready", async () => {
+    apiMocks.getAgentFeishuBinding.mockResolvedValueOnce({
+      binding: binding({ cli: { state: "ready", version: "1.2.3", clientId: "client-a" }, grantedScopes: [] }),
+    });
+    const ready = await renderSection();
+    expect(ready.querySelector('[data-channel-state="ready"]')).not.toBeNull();
+    expect(ready.textContent).toContain("Ready for Feishu tasks");
+
+    await act(async () => roots.pop()?.unmount());
+    document.body.innerHTML = "";
+    apiMocks.getAgentFeishuBinding.mockResolvedValueOnce({
+      binding: binding({ cli: { state: "missing", version: null, clientId: "client-a" } }),
+    });
+    const incomplete = await renderSection();
+    expect(incomplete.querySelector('[data-channel-state="setup-incomplete"]')).not.toBeNull();
+    expect(incomplete.textContent).toContain("The Bot is reachable. Finish the Agent setup");
+  });
+
+  it("separates an offline Computer from Bot reachability and marks the aggregate channel for attention", async () => {
+    apiMocks.getAgentFeishuBinding.mockResolvedValueOnce({
+      binding: binding({ cli: { state: "offline", version: null, clientId: null } }),
+    });
+    const container = await renderSection();
+    expect(container.querySelector('[data-channel-state="needs-attention"]')).not.toBeNull();
+    expect(container.textContent).toContain("The Bot may still receive messages");
+    expect(container.textContent).toContain("Computer offline");
+  });
+
   it("blocks Retry and explains visibility for a private Agent with an errored binding", async () => {
-    const onOpenProfileEdit = vi.fn();
+    const onOpenProfile = vi.fn();
     const privateContext = context();
     contextMock.value = context({
       agent: { ...privateContext.agent, visibility: "private" } as AgentDetailContext["agent"],
@@ -177,12 +206,12 @@ describe("Feishu Agent Detail section", () => {
     apiMocks.getAgentFeishuBinding.mockResolvedValueOnce({
       binding: binding({ status: "error", connectionStatus: "error", lastErrorMessage: "Registration failed" }),
     });
-    const container = await renderSection({ onOpenProfileEdit });
+    const container = await renderSection({ onOpenProfile });
 
     expect(container.textContent).toContain("Organization visibility is required");
     expect(buttonByText(container, "Retry")?.disabled).toBe(true);
-    await click(buttonByText(container, "Change visibility"));
-    expect(onOpenProfileEdit).toHaveBeenCalledOnce();
+    await click(buttonByText(container, "Manage in Profile"));
+    expect(onOpenProfile).toHaveBeenCalledOnce();
     expect(apiMocks.startAgentFeishuRegistration).not.toHaveBeenCalled();
   });
 
@@ -229,7 +258,22 @@ describe("Feishu Agent Detail section", () => {
       }),
     });
     const container = await renderSection();
-    expect(container.querySelector("svg")).toBeNull();
+    expect(container.querySelector("svg title")?.textContent).not.toBe("Feishu Bot registration QR code");
     expect(container.querySelector('a[href*="must-not-render"]')).toBeNull();
+    expect(buttonByText(container, "Disconnect")).toBeNull();
+    expect(buttonByText(container, "Retry")).toBeNull();
+  });
+
+  it("lets the viewer retry a failed binding read without claiming the channel is disconnected", async () => {
+    apiMocks.getAgentFeishuBinding
+      .mockRejectedValueOnce(new Error("status unavailable"))
+      .mockResolvedValueOnce({ binding: null });
+    const container = await renderSection();
+    expect(container.textContent).toContain("Couldn't check this channel");
+    expect(container.querySelector('[data-channel-state="not-connected"]')).toBeNull();
+
+    await click(buttonByText(container, "Retry"));
+    expect(apiMocks.getAgentFeishuBinding).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('[data-channel-state="not-connected"]')).not.toBeNull();
   });
 });

--- a/packages/web/src/pages/agent-detail/__tests__/feishu-section-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/feishu-section-dom.test.tsx
@@ -38,6 +38,7 @@ function context(overrides: Partial<AgentDetailContext> = {}): AgentDetailContex
       displayName: "Agent A",
       type: "agent",
       visibility: "organization",
+      status: "active",
     } as AgentDetailContext["agent"],
     isHuman: false,
     canManageAgent: true,
@@ -195,6 +196,21 @@ describe("Feishu Agent Detail section", () => {
     expect(container.querySelector('[data-channel-state="needs-attention"]')).not.toBeNull();
     expect(container.textContent).toContain("The Bot may still receive messages");
     expect(container.textContent).toContain("Computer offline");
+  });
+
+  it("gives a suspended Agent precedence over an otherwise usable Feishu handoff", async () => {
+    contextMock.value = context({
+      agent: { ...context().agent, status: "suspended" } as AgentDetailContext["agent"],
+    });
+    apiMocks.getAgentFeishuBinding.mockResolvedValueOnce({
+      binding: binding({ cli: { state: "ready", version: "1.2.3", clientId: "client-a" } }),
+    });
+
+    const container = await renderSection();
+    expect(container.querySelector('[data-channel-state="needs-attention"]')).not.toBeNull();
+    expect(container.textContent).toContain("Agent is suspended");
+    expect(container.textContent).toContain("Reactivate this Agent in Profile");
+    expect(container.textContent).not.toContain("Ready for Feishu tasks");
   });
 
   it("blocks Retry and explains visibility for a private Agent with an errored binding", async () => {

--- a/packages/web/src/pages/agent-detail/__tests__/tabs.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/tabs.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 import { buildTabs, tabKeysFor } from "../tabs.js";
 
 describe("agent-detail tabs", () => {
-  it("gives an editor the six configuration and observation tabs without Responsibilities", () => {
+  it("places Channels immediately after Profile for an editor", () => {
     const tabs = buildTabs(true, false);
     expect(tabs.map((tab) => tab.key)).toEqual([
       "profile",
+      "channels",
       "runtime",
       "prompt",
       "capabilities",
@@ -14,6 +15,7 @@ describe("agent-detail tabs", () => {
     ]);
     expect(tabs.map((tab) => tab.label)).toEqual([
       "Profile",
+      "Channels",
       "Runtime",
       "Instructions",
       "Tools & skills",
@@ -23,8 +25,8 @@ describe("agent-detail tabs", () => {
     expect(tabs.every((tab) => tab.path === tab.key)).toBe(true);
   });
 
-  it("keeps Repositories and Runtime editor-only", () => {
-    expect(tabKeysFor(false, false).map((tab) => tab.key)).toEqual(["profile", "capabilities", "usage"]);
+  it("keeps Channels visible to a non-human read-only viewer while configuration tabs stay editor-only", () => {
+    expect(tabKeysFor(false, false).map((tab) => tab.key)).toEqual(["profile", "channels", "capabilities", "usage"]);
   });
 
   it("gives a human agent only Profile", () => {

--- a/packages/web/src/pages/agent-detail/channels-tab.tsx
+++ b/packages/web/src/pages/agent-detail/channels-tab.tsx
@@ -1,0 +1,14 @@
+import { Navigate } from "react-router";
+import { FeishuSection } from "./feishu-section.js";
+import { useAgentDetailContext } from "./layout-context.js";
+
+export function ChannelsTab() {
+  const ctx = useAgentDetailContext();
+  if (ctx.isHuman) return <Navigate to="../profile" replace />;
+
+  const openProfile = ctx.canManageAgent
+    ? () => ctx.navigateAway(`/agents/${encodeURIComponent(ctx.uuid)}/profile`)
+    : undefined;
+
+  return <FeishuSection onOpenProfile={openProfile} />;
+}

--- a/packages/web/src/pages/agent-detail/feishu-section.tsx
+++ b/packages/web/src/pages/agent-detail/feishu-section.tsx
@@ -1,5 +1,6 @@
+import type { FeishuBotBinding } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { MessageSquare, QrCode, Unplug } from "lucide-react";
+import { CircleAlert, CircleCheck, CircleMinus, Clock3, MessageSquare, QrCode, Unplug } from "lucide-react";
 import {
   createAgentFeishuSetupChat,
   revokeAgentFeishuBinding,
@@ -13,15 +14,35 @@ import {
   feishuBindingLabel,
   feishuBindingQueryKey,
   feishuBindingQueryOptions,
+  isFeishuBotReachable,
 } from "../../features/feishu/binding-view.js";
 import { ConfigRow } from "./flat-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 
 type FeishuSectionProps = {
-  onOpenProfileEdit?: () => void;
+  onOpenProfile?: () => void;
+  /** Visual previews seed a fixed binding and must not start ambient API polling. */
+  poll?: boolean;
 };
 
-function VisibilityRequirement({ onOpenProfileEdit }: FeishuSectionProps) {
+export type FeishuChannelState = "not-connected" | "setup-incomplete" | "ready" | "needs-attention";
+
+/**
+ * One user-value verdict for the whole channel. A reachable Bot is only half
+ * of the promise: the Agent also needs its official CLI before it can reply.
+ * Granted scopes are deliberately not interpreted here; the live connection
+ * and CLI capability are the existing contracts that prove current use.
+ */
+export function feishuChannelState(binding: FeishuBotBinding | null): FeishuChannelState {
+  if (!binding) return "not-connected";
+  if (binding.status === "error" || binding.connectionStatus === "error" || binding.cli.state === "offline") {
+    return "needs-attention";
+  }
+  if (isFeishuBotReachable(binding) && binding.cli.state === "ready") return "ready";
+  return "setup-incomplete";
+}
+
+function VisibilityRequirement({ onOpenProfile }: FeishuSectionProps) {
   return (
     <div className="flex flex-wrap items-center justify-between gap-3" style={{ padding: "var(--sp-3) 0" }}>
       <div>
@@ -32,19 +53,86 @@ function VisibilityRequirement({ onOpenProfileEdit }: FeishuSectionProps) {
           Only organization-visible Agents can connect to a Feishu Bot.
         </div>
       </div>
-      {onOpenProfileEdit && (
-        <Button size="xs" variant="outline" onClick={onOpenProfileEdit}>
-          Change visibility
+      {onOpenProfile && (
+        <Button size="xs" variant="outline" onClick={onOpenProfile}>
+          Manage in Profile
         </Button>
       )}
     </div>
   );
 }
 
-export function FeishuSection({ onOpenProfileEdit }: FeishuSectionProps = {}) {
+function ChannelSummary({ binding }: { binding: FeishuBotBinding | null }) {
+  const state = feishuChannelState(binding);
+  const presentation = (() => {
+    switch (state) {
+      case "not-connected":
+        return {
+          icon: CircleMinus,
+          color: "var(--fg-4)",
+          title: "Not connected",
+          detail: "Teammates can't reach this Agent in Feishu yet.",
+        };
+      case "ready":
+        return {
+          icon: CircleCheck,
+          color: "var(--success)",
+          title: "Ready for Feishu tasks",
+          detail: "The Bot is reachable, and this Agent can reply from its Computer.",
+        };
+      case "needs-attention":
+        return {
+          icon: CircleAlert,
+          color: "var(--state-needs-you)",
+          title: "Needs attention",
+          detail:
+            binding?.lastErrorMessage ??
+            (binding?.cli.state === "offline"
+              ? "The Bot may still receive messages, but this Agent's Computer is offline and can't reply."
+              : "The Feishu channel needs action before this Agent can handle a task."),
+        };
+      case "setup-incomplete":
+        return {
+          icon: Clock3,
+          color: "var(--state-idle)",
+          title: "Setup incomplete",
+          detail:
+            binding && isFeishuBotReachable(binding)
+              ? "The Bot is reachable. Finish the Agent setup before teammates send it a task."
+              : "Finish connecting the Bot before teammates send this Agent a task.",
+        };
+    }
+  })();
+  const StatusIcon = presentation.icon;
+
+  return (
+    <div
+      className="flex items-start gap-3"
+      data-channel-state={state}
+      style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}
+    >
+      <StatusIcon className="h-5 w-5 shrink-0" aria-hidden="true" style={{ color: presentation.color }} />
+      <div className="min-w-0 flex-1">
+        <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          {presentation.title}
+        </div>
+        <div className="text-caption" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
+          {presentation.detail}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function FeishuSection({ onOpenProfile, poll = true }: FeishuSectionProps = {}) {
   const ctx = useAgentDetailContext();
   const queryClient = useQueryClient();
-  const query = useQuery({ ...feishuBindingQueryOptions(ctx.uuid), enabled: !ctx.isHuman });
+  const queryOptions = feishuBindingQueryOptions(ctx.uuid);
+  const query = useQuery({
+    ...queryOptions,
+    enabled: !ctx.isHuman,
+    refetchInterval: poll ? queryOptions.refetchInterval : false,
+  });
   const binding = query.data?.binding ?? null;
   const canConnect = ctx.agent.visibility === "organization";
   const visibilityBlocked = !canConnect && (!binding || binding.status === "error");
@@ -64,29 +152,52 @@ export function FeishuSection({ onOpenProfileEdit }: FeishuSectionProps = {}) {
     mutationFn: () => createAgentFeishuSetupChat(ctx.uuid, { retry: true }),
     onSuccess: ({ chatId }) => ctx.navigateAway(`/?c=${encodeURIComponent(chatId)}`),
   });
-  const error = start.error ?? revoke.error ?? setup.error ?? query.error;
+  const mutationError = start.error ?? revoke.error ?? setup.error;
 
   return (
     <Section
       headingLevel={3}
       title="Feishu"
-      description="Connect a dedicated Feishu Bot to this Agent."
+      description="Teammates reach this Agent through its dedicated Feishu Bot."
       action={
-        ctx.canManageAgent && !binding ? (
+        ctx.canManageAgent && !query.isLoading && !query.isError && !binding ? (
           <Button size="xs" variant="outline" disabled={start.isPending || !canConnect} onClick={() => start.mutate()}>
             <QrCode className="h-3.5 w-3.5" /> {start.isPending ? "Preparing…" : "Connect Bot"}
           </Button>
         ) : null
       }
     >
-      {visibilityBlocked && <VisibilityRequirement onOpenProfileEdit={onOpenProfileEdit} />}
-      {!binding ? (
+      {query.isLoading ? (
+        <div className="text-body" role="status" style={{ padding: "var(--sp-3) 0", color: "var(--fg-3)" }}>
+          Checking Feishu channel…
+        </div>
+      ) : query.isError && !query.data ? (
+        <div className="flex flex-wrap items-center justify-between gap-3" style={{ padding: "var(--sp-3) 0" }}>
+          <div role="alert">
+            <div className="text-body font-medium" style={{ color: "var(--state-error)" }}>
+              Couldn't check this channel
+            </div>
+            <div className="text-caption" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
+              {query.error instanceof Error ? query.error.message : "Feishu status is unavailable."}
+            </div>
+          </div>
+          <Button size="xs" variant="outline" disabled={query.isFetching} onClick={() => void query.refetch()}>
+            {query.isFetching ? "Retrying…" : "Retry"}
+          </Button>
+        </div>
+      ) : (
+        <>
+          <ChannelSummary binding={binding} />
+          {visibilityBlocked && <VisibilityRequirement onOpenProfile={onOpenProfile} />}
+        </>
+      )}
+      {!query.isLoading && !query.isError && !binding ? (
         canConnect ? (
           <div className="text-body" style={{ padding: "var(--sp-3) 0", color: "var(--fg-3)" }}>
-            No Feishu Bot is connected. First Tree will prepare the app and show a QR code; you only confirm in Feishu.
+            First Tree will prepare the app and show a QR code; you only confirm it in Feishu.
           </div>
         ) : null
-      ) : (
+      ) : binding ? (
         <>
           <ConfigRow
             label="Bot"
@@ -122,7 +233,15 @@ export function FeishuSection({ onOpenProfileEdit }: FeishuSectionProps = {}) {
               ) : undefined
             }
             meta={
-              <DenseBadge tone={binding.status === "error" ? "error" : binding.status === "active" ? "accent" : "warn"}>
+              <DenseBadge
+                tone={
+                  binding.status === "error" || binding.connectionStatus === "error"
+                    ? "error"
+                    : isFeishuBotReachable(binding)
+                      ? "accent"
+                      : "warn"
+                }
+              >
                 {feishuBindingLabel(binding.status, binding.connectionStatus)}
               </DenseBadge>
             }
@@ -167,7 +286,7 @@ export function FeishuSection({ onOpenProfileEdit }: FeishuSectionProps = {}) {
                     ? "Computer offline"
                     : "Not detected"
               }
-              description="The Agent records outbound intent in First Tree, then calls the official lark-cli directly with a temporary Bot credential environment."
+              description="This Agent uses the official Feishu CLI on its Computer to reply to tasks."
               action={
                 ctx.canManageAgent && binding.cli.state !== "ready" ? (
                   <Button size="xs" variant="outline" disabled={setup.isPending} onClick={() => setup.mutate()}>
@@ -178,10 +297,10 @@ export function FeishuSection({ onOpenProfileEdit }: FeishuSectionProps = {}) {
             />
           )}
         </>
-      )}
-      {error && (
+      ) : null}
+      {mutationError && (
         <div className="text-caption" role="alert" style={{ color: "var(--state-error)", padding: "var(--sp-2) 0" }}>
-          {error instanceof Error ? error.message : "Feishu setup failed."}
+          {mutationError instanceof Error ? mutationError.message : "Feishu setup failed."}
         </div>
       )}
     </Section>

--- a/packages/web/src/pages/agent-detail/feishu-section.tsx
+++ b/packages/web/src/pages/agent-detail/feishu-section.tsx
@@ -1,4 +1,4 @@
-import type { FeishuBotBinding } from "@first-tree/shared";
+import type { Agent, FeishuBotBinding } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CircleAlert, CircleCheck, CircleMinus, Clock3, MessageSquare, QrCode, Unplug } from "lucide-react";
 import {
@@ -15,6 +15,7 @@ import {
   feishuBindingQueryKey,
   feishuBindingQueryOptions,
   isFeishuBotReachable,
+  isFeishuHandoffUsable,
 } from "../../features/feishu/binding-view.js";
 import { ConfigRow } from "./flat-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
@@ -33,12 +34,13 @@ export type FeishuChannelState = "not-connected" | "setup-incomplete" | "ready" 
  * Granted scopes are deliberately not interpreted here; the live connection
  * and CLI capability are the existing contracts that prove current use.
  */
-export function feishuChannelState(binding: FeishuBotBinding | null): FeishuChannelState {
+export function feishuChannelState(binding: FeishuBotBinding | null, agentStatus: Agent["status"]): FeishuChannelState {
+  if (agentStatus !== "active") return "needs-attention";
   if (!binding) return "not-connected";
   if (binding.status === "error" || binding.connectionStatus === "error" || binding.cli.state === "offline") {
     return "needs-attention";
   }
-  if (isFeishuBotReachable(binding) && binding.cli.state === "ready") return "ready";
+  if (isFeishuHandoffUsable(binding)) return "ready";
   return "setup-incomplete";
 }
 
@@ -62,8 +64,8 @@ function VisibilityRequirement({ onOpenProfile }: FeishuSectionProps) {
   );
 }
 
-function ChannelSummary({ binding }: { binding: FeishuBotBinding | null }) {
-  const state = feishuChannelState(binding);
+function ChannelSummary({ binding, agentStatus }: { binding: FeishuBotBinding | null; agentStatus: Agent["status"] }) {
+  const state = feishuChannelState(binding, agentStatus);
   const presentation = (() => {
     switch (state) {
       case "not-connected":
@@ -84,12 +86,14 @@ function ChannelSummary({ binding }: { binding: FeishuBotBinding | null }) {
         return {
           icon: CircleAlert,
           color: "var(--state-needs-you)",
-          title: "Needs attention",
+          title: agentStatus === "suspended" ? "Agent is suspended" : "Needs attention",
           detail:
-            binding?.lastErrorMessage ??
-            (binding?.cli.state === "offline"
-              ? "The Bot may still receive messages, but this Agent's Computer is offline and can't reply."
-              : "The Feishu channel needs action before this Agent can handle a task."),
+            agentStatus === "suspended"
+              ? "Reactivate this Agent in Profile before teammates send it a Feishu task."
+              : (binding?.lastErrorMessage ??
+                (binding?.cli.state === "offline"
+                  ? "The Bot may still receive messages, but this Agent's Computer is offline and can't reply."
+                  : "The Feishu channel needs action before this Agent can handle a task.")),
         };
       case "setup-incomplete":
         return {
@@ -187,7 +191,7 @@ export function FeishuSection({ onOpenProfile, poll = true }: FeishuSectionProps
         </div>
       ) : (
         <>
-          <ChannelSummary binding={binding} />
+          <ChannelSummary binding={binding} agentStatus={ctx.agent.status} />
           {visibilityBlocked && <VisibilityRequirement onOpenProfile={onOpenProfile} />}
         </>
       )}

--- a/packages/web/src/pages/agent-detail/profile-tab.tsx
+++ b/packages/web/src/pages/agent-detail/profile-tab.tsx
@@ -3,7 +3,6 @@ import { Button } from "../../components/ui/button.js";
 import { AppearanceSection } from "./appearance-section.js";
 import { useAgentResources } from "./capability-section.js";
 import { DangerZone } from "./danger-zone.js";
-import { FeishuSection } from "./feishu-section.js";
 import { IdentitySection } from "./identity-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { ProfileEditDialog } from "./profile-edit-dialog.js";
@@ -60,7 +59,6 @@ export function ProfileTab() {
           version={resources.data.version}
         />
       ) : null}
-      {!ctx.isHuman && <FeishuSection onOpenProfileEdit={onEdit} />}
       {/* Agent lifecycle is identity-level, so destructive controls stay at the
           end of Profile instead of mixing with runtime configuration. */}
       {ctx.canManageAgent && ctx.agent.type !== "human" && (

--- a/packages/web/src/pages/agent-detail/tabs.ts
+++ b/packages/web/src/pages/agent-detail/tabs.ts
@@ -5,6 +5,7 @@ export type TabDef = { key: string; label: string; path: string; description: st
 // handled as a redirect in app.tsx and is no longer part of this collection.
 const TAB_LABELS: Record<string, string> = {
   profile: "Profile",
+  channels: "Channels",
   runtime: "Runtime",
   prompt: "Instructions",
   capabilities: "Tools & skills",
@@ -14,6 +15,7 @@ const TAB_LABELS: Record<string, string> = {
 
 const TAB_DESCRIPTIONS: Record<string, string> = {
   profile: "Identity, ownership, and lifecycle for this agent.",
+  channels: "Where teammates can reach this agent and whether it can handle a task now.",
   runtime: "Where this agent runs and how it is configured.",
   prompt: "Guidance that shapes how this agent behaves.",
   capabilities: "Skills and integrations configured for this agent.",
@@ -27,9 +29,13 @@ const TAB_DESCRIPTIONS: Record<string, string> = {
  */
 export function tabKeysFor(canEditConfig: boolean, isHuman: boolean): { key: string; path: string }[] {
   const tabs: { key: string; path: string }[] = [{ key: "profile", path: "profile" }];
+  if (!isHuman) {
+    tabs.push({ key: "channels", path: "channels" });
+  }
   if (canEditConfig) {
-    // Runtime (model/effort/computer/env) comes first, followed by Instructions
-    // and the two resource tabs. Adopted Template provenance lives inside Profile.
+    // Channels follows Profile because it is how teammates reach the Agent;
+    // runtime configuration comes next, followed by Instructions and resources.
+    // Adopted Template provenance lives inside Profile.
     // Repositories is editor-only — repos + the read-only context tree lived on
     // the old (editor-only) Environment tab, so non-editors never saw them and
     // still don't.

--- a/packages/web/src/pages/opentag/__tests__/flow.test.ts
+++ b/packages/web/src/pages/opentag/__tests__/flow.test.ts
@@ -1,7 +1,8 @@
 import type { FeishuBotBinding } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
+import { isFeishuHandoffUsable } from "../../../features/feishu/binding-view.js";
 import { shouldEnterOnboarding } from "../../onboarding/steps.js";
-import { classifyOpenTagAgent, isFeishuHandoffUsable, type OpenTagAgentRead, resolveOpenTagStep } from "../flow.js";
+import { classifyOpenTagAgent, type OpenTagAgentRead, resolveOpenTagStep } from "../flow.js";
 
 const ORG = "org-1";
 

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -1203,7 +1203,7 @@ describe("OpenTag entry — preparing the Agent's own Feishu tools", () => {
     expect(container.textContent).not.toContain("Preparing this Computer in the background");
     expect(button(container, "Try again").disabled).toBe(false);
     // Leaving lands on the Agent's own page — the one permanent repair entry.
-    expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/profile']`)?.textContent).toContain("Finish later");
+    expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/channels']`)?.textContent).toContain("Finish later");
     // Leaving does not finish onboarding, and it is not the first task.
     expect(markOnboardingCompleted).not.toHaveBeenCalled();
     expect(container.textContent).not.toContain("has its first task from Feishu");
@@ -1260,7 +1260,7 @@ describe("OpenTag entry — preparing the Agent's own Feishu tools", () => {
 
       expect(container.textContent).toContain("You are not stuck here.");
       expect(button(container, "Try again").disabled).toBe(false);
-      expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/profile']`)).not.toBeNull();
+      expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/channels']`)).not.toBeNull();
     } finally {
       vi.useRealTimers();
     }
@@ -1371,7 +1371,9 @@ describe("OpenTag entry — whose setup this step is finishing", () => {
       });
       await flush();
 
-      expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/profile']`)?.textContent).toContain("Finish later");
+      expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/channels']`)?.textContent).toContain(
+        "Finish later",
+      );
       // Retrying the automatic preparation would be a lie: it has nothing left
       // to do, and the outstanding half is the member's own confirmation.
       expect(container.textContent).not.toContain("Try again");
@@ -1490,7 +1492,7 @@ describe("OpenTag entry — an Agent with no Computer to prepare", () => {
     expect(container.textContent).toContain("This Agent has no Computer yet.");
     expect(container.textContent).not.toContain("Preparing this Computer in the background");
     // Offered immediately, and only the way out that can actually help.
-    expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/profile']`)?.textContent).toContain("Finish later");
+    expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/channels']`)?.textContent).toContain("Finish later");
     expect(container.textContent).not.toContain("Try again");
     // And nothing is asked of a Computer that does not exist.
     expect(api.createAgentFeishuSetupChat).not.toHaveBeenCalled();
@@ -1521,7 +1523,7 @@ describe("OpenTag entry — a Bot that failed", () => {
     await flush();
 
     expect(container.querySelector("[role='alert']")?.textContent).toContain("Feishu rejected the Bot credentials.");
-    expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/profile']`)?.textContent).toContain("Finish later");
+    expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/channels']`)?.textContent).toContain("Finish later");
     // The one standing heading has to hold here too: confirming is not the
     // outstanding action, and this member could not do it anyway.
     expect(container.textContent).not.toContain("Confirm the Bot in Feishu");
@@ -1553,7 +1555,7 @@ describe("OpenTag entry — retrying is scoped to the half it retries", () => {
     const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
     await flush();
 
-    expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/profile']`)?.textContent).toContain("Finish later");
+    expect(container.querySelector(`a[href='/agents/${AGENT_UUID}/channels']`)?.textContent).toContain("Finish later");
     expect(container.textContent).not.toContain("Try again");
     // One ensure call for the Computer, and nothing beyond it.
     expect(api.createAgentFeishuSetupChat).toHaveBeenCalledTimes(1);

--- a/packages/web/src/pages/opentag/flow.ts
+++ b/packages/web/src/pages/opentag/flow.ts
@@ -1,4 +1,4 @@
-import type { Agent, FeishuBotBinding } from "@first-tree/shared";
+import type { Agent } from "@first-tree/shared";
 import { canManageAgentDetail } from "../agent-detail/access.js";
 
 /**
@@ -134,19 +134,6 @@ export type OpenTagFirstUse =
  * is offered a way forward rather than an error.
  */
 export const FEISHU_TOOLS_SLOW_MS = 90_000;
-
-/**
- * Whether this Agent can actually carry Feishu work right now.
- *
- * Both halves have to hold at once. A reachable Bot with no CLI receives
- * messages the Agent cannot answer, and finishing onboarding on that would
- * declare a handoff that does not work; a ready CLI with no Bot has nothing to
- * answer. Only the pair is the thing the member was promised.
- */
-export function isFeishuHandoffUsable(binding: FeishuBotBinding | null): boolean {
-  if (!binding) return false;
-  return binding.status === "active" && binding.connectionStatus === "connected" && binding.cli.state === "ready";
-}
 
 /**
  * Where an Agent in the URL puts the member, or `null` while the facts have not

--- a/packages/web/src/pages/opentag/opentag-page.tsx
+++ b/packages/web/src/pages/opentag/opentag-page.tsx
@@ -7,14 +7,17 @@ import { ApiError } from "../../api/client.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { useComputerConnection } from "../../features/agent-setup/use-computer-connection.js";
-import { feishuBindingQueryKey, feishuBindingQueryOptions } from "../../features/feishu/binding-view.js";
+import {
+  feishuBindingQueryKey,
+  feishuBindingQueryOptions,
+  isFeishuHandoffUsable,
+} from "../../features/feishu/binding-view.js";
 import { slugify } from "../../utils/agent-naming.js";
 import { FlowHint } from "../onboarding/flow-ui.js";
 import { createOpenTagFirstUseScan, FIRST_USE_POLL_MS } from "./first-use.js";
 import {
   classifyOpenTagAgent,
   FEISHU_TOOLS_SLOW_MS,
-  isFeishuHandoffUsable,
   OPENTAG_STEPS,
   type OpenTagFirstUse,
   type OpenTagStepId,

--- a/packages/web/src/pages/opentag/steps/step-connect-feishu.tsx
+++ b/packages/web/src/pages/opentag/steps/step-connect-feishu.tsx
@@ -3,10 +3,13 @@ import type { LucideIcon } from "lucide-react";
 import { CircleAlert, CircleCheck, Clock3, QrCode } from "lucide-react";
 import type { ReactElement } from "react";
 import { Button } from "../../../components/ui/button.js";
-import { FeishuRegistrationQr, isFeishuBotReachable } from "../../../features/feishu/binding-view.js";
+import {
+  FeishuRegistrationQr,
+  isFeishuBotReachable,
+  isFeishuHandoffUsable,
+} from "../../../features/feishu/binding-view.js";
 import { FlowHint } from "../../onboarding/flow-ui.js";
 import { OPENTAG_FEISHU_READINESS_COPY } from "../copy.js";
-import { isFeishuHandoffUsable } from "../flow.js";
 
 /**
  * The focused Feishu step: one Bot for this one Agent.
@@ -301,7 +304,7 @@ function ToolsPanel({
                 preparing, and the Agent's own page is where this can be picked
                 up again for good. Onboarding stays unfinished on purpose. */}
             <Button type="button" variant="ghost" asChild>
-              <a href={`/agents/${encodeURIComponent(agentUuid)}/profile`}>{copy.finishLater}</a>
+              <a href={`/agents/${encodeURIComponent(agentUuid)}/channels`}>{copy.finishLater}</a>
             </Button>
           </div>
         </>


### PR DESCRIPTION
## Summary

- add `Channels` immediately after `Profile` in Agent Detail for non-human Agents
- move the existing Feishu Bot surface out of Profile and preserve its registration, QR confirmation, polling, repair Task, and disconnect flows
- present one task-readiness verdict across not connected, setup incomplete, ready, and needs attention states without conflating runtime presence with channel readiness
- keep read-only and human-Agent visibility rules intact, using only existing Web and API contracts

## Validation

- `pnpm check` (passes; existing unrelated warnings remain)
- `pnpm typecheck`
- `pnpm --filter @first-tree/web test` — 253 files, 2,423 tests passed
- focused Agent Detail coverage — 6 files, 92 tests passed
- visually verified the real Agent Detail preview at 1440×1000 and 390×844: the readiness verdict remains first, technical details stay secondary, rows stack cleanly, and no horizontal overflow appears

The repository-wide `pnpm test` run was also attempted. It did not complete green because existing CLI, runtime-provider, and Context Tree skill-eval timing tests failed outside `packages/web`; the complete Web suite passed independently.

## Scope

This PR changes `packages/web` only. It contains no Server, shared schema, database, migration, provider, runtime, onboarding, Workspace Task, or Settings changes.
