### PR TITLE
fix(inbox): bound ACK confirms and current-socket prefix admission

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -36,6 +36,7 @@ type FakeSessionState = {
   releaseParkedResetFenceRecovery: ReturnType<typeof vi.fn<(chatId: string, ref?: string) => ResetFenceReleaseVerdict>>;
   supersedeResetGeneration: ReturnType<typeof vi.fn<(chatId: string, reason: string) => ResetFenceReleaseVerdict>>;
   reconcileReplayFencesWithServer: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  reconcileAckSettlementAfterBind: ReturnType<typeof vi.fn<() => Promise<void>>>;
   updateTransport: ReturnType<typeof vi.fn<(sdk: unknown, agentConfigCache?: unknown) => void>>;
   shutdown: ReturnType<typeof vi.fn<(reason?: string, opts?: unknown) => Promise<void>>>;
 };
@@ -262,6 +263,7 @@ function installMocks(
             () => "accepted",
           ),
           reconcileReplayFencesWithServer: vi.fn(async () => {}),
+          reconcileAckSettlementAfterBind: vi.fn(async () => {}),
           updateTransport: vi.fn(),
           shutdown: vi.fn(async () => {}),
         };
@@ -327,6 +329,10 @@ function installMocks(
 
       reconcileReplayFencesWithServer(): Promise<void> {
         return this.state.reconcileReplayFencesWithServer();
+      }
+
+      reconcileAckSettlementAfterBind(): Promise<void> {
+        return this.state.reconcileAckSettlementAfterBind();
       }
 
       updateTransport(sdk: unknown, agentConfigCache?: unknown): void {
@@ -1279,6 +1285,30 @@ describe("AgentSlot", () => {
     expect(vi.mocked(sdk.listActiveRuntimeChatIds)).not.toHaveBeenCalled();
     expect(session.updateTransport).toHaveBeenCalledWith(nextSdk, expect.anything());
     expect(session.noteBindRecoveryComplete).toHaveBeenCalled();
+    expect(session.reconcileReplayFencesWithServer).toHaveBeenCalledTimes(1);
+    expect(session.reconcileAckSettlementAfterBind).toHaveBeenCalledTimes(1);
+
+    await slot.stop();
+  });
+
+  it("reconciles ACK settlement on this agent's bind without using runtime-proof recovery", async () => {
+    const { slot, connection, state } = await makeSlot({ activeRuntimeChatIds: ["chat-1"] });
+    await slot.start();
+    const session = state.sessions[0];
+    if (!session) throw new Error("session missing");
+    session.noteBindRecoveryComplete.mockClear();
+    session.reconcileAckSettlementAfterBind.mockClear();
+    session.reconcileReplayFencesWithServer.mockClear();
+
+    connection.emit("agent:bound", { agentId: "other-agent" });
+    expect(session.reconcileAckSettlementAfterBind).not.toHaveBeenCalled();
+    expect(session.noteBindRecoveryComplete).not.toHaveBeenCalled();
+
+    connection.emit("agent:bound", { agentId: "agent-1" });
+    await Promise.resolve();
+
+    expect(session.reconcileAckSettlementAfterBind).toHaveBeenCalledTimes(1);
+    expect(session.noteBindRecoveryComplete).not.toHaveBeenCalled();
     expect(session.reconcileReplayFencesWithServer).toHaveBeenCalledTimes(1);
 
     await slot.stop();

--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -581,6 +581,60 @@ describe("ClientConnection — WebSocket edge coverage", () => {
       disposition: "acked",
     });
     await expect(ackPromise).resolves.toBeUndefined();
+    expect(socket.closeCalls).toHaveLength(0);
+  });
+
+  it("fail-closes confirmed inbox ACKs after the second timeout without sending a third frame", async () => {
+    vi.useFakeTimers();
+    const connection = await makeConnection();
+    const events: string[] = [];
+    connection.on("reconnecting", () => events.push("reconnecting"));
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const firstAck = connection.sendInboxAck(80);
+    const secondAck = connection.sendInboxAck(81);
+    const initialAckFrames = socket.sent
+      .map((raw) => JSON.parse(raw) as { type?: string; entryId?: number; ref?: string })
+      .filter((message) => message.type === "inbox:ack");
+    expect(initialAckFrames).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(3000);
+    const ackFramesAfterRetry = socket.sent
+      .map((raw) => JSON.parse(raw) as { type?: string; entryId?: number; ref?: string })
+      .filter((message) => message.type === "inbox:ack");
+    expect(ackFramesAfterRetry).toHaveLength(4);
+    expect(ackFramesAfterRetry[2]).toEqual(initialAckFrames[0]);
+    expect(ackFramesAfterRetry[3]).toEqual(initialAckFrames[1]);
+
+    const firstRejection = expect(firstAck).rejects.toThrow("inbox ack timeout");
+    const secondRejection = expect(secondAck).rejects.toThrow("inbox ack timeout");
+    await vi.advanceTimersByTimeAsync(3000);
+    await firstRejection;
+    await secondRejection;
+
+    const ackFramesAfterClose = socket.sent
+      .map((raw) => JSON.parse(raw) as { type?: string })
+      .filter((message) => message.type === "inbox:ack");
+    expect(ackFramesAfterClose).toHaveLength(4);
+    expect(socket.closeCalls).toEqual([{ code: 1011, reason: "inbox ack timeout" }]);
+    expect(events).toContain("reconnecting");
+
+    priv(connection).clearTimers();
+  });
+
+  it("fail-closes when the pending confirmed ACK cap is hit", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const pending = Array.from({ length: 1024 }, (_, index) => connection.sendInboxAck(index + 1, "agent-cap"));
+    const overflow = connection.sendInboxAck(2000, "agent-cap");
+    await expect(overflow).rejects.toThrow("inbox ack timeout");
+    await Promise.all(pending.map((ack) => expect(ack).rejects.toThrow("inbox ack timeout")));
+    expect(socket.closeCalls).toEqual([{ code: 1011, reason: "inbox ack timeout" }]);
+    expect(
+      socket.sent.map((raw) => JSON.parse(raw) as { type?: string }).filter((message) => message.type === "inbox:ack"),
+    ).toHaveLength(0);
+
+    priv(connection).clearTimers();
   });
 
   it("sends inbox recovery requests and settles on accepted or rejected frames", async () => {
@@ -757,7 +811,7 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     await expect(ackPromise).rejects.toThrow("agent_bind_rejected:wrong_client");
   });
 
-  it("rejects held agent-scoped ACKs when unbinding on a closed socket", async () => {
+  it("rejects held agent-scoped ACKs when the socket closes", async () => {
     const connection = await makeConnection();
     const internal = priv(connection);
     const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
@@ -766,20 +820,21 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     internal.closing = true;
     socket.close(1006, "test close");
 
+    await expect(ackPromise).rejects.toThrow("WebSocket closed");
     await connection.unbindAgent("agent-1");
-
-    await expect(ackPromise).rejects.toThrow("agent_unbound");
   });
 
-  it("flushes pending confirmed inbox ACKs after reconnect and bind", async () => {
+  it("does not flush old confirmed inbox ACKs after a later socket bind", async () => {
     const connection = await makeConnection();
     const internal = priv(connection);
     const firstSocket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
 
     const ackPromise = connection.sendInboxAck(46);
     const firstAck = parseSent(firstSocket, firstSocket.sent.length - 1);
+    expect(firstAck).toMatchObject({ type: "inbox:ack", entryId: 46 });
     internal.closing = true;
     firstSocket.close(1006, "test close");
+    await expect(ackPromise).rejects.toThrow("WebSocket closed");
     internal.closing = false;
 
     const secondSocket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
@@ -794,14 +849,10 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     });
     await bindPromise;
 
-    const resentAck = parseSent(secondSocket, secondSocket.sent.length - 1);
-    expect(resentAck).toEqual(firstAck);
-    secondSocket.emitMessage({
-      type: "inbox:ack:accepted",
-      entryId: 46,
-      ref: firstAck.ref,
-      disposition: "already_acked",
-    });
-    await expect(ackPromise).resolves.toBeUndefined();
+    expect(
+      secondSocket.sent
+        .map((raw) => JSON.parse(raw) as { type?: string; entryId?: number })
+        .filter((message) => message.type === "inbox:ack"),
+    ).toEqual([]);
   });
 });

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -358,10 +358,12 @@ describe("InboxDeliveryCoordinator additional delivery coverage", () => {
     const recoverChat = vi
       .fn<(chatId: string) => Promise<{ unackedOutstanding: number }>>()
       .mockResolvedValue({ unackedOutstanding: 0 });
+    const onDeliveriesCommitted = vi.fn();
     const coordinator = new InboxDeliveryCoordinator({
       ackEntry,
       recoverChat,
       onWorkChanged: vi.fn(),
+      onDeliveriesCommitted,
       log: silentLogger(),
     });
     const entry = mockEntry({ id: 110, chatId: "chat-ack-committed", messageId: "msg-ack-committed" });
@@ -374,6 +376,8 @@ describe("InboxDeliveryCoordinator additional delivery coverage", () => {
     await vi.waitFor(() => expect(coordinator.snapshot("chat-ack-committed").entries).toEqual([]));
     expect(coordinator.snapshot("chat-ack-committed").recoveryDebt).toBe("none");
     expect(coordinator.hasRecoveryDebt("chat-ack-committed")).toBe(false);
+    expect(coordinator.takeRecoveryActivationReady("chat-ack-committed")).toBe(false);
+    expect(onDeliveriesCommitted).toHaveBeenCalledWith("chat-ack-committed", ["msg-ack-committed"]);
     expect(coordinator.markOwned({ chatId: "chat-ack-committed", entryId: 110, messageId: "msg-ack-committed" })).toBe(
       "settled",
     );
@@ -381,15 +385,21 @@ describe("InboxDeliveryCoordinator additional delivery coverage", () => {
     expect(ackEntry).toHaveBeenCalledTimes(1);
   });
 
-  it("retains terminal ledger when recover reports remaining unacked work", async () => {
-    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockRejectedValue(new Error("ack confirm lost"));
-    const recoverChat = vi
-      .fn<(chatId: string) => Promise<{ unackedOutstanding: number }>>()
-      .mockResolvedValue({ unackedOutstanding: 1 });
+  it.each([
+    { name: "unackedOutstanding is 1", result: { unackedOutstanding: 1 } },
+    { name: "old servers omit unackedOutstanding", result: undefined },
+  ])("retains terminal ledger when recovery $name and re-ACKs redelivery", async ({ result }) => {
+    const ackEntry = vi
+      .fn<(entryId: number) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("ack confirm lost"))
+      .mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<unknown>>().mockResolvedValue(result);
+    const onDeliveriesCommitted = vi.fn();
     const coordinator = new InboxDeliveryCoordinator({
       ackEntry,
       recoverChat,
       onWorkChanged: vi.fn(),
+      onDeliveriesCommitted,
       log: silentLogger(),
     });
     const entry = mockEntry({ id: 111, chatId: "chat-ack-unsettled", messageId: "msg-ack-unsettled" });
@@ -401,7 +411,13 @@ describe("InboxDeliveryCoordinator additional delivery coverage", () => {
     expect(coordinator.snapshot("chat-ack-unsettled").entries).toEqual([
       { entryId: 111, messageId: "msg-ack-unsettled", phase: "terminal" },
     ]);
+    expect(onDeliveriesCommitted).not.toHaveBeenCalled();
+
     expect(coordinator.receive(entry)).toEqual({ kind: "duplicate-in-flight" });
+    await vi.waitFor(() => expect(ackEntry).toHaveBeenCalledTimes(2));
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 111);
+    expect(coordinator.snapshot("chat-ack-unsettled").entries).toEqual([]);
+    expect(onDeliveriesCommitted).toHaveBeenCalledWith("chat-ack-unsettled", ["msg-ack-unsettled"]);
   });
 
   it("keeps a recovery redelivery burst in recovery mode until unsettled work drains", async () => {

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -420,6 +420,99 @@ describe("InboxDeliveryCoordinator additional delivery coverage", () => {
     expect(onDeliveriesCommitted).toHaveBeenCalledWith("chat-ack-unsettled", ["msg-ack-unsettled"]);
   });
 
+  it("retries ACK settlement on rebind after recover fails because the socket is closing", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockRejectedValue(new Error("inbox ack timeout"));
+    const recoverChat = vi
+      .fn<(chatId: string) => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error("inbox:recover unavailable; socket not bound"))
+      .mockResolvedValueOnce({ unackedOutstanding: 0 });
+    const onDeliveriesCommitted = vi.fn();
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      recoverChat,
+      onWorkChanged: vi.fn(),
+      onDeliveriesCommitted,
+      log: silentLogger(),
+    });
+    const entry = mockEntry({ id: 120, chatId: "chat-ack-rebind-zero", messageId: "msg-ack-rebind-zero" });
+
+    expect(coordinator.receive(entry).kind).toBe("deliver");
+    await coordinator.finishTurn("chat-ack-rebind-zero", toSessionMessage(entry), {
+      status: "success",
+      terminal: true,
+    });
+
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+    expect(coordinator.snapshot("chat-ack-rebind-zero")).toMatchObject({
+      entries: [{ entryId: 120, messageId: "msg-ack-rebind-zero", phase: "terminal" }],
+      recoveryDebt: "required",
+      needsAckSettlementReconcile: true,
+    });
+    expect(coordinator.takeRecoveryActivationReady("chat-ack-rebind-zero")).toBe(false);
+    expect(onDeliveriesCommitted).not.toHaveBeenCalled();
+
+    await coordinator.reconcileAckSettlementAfterBind();
+
+    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(coordinator.snapshot("chat-ack-rebind-zero")).toMatchObject({
+      entries: [],
+      recoveryDebt: "none",
+      needsAckSettlementReconcile: false,
+    });
+    expect(coordinator.hasRecoveryDebt("chat-ack-rebind-zero")).toBe(false);
+    expect(coordinator.takeRecoveryActivationReady("chat-ack-rebind-zero")).toBe(false);
+    expect(onDeliveriesCommitted).toHaveBeenCalledWith("chat-ack-rebind-zero", ["msg-ack-rebind-zero"]);
+    expect(coordinator.receive(entry)).toEqual({ kind: "duplicate-in-flight" });
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { name: "unackedOutstanding is 1", result: { unackedOutstanding: 1 } },
+    { name: "old servers omit unackedOutstanding", result: undefined },
+  ])("keeps terminal after rebind recovery $name and re-ACKs redelivery", async ({ result }) => {
+    const ackEntry = vi
+      .fn<(entryId: number) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("inbox ack timeout"))
+      .mockResolvedValue(undefined);
+    const recoverChat = vi
+      .fn<(chatId: string) => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error("inbox:recover unavailable; socket not bound"))
+      .mockResolvedValueOnce(result);
+    const onDeliveriesCommitted = vi.fn();
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      recoverChat,
+      onWorkChanged: vi.fn(),
+      onDeliveriesCommitted,
+      log: silentLogger(),
+    });
+    const entry = mockEntry({ id: 121, chatId: "chat-ack-rebind-unsettled", messageId: "msg-ack-rebind-unsettled" });
+
+    expect(coordinator.receive(entry).kind).toBe("deliver");
+    await coordinator.finishTurn("chat-ack-rebind-unsettled", toSessionMessage(entry), {
+      status: "success",
+      terminal: true,
+    });
+
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+    expect(coordinator.snapshot("chat-ack-rebind-unsettled").needsAckSettlementReconcile).toBe(true);
+
+    await coordinator.reconcileAckSettlementAfterBind();
+
+    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(coordinator.snapshot("chat-ack-rebind-unsettled")).toMatchObject({
+      entries: [{ entryId: 121, messageId: "msg-ack-rebind-unsettled", phase: "terminal" }],
+      needsAckSettlementReconcile: false,
+    });
+    expect(onDeliveriesCommitted).not.toHaveBeenCalled();
+
+    expect(coordinator.receive(entry)).toEqual({ kind: "duplicate-in-flight" });
+    await vi.waitFor(() => expect(ackEntry).toHaveBeenCalledTimes(2));
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 121);
+    expect(coordinator.snapshot("chat-ack-rebind-unsettled").entries).toEqual([]);
+    expect(onDeliveriesCommitted).toHaveBeenCalledWith("chat-ack-rebind-unsettled", ["msg-ack-rebind-unsettled"]);
+  });
+
   it("keeps a recovery redelivery burst in recovery mode until unsettled work drains", async () => {
     const ackEntry = mockAckEntry();
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -353,6 +353,57 @@ describe("InboxDeliveryCoordinator additional delivery coverage", () => {
     expect(coordinator.snapshot("chat-ack-fail").entries).toEqual([]);
   });
 
+  it("releases terminal ledger when recover proves unackedOutstanding is 0", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockRejectedValue(new Error("ack confirm lost"));
+    const recoverChat = vi
+      .fn<(chatId: string) => Promise<{ unackedOutstanding: number }>>()
+      .mockResolvedValue({ unackedOutstanding: 0 });
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      recoverChat,
+      onWorkChanged: vi.fn(),
+      log: silentLogger(),
+    });
+    const entry = mockEntry({ id: 110, chatId: "chat-ack-committed", messageId: "msg-ack-committed" });
+    const message = toSessionMessage(entry);
+
+    expect(coordinator.receive(entry).kind).toBe("deliver");
+    await coordinator.finishTurn("chat-ack-committed", message, { status: "success", terminal: true });
+
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-ack-committed"));
+    await vi.waitFor(() => expect(coordinator.snapshot("chat-ack-committed").entries).toEqual([]));
+    expect(coordinator.snapshot("chat-ack-committed").recoveryDebt).toBe("none");
+    expect(coordinator.hasRecoveryDebt("chat-ack-committed")).toBe(false);
+    expect(coordinator.markOwned({ chatId: "chat-ack-committed", entryId: 110, messageId: "msg-ack-committed" })).toBe(
+      "settled",
+    );
+    expect(coordinator.receive(entry)).toEqual({ kind: "duplicate-in-flight" });
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains terminal ledger when recover reports remaining unacked work", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockRejectedValue(new Error("ack confirm lost"));
+    const recoverChat = vi
+      .fn<(chatId: string) => Promise<{ unackedOutstanding: number }>>()
+      .mockResolvedValue({ unackedOutstanding: 1 });
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      recoverChat,
+      onWorkChanged: vi.fn(),
+      log: silentLogger(),
+    });
+    const entry = mockEntry({ id: 111, chatId: "chat-ack-unsettled", messageId: "msg-ack-unsettled" });
+
+    expect(coordinator.receive(entry).kind).toBe("deliver");
+    await coordinator.finishTurn("chat-ack-unsettled", toSessionMessage(entry), { status: "success", terminal: true });
+
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-ack-unsettled"));
+    expect(coordinator.snapshot("chat-ack-unsettled").entries).toEqual([
+      { entryId: 111, messageId: "msg-ack-unsettled", phase: "terminal" },
+    ]);
+    expect(coordinator.receive(entry)).toEqual({ kind: "duplicate-in-flight" });
+  });
+
   it("keeps a recovery redelivery burst in recovery mode until unsettled work drains", async () => {
     const ackEntry = mockAckEntry();
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -253,6 +253,9 @@ export class AgentSlot {
         // reconcile. Reconnects with an existing SessionRuntime are handled
         // here.
         if (!this.sessionRuntime) return;
+        void this.sessionRuntime.reconcileAckSettlementAfterBind?.().catch((err) => {
+          this.logger.warn({ err }, "inbox ACK settlement rebind reconciliation failed; will retry on next bind");
+        });
         // Replay-fence reconciliation on every (re)bind: an ACK committed
         // while this client was offline can leave a stale fence the startup
         // pass never revisits. Outstanding truth counts pending+delivered,

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -343,7 +343,7 @@ export class AgentSlot {
 
       const ackEntry = (entryId: number) => this.clientConnection.sendInboxAck(entryId, agent.agentId);
       const recoverChat = async (chatId: string) => {
-        await this.clientConnection.sendInboxRecover(agent.agentId, chatId);
+        return this.clientConnection.sendInboxRecover(agent.agentId, chatId);
       };
       const runtimeProvider = runtimeProviderSchema.safeParse(runtimeType);
       if (!runtimeProvider.success) {

--- a/packages/client/src/runtime/client-connection.ts
+++ b/packages/client/src/runtime/client-connection.ts
@@ -395,6 +395,10 @@ const RECONNECT_MAX_MS = 30_000;
 const WS_CONNECT_TIMEOUT_MS = 10_000;
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const INBOX_ACK_CONFIRM_TIMEOUT_MS = 3_000;
+const INBOX_ACK_MAX_SENDS = 2;
+const INBOX_ACK_PENDING_CAP = 1024;
+const INBOX_ACK_TIMEOUT_CLOSE_CODE = 1011;
+const INBOX_ACK_TIMEOUT_CLOSE_REASON = "inbox ack timeout";
 const INBOX_RECOVER_CONFIRM_TIMEOUT_MS = 3_000;
 const SESSION_EVENT_CONFIRM_TIMEOUT_MS = 3_000;
 const INBOX_RECOVER_TIMEOUT_CLOSE_CODE = 1011;
@@ -537,6 +541,8 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * limiter window. Cleared after one use.
    */
   private nextReconnectMinDelayMs = 0;
+  /** Guards the shared ACK confirm fail-close so a timeout and cap hit close the socket once. */
+  private inboxAckFailCloseStarted = false;
   private closing = false;
   private registered = false;
   /**
@@ -687,9 +693,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
 
   /**
    * Ack a delivered inbox entry over the WS data plane. New servers confirm
-   * ACKs with a correlated response; until then this keeps an in-memory retry
-   * record and resolves only after the server accepts/rejects it. Legacy
-   * servers keep the old fire-and-forget behaviour.
+   * ACKs with a correlated response; confirmed ACKs send at most twice on the
+   * same socket (initial + one retry) and never replay across a new socket.
+   * Legacy servers keep the old fire-and-forget behaviour.
    */
   sendInboxAck(entryId: number, agentId?: string): Promise<void> {
     if (!this.serverSupportsInboxAckConfirm) {
@@ -699,6 +705,13 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
 
     const existing = this.pendingInboxAcks.get(entryId);
     if (existing) return existing.promise;
+
+    if (this.pendingInboxAcks.size >= INBOX_ACK_PENDING_CAP) {
+      const pending = this.createPendingInboxAck(entryId, agentId);
+      this.pendingInboxAcks.set(entryId, pending);
+      this.failCloseInboxAckConfirmations("inbox ack timeout");
+      return pending.promise;
+    }
 
     const pending = this.createPendingInboxAck(entryId, agentId);
     this.pendingInboxAcks.set(entryId, pending);
@@ -932,6 +945,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       return;
     }
 
+    if (pending.attempts >= INBOX_ACK_MAX_SENDS) {
+      this.failCloseInboxAckConfirmations("inbox ack timeout");
+      return;
+    }
+
     this.clearPendingInboxAckTimer(pending);
     if (pending.firstSentAt === 0) pending.firstSentAt = Date.now();
     pending.attempts += 1;
@@ -963,8 +981,30 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         },
         "inbox:ack confirmation timed out",
       );
+      if (pending.attempts >= INBOX_ACK_MAX_SENDS) {
+        this.failCloseInboxAckConfirmations("inbox ack timeout");
+        return;
+      }
       this.sendPendingInboxAck(pending, true);
     }, INBOX_ACK_CONFIRM_TIMEOUT_MS);
+  }
+
+  private failCloseInboxAckConfirmations(reason: string): void {
+    if (this.inboxAckFailCloseStarted) return;
+    this.inboxAckFailCloseStarted = true;
+    this.rejectAllPendingInboxAcks(reason);
+    this.nextReconnectMinDelayMs = Math.max(this.nextReconnectMinDelayMs, RECONNECT_MAX_MS);
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN || this.closing) return;
+    this.wsLogger.warn(
+      {
+        closeCode: INBOX_ACK_TIMEOUT_CLOSE_CODE,
+        pendingCap: INBOX_ACK_PENDING_CAP,
+        ackEvent: "inbox_ack_timeout_reconnect",
+      },
+      "inbox:ack confirmation exhausted — closing socket to force bind recovery",
+    );
+    ws.close(INBOX_ACK_TIMEOUT_CLOSE_CODE, INBOX_ACK_TIMEOUT_CLOSE_REASON);
   }
 
   private flushPendingInboxAcks(): void {
@@ -1471,6 +1511,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
 
       ws.on("open", async () => {
         this.ws = ws;
+        this.inboxAckFailCloseStarted = false;
         // Capability negotiation is per-connection: never carry a previous
         // server's Reset support into the register frame of a socket that may
         // have landed on a rolled-back replica.
@@ -1557,13 +1598,13 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       ws.on("close", (code) => {
         this.stopHeartbeat();
         this.clearAuthRefreshTimer();
-        this.clearPendingInboxAckTimers();
         this.clearPendingInboxRecoverTimers();
         this.clearPendingSessionEventTimers();
         const wasRegistered = this.registered;
         this.registered = false;
         this.socketBoundAgentIds.clear();
         this.rejectAllPendingBinds("WebSocket closed");
+        this.rejectAllPendingInboxAcks("WebSocket closed");
         this.rejectAllPendingInboxRecovers("WebSocket closed");
         this.rejectAllPendingInboxFenceProbes("WebSocket closed");
         this.rejectAllPendingSessionEvents("WebSocket closed");

--- a/packages/client/src/runtime/client-connection.ts
+++ b/packages/client/src/runtime/client-connection.ts
@@ -99,10 +99,10 @@ export type InboxFenceProbeResult = {
 /**
  * Result of an accepted inbox recovery. `resetCount` only covers rows the
  * reset moved out of `delivered`; `unackedOutstanding` is the server's
- * authoritative pending+delivered backlog for the chat scope, and
-Only `unackedOutstanding === 0`
- * or an explicit id list may prove settlement; older servers omit them, and
- * absence must be treated as unknown, never as zero/empty.
+ * authoritative pending+delivered backlog for the chat scope. Only
+ * `unackedOutstanding === 0` or an explicit id list may prove settlement;
+ * older servers omit them, and absence must be treated as unknown, never as
+ * zero/empty.
  */
 export type InboxRecoverResult = {
   resetCount: number;

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -39,6 +39,7 @@ export type WorkSnapshot = {
   }>;
   recoveryDebt: RecoveryDebt;
   admissionPending: boolean;
+  needsAckSettlementReconcile: boolean;
 };
 
 type DeliveryPhase = "open" | "owned" | "terminal";
@@ -92,6 +93,12 @@ type ChatInboxLedger = {
   // Server recovery can redeliver several frames after one accepted request;
   // keep classifying that burst as recovery while any redelivered work is unsettled.
   recoveryWindowOpen: boolean;
+  /**
+   * ACK-through failed before the Client saw a confirm. The row may already
+   * be `acked` on the server, so bind reset will not redeliver it. Rebind
+   * must call `inbox:recover` to learn settlement; do not wait for dispatch.
+   */
+  needsAckSettlementReconcile: boolean;
   admissionQueue: Promise<void> | null;
   ackQueue: Promise<unknown> | null;
 };
@@ -221,6 +228,24 @@ export class InboxDeliveryCoordinator {
     await this.requestRecovery(chatId, reason);
   }
 
+  /**
+   * After `agent:bound`, retry `inbox:recover` only for chats whose ACK
+   * confirm was lost. Fail-close closes the socket before the first recover
+   * can send; acked rows are not redelivered, so dispatch never retries.
+   */
+  async reconcileAckSettlementAfterBind(): Promise<void> {
+    const chatIds: string[] = [];
+    for (const [chatId, ledger] of this.ledgers) {
+      if (ledger.needsAckSettlementReconcile) chatIds.push(chatId);
+    }
+    for (const chatId of chatIds) {
+      const inFlight = this.recoveringChats.get(chatId);
+      if (inFlight) await inFlight;
+      if (!this.ledgers.get(chatId)?.needsAckSettlementReconcile) continue;
+      await this.requestRecovery(chatId, "ack_settlement_rebind");
+    }
+  }
+
   private async requestRecovery(chatId: string, reason: string): Promise<void> {
     const existing = this.recoveringChats.get(chatId);
     if (existing) {
@@ -247,6 +272,7 @@ export class InboxDeliveryCoordinator {
     recovery = recoverChat(chatId)
       .then((result) => {
         const current = this.ledger(chatId);
+        current.needsAckSettlementReconcile = false;
         if (recoverProvedChatSettled(result)) {
           this.commitRemainingEntriesFromServerProof(chatId);
           current.recoveryDebt = "none";
@@ -633,7 +659,12 @@ export class InboxDeliveryCoordinator {
   hasUnsettledWork(chatId: string): boolean {
     const ledger = this.ledgers.get(chatId);
     if (!ledger) return false;
-    return ledger.entries.length > 0 || ledger.recoveryDebt !== "none" || ledger.admissionQueue !== null;
+    return (
+      ledger.entries.length > 0 ||
+      ledger.recoveryDebt !== "none" ||
+      ledger.admissionQueue !== null ||
+      ledger.needsAckSettlementReconcile
+    );
   }
 
   hasProcessingOwnedWork(chatId: string): boolean {
@@ -657,6 +688,7 @@ export class InboxDeliveryCoordinator {
       })),
       recoveryDebt: ledger?.recoveryDebt ?? "none",
       admissionPending: ledger?.admissionQueue !== null,
+      needsAckSettlementReconcile: ledger?.needsAckSettlementReconcile === true,
     };
   }
 
@@ -742,6 +774,7 @@ export class InboxDeliveryCoordinator {
             tracked.ackAttempt = undefined;
           }
         }
+        current.needsAckSettlementReconcile = true;
       }
       this.emitWorkChanged(chatId);
       void this.markRecoveryDebt(chatId, `${reason}:ack_failed`, {
@@ -766,6 +799,7 @@ export class InboxDeliveryCoordinator {
         committed.map((tracked) => tracked.messageId),
       );
     }
+    current.needsAckSettlementReconcile = false;
     if (current.entries.length === 0 && current.recoveryDebt === "required") {
       current.recoveryDebt = "none";
     }
@@ -823,11 +857,13 @@ export class InboxDeliveryCoordinator {
   private commitRemainingEntriesFromServerProof(chatId: string): void {
     const current = this.ledgers.get(chatId);
     if (!current || current.entries.length === 0) {
+      if (current) current.needsAckSettlementReconcile = false;
       this.cleanupLedger(chatId);
       return;
     }
     const committed = current.entries;
     current.entries = [];
+    current.needsAckSettlementReconcile = false;
     const messageIds = committed.map((tracked) => tracked.messageId);
     this.markFenceSettled(chatId, messageIds);
     for (const tracked of committed) {
@@ -954,6 +990,7 @@ export class InboxDeliveryCoordinator {
       recoveryDebt: "none",
       recoveryActivationReady: false,
       recoveryWindowOpen: false,
+      needsAckSettlementReconcile: false,
       admissionQueue: null,
       ackQueue: null,
     };
@@ -978,6 +1015,7 @@ export class InboxDeliveryCoordinator {
       ledger.recoveryDebt === "none" &&
       !ledger.recoveryActivationReady &&
       !ledger.recoveryWindowOpen &&
+      !ledger.needsAckSettlementReconcile &&
       ledger.admissionQueue === null &&
       ledger.ackQueue === null
     ) {

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -21,6 +21,16 @@ export type DeliveryDecision =
 
 export type DeliveryRouteOwnership = "owned" | "settled" | "lost";
 
+type InboxRecoverChatResult = {
+  unackedOutstanding?: number;
+};
+
+function recoverProvedChatSettled(result: unknown): boolean {
+  if (typeof result !== "object" || result === null) return false;
+  if (!("unackedOutstanding" in result)) return false;
+  return (result as InboxRecoverChatResult).unackedOutstanding === 0;
+}
+
 export type WorkSnapshot = {
   entries: Array<{
     entryId: number;
@@ -88,7 +98,8 @@ type ChatInboxLedger = {
 
 type InboxDeliveryCoordinatorConfig = {
   ackEntry: (entryId: number) => Promise<void>;
-  recoverChat?: (chatId: string) => Promise<void>;
+  /** Resolving `{ unackedOutstanding: 0 }` proves the chat settled; omitted is unknown. */
+  recoverChat?: (chatId: string) => Promise<unknown>;
   /** Retry a captured terminal runtime notice during recovery/redelivery. */
   postRuntimeFailureNotice?: (chatId: string, payload: ProviderRetryEventPayload) => Promise<void>;
   onWorkChanged: (chatId: string) => void;
@@ -234,9 +245,21 @@ export class InboxDeliveryCoordinator {
 
     let recovery: Promise<void>;
     recovery = recoverChat(chatId)
-      .then(() => {
-        this.clearEntriesForRecoverySuccess(chatId);
+      .then((result) => {
         const current = this.ledger(chatId);
+        if (recoverProvedChatSettled(result)) {
+          this.commitRemainingEntriesFromServerProof(chatId);
+          current.recoveryDebt = "none";
+          current.recoveryActivationReady = false;
+          current.recoveryWindowOpen = false;
+          this.cleanupLedger(chatId);
+          this.config.log.info(
+            { chatId, reason, unackedOutstanding: 0 },
+            "inbox recover proved chat settled; released retained ledger",
+          );
+          return;
+        }
+        this.clearEntriesForRecoverySuccess(chatId);
         current.recoveryDebt = "none";
         current.recoveryActivationReady = true;
         current.recoveryWindowOpen = false;
@@ -790,6 +813,32 @@ export class InboxDeliveryCoordinator {
       this.deduplicator.drop(tracked.dedupKey);
     }
     ledger.entries = retained;
+  }
+
+  /**
+   * `inbox:recover` reported no pending+delivered rows. Bind reset cannot
+   * redeliver already-acked work, so retained terminals are settlement
+   * proof rather than recovery debt.
+   */
+  private commitRemainingEntriesFromServerProof(chatId: string): void {
+    const current = this.ledgers.get(chatId);
+    if (!current || current.entries.length === 0) {
+      this.cleanupLedger(chatId);
+      return;
+    }
+    const committed = current.entries;
+    current.entries = [];
+    const messageIds = committed.map((tracked) => tracked.messageId);
+    this.markFenceSettled(chatId, messageIds);
+    for (const tracked of committed) {
+      this.deduplicator.drop(tracked.dedupKey);
+      this.recentlySettled.isDuplicate(
+        this.settledKey({ chatId, entryId: tracked.entryId, messageId: tracked.messageId }),
+      );
+    }
+    this.config.onDeliveriesCommitted?.(chatId, messageIds);
+    this.cleanupLedger(chatId);
+    this.emitWorkChanged(chatId);
   }
 
   private async settleNoticeRequiredRedelivery(chatId: string, tracked: TrackedDelivery): Promise<void> {

--- a/packages/client/src/runtime/reset-replay-authority.ts
+++ b/packages/client/src/runtime/reset-replay-authority.ts
@@ -40,7 +40,7 @@ export type ResetReplayAuthorityDeps = {
   isQuarantineRestartRequired: (chatId: string) => boolean;
   /** Lazy so SessionRuntime can construct inboxDelivery after this authority. */
   inbox: () => ResetReplayInboxHost;
-  recoverChat: () => ((chatId: string) => Promise<void>) | undefined;
+  recoverChat: () => ((chatId: string) => Promise<unknown>) | undefined;
   probeFencedSettlement: () =>
     | ((chatId: string, messageIds: readonly string[]) => Promise<readonly string[]>)
     | undefined;

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -330,9 +330,11 @@ type SessionRuntimeConfig = {
   ackEntry: (entryId: number) => Promise<void>;
   /**
    * Same-socket chat recovery: reset delivered-but-unacked entries for the
-   * chat back to pending and redeliver them on this connection.
+   * chat back to pending and redeliver them on this connection. A resolved
+   * `{ unackedOutstanding: 0 }` proves the chat has no pending+delivered
+   * notify rows left; omit the field on older servers (unknown, not zero).
    */
-  recoverChat?: (chatId: string) => Promise<void>;
+  recoverChat?: (chatId: string) => Promise<unknown>;
   /**
    * Read-only settlement probe for concrete fenced deliveries: resolves
    * with the probed message ids the server proves settled (no unsettled

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -1367,6 +1367,14 @@ export class SessionRuntime {
     this.projection.noteBindRecoveryComplete();
   }
 
+  /**
+   * Retry ACK-confirm settlement only for chats that failed inbox:ack
+   * confirmation. Independent of runtime-proof and Reset-fence recovery.
+   */
+  async reconcileAckSettlementAfterBind(): Promise<void> {
+    await this.inboxDelivery.reconcileAckSettlementAfterBind();
+  }
+
   // ---- Internal -----------------------------------------------------------
 
   private hasHealthyLiveHandler(chatId: string): boolean {

--- a/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
+++ b/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
@@ -44,7 +44,7 @@ Branch 1 — confirm lost after commit:
 
 - The notify row stays `acked` after reconnect.
 - Bind reset does not redeliver that row and does not start a second provider turn for work that already entered the first turn.
-- After `inbox:recover` reports `unackedOutstanding === 0` (or an equivalent server settlement proof), the Client must release that row from local unsettled work instead of waiting forever for a redelivery that cannot happen.
+- After `inbox:recover` reports `unackedOutstanding === 0` (or an equivalent server settlement proof), the Client must release that row from local unsettled work: ledger empty, recovery debt none, no activation window waiting for redelivery.
 
 Branch 2 — request never committed:
 

--- a/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
+++ b/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
@@ -1,0 +1,43 @@
+---
+id: inbox-ack-confirm-timeout-and-bind-reset
+description: Verify a dropped inbox ACK confirm causes one Client retry then one reconnect, and bind reset redelivers without losing or double-entering the message.
+areas: [cross-surface]
+surfaces: [server, client]
+---
+
+# Inbox ACK Confirm Timeout And Bind Reset
+
+## Goal
+
+Confirm the rare ACK-confirm failure path stays bounded and recoverable: when the Server accepts `inbox:ack` frames with `ref` but the Client never sees `inbox:ack:accepted`, the Client retries once on the same socket, then closes that socket. After reconnect and `agent:bind`, unacked work comes back through bind reset rather than disappearing or being ACKed from another socket's leftover prefix.
+
+This is live Server + Client behavior around dropped confirm frames. Deterministic unit tests already cover the timer, cap, and in-flight snapshot rules; this case is the cross-process loop those tests cannot see.
+
+## Preconditions
+
+- Isolated run cell with Server and a built Client daemon on the same network.
+- An authenticated daemon, one bound agent, and a chat that can deliver a notify-worthy inbox row to that agent.
+- A way to drop or withhold `inbox:ack:accepted` / `inbox:ack:rejected` on the Client for one turn (proxy, debug hook, or Server-side confirm suppression). Do not change schema, wire fields, or persistence.
+
+## Operate
+
+- Deliver one notify-worthy message to the bound agent and let the Client send a confirmed `inbox:ack` with a `ref`.
+- Drop the matching confirm frame.
+- Watch the same socket: the Client should send exactly one retry with the same `ref`, then close with `1011` / `inbox ack timeout`.
+- Allow reconnect and `agent:bind` to finish. Do not manually ACK leftover rows.
+
+## Observe
+
+- Client logs or WS frames: two `inbox:ack` sends for that entry, no third send, one socket close, then a new connection and bind.
+- After bind reset, the unacked notify row is pending/redelivered to the new socket. The agent does not silently skip the message, and the provider does not start a second user-visible turn for work that already entered the first turn.
+- A later ACK on the new socket commits only rows that socket actually delivered.
+
+## Expected Result
+
+`PASS`: one retry, one reconnect, bind reset redelivers the unacked row, and no message is lost or double-entered.
+
+`FAIL`: unbounded 3s retries, a third ACK on the same socket, old ACKs replayed after rebind, or an ACK that settles a row the current socket never delivered.
+
+`BLOCKED`: the run cell cannot authenticate, bind an agent, or intercept ACK confirm frames.
+
+`INCONCLUSIVE`: delivery or reconnect happened, but confirm-drop and bind-reset outcomes cannot be attributed to the target ref.

--- a/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
+++ b/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
@@ -44,7 +44,7 @@ Branch 1 — confirm lost after commit:
 
 - The notify row stays `acked` after reconnect.
 - Bind reset does not redeliver that row and does not start a second provider turn for work that already entered the first turn.
-- After `inbox:recover` reports `unackedOutstanding === 0` (or an equivalent server settlement proof), the Client must release that row from local unsettled work: ledger empty, recovery debt none, no activation window waiting for redelivery.
+- After fail-close the dying socket may fail the first `inbox:recover`. The next `agent:bound` must retry recover for that chat. When it reports `unackedOutstanding === 0`, the Client must release that row from local unsettled work: ledger empty, recovery debt none, no activation window waiting for redelivery.
 
 Branch 2 — request never committed:
 

--- a/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
+++ b/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
@@ -44,6 +44,7 @@ Branch 1 — confirm lost after commit:
 
 - The notify row stays `acked` after reconnect.
 - Bind reset does not redeliver that row and does not start a second provider turn for work that already entered the first turn.
+- After `inbox:recover` reports `unackedOutstanding === 0` (or an equivalent server settlement proof), the Client must release that row from local unsettled work instead of waiting forever for a redelivery that cannot happen.
 
 Branch 2 — request never committed:
 
@@ -53,9 +54,9 @@ Branch 2 — request never committed:
 
 ## Expected Result
 
-`PASS`: both branches keep initial + one retry, one `1011` close, and no third same-socket ACK. Branch 1 leaves the row `acked` with no redelivery and no second provider entry. Branch 2 redelivers the unsettled row after bind reset, and a later ACK settles only the current-socket delivery set.
+`PASS`: both branches keep initial + one retry, one `1011` close, and no third same-socket ACK. Branch 1 leaves the row `acked` with no redelivery, no second provider entry, and the Client ledger released after settlement proof. Branch 2 redelivers the unsettled row after bind reset, and a later ACK settles only the current-socket delivery set.
 
-`FAIL`: unbounded 3s retries; a third ACK on the same socket; old ACKs replayed after rebind; treating a committed ACK as if it must redeliver; or an ACK that settles a row the current socket never delivered.
+`FAIL`: unbounded 3s retries; a third ACK on the same socket; old ACKs replayed after rebind; treating a committed ACK as if it must redeliver; keeping the committed row as Client recovery debt after `unackedOutstanding === 0`; or an ACK that settles a row the current socket never delivered.
 
 `BLOCKED`: the run cell cannot authenticate, bind an agent, or independently intercept confirm-drop versus uncommitted-ACK.
 

--- a/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
+++ b/packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md
@@ -1,6 +1,6 @@
 ---
 id: inbox-ack-confirm-timeout-and-bind-reset
-description: Verify a dropped inbox ACK confirm causes one Client retry then one reconnect, and bind reset redelivers without losing or double-entering the message.
+description: Verify a confirmed inbox ACK stays at one same-socket retry then one 1011 close, and reconnect outcomes split on whether the ACK request already committed.
 areas: [cross-surface]
 surfaces: [server, client]
 ---
@@ -9,35 +9,54 @@ surfaces: [server, client]
 
 ## Goal
 
-Confirm the rare ACK-confirm failure path stays bounded and recoverable: when the Server accepts `inbox:ack` frames with `ref` but the Client never sees `inbox:ack:accepted`, the Client retries once on the same socket, then closes that socket. After reconnect and `agent:bind`, unacked work comes back through bind reset rather than disappearing or being ACKed from another socket's leftover prefix.
+Confirm the rare ACK-confirm failure path stays bounded: for a confirmed `inbox:ack` with `ref`, the Client sends only the initial frame plus one same-socket retry, then closes that socket once with `1011` / `inbox ack timeout`. There is no third send on that socket.
 
-This is live Server + Client behavior around dropped confirm frames. Deterministic unit tests already cover the timer, cap, and in-flight snapshot rules; this case is the cross-process loop those tests cannot see.
+Reconnect recovery then depends on whether the Server already committed the ACK request. Dropping only the `inbox:ack:accepted` / `inbox:ack:rejected` confirm is not the same as the request never landing. Deterministic unit tests already cover the timer, cap, and in-flight snapshot rules; this case is the cross-process loop those tests cannot see.
 
 ## Preconditions
 
 - Isolated run cell with Server and a built Client daemon on the same network.
 - An authenticated daemon, one bound agent, and a chat that can deliver a notify-worthy inbox row to that agent.
-- A way to drop or withhold `inbox:ack:accepted` / `inbox:ack:rejected` on the Client for one turn (proxy, debug hook, or Server-side confirm suppression). Do not change schema, wire fields, or persistence.
+- A way to intercept the ACK path without changing schema, wire fields, or persistence. Support both of these independently:
+  - drop or withhold only `inbox:ack:accepted` / `inbox:ack:rejected` after the Server has accepted and committed the request;
+  - drop the `inbox:ack` request itself, or suppress handling before the Server transaction, so the row is never settled.
 
 ## Operate
 
+Shared Client bounds for both branches:
+
 - Deliver one notify-worthy message to the bound agent and let the Client send a confirmed `inbox:ack` with a `ref`.
-- Drop the matching confirm frame.
-- Watch the same socket: the Client should send exactly one retry with the same `ref`, then close with `1011` / `inbox ack timeout`.
-- Allow reconnect and `agent:bind` to finish. Do not manually ACK leftover rows.
+- Watch the same socket: the Client should send exactly one retry with the same `ref`, then close once with `1011` / `inbox ack timeout`. No third `inbox:ack` on that socket.
+- Allow reconnect and `agent:bind` to finish. Do not manually ACK leftover rows unless a later current-socket delivery needs an ACK.
+
+Then run the two branches as separate observations of the same Client bounds:
+
+1. **Confirm dropped, request already committed.** Let the Server accept `inbox:ack` and persist the row as `acked`. Drop only the matching confirm frames.
+2. **ACK request never committed.** Drop the request, or suppress handling before the transaction, so the row stays unsettled (`pending` / `delivered` / reset-pending). After fail-close, let bind reset recover it.
 
 ## Observe
 
+Shared:
+
 - Client logs or WS frames: two `inbox:ack` sends for that entry, no third send, one socket close, then a new connection and bind.
-- After bind reset, the unacked notify row is pending/redelivered to the new socket. The agent does not silently skip the message, and the provider does not start a second user-visible turn for work that already entered the first turn.
-- A later ACK on the new socket commits only rows that socket actually delivered.
+
+Branch 1 — confirm lost after commit:
+
+- The notify row stays `acked` after reconnect.
+- Bind reset does not redeliver that row and does not start a second provider turn for work that already entered the first turn.
+
+Branch 2 — request never committed:
+
+- The notify row is still unsettled before reconnect.
+- After fail-close, bind reset redelivers it to the new socket. The agent does not silently skip the message.
+- A later ACK on the new socket commits only rows that socket actually delivered. Leftover prefix from another socket's delivery set is rejected.
 
 ## Expected Result
 
-`PASS`: one retry, one reconnect, bind reset redelivers the unacked row, and no message is lost or double-entered.
+`PASS`: both branches keep initial + one retry, one `1011` close, and no third same-socket ACK. Branch 1 leaves the row `acked` with no redelivery and no second provider entry. Branch 2 redelivers the unsettled row after bind reset, and a later ACK settles only the current-socket delivery set.
 
-`FAIL`: unbounded 3s retries, a third ACK on the same socket, old ACKs replayed after rebind, or an ACK that settles a row the current socket never delivered.
+`FAIL`: unbounded 3s retries; a third ACK on the same socket; old ACKs replayed after rebind; treating a committed ACK as if it must redeliver; or an ACK that settles a row the current socket never delivered.
 
-`BLOCKED`: the run cell cannot authenticate, bind an agent, or intercept ACK confirm frames.
+`BLOCKED`: the run cell cannot authenticate, bind an agent, or independently intercept confirm-drop versus uncommitted-ACK.
 
-`INCONCLUSIVE`: delivery or reconnect happened, but confirm-drop and bind-reset outcomes cannot be attributed to the target ref.
+`INCONCLUSIVE`: delivery or reconnect happened, but confirm-drop versus uncommitted-ACK outcomes cannot be attributed to the target ref.

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -97,6 +97,15 @@ describe("inbox WS data-plane claim helpers", () => {
       .orderBy(asc(inboxEntries.id));
   }
 
+  function ackThrough(
+    app: FastifyInstance,
+    entryId: number,
+    inboxIds: string[],
+    currentSocketDeliveredEntryIds: readonly number[],
+  ) {
+    return inboxService.ackEntryByIdForBoundAgents(app.db, entryId, inboxIds, currentSocketDeliveredEntryIds);
+  }
+
   it("claimAndBuildForPush atomically claims a pending entry and bundles it", async () => {
     const app = getApp();
     const { a2, messageId } = await seedDeliverable(app);
@@ -232,7 +241,7 @@ describe("inbox WS data-plane claim helpers", () => {
     expect(silentBeforeAck.length).toBeGreaterThan(0);
     expect(silentBeforeAck.every((r) => r.status === "pending")).toBe(true);
 
-    const acked = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [observer.inboxId]);
+    const acked = await ackThrough(app, entry.id, [observer.inboxId], [entry.id]);
     expect(acked.ok).toBe(true);
     if (!acked.ok) throw new Error("ack-through unexpectedly rejected");
     expect(acked.ackedCount).toBe(1);
@@ -291,7 +300,7 @@ describe("inbox WS data-plane claim helpers", () => {
       { allowRecipientlessSend: true },
     );
 
-    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [observer.agent.inboxId]);
+    const accepted = await ackThrough(app, entry.id, [observer.agent.inboxId], [entry.id]);
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
     expect(accepted.ackedEntryIds).toEqual([entry.id]);
@@ -357,7 +366,12 @@ describe("inbox WS data-plane claim helpers", () => {
     if (!secondDelivery) throw new Error("expected second delivery");
     expect(secondDelivery.message.precedingMessages.map((p) => p.content)).toEqual(["between triggers"]);
 
-    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, secondDelivery.id, [observer.agent.inboxId]);
+    const accepted = await ackThrough(
+      app,
+      secondDelivery.id,
+      [observer.agent.inboxId],
+      [firstDelivery.id, secondDelivery.id],
+    );
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
     expect(accepted.ackedEntryIds).toEqual([firstDelivery.id, secondDelivery.id]);
@@ -412,7 +426,7 @@ describe("inbox WS data-plane claim helpers", () => {
     expect(precedingContents).not.toContain("silent-1");
     expect(precedingContents).toContain(`silent-${total - 1}`);
 
-    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [observer.agent.inboxId]);
+    const accepted = await ackThrough(app, entry.id, [observer.agent.inboxId], [entry.id]);
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
     expect(accepted.ackedCount).toBe(1);
@@ -600,7 +614,7 @@ describe("inbox WS data-plane claim helpers", () => {
     const drained = await inboxService.claimBacklogForPush(app.db, a2.agent.inboxId, 10);
     expect(drained.map((entry) => entry.id)).toEqual([first.id, second.id]);
 
-    const firstAck = await inboxService.ackEntryByIdForBoundAgents(app.db, first.id, [a2.agent.inboxId]);
+    const firstAck = await ackThrough(app, first.id, [a2.agent.inboxId], [first.id]);
     expect(firstAck.ok).toBe(true);
     if (!firstAck.ok) throw new Error("ack-through unexpectedly rejected");
     expect(firstAck.ackedEntryIds).toEqual([first.id]);
@@ -615,7 +629,7 @@ describe("inbox WS data-plane claim helpers", () => {
       [second.id, "delivered"],
     ]);
 
-    const secondAck = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    const secondAck = await ackThrough(app, second.id, [a2.agent.inboxId], [second.id]);
     expect(secondAck.ok).toBe(true);
     if (!secondAck.ok) throw new Error("ack-through unexpectedly rejected");
     expect(secondAck.ackedEntryIds).toEqual([second.id]);
@@ -631,7 +645,7 @@ describe("inbox WS data-plane claim helpers", () => {
     await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[0] ?? "");
     await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[1] ?? "");
 
-    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    const accepted = await ackThrough(app, second.id, [a2.agent.inboxId], [first.id, second.id]);
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
     expect(accepted.disposition).toBe("acked");
@@ -664,7 +678,7 @@ describe("inbox WS data-plane claim helpers", () => {
       .set({ status: "pending" })
       .where(inArray(inboxEntries.id, [first.id, second.id]));
 
-    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    const accepted = await ackThrough(app, second.id, [a2.agent.inboxId], [first.id, second.id]);
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
     expect(accepted.disposition).toBe("accepted_from_pending");
@@ -694,7 +708,7 @@ describe("inbox WS data-plane claim helpers", () => {
       .set({ status: "delivered", deliveredAt: new Date() })
       .where(eq(inboxEntries.id, second.id));
 
-    const rejected = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    const rejected = await ackThrough(app, second.id, [a2.agent.inboxId], [second.id]);
     expect(rejected).toEqual({ ok: false, reason: "prefix_gap" });
 
     const after = await app.db
@@ -721,7 +735,7 @@ describe("inbox WS data-plane claim helpers", () => {
       .where(eq(inboxEntries.id, first.id));
     await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[1] ?? "");
 
-    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    const accepted = await ackThrough(app, second.id, [a2.agent.inboxId], [second.id]);
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
     expect(accepted.ackedCount).toBe(1);
@@ -739,14 +753,14 @@ describe("inbox WS data-plane claim helpers", () => {
     // Wrong scope: an inboxId set that does NOT include the entry's owner —
     // server treats this as 'no-op', preventing one socket from acking
     // another agent's deliveries.
-    const denied = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, ["inbox_other"]);
+    const denied = await ackThrough(app, entry.id, ["inbox_other"], [entry.id]);
     expect(denied).toEqual({ ok: false, reason: "not_found_or_not_bound" });
 
     const stillDelivered = await app.db.select().from(inboxEntries).where(eq(inboxEntries.id, entry.id));
     expect(stillDelivered[0]?.status).toBe("delivered");
 
     // Right scope: ack succeeds and flips status.
-    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    const accepted = await ackThrough(app, entry.id, [a2.agent.inboxId], [entry.id]);
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack unexpectedly rejected");
     expect(accepted.disposition).toBe("acked");
@@ -767,11 +781,7 @@ describe("inbox WS data-plane claim helpers", () => {
     const entry = claimed[0];
     if (!entry) throw new Error("seed claim failed");
 
-    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [
-      "inbox_other_a",
-      a2.agent.inboxId,
-      "inbox_other_b",
-    ]);
+    const accepted = await ackThrough(app, entry.id, ["inbox_other_a", a2.agent.inboxId, "inbox_other_b"], [entry.id]);
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack unexpectedly rejected");
     expect(accepted.throughEntry.status).toBe("acked");
@@ -786,10 +796,10 @@ describe("inbox WS data-plane claim helpers", () => {
     const entry = claimed[0];
     if (!entry) throw new Error("seed claim failed");
 
-    const first = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    const first = await ackThrough(app, entry.id, [a2.agent.inboxId], [entry.id]);
     expect(first.ok).toBe(true);
 
-    const second = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    const second = await ackThrough(app, entry.id, [a2.agent.inboxId], []);
     expect(second.ok).toBe(true);
     if (!second.ok) throw new Error("duplicate ack unexpectedly rejected");
     expect(second.disposition).toBe("already_acked");
@@ -805,13 +815,108 @@ describe("inbox WS data-plane claim helpers", () => {
     if (!entry) throw new Error("seed entry missing");
     expect(entry.status).toBe("pending");
 
-    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    const accepted = await ackThrough(app, entry.id, [a2.agent.inboxId], []);
     expect(accepted).toEqual({ ok: false, reason: "prefix_gap" });
   });
 
   it("ackEntryByIdForBoundAgents short-circuits on empty inbox list", async () => {
     const app = getApp();
-    const res = await inboxService.ackEntryByIdForBoundAgents(app.db, 1, []);
+    const res = await ackThrough(app, 1, [], []);
     expect(res).toEqual({ ok: false, reason: "not_found_or_not_bound" });
+  });
+
+  it("ackEntryByIdForBoundAgents rejects when a committable prefix row is missing from the current-socket snapshot", async () => {
+    const app = getApp();
+    const { a2, messageIds, rows } = await seedDeliverables(app, 2);
+    const first = rows[0];
+    const second = rows[1];
+    if (!first || !second) throw new Error("expected two inbox rows");
+
+    await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[0] ?? "");
+    await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[1] ?? "");
+
+    const rejected = await ackThrough(app, second.id, [a2.agent.inboxId], [second.id]);
+    expect(rejected).toEqual({ ok: false, reason: "not_found_or_not_bound" });
+
+    const after = await app.db
+      .select({ id: inboxEntries.id, status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.notify, true)))
+      .orderBy(asc(inboxEntries.id));
+    expect(after.map((row) => [row.id, row.status])).toEqual([
+      [first.id, "delivered"],
+      [second.id, "delivered"],
+    ]);
+  });
+
+  it("ackEntryByIdForBoundAgents accepts after recovery redelivery rebuilds the snapshot", async () => {
+    const app = getApp();
+    const { a2, chatId, messageIds, rows } = await seedDeliverables(app, 2);
+    const first = rows[0];
+    const second = rows[1];
+    if (!first || !second) throw new Error("expected two inbox rows");
+
+    await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[0] ?? "");
+    await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[1] ?? "");
+
+    const rejected = await ackThrough(app, second.id, [a2.agent.inboxId], [second.id]);
+    expect(rejected).toEqual({ ok: false, reason: "not_found_or_not_bound" });
+
+    await inboxService.recoverUnackedForScope(app.db, { inboxId: a2.agent.inboxId, chatId });
+    const redelivered = await inboxService.claimBacklogForPush(app.db, a2.agent.inboxId, 10);
+    expect(redelivered.map((entry) => entry.id).sort((left, right) => left - right)).toEqual([first.id, second.id]);
+
+    const accepted = await ackThrough(app, second.id, [a2.agent.inboxId], [first.id, second.id]);
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
+    expect([...accepted.ackedEntryIds].sort((left, right) => left - right)).toEqual([first.id, second.id]);
+  });
+
+  it("already_acked does not drain leftover silent rows even with an empty snapshot", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const human = await createTestAgent(app, { type: "human", name: `dup-h-${uid}` });
+    const observer = await createTestAgent(app, { type: "agent", name: `dup-obs-${uid}` });
+    const peer = await createTestAgent(app, { type: "agent", name: `dup-peer-${uid}` });
+    const chat = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid, peer.agent.uuid],
+    });
+    await app.db
+      .update(chatMembership)
+      .set({ mode: "mention_only" })
+      .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.agentId, observer.agent.uuid)));
+
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "silent leftover" },
+      { allowRecipientlessSend: true },
+    );
+    const trigger = await sendMessage(app.db, chat.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "notify leftover",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+    const claimed = await inboxService.claimAndBuildForPush(app.db, observer.agent.inboxId, trigger.message.id);
+    const entry = claimed[0];
+    if (!entry) throw new Error("expected trigger claim");
+
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "acked", ackedAt: new Date() })
+      .where(eq(inboxEntries.id, entry.id));
+
+    const silentBefore = await loadSilentRows(app, observer.agent.inboxId, chat.id);
+    expect(silentBefore.length).toBeGreaterThan(0);
+    expect(silentBefore.every((row) => row.status === "pending")).toBe(true);
+
+    const duplicate = await ackThrough(app, entry.id, [observer.agent.inboxId], []);
+    expect(duplicate).toMatchObject({ ok: true, disposition: "already_acked", ackedCount: 0 });
+
+    const silentAfter = await loadSilentRows(app, observer.agent.inboxId, chat.id);
+    expect(silentAfter.every((row) => row.status === "pending")).toBe(true);
   });
 });

--- a/packages/server/src/__tests__/messaging-e2e.test.ts
+++ b/packages/server/src/__tests__/messaging-e2e.test.ts
@@ -27,7 +27,7 @@ async function ackAll(
   inboxId: string,
 ) {
   for (const e of entries) {
-    await ackEntryByIdForBoundAgents(app.db, e.id, [inboxId]);
+    await ackEntryByIdForBoundAgents(app.db, e.id, [inboxId], [e.id]);
   }
 }
 

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -567,9 +567,12 @@ describe("Agent client WS branch fakes", () => {
     await emitMessage(socket, { type: "inbox:ack", entryId: 209, ref: "ack-cap12-tail" });
     await waitUntil(() => vi.mocked(inboxService.ackEntryByIdForBoundAgents).mock.calls.length > 0);
 
-    expect(inboxService.ackEntryByIdForBoundAgents).toHaveBeenCalledWith(db, 209, ["inbox_1"], [
-      201, 202, 203, 204, 205, 206, 207, 208, 209,
-    ]);
+    expect(inboxService.ackEntryByIdForBoundAgents).toHaveBeenCalledWith(
+      db,
+      209,
+      ["inbox_1"],
+      [201, 202, 203, 204, 205, 206, 207, 208, 209],
+    );
     expect(socket.sent).toContainEqual({
       type: "inbox:ack:accepted",
       entryId: 209,

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -72,7 +72,10 @@ function throwingSelectDb(error: unknown): unknown {
   };
 }
 
-function routeHarness(db: unknown): { handler: WsHandler; notifier: Record<string, unknown> } {
+function routeHarness(
+  db: unknown,
+  inbox: { maxInFlightPerAgent?: number; maxInFlightPerAgentChat?: number } = {},
+): { handler: WsHandler; notifier: Record<string, unknown> } {
   let handler: WsHandler | null = null;
   const notifier = {
     onAgentRouteChange: vi.fn(),
@@ -86,7 +89,7 @@ function routeHarness(db: unknown): { handler: WsHandler; notifier: Record<strin
   const app = {
     commandVersion: () => "test-version",
     config: {
-      inbox: { maxInFlightPerAgent: 1, maxInFlightPerAgentChat: 1 },
+      inbox: { maxInFlightPerAgent: 1, maxInFlightPerAgentChat: 1, ...inbox },
       secrets: { jwtSecret: "test-jwt-secret-key-for-vitest" },
     },
     db,
@@ -524,6 +527,56 @@ describe("Agent client WS branch fakes", () => {
 
     expect(socket.sent).toContainEqual(expect.objectContaining({ type: "inbox:deliver", entryId: 303, chatId: null }));
     expect(socket.sent).not.toContainEqual(expect.objectContaining({ type: "inbox:ack:accepted", entryId: 303 }));
+  });
+
+  it("passes the complete 9-id snapshot when the configured per-chat cap is 12", async () => {
+    mockSuccessfulBindServices();
+    const entryIds = [201, 209, 202, 208, 203, 207, 204, 206, 205];
+    vi.spyOn(inboxService, "claimBacklogForPushFair")
+      .mockResolvedValueOnce(
+        entryIds.map((id) =>
+          inboxEntry({
+            id,
+            messageId: `msg_${id}`,
+            message: messageRow({ id: `msg_${id}`, content: `cap12 ${id}` }),
+          }),
+        ),
+      )
+      .mockResolvedValue([]);
+    vi.spyOn(inboxService, "ackEntryByIdForBoundAgents").mockResolvedValueOnce({
+      ok: true,
+      throughEntry: inboxDbRow({ id: 209 }),
+      disposition: "acked",
+      ackedCount: 9,
+      ackedEntryIds: [...entryIds].sort((left, right) => left - right),
+    });
+    const db = queuedDb([
+      [{ id: "user_1", status: "active" }],
+      [{ userId: "user_1", retiredAt: null }],
+      [activeAgentRow()],
+      [activeAgentRow()],
+      [activeAgentRow()],
+    ]);
+    const { handler } = routeHarness(db, { maxInFlightPerAgent: 8192, maxInFlightPerAgentChat: 12 });
+    const socket = new FakeSocket();
+    await bindAgent(socket, handler, "bind-cap12");
+    await waitUntil(
+      () => socket.sent.filter((frame) => (frame as { type?: string }).type === "inbox:deliver").length === 9,
+    );
+
+    await emitMessage(socket, { type: "inbox:ack", entryId: 209, ref: "ack-cap12-tail" });
+    await waitUntil(() => vi.mocked(inboxService.ackEntryByIdForBoundAgents).mock.calls.length > 0);
+
+    expect(inboxService.ackEntryByIdForBoundAgents).toHaveBeenCalledWith(db, 209, ["inbox_1"], [
+      201, 202, 203, 204, 205, 206, 207, 208, 209,
+    ]);
+    expect(socket.sent).toContainEqual({
+      type: "inbox:ack:accepted",
+      entryId: 209,
+      ref: "ack-cap12-tail",
+      disposition: "acked",
+      ackedCount: 9,
+    });
   });
 
   it("treats runtime-switch claimed routes as no longer routed here without dropping the local binding", async () => {

--- a/packages/server/src/__tests__/ws-client-edge.test.ts
+++ b/packages/server/src/__tests__/ws-client-edge.test.ts
@@ -834,7 +834,7 @@ describe("Agent client WS edge protocol coverage", () => {
         ackedCount: 1,
       });
       expect(claimSpy).toHaveBeenCalled();
-      expect(ackSpy).toHaveBeenCalledWith(app.db, entryId, [agent.inboxId]);
+      expect(ackSpy).toHaveBeenCalledWith(app.db, entryId, [agent.inboxId], [entryId]);
     } finally {
       await closeSocket(ws);
       claimSpy.mockRestore();
@@ -1316,7 +1316,7 @@ describe("Agent client WS edge protocol coverage", () => {
         .spyOn(inboxService, "ackEntryByIdForBoundAgents")
         .mockRejectedValueOnce(new Error("ack db failed"));
       ws.send(JSON.stringify({ type: "inbox:ack", entryId: 888_888_888, ref: "ack-throws" }));
-      await vi.waitFor(() => expect(ackThrowSpy).toHaveBeenCalledWith(app.db, 888_888_888, [agent.inboxId]));
+      await vi.waitFor(() => expect(ackThrowSpy).toHaveBeenCalledWith(app.db, 888_888_888, [agent.inboxId], []));
 
       const ackOwnerFallbackSpy = vi.spyOn(inboxService, "ackEntryByIdForBoundAgents").mockResolvedValueOnce({
         ok: true,
@@ -1339,7 +1339,7 @@ describe("Agent client WS edge protocol coverage", () => {
         ref: "ack-owner-fallback",
         disposition: "acked",
       });
-      expect(ackOwnerFallbackSpy).toHaveBeenCalledWith(app.db, 777_777_777, [agent.inboxId]);
+      expect(ackOwnerFallbackSpy).toHaveBeenCalledWith(app.db, 777_777_777, [agent.inboxId], []);
 
       ws.send(JSON.stringify({ type: "inbox:ack", entryId: 999_999_999, ref: "ack-missing" }));
       await expect(

--- a/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
+++ b/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
@@ -102,16 +102,13 @@ describe("Agent WS — inbox delivery ordering", () => {
     });
   }
 
-  async function openBoundSocket(
-    seed: {
-      accessToken: string;
-      clientId: string;
-      agentId: string;
-      runtimeProvider: string;
-    },
-    url = wsUrl,
-  ): Promise<WebSocket> {
-    const ws = new WebSocket(url);
+  async function openBoundSocket(seed: {
+    accessToken: string;
+    clientId: string;
+    agentId: string;
+    runtimeProvider: string;
+  }): Promise<WebSocket> {
+    const ws = new WebSocket(wsUrl);
     await new Promise<void>((resolve, reject) => {
       ws.once("open", () => resolve());
       ws.once("error", reject);
@@ -591,85 +588,4 @@ describe("Agent WS — inbox delivery ordering", () => {
       await new Promise<void>((resolve) => ws.once("close", () => resolve()));
     }
   }, 15000);
-
-  it("acks a 9-entry prefix when the configured per-chat in-flight cap is 12", async () => {
-    const cappedApp = await createTestApp({ inbox: { maxInFlightPerAgentChat: 12 } });
-    await cappedApp.listen({ port: 0, host: "127.0.0.1" });
-    const address = cappedApp.server.address();
-    if (!address || typeof address === "string") throw new Error("capped test server has no address");
-    const cappedWsUrl = `ws://127.0.0.1:${address.port}/api/v1/agent/ws/client`;
-    let ws: WebSocket | undefined;
-
-    try {
-      const admin = await createAdminContext(cappedApp, {
-        username: `ws-ack-cap12-${crypto.randomUUID().slice(0, 6)}`,
-      });
-      const agent = await createAgent(cappedApp.db, {
-        name: `ws-ack-cap12-agent-${crypto.randomUUID().slice(0, 6)}`,
-        type: "agent",
-        managerId: admin.memberId,
-        clientId: admin.clientId,
-        organizationId: admin.organizationId,
-      });
-      const chat = await createChat(cappedApp.db, admin.humanAgentUuid, {
-        type: "group",
-        participantIds: [agent.uuid],
-      });
-      ws = await openBoundSocket(
-        {
-          accessToken: admin.accessToken,
-          clientId: admin.clientId,
-          agentId: agent.uuid,
-          runtimeProvider: agent.runtimeProvider,
-        },
-        cappedWsUrl,
-      );
-
-      const messageIds: string[] = [];
-      for (let i = 0; i < 9; i++) {
-        const sent = await sendMessage(cappedApp.db, chat.id, admin.humanAgentUuid, {
-          source: "api",
-          format: "text",
-          content: `cap12 ${i + 1}`,
-          metadata: { mentions: [agent.uuid] },
-        });
-        messageIds.push(sent.message.id);
-      }
-      const lastMessageId = messageIds.at(-1);
-      if (!lastMessageId) throw new Error("expected 9 messages");
-
-      const framesPromise = collectDeliverFrames(ws, 9, 10000);
-      await cappedApp.notifier.notify(agent.inboxId, lastMessageId);
-      const frames = await framesPromise;
-      expect(frames).toHaveLength(9);
-      const tail = [...frames].sort((left, right) => left.entryId - right.entryId).at(-1);
-      if (!tail) throw new Error("expected a tail delivery");
-
-      const acceptedPromise = waitForFrame(
-        ws,
-        (message) =>
-          (message as { type?: string; ref?: string }).type === "inbox:ack:accepted" &&
-          (message as { ref?: string }).ref === "ack-cap12-tail",
-      );
-      ws.send(JSON.stringify({ type: "inbox:ack", entryId: tail.entryId, ref: "ack-cap12-tail" }));
-      await expect(acceptedPromise).resolves.toMatchObject({
-        type: "inbox:ack:accepted",
-        entryId: tail.entryId,
-        ref: "ack-cap12-tail",
-        disposition: "acked",
-        ackedCount: 9,
-      });
-
-      for (const messageId of messageIds) {
-        expect((await loadNotifyRow(agent.inboxId, messageId, cappedApp.db))?.status).toBe("acked");
-      }
-    } finally {
-      if (ws) {
-        const socket = ws;
-        socket.close();
-        await new Promise<void>((resolve) => socket.once("close", () => resolve()));
-      }
-      await cappedApp.close();
-    }
-  }, 20000);
 });

--- a/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
+++ b/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
@@ -431,4 +431,161 @@ describe("Agent WS — inbox delivery ordering", () => {
       await new Promise<void>((resolve) => ws.once("close", () => resolve()));
     }
   }, 15000);
+
+  it("accepts an ACK for the current socket delivery set and frees the in-flight slot", async () => {
+    const admin = await createAdminContext(app, { username: `ws-ack-ok-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `ws-ack-ok-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+      organizationId: admin.organizationId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [agent.uuid],
+    });
+    const ws = await openBoundSocket({
+      accessToken: admin.accessToken,
+      clientId: admin.clientId,
+      agentId: agent.uuid,
+      runtimeProvider: agent.runtimeProvider,
+    });
+
+    try {
+      const first = await sendMessage(app.db, chat.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "ack current",
+        metadata: { mentions: [agent.uuid] },
+      });
+      const firstFramesPromise = collectDeliverFrames(ws, 1);
+      await app.notifier.notify(agent.inboxId, first.message.id);
+      const [firstFrame] = await firstFramesPromise;
+      if (!firstFrame) throw new Error("expected current-socket delivery");
+
+      const acceptedPromise = waitForFrame(
+        ws,
+        (message) =>
+          (message as { type?: string; ref?: string }).type === "inbox:ack:accepted" &&
+          (message as { ref?: string }).ref === "ack-current",
+      );
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: firstFrame.entryId, ref: "ack-current" }));
+      const accepted = await acceptedPromise;
+      expect(accepted).toMatchObject({
+        type: "inbox:ack:accepted",
+        entryId: firstFrame.entryId,
+        ref: "ack-current",
+        disposition: "acked",
+      });
+      expect((await loadNotifyRow(agent.inboxId, first.message.id))?.status).toBe("acked");
+
+      const nextPromise = collectDeliverFrames(ws, 1);
+      const second = await sendMessage(app.db, chat.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "ack next",
+        metadata: { mentions: [agent.uuid] },
+      });
+      await app.notifier.notify(agent.inboxId, second.message.id);
+      const [nextFrame] = await nextPromise;
+      expect(nextFrame?.message.id).toBe(second.message.id);
+    } finally {
+      ws.close();
+      await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+    }
+  }, 15000);
+
+  it("rejects an ACK whose target or prefix is not in the current socket delivery set", async () => {
+    const admin = await createAdminContext(app, { username: `ws-ack-foreign-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `ws-ack-foreign-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+      organizationId: admin.organizationId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [agent.uuid],
+    });
+    const ws = await openBoundSocket({
+      accessToken: admin.accessToken,
+      clientId: admin.clientId,
+      agentId: agent.uuid,
+      runtimeProvider: agent.runtimeProvider,
+    });
+
+    try {
+      const first = await sendMessage(app.db, chat.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "foreign prefix",
+        metadata: { mentions: [agent.uuid] },
+      });
+      const second = await sendMessage(app.db, chat.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "current tail",
+        metadata: { mentions: [agent.uuid] },
+      });
+      const framesPromise = collectDeliverFrames(ws, 2);
+      await app.notifier.notify(agent.inboxId, second.message.id);
+      const frames = await framesPromise;
+      const firstFrame = frames.find((frame) => frame.message.id === first.message.id);
+      const secondFrame = frames.find((frame) => frame.message.id === second.message.id);
+      if (!firstFrame || !secondFrame) throw new Error("expected both deliveries");
+
+      const acceptedFirstPromise = waitForFrame(
+        ws,
+        (message) =>
+          (message as { type?: string; ref?: string }).type === "inbox:ack:accepted" &&
+          (message as { ref?: string }).ref === "ack-release-prefix",
+      );
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: firstFrame.entryId, ref: "ack-release-prefix" }));
+      await acceptedFirstPromise;
+
+      await app.db
+        .update(inboxEntries)
+        .set({ status: "delivered", ackedAt: null })
+        .where(eq(inboxEntries.id, firstFrame.entryId));
+
+      const rejectedPrefixPromise = waitForFrame(
+        ws,
+        (message) =>
+          (message as { type?: string; ref?: string }).type === "inbox:ack:rejected" &&
+          (message as { ref?: string }).ref === "ack-foreign-prefix",
+      );
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: secondFrame.entryId, ref: "ack-foreign-prefix" }));
+      await expect(rejectedPrefixPromise).resolves.toMatchObject({
+        type: "inbox:ack:rejected",
+        entryId: secondFrame.entryId,
+        ref: "ack-foreign-prefix",
+        reason: "not_found_or_not_bound",
+      });
+      expect((await loadNotifyRow(agent.inboxId, first.message.id))?.status).toBe("delivered");
+      expect((await loadNotifyRow(agent.inboxId, second.message.id))?.status).toBe("delivered");
+
+      await app.db.update(inboxEntries).set({ status: "pending" }).where(eq(inboxEntries.id, firstFrame.entryId));
+
+      const rejectedResetPrefixPromise = waitForFrame(
+        ws,
+        (message) =>
+          (message as { type?: string; ref?: string }).type === "inbox:ack:rejected" &&
+          (message as { ref?: string }).ref === "ack-reset-prefix",
+      );
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: secondFrame.entryId, ref: "ack-reset-prefix" }));
+      await expect(rejectedResetPrefixPromise).resolves.toMatchObject({
+        type: "inbox:ack:rejected",
+        entryId: secondFrame.entryId,
+        ref: "ack-reset-prefix",
+        reason: "not_found_or_not_bound",
+      });
+      expect((await loadNotifyRow(agent.inboxId, first.message.id))?.status).toBe("pending");
+      expect((await loadNotifyRow(agent.inboxId, second.message.id))?.status).toBe("delivered");
+    } finally {
+      ws.close();
+      await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+    }
+  }, 15000);
 });

--- a/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
+++ b/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
@@ -62,8 +62,8 @@ describe("Agent WS — inbox delivery ordering", () => {
     });
   }
 
-  async function loadNotifyRow(inboxId: string, messageId: string) {
-    const [row] = await app.db
+  async function loadNotifyRow(inboxId: string, messageId: string, db = app.db) {
+    const [row] = await db
       .select({
         id: inboxEntries.id,
         status: inboxEntries.status,
@@ -102,13 +102,16 @@ describe("Agent WS — inbox delivery ordering", () => {
     });
   }
 
-  async function openBoundSocket(seed: {
-    accessToken: string;
-    clientId: string;
-    agentId: string;
-    runtimeProvider: string;
-  }): Promise<WebSocket> {
-    const ws = new WebSocket(wsUrl);
+  async function openBoundSocket(
+    seed: {
+      accessToken: string;
+      clientId: string;
+      agentId: string;
+      runtimeProvider: string;
+    },
+    url = wsUrl,
+  ): Promise<WebSocket> {
+    const ws = new WebSocket(url);
     await new Promise<void>((resolve, reject) => {
       ws.once("open", () => resolve());
       ws.once("error", reject);
@@ -588,4 +591,84 @@ describe("Agent WS — inbox delivery ordering", () => {
       await new Promise<void>((resolve) => ws.once("close", () => resolve()));
     }
   }, 15000);
+
+  it("acks a 9-entry prefix when the configured per-chat in-flight cap is 12", async () => {
+    const cappedApp = await createTestApp({ inbox: { maxInFlightPerAgentChat: 12 } });
+    await cappedApp.listen({ port: 0, host: "127.0.0.1" });
+    const address = cappedApp.server.address();
+    if (!address || typeof address === "string") throw new Error("capped test server has no address");
+    const cappedWsUrl = `ws://127.0.0.1:${address.port}/api/v1/agent/ws/client`;
+    let ws: WebSocket | undefined;
+
+    try {
+      const admin = await createAdminContext(cappedApp, {
+        username: `ws-ack-cap12-${crypto.randomUUID().slice(0, 6)}`,
+      });
+      const agent = await createAgent(cappedApp.db, {
+        name: `ws-ack-cap12-agent-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: admin.memberId,
+        clientId: admin.clientId,
+        organizationId: admin.organizationId,
+      });
+      const chat = await createChat(cappedApp.db, admin.humanAgentUuid, {
+        type: "group",
+        participantIds: [agent.uuid],
+      });
+      ws = await openBoundSocket(
+        {
+          accessToken: admin.accessToken,
+          clientId: admin.clientId,
+          agentId: agent.uuid,
+          runtimeProvider: agent.runtimeProvider,
+        },
+        cappedWsUrl,
+      );
+
+      const messageIds: string[] = [];
+      for (let i = 0; i < 9; i++) {
+        const sent = await sendMessage(cappedApp.db, chat.id, admin.humanAgentUuid, {
+          source: "api",
+          format: "text",
+          content: `cap12 ${i + 1}`,
+          metadata: { mentions: [agent.uuid] },
+        });
+        messageIds.push(sent.message.id);
+      }
+      const lastMessageId = messageIds.at(-1);
+      if (!lastMessageId) throw new Error("expected 9 messages");
+
+      const framesPromise = collectDeliverFrames(ws, 9, 10000);
+      await cappedApp.notifier.notify(agent.inboxId, lastMessageId);
+      const frames = await framesPromise;
+      expect(frames).toHaveLength(9);
+      const tail = [...frames].sort((left, right) => left.entryId - right.entryId).at(-1);
+      if (!tail) throw new Error("expected a tail delivery");
+
+      const acceptedPromise = waitForFrame(
+        ws,
+        (message) =>
+          (message as { type?: string; ref?: string }).type === "inbox:ack:accepted" &&
+          (message as { ref?: string }).ref === "ack-cap12-tail",
+      );
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: tail.entryId, ref: "ack-cap12-tail" }));
+      await expect(acceptedPromise).resolves.toMatchObject({
+        type: "inbox:ack:accepted",
+        entryId: tail.entryId,
+        ref: "ack-cap12-tail",
+        disposition: "acked",
+        ackedCount: 9,
+      });
+
+      for (const messageId of messageIds) {
+        expect((await loadNotifyRow(agent.inboxId, messageId, cappedApp.db))?.status).toBe("acked");
+      }
+    } finally {
+      if (ws) {
+        ws.close();
+        await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+      }
+      await cappedApp.close();
+    }
+  }, 20000);
 });

--- a/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
+++ b/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
@@ -665,8 +665,9 @@ describe("Agent WS — inbox delivery ordering", () => {
       }
     } finally {
       if (ws) {
-        ws.close();
-        await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+        const socket = ws;
+        socket.close();
+        await new Promise<void>((resolve) => socket.once("close", () => resolve()));
       }
       await cappedApp.close();
     }

--- a/packages/server/src/api/agent/ws-client/inbox-delivery.ts
+++ b/packages/server/src/api/agent/ws-client/inbox-delivery.ts
@@ -14,6 +14,7 @@ import type { ClientWsConnectionContext } from "./connection-context.js";
 const INBOX_BACKLOG_BATCH_LIMIT = 50;
 const INBOX_BACKLOG_REPAIR_INTERVAL_MS = 30_000;
 const INBOX_RECOVER_NO_PROGRESS_LIMIT = 2;
+const INBOX_ACK_DELIVERY_SNAPSHOT_LIMIT = 8;
 
 export type InboxDeliveryCoordinator = ReturnType<typeof createInboxDeliveryCoordinator>;
 
@@ -145,6 +146,14 @@ export function createInboxDeliveryCoordinator(
       if (bucket && bucket.entryIds.size === 0) byChat?.delete(owner.chatKey);
       if (byChat && byChat.size === 0) inboxInFlightByAgent.delete(owner.agentId);
     }
+  }
+
+  function snapshotCurrentSocketDeliverySet(entryId: number): number[] {
+    const owner = inboxInFlightOwnersByEntryId.get(entryId);
+    if (!owner) return [];
+    const bucket = inboxInFlightByAgent.get(owner.agentId)?.get(owner.chatKey);
+    if (!bucket) return [];
+    return [...bucket.entryIds].sort((left, right) => left - right).slice(0, INBOX_ACK_DELIVERY_SNAPSHOT_LIMIT);
   }
 
   function addInboxInFlight(agentId: string, chatId: string | null, entryId: number): void {
@@ -426,6 +435,7 @@ export function createInboxDeliveryCoordinator(
             app.db,
             entryId,
             routedBoundAgents.map((a) => a.inboxId),
+            snapshotCurrentSocketDeliverySet(entryId),
           );
           if (!ackResult.ok) {
             if (ref) {

--- a/packages/server/src/api/agent/ws-client/inbox-delivery.ts
+++ b/packages/server/src/api/agent/ws-client/inbox-delivery.ts
@@ -14,7 +14,6 @@ import type { ClientWsConnectionContext } from "./connection-context.js";
 const INBOX_BACKLOG_BATCH_LIMIT = 50;
 const INBOX_BACKLOG_REPAIR_INTERVAL_MS = 30_000;
 const INBOX_RECOVER_NO_PROGRESS_LIMIT = 2;
-const INBOX_ACK_DELIVERY_SNAPSHOT_LIMIT = 8;
 
 export type InboxDeliveryCoordinator = ReturnType<typeof createInboxDeliveryCoordinator>;
 
@@ -153,7 +152,8 @@ export function createInboxDeliveryCoordinator(
     if (!owner) return [];
     const bucket = inboxInFlightByAgent.get(owner.agentId)?.get(owner.chatKey);
     if (!bucket) return [];
-    return [...bucket.entryIds].sort((left, right) => left - right).slice(0, INBOX_ACK_DELIVERY_SNAPSHOT_LIMIT);
+    // Already bounded by `inboxMaxInFlightPerAgentChat` (schema 1–1024).
+    return [...bucket.entryIds].sort((left, right) => left - right);
   }
 
   function addInboxInFlight(agentId: string, chatId: string | null, entryId: number): void {

--- a/packages/server/src/services/chat/inbox.ts
+++ b/packages/server/src/services/chat/inbox.ts
@@ -619,11 +619,20 @@ async function collectPrecedingContext(
  *
  * Trusts only the `inboxId` set the connected socket has bound (no `inboxId`
  * on the wire), and short-circuits on an empty `inboxIds`.
+ *
+ * `currentSocketDeliveredEntryIds` is an in-process snapshot of the calling
+ * socket's current in-flight notify deliveries for the target chat. Every
+ * notify row that would move from `delivered` or reset-pending to `acked`
+ * must be in that snapshot; otherwise the commit is refused and left for
+ * bind/recovery redelivery. Duplicate ACKs against an already-acked prefix
+ * still succeed without consulting the snapshot, but they do not drain
+ * additional silent rows.
  */
 export async function ackThroughEntryIdForBoundAgents(
   db: Database,
   entryId: number,
   inboxIds: string[],
+  currentSocketDeliveredEntryIds: readonly number[],
 ): Promise<AckEntryResult> {
   if (inboxIds.length === 0) return { ok: false, reason: "not_found_or_not_bound" };
   return withSpan("inbox.ack.ws", { [FIRST_TREE_ATTR.INBOX_ENTRY_ID]: String(entryId) }, async () => {
@@ -677,7 +686,6 @@ export async function ackThroughEntryIdForBoundAgents(
       };
 
       if (committableIds.length === 0) {
-        await drainPendingSilentRows();
         return {
           ok: true,
           throughEntry: entry,
@@ -685,6 +693,11 @@ export async function ackThroughEntryIdForBoundAgents(
           ackedCount: 0,
           ackedEntryIds: [],
         };
+      }
+
+      const currentSocketDeliveredSet = new Set(currentSocketDeliveredEntryIds);
+      if (committableIds.some((id) => !currentSocketDeliveredSet.has(id))) {
+        return { ok: false, reason: "not_found_or_not_bound" };
       }
 
       const updated = await tx


### PR DESCRIPTION
## Summary

- **#1678:** Confirmed Client ACKs send at most twice on the same socket (initial + one 3s retry). Hitting a second timeout or the 1024 pending-ACK cap fail-closes once (`1011` / `inbox ack timeout`), rejects every pending ACK, and floors reconnect at `RECONNECT_MAX_MS`. Socket close now clears pending ACKs so they cannot flush after the next `agent:bound`.
- **#1670:** ACK-through requires an in-process snapshot of the current socket's in-flight notify ids for that chat. The snapshot is the complete per-chat bucket already bounded by `maxInFlightPerAgentChat` (schema 1–1024), not a hardcoded 8. Any `delivered` / reset-pending notify row that would become `acked` must be in that snapshot; otherwise the transaction returns `not_found_or_not_bound` and leaves recovery/redelivery to bind-reset. Duplicate `already_acked` still succeeds without a snapshot, but no longer drains new silent rows.
- **Lost confirm after commit:** Fail-close closes the socket before `inbox:recover` can send, and an already-acked row is not redelivered. Chats whose ACK-through failed keep a narrow rebind-reconcile mark; `AgentSlot` calls `reconcileAckSettlementAfterBind` on this agent's `agent:bound` (not via runtime-proof or Reset-fence sets). `unackedOutstanding === 0` is Server-authoritative settlement and clears ledger/debt; omitted or `> 0` stays conservative. A failed recover keeps the mark for the next bind.
- No schema, migration, WS field, capability, lease/generation, or `SessionManager` change. Old Client / new Server and the reverse stay rolling-compatible. Fail-safe is reject + redelivery, not a mis-ACK.

Fixes #1678
Fixes #1670

## Test plan

- [x] Client Vitest: first timeout retries once with the same `ref`; second timeout sends no third frame, rejects all pending ACKs, closes once; cap hits the same fail-close; accepted on send 1/2 does not close; ordinary close does not flush old ACKs after rebind; legacy fire-and-forget unchanged
- [x] Client recover settlement: same-socket `unackedOutstanding: 0` still clears ledger; production fail-close timing (first recover rejects as socket unavailable, then rebind reconciliation returns 0) clears ledger/debt/activation without a second provider/ACK; `1` and omitted retain terminal and converge on redelivery re-ACK
- [x] AgentSlot `agent:bound` wiring: this agent triggers ACK settlement reconcile; other agents do not; runtime-proof recovery is not reused
- [x] Server service Vitest: full current prefix ACKs; missing earlier committable row rejects with DB unchanged; reset + redelivery + rebuilt snapshot ACKs; `already_acked` ignores snapshot and does not drain leftover silent rows; authorized notify commit still drains silent
- [x] WS integration: current-socket delivery ACKs and frees the in-flight slot; leftover delivered / reset-pending prefix not in the current socket set is rejected
- [x] Fake coordinator harness: `routeHarness` inbox cap override 12, mock 9 deliveries, ACK snapshot is the complete 9 ids (no second live Fastify app)
- [x] `ws-client-edge` ACK spies: delivered entry snapshot is `[entryId]`; synthetic ids with no in-flight owner snapshot `[]`
- [x] `pnpm check` (changed files clean; repo has pre-existing warnings)
- [x] `pnpm typecheck`
- [ ] QA live: two branches in `packages/qa/cases/cross-surface/inbox-ack-confirm-timeout-and-bind-reset.md`
  - response-loss (request committed): row stays `acked`, no redelivery / no second provider entry; first recover may fail on the dying socket; after `agent:bound` recover `unackedOutstanding === 0` Client local unsettled/recovery state clears
  - request-loss: bind-reset/redelivery, later ACK only the current-socket delivery set
  Both: initial + one retry, one `1011` close, no third same-socket ACK