### PR TITLE
Adapt OpenTag onboarding for narrow desktops

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -351,6 +351,7 @@ video[data-onboarding-orientation-video]::cue {
   --opentag-status-bottom: 4.25rem;
   --opentag-status-columns: repeat(2, minmax(0, 1fr));
   --opentag-status-gap: var(--sp-10);
+  --opentag-status-item-gap: var(--sp-3);
   --opentag-picker-max-height: 10.5rem;
   --opentag-picker-anchor-gap: var(--sp-1);
   --opentag-picker-viewport-margin: var(--sp-2);
@@ -685,11 +686,12 @@ video[data-onboarding-orientation-video]::cue {
 
 @media (max-width: 68rem) {
   [data-opentag-theme="light"] {
-    --opentag-page-gutter: var(--sp-6);
-    --opentag-grid-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
-    --opentag-column-gap: var(--sp-8);
-    --opentag-status-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+    --opentag-page-gutter: var(--sp-4);
+    --opentag-grid-columns: minmax(0, 0.72fr) minmax(0, 1fr);
+    --opentag-column-gap: var(--sp-3);
+    --opentag-status-columns: minmax(0, 0.66fr) minmax(0, 1fr);
     --opentag-status-gap: var(--sp-3);
+    --opentag-status-item-gap: var(--sp-2);
     --opentag-action-padding: var(--sp-6);
     --opentag-qr-flow-offset: var(--sp-8);
     --opentag-qr-size: 10rem;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -349,10 +349,10 @@ video[data-onboarding-orientation-video]::cue {
   --opentag-content-top: 11.5rem;
   --opentag-identity-top: 5.5rem;
   --opentag-status-bottom: 4.25rem;
-  --opentag-status-columns: minmax(0, 0.84fr) minmax(0, 1.16fr);
+  --opentag-status-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
   --opentag-status-picker-columns: var(--opentag-status-columns);
-  --opentag-status-gap: var(--sp-10);
-  --opentag-status-item-gap: var(--sp-3);
+  --opentag-status-gap: var(--sp-3);
+  --opentag-status-item-gap: var(--sp-2);
   --opentag-picker-max-height: 10.5rem;
   --opentag-picker-anchor-gap: var(--sp-1);
   --opentag-picker-viewport-margin: var(--sp-2);
@@ -690,6 +690,10 @@ video[data-onboarding-orientation-video]::cue {
     --opentag-status-item-gap: var(--sp-2);
     --opentag-action-padding: var(--sp-7);
   }
+
+  .opentag-choice-trigger--compact .opentag-choice-label {
+    display: none;
+  }
 }
 
 @media (max-width: 68rem) {
@@ -697,7 +701,9 @@ video[data-onboarding-orientation-video]::cue {
     --opentag-page-gutter: var(--sp-4);
     --opentag-column-gap: var(--sp-3);
     --opentag-status-columns: minmax(0, 0.93fr) minmax(0, 1.07fr);
-    --opentag-status-picker-columns: minmax(0, 0.66fr) minmax(0, 1fr);
+    --opentag-status-picker-columns: minmax(0, 0.72fr) minmax(0, 1fr);
+    --opentag-status-gap: var(--sp-2);
+    --opentag-status-item-gap: var(--sp-1);
     --opentag-action-padding: var(--sp-6);
     --opentag-qr-flow-offset: var(--sp-8);
     --opentag-qr-size: 10rem;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -346,21 +346,22 @@ video[data-onboarding-orientation-video]::cue {
   --opentag-flow-width: 42rem;
   --opentag-grid-columns: minmax(0, var(--opentag-story-width)) minmax(0, var(--opentag-flow-width));
   --opentag-column-gap: 5.5rem;
-  --opentag-content-top: 11.5rem;
-  --opentag-identity-top: 5.5rem;
-  --opentag-status-bottom: 4.25rem;
+  --opentag-content-top: clamp(6rem, 16vh, 10.5rem);
+  --opentag-identity-top: var(--sp-12);
+  --opentag-status-bottom: var(--sp-10);
   --opentag-status-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
   --opentag-status-picker-columns: var(--opentag-status-columns);
   --opentag-status-gap: var(--sp-3);
   --opentag-status-item-gap: var(--sp-2);
+  --opentag-status-dot-size: var(--sp-3);
+  --opentag-status-row-height: var(--sp-5);
   --opentag-picker-max-height: 10.5rem;
   --opentag-picker-anchor-gap: var(--sp-1);
   --opentag-picker-viewport-margin: var(--sp-2);
   --opentag-picker-shift: 0;
-  --opentag-action-height: 10.5rem;
+  --opentag-action-height: 8.5rem;
   --opentag-action-qr-height: 21.75rem;
   --opentag-action-padding: var(--sp-8);
-  --opentag-qr-flow-offset: 4.5rem;
   --opentag-cta-height: 3.5rem;
   --opentag-qr-size: 13.5rem;
 
@@ -659,6 +660,10 @@ video[data-onboarding-orientation-video]::cue {
   --opentag-status-columns: var(--opentag-status-picker-columns);
 }
 
+.opentag-status-label {
+  line-height: var(--opentag-status-row-height);
+}
+
 .opentag-choice-panel {
   transform: translateY(calc(var(--opentag-picker-shift) * 1px));
 }
@@ -705,7 +710,6 @@ video[data-onboarding-orientation-video]::cue {
     --opentag-status-gap: var(--sp-2);
     --opentag-status-item-gap: var(--sp-1);
     --opentag-action-padding: var(--sp-6);
-    --opentag-qr-flow-offset: var(--sp-8);
     --opentag-qr-size: 10rem;
   }
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -341,15 +341,20 @@ video[data-onboarding-orientation-video]::cue {
   --opentag-accent-hover: oklch(0.7592 0.2079 131.81);
   --opentag-accent-fg: oklch(0.13 0 0);
   --opentag-page-max: 85rem;
+  --opentag-page-gutter: var(--sp-10);
   --opentag-story-width: 38rem;
   --opentag-flow-width: 42rem;
+  --opentag-grid-columns: minmax(0, var(--opentag-story-width)) minmax(0, var(--opentag-flow-width));
   --opentag-column-gap: 5.5rem;
   --opentag-content-top: 11.5rem;
   --opentag-identity-top: 5.5rem;
   --opentag-status-bottom: 4.25rem;
-  --opentag-picker-reserve: 14rem;
+  --opentag-status-gap: var(--sp-10);
+  --opentag-picker-max-height: 10.5rem;
+  --opentag-picker-lift: calc((var(--opentag-picker-max-height) + var(--sp-7)) * -1);
   --opentag-action-height: 10.5rem;
   --opentag-action-qr-height: 21.75rem;
+  --opentag-action-padding: var(--sp-8);
   --opentag-qr-flow-offset: 4.5rem;
   --opentag-cta-height: 3.5rem;
   --opentag-qr-size: 13.5rem;
@@ -645,8 +650,38 @@ video[data-onboarding-orientation-video]::cue {
   margin-bottom: var(--opentag-status-bottom);
 }
 
-.opentag-statuses:has([aria-expanded="true"]) {
-  margin-bottom: calc(var(--opentag-status-bottom) + var(--opentag-picker-reserve));
+.opentag-choice-panel {
+  transform: translateY(var(--opentag-picker-lift));
+}
+
+.opentag-choice-list {
+  max-height: calc(var(--opentag-picker-max-height) - var(--sp-6));
+  overflow-y: auto;
+}
+
+/* OpenTag remains a Desktop-only flow, but its asymmetric composition must
+   stay usable on common narrow laptop viewports. Keep these adjustments local
+   to the product surface rather than changing dashboard breakpoints. */
+@media (max-width: 80rem) {
+  [data-opentag-theme="light"] {
+    --opentag-page-gutter: var(--sp-8);
+    --opentag-grid-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+    --opentag-column-gap: var(--sp-12);
+    --opentag-status-gap: var(--sp-6);
+    --opentag-action-padding: var(--sp-7);
+  }
+}
+
+@media (max-width: 68rem) {
+  [data-opentag-theme="light"] {
+    --opentag-page-gutter: var(--sp-6);
+    --opentag-grid-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+    --opentag-column-gap: var(--sp-8);
+    --opentag-status-gap: var(--sp-5);
+    --opentag-action-padding: var(--sp-6);
+    --opentag-qr-flow-offset: var(--sp-8);
+    --opentag-qr-size: 10rem;
+  }
 }
 
 /* ============================================================================

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -351,7 +351,9 @@ video[data-onboarding-orientation-video]::cue {
   --opentag-status-bottom: 4.25rem;
   --opentag-status-gap: var(--sp-10);
   --opentag-picker-max-height: 10.5rem;
-  --opentag-picker-lift: calc((var(--opentag-picker-max-height) + var(--sp-7)) * -1);
+  --opentag-picker-anchor-gap: var(--sp-1);
+  --opentag-picker-viewport-margin: var(--sp-2);
+  --opentag-picker-shift: 0;
   --opentag-action-height: 10.5rem;
   --opentag-action-qr-height: 21.75rem;
   --opentag-action-padding: var(--sp-8);
@@ -651,7 +653,7 @@ video[data-onboarding-orientation-video]::cue {
 }
 
 .opentag-choice-panel {
-  transform: translateY(var(--opentag-picker-lift));
+  transform: translateY(calc(var(--opentag-picker-shift) * 1px));
 }
 
 .opentag-choice-list {
@@ -659,10 +661,18 @@ video[data-onboarding-orientation-video]::cue {
   overflow-y: auto;
 }
 
+.opentag-picker-placement {
+  position: absolute;
+  width: 0;
+  height: 0;
+  scroll-margin-top: var(--opentag-picker-anchor-gap);
+  scroll-margin-bottom: var(--opentag-picker-viewport-margin);
+}
+
 /* OpenTag remains a Desktop-only flow, but its asymmetric composition must
    stay usable on common narrow laptop viewports. Keep these adjustments local
    to the product surface rather than changing dashboard breakpoints. */
-@media (max-width: 80rem) {
+@media (max-width: 88rem) {
   [data-opentag-theme="light"] {
     --opentag-page-gutter: var(--sp-8);
     --opentag-grid-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -349,7 +349,8 @@ video[data-onboarding-orientation-video]::cue {
   --opentag-content-top: 11.5rem;
   --opentag-identity-top: 5.5rem;
   --opentag-status-bottom: 4.25rem;
-  --opentag-status-columns: repeat(2, minmax(0, 1fr));
+  --opentag-status-columns: minmax(0, 0.84fr) minmax(0, 1.16fr);
+  --opentag-status-picker-columns: var(--opentag-status-columns);
   --opentag-status-gap: var(--sp-10);
   --opentag-status-item-gap: var(--sp-3);
   --opentag-picker-max-height: 10.5rem;
@@ -654,6 +655,10 @@ video[data-onboarding-orientation-video]::cue {
   margin-bottom: var(--opentag-status-bottom);
 }
 
+.opentag-statuses[data-opentag-runtime-picker="true"] {
+  --opentag-status-columns: var(--opentag-status-picker-columns);
+}
+
 .opentag-choice-panel {
   transform: translateY(calc(var(--opentag-picker-shift) * 1px));
 }
@@ -676,10 +681,13 @@ video[data-onboarding-orientation-video]::cue {
    to the product surface rather than changing dashboard breakpoints. */
 @media (max-width: 88rem) {
   [data-opentag-theme="light"] {
-    --opentag-page-gutter: var(--sp-8);
-    --opentag-grid-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
-    --opentag-column-gap: var(--sp-12);
-    --opentag-status-gap: var(--sp-6);
+    --opentag-page-gutter: var(--sp-4);
+    --opentag-grid-columns: minmax(0, 0.72fr) minmax(0, 1fr);
+    --opentag-column-gap: var(--sp-4);
+    --opentag-status-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
+    --opentag-status-picker-columns: var(--opentag-status-columns);
+    --opentag-status-gap: var(--sp-3);
+    --opentag-status-item-gap: var(--sp-2);
     --opentag-action-padding: var(--sp-7);
   }
 }
@@ -687,11 +695,9 @@ video[data-onboarding-orientation-video]::cue {
 @media (max-width: 68rem) {
   [data-opentag-theme="light"] {
     --opentag-page-gutter: var(--sp-4);
-    --opentag-grid-columns: minmax(0, 0.72fr) minmax(0, 1fr);
     --opentag-column-gap: var(--sp-3);
-    --opentag-status-columns: minmax(0, 0.66fr) minmax(0, 1fr);
-    --opentag-status-gap: var(--sp-3);
-    --opentag-status-item-gap: var(--sp-2);
+    --opentag-status-columns: minmax(0, 0.93fr) minmax(0, 1.07fr);
+    --opentag-status-picker-columns: minmax(0, 0.66fr) minmax(0, 1fr);
     --opentag-action-padding: var(--sp-6);
     --opentag-qr-flow-offset: var(--sp-8);
     --opentag-qr-size: 10rem;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -349,6 +349,7 @@ video[data-onboarding-orientation-video]::cue {
   --opentag-content-top: 11.5rem;
   --opentag-identity-top: 5.5rem;
   --opentag-status-bottom: 4.25rem;
+  --opentag-status-columns: repeat(2, minmax(0, 1fr));
   --opentag-status-gap: var(--sp-10);
   --opentag-picker-max-height: 10.5rem;
   --opentag-picker-anchor-gap: var(--sp-1);
@@ -687,7 +688,8 @@ video[data-onboarding-orientation-video]::cue {
     --opentag-page-gutter: var(--sp-6);
     --opentag-grid-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
     --opentag-column-gap: var(--sp-8);
-    --opentag-status-gap: var(--sp-5);
+    --opentag-status-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+    --opentag-status-gap: var(--sp-3);
     --opentag-action-padding: var(--sp-6);
     --opentag-qr-flow-offset: var(--sp-8);
     --opentag-qr-size: 10rem;

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -388,7 +388,9 @@ describe("OpenTag single-page Desktop flow", () => {
     expect(document.body.textContent).toContain("Cursor");
     expect(document.body.textContent).toContain("Install required");
     expect(buttonExact(container, "Change").getAttribute("aria-expanded")).toBe("true");
-    expect(container.querySelector("[data-opentag-statuses]")?.classList.contains("opentag-statuses")).toBe(true);
+    const statuses = container.querySelector<HTMLElement>("[data-opentag-statuses]");
+    expect(statuses?.classList.contains("opentag-statuses")).toBe(true);
+    expect(statuses?.style.gridTemplateColumns).toBe("var(--opentag-status-columns)");
     expect(document.querySelector("[role='dialog'][aria-label='Change Agent']")?.classList).toContain(
       "opentag-choice-panel",
     );

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -298,8 +298,15 @@ describe("OpenTag single-page Desktop flow", () => {
     const state = container.querySelector("[data-opentag-state='connect-computer']");
 
     expect(container.querySelector("h1")?.textContent).toBe("Bring your agent to Feishu");
-    expect(container.querySelector<HTMLElement>("header")?.style.padding).toBe("var(--sp-3) var(--sp-12)");
-    expect(container.querySelector("[data-opentag-identity]")?.textContent).toBe("OpenTagChange name");
+    expect(container.querySelector<HTMLElement>("header")?.style.padding).toBe("var(--sp-2) var(--sp-12)");
+    expect(container.querySelector("header img")?.classList).toContain("h-10");
+    expect(container.querySelector("header img")?.classList).toContain("w-auto");
+    expect(container.querySelector("header [role='img']")?.getAttribute("style")).toContain("var(--sp-2)");
+    expect(container.querySelector("header [role='img'] span")?.classList).toContain("text-lead");
+    expect(container.querySelector<HTMLElement>("main")?.style.paddingTop).toBe("var(--opentag-content-top)");
+    const identity = container.querySelector<HTMLElement>("[data-opentag-identity]");
+    expect(identity?.textContent).toBe("OpenTagChange name");
+    expect(identity?.style.marginTop).toBe("var(--opentag-identity-top)");
     expect(state?.textContent).toContain("Copy command");
     expect(state?.querySelectorAll("button")).toHaveLength(1);
     for (const retired of ["Template", "Step 1", "Continue", "Next", "First Tree Client", "progress"]) {
@@ -384,6 +391,10 @@ describe("OpenTag single-page Desktop flow", () => {
 
     expect(container.textContent).toContain("Agent · Codex ready");
     expect(container.querySelector("[data-opentag-state='create-agent']")).not.toBeNull();
+    expect(
+      container.querySelector<HTMLElement>("[data-opentag-state='create-agent'] [data-opentag-action]")?.style
+        .minHeight,
+    ).toBe("var(--opentag-action-height)");
     await click(buttonExact(container, "Change"));
     expect(document.body.textContent).toContain("Claude Code");
     expect(document.body.textContent).toContain("Cursor");
@@ -392,6 +403,13 @@ describe("OpenTag single-page Desktop flow", () => {
     const statuses = container.querySelector<HTMLElement>("[data-opentag-statuses]");
     expect(statuses?.classList.contains("opentag-statuses")).toBe(true);
     expect(statuses?.style.gridTemplateColumns).toBe("var(--opentag-status-columns)");
+    expect(statuses?.style.marginBottom).toBe("");
+    expect(statuses?.parentElement?.style.marginTop).toBe("");
+    expect(statuses?.querySelector("span[aria-hidden='true']")?.getAttribute("style")).toContain(
+      "var(--opentag-status-dot-size)",
+    );
+    expect(statuses?.querySelector(".text-subtitle")).not.toBeNull();
+    expect(statuses?.querySelector(".text-subtitle")?.classList).toContain("opentag-status-label");
     expect(document.querySelector("[role='dialog'][aria-label='Change Agent']")?.classList).toContain(
       "opentag-choice-panel",
     );
@@ -499,6 +517,10 @@ describe("OpenTag single-page Desktop flow", () => {
     const container = await renderAt(`/opentag?agent=${AGENT_UUID}`);
     expect(agentsApi.startAgentFeishuRegistration).toHaveBeenCalledWith(AGENT_UUID, "OpenTag");
     expect(container.querySelector("[data-opentag-state='add-to-feishu']")?.textContent).toContain("Scan with Feishu");
+    expect(
+      container.querySelector<HTMLElement>("[data-opentag-state='add-to-feishu'] [data-opentag-action]")?.style
+        .minHeight,
+    ).toBe("var(--opentag-action-qr-height)");
     expect(container.querySelector("[data-opentag-qr] title")?.textContent).toBe("Feishu bot registration QR code");
     expect(container.querySelector("[data-opentag-state='add-to-feishu']")?.querySelectorAll("button")).toHaveLength(0);
     expect(agentsApi.createAgentFeishuSetupChat).toHaveBeenCalledWith(AGENT_UUID, { retry: false });
@@ -591,6 +613,10 @@ describe("OpenTag single-page Desktop flow", () => {
     expect(container.querySelector("[data-opentag-state='add-to-feishu']")?.textContent).toContain(
       "Preparing Feishu tools",
     );
+    expect(
+      container.querySelector<HTMLElement>("[data-opentag-state='add-to-feishu'] [data-opentag-action]")?.style
+        .minHeight,
+    ).toBe("var(--opentag-action-qr-height)");
   });
 
   it("preserves the Agent URL through transient read failures and retries in place", async () => {

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -16,6 +16,7 @@ import type { HubClient } from "../../../api/activity.js";
 import { ApiError } from "../../../api/client.js";
 import type { ComputerConnection } from "../../../features/agent-setup/use-computer-connection.js";
 import { OpenTagPage } from "../opentag-page.js";
+import { openTagPickerTop } from "../opentag-view.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -23,6 +24,19 @@ const AGENT_UUID = "0198b2c4-1f6a-7c31-9a02-4d5e6f708192";
 const ORG = "org-1";
 const MEMBER = "member-1";
 const clipboardWriteText = vi.fn();
+
+describe("OpenTag picker placement", () => {
+  const viewport = { panelHeight: 168, viewportTop: 0, viewportHeight: 768, margin: 8, gap: 4 };
+
+  it("opens upward when it fits and clamps a scrolled trigger to the viewport top", () => {
+    expect(openTagPickerTop({ ...viewport, triggerTop: 302 })).toBe(130);
+    expect(openTagPickerTop({ ...viewport, triggerTop: 24 })).toBe(8);
+  });
+
+  it("clamps a lower trigger's upward panel inside the viewport", () => {
+    expect(openTagPickerTop({ ...viewport, triggerTop: 800 })).toBe(592);
+  });
+});
 
 const refreshMeStrict = vi.hoisted(() => vi.fn(async () => undefined));
 const applyOnboardingStamp = vi.hoisted(() => vi.fn(() => true));
@@ -284,7 +298,7 @@ describe("OpenTag single-page Desktop flow", () => {
     const state = container.querySelector("[data-opentag-state='connect-computer']");
 
     expect(container.querySelector("h1")?.textContent).toBe("Bring your agent to Feishu");
-    expect(container.textContent).toContain("Your agentOpenTagChange name");
+    expect(container.querySelector("[data-opentag-identity]")?.textContent).toBe("OpenTagChange name");
     expect(state?.textContent).toContain("Copy command");
     expect(state?.querySelectorAll("button")).toHaveLength(1);
     for (const retired of ["Template", "Step 1", "Continue", "Next", "First Tree Client", "progress"]) {

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -298,6 +298,7 @@ describe("OpenTag single-page Desktop flow", () => {
     const state = container.querySelector("[data-opentag-state='connect-computer']");
 
     expect(container.querySelector("h1")?.textContent).toBe("Bring your agent to Feishu");
+    expect(container.querySelector<HTMLElement>("header")?.style.padding).toBe("var(--sp-3) var(--sp-12)");
     expect(container.querySelector("[data-opentag-identity]")?.textContent).toBe("OpenTagChange name");
     expect(state?.textContent).toContain("Copy command");
     expect(state?.querySelectorAll("button")).toHaveLength(1);
@@ -427,6 +428,19 @@ describe("OpenTag single-page Desktop flow", () => {
     ]);
     await click(button(container, "Create agent"));
     expect(agentsApi.createAgent.mock.calls[0]?.[0]).toMatchObject({ runtimeProvider: "pi" });
+  });
+
+  it("keeps Change available after selecting the longest ready runtime label", async () => {
+    computerMock.value = readyComputer({ codex: capability(), "claude-code": capability() });
+    const container = await renderAt("/opentag");
+
+    await click(buttonExact(container, "Change"));
+    const choices = document.querySelector("[role='dialog'][aria-label='Change Agent']");
+    if (!choices) throw new Error("missing Agent picker");
+    await click(button(choices, "Claude Code"));
+
+    expect(container.textContent).toContain("Agent · Claude Code ready");
+    expect(buttonExact(container, "Change").getAttribute("aria-expanded")).toBe("false");
   });
 
   it("pins the OpenTag light palette when the persisted root theme is dark", async () => {

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -441,6 +441,7 @@ describe("OpenTag single-page Desktop flow", () => {
 
     expect(container.textContent).toContain("Agent · Claude Code ready");
     expect(buttonExact(container, "Change").getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector<HTMLElement>("[data-opentag-statuses]")?.dataset.opentagRuntimePicker).toBe("true");
   });
 
   it("pins the OpenTag light palette when the persisted root theme is dark", async () => {

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -431,10 +431,23 @@ describe("OpenTag single-page Desktop flow", () => {
   });
 
   it("keeps Change available after selecting the longest ready runtime label", async () => {
-    computerMock.value = readyComputer({ codex: capability(), "claude-code": capability() });
+    const ready = readyComputer({ codex: capability(), "claude-code": capability() });
+    computerMock.value = computer({
+      ...ready,
+      connectedClients: [
+        ready.connectedClient as HubClient,
+        client("client-2", "Travel Mac", ready.capabilities ?? {}),
+      ],
+    });
     const container = await renderAt("/opentag");
 
-    await click(buttonExact(container, "Change"));
+    const computerChange = container.querySelector<HTMLButtonElement>("button[aria-label='Change Computer']");
+    expect(computerChange?.classList.contains("opentag-choice-trigger--compact")).toBe(true);
+    const runtimeChange = container.querySelector<HTMLButtonElement>(
+      "[data-opentag-statuses] > div:nth-child(2) button",
+    );
+    if (!runtimeChange) throw new Error("missing Agent picker trigger");
+    await click(runtimeChange);
     const choices = document.querySelector("[role='dialog'][aria-label='Change Agent']");
     if (!choices) throw new Error("missing Agent picker");
     await click(button(choices, "Claude Code"));

--- a/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
+++ b/packages/web/src/pages/opentag/__tests__/opentag-page-dom.test.tsx
@@ -375,6 +375,10 @@ describe("OpenTag single-page Desktop flow", () => {
     expect(document.body.textContent).toContain("Install required");
     expect(buttonExact(container, "Change").getAttribute("aria-expanded")).toBe("true");
     expect(container.querySelector("[data-opentag-statuses]")?.classList.contains("opentag-statuses")).toBe(true);
+    expect(document.querySelector("[role='dialog'][aria-label='Change Agent']")?.classList).toContain(
+      "opentag-choice-panel",
+    );
+    expect(document.querySelector(".opentag-choice-list")).not.toBeNull();
 
     await click(button(container, "Create agent"));
     expect(agentsApi.createAgent).toHaveBeenCalledTimes(1);

--- a/packages/web/src/pages/opentag/opentag-logo.tsx
+++ b/packages/web/src/pages/opentag/opentag-logo.tsx
@@ -3,9 +3,9 @@ import type { ReactElement } from "react";
 /** The approved self-hosted OpenTag lockup, using the production font stack. */
 export function OpenTagLogo(): ReactElement {
   return (
-    <span className="inline-flex items-center" style={{ gap: "var(--sp-3)" }} role="img" aria-label="OpenTag">
-      <img src="/opentag-mark.svg" alt="" aria-hidden="true" className="h-12 w-12 shrink-0" />
-      <span className="text-headline font-bold" style={{ color: "var(--fg)" }} aria-hidden="true">
+    <span className="inline-flex items-center" style={{ gap: "var(--sp-2)" }} role="img" aria-label="OpenTag">
+      <img src="/opentag-mark.svg" alt="" aria-hidden="true" className="h-10 w-auto shrink-0" />
+      <span className="text-lead font-bold" style={{ color: "var(--fg)" }} aria-hidden="true">
         OpenTag
       </span>
     </span>

--- a/packages/web/src/pages/opentag/opentag-shell.tsx
+++ b/packages/web/src/pages/opentag/opentag-shell.tsx
@@ -30,7 +30,7 @@ export function OpenTagShell({
     >
       <header
         className="flex items-center justify-between border-b border-border-faint"
-        style={{ padding: "var(--sp-5) var(--sp-12)" }}
+        style={{ padding: "var(--sp-3) var(--sp-12)" }}
       >
         <OpenTagLogo />
         <Button type="button" variant="link" className="h-auto p-0 text-lead font-normal" onClick={logout}>

--- a/packages/web/src/pages/opentag/opentag-shell.tsx
+++ b/packages/web/src/pages/opentag/opentag-shell.tsx
@@ -30,7 +30,7 @@ export function OpenTagShell({
     >
       <header
         className="flex items-center justify-between border-b border-border-faint"
-        style={{ padding: "var(--sp-8) var(--sp-12)" }}
+        style={{ padding: "var(--sp-5) var(--sp-12)" }}
       >
         <OpenTagLogo />
         <Button type="button" variant="link" className="h-auto p-0 text-lead font-normal" onClick={logout}>
@@ -60,10 +60,11 @@ export function OpenTagShell({
             Your agent runs on your computer. Work with it from Feishu.
           </p>
 
-          <div className="flex items-center" style={{ gap: "var(--sp-6)", marginTop: "var(--opentag-identity-top)" }}>
-            <span className="text-lead" style={{ color: "var(--fg-2)" }}>
-              Your agent
-            </span>
+          <div
+            data-opentag-identity
+            className="flex items-center"
+            style={{ gap: "var(--sp-6)", marginTop: "var(--opentag-identity-top)" }}
+          >
             {editingName ? (
               <label className="flex items-center" style={{ gap: "var(--sp-2)" }}>
                 <span className="sr-only">Agent name</span>

--- a/packages/web/src/pages/opentag/opentag-shell.tsx
+++ b/packages/web/src/pages/opentag/opentag-shell.tsx
@@ -41,8 +41,8 @@ export function OpenTagShell({
       <main
         className="mx-auto grid items-start"
         style={{
-          width: "min(calc(100% - var(--sp-20)), var(--opentag-page-max))",
-          gridTemplateColumns: "minmax(0, var(--opentag-story-width)) minmax(0, var(--opentag-flow-width))",
+          width: "min(calc(100% - (var(--opentag-page-gutter) * 2)), var(--opentag-page-max))",
+          gridTemplateColumns: "var(--opentag-grid-columns)",
           columnGap: "var(--opentag-column-gap)",
           paddingTop: "var(--opentag-content-top)",
           paddingBottom: "var(--sp-20)",

--- a/packages/web/src/pages/opentag/opentag-shell.tsx
+++ b/packages/web/src/pages/opentag/opentag-shell.tsx
@@ -30,7 +30,7 @@ export function OpenTagShell({
     >
       <header
         className="flex items-center justify-between border-b border-border-faint"
-        style={{ padding: "var(--sp-3) var(--sp-12)" }}
+        style={{ padding: "var(--sp-2) var(--sp-12)" }}
       >
         <OpenTagLogo />
         <Button type="button" variant="link" className="h-auto p-0 text-lead font-normal" onClick={logout}>

--- a/packages/web/src/pages/opentag/opentag-view.tsx
+++ b/packages/web/src/pages/opentag/opentag-view.tsx
@@ -1,7 +1,7 @@
 import { type RuntimeProvider, runtimeProviderLabel } from "@first-tree/shared";
 import { Check, ChevronDown, LoaderCircle } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
-import { type ReactElement, type ReactNode, useEffect, useRef } from "react";
+import { type ReactElement, type ReactNode, type RefObject, useEffect, useRef } from "react";
 import type { HubClient } from "../../api/activity.js";
 import { Button } from "../../components/ui/button.js";
 import { Popover } from "../../components/ui/popover.js";
@@ -319,26 +319,110 @@ function ChoicePopover({
   label: string;
   children: (close: () => void) => ReactElement;
 }): ReactElement {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+
   return (
-    <Popover
-      align="end"
-      panelAriaLabel={label}
-      panelClassName="opentag-choice-panel surface-overlay w-[var(--sp-90)] p-3"
-      trigger={({ toggle, open }) => (
-        <Button
-          type="button"
-          variant="link"
-          className="h-auto shrink-0 p-0 text-body font-normal"
-          aria-expanded={open}
-          onClick={toggle}
-        >
-          Change <ChevronDown className="h-3.5 w-3.5" />
-        </Button>
-      )}
-    >
-      {({ close }) => children(close)}
-    </Popover>
+    <span ref={anchorRef} className="contents">
+      <Popover
+        align="end"
+        panelAriaLabel={label}
+        panelClassName="opentag-choice-panel surface-overlay w-[var(--sp-90)] p-3"
+        trigger={({ toggle, open }) => (
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto shrink-0 p-0 text-body font-normal"
+            aria-expanded={open}
+            onClick={toggle}
+          >
+            Change <ChevronDown className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      >
+        {({ close }) => (
+          <>
+            <OpenTagPickerPlacement anchorRef={anchorRef} />
+            {children(close)}
+          </>
+        )}
+      </Popover>
+    </span>
   );
+}
+
+type PickerPlacement = {
+  triggerTop: number;
+  panelHeight: number;
+  viewportTop: number;
+  viewportHeight: number;
+  margin: number;
+  gap: number;
+};
+
+export function openTagPickerTop({
+  triggerTop,
+  panelHeight,
+  viewportTop,
+  viewportHeight,
+  margin,
+  gap,
+}: PickerPlacement): number {
+  const minimum = viewportTop + margin;
+  const maximum = Math.max(minimum, viewportTop + viewportHeight - margin - panelHeight);
+  const above = triggerTop - gap - panelHeight;
+  return Math.max(minimum, Math.min(above, maximum));
+}
+
+function OpenTagPickerPlacement({ anchorRef }: { anchorRef: RefObject<HTMLSpanElement | null> }): ReactElement {
+  const markerRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    let frame = 0;
+    const place = (): void => {
+      const marker = markerRef.current;
+      const panel = marker?.parentElement;
+      const trigger = anchorRef.current?.querySelector("button");
+      if (!marker || !panel || !trigger) return;
+
+      const markerStyles = window.getComputedStyle(marker);
+      const margin = Number.parseFloat(markerStyles.scrollMarginBottom);
+      const gap = Number.parseFloat(markerStyles.scrollMarginTop);
+      const viewportTop = window.visualViewport?.offsetTop ?? 0;
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const triggerRect = trigger.getBoundingClientRect();
+      const top = openTagPickerTop({
+        triggerTop: triggerRect.top,
+        panelHeight: panel.offsetHeight,
+        viewportTop,
+        viewportHeight,
+        margin,
+        gap,
+      });
+      const baseTop = Number.parseFloat(panel.style.top);
+      panel.style.setProperty("--opentag-picker-shift", String(top - baseTop));
+    };
+    const schedule = (): void => {
+      if (frame) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        frame = window.requestAnimationFrame(place);
+      });
+    };
+
+    schedule();
+    window.addEventListener("scroll", schedule, true);
+    window.addEventListener("resize", schedule);
+    window.visualViewport?.addEventListener("scroll", schedule);
+    window.visualViewport?.addEventListener("resize", schedule);
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      window.removeEventListener("scroll", schedule, true);
+      window.removeEventListener("resize", schedule);
+      window.visualViewport?.removeEventListener("scroll", schedule);
+      window.visualViewport?.removeEventListener("resize", schedule);
+    };
+  }, [anchorRef]);
+
+  return <span ref={markerRef} className="opentag-picker-placement" aria-hidden="true" />;
 }
 
 function ChoiceList({ children }: { children: ReactElement | Array<ReactElement | null> }): ReactElement {

--- a/packages/web/src/pages/opentag/opentag-view.tsx
+++ b/packages/web/src/pages/opentag/opentag-view.tsx
@@ -85,9 +85,10 @@ export function OpenTagView({
     <div style={{ marginTop: pageState === "add-to-feishu" ? "calc(var(--opentag-qr-flow-offset) * -1)" : undefined }}>
       <div
         data-opentag-statuses
-        className="opentag-statuses grid grid-cols-2"
+        className="opentag-statuses grid"
         style={{
           gap: "var(--opentag-status-gap)",
+          gridTemplateColumns: "var(--opentag-status-columns)",
           marginBottom: pageState === "add-to-feishu" ? "calc(var(--opentag-status-bottom) + var(--sp-5))" : undefined,
         }}
       >

--- a/packages/web/src/pages/opentag/opentag-view.tsx
+++ b/packages/web/src/pages/opentag/opentag-view.tsx
@@ -212,7 +212,7 @@ function ComputerStatus({
   return (
     <StatusLine ready={connected} label={`Computer · ${label}`}>
       {clients.length > 1 ? (
-        <ChoicePopover label="Change Computer">
+        <ChoicePopover label="Change Computer" compactOnNarrow>
           {(close) => (
             <ChoiceList>
               {clients.map((client) => (
@@ -318,9 +318,11 @@ function StatusLine({
 function ChoicePopover({
   label,
   children,
+  compactOnNarrow = false,
 }: {
   label: string;
   children: (close: () => void) => ReactElement;
+  compactOnNarrow?: boolean;
 }): ReactElement {
   const anchorRef = useRef<HTMLSpanElement>(null);
 
@@ -334,11 +336,12 @@ function ChoicePopover({
           <Button
             type="button"
             variant="link"
-            className="h-auto shrink-0 p-0 text-body font-normal"
+            className={`h-auto shrink-0 p-0 text-body font-normal${compactOnNarrow ? " opentag-choice-trigger--compact" : ""}`}
+            aria-label={compactOnNarrow ? label : undefined}
             aria-expanded={open}
             onClick={toggle}
           >
-            Change <ChevronDown className="h-3.5 w-3.5" />
+            <span className="opentag-choice-label">Change</span> <ChevronDown className="h-3.5 w-3.5" />
           </Button>
         )}
       >

--- a/packages/web/src/pages/opentag/opentag-view.tsx
+++ b/packages/web/src/pages/opentag/opentag-view.tsx
@@ -301,7 +301,7 @@ function StatusLine({
   children?: ReactElement | null;
 }): ReactElement {
   return (
-    <div className="flex min-w-0 items-center" style={{ gap: "var(--sp-3)" }}>
+    <div className="flex min-w-0 items-center" style={{ gap: "var(--opentag-status-item-gap)" }}>
       <span
         aria-hidden="true"
         className="h-5 w-5 shrink-0 rounded-[var(--radius-full)]"

--- a/packages/web/src/pages/opentag/opentag-view.tsx
+++ b/packages/web/src/pages/opentag/opentag-view.tsx
@@ -87,7 +87,7 @@ export function OpenTagView({
         data-opentag-statuses
         className="opentag-statuses grid grid-cols-2"
         style={{
-          gap: "var(--sp-10)",
+          gap: "var(--opentag-status-gap)",
           marginBottom: pageState === "add-to-feishu" ? "calc(var(--opentag-status-bottom) + var(--sp-5))" : undefined,
         }}
       >
@@ -323,7 +323,7 @@ function ChoicePopover({
     <Popover
       align="end"
       panelAriaLabel={label}
-      panelClassName="surface-overlay w-[var(--sp-90)] p-3"
+      panelClassName="opentag-choice-panel surface-overlay w-[var(--sp-90)] p-3"
       trigger={({ toggle, open }) => (
         <Button
           type="button"
@@ -343,7 +343,7 @@ function ChoicePopover({
 
 function ChoiceList({ children }: { children: ReactElement | Array<ReactElement | null> }): ReactElement {
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+    <div className="opentag-choice-list flex flex-col" style={{ gap: "var(--sp-1)" }}>
       {children}
     </div>
   );
@@ -385,7 +385,7 @@ function ActionSurface({ children, qr = false }: { children: ReactNode; qr?: boo
       className="flex w-full items-center text-opentag-action"
       style={{
         minHeight: qr ? "var(--opentag-action-qr-height)" : "var(--opentag-action-height)",
-        padding: "var(--sp-8)",
+        padding: "var(--opentag-action-padding)",
         borderRadius: "var(--radius-opentag-action)",
         background: "var(--opentag-action)",
         color: "var(--opentag-action-fg)",

--- a/packages/web/src/pages/opentag/opentag-view.tsx
+++ b/packages/web/src/pages/opentag/opentag-view.tsx
@@ -83,7 +83,7 @@ export function OpenTagView({
   const runtimeLabel = selectedRuntime ? runtimeProviderLabel(selectedRuntime) : "Agent";
 
   return (
-    <div style={{ marginTop: pageState === "add-to-feishu" ? "calc(var(--opentag-qr-flow-offset) * -1)" : undefined }}>
+    <div>
       <div
         data-opentag-statuses
         data-opentag-runtime-picker={hasRuntimePicker || undefined}
@@ -91,7 +91,6 @@ export function OpenTagView({
         style={{
           gap: "var(--opentag-status-gap)",
           gridTemplateColumns: "var(--opentag-status-columns)",
-          marginBottom: pageState === "add-to-feishu" ? "calc(var(--opentag-status-bottom) + var(--sp-5))" : undefined,
         }}
       >
         <ComputerStatus clients={connectedClients} selectedClientId={selectedClientId} onSelect={onSelectClient} />
@@ -112,7 +111,7 @@ export function OpenTagView({
           {leadFor(pageState, displayName, runtimeLabel, runtimeState)}
         </p>
 
-        <ActionSurface qr={pageState === "add-to-feishu" && !!feishu.registrationUrl}>
+        <ActionSurface qr={pageState === "add-to-feishu"}>
           {pageState === "connect-computer" &&
             (bootstrapError ? (
               <InlineRecovery message={bootstrapError} retrying={false} onRetry={onRetryBootstrap} />
@@ -303,13 +302,20 @@ function StatusLine({
   children?: ReactElement | null;
 }): ReactElement {
   return (
-    <div className="flex min-w-0 items-center" style={{ gap: "var(--opentag-status-item-gap)" }}>
+    <div
+      className="flex min-w-0 items-center"
+      style={{ gap: "var(--opentag-status-item-gap)", minHeight: "var(--opentag-status-row-height)" }}
+    >
       <span
         aria-hidden="true"
-        className="h-5 w-5 shrink-0 rounded-[var(--radius-full)]"
-        style={{ background: ready ? "var(--opentag-accent)" : "var(--state-offline)" }}
+        className="shrink-0 rounded-[var(--radius-full)]"
+        style={{
+          width: "var(--opentag-status-dot-size)",
+          height: "var(--opentag-status-dot-size)",
+          background: ready ? "var(--opentag-accent)" : "var(--state-offline)",
+        }}
       />
-      <span className="min-w-0 truncate text-lead">{label}</span>
+      <span className="opentag-status-label min-w-0 truncate text-subtitle">{label}</span>
       {children}
     </div>
   );

--- a/packages/web/src/pages/opentag/opentag-view.tsx
+++ b/packages/web/src/pages/opentag/opentag-view.tsx
@@ -79,12 +79,14 @@ export function OpenTagView({
   };
 }): ReactElement {
   const hasComputer = connectedClients.length > 0;
+  const hasRuntimePicker = runtimeChoices.filter((choice) => choice.ready).length > 1;
   const runtimeLabel = selectedRuntime ? runtimeProviderLabel(selectedRuntime) : "Agent";
 
   return (
     <div style={{ marginTop: pageState === "add-to-feishu" ? "calc(var(--opentag-qr-flow-offset) * -1)" : undefined }}>
       <div
         data-opentag-statuses
+        data-opentag-runtime-picker={hasRuntimePicker || undefined}
         className="opentag-statuses grid"
         style={{
           gap: "var(--opentag-status-gap)",


### PR DESCRIPTION
## Summary

- keep the OpenTag single-page flow usable at 1536×1024, 1366×768, 1280×800, and 1024×768 with no horizontal page overflow
- apply the approved compact OpenTag-only header and content rhythm while preserving the global header and onboarding behavior
- keep story, identity, status, heading, lead, and Action-top anchors stationary across `Create agent` → Feishu registration; only the Action surface grows downward for QR content
- retain viewport-safe Computer/runtime pickers, complete readiness labels, and the sole explicit durable `Create agent` boundary

## Verification

- focused OpenTag flow and DOM tests: 30 passed
- `pnpm --filter @first-tree/web typecheck` (including the design-token guard)
- focused Biome check and `git diff --check`
- real Chromium at 1536×1024, 1366×768, 1280×800, and 1024×768 with zero console warnings or errors
- header measures 57px at all four widths; the mark is 40px and remains vertically centered with `Sign out`
- all six stable anchors have a 0px create-to-add delta after motion settles at every accepted width
- add-state reserves the full 348px QR Action height before registration data arrives, so loading → QR does not cause a second layout shift
- QR and Action surfaces are fully visible at every accepted width; short Desktop viewports use only normal vertical scrolling

## Context

Follow-up to #2336. This PR remains an OpenTag-local Web presentation slice; Mobile, shared Popover/header primitives, onboarding state, server contracts, and automatic Agent creation remain out of scope.
