### PR TITLE
feat(web): explain GitHub Task Agent eligibility below the selector

### DIFF
--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -350,6 +350,7 @@ describe("extra preview pages", () => {
     expect(text(rendered.container)).toContain("waiting");
     expect(text(rendered.container)).toContain("Loading");
     expect(text(rendered.container)).toContain("Waiting for GitHub");
+    expect(text(rendered.container)).toContain("Only public Agents with a managed runtime appear here.");
 
     const detailsButtons = [...rendered.container.querySelectorAll("button")].filter((button) =>
       button.textContent?.includes("Connection details"),

--- a/packages/web/src/pages/settings-github-preview.tsx
+++ b/packages/web/src/pages/settings-github-preview.tsx
@@ -175,6 +175,9 @@ function AutomaticHandlingPreview() {
         ]}
       />
       <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+        Only public Agents with a managed runtime appear here.
+      </div>
+      <div className="text-caption" style={{ color: "var(--fg-4)" }}>
         Context Tree activity uses Context Reviewer. These roles must use different Agents.
       </div>
     </div>

--- a/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
@@ -331,6 +331,7 @@ describe("SettingsGithubPage — automatic handling", () => {
     expect(taskRouting.textContent).toContain(
       "Context Tree activity uses Context Reviewer. These roles must use different Agents.",
     );
+    expect(taskRouting.textContent).toContain("Only public Agents with a managed runtime appear here.");
 
     const controls = await waitForSelector<HTMLElement>(taskRouting, '[data-github-task-agent-controls="admin"]');
     expect(controls.parentElement?.style.cssText).toContain("border-top");

--- a/packages/web/src/pages/settings/github-task-agent-controls.tsx
+++ b/packages/web/src/pages/settings/github-task-agent-controls.tsx
@@ -174,6 +174,9 @@ export function GithubTaskAgentControls({
             searchable={candidates.length > 6}
           />
           <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+            Only public Agents with a managed runtime appear here.
+          </div>
+          <div className="text-caption" style={{ color: "var(--fg-4)" }}>
             Context Tree activity uses Context Reviewer. These roles must use different Agents.
           </div>
         </div>


### PR DESCRIPTION
## Summary

Adds a short caption directly below the GitHub Task Agent selector in Settings → GitHub → Automatic handling:

> Only public Agents with a managed runtime appear here.

This explains why some Team Agents do not show up in the list. The existing note that GitHub Task Agent and Context Reviewer must use different Agents is preserved as a separate line.

## Changes

- `packages/web/src/pages/settings/github-task-agent-controls.tsx` — new `text-caption` hint immediately below the selector, using the same typography/spacing as the existing Context Reviewer note.
- `packages/web/src/pages/settings-github-preview.tsx` — dev preview mirrors the new hint.
- `packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx` — asserts the eligibility copy renders in the Automatic handling section.
- `packages/web/src/pages/__tests__/preview-pages-extra.test.tsx` — asserts the eligibility copy renders in the preview page.

No changes to candidate filtering, APIs, persistence, schemas, migrations, or database behavior — copy only.

## Tests

- `vitest run src/pages/settings/__tests__/github-page-dom.test.tsx src/pages/__tests__/preview-pages-extra.test.tsx` — 27 passed
- `pnpm --filter @first-tree/web run typecheck` — passed (tsc + design-token guardrails)
- `biome check` on the 4 changed files — clean
