### PR TITLE
Fix attachment retention test lifecycle race

### DIFF
--- a/packages/server/src/__tests__/background-tasks-extra.test.ts
+++ b/packages/server/src/__tests__/background-tasks-extra.test.ts
@@ -212,4 +212,43 @@ describe("createBackgroundTasks", () => {
     await tasks.stop();
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it("allows callers to disable automatic attachment-retention sweeps", async () => {
+    const { createBackgroundTasks } = await import("../services/background-tasks.js");
+    const tasks = createBackgroundTasks(makeApp(), "srv_5", { attachmentRetentionSweepEnabled: false });
+
+    tasks.start();
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1_000);
+    await tasks.stop();
+
+    expect(serviceMocks.sweepExpiredMessageAttachments).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("waits for an in-flight attachment-retention sweep before stopping", async () => {
+    const { createBackgroundTasks } = await import("../services/background-tasks.js");
+    let finishSweep = (): void => undefined;
+    serviceMocks.sweepExpiredMessageAttachments.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishSweep = () =>
+            resolve({ eligibleObjects: 0, eligibleBytes: 0, deleted: 0, reclaimedBytes: 0, batches: 0 });
+        }),
+    );
+    const tasks = createBackgroundTasks(makeApp(), "srv_6");
+    tasks.start();
+
+    const stop = tasks.stop();
+    const settlement = await Promise.race([
+      stop.then(() => "stopped" as const),
+      Promise.resolve()
+        .then(() => Promise.resolve())
+        .then(() => "sweep-pending" as const),
+    ]);
+    expect(settlement).toBe("sweep-pending");
+
+    finishSweep();
+    await stop;
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -97,6 +97,8 @@ export type CreateTestAppOptions = {
   runtimeSwitchFaultInjection?: boolean;
   /** Enable the periodic cron scheduler. Disabled by default so tests that drive sweeps explicitly cannot race it. */
   cronSchedulerEnabled?: boolean;
+  /** Enable the startup and daily attachment-retention sweep. Disabled by default so database cleanup cannot race it. */
+  attachmentRetentionSweepEnabled?: boolean;
   allowedOrganizationId?: string;
   /** Official Agent Template publisher org (FIRST_TREE_AGENT_TEMPLATE_PUBLISHER_ORG_ID). */
   agentTemplatePublisherOrgId?: string;
@@ -283,7 +285,10 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
   setConfig(config);
   const app = await buildApp(config, {
     attachmentBlobStore: new MemoryAttachmentBlobStore(),
-    backgroundTasks: { cronSchedulerEnabled: opts.cronSchedulerEnabled ?? false },
+    backgroundTasks: {
+      cronSchedulerEnabled: opts.cronSchedulerEnabled ?? false,
+      attachmentRetentionSweepEnabled: opts.attachmentRetentionSweepEnabled ?? false,
+    },
     ...(opts.feishuSdk ? { feishuSdk: opts.feishuSdk } : {}),
   });
   await app.ready();

--- a/packages/server/src/__tests__/test-app-background-tasks.test.ts
+++ b/packages/server/src/__tests__/test-app-background-tasks.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const retentionSweep = vi.fn();
+
+beforeEach(() => {
+  vi.resetModules();
+  retentionSweep.mockReset();
+});
+
+afterEach(() => {
+  vi.doUnmock("../services/attachment.js");
+  vi.resetModules();
+  retentionSweep.mockReset();
+});
+
+describe("createTestApp background-task isolation", () => {
+  it("does not start the attachment-retention sweep by default", async () => {
+    retentionSweep.mockResolvedValue({
+      eligibleObjects: 0,
+      eligibleBytes: 0,
+      deleted: 0,
+      reclaimedBytes: 0,
+      batches: 0,
+    });
+    vi.doMock("../services/attachment.js", async () => {
+      const actual = await vi.importActual<typeof import("../services/attachment.js")>("../services/attachment.js");
+      return {
+        ...actual,
+        sweepExpiredMessageAttachments: retentionSweep,
+      };
+    });
+    const { createTestApp } = await import("./helpers.js");
+    const app = await createTestApp();
+
+    try {
+      expect(retentionSweep).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -25,6 +25,7 @@ export type BackgroundTasks = {
 
 export type BackgroundTaskOptions = {
   cronSchedulerEnabled?: boolean;
+  attachmentRetentionSweepEnabled?: boolean;
 };
 
 export function createBackgroundTasks(
@@ -37,6 +38,7 @@ export function createBackgroundTasks(
   let archiveSweepTimer: ReturnType<typeof setInterval> | null = null;
   let attachmentSweepTimer: ReturnType<typeof setInterval> | null = null;
   let attachmentRetentionTimer: ReturnType<typeof setInterval> | null = null;
+  const attachmentRetentionRuns = new Set<Promise<void>>();
   const cronScheduler = options.cronSchedulerEnabled === false ? null : createCronScheduler(app);
 
   async function maintainAttachments(): Promise<void> {
@@ -48,6 +50,20 @@ export function createBackgroundTasks(
     if (legacyAttachments.migrated > 0 || legacySkills.migrated > 0 || sweep.deleted > 0) {
       log.info({ legacyAttachments, legacySkills, sweep }, "attachment maintenance completed");
     }
+  }
+
+  function startAttachmentRetentionSweep(): void {
+    const run = sweepExpiredMessageAttachments(app.db, app.attachmentBlobStore, {
+      deleteEnabled: app.config.attachments.retention?.deleteEnabled ?? false,
+    })
+      .then(() => undefined)
+      .catch((err) => {
+        log.error({ err }, "attachment retention sweep failed");
+      });
+    attachmentRetentionRuns.add(run);
+    void run.finally(() => {
+      attachmentRetentionRuns.delete(run);
+    });
   }
 
   return {
@@ -111,21 +127,10 @@ export function createBackgroundTasks(
         60 * 60 * 1000,
       );
 
-      const sweepAttachmentRetention = async (): Promise<void> => {
-        await sweepExpiredMessageAttachments(app.db, app.attachmentBlobStore, {
-          deleteEnabled: app.config.attachments.retention?.deleteEnabled ?? false,
-        });
-      };
-      attachmentRetentionTimer = setInterval(async () => {
-        try {
-          await sweepAttachmentRetention();
-        } catch (err) {
-          log.error({ err }, "attachment retention sweep failed");
-        }
-      }, ATTACHMENT_RETENTION_SWEEP_INTERVAL_MS);
-      sweepAttachmentRetention().catch((err) => {
-        log.error({ err }, "initial attachment retention sweep failed");
-      });
+      if (options.attachmentRetentionSweepEnabled !== false) {
+        attachmentRetentionTimer = setInterval(startAttachmentRetentionSweep, ATTACHMENT_RETENTION_SWEEP_INTERVAL_MS);
+        startAttachmentRetentionSweep();
+      }
 
       cronScheduler?.start();
 
@@ -159,6 +164,7 @@ export function createBackgroundTasks(
         clearInterval(attachmentRetentionTimer);
         attachmentRetentionTimer = null;
       }
+      await Promise.allSettled([...attachmentRetentionRuns]);
     },
   };
 }


### PR DESCRIPTION
## Summary

- disable automatic attachment-retention scheduling in generic Server test apps while keeping production and explicit opt-in behavior enabled
- track active retention sweeps and wait for them during background-task shutdown before the database pool closes
- add deterministic regressions for the test-helper wiring and the in-flight shutdown boundary

## Root cause

Main [CI run 31784141632](https://github.com/agent-team-foundation/first-tree/actions/runs/31784141632) failed when the per-test `TRUNCATE ... CASCADE` deadlocked with the startup attachment-retention query. The retention sweep was launched fire-and-forget from `backgroundTasks.start()`, so a test app could return from `ready()` while the sweep was still using the same worker database.

The failed `me-multi-org` test was only the cleanup victim. PR #2334 did not change the test harness, background task, retention service, or failed test.

## Validation

Passed locally:

- related Server suites: 4 files / 49 tests with `--maxWorkers=2`
- background-task and bare-test-app final suites: 2 files / 7 tests
- full Server suite: 293 files / 3441 tests with `--maxWorkers=2`
- `pnpm --filter @first-tree/server typecheck`
- changed-file Biome checks
- `git diff --check`

Mutation checks also proved both regressions are effective:

- removing the in-flight `stop()` wait changes the settlement race from `sweep-pending` to `stopped`
- removing the `createTestApp()` default-disable wiring starts the mocked retention sweep and fails the helper-level test
