### PR TITLE
feat(web): add Team Agent creation entry

### DIFF
--- a/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
@@ -4,6 +4,7 @@ import type { Agent, FeishuBotBinding } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -86,7 +87,12 @@ async function renderPage(): Promise<{ container: HTMLElement; root: Root }> {
   await act(async () => {
     root.render(
       <QueryClientProvider client={queryClient}>
-        <TeamPage />
+        <MemoryRouter initialEntries={["/team"]}>
+          <Routes>
+            <Route path="/team" element={<TeamPage />} />
+            <Route path="/opentag" element={<div>Existing OpenTag flow</div>} />
+          </Routes>
+        </MemoryRouter>
       </QueryClientProvider>,
     );
   });
@@ -179,6 +185,37 @@ describe("Member Team Agents page", () => {
     expect(container.textContent).not.toContain("Computer");
     expect(container.textContent).not.toContain("Runtime");
     expect(container.querySelector(".member-team-agent-grid")).toBeNull();
+    expect([...container.querySelectorAll("a")].some((link) => link.textContent === "Create a Team Agent")).toBe(true);
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps creation secondary to ready-agent use while routing keyboard users into the existing OpenTag flow", async () => {
+    agentApi.listAgents.mockResolvedValue({ items: [agent(1, { displayName: "Atlas" })], nextCursor: null });
+    agentApi.getAgentFeishuBinding.mockResolvedValue({ binding: binding(1) });
+
+    const { container, root } = await renderPage();
+    const messageLink = container.querySelector<HTMLAnchorElement>('a[href^="https://applink.feishu.cn/"]');
+    const createLink = [...container.querySelectorAll<HTMLAnchorElement>("a")].find(
+      (link) => link.textContent === "Create a Team Agent",
+    );
+
+    expect(messageLink?.className).toContain("bg-primary");
+    expect(createLink?.getAttribute("href")).toBe("/opentag");
+    expect(createLink?.className).toContain("text-label");
+    expect(createLink?.style.color).toBe("var(--fg-3)");
+    expect(
+      messageLink && createLink
+        ? Boolean(messageLink.compareDocumentPosition(createLink) & Node.DOCUMENT_POSITION_FOLLOWING)
+        : false,
+    ).toBe(true);
+
+    createLink?.focus();
+    expect(document.activeElement).toBe(createLink);
+
+    await act(async () => createLink?.click());
+    await flush();
+    expect(container.textContent).toContain("Existing OpenTag flow");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/member-team-agents-dom.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import type { Agent, FeishuBotBinding } from "@first-tree/shared";
+import { type Agent, type FeishuBotBinding, OPENTAG_ENTRY_PATH } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -90,7 +90,7 @@ async function renderPage(): Promise<{ container: HTMLElement; root: Root }> {
         <MemoryRouter initialEntries={["/team"]}>
           <Routes>
             <Route path="/team" element={<TeamPage />} />
-            <Route path="/opentag" element={<div>Existing OpenTag flow</div>} />
+            <Route path={OPENTAG_ENTRY_PATH} element={<div>Existing OpenTag flow</div>} />
           </Routes>
         </MemoryRouter>
       </QueryClientProvider>,
@@ -201,7 +201,7 @@ describe("Member Team Agents page", () => {
     );
 
     expect(messageLink?.className).toContain("bg-primary");
-    expect(createLink?.getAttribute("href")).toBe("/opentag");
+    expect(createLink?.getAttribute("href")).toBe(OPENTAG_ENTRY_PATH);
     expect(createLink?.className).toContain("text-label");
     expect(createLink?.style.color).toBe("var(--fg-3)");
     expect(

--- a/packages/web/src/pages/team/member-team-agents.tsx
+++ b/packages/web/src/pages/team/member-team-agents.tsx
@@ -2,6 +2,7 @@ import type { Agent, FeishuBotBinding } from "@first-tree/shared";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { ExternalLink, MessageCircle } from "lucide-react";
 import type { ReactElement } from "react";
+import { Link } from "react-router";
 import { listAgents } from "../../api/agents.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Avatar } from "../../components/avatar.js";
@@ -138,8 +139,23 @@ export function MemberTeamAgentsPage(): ReactElement {
             <GroupUseHint />
           </>
         )}
+        <CreateTeamAgentEntry />
       </div>
     </>
+  );
+}
+
+function CreateTeamAgentEntry(): ReactElement {
+  return (
+    <Button
+      asChild
+      variant="link"
+      size="sm"
+      className="h-auto self-start p-0 text-label"
+      style={{ color: "var(--fg-3)" }}
+    >
+      <Link to="/opentag">Create a Team Agent</Link>
+    </Button>
   );
 }
 

--- a/packages/web/src/pages/team/member-team-agents.tsx
+++ b/packages/web/src/pages/team/member-team-agents.tsx
@@ -1,4 +1,4 @@
-import type { Agent, FeishuBotBinding } from "@first-tree/shared";
+import { type Agent, type FeishuBotBinding, OPENTAG_ENTRY_PATH } from "@first-tree/shared";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { ExternalLink, MessageCircle } from "lucide-react";
 import type { ReactElement } from "react";
@@ -154,7 +154,7 @@ function CreateTeamAgentEntry(): ReactElement {
       className="h-auto self-start p-0 text-label"
       style={{ color: "var(--fg-3)" }}
     >
-      <Link to="/opentag">Create a Team Agent</Link>
+      <Link to={OPENTAG_ENTRY_PATH}>Create a Team Agent</Link>
     </Button>
   );
 }


### PR DESCRIPTION
## Summary

- add a low-emphasis `Create a Team Agent` text entry below the Member Team Agents content
- route the entry directly to the existing `/opentag` four-step creation flow
- keep each ready Agent's `Message in Feishu` button as the primary action

## Tests

- `pnpm --filter @first-tree/web exec vitest run src/pages/team/__tests__/member-team-agents-dom.test.tsx` (4 passed)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm typecheck` (9 tasks passed)
- `pnpm check` (passed with existing out-of-scope warnings)
- `pnpm test` reached an unrelated CLI layout-suite `beforeAll` timeout under parallel package load; the exact suite then passed in isolation with all 5 tests

## Review

- risk: low, tightly local Web navigation and presentation
- Standards: pass; reuses the existing Button/Link and semantic design-token patterns
- Spec: pass; ready Team Agent discovery/use remains primary in both populated and empty states, and no alternate creation mode or flow was added
