### PR TITLE
feat(web): add member Team Agents entry

### DIFF
--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -7,8 +7,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+const authStateMock = vi.hoisted(() => ({ role: "admin" as "admin" | "member" | null }));
+
 vi.mock("../auth/auth-context.js", () => ({
   AuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useAuth: () => authStateMock,
 }));
 
 vi.mock("../auth/require-auth.js", async () => {
@@ -266,6 +269,7 @@ describe("App routes", () => {
         "~/.local/bin/first-tree-staging login FIRST_TREE_CONNECT_CODE_PLACEHOLDER",
       codePlaceholder: "FIRST_TREE_CONNECT_CODE_PLACEHOLDER",
     };
+    authStateMock.role = "admin";
     routerCommitMock.selectedChatIdAfterUrgentUpdate = null;
   });
 
@@ -440,6 +444,14 @@ describe("App routes", () => {
     setViewportWidth(390);
     expect(await renderAppAt("/m/chat")).toContain("mobile work");
     expect(window.location.pathname).toBe("/m/chat");
+  });
+
+  it("opens Team Agents from a member's bare mobile root", async () => {
+    authStateMock.role = "member";
+    setViewportWidth(390);
+
+    expect(await renderAppAt("/")).toContain("team page");
+    expect(window.location.pathname).toBe("/team");
   });
 
   it("waits for the server channel before choosing the mobile or desktop shell", async () => {

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router";
 import { RouteTracker } from "./analytics.js";
-import { AuthProvider } from "./auth/auth-context.js";
+import { AuthProvider, useAuth } from "./auth/auth-context.js";
 import { RequireAuth } from "./auth/require-auth.js";
 import { Layout } from "./components/layout.js";
 import { Button } from "./components/ui/button.js";
@@ -583,8 +583,12 @@ function ContextTreeSetupPreviewUnavailable() {
 
 function WorkspaceEntry() {
   const location = useLocation();
+  const { role } = useAuth();
   const mobileExperience = useMobileExperienceState();
   if (!mobileExperience.settled) return null;
+  if (role === "member" && shouldOpenMobileRoot(location)) {
+    return <Navigate to="/team" replace />;
+  }
   if (mobileExperience.enabled && shouldOpenMobileRoot(location)) {
     return <Navigate to="/m/chat" replace />;
   }

--- a/packages/web/src/features/feishu/binding-view.tsx
+++ b/packages/web/src/features/feishu/binding-view.tsx
@@ -23,16 +23,19 @@ export function feishuBindingQueryKey(agentUuid: string): [string, string] {
 }
 
 /**
- * One read contract for the binding: while Feishu is still provisioning the
- * Bot the member is watching the page, so it polls fast; afterwards it drops
- * back to an ambient refresh.
+ * One read contract for the binding. Setup/detail surfaces poll while the
+ * member watches provisioning; directory snapshots can explicitly opt out so
+ * one open roster does not create a per-Agent polling fan-out.
  */
-export function feishuBindingQueryOptions(agentUuid: string) {
+export function feishuBindingQueryOptions(agentUuid: string, options: { poll?: boolean } = {}) {
   return {
     queryKey: feishuBindingQueryKey(agentUuid),
     queryFn: () => getAgentFeishuBinding(agentUuid),
-    refetchInterval: (state: { state: { data?: { binding: FeishuBotBinding | null } } }) =>
-      state.state.data?.binding?.status === "provisioning" ? PROVISIONING_POLL_MS : IDLE_POLL_MS,
+    refetchInterval:
+      options.poll === false
+        ? (false as const)
+        : (state: { state: { data?: { binding: FeishuBotBinding | null } } }) =>
+            state.state.data?.binding?.status === "provisioning" ? PROVISIONING_POLL_MS : IDLE_POLL_MS,
   };
 }
 
@@ -54,6 +57,15 @@ export function feishuBindingLabel(
  */
 export function isFeishuBotReachable(binding: FeishuBotBinding): boolean {
   return binding.status === "active" && binding.connectionStatus === "connected";
+}
+
+/**
+ * Whether the Agent's Feishu handoff is configured to carry work. Both halves
+ * have to hold: the Bot must receive messages and the CLI must be ready to
+ * answer them. Agent lifecycle is a separate caller-owned constraint.
+ */
+export function isFeishuHandoffUsable(binding: FeishuBotBinding | null): boolean {
+  return !!binding && isFeishuBotReachable(binding) && binding.cli.state === "ready";
 }
 
 /**

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1377,6 +1377,124 @@ video[data-onboarding-orientation-video]::cue {
   padding: var(--sp-2) var(--sp-5) var(--sp-7);
 }
 
+/* Invited-member Team entry. Fixed column tracks keep 1/2/3-card states the
+   same width and left aligned instead of stretching sparse rows. */
+.member-team-agents-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
+  padding: var(--sp-2) var(--sp-5) var(--sp-7);
+}
+
+.member-team-agent-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: stretch;
+  gap: var(--sp-4);
+}
+
+@media (min-width: 48rem) {
+  .member-team-agent-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 75rem) {
+  .member-team-agent-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.member-team-agent-card {
+  display: flex;
+  min-width: 0;
+  height: 100%;
+  flex-direction: column;
+}
+
+.member-team-agent-card-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-5);
+}
+
+.member-team-agent-card-content {
+  flex: 1;
+  padding: 0 var(--sp-5);
+}
+
+.member-team-agent-responsibility {
+  display: -webkit-box;
+  min-height: calc(var(--text-body) * var(--text-body--line-height) * 2);
+  margin: 0;
+  overflow: hidden;
+  color: var(--fg-2);
+  font-size: var(--text-body);
+  line-height: var(--text-body--line-height);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.member-team-agent-card-footer {
+  margin-top: auto;
+  padding: var(--sp-5);
+  padding-top: var(--sp-5);
+}
+
+.member-team-agents-group-hint {
+  margin: 0;
+  color: var(--fg-3);
+  font-size: var(--text-label);
+  line-height: var(--text-label--line-height);
+}
+
+.member-team-agents-status,
+.member-team-agents-empty {
+  margin: 0;
+  color: var(--fg-3);
+  font-size: var(--text-body);
+  line-height: var(--text-body--line-height);
+}
+
+.member-team-agents-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-3);
+  padding: var(--sp-6) 0;
+}
+
+.member-team-agents-status p {
+  margin: 0;
+}
+
+.member-team-agents-empty {
+  display: flex;
+  max-width: var(--sp-95);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-2);
+  padding: var(--sp-6) 0;
+}
+
+.member-team-agents-empty h2,
+.member-team-agents-empty p {
+  margin: 0;
+}
+
+.member-team-agents-empty-icon {
+  display: inline-flex;
+  width: var(--sp-10);
+  height: var(--sp-10);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-input);
+  background: var(--bg-sunken);
+  color: var(--fg-2);
+}
+
 /* Live-sync chip in the PageHeader right slot: pulsing glow dot + "LIVE"
    eyebrow + last-synced time. Always-present liveness signal, dense. */
 .context-live-status {

--- a/packages/web/src/pages/__tests__/invite-accept-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/invite-accept-dom.test.tsx
@@ -14,10 +14,6 @@ const clientMocks = vi.hoisted(() => ({
   post: vi.fn(),
 }));
 
-const onboardingMocks = vi.hoisted(() => ({
-  markOnboardingResume: vi.fn(),
-}));
-
 const navigateMock = vi.hoisted(() => vi.fn());
 
 const authMock = vi.hoisted(() => {
@@ -59,7 +55,6 @@ vi.mock("../../auth/auth-context.js", () => ({
   AuthProvider: ({ children }: { children: ReactNode }) => children,
   useAuth: () => authMock.value,
 }));
-vi.mock("../../utils/onboarding-flags.js", () => onboardingMocks);
 vi.mock("react-router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-router")>();
   return { ...actual, useNavigate: () => navigateMock };
@@ -150,7 +145,6 @@ beforeEach(() => {
   clientMocks.get.mockReset();
   providerAvailability = { google: true, github: true };
   clientMocks.post.mockReset();
-  onboardingMocks.markOnboardingResume.mockReset();
   clientMocks.get.mockImplementation(async (path: string) => {
     if (path === "/bootstrap/config") return { authProviders: providerAvailability };
     if (path === "/me/organizations") return [org()];
@@ -181,7 +175,7 @@ afterEach(async () => {
 });
 
 describe("InviteAcceptPage", () => {
-  it("loads a preview, warns about switching teams, joins, and resumes onboarding", async () => {
+  it("loads a preview, warns about switching teams, joins, and opens Team Agents", async () => {
     const { InviteAcceptPage } = await import("../invite-accept.js");
     const container = await renderDom(<InviteAcceptPage />);
 
@@ -194,8 +188,7 @@ describe("InviteAcceptPage", () => {
     await click(buttonByText(container, "Join New Team"));
     expect(clientMocks.post).toHaveBeenCalledWith("/me/organizations/join", { token: "token-1" });
     expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-new");
-    expect(onboardingMocks.markOnboardingResume).toHaveBeenCalledWith("invite");
-    expect(navigateMock).toHaveBeenCalledWith("/onboarding", { replace: true });
+    expect(navigateMock).toHaveBeenCalledWith("/team", { replace: true });
   });
 
   it("renders public OAuth and invalid invitation states", async () => {

--- a/packages/web/src/pages/__tests__/invite-accept-join.test.tsx
+++ b/packages/web/src/pages/__tests__/invite-accept-join.test.tsx
@@ -89,6 +89,7 @@ describe("InviteAcceptPage — authenticated join", () => {
           <Routes>
             <Route path="/invite/:token" element={<InviteAcceptPage />} />
             <Route path="/" element={<div>workspace</div>} />
+            <Route path="/team" element={<div>team agents</div>} />
           </Routes>
         </MemoryRouter>,
       );
@@ -109,6 +110,7 @@ describe("InviteAcceptPage — authenticated join", () => {
     expect(apiMocks.post).toHaveBeenCalledWith("/me/organizations/join", { token: "tok-123" });
     // Switched to the just-joined org.
     expect(authMocks.selectOrganization).toHaveBeenCalledWith("org-invited");
+    expect(container?.textContent).toContain("team agents");
     // Crucially: never adopted tokens (the endpoint returns none — adopting
     // `undefined` is what corrupted the session / logged the user out).
     expect(authMocks.adoptTokens).not.toHaveBeenCalled();

--- a/packages/web/src/pages/invite-accept.tsx
+++ b/packages/web/src/pages/invite-accept.tsx
@@ -9,7 +9,6 @@ import { FirstTreeLogo } from "../components/first-tree-logo.js";
 import { Button } from "../components/ui/button.js";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
 import { useAuthProviderAvailabilityState } from "../hooks/use-server-channel.js";
-import { markOnboardingResume } from "../utils/onboarding-flags.js";
 
 /**
  * Public landing for `/invite/:token`. Two cases:
@@ -93,8 +92,7 @@ export function InviteAcceptPage() {
         role: string;
       }>("/me/organizations/join", { token });
       await selectOrganization(res.organizationId);
-      markOnboardingResume("invite");
-      navigate("/onboarding", { replace: true });
+      navigate("/team", { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to join team");
     } finally {

--- a/packages/web/src/pages/onboarding/__tests__/onboarding-page-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/onboarding-page-dom.test.tsx
@@ -228,6 +228,17 @@ describe("OnboardingPage", () => {
     expect(container.textContent).not.toContain("Get Started Step");
   });
 
+  it("keeps an unresolved role on the existing invitee recovery path", async () => {
+    authMock.value = { ...authMock.value, role: null };
+    flowMock.activeStep = "get-started";
+
+    const container = await renderRoute(<OnboardingPage />);
+
+    expect(container.textContent).toContain("Get Started Step");
+    expect(container.querySelector('[data-flow-path="invitee"]')).toBeTruthy();
+    expect(container.textContent).not.toContain("Team Agents");
+  });
+
   it("renders no body for an unknown flow step", async () => {
     flowMock.activeStep = "unknown";
 

--- a/packages/web/src/pages/onboarding/__tests__/onboarding-page-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/onboarding-page-dom.test.tsx
@@ -73,6 +73,7 @@ async function renderRoute(element: ReactElement, route = "/onboarding"): Promis
       <MemoryRouter initialEntries={[route]}>
         <Routes>
           <Route path="/" element={<div>Workspace Home</div>} />
+          <Route path="/team" element={<div>Team Agents</div>} />
           <Route path="/onboarding" element={element} />
         </Routes>
       </MemoryRouter>,
@@ -204,7 +205,6 @@ describe("OnboardingPage", () => {
       ["connect-computer", "Connect Computer Step", "admin", "admin"],
       ["create-agent", "Create Agent Step", "admin", "admin"],
       ["start-chat", "Start Chat Step", "admin", "admin"],
-      ["get-started", "Get Started Step", "member", "invitee"],
     ];
 
     for (const [step, label, role, path] of cases) {
@@ -216,6 +216,16 @@ describe("OnboardingPage", () => {
       expect(container.querySelector(`[data-flow-path="${path}"]`)).toBeTruthy();
       await cleanupRoot();
     }
+  });
+
+  it("routes invited members to Team Agents instead of personal setup", async () => {
+    authMock.value = { ...authMock.value, role: "member", currentOrgHasPersonalAgent: false };
+    flowMock.activeStep = "get-started";
+
+    const container = await renderRoute(<OnboardingPage />);
+
+    expect(container.textContent).toContain("Team Agents");
+    expect(container.textContent).not.toContain("Get Started Step");
   });
 
   it("renders no body for an unknown flow step", async () => {

--- a/packages/web/src/pages/onboarding/onboarding-page.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-page.tsx
@@ -40,6 +40,12 @@ export function OnboardingPage() {
   if (!meLoaded) {
     return <div className="min-h-screen bg-background" />;
   }
+  // Invited members enter through the Team's ready Agents. Personal Agent and
+  // Computer setup is an admin journey here; a later member-owned Agent entry
+  // belongs to its own, deliberately weaker surface.
+  if (role !== "admin") {
+    return <Navigate to="/team" replace />;
+  }
   if (leaveDecision.current === null) {
     leaveDecision.current = shouldLeaveOnboarding({
       meLoaded,

--- a/packages/web/src/pages/onboarding/onboarding-page.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-page.tsx
@@ -43,7 +43,7 @@ export function OnboardingPage() {
   // Invited members enter through the Team's ready Agents. Personal Agent and
   // Computer setup is an admin journey here; a later member-owned Agent entry
   // belongs to its own, deliberately weaker surface.
-  if (role !== "admin") {
+  if (role === "member") {
     return <Navigate to="/team" replace />;
   }
   if (leaveDecision.current === null) {

--- a/packages/web/src/pages/onboarding/onboarding-page.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-page.tsx
@@ -17,8 +17,8 @@ import { resolveOnboardingPath, shouldLeaveOnboarding } from "./steps.js";
  * here; once setup is terminally complete this route bounces back to `/`.
  *
  * The "bounce back" is an ENTRY-time guard, decided ONCE when `/me` first
- * loads — not a live leash re-checked every render. Both admin and invitee
- * have start-chat AFTER create-agent, and creating the agent flips
+ * loads — not a live leash re-checked every render. The admin path has
+ * start-chat AFTER create-agent, and creating the agent flips
  * `currentOrgHasPersonalAgent` true (the flow's own `refreshMe` surfaces it the
  * moment the agent comes online). A
  * per-render check therefore ejected an actively-onboarding user the instant
@@ -40,9 +40,9 @@ export function OnboardingPage() {
   if (!meLoaded) {
     return <div className="min-h-screen bg-background" />;
   }
-  // Invited members enter through the Team's ready Agents. Personal Agent and
-  // Computer setup is an admin journey here; a later member-owned Agent entry
-  // belongs to its own, deliberately weaker surface.
+  // A confirmed Member never enters the legacy invitee wizard: they go to the
+  // Team Agent directory. The invitee path below remains only for the
+  // unresolved-role recovery state and the explicit onboarding preview.
   if (role === "member") {
     return <Navigate to="/team" replace />;
   }

--- a/packages/web/src/pages/onboarding/steps.ts
+++ b/packages/web/src/pages/onboarding/steps.ts
@@ -10,8 +10,9 @@
  * Two paths:
  *   - "admin"   — the team creator (org admin). Creates/confirms the team,
  *                 connects a computer, creates the agent, and starts chat.
- *   - "invitee" — joining an existing team. Starts with the personal First
- *                 Tree agent journey and can explicitly continue without one.
+ *   - "invitee" — legacy preview plus unresolved-role recovery. Confirmed
+ *                 Members are redirected to the Team Agent directory before
+ *                 this sequence is mounted.
  *
  * Step ids are deliberately product-facing, jargon-free concepts — never
  * "tree" / "binding" / "runtime" / "installation". The user-facing strings
@@ -27,12 +28,10 @@
 // flow populates `selectedRepoUrls`, so the repo-aware branches downstream
 // (e.g. the `hasRepos` path in step-start-chat.tsx) stay dormant by design.
 export const ADMIN_STEPS = ["create-team", "connect-computer", "create-agent", "start-chat"] as const;
-// Invite acceptance already creates the membership and selects the joined
-// Team. Repeating "Join team" inside onboarding adds no decision or work, so
-// invited members land directly on the recommended personal-agent entry. The
-// product starts with
-// the personal-agent journey. Team-agent quick start and optional external
-// Context access are revealed only after explicit continuation.
+// Retained for the explicit onboarding preview and the unresolved-role
+// recovery state. Confirmed Members do not enter this sequence; any later
+// member-owned Agent entry is a separate weak surface, not this setup-first
+// route.
 export const INVITEE_STEPS = ["get-started", "connect-computer", "create-agent", "start-chat"] as const;
 
 /**

--- a/packages/web/src/pages/opentag/flow.ts
+++ b/packages/web/src/pages/opentag/flow.ts
@@ -1,5 +1,7 @@
-import type { Agent, FeishuBotBinding } from "@first-tree/shared";
+import type { Agent } from "@first-tree/shared";
 import { canManageAgentDetail } from "../agent-detail/access.js";
+
+export { isFeishuHandoffUsable } from "../../features/feishu/binding-view.js";
 
 /**
  * Pure step logic for the standalone `/opentag` entry.
@@ -134,19 +136,6 @@ export type OpenTagFirstUse =
  * is offered a way forward rather than an error.
  */
 export const FEISHU_TOOLS_SLOW_MS = 90_000;
-
-/**
- * Whether this Agent can actually carry Feishu work right now.
- *
- * Both halves have to hold at once. A reachable Bot with no CLI receives
- * messages the Agent cannot answer, and finishing onboarding on that would
- * declare a handoff that does not work; a ready CLI with no Bot has nothing to
- * answer. Only the pair is the thing the member was promised.
- */
-export function isFeishuHandoffUsable(binding: FeishuBotBinding | null): boolean {
-  if (!binding) return false;
-  return binding.status === "active" && binding.connectionStatus === "connected" && binding.cli.state === "ready";
-}
 
 /**
  * Where an Agent in the URL puts the member, or `null` while the facts have not

--- a/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
@@ -12,13 +12,11 @@ const agentApi = vi.hoisted(() => ({
   listAgents: vi.fn(),
   getAgentFeishuBinding: vi.fn(),
 }));
-const resourceApi = vi.hoisted(() => ({ getAgentResources: vi.fn() }));
 const authMock = vi.hoisted(() => ({
   value: { organizationId: "org-1", teamDisplayName: "Acme", role: "member" },
 }));
 
 vi.mock("../../../api/agents.js", () => agentApi);
-vi.mock("../../../api/agent-resources.js", () => resourceApi);
 vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
 
 const NOW = "2026-08-14T00:00:00.000Z";
@@ -101,9 +99,6 @@ beforeEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
   authMock.value = { organizationId: "org-1", teamDisplayName: "Acme", role: "member" };
-  resourceApi.getAgentResources.mockImplementation(async (uuid: string) => ({
-    adoptedTemplates: [{ public: { tagline: `Handles ${uuid} work.` } }],
-  }));
 });
 
 afterEach(() => {
@@ -188,10 +183,8 @@ describe("Member Team Agents page", () => {
     await act(async () => root.unmount());
   });
 
-  it("removes a handoff after the roster poll observes that its Agent went offline", async () => {
-    agentApi.listAgents
-      .mockResolvedValueOnce({ items: [agent(1, { displayName: "Atlas" })], nextCursor: null })
-      .mockResolvedValue({ items: [agent(1, { displayName: "Atlas", runtimeState: null })], nextCursor: null });
+  it("reads each eligible binding once without starting a directory polling fan-out", async () => {
+    agentApi.listAgents.mockResolvedValue({ items: [agent(1, { displayName: "Atlas" })], nextCursor: null });
     agentApi.getAgentFeishuBinding.mockResolvedValue({ binding: binding(1) });
 
     const { container, root } = await renderPage();
@@ -202,9 +195,8 @@ describe("Member Team Agents page", () => {
     });
     await flush();
 
-    expect(agentApi.listAgents).toHaveBeenCalledTimes(2);
-    expect(container.textContent).not.toContain("Atlas");
-    expect(container.textContent).toContain("You’re in Acme");
+    expect(agentApi.listAgents).toHaveBeenCalledTimes(1);
+    expect(agentApi.getAgentFeishuBinding).toHaveBeenCalledTimes(1);
     await act(async () => root.unmount());
   }, 15_000);
 });

--- a/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment happy-dom
+
+import type { Agent, FeishuBotBinding } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const agentApi = vi.hoisted(() => ({
+  listAgents: vi.fn(),
+  getAgentFeishuBinding: vi.fn(),
+}));
+const resourceApi = vi.hoisted(() => ({ getAgentResources: vi.fn() }));
+const authMock = vi.hoisted(() => ({
+  value: { organizationId: "org-1", teamDisplayName: "Acme", role: "member" },
+}));
+
+vi.mock("../../../api/agents.js", () => agentApi);
+vi.mock("../../../api/agent-resources.js", () => resourceApi);
+vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
+
+const NOW = "2026-08-14T00:00:00.000Z";
+
+function agent(index: number, overrides: Partial<Agent> = {}): Agent {
+  return {
+    uuid: overrides.uuid ?? `agent-${index}`,
+    name: overrides.name ?? `agent-${index}`,
+    displayName: overrides.displayName ?? `Agent ${index}`,
+    organizationId: "org-1",
+    type: overrides.type ?? "agent",
+    delegateMention: null,
+    inboxId: `inbox-${index}`,
+    status: overrides.status ?? "active",
+    source: "portal",
+    visibility: overrides.visibility ?? "organization",
+    metadata: {},
+    managerId: "member-admin",
+    clientId: "client-1",
+    runtimeProvider: "codex",
+    avatarColorToken: null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+    runtimeState: overrides.runtimeState === undefined ? "idle" : overrides.runtimeState,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function binding(index: number, overrides: Partial<FeishuBotBinding> = {}): FeishuBotBinding {
+  return {
+    id: `binding-${index}`,
+    agentId: `agent-${index}`,
+    appId: overrides.appId === undefined ? `cli_${index}` : overrides.appId,
+    botOpenId: `ou_${index}`,
+    botName: `Agent ${index}`,
+    botAvatarUrl: null,
+    tenantKey: "tenant-1",
+    status: overrides.status ?? "active",
+    connectionStatus: overrides.connectionStatus ?? "connected",
+    grantedScopes: [],
+    registrationUrl: null,
+    registrationExpiresAt: null,
+    lastConnectedAt: NOW,
+    lastEventAt: NOW,
+    lastErrorCode: null,
+    lastErrorMessage: null,
+    cli: overrides.cli ?? { state: "ready", version: "1.0.0", clientId: "client-1" },
+  };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function renderPage(): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false }, mutations: { retry: false } },
+  });
+  const { TeamPage } = await import("../index.js");
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <TeamPage />
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  await flush();
+  return { container, root };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+  authMock.value = { organizationId: "org-1", teamDisplayName: "Acme", role: "member" };
+  resourceApi.getAgentResources.mockImplementation(async (uuid: string) => ({
+    adoptedTemplates: [{ public: { tagline: `Handles ${uuid} work.` } }],
+  }));
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("Member Team Agents page", () => {
+  it("renders only ready cards in roster order with exact Bot AppLinks and the page-level group hint after the grid", async () => {
+    const agents = [
+      agent(1, { displayName: "Alpha" }),
+      agent(2, { displayName: "Beta" }),
+      agent(3, { displayName: "Gamma" }),
+      agent(4, { displayName: "Delta" }),
+      agent(5, { displayName: "Private", visibility: "private" }),
+      agent(6, { displayName: "Offline", runtimeState: null }),
+      agent(7, { displayName: "Bot not ready" }),
+    ];
+    agentApi.listAgents.mockResolvedValue({ items: agents, nextCursor: null });
+    agentApi.getAgentFeishuBinding.mockImplementation(async (uuid: string) => {
+      const index = Number(uuid.split("-")[1]);
+      return { binding: binding(index, index === 7 ? { connectionStatus: "disconnected" } : {}) };
+    });
+
+    const { container, root } = await renderPage();
+    const grid = container.querySelector<HTMLElement>(".member-team-agent-grid");
+    const cards = [...container.querySelectorAll<HTMLElement>(".member-team-agent-card")];
+    const links = [...container.querySelectorAll<HTMLAnchorElement>('a[href^="https://applink.feishu.cn/"]')];
+    const hint = container.querySelector<HTMLElement>(".member-team-agents-group-hint");
+
+    expect(grid?.dataset.teamAgentCount).toBe("4");
+    expect(cards.map((card) => card.querySelector("[class*='CardTitle']")?.textContent ?? card.textContent)).toEqual(
+      expect.arrayContaining([expect.stringContaining("Alpha"), expect.stringContaining("Beta")]),
+    );
+    expect(cards.map((card) => card.textContent?.match(/Alpha|Beta|Gamma|Delta/)?.[0])).toEqual([
+      "Alpha",
+      "Beta",
+      "Gamma",
+      "Delta",
+    ]);
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "https://applink.feishu.cn/client/bot/open?appId=cli_1",
+      "https://applink.feishu.cn/client/bot/open?appId=cli_2",
+      "https://applink.feishu.cn/client/bot/open?appId=cli_3",
+      "https://applink.feishu.cn/client/bot/open?appId=cli_4",
+    ]);
+    expect(links.every((link) => link.textContent?.includes("Message in Feishu"))).toBe(true);
+    expect(links.every((link) => link.target === "_blank" && link.rel === "noreferrer")).toBe(true);
+    expect(grid && hint ? Boolean(grid.compareDocumentPosition(hint) & Node.DOCUMENT_POSITION_FOLLOWING) : false).toBe(
+      true,
+    );
+    expect(hint?.textContent).toContain("search for the agent by name");
+    expect(hint?.textContent).toContain("@mention");
+    expect(container.textContent).not.toContain("First Tree");
+    expect(agentApi.listAgents).toHaveBeenCalledWith({
+      limit: 100,
+      type: "agent",
+      addressableOnly: true,
+      cursor: undefined,
+    });
+    expect(agentApi.getAgentFeishuBinding).not.toHaveBeenCalledWith("agent-5");
+    expect(agentApi.getAgentFeishuBinding).not.toHaveBeenCalledWith("agent-6");
+
+    await act(async () => root.unmount());
+  });
+
+  it("shows the same-page Team empty state without personal Agent, Computer, or Runtime setup", async () => {
+    agentApi.listAgents.mockResolvedValue({ items: [agent(1)], nextCursor: null });
+    agentApi.getAgentFeishuBinding.mockResolvedValue({
+      binding: binding(1, { cli: { state: "missing", version: null, clientId: "client-1" } }),
+    });
+
+    const { container, root } = await renderPage();
+
+    expect(container.textContent).toContain("You’re in Acme");
+    expect(container.textContent).toContain("Check with your team admins");
+    expect(container.textContent).not.toContain("personal agent");
+    expect(container.textContent).not.toContain("Computer");
+    expect(container.textContent).not.toContain("Runtime");
+    expect(container.querySelector(".member-team-agent-grid")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
@@ -107,6 +107,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   document.body.innerHTML = "";
 });
 
@@ -186,4 +187,24 @@ describe("Member Team Agents page", () => {
 
     await act(async () => root.unmount());
   });
+
+  it("removes a handoff after the roster poll observes that its Agent went offline", async () => {
+    agentApi.listAgents
+      .mockResolvedValueOnce({ items: [agent(1, { displayName: "Atlas" })], nextCursor: null })
+      .mockResolvedValue({ items: [agent(1, { displayName: "Atlas", runtimeState: null })], nextCursor: null });
+    agentApi.getAgentFeishuBinding.mockResolvedValue({ binding: binding(1) });
+
+    const { container, root } = await renderPage();
+    expect(container.textContent).toContain("Atlas");
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10_100));
+    });
+    await flush();
+
+    expect(agentApi.listAgents).toHaveBeenCalledTimes(2);
+    expect(container.textContent).not.toContain("Atlas");
+    expect(container.textContent).toContain("You’re in Acme");
+    await act(async () => root.unmount());
+  }, 15_000);
 });

--- a/packages/web/src/pages/team/__tests__/member-team-agents.test.ts
+++ b/packages/web/src/pages/team/__tests__/member-team-agents.test.ts
@@ -1,4 +1,4 @@
-import type { Agent, AgentResourcesOutput, FeishuBotBinding } from "@first-tree/shared";
+import type { Agent, FeishuBotBinding } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
 import { feishuBotChatUrl, selectReadyTeamAgents, teamAgentResponsibility } from "../member-team-agents.js";
 
@@ -100,11 +100,7 @@ describe("member Team Agent copy and destination", () => {
     );
   });
 
-  it("uses the first public Template tagline as the short responsibility", () => {
-    const resources = {
-      adoptedTemplates: [{ public: { tagline: "Reviews production pull requests." } }],
-    } as AgentResourcesOutput;
-    expect(teamAgentResponsibility(resources, "Acme")).toBe("Reviews production pull requests.");
-    expect(teamAgentResponsibility(undefined, "Acme")).toBe("Ready to help Acme in Feishu.");
+  it("uses a short Team-scoped responsibility without fetching the full resource catalog", () => {
+    expect(teamAgentResponsibility("Acme")).toBe("Ready to help Acme in Feishu.");
   });
 });

--- a/packages/web/src/pages/team/__tests__/member-team-agents.test.ts
+++ b/packages/web/src/pages/team/__tests__/member-team-agents.test.ts
@@ -1,0 +1,110 @@
+import type { Agent, AgentResourcesOutput, FeishuBotBinding } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import { feishuBotChatUrl, selectReadyTeamAgents, teamAgentResponsibility } from "../member-team-agents.js";
+
+const NOW = "2026-08-14T00:00:00.000Z";
+
+function agent(index: number, overrides: Partial<Agent> = {}): Agent {
+  return {
+    uuid: overrides.uuid ?? `agent-${index}`,
+    name: overrides.name ?? `agent-${index}`,
+    displayName: overrides.displayName ?? `Agent ${index}`,
+    organizationId: overrides.organizationId ?? "org-1",
+    type: overrides.type ?? "agent",
+    delegateMention: overrides.delegateMention ?? null,
+    inboxId: overrides.inboxId ?? `inbox-${index}`,
+    status: overrides.status ?? "active",
+    source: overrides.source ?? "portal",
+    visibility: overrides.visibility ?? "organization",
+    metadata: overrides.metadata ?? {},
+    managerId: overrides.managerId ?? "member-admin",
+    clientId: overrides.clientId ?? "client-1",
+    runtimeProvider: overrides.runtimeProvider ?? "codex",
+    avatarColorToken: overrides.avatarColorToken ?? null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+    runtimeState: overrides.runtimeState === undefined ? "idle" : overrides.runtimeState,
+    createdAt: overrides.createdAt ?? NOW,
+    updatedAt: overrides.updatedAt ?? NOW,
+  };
+}
+
+function binding(index: number, overrides: Partial<FeishuBotBinding> = {}): FeishuBotBinding {
+  return {
+    id: overrides.id ?? `binding-${index}`,
+    agentId: overrides.agentId ?? `agent-${index}`,
+    appId: overrides.appId === undefined ? `cli_${index}` : overrides.appId,
+    botOpenId: overrides.botOpenId ?? `ou_${index}`,
+    botName: overrides.botName ?? `Agent ${index}`,
+    botAvatarUrl: overrides.botAvatarUrl ?? null,
+    tenantKey: overrides.tenantKey ?? "tenant-1",
+    status: overrides.status ?? "active",
+    connectionStatus: overrides.connectionStatus ?? "connected",
+    grantedScopes: overrides.grantedScopes ?? [],
+    registrationUrl: overrides.registrationUrl ?? null,
+    registrationExpiresAt: overrides.registrationExpiresAt ?? null,
+    lastConnectedAt: overrides.lastConnectedAt ?? NOW,
+    lastEventAt: overrides.lastEventAt ?? NOW,
+    lastErrorCode: overrides.lastErrorCode ?? null,
+    lastErrorMessage: overrides.lastErrorMessage ?? null,
+    cli: overrides.cli ?? { state: "ready", version: "1.0.0", clientId: "client-1" },
+  };
+}
+
+function readyBindings(count: number): Map<string, FeishuBotBinding | null> {
+  return new Map(Array.from({ length: count }, (_, index) => [`agent-${index + 1}`, binding(index + 1)]));
+}
+
+describe("member Team Agent selection", () => {
+  for (const count of [0, 1, 2, 3, 4]) {
+    it(`keeps the roster order for the ${count}-ready-Agent state`, () => {
+      const agents = Array.from({ length: count }, (_, index) => agent(index + 1));
+
+      expect(selectReadyTeamAgents(agents, readyBindings(count)).map(({ agent: item }) => item.uuid)).toEqual(
+        agents.map((item) => item.uuid),
+      );
+    });
+  }
+
+  it("filters every non-ready, private, lifecycle, human, and imprecisely-addressed row", () => {
+    const agents = [
+      agent(1),
+      agent(2, { visibility: "private" }),
+      agent(3, { status: "suspended" }),
+      agent(4, { type: "human" }),
+      agent(5, { runtimeState: null }),
+      agent(6),
+      agent(7),
+      agent(8),
+      agent(9),
+    ];
+    const bindings = new Map<string, FeishuBotBinding | null>([
+      ["agent-1", binding(1)],
+      ["agent-2", binding(2)],
+      ["agent-3", binding(3)],
+      ["agent-4", binding(4)],
+      ["agent-5", binding(5)],
+      ["agent-6", binding(6, { status: "provisioning" })],
+      ["agent-7", binding(7, { connectionStatus: "disconnected" })],
+      ["agent-8", binding(8, { cli: { state: "missing", version: null, clientId: "client-1" } })],
+      ["agent-9", binding(9, { appId: null })],
+    ]);
+
+    expect(selectReadyTeamAgents(agents, bindings).map(({ agent: item }) => item.uuid)).toEqual(["agent-1"]);
+  });
+});
+
+describe("member Team Agent copy and destination", () => {
+  it("builds the official Bot AppLink and percent-encodes the exact App ID", () => {
+    expect(feishuBotChatUrl("cli_1&next=wrong")).toBe(
+      "https://applink.feishu.cn/client/bot/open?appId=cli_1%26next%3Dwrong",
+    );
+  });
+
+  it("uses the first public Template tagline as the short responsibility", () => {
+    const resources = {
+      adoptedTemplates: [{ public: { tagline: "Reviews production pull requests." } }],
+    } as AgentResourcesOutput;
+    expect(teamAgentResponsibility(resources, "Acme")).toBe("Reviews production pull requests.");
+    expect(teamAgentResponsibility(undefined, "Acme")).toBe("Ready to help Acme in Feishu.");
+  });
+});

--- a/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
@@ -670,33 +670,6 @@ describe("TeamPage", () => {
     await act(async () => root.unmount());
   });
 
-  it("uses member-scoped agent listing and opens read-only profiles for non-admins", async () => {
-    authMock.value = { role: "member", memberId: "member-self" };
-    const { TeamPage } = await import("../index.js");
-    const { container, root } = await renderDom(<TeamPage />);
-
-    await waitForText(container, "Nova");
-    expect(agentMocks.listAgents).toHaveBeenCalledWith({ limit: 100 });
-    expect(agentMocks.listAllAgents).not.toHaveBeenCalled();
-    // Issue 836: sharing the invite link is member-level, so the "Invite link"
-    // entry is no longer admin-gated — non-admins see it too.
-    expect(container.textContent).toContain("Invite link");
-    expect(container.textContent).not.toContain("Design Critique");
-    expect(container.textContent).toContain("Ops Helper");
-
-    await click(container.querySelector('[aria-label="Open Alice"]'));
-    await waitForText(document.body, "Profile");
-    expect(document.body.textContent).not.toContain("Demoting the last admin");
-    expect(exactButton(document.body, "Save")).toBeNull();
-    await click(exactButton(document.body, "Close"));
-
-    await click(container.querySelector('button[aria-label="Actions for Ops Helper"]'));
-    await waitForText(container, "Chat");
-    expect(exactButton(container, "Suspend")).toBeNull();
-
-    await act(async () => root.unmount());
-  });
-
   it("remembers the agent filter preference", async () => {
     window.localStorage.setItem("first-tree:team-agent-filter:v1", "mine");
     const { TeamPage } = await import("../index.js");

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -37,6 +37,7 @@ import {
   readAgentFilterPreference,
   writeAgentFilterPreference,
 } from "./agent-filter.js";
+import { MemberTeamAgentsPage } from "./member-team-agents.js";
 import { type AgentRow, type HumanRow, type RowAction, TeamTable } from "./team-table.js";
 
 /**
@@ -97,6 +98,12 @@ export async function fetchAllAgents(
 }
 
 export function TeamPage() {
+  const { role } = useAuth();
+  if (role !== "admin") return <MemberTeamAgentsPage />;
+  return <TeamManagementPage />;
+}
+
+function TeamManagementPage() {
   const { role, memberId, refreshMe } = useAuth();
   const isAdmin = role === "admin";
   const navigate = useNavigate();

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -99,7 +99,7 @@ export async function fetchAllAgents(
 
 export function TeamPage() {
   const { role } = useAuth();
-  if (role !== "admin") return <MemberTeamAgentsPage />;
+  if (role === "member") return <MemberTeamAgentsPage />;
   return <TeamManagementPage />;
 }
 

--- a/packages/web/src/pages/team/member-team-agents.tsx
+++ b/packages/web/src/pages/team/member-team-agents.tsx
@@ -1,0 +1,217 @@
+import type { Agent, AgentResourcesOutput, FeishuBotBinding } from "@first-tree/shared";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { ExternalLink, MessageCircle } from "lucide-react";
+import type { ReactElement } from "react";
+import { getAgentResources } from "../../api/agent-resources.js";
+import { getAgentFeishuBinding, listAgents } from "../../api/agents.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { Avatar } from "../../components/avatar.js";
+import { Button } from "../../components/ui/button.js";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../../components/ui/card.js";
+import { PageHeader } from "../../components/ui/page-header.js";
+import { isFeishuHandoffUsable } from "../opentag/flow.js";
+
+const AGENT_PAGE_SIZE = 100;
+
+type ReadyFeishuBotBinding = FeishuBotBinding & { appId: string };
+
+type TeamAgentBinding = {
+  agent: Agent;
+  binding: ReadyFeishuBotBinding;
+};
+
+async function listAllAddressableTeamAgents(): Promise<Agent[]> {
+  const agents: Agent[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  for (;;) {
+    const page = await listAgents({ limit: AGENT_PAGE_SIZE, type: "agent", addressableOnly: true, cursor });
+    agents.push(...page.items);
+    if (!page.nextCursor || seenCursors.has(page.nextCursor)) return agents;
+    seenCursors.add(page.nextCursor);
+    cursor = page.nextCursor;
+  }
+}
+
+/**
+ * Keep the Team roster's server-authored order. This page is a directory, not
+ * a recommendation surface, so readiness only removes unavailable rows; it
+ * never promotes or re-ranks the remaining Agents.
+ */
+export function selectReadyTeamAgents(
+  agents: readonly Agent[],
+  bindings: ReadonlyMap<string, FeishuBotBinding | null>,
+): TeamAgentBinding[] {
+  const ready: TeamAgentBinding[] = [];
+  for (const agent of agents) {
+    if (
+      agent.type !== "agent" ||
+      agent.status !== "active" ||
+      agent.visibility !== "organization" ||
+      agent.runtimeState == null
+    ) {
+      continue;
+    }
+    const binding = bindings.get(agent.uuid);
+    const appId = binding?.appId?.trim();
+    if (!binding || !appId || !isFeishuHandoffUsable(binding)) continue;
+    ready.push({ agent, binding: { ...binding, appId } });
+  }
+  return ready;
+}
+
+/** Official Feishu AppLink for opening one Bot's private chat. */
+export function feishuBotChatUrl(appId: string): string {
+  const url = new URL("https://applink.feishu.cn/client/bot/open");
+  url.searchParams.set("appId", appId);
+  return url.toString();
+}
+
+export function teamAgentResponsibility(resources: AgentResourcesOutput | undefined, teamName: string): string {
+  const publicProfile = resources?.adoptedTemplates.find((template) => template.public)?.public;
+  return publicProfile?.tagline ?? `Ready to help ${teamName} in Feishu.`;
+}
+
+export function MemberTeamAgentsPage(): ReactElement {
+  const { organizationId, teamDisplayName } = useAuth();
+  const teamName = teamDisplayName ?? "your team";
+  const agentsQuery = useQuery({
+    queryKey: ["agents", "member-team-agents", organizationId],
+    queryFn: listAllAddressableTeamAgents,
+    staleTime: 30_000,
+  });
+
+  const eligibleAgents = (agentsQuery.data ?? []).filter(
+    (agent) =>
+      agent.type === "agent" &&
+      agent.status === "active" &&
+      agent.visibility === "organization" &&
+      agent.runtimeState != null,
+  );
+  const bindingQueries = useQueries({
+    queries: eligibleAgents.map((agent) => ({
+      queryKey: ["agent-feishu-binding", agent.uuid],
+      queryFn: () => getAgentFeishuBinding(agent.uuid),
+      staleTime: 10_000,
+      refetchInterval: 10_000,
+    })),
+  });
+  const bindings = new Map<string, FeishuBotBinding | null>();
+  eligibleAgents.forEach((agent, index) => {
+    bindings.set(agent.uuid, bindingQueries[index]?.data?.binding ?? null);
+  });
+  const readyAgents = selectReadyTeamAgents(eligibleAgents, bindings);
+
+  const resourceQueries = useQueries({
+    queries: readyAgents.map(({ agent }) => ({
+      queryKey: ["agent-resources", agent.uuid],
+      queryFn: () => getAgentResources(agent.uuid),
+      staleTime: 60_000,
+    })),
+  });
+
+  const bindingReadFailed = bindingQueries.some((query) => query.isError);
+  const loading = agentsQuery.isPending || bindingQueries.some((query) => query.isPending);
+  const retry = (): void => {
+    void agentsQuery.refetch();
+    for (const query of bindingQueries) void query.refetch();
+  };
+
+  return (
+    <>
+      <PageHeader title="Team agents" subtitle={`Message ${teamName}'s ready agents in Feishu.`} />
+      <div className="member-team-agents-page">
+        {loading ? (
+          <p className="member-team-agents-status" role="status">
+            Loading team agents…
+          </p>
+        ) : agentsQuery.isError || bindingReadFailed ? (
+          <div className="member-team-agents-status" role="alert">
+            <p>We couldn’t check which team agents are ready.</p>
+            <Button type="button" variant="outline" size="sm" onClick={retry}>
+              Try again
+            </Button>
+          </div>
+        ) : readyAgents.length === 0 ? (
+          <EmptyTeamAgents teamName={teamName} />
+        ) : (
+          <>
+            <div className="member-team-agent-grid" data-team-agent-count={readyAgents.length}>
+              {readyAgents.map(({ agent, binding }, index) => (
+                <TeamAgentCard
+                  key={agent.uuid}
+                  agent={agent}
+                  binding={binding}
+                  responsibility={teamAgentResponsibility(resourceQueries[index]?.data, teamName)}
+                />
+              ))}
+            </div>
+            <GroupUseHint />
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+function TeamAgentCard({
+  agent,
+  binding,
+  responsibility,
+}: {
+  agent: Agent;
+  binding: ReadyFeishuBotBinding;
+  responsibility: string;
+}): ReactElement {
+  return (
+    <Card className="member-team-agent-card">
+      <CardHeader className="member-team-agent-card-header">
+        <Avatar
+          name={agent.displayName}
+          src={agent.avatarImageUrl ?? binding.botAvatarUrl}
+          colorToken={agent.avatarColorToken}
+          seed={agent.uuid}
+          size={40}
+        />
+        <CardTitle className="min-w-0 truncate">{agent.displayName}</CardTitle>
+      </CardHeader>
+      <CardContent className="member-team-agent-card-content">
+        <p className="member-team-agent-responsibility">{responsibility}</p>
+      </CardContent>
+      <CardFooter className="member-team-agent-card-footer">
+        <Button asChild className="w-full">
+          <a href={feishuBotChatUrl(binding.appId)} target="_blank" rel="noreferrer">
+            <MessageCircle className="h-4 w-4" aria-hidden="true" />
+            Message in Feishu
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+          </a>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+function EmptyTeamAgents({ teamName }: { teamName: string }): ReactElement {
+  return (
+    <section className="member-team-agents-empty" aria-labelledby="team-agents-empty-title">
+      <div className="member-team-agents-empty-icon" aria-hidden="true">
+        <MessageCircle className="h-5 w-5" />
+      </div>
+      <h2 id="team-agents-empty-title" className="text-subtitle font-semibold">
+        You’re in {teamName}
+      </h2>
+      <p className="text-body">
+        No team agents are ready in Feishu yet. Check with your team admins to find out what’s available.
+      </p>
+    </section>
+  );
+}
+
+function GroupUseHint(): ReactElement {
+  return (
+    <p className="member-team-agents-group-hint">
+      Want to use an agent in a group? In Feishu, search for the agent by name, add it to the group, then @mention it.
+    </p>
+  );
+}

--- a/packages/web/src/pages/team/member-team-agents.tsx
+++ b/packages/web/src/pages/team/member-team-agents.tsx
@@ -9,7 +9,7 @@ import { Avatar } from "../../components/avatar.js";
 import { Button } from "../../components/ui/button.js";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../../components/ui/card.js";
 import { PageHeader } from "../../components/ui/page-header.js";
-import { isFeishuHandoffUsable } from "../opentag/flow.js";
+import { isFeishuBotReachable } from "../../features/feishu/binding-view.js";
 
 const AGENT_PAGE_SIZE = 100;
 
@@ -55,7 +55,7 @@ export function selectReadyTeamAgents(
     }
     const binding = bindings.get(agent.uuid);
     const appId = binding?.appId?.trim();
-    if (!binding || !appId || !isFeishuHandoffUsable(binding)) continue;
+    if (!binding || !appId || !isFeishuBotReachable(binding) || binding.cli.state !== "ready") continue;
     ready.push({ agent, binding: { ...binding, appId } });
   }
   return ready;

--- a/packages/web/src/pages/team/member-team-agents.tsx
+++ b/packages/web/src/pages/team/member-team-agents.tsx
@@ -1,15 +1,14 @@
-import type { Agent, AgentResourcesOutput, FeishuBotBinding } from "@first-tree/shared";
+import type { Agent, FeishuBotBinding } from "@first-tree/shared";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { ExternalLink, MessageCircle } from "lucide-react";
 import type { ReactElement } from "react";
-import { getAgentResources } from "../../api/agent-resources.js";
-import { getAgentFeishuBinding, listAgents } from "../../api/agents.js";
+import { listAgents } from "../../api/agents.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Avatar } from "../../components/avatar.js";
 import { Button } from "../../components/ui/button.js";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../../components/ui/card.js";
 import { PageHeader } from "../../components/ui/page-header.js";
-import { isFeishuBotReachable } from "../../features/feishu/binding-view.js";
+import { feishuBindingQueryOptions, isFeishuHandoffUsable } from "../../features/feishu/binding-view.js";
 
 const AGENT_PAGE_SIZE = 100;
 
@@ -55,7 +54,7 @@ export function selectReadyTeamAgents(
     }
     const binding = bindings.get(agent.uuid);
     const appId = binding?.appId?.trim();
-    if (!binding || !appId || !isFeishuBotReachable(binding) || binding.cli.state !== "ready") continue;
+    if (!binding || !appId || !isFeishuHandoffUsable(binding)) continue;
     ready.push({ agent, binding: { ...binding, appId } });
   }
   return ready;
@@ -68,9 +67,8 @@ export function feishuBotChatUrl(appId: string): string {
   return url.toString();
 }
 
-export function teamAgentResponsibility(resources: AgentResourcesOutput | undefined, teamName: string): string {
-  const publicProfile = resources?.adoptedTemplates.find((template) => template.public)?.public;
-  return publicProfile?.tagline ?? `Ready to help ${teamName} in Feishu.`;
+export function teamAgentResponsibility(teamName: string): string {
+  return `Ready to help ${teamName} in Feishu.`;
 }
 
 export function MemberTeamAgentsPage(): ReactElement {
@@ -80,10 +78,6 @@ export function MemberTeamAgentsPage(): ReactElement {
     queryKey: ["agents", "member-team-agents", organizationId],
     queryFn: listAllAddressableTeamAgents,
     staleTime: 30_000,
-    // runtimeState is the current reachability authority, and presence flips
-    // do not invalidate this roster query. Match the existing Team roster's
-    // polling floor so a card and its handoff disappear after an Agent drops.
-    refetchInterval: 10_000,
   });
 
   const eligibleAgents = (agentsQuery.data ?? []).filter(
@@ -95,10 +89,8 @@ export function MemberTeamAgentsPage(): ReactElement {
   );
   const bindingQueries = useQueries({
     queries: eligibleAgents.map((agent) => ({
-      queryKey: ["agent-feishu-binding", agent.uuid],
-      queryFn: () => getAgentFeishuBinding(agent.uuid),
+      ...feishuBindingQueryOptions(agent.uuid, { poll: false }),
       staleTime: 10_000,
-      refetchInterval: 10_000,
     })),
   });
   const bindings = new Map<string, FeishuBotBinding | null>();
@@ -106,14 +98,6 @@ export function MemberTeamAgentsPage(): ReactElement {
     bindings.set(agent.uuid, bindingQueries[index]?.data?.binding ?? null);
   });
   const readyAgents = selectReadyTeamAgents(eligibleAgents, bindings);
-
-  const resourceQueries = useQueries({
-    queries: readyAgents.map(({ agent }) => ({
-      queryKey: ["agent-resources", agent.uuid],
-      queryFn: () => getAgentResources(agent.uuid),
-      staleTime: 60_000,
-    })),
-  });
 
   const bindingReadFailed = bindingQueries.some((query) => query.isError);
   const loading = agentsQuery.isPending || bindingQueries.some((query) => query.isPending);
@@ -142,12 +126,12 @@ export function MemberTeamAgentsPage(): ReactElement {
         ) : (
           <>
             <div className="member-team-agent-grid" data-team-agent-count={readyAgents.length}>
-              {readyAgents.map(({ agent, binding }, index) => (
+              {readyAgents.map(({ agent, binding }) => (
                 <TeamAgentCard
                   key={agent.uuid}
                   agent={agent}
                   binding={binding}
-                  responsibility={teamAgentResponsibility(resourceQueries[index]?.data, teamName)}
+                  responsibility={teamAgentResponsibility(teamName)}
                 />
               ))}
             </div>

--- a/packages/web/src/pages/team/member-team-agents.tsx
+++ b/packages/web/src/pages/team/member-team-agents.tsx
@@ -80,6 +80,10 @@ export function MemberTeamAgentsPage(): ReactElement {
     queryKey: ["agents", "member-team-agents", organizationId],
     queryFn: listAllAddressableTeamAgents,
     staleTime: 30_000,
+    // runtimeState is the current reachability authority, and presence flips
+    // do not invalidate this roster query. Match the existing Team roster's
+    // polling floor so a card and its handoff disappear after an Agent drops.
+    refetchInterval: 10_000,
   });
 
   const eligibleAgents = (agentsQuery.data ?? []).filter(

--- a/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
+++ b/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
@@ -10,7 +10,7 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 const authMock = vi.hoisted(() => ({
   value: {
     meLoaded: true,
-    role: "admin" as "admin" | "member",
+    role: "admin" as "admin" | "member" | null,
     onboardingStep: "completed" as "connect" | "create_agent" | "completed" | null,
     onboardingDismissedAt: null as string | null,
     onboardingCompletedAt: "2026-05-28T00:00:00.000Z" as string | null,
@@ -448,5 +448,22 @@ describe("WorkspacePage DOM behavior", () => {
     expect(deepLink.container.textContent).toContain("center:chat-1");
     expect(deepLink.container.textContent).not.toContain("Team Agents route");
     await act(async () => deepLink.root.unmount());
+  });
+
+  it("does not treat an unresolved role as a Team Member", async () => {
+    const { WorkspacePage } = await import("../index.js");
+    authMock.value = {
+      ...authMock.value,
+      role: null,
+      onboardingStep: "connect",
+      onboardingCompletedAt: null,
+      currentOrgHasPersonalAgent: false,
+    };
+
+    const unresolved = await renderDom("/", <WorkspacePage />);
+
+    expect(unresolved.container.textContent).toContain("Onboarding route");
+    expect(unresolved.container.textContent).not.toContain("Team Agents route");
+    await act(async () => unresolved.root.unmount());
   });
 });

--- a/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
+++ b/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
@@ -10,6 +10,7 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 const authMock = vi.hoisted(() => ({
   value: {
     meLoaded: true,
+    role: "admin" as "admin" | "member",
     onboardingStep: "completed" as "connect" | "create_agent" | "completed" | null,
     onboardingDismissedAt: null as string | null,
     onboardingCompletedAt: "2026-05-28T00:00:00.000Z" as string | null,
@@ -190,6 +191,15 @@ async function renderDom(initialEntry: string, element: ReactElement): Promise<{
               </>
             }
           />
+          <Route
+            path="/team"
+            element={
+              <>
+                <LocationProbe />
+                <div>Team Agents route</div>
+              </>
+            }
+          />
         </Routes>
       </MemoryRouter>,
     );
@@ -236,6 +246,7 @@ beforeEach(() => {
   viewportMock.value = "xl";
   authMock.value = {
     meLoaded: true,
+    role: "admin",
     onboardingStep: "completed",
     onboardingDismissedAt: null,
     onboardingCompletedAt: "2026-05-28T00:00:00.000Z",
@@ -396,6 +407,7 @@ describe("WorkspacePage DOM behavior", () => {
     const { WorkspacePage } = await import("../index.js");
     authMock.value = {
       meLoaded: true,
+      role: "admin",
       onboardingStep: "connect",
       onboardingDismissedAt: null,
       onboardingCompletedAt: null,
@@ -409,11 +421,32 @@ describe("WorkspacePage DOM behavior", () => {
 
     authMock.value = {
       meLoaded: true,
+      role: "admin",
       onboardingStep: "completed",
       onboardingDismissedAt: null,
       onboardingCompletedAt: "2026-05-28T00:00:00.000Z",
       currentOrgHasUsableAgent: true,
       currentOrgHasPersonalAgent: true,
     };
+  });
+
+  it("defaults a member's bare root to Team Agents while preserving direct chat deep links", async () => {
+    const { WorkspacePage } = await import("../index.js");
+    authMock.value = {
+      ...authMock.value,
+      role: "member",
+      currentOrgHasPersonalAgent: false,
+      onboardingCompletedAt: null,
+    };
+
+    const bare = await renderDom("/", <WorkspacePage />);
+    expect(bare.container.textContent).toContain("Team Agents route");
+    expect(bare.container.querySelector('[data-testid="location"]')?.textContent).toBe("/team");
+    await act(async () => bare.root.unmount());
+
+    const deepLink = await renderDom("/?c=chat-1", <WorkspacePage />);
+    expect(deepLink.container.textContent).toContain("center:chat-1");
+    expect(deepLink.container.textContent).not.toContain("Team Agents route");
+    await act(async () => deepLink.root.unmount());
   });
 });

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -101,8 +101,16 @@ export function parseParticipantList(params: URLSearchParams): string[] {
 }
 
 export function WorkspacePage() {
-  const { meLoaded, onboardingStep, onboardingDismissedAt, onboardingCompletedAt, currentOrgHasPersonalAgent } =
+  const location = useLocation();
+  const { meLoaded, role, onboardingStep, onboardingDismissedAt, onboardingCompletedAt, currentOrgHasPersonalAgent } =
     useAuth();
+
+  if (meLoaded && role !== "admin") {
+    if (location.pathname === "/" && !location.search && !location.hash) {
+      return <Navigate to="/team" replace />;
+    }
+    return <WorkspaceBody />;
+  }
 
   // Users who haven't finished setup go through the standalone /onboarding
   // flow — including the server-`completed`-but-no-start-chat case. Only

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -105,7 +105,7 @@ export function WorkspacePage() {
   const { meLoaded, role, onboardingStep, onboardingDismissedAt, onboardingCompletedAt, currentOrgHasPersonalAgent } =
     useAuth();
 
-  if (meLoaded && role !== "admin") {
+  if (meLoaded && role === "member") {
     if (location.pathname === "/" && !location.search && !location.hash) {
       return <Navigate to="/team" replace />;
     }


### PR DESCRIPTION
## Summary

- route invited members directly into a Team Agents page instead of personal Agent or Computer onboarding
- show only organization-visible, active, reachable Agents whose Feishu Bot and CLI handoff is ready
- open each ready Agent's exact Feishu Bot private chat through the official Bot AppLink
- read the directory as a bounded snapshot: no per-Agent polling or full resource-catalog fan-out
- preserve the existing admin Team management surface and member chat deep links

## Validation

- [x] `pnpm --filter @first-tree/web build`
- [x] `pnpm --filter @first-tree/web test` (254 files, 2435 tests)
- [x] focused Biome check and `git diff --check`
- [x] Playwright browser checks at 1440×900, 1024×900, and 390×844

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- No schema, migration, endpoint, DTO, permission, analytics, or new provider-readiness state was added.
- The live Feishu creator/member DM, exact group mention, Task creation, outcome return, and reload/resume qualification remains the separate B7/W4 provider staging gate.
