### PR TITLE
fix(web): keep mobile Chat list position when returning from detail

### DIFF
--- a/packages/client/src/providers/claude/__tests__/provider-error-result.test.ts
+++ b/packages/client/src/providers/claude/__tests__/provider-error-result.test.ts
@@ -130,7 +130,12 @@ function firstProviderPayload(payloads: readonly ProviderRetryEventPayload[]): P
 }
 
 async function waitForCondition(predicate: () => boolean, description: string): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  // Wall-clock bound: under CI load the retry's post-timer Promise work can
+  // take more than a fixed handful of setImmediate ticks. Fake timers still
+  // own setTimeout; Date.now stays real because this file only fakes
+  // setTimeout/clearTimeout.
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
     if (predicate()) return;
     await new Promise((resolve) => setImmediate(resolve));
   }
@@ -326,6 +331,7 @@ describe("claude-code handler — structured provider error result", () => {
     try {
       const result = await startSingleResultTurn();
       await waitForCondition(() => providerRetryPayloads(result.emitted).length === 1, "first scheduled retry");
+      await waitForCondition(() => vi.getTimerCount() > 0, "retry backoff timer");
 
       expect(mockState.queryCalls).toBe(1);
       await vi.advanceTimersByTimeAsync(499);

--- a/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
@@ -6,12 +6,24 @@ import { act } from "react";
 import { MemoryRouter, Route, Routes, useNavigationType } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { MobileShell } from "../shell.js";
 import { MobileWorkPage } from "../work.js";
 
-const authMock = vi.hoisted(() => ({ value: { agentId: "human-agent-self" } }));
+const authMock = vi.hoisted(() => ({
+  value: {
+    agentId: "human-agent-self",
+    organizationId: "org-1",
+    meLoaded: true,
+    onboardingStep: "completed" as const,
+    onboardingDismissedAt: null,
+    onboardingCompletedAt: "2026-07-01T00:00:00.000Z",
+    currentOrgHasPersonalAgent: true,
+  },
+}));
 const meChatMocks = vi.hoisted(() => ({
   listMeChats: vi.fn(),
   listMeChatSourceCounts: vi.fn(),
+  listNeedYouRequests: vi.fn(),
 }));
 
 function chatRow(overrides: Partial<MeChatRow> = {}): MeChatRow {
@@ -44,6 +56,8 @@ function chatRow(overrides: Partial<MeChatRow> = {}): MeChatRow {
 
 vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
 vi.mock("../../../api/me-chats.js", () => meChatMocks);
+vi.mock("../../../hooks/use-admin-ws.js", () => ({ useAdminWs: () => undefined }));
+vi.mock("../../../components/team-switch-overlay.js", () => ({ TeamSwitchOverlay: () => null }));
 // Stub the heavy chat-detail so we can drive the back affordance directly.
 vi.mock("../../workspace/center/index.js", () => ({
   CenterPanel: ({ onShowConversations }: { onShowConversations: (() => void) | null }) => (
@@ -65,12 +79,14 @@ describe("MobileWorkPage back navigation", () => {
   beforeEach(() => {
     harness = createDomHarness();
     meChatMocks.listMeChats.mockReset();
+    meChatMocks.listNeedYouRequests.mockReset();
     meChatMocks.listMeChats.mockResolvedValue({
       priorityRows: { pinned: [] },
       rows: [],
       nextCursor: null,
     });
     meChatMocks.listMeChatSourceCounts.mockResolvedValue({ counts: {} });
+    meChatMocks.listNeedYouRequests.mockResolvedValue({ items: [], total: 0 });
     lastNavType = "";
   });
 
@@ -213,5 +229,71 @@ describe("MobileWorkPage back navigation", () => {
     expect(restoredScroller).toBe(scroller);
     expect(restoredScroller?.scrollTop).toBe(640);
     expect(harness.container.textContent).toContain("Thread 1");
+  });
+
+  it("restores near-max list scroll after MobileShell hides the bottom tabs", async () => {
+    const rows = Array.from({ length: 24 }, (_, index) =>
+      chatRow({
+        chatId: `chat-${index + 1}`,
+        title: `Thread ${index + 1}`,
+        topic: `Thread ${index + 1}`,
+      }),
+    );
+    meChatMocks.listMeChats.mockResolvedValue({
+      priorityRows: { pinned: [] },
+      rows,
+      nextCursor: null,
+    });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    harness.render(
+      <MemoryRouter initialEntries={["/m/chat"]}>
+        <QueryClientProvider client={queryClient}>
+          <Routes>
+            <Route element={<MobileShell />}>
+              <Route path="/m/chat" element={<MobileWorkPage />} />
+            </Route>
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    await harness.waitFor(() => expect(harness.container.textContent).toContain("Thread 1"));
+    expect(harness.container.querySelector('nav[aria-label="Mobile"]')).not.toBeNull();
+
+    const scroller = harness.container.querySelector<HTMLElement>("[data-mobile-work-list-pane] .overflow-y-auto");
+    expect(scroller).not.toBeNull();
+    if (!scroller) throw new Error("Missing Chat list scroller");
+
+    const listViewport = 400;
+    const detailViewport = 480;
+    const contentHeight = 2400;
+    Object.defineProperty(scroller, "clientHeight", { configurable: true, get: () => currentViewport });
+    Object.defineProperty(scroller, "scrollHeight", { configurable: true, value: contentHeight });
+    let currentViewport = listViewport;
+    scroller.scrollTop = contentHeight - listViewport - 10;
+
+    const chatCard = harness.container.querySelector<HTMLButtonElement>('[data-mobile-card="work"]');
+    await act(async () => {
+      chatCard?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await harness.flush();
+
+    expect(harness.container.querySelector('nav[aria-label="Mobile"]')).toBeNull();
+    expect(harness.container.querySelector("[data-mobile-work-list-pane]")?.getAttribute("style")).toContain("400px");
+
+    currentViewport = detailViewport;
+    scroller.scrollTop = Math.min(scroller.scrollTop, contentHeight - currentViewport);
+
+    await act(async () => {
+      harness.container
+        .querySelector<HTMLButtonElement>('button[aria-label="back"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await harness.flush();
+
+    currentViewport = listViewport;
+    expect(harness.container.querySelector('nav[aria-label="Mobile"]')).not.toBeNull();
+    expect(scroller.scrollTop).toBe(contentHeight - listViewport - 10);
   });
 });

--- a/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
@@ -154,4 +154,64 @@ describe("MobileWorkPage back navigation", () => {
     expect(restoredPinnedQuickView?.getAttribute("aria-pressed")).toBe("true");
     expect(harness.container.textContent).toContain("Pinned planning");
   });
+
+  it("keeps the Chat list scroll offset after opening a conversation and going back", async () => {
+    const rows = Array.from({ length: 24 }, (_, index) =>
+      chatRow({
+        chatId: `chat-${index + 1}`,
+        title: `Thread ${index + 1}`,
+        topic: `Thread ${index + 1}`,
+      }),
+    );
+    meChatMocks.listMeChats.mockResolvedValue({
+      priorityRows: { pinned: [] },
+      rows,
+      nextCursor: null,
+    });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    harness.render(
+      <MemoryRouter initialEntries={["/m/chat"]}>
+        <QueryClientProvider client={queryClient}>
+          <Routes>
+            <Route path="/m/chat" element={<MobileWorkPage />} />
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    await harness.waitFor(() => expect(harness.container.textContent).toContain("Thread 1"));
+    const pane = harness.container.querySelector("[data-mobile-work-list-pane]");
+    const scroller = pane?.querySelector<HTMLElement>(".overflow-y-auto");
+    expect(pane?.getAttribute("data-mobile-work-list-pane")).toBe("active");
+    expect(scroller).not.toBeNull();
+    if (!scroller) throw new Error("Missing Chat list scroller");
+
+    Object.defineProperty(scroller, "clientHeight", { configurable: true, value: 400 });
+    Object.defineProperty(scroller, "scrollHeight", { configurable: true, value: 2400 });
+    scroller.scrollTop = 640;
+
+    const chatCard = harness.container.querySelector<HTMLButtonElement>('[data-mobile-card="work"]');
+    await act(async () => {
+      chatCard?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await harness.flush();
+    expect(harness.container.querySelector('button[aria-label="back"]')).not.toBeNull();
+    expect(pane?.getAttribute("data-mobile-work-list-pane")).toBe("parked");
+    expect(scroller.scrollTop).toBe(640);
+
+    await act(async () => {
+      harness.container
+        .querySelector<HTMLButtonElement>('button[aria-label="back"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await harness.flush();
+
+    const restoredPane = harness.container.querySelector("[data-mobile-work-list-pane]");
+    const restoredScroller = restoredPane?.querySelector<HTMLElement>(".overflow-y-auto");
+    expect(restoredPane?.getAttribute("data-mobile-work-list-pane")).toBe("active");
+    expect(restoredScroller).toBe(scroller);
+    expect(restoredScroller?.scrollTop).toBe(640);
+    expect(harness.container.textContent).toContain("Thread 1");
+  });
 });

--- a/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
@@ -280,7 +280,9 @@ describe("MobileWorkPage back navigation", () => {
     await harness.flush();
 
     expect(harness.container.querySelector('nav[aria-label="Mobile"]')).toBeNull();
-    expect(harness.container.querySelector("[data-mobile-work-list-pane]")?.getAttribute("style")).toContain("400px");
+    expect(Number.parseFloat(harness.container.querySelector("[data-mobile-work-list-pane]")?.style.height ?? "")).toBe(
+      listViewport,
+    );
 
     currentViewport = detailViewport;
     scroller.scrollTop = Math.min(scroller.scrollTop, contentHeight - currentViewport);

--- a/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
@@ -280,9 +280,8 @@ describe("MobileWorkPage back navigation", () => {
     await harness.flush();
 
     expect(harness.container.querySelector('nav[aria-label="Mobile"]')).toBeNull();
-    expect(Number.parseFloat(harness.container.querySelector("[data-mobile-work-list-pane]")?.style.height ?? "")).toBe(
-      listViewport,
-    );
+    const parkedPane = harness.container.querySelector<HTMLElement>("[data-mobile-work-list-pane]");
+    expect(Number.parseFloat(parkedPane?.style.height ?? "")).toBe(listViewport);
 
     currentViewport = detailViewport;
     scroller.scrollTop = Math.min(scroller.scrollTop, contentHeight - currentViewport);

--- a/packages/web/src/pages/mobile/components.tsx
+++ b/packages/web/src/pages/mobile/components.tsx
@@ -1,5 +1,5 @@
 import { CircleUserRound, ListTodo, UsersRound } from "lucide-react";
-import type { CSSProperties, ReactNode } from "react";
+import type { CSSProperties, ReactNode, Ref } from "react";
 import { NavLink } from "react-router";
 import { StatusGlyph } from "../../components/ui/status-glyph.js";
 import { cn } from "../../lib/utils.js";
@@ -78,13 +78,16 @@ export function MobilePage({
   children,
   className,
   padded = true,
+  scrollerRef,
 }: {
   children: ReactNode;
   className?: string;
   padded?: boolean;
+  scrollerRef?: Ref<HTMLDivElement>;
 }) {
   return (
     <div
+      ref={scrollerRef}
       className={cn("h-full overflow-y-auto", className)}
       style={{
         padding: padded ? "var(--sp-4) var(--sp-4) var(--sp-6)" : undefined,

--- a/packages/web/src/pages/mobile/work.tsx
+++ b/packages/web/src/pages/mobile/work.tsx
@@ -1,7 +1,7 @@
 import type { MeChatRow } from "@first-tree/shared";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Filter, Pin, Plus, Search, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { isAskAgentNavLocked } from "../../components/chat/ask-agent-nav-lock.js";
@@ -28,16 +28,28 @@ const DEFAULT_FILTERS: MobileWorkFilters = {
 const MOBILE_WORK_INITIAL_RENDER_COUNT = 16;
 const MOBILE_WORK_RENDER_BATCH_SIZE = 16;
 
+type ParkedListGeometry = { scrollTop: number; height: number };
+
 export function MobileWorkPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [quickView, setQuickView] = useState<MobileWorkQuickView>("all");
   const [filters, setFilters] = useState<MobileWorkFilters>(DEFAULT_FILTERS);
   const selectedChatId = searchParams.get("c");
+  const listScrollerRef = useRef<HTMLDivElement>(null);
+  const parkedListRef = useRef<ParkedListGeometry | null>(null);
+
+  const snapshotListScroll = useCallback(() => {
+    if (parkedListRef.current) return;
+    const scroller = listScrollerRef.current;
+    if (!scroller) return;
+    parkedListRef.current = { scrollTop: scroller.scrollTop, height: scroller.clientHeight };
+  }, []);
 
   const selectChat = useCallback(
     (chatId: string) => {
       // Unmounts a pending Ask agent's owning surface — refuse while locked.
       if (isAskAgentNavLocked()) return;
+      snapshotListScroll();
       const next = new URLSearchParams(searchParams);
       next.set("c", chatId);
       next.delete("review");
@@ -47,7 +59,7 @@ export function MobileWorkPage() {
       next.delete("nq");
       setSearchParams(next);
     },
-    [searchParams, setSearchParams],
+    [searchParams, setSearchParams, snapshotListScroll],
   );
 
   const clearChat = useCallback(() => {
@@ -69,6 +81,7 @@ export function MobileWorkPage() {
   const openNeedYouChat = useCallback(
     (chatId: string) => {
       if (isAskAgentNavLocked()) return;
+      snapshotListScroll();
       const next = new URLSearchParams(searchParams);
       next.set("c", chatId);
       next.set("nq", "1");
@@ -78,24 +91,40 @@ export function MobileWorkPage() {
       next.delete("focusMsg");
       setSearchParams(next);
     },
-    [searchParams, setSearchParams],
+    [searchParams, setSearchParams, snapshotListScroll],
   );
 
   const viewingChat = selectedChatId !== null;
+  const parkedGeometry = viewingChat ? parkedListRef.current : null;
+
+  useLayoutEffect(() => {
+    if (viewingChat) return;
+    const parked = parkedListRef.current;
+    const scroller = listScrollerRef.current;
+    if (!parked || !scroller) return;
+    scroller.scrollTop = parked.scrollTop;
+    parkedListRef.current = null;
+  }, [viewingChat]);
 
   return (
     <>
       <div className="relative h-full min-h-0">
         {/* Keep the list mounted under detail so back restores the same
-            scroll offset, rendered window, search, and filter chrome. */}
+            scroll offset, rendered window, search, and filter chrome.
+            Freeze the parked pane at list-mode height: hiding the shell tab
+            bar grows `<main>`, and stretching the list with it would clamp
+            a near-max scrollTop that does not come back with the tabs. */}
         <div
-          className={cn("h-full min-h-0", viewingChat && "pointer-events-none invisible absolute inset-0")}
+          className={cn("h-full min-h-0", viewingChat && "pointer-events-none invisible absolute top-0 right-0 left-0")}
+          style={parkedGeometry ? { height: parkedGeometry.height } : undefined}
           aria-hidden={viewingChat}
           inert={viewingChat || undefined}
           data-mobile-work-list-pane={viewingChat ? "parked" : "active"}
         >
           <MobileWorkList
+            scrollerRef={listScrollerRef}
             onSelectChat={selectChat}
+            onParkList={snapshotListScroll}
             quickView={quickView}
             onQuickViewChange={setQuickView}
             filters={filters}
@@ -123,14 +152,18 @@ export function MobileWorkPage() {
 }
 
 function MobileWorkList({
+  scrollerRef,
   onSelectChat,
+  onParkList,
   quickView,
   onQuickViewChange,
   filters,
   onFiltersChange,
   onOpenNeedYou,
 }: {
+  scrollerRef: RefObject<HTMLDivElement | null>;
   onSelectChat: (chatId: string) => void;
+  onParkList: () => void;
   quickView: MobileWorkQuickView;
   onQuickViewChange: (quickView: MobileWorkQuickView) => void;
   filters: MobileWorkFilters;
@@ -229,7 +262,7 @@ function MobileWorkList({
 
   return (
     <>
-      <MobilePage className="flex flex-col" padded>
+      <MobilePage className="flex flex-col" padded scrollerRef={scrollerRef}>
         <div className="flex items-center" style={{ gap: "var(--sp-2)", marginBottom: "var(--sp-3)" }}>
           <h1 className="text-mobile-title min-w-0 flex-1" style={{ color: "var(--fg)", margin: 0 }}>
             Chat
@@ -253,6 +286,7 @@ function MobileWorkList({
           <Link
             to="/m/chat?c=draft"
             aria-label="Start new chat"
+            onClick={onParkList}
             className="inline-flex h-11 w-11 items-center justify-center rounded-[var(--radius-full)]"
             style={{ background: "var(--bg-active)", color: "var(--fg)", textDecoration: "none" }}
           >

--- a/packages/web/src/pages/mobile/work.tsx
+++ b/packages/web/src/pages/mobile/work.tsx
@@ -81,30 +81,42 @@ export function MobileWorkPage() {
     [searchParams, setSearchParams],
   );
 
+  const viewingChat = selectedChatId !== null;
+
   return (
     <>
-      {selectedChatId !== null ? (
-        <div className="flex h-full min-h-0 overflow-hidden">
-          <CenterPanel
-            selectedChatId={selectedChatId}
+      <div className="relative h-full min-h-0">
+        {/* Keep the list mounted under detail so back restores the same
+            scroll offset, rendered window, search, and filter chrome. */}
+        <div
+          className={cn("h-full min-h-0", viewingChat && "pointer-events-none invisible absolute inset-0")}
+          aria-hidden={viewingChat}
+          inert={viewingChat || undefined}
+          data-mobile-work-list-pane={viewingChat ? "parked" : "active"}
+        >
+          <MobileWorkList
             onSelectChat={selectChat}
-            onClearChat={clearChat}
-            narrow
-            onShowConversations={clearChat}
-            initialParticipantIds={parseParticipantList(searchParams)}
-            presentation="mobile"
+            quickView={quickView}
+            onQuickViewChange={setQuickView}
+            filters={filters}
+            onFiltersChange={setFilters}
+            onOpenNeedYou={openNeedYouChat}
           />
         </div>
-      ) : (
-        <MobileWorkList
-          onSelectChat={selectChat}
-          quickView={quickView}
-          onQuickViewChange={setQuickView}
-          filters={filters}
-          onFiltersChange={setFilters}
-          onOpenNeedYou={openNeedYouChat}
-        />
-      )}
+        {selectedChatId !== null ? (
+          <div className="flex h-full min-h-0 overflow-hidden">
+            <CenterPanel
+              selectedChatId={selectedChatId}
+              onSelectChat={selectChat}
+              onClearChat={clearChat}
+              narrow
+              onShowConversations={clearChat}
+              initialParticipantIds={parseParticipantList(searchParams)}
+              presentation="mobile"
+            />
+          </div>
+        ) : null}
+      </div>
       <DocPreviewDrawer />
     </>
   );


### PR DESCRIPTION
## Summary

- Mobile Chat already uses `/m/chat` for the list and `?c=` for conversation detail. Opening a chat previously unmounted the list, so going back jumped to the top.
- This parks the list under the detail view (hidden, inert, still mounted) so back keeps the same scroll offset, rendered window, search, and quick-view chrome.

## Test plan

- [ ] On a phone-width `/m/chat` list, scroll down, open a conversation, tap back — the same chats should still be on screen
- [ ] Quick view (Unread / Pinned) should still be selected after returning
- [ ] Bottom tabs stay hidden while in chat detail and return on the list
- [x] `packages/web` vitest: `chat-nav`, `card-actions-dom`, `shell-dom`, `density-dom` (25 tests)

## Validation

- [ ] `pnpm check`
- [ ] `pnpm typecheck`
- [x] focused `packages/web` vitest for the mobile Chat list/detail tests

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: added a DOM test that the list scroller keeps `scrollTop` across open/back
- follow-up work: none

Made with [Cursor](https://cursor.com)