### PR TITLE
feat(scripts): report install progress in both installers

### DIFF
--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ENSURE_SERVICE_DEFERRED_EXIT_CODE } from "../commands/daemon/ensure-service.js";
 
 const sharedConfigMocks = vi.hoisted(() => ({
   clientConfigSchema: {
@@ -277,13 +278,19 @@ describe("daemon utility commands", () => {
       "supervisor definition rewritten",
     );
 
+    // Both branches deliberately do nothing, which the portable installer has to
+    // tell apart from a real repair; they exit deferred rather than zero.
     coreMocks.isServiceSupported.mockReturnValueOnce(false);
-    await runDaemon(["ensure-service"]);
+    await expect(runDaemon(["ensure-service"])).rejects.toMatchObject({
+      code: ENSURE_SERVICE_DEFERRED_EXIT_CODE,
+    });
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("not supported");
 
     coreMocks.isServiceSupported.mockReturnValue(true);
     coreMocks.loadCredentials.mockReturnValueOnce(null);
-    await runDaemon(["ensure-service"]);
+    await expect(runDaemon(["ensure-service"])).rejects.toMatchObject({
+      code: ENSURE_SERVICE_DEFERRED_EXIT_CODE,
+    });
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("no credentials");
 
     coreMocks.installClientService.mockClear();

--- a/apps/cli/src/__tests__/daemon-ensure-service-exit.test.ts
+++ b/apps/cli/src/__tests__/daemon-ensure-service-exit.test.ts
@@ -1,0 +1,95 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ENSURE_SERVICE_DEFERRED_EXIT_CODE } from "../commands/daemon/ensure-service.js";
+
+const outputMocks = vi.hoisted(() => ({
+  print: { line: vi.fn() },
+}));
+
+const coreMocks = vi.hoisted(() => ({
+  isServiceSupported: vi.fn(),
+  loadCredentials: vi.fn(),
+  getClientServiceStatus: vi.fn(),
+  isServiceUnitDriftDetected: vi.fn(),
+  installClientService: vi.fn(),
+  restartClientService: vi.fn(),
+}));
+
+vi.mock("../core/output.js", () => outputMocks);
+vi.mock("../core/index.js", () => coreMocks);
+
+async function runEnsureService(): Promise<void> {
+  const { registerDaemonEnsureServiceCommand } = await import("../commands/daemon/ensure-service.js");
+  const daemon = new Command();
+  registerDaemonEnsureServiceCommand(daemon);
+  await daemon.parseAsync(["ensure-service"], { from: "user" });
+}
+
+/**
+ * The portable installer decides whether to tell the operator the background
+ * service is set up purely from this command's exit status. "Did nothing" is
+ * the normal first-install path, so it must be distinguishable from readiness:
+ * a zero here would make the installer print a success line directly under the
+ * command's own "run login" notice.
+ */
+describe("daemon ensure-service — ready / deferred / failed exit contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined): never => {
+      throw Object.assign(new Error(`process.exit ${code}`), { exitCode: code });
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("keeps the deferred exit code in sync with the portable installer", () => {
+    // scripts/portable/install.sh mirrors this as ENSURE_SERVICE_DEFERRED=3.
+    expect(ENSURE_SERVICE_DEFERRED_EXIT_CODE).toBe(3);
+  });
+
+  it("defers rather than reporting readiness when no credentials exist yet", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.loadCredentials.mockReturnValue(null);
+
+    await expect(runEnsureService()).rejects.toMatchObject({ exitCode: ENSURE_SERVICE_DEFERRED_EXIT_CODE });
+
+    expect(outputMocks.print.line).toHaveBeenCalledWith(expect.stringContaining("no credentials found"));
+    expect(coreMocks.installClientService).not.toHaveBeenCalled();
+  });
+
+  it("defers when service control is unsupported on this platform", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(false);
+
+    await expect(runEnsureService()).rejects.toMatchObject({ exitCode: ENSURE_SERVICE_DEFERRED_EXIT_CODE });
+
+    expect(outputMocks.print.line).toHaveBeenCalledWith(expect.stringContaining("not supported"));
+    expect(coreMocks.loadCredentials).not.toHaveBeenCalled();
+  });
+
+  it("exits zero only when the unit is actually installed and running", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.loadCredentials.mockReturnValue({ clientId: "c1" });
+    coreMocks.getClientServiceStatus.mockReturnValue({ state: "active", platform: "launchd" });
+    coreMocks.isServiceUnitDriftDetected.mockReturnValue(false);
+
+    await runEnsureService();
+
+    expect(process.exit).not.toHaveBeenCalled();
+    expect(outputMocks.print.line).toHaveBeenCalledWith(expect.stringContaining("already running"));
+  });
+
+  it("reports failure distinctly when service repair is attempted and fails", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.loadCredentials.mockReturnValue({ clientId: "c1" });
+    coreMocks.getClientServiceStatus.mockReturnValue({ state: "inactive", platform: "launchd" });
+    coreMocks.isServiceUnitDriftDetected.mockReturnValue(false);
+    coreMocks.installClientService.mockReturnValue({ state: "inactive", platform: "launchd", detail: "boom" });
+
+    // Distinct from the deferred code so the installer can warn instead of
+    // quietly deferring to a login that would not fix this.
+    await expect(runEnsureService()).rejects.toMatchObject({ exitCode: 1 });
+  });
+});

--- a/apps/cli/src/__tests__/daemon-ensure-service-exit.test.ts
+++ b/apps/cli/src/__tests__/daemon-ensure-service-exit.test.ts
@@ -1,6 +1,11 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ENSURE_SERVICE_DEFERRED_EXIT_CODE } from "../commands/daemon/ensure-service.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
 
 const outputMocks = vi.hoisted(() => ({
   print: { line: vi.fn() },
@@ -45,9 +50,16 @@ describe("daemon ensure-service — ready / deferred / failed exit contract", ()
     vi.resetModules();
   });
 
-  it("keeps the deferred exit code in sync with the portable installer", () => {
-    // scripts/portable/install.sh mirrors this as ENSURE_SERVICE_DEFERRED=3.
-    expect(ENSURE_SERVICE_DEFERRED_EXIT_CODE).toBe(3);
+  it("keeps the deferred exit code in sync with the portable installer's copy", () => {
+    // The installer is shell and cannot import the constant, so the two copies
+    // are compared directly here rather than asserting a literal on this side.
+    const installer = readFileSync(join(REPO_ROOT, "scripts", "portable", "install.sh"), "utf8");
+    const declared = installer.match(/^ENSURE_SERVICE_DEFERRED=(\d+)$/m);
+    expect(declared, "install.sh must declare ENSURE_SERVICE_DEFERRED").not.toBeNull();
+    expect(Number(declared?.[1])).toBe(ENSURE_SERVICE_DEFERRED_EXIT_CODE);
+
+    // And that it is actually the value the installer branches on.
+    expect(installer).toContain('[ "$ensure_service_rc" -eq "$ENSURE_SERVICE_DEFERRED" ]');
   });
 
   it("defers rather than reporting readiness when no credentials exist yet", async () => {

--- a/apps/cli/src/commands/daemon/ensure-service.ts
+++ b/apps/cli/src/commands/daemon/ensure-service.ts
@@ -11,6 +11,19 @@ import {
 import { print } from "../../core/output.js";
 
 /**
+ * Returned instead of `0` when the command intentionally did nothing: service
+ * control is unsupported on this platform, or no credentials exist yet and the
+ * follow-up `login` owns starting the daemon.
+ *
+ * The exit status is a three-state contract, because "did nothing" is the
+ * normal first-install path and callers must not report the service as ready
+ * there: `0` means the unit is installed and running, this code means setup is
+ * deferred, and any other non-zero means repair was attempted and failed.
+ * Consumed by `ensure_daemon_service` in `scripts/portable/install.sh`.
+ */
+export const ENSURE_SERVICE_DEFERRED_EXIT_CODE = 3;
+
+/**
  * Hidden recovery hook used by the portable installer after it has switched the
  * channel shim to the freshly installed version. It is intentionally narrower
  * than `login <code>`: credentials are never created or replaced here. If a
@@ -26,12 +39,12 @@ export function registerDaemonEnsureServiceCommand(daemon: Command): void {
       const binName = channelConfig.binName;
       if (!isServiceSupported()) {
         print.line(`  ensure-service: service control is not supported on ${process.platform}; skipping.\n`);
-        return;
+        process.exit(ENSURE_SERVICE_DEFERRED_EXIT_CODE);
       }
 
       if (!loadCredentials()) {
         print.line(`  ensure-service: no credentials found; run \`${binName} login <code>\` after install.\n`);
-        return;
+        process.exit(ENSURE_SERVICE_DEFERRED_EXIT_CODE);
       }
 
       const svc = getClientServiceStatus();

--- a/apps/cli/tests/portable-builder.test.ts
+++ b/apps/cli/tests/portable-builder.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   cpSync,
@@ -13,6 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -644,7 +645,7 @@ describe("portable installer", () => {
     root: string,
     version: string,
     platform: string,
-    options: { failRuntimeSmoke?: boolean; integrationRuntime?: boolean } = {},
+    options: { failRuntimeSmoke?: boolean; integrationRuntime?: boolean; failEnsureService?: boolean } = {},
   ): Promise<void> {
     const channelDir = join(root, "prod");
     const versionDir = join(channelDir, version);
@@ -662,6 +663,13 @@ if [ -n "\${FT_TEST_NODE_ARGS_LOG:-}" ]; then
 fi
 if [ "$2" = "--version" ]; then ${options.failRuntimeSmoke ? "exit 51" : `echo ${version}; exit 0;`} fi
 if [ "$1" = "--version" ]; then ${options.failRuntimeSmoke ? "exit 51" : `echo ${version}; exit 0;`} fi
+${
+  options.failEnsureService
+    ? `case "$*" in
+  *ensure-service*) printf 'service repair unavailable\\n' >&2; exit 9 ;;
+esac`
+    : ""
+}
 echo node-stub "$@"
 `;
     await writeFile(join(payload, "node", "bin", "node"), nodeScript, { mode: 0o755 });
@@ -1198,4 +1206,173 @@ if (args[0] === "--version") {
     expect(res.status).not.toBe(0);
     expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("old\n");
   });
+
+  it("limits --quiet output to errors and the final summary", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makeFixture(platform);
+    const home = tempDir("first-tree-home-");
+    const prefix = join(home, "prefix");
+    const binDir = join(home, "bin");
+    const res = spawnSync(
+      "sh",
+      [
+        join(REPO_ROOT, "scripts", "portable", "install.sh"),
+        "--prefix",
+        prefix,
+        "--bin-dir",
+        binDir,
+        "--no-path-edit",
+        "--quiet",
+      ],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          HOME: home,
+          FIRST_TREE_PORTABLE_CHANNEL: "prod",
+          FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL: `file://${fixture}`,
+        },
+        encoding: "utf8",
+      },
+    );
+
+    expect(res.status, res.stderr || res.stdout).toBe(0);
+    // The fixture runtime echoes "node-stub ..." for `daemon ensure-service`;
+    // quiet mode must hold back successful lifecycle output, not just its own.
+    expect(res.stdout).not.toContain("node-stub");
+    expect(res.stdout).not.toContain("[1/9]");
+    expect(res.stdout).not.toContain("Downloading payload");
+    expect(res.stdout).not.toContain("first-tree.ai");
+    expect(res.stdout).toContain("First Tree 1.2.3 installed");
+    expect(res.stdout).toContain(`Add this to your shell profile: export PATH="${binDir}:$PATH"`);
+  });
+
+  it("does not claim the background service is set up when service repair fails", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = tempDir("first-tree-install-test-");
+    await writeFixtureVersion(fixture, "1.2.3", platform, { failEnsureService: true });
+    const home = tempDir("first-tree-home-");
+    const prefix = join(home, "prefix");
+    const binDir = join(home, "bin");
+    const res = spawnSync(
+      "sh",
+      [join(REPO_ROOT, "scripts", "portable", "install.sh"), "--prefix", prefix, "--bin-dir", binDir, "--no-path-edit"],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          HOME: home,
+          FIRST_TREE_PORTABLE_CHANNEL: "prod",
+          FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL: `file://${fixture}`,
+        },
+        encoding: "utf8",
+      },
+    );
+
+    // A recoverable service failure must not fail the install, and must not be
+    // followed by a success line contradicting the warning above it.
+    expect(res.status, res.stderr || res.stdout).toBe(0);
+    expect(res.stdout).toContain("Background service repair failed or is not available yet.");
+    expect(res.stdout).not.toContain("Shell and background service are set up");
+    expect(res.stdout).toContain("Install is complete; background service setup still needs login.");
+    expect(res.stdout).toContain("First Tree 1.2.3 installed");
+    expect(res.stderr).toContain("service repair unavailable");
+  });
+
+  it("reaps the payload transfer when the installer is signalled mid-download", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makeFixture(platform);
+    const home = tempDir("first-tree-home-");
+    const prefix = join(home, "prefix");
+    const binDir = join(home, "bin");
+
+    const latestPath = join(fixture, "prod", "latest.json");
+    const latest = JSON.parse(readFileSync(latestPath, "utf8")) as {
+      assets: Array<{ fileName: string; url: string }>;
+    };
+    const payload = readFileSync(join(fixture, "prod", "1.2.3", latest.assets[0].fileName));
+
+    const totalSlices = 20;
+    let requestSeen = false;
+    let transferClosed = false;
+    let slicesSent = 0;
+    const server = createServer(async (_req, res) => {
+      requestSeen = true;
+      res.on("close", () => {
+        transferClosed = true;
+      });
+      res.writeHead(200, { "content-type": "application/gzip", "content-length": String(payload.length) });
+      const slice = Math.max(1, Math.ceil(payload.length / totalSlices));
+      for (let offset = 0; offset < payload.length; offset += slice) {
+        if (res.destroyed) return;
+        res.write(payload.subarray(offset, offset + slice));
+        slicesSent += 1;
+        await new Promise((done) => setTimeout(done, 150));
+      }
+      res.end();
+    });
+    await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready));
+    const address = server.address();
+    if (address === null || typeof address === "string") throw new Error("throttled fixture server has no TCP port");
+    latest.assets[0].url = `http://127.0.0.1:${address.port}/payload.tar.gz`;
+    writeFileSync(latestPath, JSON.stringify(latest, null, 2));
+
+    try {
+      const child = spawn(
+        "sh",
+        [
+          join(REPO_ROOT, "scripts", "portable", "install.sh"),
+          "--prefix",
+          prefix,
+          "--bin-dir",
+          binDir,
+          "--no-path-edit",
+        ],
+        {
+          cwd: REPO_ROOT,
+          env: {
+            ...process.env,
+            HOME: home,
+            FIRST_TREE_PORTABLE_CHANNEL: "prod",
+            FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL: `file://${fixture}`,
+            // The background-download path only runs when stderr is a terminal,
+            // which spawn() pipes are not.
+            FIRST_TREE_PORTABLE_FORCE_PROGRESS: "1",
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      child.stdout.resume();
+      child.stderr.resume();
+      const exited = new Promise<number | null>((done) => child.on("exit", (code) => done(code)));
+
+      const startDeadline = Date.now() + 10_000;
+      while (!requestSeen && Date.now() < startDeadline) await new Promise((done) => setTimeout(done, 25));
+      expect(requestSeen).toBe(true);
+      await new Promise((done) => setTimeout(done, 400));
+
+      child.kill("SIGTERM");
+      // The trap aborts instead of resuming, so the shell exits deliberately.
+      expect(await exited).toBe(130);
+
+      // The transfer must die with the installer. Killing only the wrapper that
+      // waits on it reparents curl/wget to init, where it keeps writing into a
+      // work directory that has already been removed.
+      const closeDeadline = Date.now() + 5_000;
+      while (!transferClosed && Date.now() < closeDeadline) await new Promise((done) => setTimeout(done, 25));
+      expect(transferClosed).toBe(true);
+      // Guards against passing vacuously: the signal has to cut the transfer
+      // short rather than the installer quietly finishing the download first.
+      expect(slicesSent).toBeLessThan(totalSlices);
+      const slicesAtAbort = slicesSent;
+      await new Promise((done) => setTimeout(done, 600));
+      expect(slicesSent).toBe(slicesAtAbort);
+      expect(existsSync(join(prefix, "current"))).toBe(false);
+    } finally {
+      await new Promise<void>((closed) => server.close(() => closed()));
+    }
+  }, 30_000);
 });

--- a/apps/cli/tests/portable-builder.test.ts
+++ b/apps/cli/tests/portable-builder.test.ts
@@ -1327,6 +1327,8 @@ if (args[0] === "--version") {
     expect(res.stdout).toContain("First Tree 1.2.3 installed");
   });
 
+  // stdio here is pipes, not a terminal, so this exercises the same branch a
+  // `curl ... | sh` bootstrap takes: no progress bar, and no test-only flag.
   it("reaps the payload transfer when the installer is signalled mid-download", async () => {
     const platform = currentPlatform();
     if (platform === null) return;
@@ -1384,9 +1386,6 @@ if (args[0] === "--version") {
             HOME: home,
             FIRST_TREE_PORTABLE_CHANNEL: "prod",
             FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL: `file://${fixture}`,
-            // The background-download path only runs when stderr is a terminal,
-            // which spawn() pipes are not.
-            FIRST_TREE_PORTABLE_FORCE_PROGRESS: "1",
           },
           stdio: ["ignore", "pipe", "pipe"],
         },

--- a/apps/cli/tests/portable-builder.test.ts
+++ b/apps/cli/tests/portable-builder.test.ts
@@ -645,7 +645,12 @@ describe("portable installer", () => {
     root: string,
     version: string,
     platform: string,
-    options: { failRuntimeSmoke?: boolean; integrationRuntime?: boolean; failEnsureService?: boolean } = {},
+    options: {
+      failRuntimeSmoke?: boolean;
+      integrationRuntime?: boolean;
+      failEnsureService?: boolean;
+      deferEnsureService?: boolean;
+    } = {},
   ): Promise<void> {
     const channelDir = join(root, "prod");
     const versionDir = join(channelDir, version);
@@ -667,6 +672,14 @@ ${
   options.failEnsureService
     ? `case "$*" in
   *ensure-service*) printf 'service repair unavailable\\n' >&2; exit 9 ;;
+esac`
+    : ""
+}
+${
+  // Mirrors ENSURE_SERVICE_DEFERRED_EXIT_CODE: setup skipped, not failed.
+  options.deferEnsureService
+    ? `case "$*" in
+  *ensure-service*) printf '  ensure-service: no credentials found; run login after install.\\n'; exit 3 ;;
 esac`
     : ""
 }
@@ -1279,6 +1292,39 @@ if (args[0] === "--version") {
     expect(res.stdout).toContain("Install is complete; background service setup still needs login.");
     expect(res.stdout).toContain("First Tree 1.2.3 installed");
     expect(res.stderr).toContain("service repair unavailable");
+  });
+
+  it("does not claim readiness when service setup is deferred to a later login", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = tempDir("first-tree-install-test-");
+    await writeFixtureVersion(fixture, "1.2.3", platform, { deferEnsureService: true });
+    const home = tempDir("first-tree-home-");
+    const prefix = join(home, "prefix");
+    const binDir = join(home, "bin");
+    const res = spawnSync(
+      "sh",
+      [join(REPO_ROOT, "scripts", "portable", "install.sh"), "--prefix", prefix, "--bin-dir", binDir, "--no-path-edit"],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          HOME: home,
+          FIRST_TREE_PORTABLE_CHANNEL: "prod",
+          FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL: `file://${fixture}`,
+        },
+        encoding: "utf8",
+      },
+    );
+
+    // A fresh install with no credentials is the normal path: it succeeds, and
+    // must not print a readiness line under the command's own login notice.
+    expect(res.status, res.stderr || res.stdout).toBe(0);
+    expect(res.stdout).toContain("no credentials found");
+    expect(res.stdout).not.toContain("Shell and background service are set up");
+    expect(res.stdout).toContain("Install is complete; the background service starts after login.");
+    expect(res.stdout).not.toContain("Background service repair failed");
+    expect(res.stdout).toContain("First Tree 1.2.3 installed");
   });
 
   it("reaps the payload transfer when the installer is signalled mid-download", async () => {

--- a/apps/doc-website/docs/cli/index.md
+++ b/apps/doc-website/docs/cli/index.md
@@ -28,3 +28,21 @@ login command receive the correct server and download-base overrides.
 
 Development builds use `scripts/dev-install.sh` from a source checkout and
 sign in with `first-tree-dev login <connect-code>`.
+
+## Installer output and flags
+
+The installer names each phase as it runs and shows a byte-level progress bar
+while downloading. Colour, the bar, and the full banner appear only on a
+terminal, so piped and CI output stays plain text; `NO_COLOR` disables colour
+on a terminal as well.
+
+Flags go after `--` when piping:
+
+```bash
+curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh -s -- --quiet
+```
+
+`--quiet` prints only errors and the final summary, and `--no-banner` drops the
+banner while keeping the phase reporting. `--version`, `--prefix`, `--bin-dir`,
+`--no-path-edit`, and `--path-mode` are documented in
+[the CLI reference](https://github.com/agent-team-foundation/first-tree/blob/main/docs/cli-reference.md#installer-flags).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -42,6 +42,34 @@ console. It includes the server and portable download-base overrides when
 needed. Development builds continue to use `scripts/dev-install.sh` and
 `first-tree-dev login <connect-code>`.
 
+### Installer flags
+
+The installer reports each phase as it runs — preflight, metadata, download
+(with a byte-level progress bar), checksum, extraction, runtime smoke check,
+activation, and PATH/service setup. Pass flags after `--` when piping:
+
+```bash
+curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh -s -- --quiet
+```
+
+| Flag | Effect |
+|---|---|
+| `--version <version>` | Install an immutable version instead of latest. |
+| `--prefix <path>` | Install root (default `~/.local/share/first-tree/<channel>`). Must be absolute. |
+| `--bin-dir <path>` | Shim directory (default `~/.local/bin`). Must be absolute. |
+| `--no-path-edit` | Do not edit shell startup files. Same as `--path-mode off`. |
+| `--path-mode <mode>` | `auto` (default), `prompt`, or `off`. `prompt` requires an interactive shell. |
+| `--quiet`, `-q` | Print only errors and the final summary. |
+| `--no-banner` | Skip the startup banner, keep the phase reporting. |
+| `--help` | Print installer help. |
+
+Colour, the progress bar, and the full banner are enabled only when the
+installer is attached to a terminal, so piped and CI output stays plain text.
+Set `NO_COLOR` to any value to disable colour on a terminal too.
+
+`scripts/dev-install.sh` accepts the same `--quiet` / `--no-banner` / `--help`
+flags and honours `NO_COLOR`.
+
 ## Global flags
 
 | Flag | Effect |

--- a/docs/development/local-dev-isolation.md
+++ b/docs/development/local-dev-isolation.md
@@ -45,6 +45,13 @@ service picks up the new build:
 ./scripts/dev-install.sh
 ```
 
+The script reports each phase (dev home, dependencies, build, linking, CLI
+verification, daemon restart) with timings, and passes `pnpm` / `turbo` output
+through untouched. `--quiet` buffers that output and replays it only on
+failure, printing just errors and the final summary; `--no-banner` drops the
+banner and keeps the phase reporting. `NO_COLOR` disables colour, and colour is
+off automatically when stdout is not a terminal.
+
 After login, on Linux:
 
 ```bash

--- a/packages/qa/cases/cross-surface/portable-shell-onboarding.md
+++ b/packages/qa/cases/cross-surface/portable-shell-onboarding.md
@@ -97,6 +97,13 @@ For each of `prod` and `staging`:
   shell profile, and installed metadata identifies the matching channel and portable install mode.
 - `observe cli-output`: the installed executable launches with its bundled Node.js runtime and the first `login` exits
   successfully against the isolated server without `--no-start`.
+- `observe installer-output`: the installer identifies itself as First Tree before doing any work, names each phase as it
+  runs, and reports the resolved channel, platform, version, and download size. The payload download reports byte
+  progress against the size in the release metadata rather than going silent. Because the bootstrap is piped through
+  `sh`, the installer's own stdin is not a terminal — confirm the progress reporting is gated on stdout/stderr, so a
+  runner that captures stdout receives plain text with no carriage returns or ANSI escapes while a terminal run shows
+  the bar. A failure surfaces which phase failed, and the checksum, smoke-check, and PATH-guidance messages keep their
+  existing wording.
 - `observe service-state`: login installs and starts the channel-correct systemd service. For a normal Linux user,
   `systemctl --user` reports the user unit active through the runner's real user manager and bus. For root,
   `systemctl status <channel-service-unit>` reports the system unit active, and `journalctl -u <channel-service-unit>`

--- a/packages/qa/cases/cross-surface/portable-shell-onboarding.md
+++ b/packages/qa/cases/cross-surface/portable-shell-onboarding.md
@@ -103,7 +103,12 @@ For each of `prod` and `staging`:
   `sh`, the installer's own stdin is not a terminal — confirm the progress reporting is gated on stdout/stderr, so a
   runner that captures stdout receives plain text with no carriage returns or ANSI escapes while a terminal run shows
   the bar. A failure surfaces which phase failed, and the checksum, smoke-check, and PATH-guidance messages keep their
-  existing wording.
+  existing wording. `--quiet` is limited to errors and the final summary, including any output the installer relays from
+  the CLI's own service lifecycle. The installer never claims the background service is set up when service repair
+  failed; a warning is not followed by a contradicting success line.
+- `observe process-state`: interrupting the installer mid-download stops the payload transfer itself, not just the shell
+  that waits on it. After the installer exits, no `curl`/`wget` child remains reparented to init writing into the
+  removed work directory, and the previously active version is left untouched.
 - `observe service-state`: login installs and starts the channel-correct systemd service. For a normal Linux user,
   `systemctl --user` reports the user unit active through the runner's real user manager and bus. For root,
   `systemctl status <channel-service-unit>` reports the system unit active, and `journalctl -u <channel-service-unit>`

--- a/packages/qa/cases/cross-surface/portable-shell-onboarding.md
+++ b/packages/qa/cases/cross-surface/portable-shell-onboarding.md
@@ -104,8 +104,12 @@ For each of `prod` and `staging`:
   runner that captures stdout receives plain text with no carriage returns or ANSI escapes while a terminal run shows
   the bar. A failure surfaces which phase failed, and the checksum, smoke-check, and PATH-guidance messages keep their
   existing wording. `--quiet` is limited to errors and the final summary, including any output the installer relays from
-  the CLI's own service lifecycle. The installer never claims the background service is set up when service repair
-  failed; a warning is not followed by a contradicting success line.
+  the CLI's own service lifecycle.
+- `observe service-readiness`: this flow installs before any login exists, which is the deferred case, not the ready one.
+  Confirm the installer reports readiness only when the unit is actually installed and running: after a first install
+  with no credentials it relays the command's own "run login" notice and must not follow it with a line claiming the
+  background service is set up, and a genuine service-repair failure produces a warning rather than either. Judge this
+  from the installer's own reporting against the observed unit state, not from the exit status of the install alone.
 - `observe process-state`: interrupting the installer mid-download stops the payload transfer itself, not just the shell
   that waits on it. After the installer exits, no `curl`/`wget` child remains reparented to init writing into the
   removed work directory, and the previously active version is left untouched.

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -200,6 +200,15 @@ ui_fail() {
   printf '%s  %s  %s%s\n' "$C_WARN" "$G_WARN" "$*" "$C_RESET" >&2
 }
 
+# Relay captured child output on a success path. Suppressed by --quiet, which
+# promises errors and the final summary only; failure paths below print the same
+# text to stderr unconditionally.
+ui_relay() {
+  ((QUIET == 0)) || return 0
+  [[ -n "$1" ]] || return 0
+  printf '%s\n' "$1"
+}
+
 # Always printed.
 say() {
   printf '%s\n' "$*"
@@ -325,10 +334,10 @@ fi
 
 ui_step "Restarting dev daemon"
 if restart_output=$("$BIN_DIR/first-tree-dev" daemon restart 2>&1); then
-  printf "%s\n" "$restart_output"
+  ui_relay "$restart_output"
   ui_ok "Daemon restarted on the new build"
 elif grep -q "No background service installed" <<<"$restart_output"; then
-  printf "%s\n" "$restart_output"
+  ui_relay "$restart_output"
   ui_detail "daemon service is not installed yet; run first-tree-dev login <code> to create it."
   ui_ok "Nothing to restart yet"
 else

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -11,6 +11,7 @@
 #
 # Usage:
 #   ./scripts/dev-install.sh                    # build + (re)link + restart installed daemon
+#   ./scripts/dev-install.sh --quiet            # only errors and the final summary
 #   first-tree-dev login <code>                # first-time setup creates the service
 #   first-tree-dev daemon status                # same verbs as staging/prod
 #
@@ -25,17 +26,258 @@ REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 DIST="$REPO/apps/cli/dist/cli/index.mjs"
 BIN_DIR="${HOME}/.local/bin"
 
+# ---------------------------------------------------------------------------
+# Terminal UI.
+#
+# Deliberately duplicated from scripts/portable/install.sh rather than shared:
+# that file is published as a single self-contained object and consumed through
+# `curl ... | sh`, so it cannot source a helper library. Keep the two copies
+# conceptually in sync. This one may use bashisms; the portable installer may
+# not (it runs under dash in CI).
+# ---------------------------------------------------------------------------
+QUIET=0
+SHOW_BANNER=1
+UI_COLOR=0
+UI_UNICODE=0
+UI_WIDTH=80
+UI_STEP=0
+UI_TOTAL_STEPS=6
+
+C_RESET=""
+C_DIM=""
+C_BOLD=""
+C_BRAND=""
+C_WARN=""
+
+G_OK="[ok]"
+G_WARN="[!]"
+G_ARROW="->"
+G_DOT="-"
+G_RULE="="
+
+usage() {
+  cat <<EOF
+Usage: ./scripts/dev-install.sh [options]
+
+Builds the in-tree CLI and links it onto PATH as first-tree-dev (alias ftd),
+then restarts the installed dev daemon.
+
+Options:
+  --quiet, -q     Only print errors and the final summary
+  --no-banner     Skip the startup banner
+  --help, -h      Show this help
+
+Environment:
+  NO_COLOR        Set to any value to disable coloured output
+EOF
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --quiet | -q)
+      QUIET=1
+      SHOW_BANNER=0
+      shift
+      ;;
+    --no-banner)
+      SHOW_BANNER=0
+      shift
+      ;;
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    *)
+      printf '[dev-install] unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+ui_detect() {
+  if ((QUIET == 0)) && [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]] && [[ "${TERM:-dumb}" != "dumb" ]]; then
+    UI_COLOR=1
+  fi
+
+  case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+    *[Uu][Tt][Ff]*) UI_UNICODE=1 ;;
+  esac
+
+  # `tput cols` reports the terminfo default inside a command substitution,
+  # because its stdout is a pipe and ncurses cannot ioctl the real terminal.
+  # Duplicate a terminal descriptor and let stty ioctl that instead.
+  local cols=""
+  if [[ -t 1 ]]; then
+    exec 9>&1
+  elif [[ -t 2 ]]; then
+    exec 9>&2
+  fi
+  if [[ -t 1 || -t 2 ]]; then
+    cols="$(stty size <&9 2>/dev/null | awk '{print $2}' || true)"
+    exec 9>&-
+  fi
+  [[ "$cols" =~ ^[0-9]+$ ]] || cols="$(tput cols 2>/dev/null || true)"
+  [[ "$cols" =~ ^[0-9]+$ ]] || cols="${COLUMNS:-80}"
+  [[ "$cols" =~ ^[0-9]+$ ]] || cols=80
+  ((cols >= 20)) || cols=80
+  UI_WIDTH="$cols"
+
+  if ((UI_COLOR == 1)); then
+    local depth
+    depth="$(tput colors 2>/dev/null || printf '8')"
+    [[ "$depth" =~ ^[0-9]+$ ]] || depth=8
+    # Brand green: --brand oklch(0.72 0.17 150) in packages/web/src/index.css.
+    if ((depth >= 256)); then
+      C_BRAND=$'\033[38;5;42m'
+    else
+      C_BRAND=$'\033[32m'
+    fi
+    C_RESET=$'\033[0m'
+    C_DIM=$'\033[2m'
+    C_BOLD=$'\033[1m'
+    C_WARN=$'\033[33m'
+  fi
+
+  if ((UI_UNICODE == 1)); then
+    G_OK="✓"
+    G_WARN="⚠"
+    G_ARROW="→"
+    G_DOT="·"
+    G_RULE="━"
+  fi
+}
+
+# Suppressed by --quiet.
+ui_step() {
+  UI_STEP=$((UI_STEP + 1))
+  ((QUIET == 0)) || return 0
+  printf '\n%s\n' "${C_BOLD}  [${UI_STEP}/${UI_TOTAL_STEPS}] $1${C_RESET}"
+}
+
+# Section header for commands whose own output is passed through untouched.
+ui_rule() {
+  UI_STEP=$((UI_STEP + 1))
+  ((QUIET == 0)) || return 0
+  local title="${G_RULE}${G_RULE} [${UI_STEP}/${UI_TOTAL_STEPS}] $1 "
+  local pad=$((UI_WIDTH - ${#title}))
+  ((pad < 0)) && pad=0
+  local fill=""
+  local i
+  for ((i = 0; i < pad; i++)); do fill+="$G_RULE"; done
+  printf '\n%s\n\n' "${C_BOLD}${title}${fill}${C_RESET}"
+}
+
+ui_kv() {
+  ((QUIET == 0)) || return 0
+  printf '%s        %-14s %s%s\n' "$C_DIM" "$1" "$2" "$C_RESET"
+}
+
+# Completion line for a ui_rule section. pnpm and turbo end on a redrawn
+# progress line, so open a blank line first rather than landing on top of it.
+ui_section_ok() {
+  ((QUIET == 0)) || return 0
+  printf '\n'
+  ui_ok "$@"
+}
+
+ui_detail() {
+  ((QUIET == 0)) || return 0
+  printf '%s        %s%s\n' "$C_DIM" "$*" "$C_RESET"
+}
+
+ui_ok() {
+  ((QUIET == 0)) || return 0
+  printf '%s  %s  %s%s\n' "$C_BRAND" "$G_OK" "$*" "$C_RESET"
+}
+
+ui_warn() {
+  printf '%s  %s  %s%s\n' "$C_WARN" "$G_WARN" "$*" "$C_RESET"
+}
+
+# Fatal: goes to stderr so it survives a redirected stdout.
+ui_fail() {
+  printf '%s  %s  %s%s\n' "$C_WARN" "$G_WARN" "$*" "$C_RESET" >&2
+}
+
+# Always printed.
+say() {
+  printf '%s\n' "$*"
+}
+
+# pnpm and turbo keep their inherited stdout/stderr by default: piping them
+# would cost their own TTY progress rendering, which is better than anything
+# this script could print in its place. Under --quiet there is nothing to
+# preserve, so buffer instead and replay only if the command fails.
+run_build_command() {
+  if ((QUIET == 0)); then
+    "$@"
+    return
+  fi
+  local log
+  log="$(mktemp "${TMPDIR:-/tmp}/first-tree-dev-install.XXXXXX")"
+  if "$@" >"$log" 2>&1; then
+    rm -f "$log"
+    return 0
+  fi
+  cat "$log" >&2
+  rm -f "$log"
+  return 1
+}
+
+ui_elapsed() {
+  local secs=$(($(date +%s) - $1))
+  ((secs >= 0)) || secs=0
+  if ((secs < 60)); then
+    printf '%ss' "$secs"
+  else
+    printf '%sm %ss' "$((secs / 60))" "$((secs % 60))"
+  fi
+}
+
+print_banner() {
+  ((SHOW_BANNER == 1)) || return 0
+  ((QUIET == 0)) || return 0
+  if ((UI_UNICODE != 1)) || [[ ! -t 1 ]] || ((UI_WIDTH < 60)); then
+    printf '\n%s\n' "${C_BRAND}  first-tree ${G_DOT} dev installer ${G_DOT} https://first-tree.ai${C_RESET}"
+    printf '%s\n' "${C_DIM}  dev ${G_DOT} in-tree build ${G_DOT} ${REPO}${C_RESET}"
+    return 0
+  fi
+  printf '%s' "$C_BRAND"
+  cat <<'BANNER'
+
+     ▄█▄
+    █████     ╔═╗╦╦═╗╔═╗╔╦╗  ╔╦╗╦═╗╔═╗╔═╗
+   ▄█████▄    ╠╣ ║╠╦╝╚═╗ ║    ║ ╠╦╝║╣ ║╣
+    █████     ╚  ╩╩╚═╚═╝ ╩    ╩ ╩╚═╚═╝╚═╝
+   ▄█████▄
+  ▄███████▄   Context-grounded agentic work for teams.
+     ███      https://first-tree.ai
+BANNER
+  printf '%s' "$C_RESET"
+  printf '%s\n' "${C_DIM}              dev ${G_DOT} in-tree build ${G_DOT} ${REPO}${C_RESET}"
+}
+
+ui_detect
+print_banner
+TOTAL_START=$(date +%s)
+
 # Auto-migrate the legacy dev home from the pre-multi-env layout
 # (scripts/dev-cli.sh used ~/.first-tree/hub-dev). One-shot mv — never
 # copies, so the data structure is preserved bit-for-bit. Limited to
 # the legacy dev-only path so it cannot touch peer staging / prod
 # state (the cli-side auto unit cleanup was removed for that exact
 # reason — see service-install.ts docblocks).
+ui_step "Preparing dev home"
 LEGACY_DEV_HOME="${HOME}/.first-tree/hub-dev"
 NEW_DEV_HOME="${HOME}/.first-tree-dev"
 if [[ -d "$LEGACY_DEV_HOME" && ! -d "$NEW_DEV_HOME" ]]; then
-  echo "[dev-install] migrating legacy dev home: $LEGACY_DEV_HOME → $NEW_DEV_HOME"
+  ui_detail "migrating legacy dev home: $LEGACY_DEV_HOME $G_ARROW $NEW_DEV_HOME"
   mv "$LEGACY_DEV_HOME" "$NEW_DEV_HOME"
+  ui_ok "Legacy dev home migrated"
+else
+  ui_kv "Home" "$NEW_DEV_HOME"
+  ui_ok "Dev home ready"
 fi
 
 # Ensure all workspace packages are installed. Idempotent — a no-op
@@ -44,7 +286,11 @@ fi
 # fresh checkout or a lockfile bump) blows up `pnpm build` with the
 # unhelpful "tsdown: not found" error from a transitive workspace
 # package, not from us.
-pnpm install
+#
+ui_rule "Installing workspace dependencies"
+STEP_START=$(date +%s)
+run_build_command pnpm install
+ui_section_ok "Dependencies ready in $(ui_elapsed "$STEP_START")"
 
 # Build everything (full monorepo). Turbo respects per-task
 # `dependsOn` so packages build in dependency order, and a warm cache
@@ -52,31 +298,53 @@ pnpm install
 # dev workflow aligned with CI (`.github/workflows/ci.yml` also runs
 # `pnpm build`) — any filter-based partial build risks the multi-env
 # foot-gun of leaving `packages/shared/dist/` stale.
-pnpm build
+ui_rule "Building workspace (turbo)"
+STEP_START=$(date +%s)
+run_build_command pnpm build
+ui_section_ok "Build finished in $(ui_elapsed "$STEP_START")"
 
 # Symlink to user-local PATH. Both names point at the same dist so they
 # stay in sync without a second link step.
+ui_step "Linking CLI binaries"
 mkdir -p "$BIN_DIR"
 ln -sf "$DIST" "$BIN_DIR/first-tree-dev"
 ln -sf "$DIST" "$BIN_DIR/ftd"
+ui_kv "first-tree-dev" "$G_ARROW $DIST"
+ui_kv "ftd" "$G_ARROW $DIST"
+ui_ok "Linked into $BIN_DIR"
 
-echo "[dev-install] installed:"
-echo "  $BIN_DIR/first-tree-dev → $DIST"
-echo "  $BIN_DIR/ftd            → $DIST"
-echo
-echo "[dev-install] restarting first-tree-dev daemon..."
-if restart_output=$("$BIN_DIR/first-tree-dev" daemon restart 2>&1); then
-  printf "%s\n" "$restart_output"
-elif grep -q "No background service installed" <<<"$restart_output"; then
-  printf "%s\n" "$restart_output"
-  echo "[dev-install] daemon service is not installed yet; run first-tree-dev login <code> to create it."
+ui_step "Verifying installed CLI"
+if cli_version=$("$BIN_DIR/first-tree-dev" --version 2>&1); then
+  ui_kv "Version" "$cli_version"
+  ui_ok "CLI starts from the freshly built dist"
 else
-  printf "%s\n" "$restart_output" >&2
-  echo "[dev-install] daemon restart failed; install output is on disk, but the running daemon was not updated." >&2
+  printf '%s\n' "$cli_version" >&2
+  ui_fail "first-tree-dev --version failed; the link is in place but the build looks broken."
   exit 1
 fi
-echo
-echo "Next:"
-echo "  1. Make sure $BIN_DIR is on \$PATH"
-echo "  2. Start your local First Tree server on http://127.0.0.1:8000"
-echo "  3. first-tree-dev login <code>      # token from http://127.0.0.1:8000/clients"
+
+ui_step "Restarting dev daemon"
+if restart_output=$("$BIN_DIR/first-tree-dev" daemon restart 2>&1); then
+  printf "%s\n" "$restart_output"
+  ui_ok "Daemon restarted on the new build"
+elif grep -q "No background service installed" <<<"$restart_output"; then
+  printf "%s\n" "$restart_output"
+  ui_detail "daemon service is not installed yet; run first-tree-dev login <code> to create it."
+  ui_ok "Nothing to restart yet"
+else
+  printf "%s\n" "$restart_output" >&2
+  ui_fail "Daemon restart failed; install output is on disk, but the running daemon was not updated."
+  exit 1
+fi
+
+say ""
+say "${C_BRAND}${C_BOLD}  $G_OK  first-tree-dev installed$C_RESET"
+say "${C_DIM}        $DIST $G_DOT completed in $(ui_elapsed "$TOTAL_START")$C_RESET"
+say ""
+say "  Commands: $BIN_DIR/first-tree-dev, $BIN_DIR/ftd"
+say ""
+say "  Next:"
+say "    1. Make sure $BIN_DIR is on \$PATH"
+say "    2. Start your local First Tree server on http://127.0.0.1:8000"
+say "    3. first-tree-dev login <code>      # token from http://127.0.0.1:8000/clients"
+say ""

--- a/scripts/portable/install.sh
+++ b/scripts/portable/install.sh
@@ -15,6 +15,65 @@ ORIGINAL_PATH="${PATH:-}"
 START_MARKER="# >>> first-tree portable >>>"
 END_MARKER="# <<< first-tree portable <<<"
 
+# The two assignments above (PORTABLE_CHANNEL / DOWNLOAD_BASE_URL) are rewritten
+# per channel by renderInstallerForChannel() in scripts/portable/build-portable.mjs.
+# Those replacements are regex-based and non-global: never repeat either
+# assignment's exact shape anywhere else in this file, because only the first
+# match is rewritten and a later duplicate would ship the unrewritten default.
+# Downstream code must read $PORTABLE_CHANNEL / $DOWNLOAD_BASE_URL instead.
+
+# ---------------------------------------------------------------------------
+# Terminal UI.
+#
+# Deliberately duplicated in scripts/dev-install.sh rather than shared: this
+# file is published as a single self-contained object and consumed through
+# `curl ... | sh`, so it cannot source a helper library. Keep the two copies
+# conceptually in sync.
+#
+# Output contract:
+#   - Human status lines go to stdout, matching the behaviour that
+#     apps/cli/tests/portable-builder.test.ts asserts on.
+#   - Only redrawn frames (the download bar) go to stderr, and only when stderr
+#     is a TTY, so a captured/redirected stdout never sees a carriage return.
+#   - Colour wraps a whole line and is never spliced into the middle of a
+#     message. Those tests match plain substrings without stripping ANSI, so a
+#     spliced escape sequence would break them.
+#   - `curl | sh` means stdin is the script itself, so capability detection
+#     looks at stdout/stderr and never at stdin.
+# ---------------------------------------------------------------------------
+QUIET=0
+SHOW_BANNER=1
+UI_COLOR=0
+UI_ANIM=0
+UI_UNICODE=0
+UI_WIDTH=80
+UI_TICK=1
+UI_STEP=0
+UI_TOTAL_STEPS=9
+UI_CURRENT_STEP=""
+UI_BAR_ACTIVE=0
+
+C_RESET=""
+C_DIM=""
+C_BOLD=""
+C_BRAND=""
+C_WARN=""
+C_ERR=""
+
+G_OK="[ok]"
+G_FAIL="[!!]"
+G_WARN="[!]"
+G_DOWN=">>"
+G_ARROW="->"
+G_DOT="-"
+G_ELLIPSIS="..."
+G_BAR_FILL="#"
+G_BAR_EMPTY="."
+
+DOWNLOADER=""
+SHA_TOOL=""
+DOWNLOAD_PID=""
+
 usage() {
   cat <<EOF
 Usage: sh install.sh [options]
@@ -25,17 +84,245 @@ Options:
   --bin-dir <path>          Shim directory (default: $DEFAULT_BIN_DIR)
   --no-path-edit            Do not edit shell startup files
   --path-mode <mode>        auto, prompt, or off (default: auto)
+  --quiet, -q               Only print errors and the final summary
+  --no-banner               Skip the startup banner
   --help                    Show this help
+
+Environment:
+  NO_COLOR                  Set to any value to disable coloured output
+
+Colour, the progress bar and other animations are disabled automatically when
+stdout/stderr is not a terminal. When piping this script, pass options after
+'--', for example: curl -fsSL <url> | sh -s -- --quiet
 EOF
 }
 
+# Suppressed by --quiet. Use for progress narration.
 log() {
+  [ "$QUIET" -eq 0 ] || return 0
+  printf '%s\n' "$*"
+}
+
+# Always printed. Use for the final summary and actionable guidance.
+say() {
   printf '%s\n' "$*"
 }
 
 die() {
+  if [ "$UI_BAR_ACTIVE" -eq 1 ]; then
+    printf '\r\033[K' >&2
+    UI_BAR_ACTIVE=0
+  fi
+  if [ -n "$UI_CURRENT_STEP" ]; then
+    printf '%s\n' "${C_ERR}  ${G_FAIL}  ${UI_CURRENT_STEP} failed${C_RESET}" >&2
+  fi
   printf 'first-tree portable installer: %s\n' "$*" >&2
   exit 1
+}
+
+ui_detect() {
+  if [ "$QUIET" -eq 0 ] && [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-dumb}" != "dumb" ]; then
+    UI_COLOR=1
+  fi
+  if [ "$QUIET" -eq 0 ] && [ -t 2 ] && [ "${TERM:-dumb}" != "dumb" ]; then
+    UI_ANIM=1
+  fi
+
+  case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+    *[Uu][Tt][Ff]*) UI_UNICODE=1 ;;
+  esac
+
+  # `tput cols` is unreliable here: inside a command substitution its stdout is
+  # a pipe, so ncurses cannot ioctl the real terminal and silently returns the
+  # terminfo default of 80. Duplicate a terminal descriptor first and let stty
+  # ioctl that instead; dup'd descriptors keep the terminal's access mode, and
+  # fd 9 is closed again so it never leaks into the CLI we exec later.
+  ui_cols=""
+  if [ -t 1 ]; then
+    exec 9>&1
+  elif [ -t 2 ]; then
+    exec 9>&2
+  fi
+  if [ -t 1 ] || [ -t 2 ]; then
+    ui_cols="$(stty size <&9 2>/dev/null | awk '{print $2}' || true)"
+    exec 9>&-
+  fi
+  case "$ui_cols" in
+    ''|*[!0-9]*) ui_cols="$(tput cols 2>/dev/null || true)" ;;
+  esac
+  case "$ui_cols" in
+    ''|*[!0-9]*) ui_cols="${COLUMNS:-80}" ;;
+  esac
+  case "$ui_cols" in
+    ''|*[!0-9]*) ui_cols=80 ;;
+  esac
+  [ "$ui_cols" -ge 20 ] || ui_cols=80
+  UI_WIDTH="$ui_cols"
+
+  if [ "$UI_COLOR" -eq 1 ]; then
+    ui_depth="$(tput colors 2>/dev/null || printf '8')"
+    case "$ui_depth" in
+      ''|*[!0-9]*) ui_depth=8 ;;
+    esac
+    # Brand green: --brand oklch(0.72 0.17 150) in packages/web/src/index.css.
+    if [ "$ui_depth" -ge 256 ]; then
+      C_BRAND="$(printf '\033[38;5;42m')"
+    else
+      C_BRAND="$(printf '\033[32m')"
+    fi
+    C_RESET="$(printf '\033[0m')"
+    C_DIM="$(printf '\033[2m')"
+    C_BOLD="$(printf '\033[1m')"
+    C_WARN="$(printf '\033[33m')"
+    C_ERR="$(printf '\033[31m')"
+  fi
+
+  if [ "$UI_UNICODE" -eq 1 ]; then
+    G_OK="✓"
+    G_FAIL="✗"
+    G_WARN="⚠"
+    G_DOWN="⬇"
+    G_ARROW="→"
+    G_DOT="·"
+    G_ELLIPSIS="…"
+    G_BAR_FILL="█"
+    G_BAR_EMPTY="░"
+  fi
+
+  # POSIX only guarantees integer sleeps; GNU and BSD sleep both accept
+  # fractions, and detect_platform already restricts us to Linux and macOS.
+  if sleep 0.2 2>/dev/null; then
+    UI_TICK="0.2"
+  else
+    UI_TICK=1
+  fi
+}
+
+ui_step() {
+  UI_STEP=$((UI_STEP + 1))
+  UI_CURRENT_STEP="$1"
+  [ "$QUIET" -eq 0 ] || return 0
+  printf '\n%s\n' "${C_BOLD}  [${UI_STEP}/${UI_TOTAL_STEPS}] $1${C_RESET}"
+}
+
+ui_kv() {
+  [ "$QUIET" -eq 0 ] || return 0
+  printf '%s        %-11s %s%s\n' "$C_DIM" "$1" "$2" "$C_RESET"
+}
+
+ui_detail() {
+  [ "$QUIET" -eq 0 ] || return 0
+  printf '%s        %s%s\n' "$C_DIM" "$*" "$C_RESET"
+}
+
+ui_ok() {
+  [ "$QUIET" -eq 0 ] || return 0
+  printf '%s  %s  %s%s\n' "$C_BRAND" "$G_OK" "$*" "$C_RESET"
+}
+
+ui_warn() {
+  printf '%s  %s  %s%s\n' "$C_WARN" "$G_WARN" "$*" "$C_RESET"
+}
+
+ui_now() {
+  date +%s 2>/dev/null || printf '0'
+}
+
+ui_elapsed() {
+  ui_start="$1"
+  ui_end="$(ui_now)"
+  case "${ui_start}${ui_end}" in
+    ''|*[!0-9]*) printf 'n/a'; return 0 ;;
+  esac
+  ui_secs=$((ui_end - ui_start))
+  [ "$ui_secs" -ge 0 ] || ui_secs=0
+  if [ "$ui_secs" -lt 60 ]; then
+    printf '%ss' "$ui_secs"
+  else
+    printf '%sm %ss' "$((ui_secs / 60))" "$((ui_secs % 60))"
+  fi
+}
+
+ui_bytes_human() {
+  ui_bytes="$1"
+  case "$ui_bytes" in
+    ''|*[!0-9]*) printf '?'; return 0 ;;
+  esac
+  if [ "$ui_bytes" -ge 1048576 ]; then
+    ui_tenths=$((ui_bytes * 10 / 1048576))
+    printf '%s.%s MB' "$((ui_tenths / 10))" "$((ui_tenths % 10))"
+  elif [ "$ui_bytes" -ge 1024 ]; then
+    ui_tenths=$((ui_bytes * 10 / 1024))
+    printf '%s.%s KB' "$((ui_tenths / 10))" "$((ui_tenths % 10))"
+  else
+    printf '%s B' "$ui_bytes"
+  fi
+}
+
+# `stat` flags differ between macOS (-f%z) and Linux (-c%s); `wc -c` does not.
+ui_file_bytes() {
+  if [ ! -f "$1" ]; then
+    printf '0'
+    return 0
+  fi
+  ui_count="$(wc -c <"$1" 2>/dev/null | tr -d ' \n' || true)"
+  case "$ui_count" in
+    ''|*[!0-9]*) ui_count=0 ;;
+  esac
+  printf '%s' "$ui_count"
+}
+
+ui_sha_short() {
+  printf '%.12s%s' "$1" "$G_ELLIPSIS"
+}
+
+ui_repeat() {
+  ui_i=0
+  while [ "$ui_i" -lt "$2" ]; do
+    printf '%s' "$1"
+    ui_i=$((ui_i + 1))
+  done
+}
+
+ui_render_bar() {
+  ui_cur="$1"
+  ui_total="$2"
+  [ "$ui_total" -gt 0 ] || return 0
+  [ "$ui_cur" -le "$ui_total" ] || ui_cur="$ui_total"
+  ui_pct=$((ui_cur * 100 / ui_total))
+  ui_barw=$((UI_WIDTH - 38))
+  [ "$ui_barw" -ge 10 ] || ui_barw=10
+  [ "$ui_barw" -le 40 ] || ui_barw=40
+  ui_filled=$((ui_cur * ui_barw / ui_total))
+  printf '\r\033[K     [%s%s] %3s%%   %s / %s' \
+    "$(ui_repeat "$G_BAR_FILL" "$ui_filled")" \
+    "$(ui_repeat "$G_BAR_EMPTY" "$((ui_barw - ui_filled))")" \
+    "$ui_pct" \
+    "$(ui_bytes_human "$ui_cur")" \
+    "$(ui_bytes_human "$ui_total")" >&2
+}
+
+print_banner() {
+  [ "$SHOW_BANNER" -eq 1 ] || return 0
+  [ "$QUIET" -eq 0 ] || return 0
+  if [ "$UI_UNICODE" -ne 1 ] || [ ! -t 1 ] || [ "$UI_WIDTH" -lt 60 ]; then
+    printf '\n%s\n' "${C_BRAND}  first-tree ${G_DOT} portable installer ${G_DOT} https://first-tree.ai${C_RESET}"
+    printf '%s\n' "${C_DIM}  ${PORTABLE_CHANNEL} ${G_DOT} ${PLATFORM}${C_RESET}"
+    return 0
+  fi
+  printf '%s' "$C_BRAND"
+  cat <<'BANNER'
+
+     ▄█▄
+    █████     ╔═╗╦╦═╗╔═╗╔╦╗  ╔╦╗╦═╗╔═╗╔═╗
+   ▄█████▄    ╠╣ ║╠╦╝╚═╗ ║    ║ ╠╦╝║╣ ║╣
+    █████     ╚  ╩╩╚═╚═╝ ╩    ╩ ╩╚═╚═╝╚═╝
+   ▄█████▄
+  ▄███████▄   Context-grounded agentic work for teams.
+     ███      https://first-tree.ai
+BANNER
+  printf '%s' "$C_RESET"
+  printf '%s\n' "${C_DIM}              ${PORTABLE_CHANNEL} ${G_DOT} ${PLATFORM} ${G_DOT} portable installer${C_RESET}"
 }
 
 need_value() {
@@ -74,6 +361,15 @@ while [ "$#" -gt 0 ]; do
       esac
       shift 2
       ;;
+    --quiet|-q)
+      QUIET=1
+      SHOW_BANNER=0
+      shift
+      ;;
+    --no-banner)
+      SHOW_BANNER=0
+      shift
+      ;;
     --help|-h)
       usage
       exit 0
@@ -101,27 +397,108 @@ trim_slashes() {
   printf '%s' "$1" | sed 's:/*$::'
 }
 
-download_to() {
-  url="$1"
-  dest="$2"
+# Resolved once in the foreground so download_to never has to `die`. A `die`
+# inside the backgrounded download would only exit that subshell, and the
+# progress loop would then misreport a missing tool as a failed transfer.
+resolve_downloader() {
   if command_exists curl; then
-    curl -fsSL "$url" -o "$dest"
+    DOWNLOADER="curl"
   elif command_exists wget; then
-    wget -qO "$dest" "$url"
+    DOWNLOADER="wget"
   else
     die "curl or wget is required"
   fi
 }
 
-sha256_file() {
-  file="$1"
+resolve_sha_tool() {
   if command_exists sha256sum; then
-    sha256sum "$file" | awk '{print $1}'
+    SHA_TOOL="sha256sum"
   elif command_exists shasum; then
-    shasum -a 256 "$file" | awk '{print $1}'
+    SHA_TOOL="shasum"
   else
     die "sha256sum or shasum is required"
   fi
+}
+
+download_to() {
+  url="$1"
+  dest="$2"
+  case "$DOWNLOADER" in
+    curl) curl -fsSL "$url" -o "$dest" ;;
+    wget) wget -qO "$dest" "$url" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Byte-level progress driven by the asset size already present in the release
+# metadata, so curl, wget and busybox wget all render identically. Completion is
+# signalled through a status file rather than process state: whether a shell
+# reaps a background child before `wait` runs is not portable, but the status
+# file is written before the subshell exits.
+download_with_progress() {
+  dl_url="$1"
+  dl_dest="$2"
+  dl_expected="$3"
+
+  if [ "$UI_ANIM" -ne 1 ]; then
+    download_to "$dl_url" "$dl_dest"
+    return 0
+  fi
+  case "$dl_expected" in
+    ''|*[!0-9]*)
+      download_to "$dl_url" "$dl_dest"
+      return 0
+      ;;
+  esac
+  if [ "$dl_expected" -le 0 ]; then
+    download_to "$dl_url" "$dl_dest"
+    return 0
+  fi
+
+  dl_status="$WORK_DIR/download.status"
+  rm -f "$dl_status" "${dl_status}.tmp"
+  {
+    # Whether a subshell inherits the parent EXIT trap is not portable, and
+    # cleanup() removes WORK_DIR. Drop the traps so this child can never delete
+    # the directory it is downloading into.
+    trap - EXIT HUP INT TERM
+    if download_to "$dl_url" "$dl_dest"; then
+      printf '0' >"${dl_status}.tmp"
+    else
+      printf '1' >"${dl_status}.tmp"
+    fi
+    mv -f "${dl_status}.tmp" "$dl_status"
+  } &
+  DOWNLOAD_PID=$!
+  UI_BAR_ACTIVE=1
+
+  while [ ! -f "$dl_status" ] && kill -0 "$DOWNLOAD_PID" 2>/dev/null; do
+    ui_render_bar "$(ui_file_bytes "$dl_dest")" "$dl_expected"
+    sleep "$UI_TICK"
+  done
+  wait "$DOWNLOAD_PID" 2>/dev/null || true
+  DOWNLOAD_PID=""
+
+  dl_rc=1
+  if [ -f "$dl_status" ]; then
+    dl_rc="$(cat "$dl_status" 2>/dev/null || printf '1')"
+  fi
+  if [ "$dl_rc" = "0" ]; then
+    ui_render_bar "$dl_expected" "$dl_expected"
+    printf '\n' >&2
+    UI_BAR_ACTIVE=0
+    return 0
+  fi
+  die "download failed: $dl_url"
+}
+
+sha256_file() {
+  file="$1"
+  case "$SHA_TOOL" in
+    sha256sum) sha256sum "$file" | awk '{print $1}' ;;
+    shasum) shasum -a 256 "$file" | awk '{print $1}' ;;
+    *) return 1 ;;
+  esac
 }
 
 extract_tarball() {
@@ -281,19 +658,23 @@ rewrite_path_block() {
 
 maybe_edit_path() {
   bin_name="$1"
-  [ "$PATH_MODE" != "off" ] || return 0
+  if [ "$PATH_MODE" = "off" ]; then
+    ui_detail "PATH editing disabled by --no-path-edit / --path-mode off"
+    return 0
+  fi
   if path_contains_bin_dir "$ORIGINAL_PATH" && portable_shim_wins_on_original_path "$bin_name"; then
+    ui_detail "$BIN_DIR already takes precedence on PATH"
     return 0
   fi
 
   if ! profile="$(profile_for_shell)"; then
-    log "Automatic PATH setup skipped: this shell is not recognized."
+    ui_detail "Automatic PATH setup skipped: this shell is not recognized."
     return 0
   fi
 
   if [ "$PATH_MODE" = "prompt" ]; then
     if [ ! -t 0 ]; then
-      log "Automatic PATH setup skipped because prompt mode requires an interactive shell."
+      ui_detail "Automatic PATH setup skipped because prompt mode requires an interactive shell."
       return 0
     fi
     printf 'Add %s to PATH in %s? [Y/n] ' "$BIN_DIR" "$profile"
@@ -301,7 +682,7 @@ maybe_edit_path() {
     case "$answer" in
       ""|y|Y|yes|YES) ;;
       *)
-        log "Skipped PATH setup."
+        ui_detail "Skipped PATH setup."
         return 0
         ;;
     esac
@@ -309,21 +690,24 @@ maybe_edit_path() {
 
   if rewrite_path_block "$profile"; then
     PATH_UPDATED_PROFILE="$profile"
-    log "Updated PATH block in $profile"
+    ui_detail "Updated PATH block in $profile"
   else
-    log "PATH setup failed for $profile."
+    ui_warn "PATH setup failed for $profile."
   fi
 }
 
 print_path_guidance() {
+  # The three messages below are asserted verbatim (plain substring, no ANSI
+  # stripping) by apps/cli/tests/portable-builder.test.ts. Never colour them
+  # mid-line and never emit them outside their own branch.
   if [ -n "$PATH_UPDATED_PROFILE" ]; then
-    log "Restart your shell, or run: . \"$PATH_UPDATED_PROFILE\""
+    say "  Restart your shell, or run: . \"$PATH_UPDATED_PROFILE\""
   elif path_contains_bin_dir "$ORIGINAL_PATH"; then
     # Judge against the user's incoming PATH: the installer prepends BIN_DIR
     # to its own PATH for recovery, which says nothing about the user's shell.
-    log "$BIN_NAME should be available now."
+    say "  $BIN_NAME should be available now."
   else
-    log "Add this to your shell profile: export PATH=\"$BIN_DIR:\$PATH\""
+    say "  Add this to your shell profile: export PATH=\"$BIN_DIR:\$PATH\""
   fi
 }
 
@@ -343,7 +727,7 @@ clean_npm_temp_residue() {
     [ -e "$residue" ] || continue
     [ -d "$residue" ] || continue
     rm -rf "$residue"
-    log "Removed stale npm temp directory: $residue"
+    ui_detail "Removed stale npm temp directory: $residue"
   done
 }
 
@@ -352,17 +736,45 @@ ensure_daemon_service() {
   if "$BIN_DIR/$bin_name" daemon ensure-service; then
     return 0
   fi
-  log "Background service repair failed or is not available yet."
-  log "Run $BIN_DIR/$bin_name login <code> to refresh credentials and service state."
+  ui_warn "Background service repair failed or is not available yet."
+  say "  Run $BIN_DIR/$bin_name login <code> to refresh credentials and service state."
 }
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/first-tree-portable.XXXXXX")"
 cleanup() {
+  if [ -n "$DOWNLOAD_PID" ]; then
+    kill "$DOWNLOAD_PID" 2>/dev/null || true
+    DOWNLOAD_PID=""
+  fi
+  if [ "$UI_BAR_ACTIVE" -eq 1 ]; then
+    printf '\r\033[K\n' >&2
+    UI_BAR_ACTIVE=0
+  fi
   rm -rf "$WORK_DIR"
 }
-trap cleanup EXIT HUP INT TERM
+# Split from the EXIT trap on purpose: a bare `trap cleanup INT` runs cleanup
+# and then *resumes* the script, so Ctrl-C used to delete the work directory out
+# from under an install that kept going. Abort explicitly instead. cleanup is
+# idempotent, so the EXIT trap re-running it is harmless.
+trap cleanup EXIT
+trap 'cleanup; exit 130' HUP INT TERM
 
 PLATFORM="$(detect_platform)"
+ui_detect
+print_banner
+TOTAL_START="$(ui_now)"
+
+ui_step "Preflight"
+resolve_downloader
+resolve_sha_tool
+command_exists tar || die "tar is required"
+ui_kv "Channel" "$PORTABLE_CHANNEL"
+ui_kv "Platform" "$PLATFORM"
+ui_kv "Prefix" "$PREFIX"
+ui_kv "Bin dir" "$BIN_DIR"
+ui_kv "Tools" "$DOWNLOADER, $SHA_TOOL, tar"
+ui_ok "Environment ready"
+
 BASE="$(trim_slashes "$DOWNLOAD_BASE_URL")"
 if [ -n "$REQUESTED_VERSION" ]; then
   MANIFEST_URL="${BASE}/${PORTABLE_CHANNEL}/${REQUESTED_VERSION}/manifest.json"
@@ -371,9 +783,13 @@ else
 fi
 
 MANIFEST_FILE="$WORK_DIR/manifest.json"
-log "Downloading First Tree portable metadata: $MANIFEST_URL"
+ui_step "Fetching release metadata"
+ui_kv "Source" "$MANIFEST_URL"
+STEP_START="$(ui_now)"
 download_to "$MANIFEST_URL" "$MANIFEST_FILE"
+ui_ok "Metadata received in $(ui_elapsed "$STEP_START")"
 
+ui_step "Resolving version and asset"
 VERSION="$(json_string "$MANIFEST_FILE" version)"
 PACKAGE_NAME="$(json_string "$MANIFEST_FILE" packageName)"
 BIN_NAME="$(json_string "$MANIFEST_FILE" binName)"
@@ -393,6 +809,12 @@ ASSET_SIZE="$(json_number "$ASSET_FILE" size)"
 [ -n "$ASSET_URL" ] || die "asset missing url"
 [ -n "$ASSET_SHA" ] || die "asset missing sha256"
 [ -n "$ASSET_SIZE" ] || die "asset missing size"
+ui_kv "Version" "$VERSION"
+ui_kv "Package" "$PACKAGE_NAME"
+ui_kv "Command" "$BIN_NAME ($ALIAS_NAME)"
+ui_kv "Download" "$(ui_bytes_human "$ASSET_SIZE")"
+ui_kv "SHA-256" "$(ui_sha_short "$ASSET_SHA")"
+ui_ok "Resolved $BIN_NAME $VERSION for $PLATFORM"
 
 clean_npm_temp_residue "$PACKAGE_NAME"
 mkdir -p "$PREFIX/versions" "$PREFIX/.tmp" "$BIN_DIR"
@@ -402,13 +824,21 @@ mkdir -p "$PREFIX/versions" "$PREFIX/.tmp" "$BIN_DIR"
 PREFIX="$(CDPATH= cd -L "$PREFIX" && pwd -L)"
 BIN_DIR="$(CDPATH= cd -L "$BIN_DIR" && pwd -L)"
 TARBALL="$WORK_DIR/payload.tar.gz"
-log "Downloading First Tree ${VERSION} for ${PLATFORM}"
-download_to "$ASSET_URL" "$TARBALL"
+
+ui_step "Downloading payload"
+log "${C_DIM}     ${G_DOWN}  $BIN_NAME $VERSION $G_DOT $(ui_bytes_human "$ASSET_SIZE") $G_DOT bundled Node.js runtime included${C_RESET}"
+STEP_START="$(ui_now)"
+download_with_progress "$ASSET_URL" "$TARBALL" "$ASSET_SIZE"
+ui_ok "Downloaded $(ui_bytes_human "$(ui_file_bytes "$TARBALL")") in $(ui_elapsed "$STEP_START")"
+
+ui_step "Verifying checksum"
 ACTUAL_SHA="$(sha256_file "$TARBALL")"
 if [ "$ACTUAL_SHA" != "$ASSET_SHA" ]; then
   die "checksum mismatch for portable payload: expected $ASSET_SHA, got $ACTUAL_SHA"
 fi
+ui_ok "Checksum verified  sha256:$(ui_sha_short "$ACTUAL_SHA")"
 
+ui_step "Extracting and validating payload"
 FINAL_VERSION_DIR="$PREFIX/versions/$VERSION"
 TEMP_VERSION_DIR="$PREFIX/.tmp/${VERSION}.$$"
 rm -rf "$TEMP_VERSION_DIR"
@@ -418,6 +848,7 @@ extract_tarball "$TARBALL" "$TEMP_VERSION_DIR"
 if [ -e "$FINAL_VERSION_DIR" ]; then
   rm -rf "$TEMP_VERSION_DIR"
   VALIDATION_DIR="$FINAL_VERSION_DIR"
+  ui_detail "Version $VERSION is already unpacked, reusing $FINAL_VERSION_DIR"
 else
   VALIDATION_DIR="$TEMP_VERSION_DIR"
 fi
@@ -442,6 +873,8 @@ INSTALL_ENTRY="$(json_string "$INSTALL_FILE" appEntry)"
 if [ "$VALIDATION_DIR" = "$TEMP_VERSION_DIR" ]; then
   mv "$TEMP_VERSION_DIR" "$FINAL_VERSION_DIR"
 fi
+ui_kv "Unpacked" "$FINAL_VERSION_DIR"
+ui_ok "Payload contents match the release metadata"
 
 CURRENT_LINK="$PREFIX/current"
 if [ -e "$CURRENT_LINK" ] && [ ! -L "$CURRENT_LINK" ]; then
@@ -452,24 +885,40 @@ NEW_LINK="$PREFIX/.current.$$"
 # Exercise the candidate runtime directly before changing stable shims or
 # `current`. Once `current` moves, every remaining operation is best-effort or
 # non-failing so installer success/failure always reflects the active version.
+ui_step "Runtime smoke check"
 if ! "$FINAL_VERSION_DIR/node/bin/node" "$FINAL_VERSION_DIR/app/cli/index.mjs" --version >/dev/null; then
   die "portable payload failed the pre-commit runtime smoke check"
 fi
+ui_ok "Bundled runtime starts and reports a version"
 
 # Prepare both stable shims while current still names the old version. The
 # current symlink is the final commit point, so a shim write failure never
 # reports failure after activating the new runtime.
+ui_step "Activating version"
 write_shim "$BIN_DIR/$BIN_NAME" "$CURRENT_LINK" "$BIN_DIR"
 write_shim "$BIN_DIR/$ALIAS_NAME" "$CURRENT_LINK" "$BIN_DIR"
 rm -f "$NEW_LINK"
 ln -s "$FINAL_VERSION_DIR" "$NEW_LINK"
 atomic_replace_current_link "$NEW_LINK" "$CURRENT_LINK"
+ui_kv "Shim" "$BIN_DIR/$BIN_NAME"
+ui_kv "Shim" "$BIN_DIR/$ALIAS_NAME"
+ui_kv "Current" "$CURRENT_LINK $G_ARROW $FINAL_VERSION_DIR"
+ui_ok "$BIN_NAME $VERSION is now the active version"
 
+ui_step "PATH and background service"
 PATH="$BIN_DIR:${PATH:-}"
 export PATH
 maybe_edit_path "$BIN_NAME"
 ensure_daemon_service "$BIN_NAME"
+ui_ok "Shell and service state updated"
 
-log "First Tree ${VERSION} installed at $FINAL_VERSION_DIR"
-log "Command: $BIN_DIR/$BIN_NAME"
+say ""
+say "${C_BRAND}${C_BOLD}  $G_OK  First Tree $VERSION installed$C_RESET"
+say "${C_DIM}        $FINAL_VERSION_DIR $G_DOT completed in $(ui_elapsed "$TOTAL_START")$C_RESET"
+say ""
+say "  Command: $BIN_DIR/$BIN_NAME"
 print_path_guidance
+say ""
+say "  Next:"
+say "    $BIN_DIR/$BIN_NAME login <connect-code>"
+say ""

--- a/scripts/portable/install.sh
+++ b/scripts/portable/install.sh
@@ -74,6 +74,7 @@ DOWNLOADER=""
 SHA_TOOL=""
 DOWNLOAD_PID=""
 DOWNLOAD_IN_FLIGHT=0
+DOWNLOAD_PENDING_SIGNAL=""
 DAEMON_SERVICE_STATE="unknown"
 # `daemon ensure-service` exits with this when it deliberately did nothing:
 # unsupported platform, or no credentials yet and `login` owns starting the
@@ -132,12 +133,6 @@ ui_detect() {
     UI_COLOR=1
   fi
   if [ "$QUIET" -eq 0 ] && [ -t 2 ] && [ "${TERM:-dumb}" != "dumb" ]; then
-    UI_ANIM=1
-  fi
-  # Internal test seam, not an operator switch: the progress and cancellation
-  # paths only run when stderr is a terminal, which a test harness cannot
-  # provide without allocating a pseudo-terminal.
-  if [ "$QUIET" -eq 0 ] && [ -n "${FIRST_TREE_PORTABLE_FORCE_PROGRESS:-}" ]; then
     UI_ANIM=1
   fi
 
@@ -444,8 +439,58 @@ exec_downloader() {
   return 1
 }
 
+# Every transfer runs through here, terminal or not: which process owns the
+# download must not depend on whether a progress bar is being drawn. `render`
+# only decides what is printed. Returns the transfer's exit status.
+run_download() {
+  rd_url="$1"
+  rd_dest="$2"
+  rd_expected="$3"
+  rd_render="$4"
+
+  # A signal can arrive between forking the transfer and recording $! below.
+  # Acting on it there would leave the child unowned — and before it reaches
+  # `exec` it still carries this shell's command name, so it cannot be found by
+  # inspecting the process table either. Record the signal instead and honour it
+  # once the pid is captured.
+  DOWNLOAD_PENDING_SIGNAL=""
+  trap 'DOWNLOAD_PENDING_SIGNAL=1' HUP INT TERM
+  DOWNLOAD_IN_FLIGHT=1
+  exec_downloader "$rd_url" "$rd_dest" &
+  DOWNLOAD_PID=$!
+  trap 'cleanup; exit 130' HUP INT TERM
+  if [ -n "$DOWNLOAD_PENDING_SIGNAL" ]; then
+    cleanup
+    exit 130
+  fi
+
+  if [ "$rd_render" -eq 1 ]; then
+    UI_BAR_ACTIVE=1
+  fi
+  while kill -0 "$DOWNLOAD_PID" 2>/dev/null; do
+    if [ "$rd_render" -eq 1 ]; then
+      ui_render_bar "$(ui_file_bytes "$rd_dest")" "$rd_expected"
+    fi
+    sleep "$UI_TICK"
+  done
+
+  rd_rc=0
+  wait "$DOWNLOAD_PID" || rd_rc=$?
+  DOWNLOAD_PID=""
+  DOWNLOAD_IN_FLIGHT=0
+
+  if [ "$rd_render" -eq 1 ]; then
+    if [ "$rd_rc" -eq 0 ]; then
+      ui_render_bar "$rd_expected" "$rd_expected"
+      printf '\n' >&2
+    fi
+    UI_BAR_ACTIVE=0
+  fi
+  return "$rd_rc"
+}
+
 download_to() {
-  (exec_downloader "$1" "$2")
+  run_download "$1" "$2" "" 0
 }
 
 # Byte-level progress driven by the asset size already present in the release
@@ -453,50 +498,25 @@ download_to() {
 # signalled through a status file rather than process state: whether a shell
 # reaps a background child before `wait` runs is not portable, but the status
 # file is written before the subshell exits.
+# Only the rendering differs from any other transfer; ownership is identical.
 download_with_progress() {
   dl_url="$1"
   dl_dest="$2"
   dl_expected="$3"
 
-  if [ "$UI_ANIM" -ne 1 ]; then
-    download_to "$dl_url" "$dl_dest"
-    return 0
-  fi
-  case "$dl_expected" in
-    ''|*[!0-9]*)
-      download_to "$dl_url" "$dl_dest"
-      return 0
-      ;;
-  esac
-  if [ "$dl_expected" -le 0 ]; then
-    download_to "$dl_url" "$dl_dest"
-    return 0
+  dl_render=0
+  if [ "$UI_ANIM" -eq 1 ]; then
+    case "$dl_expected" in
+      ''|*[!0-9]*) ;;
+      *)
+        if [ "$dl_expected" -gt 0 ]; then
+          dl_render=1
+        fi
+        ;;
+    esac
   fi
 
-  # No wrapper shell between this script and the transfer: exec_downloader
-  # replaces the forked subshell with curl/wget, so $! is the transfer itself.
-  # An intermediate wrapper would have to publish the real pid somewhere, and a
-  # signal arriving before that publication would orphan the transfer.
-  # DOWNLOAD_IN_FLIGHT is raised first so cancellation knows a transfer may
-  # exist even before $! has been recorded.
-  DOWNLOAD_IN_FLIGHT=1
-  exec_downloader "$dl_url" "$dl_dest" &
-  DOWNLOAD_PID=$!
-  UI_BAR_ACTIVE=1
-
-  while kill -0 "$DOWNLOAD_PID" 2>/dev/null; do
-    ui_render_bar "$(ui_file_bytes "$dl_dest")" "$dl_expected"
-    sleep "$UI_TICK"
-  done
-  dl_rc=0
-  wait "$DOWNLOAD_PID" || dl_rc=$?
-  DOWNLOAD_PID=""
-  DOWNLOAD_IN_FLIGHT=0
-
-  if [ "$dl_rc" -eq 0 ]; then
-    ui_render_bar "$dl_expected" "$dl_expected"
-    printf '\n' >&2
-    UI_BAR_ACTIVE=0
+  if run_download "$dl_url" "$dl_dest" "$dl_expected" "$dl_render"; then
     return 0
   fi
   die "download failed: $dl_url"
@@ -772,38 +792,27 @@ ensure_daemon_service() {
 }
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/first-tree-portable.XXXXXX")"
-# Live transfers, found by parentage and command name rather than by a recorded
-# pid. A signal can land between forking the transfer and recording $!, and a
-# pid-only path leaves it running in exactly that window.
-download_children() {
-  [ -n "$DOWNLOADER" ] || return 0
-  ps -A -o pid=,ppid=,comm= 2>/dev/null |
-    awk -v parent="$$" -v tool="$DOWNLOADER" '$2 == parent && $3 ~ tool { print $1 }' || true
-}
-
 # Cancellation owns the transfer itself and has to see it gone before WORK_DIR
-# disappears underneath it.
+# disappears underneath it. DOWNLOAD_PID is always set whenever a transfer
+# exists: run_download defers signal handling across the fork so this can never
+# be reached with a live-but-unrecorded child.
 stop_download() {
   [ "$DOWNLOAD_IN_FLIGHT" -eq 1 ] || return 0
   DOWNLOAD_IN_FLIGHT=0
+  [ -n "$DOWNLOAD_PID" ] || return 0
 
-  for stop_kid in $(download_children); do
-    kill "$stop_kid" 2>/dev/null || true
-  done
-  if [ -n "$DOWNLOAD_PID" ]; then
-    kill "$DOWNLOAD_PID" 2>/dev/null || true
-    wait "$DOWNLOAD_PID" 2>/dev/null || true
-    DOWNLOAD_PID=""
-  fi
+  kill "$DOWNLOAD_PID" 2>/dev/null || true
+  wait "$DOWNLOAD_PID" 2>/dev/null || true
 
   stop_wait=0
-  while [ "$stop_wait" -lt 10 ] && [ -n "$(download_children)" ]; do
+  while [ "$stop_wait" -lt 10 ] && kill -0 "$DOWNLOAD_PID" 2>/dev/null; do
     sleep "$UI_TICK"
     stop_wait=$((stop_wait + 1))
   done
-  for stop_kid in $(download_children); do
-    kill -9 "$stop_kid" 2>/dev/null || true
-  done
+  if kill -0 "$DOWNLOAD_PID" 2>/dev/null; then
+    kill -9 "$DOWNLOAD_PID" 2>/dev/null || true
+  fi
+  DOWNLOAD_PID=""
 }
 
 cleanup() {

--- a/scripts/portable/install.sh
+++ b/scripts/portable/install.sh
@@ -494,11 +494,9 @@ download_to() {
 }
 
 # Byte-level progress driven by the asset size already present in the release
-# metadata, so curl, wget and busybox wget all render identically. Completion is
-# signalled through a status file rather than process state: whether a shell
-# reaps a background child before `wait` runs is not portable, but the status
-# file is written before the subshell exits.
-# Only the rendering differs from any other transfer; ownership is identical.
+# metadata, so curl, wget and busybox wget all render identically. Only the
+# rendering differs from any other transfer; run_download owns the child and
+# reads its status the same way either way.
 download_with_progress() {
   dl_url="$1"
   dl_dest="$2"

--- a/scripts/portable/install.sh
+++ b/scripts/portable/install.sh
@@ -73,8 +73,13 @@ G_BAR_EMPTY="."
 DOWNLOADER=""
 SHA_TOOL=""
 DOWNLOAD_PID=""
-DOWNLOAD_CHILD_FILE=""
+DOWNLOAD_IN_FLIGHT=0
 DAEMON_SERVICE_STATE="unknown"
+# `daemon ensure-service` exits with this when it deliberately did nothing:
+# unsupported platform, or no credentials yet and `login` owns starting the
+# daemon. Mirrors ENSURE_SERVICE_DEFERRED_EXIT_CODE in
+# apps/cli/src/commands/daemon/ensure-service.ts.
+ENSURE_SERVICE_DEFERRED=3
 
 usage() {
   cat <<EOF
@@ -468,43 +473,27 @@ download_with_progress() {
     return 0
   fi
 
-  dl_status="$WORK_DIR/download.status"
-  DOWNLOAD_CHILD_FILE="$WORK_DIR/download.child"
-  rm -f "$dl_status" "${dl_status}.tmp" "$DOWNLOAD_CHILD_FILE" "${DOWNLOAD_CHILD_FILE}.tmp"
-  {
-    # Whether a subshell inherits the parent EXIT trap is not portable, and
-    # cleanup() removes WORK_DIR. Drop the traps so this child can never delete
-    # the directory it is downloading into.
-    trap - EXIT HUP INT TERM
-    # Publish the transfer's own pid before waiting on it. Signalling only this
-    # wrapper would reparent curl/wget to init, where it keeps writing into the
-    # work directory cleanup is about to remove.
-    exec_downloader "$dl_url" "$dl_dest" &
-    dl_child=$!
-    printf '%s' "$dl_child" >"${DOWNLOAD_CHILD_FILE}.tmp"
-    mv -f "${DOWNLOAD_CHILD_FILE}.tmp" "$DOWNLOAD_CHILD_FILE"
-    if wait "$dl_child"; then
-      printf '0' >"${dl_status}.tmp"
-    else
-      printf '1' >"${dl_status}.tmp"
-    fi
-    mv -f "${dl_status}.tmp" "$dl_status"
-  } &
+  # No wrapper shell between this script and the transfer: exec_downloader
+  # replaces the forked subshell with curl/wget, so $! is the transfer itself.
+  # An intermediate wrapper would have to publish the real pid somewhere, and a
+  # signal arriving before that publication would orphan the transfer.
+  # DOWNLOAD_IN_FLIGHT is raised first so cancellation knows a transfer may
+  # exist even before $! has been recorded.
+  DOWNLOAD_IN_FLIGHT=1
+  exec_downloader "$dl_url" "$dl_dest" &
   DOWNLOAD_PID=$!
   UI_BAR_ACTIVE=1
 
-  while [ ! -f "$dl_status" ] && kill -0 "$DOWNLOAD_PID" 2>/dev/null; do
+  while kill -0 "$DOWNLOAD_PID" 2>/dev/null; do
     ui_render_bar "$(ui_file_bytes "$dl_dest")" "$dl_expected"
     sleep "$UI_TICK"
   done
-  wait "$DOWNLOAD_PID" 2>/dev/null || true
+  dl_rc=0
+  wait "$DOWNLOAD_PID" || dl_rc=$?
   DOWNLOAD_PID=""
+  DOWNLOAD_IN_FLIGHT=0
 
-  dl_rc=1
-  if [ -f "$dl_status" ]; then
-    dl_rc="$(cat "$dl_status" 2>/dev/null || printf '1')"
-  fi
-  if [ "$dl_rc" = "0" ]; then
+  if [ "$dl_rc" -eq 0 ]; then
     ui_render_bar "$dl_expected" "$dl_expected"
     printf '\n' >&2
     UI_BAR_ACTIVE=0
@@ -753,50 +742,68 @@ clean_npm_temp_residue() {
 }
 
 # Captured rather than streamed so --quiet can hold back a successful lifecycle
-# line, and so the caller can tell whether the service is actually up instead of
-# claiming success right after a warning.
+# line, and so the caller can tell whether the service is actually up.
+#
+# Exit status is a three-state contract, not a boolean: `ensure-service`
+# deliberately does nothing when the platform has no service control or when no
+# credentials exist yet, and that deferred case is the normal first install.
+# Reporting it as ready would contradict the command's own "run login" output.
 ensure_daemon_service() {
   bin_name="$1"
-  if ensure_service_output="$("$BIN_DIR/$bin_name" daemon ensure-service 2>&1)"; then
+  ensure_service_output=""
+  ensure_service_rc=0
+  ensure_service_output="$("$BIN_DIR/$bin_name" daemon ensure-service 2>&1)" || ensure_service_rc=$?
+
+  if [ "$ensure_service_rc" -eq 0 ]; then
     DAEMON_SERVICE_STATE="ready"
     [ -z "$ensure_service_output" ] || log "$ensure_service_output"
     return 0
   fi
-  DAEMON_SERVICE_STATE="deferred"
+  if [ "$ensure_service_rc" -eq "$ENSURE_SERVICE_DEFERRED" ]; then
+    DAEMON_SERVICE_STATE="deferred"
+    [ -z "$ensure_service_output" ] || log "$ensure_service_output"
+    return 0
+  fi
+
+  DAEMON_SERVICE_STATE="failed"
   [ -z "$ensure_service_output" ] || printf '%s\n' "$ensure_service_output" >&2
   ui_warn "Background service repair failed or is not available yet."
   say "  Run $BIN_DIR/$bin_name login <code> to refresh credentials and service state."
 }
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/first-tree-portable.XXXXXX")"
-# Cancellation has to own the whole transfer, not just the wrapper that waits on
-# it, and has to see it gone before WORK_DIR disappears underneath it.
+# Live transfers, found by parentage and command name rather than by a recorded
+# pid. A signal can land between forking the transfer and recording $!, and a
+# pid-only path leaves it running in exactly that window.
+download_children() {
+  [ -n "$DOWNLOADER" ] || return 0
+  ps -A -o pid=,ppid=,comm= 2>/dev/null |
+    awk -v parent="$$" -v tool="$DOWNLOADER" '$2 == parent && $3 ~ tool { print $1 }' || true
+}
+
+# Cancellation owns the transfer itself and has to see it gone before WORK_DIR
+# disappears underneath it.
 stop_download() {
-  [ -n "$DOWNLOAD_PID" ] || return 0
-  stop_child=""
-  if [ -n "$DOWNLOAD_CHILD_FILE" ] && [ -f "$DOWNLOAD_CHILD_FILE" ]; then
-    stop_child="$(cat "$DOWNLOAD_CHILD_FILE" 2>/dev/null || true)"
-  fi
-  case "$stop_child" in
-    ''|*[!0-9]*) stop_child="" ;;
-  esac
+  [ "$DOWNLOAD_IN_FLIGHT" -eq 1 ] || return 0
+  DOWNLOAD_IN_FLIGHT=0
 
-  # Transfer first, so the wrapper's own `wait` returns on its own.
-  [ -z "$stop_child" ] || kill "$stop_child" 2>/dev/null || true
-  kill "$DOWNLOAD_PID" 2>/dev/null || true
-  wait "$DOWNLOAD_PID" 2>/dev/null || true
-  DOWNLOAD_PID=""
-
-  if [ -n "$stop_child" ]; then
-    stop_wait=0
-    while [ "$stop_wait" -lt 10 ] && kill -0 "$stop_child" 2>/dev/null; do
-      sleep "$UI_TICK"
-      stop_wait=$((stop_wait + 1))
-    done
-    if kill -0 "$stop_child" 2>/dev/null; then
-      kill -9 "$stop_child" 2>/dev/null || true
-    fi
+  for stop_kid in $(download_children); do
+    kill "$stop_kid" 2>/dev/null || true
+  done
+  if [ -n "$DOWNLOAD_PID" ]; then
+    kill "$DOWNLOAD_PID" 2>/dev/null || true
+    wait "$DOWNLOAD_PID" 2>/dev/null || true
+    DOWNLOAD_PID=""
   fi
+
+  stop_wait=0
+  while [ "$stop_wait" -lt 10 ] && [ -n "$(download_children)" ]; do
+    sleep "$UI_TICK"
+    stop_wait=$((stop_wait + 1))
+  done
+  for stop_kid in $(download_children); do
+    kill -9 "$stop_kid" 2>/dev/null || true
+  done
 }
 
 cleanup() {
@@ -966,13 +973,13 @@ export PATH
 maybe_edit_path "$BIN_NAME"
 ensure_daemon_service "$BIN_NAME"
 # Only claim the service is set up when it actually is. ensure_daemon_service
-# deliberately does not fail the install, so the warning it prints must not be
-# followed by a success line contradicting it.
-if [ "$DAEMON_SERVICE_STATE" = "ready" ]; then
-  ui_ok "Shell and background service are set up"
-else
-  ui_detail "Install is complete; background service setup still needs login."
-fi
+# deliberately does not fail the install, so neither its "run login" notice nor
+# its warning may be followed by a success line contradicting it.
+case "$DAEMON_SERVICE_STATE" in
+  ready) ui_ok "Shell and background service are set up" ;;
+  deferred) ui_detail "Install is complete; the background service starts after login." ;;
+  *) ui_detail "Install is complete; background service setup still needs login." ;;
+esac
 
 say ""
 say "${C_BRAND}${C_BOLD}  $G_OK  First Tree $VERSION installed$C_RESET"

--- a/scripts/portable/install.sh
+++ b/scripts/portable/install.sh
@@ -73,6 +73,8 @@ G_BAR_EMPTY="."
 DOWNLOADER=""
 SHA_TOOL=""
 DOWNLOAD_PID=""
+DOWNLOAD_CHILD_FILE=""
+DAEMON_SERVICE_STATE="unknown"
 
 usage() {
   cat <<EOF
@@ -125,6 +127,12 @@ ui_detect() {
     UI_COLOR=1
   fi
   if [ "$QUIET" -eq 0 ] && [ -t 2 ] && [ "${TERM:-dumb}" != "dumb" ]; then
+    UI_ANIM=1
+  fi
+  # Internal test seam, not an operator switch: the progress and cancellation
+  # paths only run when stderr is a terminal, which a test harness cannot
+  # provide without allocating a pseudo-terminal.
+  if [ "$QUIET" -eq 0 ] && [ -n "${FIRST_TREE_PORTABLE_FORCE_PROGRESS:-}" ]; then
     UI_ANIM=1
   fi
 
@@ -420,14 +428,19 @@ resolve_sha_tool() {
   fi
 }
 
-download_to() {
-  url="$1"
-  dest="$2"
+# Replaces the calling process with the transfer itself. Backgrounded with `&`
+# this makes `$!` the curl/wget pid rather than a wrapper shell's, which is what
+# lets cancellation reach the transfer instead of orphaning it.
+exec_downloader() {
   case "$DOWNLOADER" in
-    curl) curl -fsSL "$url" -o "$dest" ;;
-    wget) wget -qO "$dest" "$url" ;;
-    *) return 1 ;;
+    curl) exec curl -fsSL "$1" -o "$2" ;;
+    wget) exec wget -qO "$2" "$1" ;;
   esac
+  return 1
+}
+
+download_to() {
+  (exec_downloader "$1" "$2")
 }
 
 # Byte-level progress driven by the asset size already present in the release
@@ -456,13 +469,21 @@ download_with_progress() {
   fi
 
   dl_status="$WORK_DIR/download.status"
-  rm -f "$dl_status" "${dl_status}.tmp"
+  DOWNLOAD_CHILD_FILE="$WORK_DIR/download.child"
+  rm -f "$dl_status" "${dl_status}.tmp" "$DOWNLOAD_CHILD_FILE" "${DOWNLOAD_CHILD_FILE}.tmp"
   {
     # Whether a subshell inherits the parent EXIT trap is not portable, and
     # cleanup() removes WORK_DIR. Drop the traps so this child can never delete
     # the directory it is downloading into.
     trap - EXIT HUP INT TERM
-    if download_to "$dl_url" "$dl_dest"; then
+    # Publish the transfer's own pid before waiting on it. Signalling only this
+    # wrapper would reparent curl/wget to init, where it keeps writing into the
+    # work directory cleanup is about to remove.
+    exec_downloader "$dl_url" "$dl_dest" &
+    dl_child=$!
+    printf '%s' "$dl_child" >"${DOWNLOAD_CHILD_FILE}.tmp"
+    mv -f "${DOWNLOAD_CHILD_FILE}.tmp" "$DOWNLOAD_CHILD_FILE"
+    if wait "$dl_child"; then
       printf '0' >"${dl_status}.tmp"
     else
       printf '1' >"${dl_status}.tmp"
@@ -731,21 +752,55 @@ clean_npm_temp_residue() {
   done
 }
 
+# Captured rather than streamed so --quiet can hold back a successful lifecycle
+# line, and so the caller can tell whether the service is actually up instead of
+# claiming success right after a warning.
 ensure_daemon_service() {
   bin_name="$1"
-  if "$BIN_DIR/$bin_name" daemon ensure-service; then
+  if ensure_service_output="$("$BIN_DIR/$bin_name" daemon ensure-service 2>&1)"; then
+    DAEMON_SERVICE_STATE="ready"
+    [ -z "$ensure_service_output" ] || log "$ensure_service_output"
     return 0
   fi
+  DAEMON_SERVICE_STATE="deferred"
+  [ -z "$ensure_service_output" ] || printf '%s\n' "$ensure_service_output" >&2
   ui_warn "Background service repair failed or is not available yet."
   say "  Run $BIN_DIR/$bin_name login <code> to refresh credentials and service state."
 }
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/first-tree-portable.XXXXXX")"
-cleanup() {
-  if [ -n "$DOWNLOAD_PID" ]; then
-    kill "$DOWNLOAD_PID" 2>/dev/null || true
-    DOWNLOAD_PID=""
+# Cancellation has to own the whole transfer, not just the wrapper that waits on
+# it, and has to see it gone before WORK_DIR disappears underneath it.
+stop_download() {
+  [ -n "$DOWNLOAD_PID" ] || return 0
+  stop_child=""
+  if [ -n "$DOWNLOAD_CHILD_FILE" ] && [ -f "$DOWNLOAD_CHILD_FILE" ]; then
+    stop_child="$(cat "$DOWNLOAD_CHILD_FILE" 2>/dev/null || true)"
   fi
+  case "$stop_child" in
+    ''|*[!0-9]*) stop_child="" ;;
+  esac
+
+  # Transfer first, so the wrapper's own `wait` returns on its own.
+  [ -z "$stop_child" ] || kill "$stop_child" 2>/dev/null || true
+  kill "$DOWNLOAD_PID" 2>/dev/null || true
+  wait "$DOWNLOAD_PID" 2>/dev/null || true
+  DOWNLOAD_PID=""
+
+  if [ -n "$stop_child" ]; then
+    stop_wait=0
+    while [ "$stop_wait" -lt 10 ] && kill -0 "$stop_child" 2>/dev/null; do
+      sleep "$UI_TICK"
+      stop_wait=$((stop_wait + 1))
+    done
+    if kill -0 "$stop_child" 2>/dev/null; then
+      kill -9 "$stop_child" 2>/dev/null || true
+    fi
+  fi
+}
+
+cleanup() {
+  stop_download
   if [ "$UI_BAR_ACTIVE" -eq 1 ]; then
     printf '\r\033[K\n' >&2
     UI_BAR_ACTIVE=0
@@ -910,7 +965,14 @@ PATH="$BIN_DIR:${PATH:-}"
 export PATH
 maybe_edit_path "$BIN_NAME"
 ensure_daemon_service "$BIN_NAME"
-ui_ok "Shell and service state updated"
+# Only claim the service is set up when it actually is. ensure_daemon_service
+# deliberately does not fail the install, so the warning it prints must not be
+# followed by a success line contradicting it.
+if [ "$DAEMON_SERVICE_STATE" = "ready" ]; then
+  ui_ok "Shell and background service are set up"
+else
+  ui_detail "Install is complete; background service setup still needs login."
+fi
 
 say ""
 say "${C_BRAND}${C_BOLD}  $G_OK  First Tree $VERSION installed$C_RESET"


### PR DESCRIPTION
## Why

Both installers were silent for long stretches.

`scripts/portable/install.sh` printed six bare lines for a flow that downloads a
~60 MB tarball, verifies a checksum, extracts, smoke-tests a bundled Node
runtime, rewrites shims, edits a shell profile and installs a background
service. `scripts/dev-install.sh` had no identity and no timings, so a cold
`turbo` build looked like a hang.

## What

**Banner.** The brand asset (`assets/banner-light.png`) is already pixel art — a
stepped conifer plus a blocky lowercase `first-tree` wordmark — so the terminal
banner echoes it rather than inventing new art. Falls back to a single compact
line on narrow terminals (<60 cols) or a non-UTF-8 locale.

```
     ▄█▄
    █████     ╔═╗╦╦═╗╔═╗╔╦╗  ╔╦╗╦═╗╔═╗╔═╗
   ▄█████▄    ╠╣ ║╠╦╝╚═╗ ║    ║ ╠╦╝║╣ ║╣
    █████     ╚  ╩╩╚═╚═╝ ╩    ╩ ╩╚═╚═╝╚═╝
   ▄█████▄
  ▄███████▄   Context-grounded agentic work for teams.
     ███      https://first-tree.ai

              prod · darwin-arm64 · portable installer
```

**`portable/install.sh`** — nine named phases, each reporting its resolved
values (channel, platform, version, download size, truncated sha256, prefix,
bin dir) and elapsed time. The download bar is driven by the asset `size`
already present in the release metadata and polls the destination file, so
curl, wget and busybox wget render identically:

```
  [4/9] Downloading payload
     ⬇  first-tree 1.4.2 · 62.8 MB · bundled Node.js runtime included
     [██████████████████░░░░░░░░░░]  64%   40.2 MB / 62.8 MB
  ✓  Downloaded 62.8 MB in 7s
  ✓  Checksum verified  sha256:9f3c1ab2e0d4…
```

**`dev-install.sh`** — six named phases with timings. `pnpm` / `turbo` keep
their inherited stdout/stderr so their own TTY progress rendering survives;
they are framed, not replaced. Adds a step that verifies the freshly linked
CLI actually starts (`--version`).

**Opt-outs.** Both gain `--quiet` / `--no-banner` / `--help` and honour
`NO_COLOR`. Colour, animation and the full banner are gated on **stdout/stderr**
being a terminal, never stdin — `curl | sh` makes stdin the script itself.

## Pre-existing bugs fixed along the way

1. **Ctrl-C did not abort.** `trap cleanup EXIT HUP INT TERM` ran `cleanup`
   (which removes the work directory) and then *resumed* the script, because
   the handler never exits. Split into `trap cleanup EXIT` +
   `trap 'cleanup; exit 130' HUP INT TERM`.
2. **`tput cols` silently returned 80.** Inside a command substitution its
   stdout is a pipe, so ncurses cannot ioctl the real terminal and falls back to
   the terminfo default. Now reads the width via `stty size` against a dup'd
   terminal descriptor.
3. **Tool checks were inside `download_to`.** A `die` there would only exit the
   (now backgrounded) subshell and be misreported as a failed transfer. Hoisted
   `curl`/`wget` and `sha256sum`/`shasum` resolution into preflight, which also
   fails fast instead of 40 s in.

## Contracts respected

- `install.sh` lines 4–5 keep their exact shape. `renderInstallerForChannel`
  (`scripts/portable/build-portable.mjs`) rewrites them with **non-global**
  regexes, so a second matching line would ship an unrewritten default — no
  other line in the file matches either pattern.
- Human status output stays on **stdout**, and colour only ever wraps a whole
  line. The three output assertions in `apps/cli/tests/portable-builder.test.ts`
  are plain substrings with no ANSI stripping.
- `install.sh` remains POSIX `sh` (CI runs it under dash) and a single
  self-contained file, so the UI helpers are duplicated into `dev-install.sh`
  by design — noted in a comment on both sides.

## Verification

- `sh -n`, `dash -n`, `bash -n` — all pass.
- `apps/cli/tests/portable-builder.test.ts` — **39/39 pass**, no test edits.
- `pnpm check` (exit 0), `pnpm typecheck`, `scripts/check-no-old-names.sh`.
- Real end-to-end against a throttled local HTTP fixture under a pseudo-terminal:
  full install, `NO_COLOR`, `LC_ALL=C` ASCII fallback, 50-column terminal,
  `--quiet`, and a mid-download signal (exit 130, background `curl` reaped, work
  dir removed, `current` not activated, no shims written).
- Non-TTY parity: piped stdout contains **zero** carriage returns and zero ANSI
  escapes; both PATH-guidance strings appear byte-identical.
- `dev-install.sh` exercised with an isolated `HOME` so no real symlink or
  daemon was touched.

Not run: the real staging CDN path, because it ends in `daemon ensure-service`
and would install a launchd service on the dev machine. The local fixture covers
the same code path.

## Docs and QA

Documents the installer flag set in `docs/cli-reference.md`, including
`--version` / `--prefix` / `--bin-dir` / `--no-path-edit` / `--path-mode`, which
were previously documented **nowhere** outside the script's own `usage()`.

Extends the existing `observe` clauses in
`packages/qa/cases/cross-surface/portable-shell-onboarding.md` with an
`observe installer-output` clause (phase reporting, byte progress, non-TTY
parity) rather than adding a new case. This touches the portable bootstrap
path, so it is worth an agent-run pass of that case before the next release;
nothing here changes what gets installed, only what is printed.

## Note for reviewers

Four tests in `apps/cli/src/__tests__/context-byo-repository.test.ts` fail on
this branch — they fail identically on `main` with these changes stashed, so
they are pre-existing and unrelated (they appear to dislike running from inside
a git worktree).
