### PR TITLE
fix(chat): surface recovery for blocked and stale in-flight agents

### DIFF
--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -565,14 +565,26 @@ describe("agent-chat-status", () => {
       expect(s?.main).toBe("offline");
     });
 
-    it("stale per-chat runtime_state='error' fail-closes (does not surface as errored)", async () => {
+    it("stale per-chat in-flight runtime still surfaces as recovery (errored)", async () => {
       const { app, peer, chatId } = await newChatWithAgent();
       await bindPresence(peer.agent.uuid, peer.clientId);
       await setSession(peer.agent.uuid, chatId, "active");
-      // Seed error stamp older than RUNTIME_STALE_MS.
-      await setRuntime(peer.agent.uuid, chatId, "error", -(RUNTIME_STALE_MS + 5_000));
+      await setRuntime(peer.agent.uuid, chatId, "working", -(RUNTIME_STALE_MS + 5_000));
       const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
-      expect(s?.errored).toBe(false);
+      expect(s?.working).toBe(false);
+      expect(s?.errored).toBe(true);
+      expect(s?.main).toBe("failed");
+    });
+
+    it("fresh blocked runtime surfaces as recovery, not working", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await setRuntime(peer.agent.uuid, chatId, "blocked");
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      expect(s?.working).toBe(false);
+      expect(s?.errored).toBe(true);
+      expect(s?.main).toBe("failed");
     });
 
     it("a reachable agent with a healthy active session is not failed", async () => {
@@ -755,17 +767,34 @@ describe("agent-chat-status", () => {
       expect(computeWorking({ ...active, state: "suspended" }, activity, now)).toBe(false);
     });
 
-    it("computeErrored — new-client authoritative: state='errored' OR fresh runtime='error'", () => {
+    it("computeErrored — new-client authoritative: state='errored' OR fresh error/blocked OR stale in-flight", () => {
       // C-axis lifecycle errored sticks regardless of D-axis state, irrespective of stamp.
       expect(computeErrored({ state: "errored", runtimeState: "idle", runtimeStateAt: null }, null, now)).toBe(true);
       expect(computeErrored({ state: "errored", runtimeState: "idle", runtimeStateAt: null }, "error", now)).toBe(true);
-      // D-axis 'error' only counts when fresh + active (new-client path).
+      // D-axis fault counts when fresh + active.
       expect(computeErrored({ state: "active", runtimeState: "error", runtimeStateAt: recent(-1000) }, null, now)).toBe(
         true,
       );
       expect(
+        computeErrored({ state: "active", runtimeState: "blocked", runtimeStateAt: recent(-1000) }, null, now),
+      ).toBe(true);
+      // Fresh working is slow-but-alive, not recovery.
+      expect(
+        computeErrored({ state: "active", runtimeState: "working", runtimeStateAt: recent(-1000) }, null, now),
+      ).toBe(false);
+      expect(
         computeErrored({ state: "suspended", runtimeState: "error", runtimeStateAt: recent(-1000) }, null, now),
       ).toBe(false);
+      // Stale in-flight must not look idle.
+      const staleAt = recent(-(RUNTIME_STALE_MS + 1000));
+      expect(computeErrored({ state: "active", runtimeState: "working", runtimeStateAt: staleAt }, null, now)).toBe(
+        true,
+      );
+      expect(computeErrored({ state: "active", runtimeState: "blocked", runtimeStateAt: staleAt }, null, now)).toBe(
+        true,
+      );
+      expect(computeErrored({ state: "active", runtimeState: "error", runtimeStateAt: staleAt }, null, now)).toBe(true);
+      expect(computeErrored({ state: "active", runtimeState: "idle", runtimeStateAt: staleAt }, null, now)).toBe(false);
     });
 
     it("computeErrored — old-client fallback (NULL stamp): legacy presence.runtime_state OR-fold", () => {
@@ -774,6 +803,7 @@ describe("agent-chat-status", () => {
       // is pre-PR behaviour, retained for one release cycle; self-closes the
       // moment the client upgrades and starts reporting per-chat runtime.
       expect(computeErrored(active, "error", now)).toBe(true);
+      expect(computeErrored(active, "blocked", now)).toBe(true);
       // Non-error presence on an old-client active row: not errored.
       expect(computeErrored(active, "working", now)).toBe(false);
       expect(computeErrored(active, null, now)).toBe(false);

--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -803,7 +803,9 @@ describe("agent-chat-status", () => {
       // is pre-PR behaviour, retained for one release cycle; self-closes the
       // moment the client upgrades and starts reporting per-chat runtime.
       expect(computeErrored(active, "error", now)).toBe(true);
-      expect(computeErrored(active, "blocked", now)).toBe(true);
+      // Global `blocked` must stay out of the NULL-stamp fallback — it is not
+      // chat-scoped and historically false-alarmed during long reasoning.
+      expect(computeErrored(active, "blocked", now)).toBe(false);
       // Non-error presence on an old-client active row: not errored.
       expect(computeErrored(active, "working", now)).toBe(false);
       expect(computeErrored(active, null, now)).toBe(false);

--- a/packages/server/src/__tests__/me-chats-http-e2e.test.ts
+++ b/packages/server/src/__tests__/me-chats-http-e2e.test.ts
@@ -136,6 +136,39 @@ describe("GET /orgs/:orgId/chats — liveActivity wire shape", () => {
     expect(row?.liveActivity).toBeNull();
   });
 
+  it("blocked runtime lights failedAgentIds recovery without busyAgentIds", async () => {
+    const app = getApp();
+    const alice = await createTestAdmin(app);
+    const peer = await createAgent(app.db, {
+      name: `e2e-blocked-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Blocked Peer",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+    });
+    const { chatId } = await createMeChat(app.db, alice.humanAgentUuid, alice.organizationId, {
+      participantIds: [peer.uuid],
+    });
+    await app.db.execute(sql`
+      INSERT INTO agent_chat_sessions (agent_id, chat_id, state, runtime_state, runtime_state_at, updated_at)
+      VALUES (${peer.uuid}, ${chatId}, 'active', 'blocked', NOW(), NOW())
+      ON CONFLICT (agent_id, chat_id) DO UPDATE
+        SET state = EXCLUDED.state,
+            runtime_state = EXCLUDED.runtime_state,
+            runtime_state_at = EXCLUDED.runtime_state_at
+    `);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${encodeURIComponent(alice.organizationId)}/chats`,
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const row = res.json<{ rows: Array<Record<string, unknown>> }>().rows.find((r) => r.chatId === chatId);
+    expect(row?.failedAgentIds).toEqual([peer.uuid]);
+    expect(row?.busyAgentIds).toEqual([]);
+  });
+
   it("idle session → liveActivity null", async () => {
     const app = getApp();
     const alice = await createTestAdmin(app);

--- a/packages/server/src/services/chat/sessions/status.ts
+++ b/packages/server/src/services/chat/sessions/status.ts
@@ -37,7 +37,9 @@ import { isConsistentAgentRoute, metadataSupportsSessionReset } from "../../runt
  *   - reachability (A): the agent has a bound client (`agent_presence.client_id`)
  *   - engagement   (C): `agent_chat_sessions.state` for this pair
  *   - activity     (D): a fresh, non-terminal latest `session_events` row
- *   - attention       : a failure (session `errored` OR runtime `error`)
+ *   - attention       : recovery the user can notice — session `errored`,
+ *     fresh runtime `error` / `blocked`, or a stale in-flight D-axis
+ *     (`working` / `blocked` / `error`) after the client stopped reaffirming
  *
  * The `errored` predicate lives here ONCE (it used to be duplicated as a TS
  * predicate in this file AND a Drizzle clause in `me-chat.ts:deriveFailedAgents`,
@@ -601,13 +603,14 @@ export async function resolveAgentChatStatuses(
 // signals for one release cycle:
 //   - working: the latest non-terminal `session_events` row within
 //     LIVE_ACTIVITY_STALE_MS (the pre-PR proxy).
-//   - errored: the agent-global `presence.runtime_state === 'error'`
+//   - errored: the agent-global `presence.runtime_state === 'error' | 'blocked'`
 //     OR-fold (the pre-PR behaviour — yes, this still has the reverse-#366
 //     cross-chat leak for old clients, but that's the existing prod
 //     behaviour, not a new regression — and it self-closes the moment the
 //     client upgrades and starts reporting per-chat).
 // `state === 'errored'` (C-axis lifecycle) always contributes to errored
-// independently of the D-axis on both paths.
+// independently of the D-axis on both paths. Fresh `working` is never
+// recovery; stale in-flight D-axis is.
 //
 // Spec reference: proposals/hub-agent-status-working-freshness.20260525.md
 // §6.1 §10 ("保留旧 client 兼容兜底一个发布周期").
@@ -631,7 +634,8 @@ type RuntimeSessionRow =
  * the client has reported per-chat runtime within the freshness window.
  * Returns false for old clients (NULL stamp), stale stamps, and non-active
  * sessions; the caller should fall back to legacy signals on false-with-
- * NULL-stamp and treat false-with-stale-stamp as fail-closed.
+ * NULL-stamp. Stale in-flight runtime is recovery (`computeErrored`), not
+ * working.
  */
 export function isRuntimeFresh(session: RuntimeSessionRow, now: number): boolean {
   if (!session || session.state !== "active") return false;
@@ -658,22 +662,34 @@ export function computeWorking(session: RuntimeSessionRow, activity: LiveActivit
   return isRuntimeFresh(session, now) && session.runtimeState === ("working" satisfies RuntimeState);
 }
 
+function isFaultRuntime(runtimeState: string): boolean {
+  return runtimeState === ("error" satisfies RuntimeState) || runtimeState === ("blocked" satisfies RuntimeState);
+}
+
+function isInFlightRuntime(runtimeState: string): boolean {
+  return isFaultRuntime(runtimeState) || runtimeState === ("working" satisfies RuntimeState);
+}
+
 /**
- * Authoritative path: C-axis `state === 'errored'` always contributes; the
- * D-axis 'error' axis contributes when active + fresh. Old-client fallback
- * (NULL stamp on an active session): legacy `presence.runtime_state ===
- * 'error'` OR-fold, which is pre-PR behaviour (still has the reverse-#366
- * cross-chat leak for old clients; that's the existing prod regression
- * envelope and self-closes when the client upgrades). Spec §6.1 §10.
+ * Authoritative path: C-axis `state === 'errored'` always contributes.
+ * D-axis recovery contributes when the session is active and either:
+ *   - the stamp is fresh and runtime is `error` or `blocked`, or
+ *   - the stamp is stale and the last runtime was still in-flight
+ *     (`working` / `blocked` / `error`) — a dead client must not look idle.
+ * Fresh `working` is never recovery. Old-client fallback (NULL stamp on an
+ * active session): legacy `presence.runtime_state === 'error' | 'blocked'`
+ * OR-fold (still has the reverse-#366 cross-chat leak for old clients; that
+ * is the existing prod envelope and self-closes when the client upgrades).
  */
 export function computeErrored(session: RuntimeSessionRow, presenceRuntimeState: string | null, now: number): boolean {
   if (session?.state === "errored") return true;
   if (!session || session.state !== "active") return false;
   if (session.runtimeStateAt == null) {
-    // Old client (one release cycle): legacy agent-global error fallback.
-    return presenceRuntimeState === "error";
+    // Old client (one release cycle): legacy agent-global fault fallback.
+    return presenceRuntimeState != null && isFaultRuntime(presenceRuntimeState);
   }
-  return isRuntimeFresh(session, now) && session.runtimeState === ("error" satisfies RuntimeState);
+  if (isRuntimeFresh(session, now)) return isFaultRuntime(session.runtimeState);
+  return isInFlightRuntime(session.runtimeState);
 }
 
 /**

--- a/packages/server/src/services/chat/sessions/status.ts
+++ b/packages/server/src/services/chat/sessions/status.ts
@@ -603,14 +603,15 @@ export async function resolveAgentChatStatuses(
 // signals for one release cycle:
 //   - working: the latest non-terminal `session_events` row within
 //     LIVE_ACTIVITY_STALE_MS (the pre-PR proxy).
-//   - errored: the agent-global `presence.runtime_state === 'error' | 'blocked'`
-//     OR-fold (the pre-PR behaviour — yes, this still has the reverse-#366
-//     cross-chat leak for old clients, but that's the existing prod
-//     behaviour, not a new regression — and it self-closes the moment the
-//     client upgrades and starts reporting per-chat).
+//   - errored: the agent-global `presence.runtime_state === 'error'` OR-fold
+//     only (never `blocked` — that signal is not chat-scoped and used to
+//     false-alarm on long reasoning). Still has the reverse-#366 cross-chat
+//     leak for old clients on `error`; that is the existing prod envelope and
+//     self-closes when the client upgrades and starts reporting per-chat.
 // `state === 'errored'` (C-axis lifecycle) always contributes to errored
 // independently of the D-axis on both paths. Fresh `working` is never
-// recovery; stale in-flight D-axis is.
+// recovery; stale in-flight D-axis is. Per-chat `blocked` recovery requires a
+// non-NULL per-chat stamp.
 //
 // Spec reference: proposals/hub-agent-status-working-freshness.20260525.md
 // §6.1 §10 ("保留旧 client 兼容兜底一个发布周期").
@@ -677,16 +678,18 @@ function isInFlightRuntime(runtimeState: string): boolean {
  *   - the stamp is stale and the last runtime was still in-flight
  *     (`working` / `blocked` / `error`) — a dead client must not look idle.
  * Fresh `working` is never recovery. Old-client fallback (NULL stamp on an
- * active session): legacy `presence.runtime_state === 'error' | 'blocked'`
- * OR-fold (still has the reverse-#366 cross-chat leak for old clients; that
- * is the existing prod envelope and self-closes when the client upgrades).
+ * active session): legacy `presence.runtime_state === 'error'` only — never
+ * agent-global `blocked`, which is not chat-scoped and historically false-
+ * alarmed during long reasoning turns. The reverse-#366 cross-chat leak for
+ * global `error` remains the existing prod envelope and self-closes when the
+ * client upgrades and starts reporting per-chat runtime.
  */
 export function computeErrored(session: RuntimeSessionRow, presenceRuntimeState: string | null, now: number): boolean {
   if (session?.state === "errored") return true;
   if (!session || session.state !== "active") return false;
   if (session.runtimeStateAt == null) {
-    // Old client (one release cycle): legacy agent-global fault fallback.
-    return presenceRuntimeState != null && isFaultRuntime(presenceRuntimeState);
+    // Old client (one release cycle): legacy agent-global error fallback only.
+    return presenceRuntimeState === "error";
   }
   if (isRuntimeFresh(session, now)) return isFaultRuntime(session.runtimeState);
   return isInFlightRuntime(session.runtimeState);

--- a/packages/server/src/services/chat/workspace/me-chat.ts
+++ b/packages/server/src/services/chat/workspace/me-chat.ts
@@ -552,7 +552,8 @@ async function enrichMeChatRows(
       // agent in a shared chat no longer pins my row to "Needs attention".
       // Use the errored axis rather than composite `main`: reachability makes an
       // errored agent display as offline, but recovery attention must remain
-      // until the per-chat error itself clears.
+      // until the per-chat recovery itself clears (session errored, fresh
+      // blocked/error, or stale in-flight working/blocked/error).
       if (isSpeaker && s.errored && isMine) failed.push(s.agentId);
       // busy — speakers with composite `working` (the D-axis truth from
       // `agent_chat_sessions.runtime_state`). NOT narrowed to mine — "someone

--- a/packages/shared/src/schemas/agent-status.ts
+++ b/packages/shared/src/schemas/agent-status.ts
@@ -67,13 +67,16 @@ export type AgentEngagement = z.infer<typeof agentEngagementSchema>;
  * client re-affirms `working` / `blocked` / `error` sessions on a ~20s timer
  * (RUNTIME_REAFFIRM_BASE_MS) with ±20% jitter so a long turn keeps
  * `runtime_state_at` fresh; if no re-affirm lands within this window the
- * server stops treating the session as working/errored (self-heals after a
- * silent client death where the `idle` transition was never received).
- * 60s = 3× the nominal re-affirm interval, matching the approved spec
- * (proposals/hub-agent-status-working-freshness.20260525.md §6.1 §10).
+ * server stops treating the session as *working*. Stale in-flight runtime
+ * (`working` / `blocked` / `error`) still lights recovery so a silent client
+ * death does not look idle. 60s = 3× the nominal re-affirm interval, matching
+ * the approved spec (proposals/hub-agent-status-working-freshness.20260525.md
+ * §6.1 §10) for the working cutoff.
  *
- * Direct consequence: when a client process crashes mid-turn the user-visible
- * "stuck-working" upper bound is RUNTIME_STALE_MS.
+ * Direct consequence: when a client process crashes mid-turn, composite
+ * `working` clears once RUNTIME_STALE_MS elapses. Recovery attention then
+ * stays on the `errored` axis (chat-row `failedAgentIds`) so a dead in-flight
+ * turn does not look merely idle.
  */
 export const RUNTIME_STALE_MS = 60_000;
 
@@ -81,7 +84,7 @@ export const RUNTIME_STALE_MS = 60_000;
 export type DeriveMainStatusInput = {
   /** Reachability (A): is the agent's runtime/client reachable at all? */
   reachable: boolean;
-  /** A concrete failure the user should see (session `errored` OR runtime `error`). */
+  /** Recovery the user should see: session `errored`, runtime `error`/`blocked`, or a stale in-flight D-axis. */
   errored: boolean;
   /** Activity (D): the agent is producing output right now (live activity present). */
   working: boolean;

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -169,13 +169,11 @@ export function ConversationList({
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     // Bounded refetch is the safety floor for the per-chat composite
     // signals projected onto each row: `busyAgentIds` lights the chat-list
-    // dot for the working / codex-no-events case, and the only way the
-    // dot self-heals after a client crash is for a fresh `listMeChats` to
-    // discover `runtime_state_at` aged past `RUNTIME_STALE_MS` (60s) — the
-    // server emits no notification when staleness is reached passively. An
-    // infinite query refetches every loaded page on each interval, so every
-    // row (not just the first page) self-heals within `RUNTIME_STALE_MS` +
-    // one refetch (~90s). 30s matches the `chat-agent-status` query.
+    // dots for a *fresh* working turn, and `failedAgentIds` lights recovery
+    // when runtime is blocked/error or the working stamp aged past
+    // `RUNTIME_STALE_MS` (60s). The server emits no notification when
+    // staleness is reached passively, so an infinite query refetches every
+    // loaded page on each interval. 30s matches the `chat-agent-status` query.
     refetchInterval: 30_000,
   });
 


### PR DESCRIPTION
## Summary
- Treat handler `blocked` and stale in-flight runtime (`working` / `blocked` / `error`) as recovery via the existing `errored` → `failedAgentIds` chat-row path.
- Keep **fresh** `working` as green/slow-but-alive so long legitimate turns do not look stuck.
- Stale idle stays idle; Need you is unchanged.

## How states are judged
| Signal | Rule | Chat-row effect |
|---|---|---|
| Fresh `working` | active session + `runtime_state_at` within 60s + `runtime_state=working` | `busyAgentIds` (ActivityDots) |
| Fresh `blocked` | same freshness + `runtime_state=blocked` (handler: no output + no prompt) | `failedAgentIds` (`!`) |
| Fresh `error` / session `errored` | existing fault path | `failedAgentIds` (`!`) |
| Stale in-flight | active + stamp older than 60s + last state was working/blocked/error | `failedAgentIds` (`!`), not busy |
| Stale `idle` | last state idle | no recovery |

## Test plan
- [x] `agent-chat-status.test.ts` (46) including new blocked + stale in-flight cases
- [x] `me-chats-http-e2e.test.ts` (9) including blocked → `failedAgentIds`
- [ ] Manual: leave a chat green working with live activity for >1m → still working
- [ ] Manual: stop client mid-turn → after ~60–90s row shows recovery `!` instead of idle

Made with [Cursor](https://cursor.com)