### PR TITLE
fix(cli): point package repository identity at first-tree-ai org

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,9 +11,9 @@
     "github",
     "collaboration"
   ],
-  "homepage": "https://github.com/agent-team-foundation/first-tree#readme",
+  "homepage": "https://github.com/first-tree-ai/first-tree#readme",
   "bugs": {
-    "url": "https://github.com/agent-team-foundation/first-tree/issues"
+    "url": "https://github.com/first-tree-ai/first-tree/issues"
   },
   "exports": {
     ".": {
@@ -54,7 +54,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/agent-team-foundation/first-tree.git",
+    "url": "https://github.com/first-tree-ai/first-tree.git",
     "directory": "apps/cli"
   },
   "engines": {


### PR DESCRIPTION
## What

Updates the npm package repository identity in `apps/cli/package.json` to the canonical GitHub organization after the org rename `agent-team-foundation` → `first-tree-ai`:

- `homepage`: `https://github.com/agent-team-foundation/first-tree#readme` → `https://github.com/first-tree-ai/first-tree#readme`
- `bugs.url`: `https://github.com/agent-team-foundation/first-tree/issues` → `https://github.com/first-tree-ai/first-tree/issues`
- `repository.url`: `https://github.com/agent-team-foundation/first-tree.git` → `https://github.com/first-tree-ai/first-tree.git` (keeps `.git` suffix and `directory: "apps/cli"`)

This is the only change. Package name, version, `bin`, `build-info.ts`, lockfile, workflows, database, and all other files are untouched.

## Why

npm trusted publishing requires the published package's `repository.url` to exactly match the GitHub repository the OIDC token is minted for. After the GitHub org rename, the npm Publish workflow's staging publish (`first-tree-staging@0.5.22-staging.1199.x`) failed twice with registry `404` on PUT, while install/check/build/typecheck/CLI smoke/S3 preflight all passed. The last successful publish completed before the org metadata update; the two failures came after it. Aligning the package metadata with the canonical repo `first-tree-ai/first-tree` restores the trusted-publishing identity check. This blocks the `v0.5.21` production release, which must not be tagged until the publish pipeline is healthy again.

## Verification

- `pnpm install --frozen-lockfile` — pass; lockfile unchanged (metadata-only edit).
- `pnpm check` — pass (0 errors; pre-existing lint warnings unchanged).
- `pnpm typecheck` — pass (turbo, all packages).

## Out of scope

- No repo-wide org-name migration (docs, other packages, workflows) — reported separately if needed.
- No npm workflow rerun, no tag, no GitHub Release.
