### PR TITLE
feat: add controlled runtime install command

### DIFF
--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -23,6 +23,7 @@ const coreMocks = vi.hoisted(() => ({
   createApiNameResolver: vi.fn(),
   createExecuteUpdate: vi.fn(),
   createLoggerRuntimeOutput: vi.fn(),
+  createRuntimeInstallRunner: vi.fn(),
   daemonRuntimeHomesEqual: vi.fn(),
   declineUpdate: vi.fn(),
   ensureActiveRootClientIdPersisted: vi.fn(),
@@ -30,6 +31,8 @@ const coreMocks = vi.hoisted(() => ({
   getClientSwitchStartupBlock: vi.fn(),
   getClientServiceStatus: vi.fn(),
   handleClientOrgMismatch: vi.fn(),
+  installClaudeRuntime: vi.fn(),
+  installCodexRuntime: vi.fn(),
   isDaemonRuntimeOwnershipError: vi.fn(),
   isServiceSupported: vi.fn(),
   listPinnedAgents: vi.fn(),
@@ -102,8 +105,10 @@ let runtimeInstance: {
   watchAgentsDir: ReturnType<typeof vi.fn>;
   onReconnect: ReturnType<typeof vi.fn>;
   onRuntimeAuthStart: ReturnType<typeof vi.fn>;
+  onRuntimeInstallStart: ReturnType<typeof vi.fn>;
   onProviderModelsList: ReturnType<typeof vi.fn>;
   sendProviderModelsResult: ReturnType<typeof vi.fn>;
+  sendRuntimeInstallResult: ReturnType<typeof vi.fn>;
   emitConnectionResilienceEvent: ReturnType<typeof vi.fn>;
 };
 let refresherInstance: {
@@ -183,6 +188,9 @@ beforeEach(() => {
   coreMocks.registerClientRuntimeMarker.mockReturnValue(vi.fn());
   coreMocks.createApiNameResolver.mockReturnValue(async () => "nova");
   coreMocks.createExecuteUpdate.mockReturnValue(async () => undefined);
+  coreMocks.createRuntimeInstallRunner.mockReturnValue({ run: vi.fn(async () => undefined) });
+  coreMocks.installClaudeRuntime.mockResolvedValue({ ok: true, installedVersion: null });
+  coreMocks.installCodexRuntime.mockResolvedValue({ ok: true, installedVersion: null });
   coreMocks.createLoggerRuntimeOutput.mockImplementation(
     (logger: {
       error: (message: string) => void;
@@ -219,8 +227,10 @@ beforeEach(() => {
     }),
     onReconnect: vi.fn(),
     onRuntimeAuthStart: vi.fn(),
+    onRuntimeInstallStart: vi.fn(),
     onProviderModelsList: vi.fn(),
     sendProviderModelsResult: vi.fn(),
+    sendRuntimeInstallResult: vi.fn(),
     emitConnectionResilienceEvent: vi.fn(),
   };
   coreMocks.ClientRuntime.mockImplementation(() => runtimeInstance);
@@ -585,6 +595,22 @@ describe("daemon start command", () => {
     );
     expect(coreMocks.CapabilityRefresher.mock.calls[0]?.[0]).not.toHaveProperty("initial");
     expect(runtimeInstance.onReconnect).toHaveBeenCalledWith(expect.any(Function));
+    expect(coreMocks.createRuntimeInstallRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installClaude: expect.any(Function),
+        installCodex: expect.any(Function),
+        reprobe: expect.any(Function),
+        send: expect.any(Function),
+      }),
+    );
+    expect(runtimeInstance.onRuntimeInstallStart).toHaveBeenCalledWith(expect.any(Function));
+    const installRunnerDeps = coreMocks.createRuntimeInstallRunner.mock.calls[0]?.[0] as
+      | { installClaude: () => Promise<unknown>; installCodex: () => Promise<unknown> }
+      | undefined;
+    await installRunnerDeps?.installClaude();
+    await installRunnerDeps?.installCodex();
+    expect(coreMocks.installClaudeRuntime).toHaveBeenCalledWith("latest", expect.any(Function));
+    expect(coreMocks.installCodexRuntime).toHaveBeenCalledWith("latest", expect.any(Function));
     expect(runtimeInstance.onProviderModelsList).toHaveBeenCalledWith(expect.any(Function));
     expect(refresherInstance.start).toHaveBeenCalled();
     expect(coreMocks.listPinnedAgents).toHaveBeenCalledWith({

--- a/apps/cli/src/__tests__/runtime-install-extra.test.ts
+++ b/apps/cli/src/__tests__/runtime-install-extra.test.ts
@@ -242,6 +242,28 @@ describe("native runtime installers", () => {
     });
   });
 
+  it("routes npm stderr to an injected sink without also writing through CLI Print", async () => {
+    const { installCodexRuntime } = await import("../core/install-codex-runtime.js");
+    const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
+    const stderrSink = vi.fn();
+
+    const codexChild = prepareSpawn().child;
+    const codexResult = installCodexRuntime("latest", stderrSink);
+    codexChild.stderr.emit("data", Buffer.from("codex registry diagnostic\n"));
+    codexChild.emit("exit", 1, null);
+    await codexResult;
+
+    const claudeChild = prepareSpawn().child;
+    const claudeResult = installClaudeRuntime("latest", stderrSink);
+    claudeChild.stderr.emit("data", Buffer.from("claude registry diagnostic\n"));
+    claudeChild.emit("exit", 1, null);
+    await claudeResult;
+
+    expect(stderrSink).toHaveBeenNthCalledWith(1, "codex registry diagnostic\n");
+    expect(stderrSink).toHaveBeenNthCalledWith(2, "claude registry diagnostic\n");
+    expect(outputMocks.line).not.toHaveBeenCalled();
+  });
+
   it("maps synchronous registry spawn failures for both runtime installers", async () => {
     const spawnError = Object.assign(new Error("spawn EINVAL"), { code: "EINVAL" });
     clientMocks.getChildProcessRegistry.mockReturnValue({

--- a/apps/cli/src/__tests__/runtime-install-runner.test.ts
+++ b/apps/cli/src/__tests__/runtime-install-runner.test.ts
@@ -85,4 +85,24 @@ describe("runtime install runner", () => {
       retryable: true,
     });
   });
+
+  it("redacts secrets before publishing installer failures", async () => {
+    const sent: RuntimeInstallResultFrame[] = [];
+    const runner = createRuntimeInstallRunner({
+      installClaude: vi.fn(),
+      installCodex: vi.fn().mockResolvedValue({
+        ok: false,
+        reason: "registry rejected token=ghp_AbCdEf0123456789abcdef0123456789abcd",
+        reasonCode: "npm_auth",
+        retryable: false,
+      }),
+      reprobe: vi.fn(),
+      send: (result) => sent.push(result),
+      log: vi.fn(),
+    });
+
+    await runner.run(CODEX);
+    expect(sent.at(-1)).toMatchObject({ status: "failed", reasonCode: "npm_auth" });
+    expect(sent.at(-1)).not.toEqual(expect.objectContaining({ reason: expect.stringContaining("ghp_") }));
+  });
 });

--- a/apps/cli/src/__tests__/runtime-install-runner.test.ts
+++ b/apps/cli/src/__tests__/runtime-install-runner.test.ts
@@ -1,0 +1,88 @@
+import type { RuntimeInstallResultFrame, RuntimeInstallStartCommand } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createRuntimeInstallRunner } from "../core/runtime-install.js";
+
+const CODEX: RuntimeInstallStartCommand = {
+  type: "runtime-install:start",
+  provider: "codex",
+  ref: "123e4567-e89b-42d3-a456-426614174000",
+};
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("runtime install runner", () => {
+  it.each([
+    ["codex", "installCodex"],
+    ["claude-code", "installClaude"],
+  ] as const)("invokes only the fixed %s installer and re-probes after success", async (provider, expectedInstaller) => {
+    const sent: RuntimeInstallResultFrame[] = [];
+    const installClaude = vi.fn().mockResolvedValue({ ok: true, installedVersion: "2.1.0" });
+    const installCodex = vi.fn().mockResolvedValue({ ok: true, installedVersion: "0.140.0" });
+    const reprobe = vi.fn().mockResolvedValue(undefined);
+    const runner = createRuntimeInstallRunner({
+      installClaude,
+      installCodex,
+      reprobe,
+      send: (result) => sent.push(result),
+      log: vi.fn(),
+    });
+
+    await runner.run({ ...CODEX, provider });
+
+    expect(installCodex).toHaveBeenCalledTimes(expectedInstaller === "installCodex" ? 1 : 0);
+    expect(installClaude).toHaveBeenCalledTimes(expectedInstaller === "installClaude" ? 1 : 0);
+    expect(reprobe).toHaveBeenCalledWith(provider);
+    expect(sent.map((result) => result.status)).toEqual(["accepted", "in-progress", "succeeded"]);
+  });
+
+  it("rejects a concurrent duplicate without spawning another install and allows retry after failure", async () => {
+    const first = deferred<{ ok: false; reason: string; retryable: boolean; reasonCode: string }>();
+    const sent: RuntimeInstallResultFrame[] = [];
+    const installCodex = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValueOnce({ ok: true, installedVersion: "0.140.0" });
+    const runner = createRuntimeInstallRunner({
+      installClaude: vi.fn(),
+      installCodex,
+      reprobe: vi.fn().mockResolvedValue(undefined),
+      send: (result) => sent.push(result),
+      log: vi.fn(),
+    });
+
+    const running = runner.run(CODEX);
+    await runner.run({ ...CODEX, ref: "223e4567-e89b-42d3-a456-426614174000" });
+    expect(installCodex).toHaveBeenCalledTimes(1);
+    expect(sent.at(-1)).toMatchObject({ status: "failed", reasonCode: "already_in_progress", retryable: true });
+
+    first.resolve({ ok: false, reason: "network down", retryable: true, reasonCode: "network_error" });
+    await running;
+    await runner.run({ ...CODEX, ref: "323e4567-e89b-42d3-a456-426614174000" });
+    expect(installCodex).toHaveBeenCalledTimes(2);
+    expect(sent.at(-1)).toMatchObject({ status: "succeeded" });
+  });
+
+  it("surfaces installer and capability re-probe failures as retryable terminal results", async () => {
+    const sent: RuntimeInstallResultFrame[] = [];
+    const runner = createRuntimeInstallRunner({
+      installClaude: vi.fn(),
+      installCodex: vi.fn().mockResolvedValue({ ok: true, installedVersion: null }),
+      reprobe: vi.fn().mockRejectedValue(new Error("probe unavailable")),
+      send: (result) => sent.push(result),
+      log: vi.fn(),
+    });
+
+    await runner.run(CODEX);
+    expect(sent.at(-1)).toMatchObject({
+      status: "failed",
+      reasonCode: "capability_reprobe_failed",
+      retryable: true,
+    });
+  });
+});

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -11,6 +11,8 @@ import {
   discoverProviderModels,
   flushClientSentry,
   initClientSentry,
+  probeClaudeCodeCapability,
+  probeCodexCapability,
 } from "@first-tree/client";
 import {
   agentConfigSchema,
@@ -35,6 +37,7 @@ import {
   createApiNameResolver,
   createExecuteUpdate,
   createLoggerRuntimeOutput,
+  createRuntimeInstallRunner,
   daemonRuntimeHomesEqual,
   declineUpdate,
   ensureActiveRootClientIdPersisted,
@@ -42,6 +45,8 @@ import {
   getClientServiceStatus,
   getClientSwitchStartupBlock,
   handleClientOrgMismatch,
+  installClaudeRuntime,
+  installCodexRuntime,
   isDaemonRuntimeOwnershipError,
   isServiceSupported,
   listPinnedAgents,
@@ -415,6 +420,20 @@ export function registerDaemonStartCommand(daemon: Command): void {
             setProviderEntry: (provider, entry) => capabilityRefresher.setProviderEntry(provider, entry),
             log: (symbol, msg) => writeStatus(symbol, msg),
           }).finally(() => capabilityRefresher.endInteractive(command.provider));
+        });
+
+        const runtimeInstallRunner = createRuntimeInstallRunner({
+          installClaude: () => installClaudeRuntime(),
+          installCodex: () => installCodexRuntime(),
+          reprobe: async (provider) => {
+            const entry = provider === "codex" ? await probeCodexCapability() : await probeClaudeCodeCapability();
+            await capabilityRefresher.setProviderEntry(provider, entry);
+          },
+          send: (result) => runtime.sendRuntimeInstallResult(result),
+          log: (symbol, message) => writeStatus(symbol, message),
+        });
+        runtime.onRuntimeInstallStart((command) => {
+          void runtimeInstallRunner.run(command);
         });
 
         // Host-local model catalog: web opens Model settings → server asks this

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -423,8 +423,11 @@ export function registerDaemonStartCommand(daemon: Command): void {
         });
 
         const runtimeInstallRunner = createRuntimeInstallRunner({
-          installClaude: () => installClaudeRuntime(),
-          installCodex: () => installCodexRuntime(),
+          // npm stderr is retained in the installer result. Keep raw chunks
+          // off supervisor streams; the runner emits one bounded, redacted
+          // terminal diagnostic through the daemon logger instead.
+          installClaude: () => installClaudeRuntime("latest", () => undefined),
+          installCodex: () => installCodexRuntime("latest", () => undefined),
           reprobe: async (provider) => {
             const entry = provider === "codex" ? await probeCodexCapability() : await probeClaudeCodeCapability();
             await capabilityRefresher.setProviderEntry(provider, entry);

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -11,6 +11,7 @@ import {
   type HandlerFactory,
   type ProviderModelsListCommand,
   type RuntimeAuthCommand,
+  type RuntimeInstallCommand,
   resolveAndLogClaudeExecutable,
   type UpdateHooks,
   UpdateManager,
@@ -20,6 +21,7 @@ import {
   type AgentPinnedMessage,
   type ClientPausedReason,
   type ProviderModelCatalog,
+  type RuntimeInstallResultFrame,
   type RuntimeProvider,
   runtimeProviderSchema,
 } from "@first-tree/shared";
@@ -303,6 +305,16 @@ export class ClientRuntime {
    */
   onRuntimeAuthStart(callback: (command: RuntimeAuthCommand) => void): void {
     this.connection.on("runtime-auth:start", callback);
+  }
+
+  /** Register a handler for the controlled runtime-install command. */
+  onRuntimeInstallStart(callback: (command: RuntimeInstallCommand) => void): void {
+    this.connection.on("runtime-install:start", callback);
+  }
+
+  /** Publish runtime-install progress or its terminal outcome. */
+  sendRuntimeInstallResult(result: RuntimeInstallResultFrame): void {
+    this.connection.sendRuntimeInstallResult(result);
   }
 
   /**

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -211,6 +211,11 @@ export { blank, status } from "./output.js";
 export { isInteractive, promptAddAgent, promptMissingFields } from "./prompt.js";
 // Runtime-auth login orchestrator (browser-OAuth provider login)
 export { type RuntimeAuthLoginDeps, runRuntimeAuthLogin } from "./runtime-auth-login.js";
+export {
+  createRuntimeInstallRunner,
+  type RuntimeInstallRunner,
+  type RuntimeInstallRunnerDeps,
+} from "./runtime-install.js";
 export type { PinnedAgentRuntimeRecord } from "./runtime-provider-reconcile.js";
 // Pre-flight runtime-provider reconciliation (P2 — capabilities + YAML rewrite)
 export {

--- a/apps/cli/src/core/install-claude-runtime.ts
+++ b/apps/cli/src/core/install-claude-runtime.ts
@@ -43,7 +43,10 @@ function parseInstalledVersion(stdout: string): string | null {
  * the caller is expected to re-probe the claude-code capability so the new
  * binary is picked up via PATH resolution. Does not exit the process.
  */
-export async function installClaudeRuntime(spec = "latest"): Promise<InstallClaudeResult> {
+export async function installClaudeRuntime(
+  spec = "latest",
+  stderrSink: (chunk: string) => void = (chunk) => print.line(chunk),
+): Promise<InstallClaudeResult> {
   if (!isSafeInstallSpec(spec)) {
     return {
       ok: false,
@@ -82,7 +85,7 @@ export async function installClaudeRuntime(spec = "latest"): Promise<InstallClau
     child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
     child.stderr?.on("data", (chunk: Buffer) => {
       stderrChunks.push(chunk);
-      print.line(chunk.toString("utf8"));
+      stderrSink(chunk.toString("utf8"));
     });
 
     child.on("error", (err) => {

--- a/apps/cli/src/core/install-codex-runtime.ts
+++ b/apps/cli/src/core/install-codex-runtime.ts
@@ -43,7 +43,10 @@ function parseInstalledVersion(stdout: string): string | null {
  * the caller is expected to re-probe the codex capability so the new binary is
  * picked up via PATH resolution. Does not exit the process.
  */
-export async function installCodexRuntime(spec = "latest"): Promise<InstallCodexResult> {
+export async function installCodexRuntime(
+  spec = "latest",
+  stderrSink: (chunk: string) => void = (chunk) => print.line(chunk),
+): Promise<InstallCodexResult> {
   if (!isSafeInstallSpec(spec)) {
     return {
       ok: false,
@@ -82,7 +85,7 @@ export async function installCodexRuntime(spec = "latest"): Promise<InstallCodex
     child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
     child.stderr?.on("data", (chunk: Buffer) => {
       stderrChunks.push(chunk);
-      print.line(chunk.toString("utf8"));
+      stderrSink(chunk.toString("utf8"));
     });
 
     child.on("error", (err) => {

--- a/apps/cli/src/core/runtime-install.ts
+++ b/apps/cli/src/core/runtime-install.ts
@@ -1,0 +1,115 @@
+import type { RuntimeInstallProvider, RuntimeInstallResultFrame } from "@first-tree/shared";
+import type { InstallClaudeResult } from "./install-claude-runtime.js";
+import type { InstallCodexResult } from "./install-codex-runtime.js";
+
+type InstallResult = InstallClaudeResult | InstallCodexResult;
+
+export type RuntimeInstallRunnerDeps = {
+  installClaude: () => Promise<InstallClaudeResult>;
+  installCodex: () => Promise<InstallCodexResult>;
+  reprobe: (provider: RuntimeInstallProvider) => Promise<void>;
+  send: (result: RuntimeInstallResultFrame) => void;
+  log: (symbol: string, message: string) => void;
+};
+
+export type RuntimeInstallRunner = {
+  run: (command: { provider: RuntimeInstallProvider; ref: string }) => Promise<void>;
+};
+
+function boundedReason(reason: string): string {
+  const trimmed = reason.trim() || "Runtime installation failed";
+  return trimmed.length <= 500 ? trimmed : `${trimmed.slice(0, 497)}...`;
+}
+
+/**
+ * Build the daemon's controlled runtime installer.
+ *
+ * The caller supplies only an allowlisted provider. Package names, versions,
+ * URLs, and shell fragments never cross the wire; each branch invokes the
+ * existing installer with its built-in `latest` default. One global in-flight
+ * guard prevents concurrent global npm mutations, while terminal cleanup makes
+ * both failures and successes immediately retryable.
+ */
+export function createRuntimeInstallRunner(deps: RuntimeInstallRunnerDeps): RuntimeInstallRunner {
+  let active: { provider: RuntimeInstallProvider; ref: string } | null = null;
+
+  const sendFailed = (
+    command: { provider: RuntimeInstallProvider; ref: string },
+    input: { reason: string; reasonCode: string; retryable: boolean },
+  ): void => {
+    deps.send({
+      type: "runtime-install:result",
+      provider: command.provider,
+      ref: command.ref,
+      status: "failed",
+      reason: boundedReason(input.reason),
+      reasonCode: input.reasonCode.slice(0, 100) || "runtime_install_failed",
+      retryable: input.retryable,
+    });
+  };
+
+  return {
+    async run(command): Promise<void> {
+      if (active) {
+        sendFailed(command, {
+          reason: `A ${active.provider} runtime install is already in progress. Retry after it finishes.`,
+          reasonCode: "already_in_progress",
+          retryable: true,
+        });
+        return;
+      }
+
+      active = { provider: command.provider, ref: command.ref };
+      deps.send({ ...command, type: "runtime-install:result", status: "accepted" });
+      deps.send({ ...command, type: "runtime-install:result", status: "in-progress" });
+      deps.log("•", `runtime-install: installing ${command.provider} (ref ${command.ref})`);
+
+      try {
+        let result: InstallResult;
+        if (command.provider === "codex") {
+          result = await deps.installCodex();
+        } else {
+          result = await deps.installClaude();
+        }
+
+        if (!result.ok) {
+          sendFailed(command, result);
+          deps.log("⚠️", `runtime-install: ${command.provider} failed: ${boundedReason(result.reason)}`);
+          return;
+        }
+
+        try {
+          await deps.reprobe(command.provider);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          sendFailed(command, {
+            reason: `Runtime installed, but the capability re-probe failed: ${message}`,
+            reasonCode: "capability_reprobe_failed",
+            retryable: true,
+          });
+          deps.log("⚠️", `runtime-install: ${command.provider} re-probe failed: ${boundedReason(message)}`);
+          return;
+        }
+
+        deps.send({
+          type: "runtime-install:result",
+          provider: command.provider,
+          ref: command.ref,
+          status: "succeeded",
+          installedVersion: result.installedVersion,
+        });
+        deps.log("✓", `runtime-install: ${command.provider} installed (ref ${command.ref})`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        sendFailed(command, {
+          reason: message,
+          reasonCode: "runtime_install_exception",
+          retryable: true,
+        });
+        deps.log("⚠️", `runtime-install: ${command.provider} failed: ${boundedReason(message)}`);
+      } finally {
+        if (active?.ref === command.ref) active = null;
+      }
+    },
+  };
+}

--- a/apps/cli/src/core/runtime-install.ts
+++ b/apps/cli/src/core/runtime-install.ts
@@ -1,3 +1,4 @@
+import { redactErrorPreview } from "@first-tree/client";
 import type { RuntimeInstallProvider, RuntimeInstallResultFrame } from "@first-tree/shared";
 import type { InstallClaudeResult } from "./install-claude-runtime.js";
 import type { InstallCodexResult } from "./install-codex-runtime.js";
@@ -18,7 +19,7 @@ export type RuntimeInstallRunner = {
 
 function boundedReason(reason: string): string {
   const trimmed = reason.trim() || "Runtime installation failed";
-  return trimmed.length <= 500 ? trimmed : `${trimmed.slice(0, 497)}...`;
+  return redactErrorPreview(trimmed, 499);
 }
 
 /**

--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -759,6 +759,53 @@ describe("ClientConnection — additional branch coverage", () => {
     priv(connection).clearTimers();
   });
 
+  it("negotiates runtime-install v1, emits only allowlisted commands, and sends results", async () => {
+    const connection = await makeConnection();
+    const openPromise = priv(connection).openWebSocket();
+    const socket = FakeWebSocket.instances.at(-1);
+    if (!socket) throw new Error("missing fake socket");
+    socket.emitOpen();
+    await flushMicrotasks();
+    socket.emitMessage({
+      type: "server:welcome",
+      serverCommandVersion: "1.0.0",
+      serverTimeMs: Date.now(),
+      capabilities: { runtimeInstallV1: true },
+    });
+    socket.emitMessage({ type: "auth:ok" });
+    socket.emitMessage({ type: "client:registered" });
+    await openPromise;
+
+    const register = socket.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .find((frame) => frame.type === "client:register");
+    expect(register?.wireCapabilities).toEqual({ runtimeInstallV1: true });
+
+    const starts: unknown[] = [];
+    connection.on("runtime-install:start", (command) => starts.push(command));
+    const ref = "123e4567-e89b-42d3-a456-426614174000";
+    socket.emitMessage({ type: "runtime-install:start", provider: "codex", ref });
+    socket.emitMessage({ type: "runtime-install:start", provider: "cursor", ref });
+    expect(starts).toEqual([{ provider: "codex", ref }]);
+
+    connection.sendRuntimeInstallResult({
+      type: "runtime-install:result",
+      provider: "codex",
+      ref,
+      status: "succeeded",
+      installedVersion: "0.140.0",
+    });
+    expect(parseSent(socket, socket.sent.length - 1)).toEqual({
+      type: "runtime-install:result",
+      provider: "codex",
+      ref,
+      status: "succeeded",
+      installedVersion: "0.140.0",
+    });
+
+    priv(connection).clearTimers();
+  });
+
   it("advertises no Reset capability at all to a server that never offered v1", async () => {
     const connection = await makeConnection();
     // This harness emits `auth:ok` before `server:welcome` and advertises

--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -761,6 +761,8 @@ describe("ClientConnection — additional branch coverage", () => {
 
   it("negotiates runtime-install v1, emits only allowlisted commands, and sends results", async () => {
     const connection = await makeConnection();
+    const starts: unknown[] = [];
+    connection.on("runtime-install:start", (command) => starts.push(command));
     const openPromise = priv(connection).openWebSocket();
     const socket = FakeWebSocket.instances.at(-1);
     if (!socket) throw new Error("missing fake socket");
@@ -781,8 +783,6 @@ describe("ClientConnection — additional branch coverage", () => {
       .find((frame) => frame.type === "client:register");
     expect(register?.wireCapabilities).toEqual({ runtimeInstallV1: true });
 
-    const starts: unknown[] = [];
-    connection.on("runtime-install:start", (command) => starts.push(command));
     const ref = "123e4567-e89b-42d3-a456-426614174000";
     socket.emitMessage({ type: "runtime-install:start", provider: "codex", ref });
     socket.emitMessage({ type: "runtime-install:start", provider: "cursor", ref });
@@ -803,6 +803,31 @@ describe("ClientConnection — additional branch coverage", () => {
       installedVersion: "0.140.0",
     });
 
+    priv(connection).clearTimers();
+  });
+
+  it("does not advertise runtime-install v1 without a local install handler", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const openPromise = internal.openWebSocket();
+    const socket = FakeWebSocket.instances.at(-1);
+    if (!socket) throw new Error("missing fake socket");
+    socket.emitOpen();
+    await flushMicrotasks();
+    socket.emitMessage({
+      type: "server:welcome",
+      serverCommandVersion: "1.0.0",
+      serverTimeMs: Date.now(),
+      capabilities: { runtimeInstallV1: true },
+    });
+    socket.emitMessage({ type: "auth:ok" });
+    socket.emitMessage({ type: "client:registered" });
+    await openPromise;
+
+    const register = socket.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .find((frame) => frame.type === "client:register");
+    expect(register?.wireCapabilities).toEqual({});
     priv(connection).clearTimers();
   });
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -176,6 +176,7 @@ export type {
   ClientConnectionConfig,
   ProviderModelsListCommand,
   RuntimeAuthCommand,
+  RuntimeInstallCommand,
   ServerWelcome,
   SessionCommand,
 } from "./runtime/client-connection.js";

--- a/packages/client/src/runtime/client-connection.ts
+++ b/packages/client/src/runtime/client-connection.ts
@@ -1656,7 +1656,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           // servers ignore the unknown v1 field.
           wireCapabilities: {
             ...(this.serverSupportsSessionResetV1 ? { wsSessionResetV1: true } : {}),
-            ...(this.serverSupportsRuntimeInstallV1 ? { runtimeInstallV1: true } : {}),
+            ...(this.serverSupportsRuntimeInstallV1 && this.listenerCount("runtime-install:start") > 0
+              ? { runtimeInstallV1: true }
+              : {}),
           },
           ...(lastUpdateAttempt ? { lastUpdateAttempt } : {}),
         }),

--- a/packages/client/src/runtime/client-connection.ts
+++ b/packages/client/src/runtime/client-connection.ts
@@ -23,11 +23,16 @@ import {
   type ProviderModelCatalog,
   providerModelsListCommandSchema,
   RUNTIME_AUTH_START_TYPE,
+  RUNTIME_INSTALL_RESULT_TYPE,
+  RUNTIME_INSTALL_START_TYPE,
   type RuntimeAuthMethod,
   type RuntimeAuthProvider,
+  type RuntimeInstallProvider,
+  type RuntimeInstallResultFrame,
   type RuntimeProvider,
   type RuntimeState,
   runtimeAuthStartCommandSchema,
+  runtimeInstallStartCommandSchema,
   type ServerWelcomeFrame,
   type SessionCommandAbortedFrame,
   type SessionCommandFinalizedFrame,
@@ -224,6 +229,12 @@ export type ProviderModelsListCommand = {
   ref: string;
 };
 
+/** Server -> daemon request to install one allowlisted runtime engine. */
+export type RuntimeInstallCommand = {
+  provider: RuntimeInstallProvider;
+  ref: string;
+};
+
 /**
  * Welcome frame received after `auth:ok`. `isReconnect` is true for every
  * occurrence after the first welcome in the lifetime of this `ClientConnection`
@@ -277,6 +288,7 @@ type ClientConnectionEvents = {
    */
   "session:command:aborted": [frame: SessionCommandAbortedFrame];
   "runtime-auth:start": [command: RuntimeAuthCommand];
+  "runtime-install:start": [command: RuntimeInstallCommand];
   "provider-models:list": [command: ProviderModelsListCommand];
   "session:reconcile:result": [result: SessionReconcileResult];
   "auth:expired": [];
@@ -562,6 +574,8 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * sends ahead of `auth:ok`.
    */
   private serverSupportsSessionResetV1 = false;
+  /** Negotiated support for the controlled runtime-install command/result flow. */
+  private serverSupportsRuntimeInstallV1 = false;
   /**
    * Last handshake error, stashed for the `close` handler to surface a typed
    * reason (e.g. {@link ClientOrgMismatchError}) instead of a generic
@@ -1388,6 +1402,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.ws.send(JSON.stringify({ type: PROVIDER_MODELS_RESULT_TYPE, ref, catalog }));
   }
 
+  /** Publish runtime-install progress or a terminal result to the server. */
+  sendRuntimeInstallResult(result: RuntimeInstallResultFrame): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ ...result, type: RUNTIME_INSTALL_RESULT_TYPE }));
+  }
+
   async disconnect(): Promise<void> {
     this.closing = true;
     this.connectAbort?.abort();
@@ -1475,6 +1495,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         // server's Reset support into the register frame of a socket that may
         // have landed on a rolled-back replica.
         this.serverSupportsSessionResetV1 = false;
+        this.serverSupportsRuntimeInstallV1 = false;
         // Don't reset reconnectAttempt here — a TCP/WS handshake succeeding
         // but the auth phase failing is exactly the loop the client.log
         // captured at 19:40 (1 Hz reconnect storm with `failed to obtain
@@ -1635,6 +1656,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           // servers ignore the unknown v1 field.
           wireCapabilities: {
             ...(this.serverSupportsSessionResetV1 ? { wsSessionResetV1: true } : {}),
+            ...(this.serverSupportsRuntimeInstallV1 ? { runtimeInstallV1: true } : {}),
           },
           ...(lastUpdateAttempt ? { lastUpdateAttempt } : {}),
         }),
@@ -1659,6 +1681,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       this.serverSupportsInboxAckConfirm = parsed.data.capabilities?.wsInboxAckConfirm === true;
       this.serverSupportsSessionEventConfirm = parsed.data.capabilities?.wsSessionEventConfirm === true;
       this.serverSupportsSessionResetV1 = parsed.data.capabilities?.wsSessionResetV1 === true;
+      this.serverSupportsRuntimeInstallV1 = parsed.data.capabilities?.runtimeInstallV1 === true;
       this.emit("server:welcome", { frame: parsed.data, isReconnect });
       return;
     }
@@ -1936,6 +1959,15 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       if (parsed.success) {
         const { provider, method, ref } = parsed.data;
         this.emit("runtime-auth:start", { provider, method, ref });
+      }
+      return;
+    }
+
+    if (type === RUNTIME_INSTALL_START_TYPE) {
+      const parsed = runtimeInstallStartCommandSchema.safeParse(msg);
+      if (parsed.success) {
+        const { provider, ref } = parsed.data;
+        this.emit("runtime-install:start", { provider, ref });
       }
       return;
     }

--- a/packages/server/src/__tests__/clients-runtime-install.test.ts
+++ b/packages/server/src/__tests__/clients-runtime-install.test.ts
@@ -1,0 +1,216 @@
+import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { clients } from "../db/schema/clients.js";
+import {
+  clearPendingClientRepliesForTests,
+  removeClientConnection,
+  resolveClientReply,
+  setClientConnection,
+} from "../services/runtime/connection-manager.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+describe("POST /clients/:clientId/runtime-install/start", () => {
+  const getApp = useTestApp();
+
+  afterEach(() => {
+    clearPendingClientRepliesForTests();
+  });
+
+  async function markCapable(
+    app: ReturnType<typeof getApp>,
+    clientId: string,
+    input: { instanceId?: string; lastSeenAt?: Date; status?: "connected" | "disconnected" } = {},
+  ): Promise<void> {
+    await app.db
+      .update(clients)
+      .set({
+        status: input.status ?? "connected",
+        instanceId: input.instanceId ?? app.config.instanceId,
+        lastSeenAt: input.lastSeenAt ?? new Date(),
+        metadata: { wireCapabilities: { runtimeInstallV1: true } },
+      })
+      .where(eq(clients.id, clientId));
+  }
+
+  it("lets the exact owner install an allowlisted runtime on the live selected Computer", async () => {
+    const app = getApp();
+    const owner = await createAdminContext(app, { username: `ri-own-${crypto.randomUUID().slice(0, 6)}` });
+    await markCapable(app, owner.clientId);
+    const ws = { readyState: 1, send: vi.fn(), close: vi.fn() };
+    setClientConnection(owner.clientId, ws as unknown as WebSocket, { runtimeInstallV1: true });
+    try {
+      const pending = app.inject({
+        method: "POST",
+        url: `/api/v1/clients/${owner.clientId}/runtime-install/start`,
+        headers: { authorization: `Bearer ${owner.accessToken}` },
+        payload: { provider: "codex" },
+      });
+
+      await vi.waitFor(() => expect(ws.send).toHaveBeenCalledTimes(1));
+      const command = JSON.parse(String(ws.send.mock.calls[0]?.[0]));
+      expect(command).toMatchObject({ type: "runtime-install:start", provider: "codex" });
+      expect(
+        resolveClientReply(owner.clientId, command.ref, {
+          type: "runtime-install:result",
+          provider: "codex",
+          ref: command.ref,
+          status: "succeeded",
+          installedVersion: "0.140.0",
+        }),
+      ).toBe(true);
+
+      const response = await pending;
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        provider: "codex",
+        ref: command.ref,
+        status: "succeeded",
+        installedVersion: "0.140.0",
+        progress: ["accepted", "in-progress"],
+      });
+    } finally {
+      removeClientConnection(owner.clientId, ws as unknown as WebSocket);
+    }
+  });
+
+  it("rejects owner mismatch and non-allowlisted input before delivery", async () => {
+    const app = getApp();
+    const owner = await createAdminContext(app, { username: `ri-owner-${crypto.randomUUID().slice(0, 6)}` });
+    const other = await createAdminContext(app, { username: `ri-other-${crypto.randomUUID().slice(0, 6)}` });
+    await markCapable(app, owner.clientId);
+    const ws = { readyState: 1, send: vi.fn(), close: vi.fn() };
+    setClientConnection(owner.clientId, ws as unknown as WebSocket, { runtimeInstallV1: true });
+    try {
+      const unauthorized = await app.inject({
+        method: "POST",
+        url: `/api/v1/clients/${owner.clientId}/runtime-install/start`,
+        headers: { authorization: `Bearer ${other.accessToken}` },
+        payload: { provider: "codex" },
+      });
+      expect(unauthorized.statusCode).toBe(404);
+
+      const disallowed = await app.inject({
+        method: "POST",
+        url: `/api/v1/clients/${owner.clientId}/runtime-install/start`,
+        headers: { authorization: `Bearer ${owner.accessToken}` },
+        payload: { provider: "cursor", command: "npm install anything" },
+      });
+      expect(disallowed.statusCode).toBe(400);
+
+      const arbitraryCommand = await app.inject({
+        method: "POST",
+        url: `/api/v1/clients/${owner.clientId}/runtime-install/start`,
+        headers: { authorization: `Bearer ${owner.accessToken}` },
+        payload: { provider: "codex", command: "npm install anything" },
+      });
+      expect(arbitraryCommand.statusCode).toBe(400);
+      expect(ws.send).not.toHaveBeenCalled();
+    } finally {
+      removeClientConnection(owner.clientId, ws as unknown as WebSocket);
+    }
+  });
+
+  it.each([
+    ["disconnected", "not connected", { status: "disconnected" as const }],
+    ["stale", "stale", { lastSeenAt: new Date(0) }],
+  ])("returns an explicit error for a %s Computer", async (_label, expectedMessage, clientState) => {
+    const app = getApp();
+    const owner = await createAdminContext(app, { username: `ri-live-${crypto.randomUUID().slice(0, 6)}` });
+    await markCapable(app, owner.clientId, clientState);
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/clients/${owner.clientId}/runtime-install/start`,
+      headers: { authorization: `Bearer ${owner.accessToken}` },
+      payload: { provider: "claude-code" },
+    });
+    expect(response.statusCode).toBe(503);
+    expect(response.json().error.toLowerCase()).toContain(expectedMessage);
+  });
+
+  it("surfaces a retryable daemon failure and permits a later request", async () => {
+    const app = getApp();
+    const owner = await createAdminContext(app, { username: `ri-fail-${crypto.randomUUID().slice(0, 6)}` });
+    await markCapable(app, owner.clientId);
+    const ws = { readyState: 1, send: vi.fn(), close: vi.fn() };
+    setClientConnection(owner.clientId, ws as unknown as WebSocket, { runtimeInstallV1: true });
+    try {
+      const request = () =>
+        app.inject({
+          method: "POST",
+          url: `/api/v1/clients/${owner.clientId}/runtime-install/start`,
+          headers: { authorization: `Bearer ${owner.accessToken}` },
+          payload: { provider: "claude-code" },
+        });
+      const first = request();
+      await vi.waitFor(() => expect(ws.send).toHaveBeenCalledTimes(1));
+      const firstCommand = JSON.parse(String(ws.send.mock.calls[0]?.[0]));
+      resolveClientReply(owner.clientId, firstCommand.ref, {
+        type: "runtime-install:result",
+        provider: "claude-code",
+        ref: firstCommand.ref,
+        status: "failed",
+        reason: "npm registry unavailable",
+        reasonCode: "network_error",
+        retryable: true,
+      });
+      const failed = await first;
+      expect(failed.statusCode).toBe(200);
+      expect(failed.json()).toMatchObject({ status: "failed", reasonCode: "network_error", retryable: true });
+
+      const retry = request();
+      await vi.waitFor(() => expect(ws.send).toHaveBeenCalledTimes(2));
+      const retryCommand = JSON.parse(String(ws.send.mock.calls[1]?.[0]));
+      expect(retryCommand.ref).not.toBe(firstCommand.ref);
+      resolveClientReply(owner.clientId, retryCommand.ref, {
+        type: "runtime-install:result",
+        provider: "claude-code",
+        ref: retryCommand.ref,
+        status: "succeeded",
+        installedVersion: null,
+      });
+      expect((await retry).json()).toMatchObject({ status: "succeeded" });
+    } finally {
+      removeClientConnection(owner.clientId, ws as unknown as WebSocket);
+    }
+  });
+
+  it("fans the command to the DB-authoritative remote replica", async () => {
+    const app = getApp();
+    const owner = await createAdminContext(app, { username: `ri-remote-${crypto.randomUUID().slice(0, 6)}` });
+    await markCapable(app, owner.clientId, { instanceId: "remote-instance" });
+    const notify = vi.spyOn(app.notifier, "notifyDaemonClientCommand").mockResolvedValue();
+    try {
+      const pending = app.inject({
+        method: "POST",
+        url: `/api/v1/clients/${owner.clientId}/runtime-install/start`,
+        headers: { authorization: `Bearer ${owner.accessToken}` },
+        payload: { provider: "codex" },
+      });
+      await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1));
+      const command = notify.mock.calls[0]?.[0];
+      expect(command).toMatchObject({
+        type: "runtime-install:start",
+        clientId: owner.clientId,
+        provider: "codex",
+        targetInstanceId: "remote-instance",
+      });
+      if (!command) throw new Error("expected remote command");
+      await app.notifier.notifyDaemonClientCommandResult({
+        clientId: owner.clientId,
+        ref: command.ref,
+        result: {
+          type: "runtime-install:result",
+          provider: "codex",
+          ref: command.ref,
+          status: "succeeded",
+          installedVersion: null,
+        },
+      });
+      expect((await pending).statusCode).toBe(200);
+    } finally {
+      notify.mockRestore();
+    }
+  });
+});

--- a/packages/server/src/__tests__/clients-runtime-install.test.ts
+++ b/packages/server/src/__tests__/clients-runtime-install.test.ts
@@ -51,15 +51,29 @@ describe("POST /clients/:clientId/runtime-install/start", () => {
       await vi.waitFor(() => expect(ws.send).toHaveBeenCalledTimes(1));
       const command = JSON.parse(String(ws.send.mock.calls[0]?.[0]));
       expect(command).toMatchObject({ type: "runtime-install:start", provider: "codex" });
-      expect(
-        resolveClientReply(owner.clientId, command.ref, {
-          type: "runtime-install:result",
-          provider: "codex",
+      for (const result of [
+        {
+          type: "runtime-install:result" as const,
+          provider: "codex" as const,
           ref: command.ref,
-          status: "succeeded",
+          status: "accepted" as const,
+        },
+        {
+          type: "runtime-install:result" as const,
+          provider: "codex" as const,
+          ref: command.ref,
+          status: "in-progress" as const,
+        },
+        {
+          type: "runtime-install:result" as const,
+          provider: "codex" as const,
+          ref: command.ref,
+          status: "succeeded" as const,
           installedVersion: "0.140.0",
-        }),
-      ).toBe(true);
+        },
+      ]) {
+        await app.notifier.notifyDaemonClientCommandResult({ clientId: owner.clientId, ref: command.ref, result });
+      }
 
       const response = await pending;
       expect(response.statusCode).toBe(200);
@@ -157,7 +171,12 @@ describe("POST /clients/:clientId/runtime-install/start", () => {
       });
       const failed = await first;
       expect(failed.statusCode).toBe(200);
-      expect(failed.json()).toMatchObject({ status: "failed", reasonCode: "network_error", retryable: true });
+      expect(failed.json()).toMatchObject({
+        status: "failed",
+        reasonCode: "network_error",
+        retryable: true,
+        progress: [],
+      });
 
       const retry = request();
       await vi.waitFor(() => expect(ws.send).toHaveBeenCalledTimes(2));
@@ -204,11 +223,33 @@ describe("POST /clients/:clientId/runtime-install/start", () => {
           type: "runtime-install:result",
           provider: "codex",
           ref: command.ref,
+          status: "in-progress",
+        },
+      });
+      await app.notifier.notifyDaemonClientCommandResult({
+        clientId: owner.clientId,
+        ref: command.ref,
+        result: {
+          type: "runtime-install:result",
+          provider: "codex",
+          ref: command.ref,
+          status: "accepted",
+        },
+      });
+      await app.notifier.notifyDaemonClientCommandResult({
+        clientId: owner.clientId,
+        ref: command.ref,
+        result: {
+          type: "runtime-install:result",
+          provider: "codex",
+          ref: command.ref,
           status: "succeeded",
           installedVersion: null,
         },
       });
-      expect((await pending).statusCode).toBe(200);
+      const response = await pending;
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ status: "succeeded", progress: ["accepted"] });
     } finally {
       notify.mockRestore();
     }

--- a/packages/server/src/__tests__/ws-client-edge.test.ts
+++ b/packages/server/src/__tests__/ws-client-edge.test.ts
@@ -1525,6 +1525,54 @@ describe("Agent client WS edge protocol coverage", () => {
     }
   });
 
+  it("dispatches runtime install progress and terminal results through the attached client WebSocket", async () => {
+    const seed = await createAdminContext(app, { username: `ws-install-${crypto.randomUUID().slice(0, 8)}` });
+    const ws = await openRegisteredSocket(seed, { runtimeInstallV1: true });
+    const notifyResult = vi.spyOn(app.notifier, "notifyDaemonClientCommandResult");
+
+    try {
+      const commandFrame = waitForFrame(
+        ws,
+        (message) => (message as { type?: string }).type === "runtime-install:start",
+      );
+      const pending = app.inject({
+        method: "POST",
+        url: `/api/v1/clients/${seed.clientId}/runtime-install/start`,
+        headers: { authorization: `Bearer ${seed.accessToken}` },
+        payload: { provider: "codex" },
+      });
+      const command = (await commandFrame) as { ref: string };
+
+      for (const result of [
+        { type: "runtime-install:result", provider: "codex", ref: command.ref, status: "accepted" },
+        { type: "runtime-install:result", provider: "codex", ref: command.ref, status: "in-progress" },
+        {
+          type: "runtime-install:result",
+          provider: "codex",
+          ref: command.ref,
+          status: "succeeded",
+          installedVersion: "0.140.0",
+        },
+      ]) {
+        ws.send(JSON.stringify(result));
+        await vi.waitFor(() =>
+          expect(notifyResult).toHaveBeenCalledWith({ clientId: seed.clientId, ref: command.ref, result }),
+        );
+      }
+
+      const response = await pending;
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        status: "succeeded",
+        installedVersion: "0.140.0",
+        progress: ["accepted", "in-progress"],
+      });
+    } finally {
+      notifyResult.mockRestore();
+      await closeSocket(ws);
+    }
+  });
+
   it("forwards a fanned-out session:terminate to the owning socket only when the binding is current", async () => {
     // Cross-replica command delivery: the daemon_client_commands handler on
     // the socket-owning replica re-checks the live agent→client binding

--- a/packages/server/src/api/agent/ws-client/auth.ts
+++ b/packages/server/src/api/agent/ws-client/auth.ts
@@ -299,6 +299,7 @@ export function createClientWsAuthGate(
           wsInboxAckConfirm: true,
           wsSessionEventConfirm: true,
           wsSessionResetV1: true,
+          runtimeInstallV1: true,
         },
       });
       sendJsonOrThrow(socket, { type: "auth:ok" });

--- a/packages/server/src/api/agent/ws-client/client-frames.ts
+++ b/packages/server/src/api/agent/ws-client/client-frames.ts
@@ -18,7 +18,10 @@ import * as clientService from "../../../services/runtime/client.js";
 import * as connectionManager from "../../../services/runtime/connection-manager.js";
 import * as runtimeLivenessService from "../../../services/runtime/liveness.js";
 import { storeModelCatalogRpcResult } from "../../../services/runtime/rpc/provider-models.js";
-import { metadataSupportsRuntimeInstallV1 } from "../../../services/runtime/rpc/runtime-install.js";
+import {
+  metadataSupportsRuntimeInstallV1,
+  recordRuntimeInstallProgress,
+} from "../../../services/runtime/rpc/runtime-install.js";
 import { setAuthWsAttrs } from "./auth.js";
 import type { ClientWsConnectionContext } from "./connection-context.js";
 import type { InboxDeliveryCoordinator } from "./inbox-delivery.js";
@@ -224,6 +227,7 @@ export function createClientFrameHandler(
         );
         return;
       }
+      recordRuntimeInstallProgress(clientId, result.data);
       const terminal = runtimeInstallTerminalResultFrameSchema.safeParse(result.data);
       if (terminal.success) {
         connectionManager.resolveClientReply(clientId, terminal.data.ref, terminal.data);

--- a/packages/server/src/api/agent/ws-client/client-frames.ts
+++ b/packages/server/src/api/agent/ws-client/client-frames.ts
@@ -3,6 +3,9 @@ import {
   clientRegisterSchema,
   PROVIDER_MODELS_RESULT_TYPE,
   providerModelsResultFrameSchema,
+  RUNTIME_INSTALL_RESULT_TYPE,
+  runtimeInstallResultFrameSchema,
+  runtimeInstallTerminalResultFrameSchema,
 } from "@first-tree/shared";
 import { and, desc, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
@@ -15,6 +18,7 @@ import * as clientService from "../../../services/runtime/client.js";
 import * as connectionManager from "../../../services/runtime/connection-manager.js";
 import * as runtimeLivenessService from "../../../services/runtime/liveness.js";
 import { storeModelCatalogRpcResult } from "../../../services/runtime/rpc/provider-models.js";
+import { metadataSupportsRuntimeInstallV1 } from "../../../services/runtime/rpc/runtime-install.js";
 import { setAuthWsAttrs } from "./auth.js";
 import type { ClientWsConnectionContext } from "./connection-context.js";
 import type { InboxDeliveryCoordinator } from "./inbox-delivery.js";
@@ -193,6 +197,38 @@ export function createClientFrameHandler(
         await reconcilePinnedAgentsForClient();
       }
       socket.send(JSON.stringify({ type: "heartbeat:ack" }));
+    } else if (type === RUNTIME_INSTALL_RESULT_TYPE) {
+      if (!clientId) {
+        socket.send(JSON.stringify({ type: "error", message: "Must register client first" }));
+        return;
+      }
+      const result = runtimeInstallResultFrameSchema.safeParse(msg);
+      if (!result.success) {
+        socket.send(JSON.stringify({ type: "error", message: "Malformed runtime-install:result frame" }));
+        return;
+      }
+      if (!connectionManager.isActiveClientConnection(clientId, socket)) {
+        app.log.debug({ clientId, ref: result.data.ref }, "ignoring runtime-install result from replaced local socket");
+        return;
+      }
+      const client = await clientService.getClient(app.db, clientId);
+      if (
+        !client ||
+        client.status !== "connected" ||
+        client.instanceId !== instanceId ||
+        !metadataSupportsRuntimeInstallV1(client.metadata)
+      ) {
+        app.log.debug(
+          { clientId, ref: result.data.ref, instanceId },
+          "ignoring runtime-install result from stale or incapable client route",
+        );
+        return;
+      }
+      const terminal = runtimeInstallTerminalResultFrameSchema.safeParse(result.data);
+      if (terminal.success) {
+        connectionManager.resolveClientReply(clientId, terminal.data.ref, terminal.data);
+      }
+      await notifier.notifyDaemonClientCommandResult({ clientId, ref: result.data.ref, result: result.data });
     } else if (type === PROVIDER_MODELS_RESULT_TYPE) {
       if (!clientId) {
         socket.send(JSON.stringify({ type: "error", message: "Must register client first" }));

--- a/packages/server/src/api/agent/ws-client/connection.ts
+++ b/packages/server/src/api/agent/ws-client/connection.ts
@@ -1,4 +1,4 @@
-import { PROVIDER_MODELS_RESULT_TYPE } from "@first-tree/shared";
+import { PROVIDER_MODELS_RESULT_TYPE, RUNTIME_INSTALL_RESULT_TYPE } from "@first-tree/shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { WebSocket } from "ws";
 import { z } from "zod";
@@ -78,6 +78,7 @@ export function attachClientWsConnection(
         switch (type) {
           case "client:register":
           case "heartbeat":
+          case RUNTIME_INSTALL_RESULT_TYPE:
           case PROVIDER_MODELS_RESULT_TYPE:
             await handleClientFrame(type, msg);
             break;

--- a/packages/server/src/api/agent/ws-client/server-events.ts
+++ b/packages/server/src/api/agent/ws-client/server-events.ts
@@ -1,8 +1,15 @@
-import { agentPinnedMessageSchema, PROVIDER_MODELS_LIST_TYPE } from "@first-tree/shared";
+import {
+  agentPinnedMessageSchema,
+  PROVIDER_MODELS_LIST_TYPE,
+  RUNTIME_INSTALL_START_TYPE,
+  runtimeInstallTerminalResultFrameSchema,
+} from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
 import type { Notifier } from "../../../services/notifier.js";
+import * as clientService from "../../../services/runtime/client.js";
 import * as connectionManager from "../../../services/runtime/connection-manager.js";
 import { readModelCatalogRpcResult } from "../../../services/runtime/rpc/provider-models.js";
+import { metadataSupportsRuntimeInstallV1 } from "../../../services/runtime/rpc/runtime-install.js";
 import { agentRoutedTo, readSessionCommandRpcResult } from "../../../services/runtime/rpc/session-command.js";
 
 export function registerClientWsServerEvents(app: FastifyInstance, notifier: Notifier, instanceId: string): void {
@@ -35,6 +42,27 @@ export function registerClientWsServerEvents(app: FastifyInstance, notifier: Not
         type: PROVIDER_MODELS_LIST_TYPE,
         provider: payload.provider,
         ref: payload.ref,
+      });
+      return;
+    }
+    if (payload.type === RUNTIME_INSTALL_START_TYPE) {
+      void (async () => {
+        const client = await clientService.getClient(app.db, payload.clientId);
+        if (
+          !client ||
+          client.status !== "connected" ||
+          client.instanceId !== payload.targetInstanceId ||
+          !metadataSupportsRuntimeInstallV1(client.metadata)
+        ) {
+          return;
+        }
+        connectionManager.sendToClient(payload.clientId, {
+          type: RUNTIME_INSTALL_START_TYPE,
+          provider: payload.provider,
+          ref: payload.ref,
+        });
+      })().catch((err) => {
+        app.log.warn({ err, clientId: payload.clientId, ref: payload.ref }, "runtime install fan-out failed");
       });
       return;
     }
@@ -78,6 +106,13 @@ export function registerClientWsServerEvents(app: FastifyInstance, notifier: Not
   });
 
   notifier.onDaemonClientCommandResult((payload) => {
+    if (payload.result) {
+      const terminal = runtimeInstallTerminalResultFrameSchema.safeParse(payload.result);
+      if (terminal.success) {
+        connectionManager.resolveClientReply(payload.clientId, payload.ref, terminal.data);
+      }
+      return;
+    }
     void (async () => {
       const ack = await readSessionCommandRpcResult(app.db, payload.clientId, payload.ref);
       if (ack) {

--- a/packages/server/src/api/agent/ws-client/server-events.ts
+++ b/packages/server/src/api/agent/ws-client/server-events.ts
@@ -9,7 +9,10 @@ import type { Notifier } from "../../../services/notifier.js";
 import * as clientService from "../../../services/runtime/client.js";
 import * as connectionManager from "../../../services/runtime/connection-manager.js";
 import { readModelCatalogRpcResult } from "../../../services/runtime/rpc/provider-models.js";
-import { metadataSupportsRuntimeInstallV1 } from "../../../services/runtime/rpc/runtime-install.js";
+import {
+  metadataSupportsRuntimeInstallV1,
+  recordRuntimeInstallProgress,
+} from "../../../services/runtime/rpc/runtime-install.js";
 import { agentRoutedTo, readSessionCommandRpcResult } from "../../../services/runtime/rpc/session-command.js";
 
 export function registerClientWsServerEvents(app: FastifyInstance, notifier: Notifier, instanceId: string): void {
@@ -107,6 +110,7 @@ export function registerClientWsServerEvents(app: FastifyInstance, notifier: Not
 
   notifier.onDaemonClientCommandResult((payload) => {
     if (payload.result) {
+      recordRuntimeInstallProgress(payload.clientId, payload.result);
       const terminal = runtimeInstallTerminalResultFrameSchema.safeParse(payload.result);
       if (terminal.success) {
         connectionManager.resolveClientReply(payload.clientId, payload.ref, terminal.data);

--- a/packages/server/src/api/clients.ts
+++ b/packages/server/src/api/clients.ts
@@ -27,9 +27,11 @@ import {
 } from "../services/runtime/connection-manager.js";
 import { isClientConnectedSomewhere, readModelCatalogRpcResult } from "../services/runtime/rpc/provider-models.js";
 import {
+  beginRuntimeInstallProgress,
   metadataSupportsRuntimeInstallV1,
   RUNTIME_INSTALL_REPLY_TIMEOUT_MS,
   runtimeInstallClientLiveness,
+  takeRuntimeInstallProgress,
 } from "../services/runtime/rpc/runtime-install.js";
 import { serializeDate } from "../utils.js";
 import { clientCommandVersionHint } from "./client-command-version.js";
@@ -144,6 +146,7 @@ export async function clientRoutes(app: FastifyInstance): Promise<void> {
     if (!targetInstanceId) throw new Error("unreachable: live client missing instance id");
 
     const ref = randomUUID();
+    beginRuntimeInstallProgress(clientId, body.provider, ref);
     const replyPromise = waitForClientReply(clientId, ref, RUNTIME_INSTALL_REPLY_TIMEOUT_MS);
     const command = { type: RUNTIME_INSTALL_START_TYPE, provider: body.provider, ref };
     if (targetInstanceId === app.config.instanceId) {
@@ -151,6 +154,7 @@ export async function clientRoutes(app: FastifyInstance): Promise<void> {
       if (!delivered) {
         cancelClientReply(clientId, ref, new Error("Computer not connected"));
         await replyPromise.catch(() => undefined);
+        takeRuntimeInstallProgress(clientId, ref);
         throw new ServiceUnavailableError(
           "Runtime installation could not start because this computer is not connected. Start its daemon, then retry.",
         );
@@ -165,13 +169,11 @@ export async function clientRoutes(app: FastifyInstance): Promise<void> {
 
     try {
       const terminal = runtimeInstallTerminalResultFrameSchema.parse(await replyPromise);
-      const progress =
-        terminal.status === "failed" && terminal.reasonCode === "already_in_progress"
-          ? []
-          : (["accepted", "in-progress"] as const);
+      const progress = takeRuntimeInstallProgress(clientId, ref);
       const { type: _type, ...result } = terminal;
       return runtimeInstallStartResponseSchema.parse({ ...result, progress });
     } catch (err) {
+      takeRuntimeInstallProgress(clientId, ref);
       const timedOut = err instanceof Error && err.message.toLowerCase().includes("timed out");
       if (timedOut) {
         throw new GatewayTimeoutError(

--- a/packages/server/src/api/clients.ts
+++ b/packages/server/src/api/clients.ts
@@ -3,7 +3,11 @@ import {
   PROVIDER_MODELS_LIST_TYPE,
   providerModelCatalogSchema,
   RUNTIME_AUTH_START_TYPE,
+  RUNTIME_INSTALL_START_TYPE,
   runtimeAuthStartRequestSchema,
+  runtimeInstallStartRequestSchema,
+  runtimeInstallStartResponseSchema,
+  runtimeInstallTerminalResultFrameSchema,
   runtimeProviderSchema,
   updateClientCapabilitiesSchema,
 } from "@first-tree/shared";
@@ -15,12 +19,18 @@ import { requireUser } from "../scope/require-user.js";
 import { expiryToSeconds } from "../services/auth/tokens.js";
 import * as clientService from "../services/runtime/client.js";
 import {
+  cancelClientReply,
   forceDisconnectClient,
   rejectPendingRepliesForClient,
   sendToClient,
   waitForClientReply,
 } from "../services/runtime/connection-manager.js";
 import { isClientConnectedSomewhere, readModelCatalogRpcResult } from "../services/runtime/rpc/provider-models.js";
+import {
+  metadataSupportsRuntimeInstallV1,
+  RUNTIME_INSTALL_REPLY_TIMEOUT_MS,
+  runtimeInstallClientLiveness,
+} from "../services/runtime/rpc/runtime-install.js";
 import { serializeDate } from "../utils.js";
 import { clientCommandVersionHint } from "./client-command-version.js";
 
@@ -98,6 +108,80 @@ export async function clientRoutes(app: FastifyInstance): Promise<void> {
       );
     }
     return { ref, started: true as const };
+  });
+
+  // Install one allowlisted runtime engine on the selected Computer. The HTTP
+  // request stays open for the terminal result so no durable job/progress state
+  // is introduced; daemon progress/result frames are ref-correlated across
+  // replicas through the existing reverse-command notifier channel.
+  app.post<{ Params: { clientId: string } }>("/:clientId/runtime-install/start", async (request) => {
+    const { userId } = requireUser(request);
+    const { clientId } = request.params;
+    stampClientResource(request, clientId);
+    await clientService.assertClientOwner(app.db, clientId, { userId });
+    await clientService.assertClientNotRetired(app.db, clientId);
+    const body = runtimeInstallStartRequestSchema.parse(request.body);
+    const client = await clientService.getClient(app.db, clientId);
+    if (!client) throw new Error("unreachable: client missing after owner check");
+
+    const liveness = runtimeInstallClientLiveness(client, new Date(), app.config.runtime.presenceCleanupSeconds);
+    if (liveness === "disconnected") {
+      throw new ServiceUnavailableError(
+        "Runtime installation could not start because this computer is not connected. Start its daemon, then retry.",
+      );
+    }
+    if (liveness === "stale") {
+      throw new ServiceUnavailableError(
+        "Runtime installation could not start because this computer's connection is stale. Restart its daemon, then retry.",
+      );
+    }
+    if (!metadataSupportsRuntimeInstallV1(client.metadata)) {
+      throw new ServiceUnavailableError(
+        "Runtime installation is unavailable because this computer's daemon does not support controlled installs. Update and restart it, then retry.",
+      );
+    }
+    const targetInstanceId = client.instanceId;
+    if (!targetInstanceId) throw new Error("unreachable: live client missing instance id");
+
+    const ref = randomUUID();
+    const replyPromise = waitForClientReply(clientId, ref, RUNTIME_INSTALL_REPLY_TIMEOUT_MS);
+    const command = { type: RUNTIME_INSTALL_START_TYPE, provider: body.provider, ref };
+    if (targetInstanceId === app.config.instanceId) {
+      const delivered = sendToClient(clientId, command);
+      if (!delivered) {
+        cancelClientReply(clientId, ref, new Error("Computer not connected"));
+        await replyPromise.catch(() => undefined);
+        throw new ServiceUnavailableError(
+          "Runtime installation could not start because this computer is not connected. Start its daemon, then retry.",
+        );
+      }
+    } else {
+      await app.notifier.notifyDaemonClientCommand({
+        ...command,
+        clientId,
+        targetInstanceId,
+      });
+    }
+
+    try {
+      const terminal = runtimeInstallTerminalResultFrameSchema.parse(await replyPromise);
+      const progress =
+        terminal.status === "failed" && terminal.reasonCode === "already_in_progress"
+          ? []
+          : (["accepted", "in-progress"] as const);
+      const { type: _type, ...result } = terminal;
+      return runtimeInstallStartResponseSchema.parse({ ...result, progress });
+    } catch (err) {
+      const timedOut = err instanceof Error && err.message.toLowerCase().includes("timed out");
+      if (timedOut) {
+        throw new GatewayTimeoutError(
+          "Timed out waiting for this computer to finish installing the runtime. Check the daemon log before retrying.",
+        );
+      }
+      throw new BadGatewayError(
+        err instanceof Error ? err.message : "The computer did not return a valid runtime installation result.",
+      );
+    }
   });
 
   // Host-local model catalog: ask the connected daemon to discover models from

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -1,4 +1,11 @@
-import { PROVIDER_MODELS_LIST_TYPE, type SessionCommandAbortReason } from "@first-tree/shared";
+import {
+  PROVIDER_MODELS_LIST_TYPE,
+  RUNTIME_INSTALL_START_TYPE,
+  type RuntimeInstallResultFrame,
+  runtimeInstallProviderSchema,
+  runtimeInstallResultFrameSchema,
+  type SessionCommandAbortReason,
+} from "@first-tree/shared";
 import type postgres from "postgres";
 import type { WebSocket } from "ws";
 
@@ -120,6 +127,13 @@ export type AgentRouteChangeHandler = (payload: AgentRouteChangePayload) => void
 /** Small reverse-command frame fan-out for host-local daemon RPCs. */
 export type DaemonClientCommandPayload =
   | {
+      type: typeof RUNTIME_INSTALL_START_TYPE;
+      clientId: string;
+      provider: "claude-code" | "codex";
+      ref: string;
+      targetInstanceId: string;
+    }
+  | {
       type: typeof PROVIDER_MODELS_LIST_TYPE;
       clientId: string;
       provider: string;
@@ -172,6 +186,8 @@ export type DaemonClientCommandHandler = (payload: DaemonClientCommandPayload) =
 export type DaemonClientCommandResultPayload = {
   clientId: string;
   ref: string;
+  /** Present for ephemeral runtime-install progress/results; omitted for durable catalog wakes. */
+  result?: RuntimeInstallResultFrame;
 };
 export type DaemonClientCommandResultHandler = (payload: DaemonClientCommandResultPayload) => void;
 export type MeChatsChangedHandler = (payload: { humanAgentId: string; organizationId: string }) => void;
@@ -800,6 +816,8 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
             if (parsed.type === "session:command:aborted" && typeof sessionPayload.reason !== "string") return;
           } else if (parsed.type === PROVIDER_MODELS_LIST_TYPE) {
             if (typeof (parsed as { provider?: unknown }).provider !== "string") return;
+          } else if (parsed.type === RUNTIME_INSTALL_START_TYPE) {
+            if (!runtimeInstallProviderSchema.safeParse((parsed as { provider?: unknown }).provider).success) return;
           } else {
             return;
           }
@@ -825,6 +843,8 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
             if (typeof parsed.clientId !== "string" || typeof parsed.ref !== "string") {
               return;
             }
+            if (parsed.result !== undefined && !runtimeInstallResultFrameSchema.safeParse(parsed.result).success)
+              return;
             for (const handler of daemonClientCommandResultHandlers) {
               try {
                 handler(parsed as DaemonClientCommandResultPayload);

--- a/packages/server/src/services/runtime/rpc/runtime-install.ts
+++ b/packages/server/src/services/runtime/rpc/runtime-install.ts
@@ -1,0 +1,21 @@
+import { clientWireCapabilitiesSchema } from "@first-tree/shared";
+
+/** Installer hard timeout is eight minutes; leave thirty seconds for the result frame. */
+export const RUNTIME_INSTALL_REPLY_TIMEOUT_MS = 8 * 60 * 1000 + 30_000;
+
+export function metadataSupportsRuntimeInstallV1(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false;
+  const wire = (metadata as Record<string, unknown>).wireCapabilities;
+  const parsed = clientWireCapabilitiesSchema.safeParse(wire);
+  return parsed.success && parsed.data.runtimeInstallV1 === true;
+}
+
+export function runtimeInstallClientLiveness(
+  client: { status: string; instanceId: string | null; lastSeenAt: Date },
+  now: Date,
+  staleSeconds: number,
+): "live" | "disconnected" | "stale" {
+  if (client.status !== "connected" || !client.instanceId) return "disconnected";
+  if (now.getTime() - client.lastSeenAt.getTime() > staleSeconds * 1000) return "stale";
+  return "live";
+}

--- a/packages/server/src/services/runtime/rpc/runtime-install.ts
+++ b/packages/server/src/services/runtime/rpc/runtime-install.ts
@@ -1,7 +1,46 @@
-import { clientWireCapabilitiesSchema } from "@first-tree/shared";
+import {
+  clientWireCapabilitiesSchema,
+  type RuntimeInstallProgressStatus,
+  type RuntimeInstallProvider,
+  type RuntimeInstallResultFrame,
+} from "@first-tree/shared";
 
 /** Installer hard timeout is eight minutes; leave thirty seconds for the result frame. */
 export const RUNTIME_INSTALL_REPLY_TIMEOUT_MS = 8 * 60 * 1000 + 30_000;
+
+type RuntimeInstallProgress = {
+  clientId: string;
+  provider: RuntimeInstallProvider;
+  statuses: RuntimeInstallProgressStatus[];
+};
+
+const progressByRef = new Map<string, RuntimeInstallProgress>();
+
+/** Start tracking only the in-memory progress needed by one live HTTP request. */
+export function beginRuntimeInstallProgress(clientId: string, provider: RuntimeInstallProvider, ref: string): void {
+  progressByRef.set(ref, { clientId, provider, statuses: [] });
+}
+
+/** Record valid ordered progress; duplicates and out-of-order frames are ignored. */
+export function recordRuntimeInstallProgress(clientId: string, result: RuntimeInstallResultFrame): void {
+  const progress = progressByRef.get(result.ref);
+  if (!progress || progress.clientId !== clientId || progress.provider !== result.provider) return;
+  if (result.status === "accepted" && progress.statuses.length === 0) {
+    progress.statuses.push("accepted");
+    return;
+  }
+  if (result.status === "in-progress" && progress.statuses.length === 1 && progress.statuses[0] === "accepted") {
+    progress.statuses.push("in-progress");
+  }
+}
+
+/** Return and delete the observed progress for a completed/failed HTTP request. */
+export function takeRuntimeInstallProgress(clientId: string, ref: string): RuntimeInstallProgressStatus[] {
+  const progress = progressByRef.get(ref);
+  if (!progress || progress.clientId !== clientId) return [];
+  progressByRef.delete(ref);
+  return [...progress.statuses];
+}
 
 export function metadataSupportsRuntimeInstallV1(metadata: unknown): boolean {
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false;

--- a/packages/shared/src/__tests__/runtime-install-schema.test.ts
+++ b/packages/shared/src/__tests__/runtime-install-schema.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  runtimeInstallResultFrameSchema,
+  runtimeInstallStartCommandSchema,
+  runtimeInstallStartRequestSchema,
+} from "../schemas/runtime-install.js";
+
+describe("runtime install schemas", () => {
+  it.each(["codex", "claude-code"] as const)("accepts the fixed %s provider", (provider) => {
+    expect(runtimeInstallStartRequestSchema.parse({ provider })).toEqual({ provider });
+    expect(
+      runtimeInstallStartCommandSchema.parse({
+        type: "runtime-install:start",
+        provider,
+        ref: "123e4567-e89b-42d3-a456-426614174000",
+      }),
+    ).toMatchObject({ provider });
+  });
+
+  it.each([
+    "cursor",
+    "kimi-code",
+    "codex@latest",
+    "npm install -g anything",
+  ])("rejects non-allowlisted provider input %s", (provider) => {
+    expect(runtimeInstallStartRequestSchema.safeParse({ provider }).success).toBe(false);
+  });
+
+  it("bounds failure output and rejects caller-controlled extra fields", () => {
+    expect(
+      runtimeInstallResultFrameSchema.safeParse({
+        type: "runtime-install:result",
+        provider: "codex",
+        ref: "123e4567-e89b-42d3-a456-426614174000",
+        status: "failed",
+        reason: "x".repeat(501),
+        reasonCode: "npm_failed",
+        retryable: true,
+      }).success,
+    ).toBe(false);
+    expect(runtimeInstallStartRequestSchema.safeParse({ provider: "codex", command: "rm -rf /" }).success).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1478,6 +1478,24 @@ export {
   runtimeAuthStartResponseSchema,
 } from "./schemas/runtime-auth.js";
 export {
+  RUNTIME_INSTALL_RESULT_TYPE,
+  RUNTIME_INSTALL_START_TYPE,
+  type RuntimeInstallProgressStatus,
+  type RuntimeInstallProvider,
+  type RuntimeInstallResultFrame,
+  type RuntimeInstallStartCommand,
+  type RuntimeInstallStartRequest,
+  type RuntimeInstallStartResponse,
+  type RuntimeInstallTerminalResultFrame,
+  runtimeInstallProgressStatusSchema,
+  runtimeInstallProviderSchema,
+  runtimeInstallResultFrameSchema,
+  runtimeInstallStartCommandSchema,
+  runtimeInstallStartRequestSchema,
+  runtimeInstallStartResponseSchema,
+  runtimeInstallTerminalResultFrameSchema,
+} from "./schemas/runtime-install.js";
+export {
   asRuntimeProvider,
   DEFAULT_RUNTIME_PROVIDER,
   DISABLED_RUNTIME_PROVIDERS,

--- a/packages/shared/src/schemas/client.ts
+++ b/packages/shared/src/schemas/client.ts
@@ -74,6 +74,12 @@ export const clientWireCapabilitiesSchema = z
      * `terminate?waitForApply=true` on this field alone.
      */
     wsSessionResetV1: z.boolean().default(false),
+    /**
+     * Version 1 of the controlled runtime-install command/result protocol.
+     * Declared only after the server advertises the same capability, so a
+     * request cannot be sent to an older daemon that would silently ignore it.
+     */
+    runtimeInstallV1: z.boolean().default(false),
   })
   .partial();
 export type ClientWireCapabilities = z.infer<typeof clientWireCapabilitiesSchema>;

--- a/packages/shared/src/schemas/runtime-install.ts
+++ b/packages/shared/src/schemas/runtime-install.ts
@@ -68,7 +68,7 @@ export type RuntimeInstallTerminalResultFrame = z.infer<typeof runtimeInstallTer
 /** Terminal HTTP response. `progress` proves the daemon accepted and started the controlled install. */
 export const runtimeInstallStartResponseSchema = z.discriminatedUnion("status", [
   runtimeInstallTerminalResultFrameSchema.options[0].omit({ type: true }).extend({
-    progress: z.tuple([z.literal("accepted"), z.literal("in-progress")]),
+    progress: z.array(runtimeInstallProgressStatusSchema).max(2),
   }),
   runtimeInstallTerminalResultFrameSchema.options[1].omit({ type: true }).extend({
     progress: z.array(runtimeInstallProgressStatusSchema).max(2),

--- a/packages/shared/src/schemas/runtime-install.ts
+++ b/packages/shared/src/schemas/runtime-install.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+/** Runtime engines that the daemon may install from a server command. */
+export const runtimeInstallProviderSchema = z.enum(["claude-code", "codex"]);
+export type RuntimeInstallProvider = z.infer<typeof runtimeInstallProviderSchema>;
+
+export const RUNTIME_INSTALL_START_TYPE = "runtime-install:start" as const;
+export const RUNTIME_INSTALL_RESULT_TYPE = "runtime-install:result" as const;
+
+/** Server -> daemon command. No caller-controlled package, version, or shell input is allowed. */
+export const runtimeInstallStartCommandSchema = z
+  .object({
+    type: z.literal(RUNTIME_INSTALL_START_TYPE),
+    provider: runtimeInstallProviderSchema,
+    ref: z.string().uuid(),
+  })
+  .strict();
+export type RuntimeInstallStartCommand = z.infer<typeof runtimeInstallStartCommandSchema>;
+
+/** Web -> server request. The selected Computer is carried by the route parameter. */
+export const runtimeInstallStartRequestSchema = z
+  .object({
+    provider: runtimeInstallProviderSchema,
+  })
+  .strict();
+export type RuntimeInstallStartRequest = z.infer<typeof runtimeInstallStartRequestSchema>;
+
+export const runtimeInstallProgressStatusSchema = z.enum(["accepted", "in-progress"]);
+export type RuntimeInstallProgressStatus = z.infer<typeof runtimeInstallProgressStatusSchema>;
+
+const runtimeInstallResultBaseSchema = z.object({
+  type: z.literal(RUNTIME_INSTALL_RESULT_TYPE),
+  provider: runtimeInstallProviderSchema,
+  ref: z.string().uuid(),
+});
+
+/** Daemon -> server progress and terminal result frames. */
+export const runtimeInstallResultFrameSchema = z.discriminatedUnion("status", [
+  runtimeInstallResultBaseSchema.extend({ status: z.literal("accepted") }),
+  runtimeInstallResultBaseSchema.extend({ status: z.literal("in-progress") }),
+  runtimeInstallResultBaseSchema.extend({
+    status: z.literal("succeeded"),
+    installedVersion: z.string().max(64).nullable(),
+  }),
+  runtimeInstallResultBaseSchema.extend({
+    status: z.literal("failed"),
+    reason: z.string().min(1).max(500),
+    reasonCode: z.string().min(1).max(100),
+    retryable: z.boolean(),
+  }),
+]);
+export type RuntimeInstallResultFrame = z.infer<typeof runtimeInstallResultFrameSchema>;
+
+export const runtimeInstallTerminalResultFrameSchema = z.discriminatedUnion("status", [
+  runtimeInstallResultBaseSchema.extend({
+    status: z.literal("succeeded"),
+    installedVersion: z.string().max(64).nullable(),
+  }),
+  runtimeInstallResultBaseSchema.extend({
+    status: z.literal("failed"),
+    reason: z.string().min(1).max(500),
+    reasonCode: z.string().min(1).max(100),
+    retryable: z.boolean(),
+  }),
+]);
+export type RuntimeInstallTerminalResultFrame = z.infer<typeof runtimeInstallTerminalResultFrameSchema>;
+
+/** Terminal HTTP response. `progress` proves the daemon accepted and started the controlled install. */
+export const runtimeInstallStartResponseSchema = z.discriminatedUnion("status", [
+  runtimeInstallTerminalResultFrameSchema.options[0].omit({ type: true }).extend({
+    progress: z.tuple([z.literal("accepted"), z.literal("in-progress")]),
+  }),
+  runtimeInstallTerminalResultFrameSchema.options[1].omit({ type: true }).extend({
+    progress: z.array(runtimeInstallProgressStatusSchema).max(2),
+  }),
+]);
+export type RuntimeInstallStartResponse = z.infer<typeof runtimeInstallStartResponseSchema>;

--- a/packages/shared/src/schemas/ws-auth.ts
+++ b/packages/shared/src/schemas/ws-auth.ts
@@ -121,6 +121,8 @@ export const serverCapabilitiesSchema = z
      * frame alone.
      */
     wsSessionResetV1: z.boolean().default(false),
+    /** Server supports the ref-correlated controlled runtime-install protocol. */
+    runtimeInstallV1: z.boolean().default(false),
   })
   .partial();
 export type ServerCapabilities = z.infer<typeof serverCapabilitiesSchema>;


### PR DESCRIPTION
## Summary

- add a strict shared command/result contract for only Codex and Claude Code runtime installation
- authorize the exact Computer owner, reject disconnected/stale/incapable Computers, and route commands across server replicas through the existing daemon notifier seam
- reuse the existing daemon installers with a single in-flight guard, real progress/result reporting, secret-redacted failures, and a capability re-probe after success
- negotiate runtime-install support only when both peers support v1 and the local daemon has registered an installer handler

## Scope

This is the backend-only foundation for a later Web action. It adds no UI, database state, migrations, provider authentication, caller-supplied command/package/version input, or Windows-specific bootstrap behavior.

The paired durable runtime-boundary update is in draft Context Tree PR [agent-team-foundation/first-tree-context#946](https://github.com/agent-team-foundation/first-tree-context/pull/946).

## Verification

- `pnpm typecheck`
- focused shared tests: 7 passed
- focused client tests: 19 passed
- focused CLI runtime-install and daemon-start tests: 52 passed
- focused Server runtime-install and attached-WebSocket tests: 41 passed
- CI-equivalent CLI shard 2/2 passed
- adjacent shared handshake tests: 21 passed
- adjacent notifier tests: 6 passed
- adjacent server welcome test: 1 passed
- full `@first-tree/client` suite passed
- changed-file Biome check passed
- `git diff --check` passed

`pnpm test` was also attempted. The shared suite completed with 933 tests passing, then Turbo concurrently ran the Client build and test presteps; both rebuild `packages/client/skills`, producing an `ENOTEMPTY` race. Running the Client suite separately passed.

## Review

Independent Standards and Spec review on `8b979c64ec491f83f76db8cb5e713e9c75d9864f` identified and cleared the handler-less capability-advertisement and synthesized-progress findings. Maintainer review then identified two additional blockers: the top-level WebSocket dispatcher omitted runtime-install result frames, and supervised installs could stream raw npm stderr through CLI Print. Exact head `9076e52f371ff707c704302984cdddfe90e2f849` wires the attached-socket path with an end-to-end regression and injects a quiet stderr sink for remote daemon installs while preserving interactive CLI output; exact-head re-review is pending.
