### PR TITLE
release: bump apps/cli to v0.5.21

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## What

Bumps `apps/cli/package.json` version from `0.5.20` to `0.5.21` — the only change in this PR. Package name stays `first-tree-dev`; no changes to `bin`, `apps/cli/src/build-info.ts`, lockfile, database, or any other file.

Base: `origin/main` at exact SHA `497eb7f0c812a0a68bbbc903d80aff61b82db8bb`.

## Draft GitHub Release

Title: `v0.5.21 — Feishu Agent channels, simpler setup, local Context`

Body:

## Highlights

- Connect Team Agents to Feishu through the new optional Agent Channel. The single-page OpenTag flow creates or selects an Agent, registers its bot, prepares local Feishu tooling, and supports DMs, exact group mentions, direct replies, activated threads, reactions, attachments, and bounded conversation context.
- Create and manage Team Agents with a shorter flow: team-visible defaults, responsibility provenance in Profile, restored Member Workspace and Team access, clearer GitHub Task Agent eligibility, and a direct Add to Feishu handoff.
- Managed Agents whose Team has no bound shared Context Tree can now use an Agent-local Context Tree fallback while valid Team bindings remain authoritative.
- Cursor users can select the Router's Auto · Intelligence, Auto · Balance, and Auto · Cost modes directly in runtime settings.

## Notable fixes

- macOS managed updates keep the launchd wrapper online across CLI replacement and report stopped services accurately.
- Inbox acknowledgements no longer confirm deliveries outside the current socket's admitted prefix, and timeout recovery now converges safely after rebind.
- Missing optional integrations degrade only the dependent operation, Grok Build 1.x is accepted, and member Workspace/Team navigation is restored.
- OpenTag onboarding now completes only at a usable Feishu handoff and remains stable on narrower desktop layouts.

## Operations and compatibility

- Existing Feishu bots must explicitly reauthorize through the visible QR flow to grant the new group-message permission; the current connection remains usable until replacement authorization succeeds.
- Attachment-retention deletion remains disabled unless `FIRST_TREE_ATTACHMENT_RETENTION_DELETE_ENABLED=true`. When enabled, eligible message attachments older than 14 days are permanently removed unless protected by a Team Skill Resource or Agent Template bundle.
- Clients older than `v0.5.12` are unsupported. Deploy Web and Server from the same Docker image.

## Verification

- `pnpm check` — pass (0 errors; 36 pre-existing lint warnings / 8 infos, unchanged by this diff).
- `pnpm typecheck` — pass (9/9 packages via turbo).
- `pnpm test` — run multiple times locally on macOS:
  - Full turbo run: all packages pass except `@first-tree/skill-evals`, where all 748 assertions pass but vitest reports a worker-level `onTaskUpdate` RPC timeout under parallel turbo load. Standalone `pnpm --filter @first-tree/skill-evals test` passes cleanly (748/748).
  - Per-package: `@first-tree/client` 2677 passed / 7 skipped, `@first-tree/server` 3449 passed, `@first-tree/web` 2374 passed — all green.
  - `first-tree-dev` (apps/cli): full batch suite run; 3 test files failed locally due to host environment leakage, not the diff: (a) `update-detect-install-mode.test.ts` (11) and `daemon-refresh-unit.test.ts` (3) fail only because the local shell exports `FIRST_TREE_PORTABLE_ROOT`/`FIRST_TREE_PORTABLE_BIN_DIR`/`FIRST_TREE_INSTALL_MODE` and a stale host shim — both files pass with `FIRST_TREE_*` env unset; (b) `tree-init-command-extra.test.ts` has 1 local failure from macOS `/var` → `/private/var` tmpdir canonicalization in a spy path assertion. This PR changes only the version string and cannot affect any of these paths.

Independent release-qualification (Feishu live-provider gates and macOS launchd staging gates for this range) is being assessed separately by QA; this PR stays Draft until that assessment concludes.

## Post-merge steps

1. Wait for main CI, npm Publish, and Docker workflows to pass on the exact merge SHA.
2. Only after confirming the exact merge SHA, create the `v0.5.21` tag and GitHub Release with the draft title/body above.
3. Verify `first-tree@0.5.21` on npm and the GHCR Docker image.
