### PR TITLE
feat(web): add Cursor Auto optimization modes

### DIFF
--- a/packages/client/src/providers/cursor/__tests__/handler-engine.test.ts
+++ b/packages/client/src/providers/cursor/__tests__/handler-engine.test.ts
@@ -211,6 +211,22 @@ describe("buildCursorTurnArgs — canonical spawn contract", () => {
     ]);
     expect(buildCursorMcpEnableArgs("managed-docs")).toEqual(["mcp", "enable", "managed-docs"]);
   });
+
+  it("passes a parameterized Cursor Router id through as a single verbatim --model argument", () => {
+    // Cursor Router ("Auto") optimization modes ride the model string via the
+    // CLI's `model[param=value]` syntax — the handler must not parse, split,
+    // or escape it. https://cursor.com/docs/cursor-router
+    expect(buildCursorTurnArgs({ model: "auto-smart[optimize_for=cost]", resumeSessionId: null })).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--sandbox",
+      "disabled",
+      "--force",
+      "--model",
+      "auto-smart[optimize_for=cost]",
+    ]);
+  });
 });
 
 describe("cursor handler — per-turn CLI transport", () => {

--- a/packages/qa/cases/runtime/cursor-provider.md
+++ b/packages/qa/cases/runtime/cursor-provider.md
@@ -64,6 +64,15 @@ that case and the run-local plan, not this one.
 - Free-form model: set an exact model id through Web (free-form input with the `auto` hint — no reasoning-effort
   control for Cursor), confirm it round-trips and reaches the next turn's spawn; an id the provider rejects must fail
   visibly as a configuration failure with no silent fallback, and recover after an explicit config change.
+- Cursor Router modes: the Web Model picker offers `Auto · Intelligence`, `Auto · Balance`, and `Auto · Cost` in
+  that order on both the loaded-catalog list and the catalog-unavailable or unbound fallback; a catalog that already
+  reports the same exact parameterized id must not duplicate the preset, and `(unset — inherits local)`, discovered
+  models, and `Custom model id…` must remain. Selecting Balance round-trips the exact value
+  `auto-smart[optimize_for=balanced]` through save and reload, and it reaches the next turn's spawn as one complete
+  argv item after `--model`, never parsed, split, or rewritten. Sample at least one non-Cursor provider to confirm
+  the three presets never appear there. A missing Cursor Teams/Enterprise entitlement is an external limitation, not
+  a product failure, but any provider rejection must surface visibly as a configuration failure with no silent
+  fallback.
 - Context Tree I/O: in a chat whose agent has a bound Context Tree, have the agent read a tree node via shell and edit
   a tree file; the Context tab must record repo-qualified read/write evidence for both the native edit path and the
   shell-read path (`git_status_delta` may carry the write). This is the regression slice the old prototype missed.

--- a/packages/web/src/pages/agent-detail/__tests__/model-section-catalog.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/model-section-catalog.test.tsx
@@ -95,6 +95,56 @@ describe("buildCatalogModelOptions", () => {
     expect(items.map((o) => o.value)).toEqual(["", "kimi-code/k3", CUSTOM_MODEL_OPTION_VALUE]);
     expect(items[0]?.hint).toBeUndefined();
   });
+
+  it("builds the three Cursor Auto optimization modes in Cursor's order with exact parameterized ids", () => {
+    const items = buildCatalogModelOptions(CURSOR_CATALOG, "", "cursor");
+    expect(items.map((o) => o.value)).toEqual([
+      "",
+      "auto-smart[optimize_for=intelligence]",
+      "auto-smart[optimize_for=balanced]",
+      "auto-smart[optimize_for=cost]",
+      "gpt-5.3-codex-high",
+      "composer-1",
+      CUSTOM_MODEL_OPTION_VALUE,
+    ]);
+    expect(items[1]?.label).toBe("Auto · Intelligence");
+    expect(items[2]?.label).toBe("Auto · Balance");
+    expect(items[3]?.label).toBe("Auto · Cost");
+  });
+
+  it("keeps the Cursor Auto options when the catalog is empty or unavailable", () => {
+    const items = buildCatalogModelOptions({ models: [], defaultModelId: null }, "", "cursor");
+    expect(items.map((o) => o.value)).toEqual([
+      "",
+      "auto-smart[optimize_for=intelligence]",
+      "auto-smart[optimize_for=balanced]",
+      "auto-smart[optimize_for=cost]",
+      CUSTOM_MODEL_OPTION_VALUE,
+    ]);
+  });
+
+  it("does not duplicate a Cursor Auto value already in the catalog or currently saved", () => {
+    const catalog = {
+      models: [{ id: "auto-smart[optimize_for=cost]", label: "Auto Cost (catalog)" }, { id: "composer-1" }],
+      defaultModelId: null,
+    };
+    const items = buildCatalogModelOptions(catalog, "auto-smart[optimize_for=balanced]", "cursor");
+    expect(items.map((o) => o.value)).toEqual([
+      "",
+      "auto-smart[optimize_for=intelligence]",
+      "auto-smart[optimize_for=balanced]",
+      "auto-smart[optimize_for=cost]",
+      "composer-1",
+      CUSTOM_MODEL_OPTION_VALUE,
+    ]);
+    // A saved preset value renders as the preset row, never as a "custom" row.
+    expect(items.some((o) => o.hint === "custom")).toBe(false);
+  });
+
+  it("does not leak the Cursor Auto options into other providers", () => {
+    const items = buildCatalogModelOptions(GROK_CATALOG, "", "grok");
+    expect(items.map((o) => o.value)).toEqual(["", "grok-4-heavy", "grok-code-fast-1", CUSTOM_MODEL_OPTION_VALUE]);
+  });
 });
 
 describe("ModelSection — daemon catalog", () => {
@@ -369,5 +419,90 @@ describe("ModelSection — daemon catalog", () => {
       option?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     expect(saved).toEqual(["grok-code-fast-1"]);
+  });
+});
+
+describe("ModelSection — Cursor Auto optimization modes", () => {
+  it("saves the exact parameterized id when an Auto option is clicked (loaded catalog)", async () => {
+    providerModelsMocks.getProviderModels.mockResolvedValue(CURSOR_CATALOG);
+    const saved: string[] = [];
+    const el = await renderWithQuery(
+      <ModelSection value="" onChange={(v) => saved.push(v)} provider="cursor" clientId="c1" />,
+    );
+
+    await flushUntil(() => {
+      const b = el.querySelector<HTMLButtonElement>('button[aria-label="Model"]');
+      return !!b && !b.disabled;
+    });
+    await act(async () => {
+      el.querySelector('button[aria-label="Model"]')?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const body = document.body.textContent ?? "";
+    expect(body).toContain("Auto · Intelligence");
+    expect(body).toContain("Auto · Balance");
+    expect(body).toContain("Auto · Cost");
+    const option = Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')).find((b) =>
+      b.textContent?.includes("Auto · Balance"),
+    );
+    expect(option).toBeDefined();
+    await act(async () => {
+      option?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(saved).toEqual(["auto-smart[optimize_for=balanced]"]);
+  });
+
+  it("offers the Auto options while the catalog is still loading", async () => {
+    providerModelsMocks.getProviderModels.mockImplementation(() => new Promise<ProviderModelCatalog>(() => {}));
+    const el = await renderWithQuery(<ModelSection value="" onChange={() => {}} provider="cursor" clientId="c1" />);
+
+    await flushUntil(() => el.querySelector('button[aria-label="Model"]') !== null);
+    const trigger = el.querySelector<HTMLButtonElement>('button[aria-label="Model"]');
+    expect(trigger?.disabled).toBe(false);
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const body = document.body.textContent ?? "";
+    expect(body).toContain("Auto · Intelligence");
+    expect(body).toContain("Auto · Balance");
+    expect(body).toContain("Auto · Cost");
+    expect(body).toContain("(unset — inherits local)");
+    expect(body).toContain("Custom model id…");
+  });
+
+  it("offers the Auto options when the catalog is unavailable", async () => {
+    providerModelsMocks.getProviderModels.mockResolvedValue(null);
+    const el = await renderWithQuery(<ModelSection value="" onChange={() => {}} provider="cursor" clientId="c1" />);
+
+    await flushUntil(
+      () =>
+        el
+          .querySelector('[role="img"]')
+          ?.getAttribute("aria-label")
+          ?.includes("Couldn't read this computer's model list") ?? false,
+    );
+    const trigger = el.querySelector<HTMLButtonElement>('button[aria-label="Model"]');
+    expect(trigger?.disabled).toBe(false);
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const body = document.body.textContent ?? "";
+    expect(body).toContain("Auto · Intelligence");
+    expect(body).toContain("Auto · Balance");
+    expect(body).toContain("Auto · Cost");
+    expect(body).toContain("(unset — inherits local)");
+    expect(body).toContain("Custom model id…");
+  });
+
+  it("describes the Router scope and billing in the Cursor help copy", async () => {
+    providerModelsMocks.getProviderModels.mockResolvedValue(CURSOR_CATALOG);
+    const el = await renderWithQuery(<ModelSection value="" onChange={() => {}} provider="cursor" clientId="c1" />);
+
+    await flushUntil(() => el.querySelector('button[aria-label="Model"]') !== null);
+    // helpText rides the ? icon's aria-label, not inline text (see ConfigRow).
+    const help = el.querySelector('[role="img"]')?.getAttribute("aria-label") ?? "";
+    expect(help).toContain("Cursor Teams/Enterprise");
+    expect(help).toContain("verbatim");
+    expect(help).toContain("no silent fallback");
+    expect(help).toContain("bundled Auto pricing");
   });
 });

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -71,6 +71,33 @@ export const CODEX_MODEL_OPTIONS: Array<ModelOption & { value: CodexModelId }> =
 ];
 
 /**
+ * Cursor Router ("Auto") optimization modes, always offered on the Cursor
+ * path — with or without a discovered catalog. The Cursor CLI accepts a
+ * parameterized model id (`model[param=value]`), and the handler passes the
+ * saved value verbatim as the next `--model` argument, so these exact ids
+ * carry the mode. Router model id and parameter values per
+ * https://cursor.com/docs/cursor-router. Order matches Cursor's own picker:
+ * Intelligence, Balance, Cost.
+ */
+export const CURSOR_AUTO_MODEL_OPTIONS: ModelOption[] = [
+  {
+    value: "auto-smart[optimize_for=intelligence]",
+    label: "Auto · Intelligence",
+    hint: "Router · billed per routed model",
+  },
+  {
+    value: "auto-smart[optimize_for=balanced]",
+    label: "Auto · Balance",
+    hint: "Router · billed per routed model",
+  },
+  {
+    value: "auto-smart[optimize_for=cost]",
+    label: "Auto · Cost",
+    hint: "Router · bundled Auto pricing",
+  },
+];
+
+/**
  * Curated per-provider fallback, rendered when no computer is bound or the
  * daemon's catalog is unavailable. Cursor/Kimi have no curated list on
  * purpose (the account-dependent SKU catalog is large and shifting), so
@@ -92,7 +119,7 @@ const MODEL_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
   "claude-code-tui": "Applies to new sessions immediately. Model swap restarts the tmux session (~2–4s).",
   codex: "Applies to new sessions immediately. Unset lets the CLI pick by auth mode.",
   cursor:
-    "Options come from this computer's Cursor CLI when reachable. The id is passed through verbatim on the next turn — one your account can't use fails visibly, no silent fallback. Unset uses the Cursor default (auto).",
+    "Options come from this computer's Cursor CLI when reachable. The Auto · * picks route through the Cursor Router (Cursor Teams/Enterprise only). The id is passed through verbatim on the next turn — one your account or team can't use fails visibly, no silent fallback. Auto · Balance/Intelligence bill per routed model; Auto · Cost uses bundled Auto pricing. Unset uses the Cursor default (auto).",
   grok: "Options come from this computer's Grok Build CLI when reachable. The id is passed through verbatim on the next turn — one your account can't use fails visibly, no silent fallback. Unset uses the Grok default (auto).",
   "kimi-code":
     "Options come from this computer's ~/.kimi-code config when reachable. Passed to new sessions. Unset uses the model configured in ~/.kimi-code.",
@@ -270,20 +297,28 @@ function emptyUnavailableCatalog(provider: RuntimeProvider): ProviderModelCatalo
   };
 }
 
-/** The loaded catalog as a Select list: unset (+ local default hint) → models → current custom value → custom entry. */
+/** The loaded catalog as a Select list: unset (+ local default hint) → provider presets → models → current custom value → custom entry. */
 export function buildCatalogModelOptions(
   catalog: Pick<ProviderModelCatalog, "models" | "defaultModelId">,
   value: string,
+  provider?: RuntimeProvider,
 ): ModelOption[] {
+  // Cursor's Router modes are First Tree presets, not daemon-discovered ids —
+  // they must survive loading/unavailable/empty catalogs, and must not repeat
+  // when the provider catalog already lists the same exact parameterized id.
+  const presetOptions = provider === "cursor" ? CURSOR_AUTO_MODEL_OPTIONS : [];
+  const presetValues = new Set(presetOptions.map((o) => o.value));
+  const models = catalog.models.filter((m) => !presetValues.has(m.id));
   const items: ModelOption[] = [
     { ...UNSET_OPTION, hint: catalog.defaultModelId ? `default: ${catalog.defaultModelId}` : undefined },
-    ...catalog.models.map((m) => ({
+    ...presetOptions,
+    ...models.map((m) => ({
       value: m.id,
       label: m.label ?? m.id,
       hint: [m.hint, m.isDefault ? "default" : null].filter(Boolean).join(" · ") || undefined,
     })),
   ];
-  if (value !== "" && !catalog.models.some((m) => m.id === value)) {
+  if (value !== "" && !presetValues.has(value) && !models.some((m) => m.id === value)) {
     items.push({ value, label: value, hint: "custom" });
   }
   items.push({ value: CUSTOM_MODEL_OPTION_VALUE, label: "Custom model id…" });
@@ -308,7 +343,7 @@ function CatalogModelPicker({
   description?: ReactNode;
 }) {
   const [customMode, setCustomMode] = useState(false);
-  const items = useMemo(() => buildCatalogModelOptions(catalog, value), [catalog, value]);
+  const items = useMemo(() => buildCatalogModelOptions(catalog, value, provider), [catalog, value, provider]);
   const helpText = helpSuffix ? `${MODEL_HELP_BY_PROVIDER[provider]} ${helpSuffix}` : MODEL_HELP_BY_PROVIDER[provider];
 
   if (customMode) {

--- a/packages/web/src/pages/clients/__tests__/cursor-provider-surfaces.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/cursor-provider-surfaces.test.tsx
@@ -120,6 +120,32 @@ describe("cursor provider — DEFAULT + Custom model picker", () => {
     expect(el.querySelector('button[aria-label="Model"]')).not.toBeNull();
   });
 
+  it("offers the three Cursor Auto optimization modes without a bound computer and saves the exact id", async () => {
+    const saved: string[] = [];
+    const el = await render(<ModelSection value="" onChange={(v) => saved.push(v)} provider="cursor" />);
+
+    const trigger = el.querySelector<HTMLButtonElement>('button[aria-label="Model"]');
+    expect(trigger).not.toBeNull();
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const body = document.body.textContent ?? "";
+    expect(body).toContain("Auto · Intelligence");
+    expect(body).toContain("Auto · Balance");
+    expect(body).toContain("Auto · Cost");
+    expect(body).toContain("(unset — inherits local)");
+    expect(body).toContain("Custom model id…");
+
+    const cost = Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')).find((b) =>
+      b.textContent?.includes("Auto · Cost"),
+    );
+    expect(cost).toBeDefined();
+    await act(async () => {
+      cost?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(saved).toEqual(["auto-smart[optimize_for=cost]"]);
+  });
+
   it("keeps the dropdown for claude/codex providers (no free-form regression)", async () => {
     const el = await render(<ModelSection value="opus" onChange={() => {}} provider="claude-code" />);
     expect(el.querySelector('input[aria-label="Model"]')).toBeNull();


### PR DESCRIPTION
## Summary

- expose Cursor Router's Auto · Intelligence, Auto · Balance, and Auto · Cost choices in the Cursor runtime model picker
- save Cursor's exact parameterized model ids and pass them through as one `--model` argument without parsing or fallback
- keep unset/local inheritance, discovered models, custom ids, catalog fallback paths, and every non-Cursor provider unchanged
- extend the reusable Cursor runtime QA case with the three first-class Router modes

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] Cursor Web model tests: 28 passed
- [x] Cursor handler test: 25 passed
- [x] focused-local QA PASS on product commit `7735a1076`: real Web catalog/fallback/provider-isolation paths, exact Balance save/readback, refresh and navigation round-trip, and screenshots
- [x] reusable QA case maintenance: `git diff --check`

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing
- [x] Web runtime configuration UI
- [x] Cursor provider model forwarding contract (regression test; production forwarding already passes model ids verbatim)
- [x] reusable Cursor runtime QA case

## Notes

- no payload field, shared schema, server, database, migration, default, or backfill change
- QA used a task-owned local environment and did not perform a paid Cursor turn; Teams/Enterprise entitlement and provider-side billing remain an external evidence boundary
- Router modes are available to Cursor Teams/Enterprise accounts; unsupported account/team selections remain provider-visible failures with no silent downgrade
- Cursor contract: https://cursor.com/docs/cursor-router and https://cursor.com/docs/sdk/typescript#cursor-router
- Context Tree impact: this follows the existing provider-native configuration decision; the exact external model ids remain implementation detail, so no Tree write is needed
