### PR TITLE
fix(client): fall through unusable Codex binaries

### DIFF
--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -782,7 +782,7 @@ describe("daemon start command", () => {
     expect(unregisterCodexCandidateChange).toHaveBeenCalledTimes(1);
   });
 
-  it("defers an in-flight Codex provenance write until interactive login releases pendingAuth", async () => {
+  it("defers in-flight Codex provenance and preserves a terminal auth failure", async () => {
     const verifiedEntry = {
       state: "ok" as const,
       available: true,
@@ -807,6 +807,14 @@ describe("daemon start command", () => {
         expiresAt: "2026-08-20T00:05:00.000Z",
       },
     };
+    const failedEntry = {
+      ...verifiedEntry,
+      lastAuthError: {
+        reason: "exit-nonzero" as const,
+        message: "account not authorized",
+        at: "2026-08-20T00:01:00.000Z",
+      },
+    };
     coreMocks.runRuntimeAuthLogin.mockImplementationOnce(
       async (
         _command: { provider: string; ref: string },
@@ -814,6 +822,7 @@ describe("daemon start command", () => {
       ) => {
         await deps.setProviderEntry("codex", pendingEntry);
         await loginPending;
+        await deps.setProviderEntry("codex", failedEntry);
       },
     );
 
@@ -824,6 +833,13 @@ describe("daemon start command", () => {
     });
     refresherInstance.endInteractive.mockImplementation((provider: string) => {
       if (provider === "codex") codexInteractive = false;
+    });
+    let currentCodexEntry: unknown;
+    refresherInstance.currentEntry.mockImplementation((provider: string) =>
+      provider === "codex" ? currentCodexEntry : undefined,
+    );
+    refresherInstance.setProviderEntry.mockImplementation(async (provider: string, entry: unknown) => {
+      if (provider === "codex") currentCodexEntry = entry;
     });
 
     let finishSkillUpload!: () => void;
@@ -857,12 +873,18 @@ describe("daemon start command", () => {
     expect(refresherInstance.setProviderEntry).not.toHaveBeenCalledWith("codex", verifiedEntry);
 
     finishLogin();
-    await waitForAsyncWork(() => refresherInstance.setProviderEntry.mock.calls.length === 2);
+    await waitForAsyncWork(() => refresherInstance.setProviderEntry.mock.calls.length === 3);
     expect(refresherInstance.endInteractive).toHaveBeenCalledWith("codex");
-    expect(refresherInstance.setProviderEntry.mock.calls).toEqual([
+    expect(refresherInstance.setProviderEntry.mock.calls.slice(0, 2)).toEqual([
       ["codex", pendingEntry],
-      ["codex", verifiedEntry],
+      ["codex", failedEntry],
     ]);
+    const publishedAfterFailure = refresherInstance.setProviderEntry.mock.calls[2]?.[1];
+    expect(publishedAfterFailure).toMatchObject({
+      runtimePath: verifiedEntry.runtimePath,
+      lastAuthError: failedEntry.lastAuthError,
+    });
+    expect(publishedAfterFailure).not.toHaveProperty("pendingAuth");
 
     finishSkillUpload();
     await expect(start).rejects.toMatchObject({ exitCode: 1 });

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -782,6 +782,92 @@ describe("daemon start command", () => {
     expect(unregisterCodexCandidateChange).toHaveBeenCalledTimes(1);
   });
 
+  it("defers an in-flight Codex provenance write until interactive login releases pendingAuth", async () => {
+    const verifiedEntry = {
+      state: "ok" as const,
+      available: true,
+      runtimeSource: "path" as const,
+      runtimePath: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      detectedAt: "2026-08-20T00:00:00.000Z",
+    };
+    let resolveProbe!: (entry: typeof verifiedEntry) => void;
+    const delayedProbe = new Promise<typeof verifiedEntry>((resolve) => {
+      resolveProbe = resolve;
+    });
+    clientMocks.probeCodexCapability.mockReturnValueOnce(delayedProbe);
+
+    let finishLogin!: () => void;
+    const loginPending = new Promise<void>((resolve) => {
+      finishLogin = resolve;
+    });
+    const pendingEntry = {
+      state: "ok" as const,
+      pendingAuth: {
+        method: "browser" as const,
+        expiresAt: "2026-08-20T00:05:00.000Z",
+      },
+    };
+    coreMocks.runRuntimeAuthLogin.mockImplementationOnce(
+      async (
+        _command: { provider: string; ref: string },
+        deps: { setProviderEntry: (provider: string, entry: unknown) => Promise<void> },
+      ) => {
+        await deps.setProviderEntry("codex", pendingEntry);
+        await loginPending;
+      },
+    );
+
+    let codexInteractive = false;
+    refresherInstance.isInteractive.mockImplementation((provider: string) => provider === "codex" && codexInteractive);
+    refresherInstance.beginInteractive.mockImplementation((provider: string) => {
+      if (provider === "codex") codexInteractive = true;
+    });
+    refresherInstance.endInteractive.mockImplementation((provider: string) => {
+      if (provider === "codex") codexInteractive = false;
+    });
+
+    let finishSkillUpload!: () => void;
+    const skillUploadPending = new Promise<void>((resolve) => {
+      finishSkillUpload = resolve;
+    });
+    coreMocks.uploadAgentSkills.mockImplementationOnce(async () => {
+      codexCandidateChangeListener?.();
+      await skillUploadPending;
+    });
+
+    const start = runStart(["--foreground"]);
+    await waitForAsyncWork(() => clientMocks.probeCodexCapability.mock.calls.length === 1);
+
+    const runtimeAuthStart = runtimeInstance.onRuntimeAuthStart.mock.calls[0]?.[0] as
+      | ((command: { provider: string; ref: string }) => void)
+      | undefined;
+    if (typeof runtimeAuthStart !== "function") throw new Error("runtime-auth callback was not registered");
+    runtimeAuthStart({ provider: "codex", ref: "pending-provenance" });
+    await waitForAsyncWork(() =>
+      refresherInstance.setProviderEntry.mock.calls.some(
+        ([provider, entry]) => provider === "codex" && entry === pendingEntry,
+      ),
+    );
+
+    // The launch-free provenance probe finishes after pendingAuth is visible.
+    // Its plain entry must not replace the interactive row.
+    resolveProbe(verifiedEntry);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(refresherInstance.setProviderEntry).not.toHaveBeenCalledWith("codex", verifiedEntry);
+
+    finishLogin();
+    await waitForAsyncWork(() => refresherInstance.setProviderEntry.mock.calls.length === 2);
+    expect(refresherInstance.endInteractive).toHaveBeenCalledWith("codex");
+    expect(refresherInstance.setProviderEntry.mock.calls).toEqual([
+      ["codex", pendingEntry],
+      ["codex", verifiedEntry],
+    ]);
+
+    finishSkillUpload();
+    await expect(start).rejects.toMatchObject({ exitCode: 1 });
+  });
+
   it("skips skill upload for stale local aliases that are not pinned to this client", async () => {
     mkdirSync(join(home, "config", "agents", "developer"), { recursive: true });
     writeFileSync(

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -12,7 +12,9 @@ const clientMocks = vi.hoisted(() => ({
   discoverClaudeCodeSkills: vi.fn(),
   flushClientSentry: vi.fn(),
   initClientSentry: vi.fn(),
+  onCodexVerifiedAutomaticCandidateChange: vi.fn(),
   probeCapabilities: vi.fn(),
+  probeCodexCapability: vi.fn(),
   reprobeOnReconnect: vi.fn(),
 }));
 
@@ -94,6 +96,8 @@ const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | nu
 
 let home: string;
 let runtimeOwnershipRelease: ReturnType<typeof vi.fn>;
+let codexCandidateChangeListener: (() => void) | null;
+let unregisterCodexCandidateChange: ReturnType<typeof vi.fn>;
 let runtimeInstance: {
   addAgent: ReturnType<typeof vi.fn>;
   start: ReturnType<typeof vi.fn>;
@@ -142,6 +146,19 @@ beforeEach(() => {
   });
 
   clientMocks.probeCapabilities.mockResolvedValue({ "claude-code": { state: "ok" } });
+  clientMocks.probeCodexCapability.mockResolvedValue({
+    state: "ok",
+    available: true,
+    runtimeSource: "path",
+    runtimePath: "/Applications/ChatGPT.app/Contents/Resources/codex",
+    detectedAt: "2026-08-20T00:00:00.000Z",
+  });
+  codexCandidateChangeListener = null;
+  unregisterCodexCandidateChange = vi.fn();
+  clientMocks.onCodexVerifiedAutomaticCandidateChange.mockImplementation((listener: () => void) => {
+    codexCandidateChangeListener = listener;
+    return unregisterCodexCandidateChange;
+  });
   clientMocks.createLogger.mockReturnValue({
     debug: vi.fn(),
     info: vi.fn(),
@@ -742,6 +759,27 @@ describe("daemon start command", () => {
     expect(refresherInstance.currentEntry).toHaveBeenCalledWith("codex");
     expect(refresherInstance.setProviderEntry).toHaveBeenCalledWith("codex", { state: "ok" });
     expect(output()).toContain("runtime auth progress");
+  });
+
+  it("publishes a runtime-verified Codex selection through the live capability refresher", async () => {
+    runtimeInstance.start.mockImplementationOnce(async () => {
+      codexCandidateChangeListener?.();
+    });
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+    await waitForAsyncWork(() => refresherInstance.setProviderEntry.mock.calls.length > 0);
+
+    expect(clientMocks.onCodexVerifiedAutomaticCandidateChange).toHaveBeenCalledTimes(1);
+    expect(clientMocks.probeCodexCapability).toHaveBeenCalledTimes(1);
+    expect(refresherInstance.start).toHaveBeenCalledTimes(1);
+    expect(refresherInstance.setProviderEntry).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({
+        state: "ok",
+        runtimePath: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      }),
+    );
+    expect(unregisterCodexCandidateChange).toHaveBeenCalledTimes(1);
   });
 
   it("skips skill upload for stale local aliases that are not pinned to this client", async () => {

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -396,20 +396,37 @@ export function registerDaemonStartCommand(daemon: Command): void {
         let codexCapabilityPublicationInFlight = false;
         let codexCapabilityPublicationPending = false;
         const publishCodexVerifiedSelection = (): void => {
-          if (!codexCapabilityPublicationStarted || codexCapabilityPublicationInFlight) {
+          // Runtime-auth owns the whole provider entry while browser login is
+          // interactive. A verified selection can be emitted by resolveLogin(),
+          // before the pending-auth marker is published, so coalesce it until
+          // the login's terminal reflection has released that ownership.
+          if (
+            !codexCapabilityPublicationStarted ||
+            codexCapabilityPublicationInFlight ||
+            capabilityRefresher.isInteractive("codex")
+          ) {
             codexCapabilityPublicationPending = true;
             return;
           }
           codexCapabilityPublicationInFlight = true;
           void probeCodexCapability()
-            .then((entry) => capabilityRefresher.setProviderEntry("codex", entry))
+            .then(async (entry) => {
+              // Interactive login may have started while the launch-free probe
+              // was in flight. Re-check at write time so its pendingAuth entry
+              // cannot be replaced by this plain provenance snapshot.
+              if (!codexCapabilityPublicationStarted || capabilityRefresher.isInteractive("codex")) {
+                codexCapabilityPublicationPending = true;
+                return;
+              }
+              await capabilityRefresher.setProviderEntry("codex", entry);
+            })
             .catch((err) => {
               const message = err instanceof Error ? err.message : String(err);
               writeStatus("⚠️", `codex capability provenance update skipped: ${message}`);
             })
             .finally(() => {
               codexCapabilityPublicationInFlight = false;
-              if (codexCapabilityPublicationPending) {
+              if (codexCapabilityPublicationPending && !capabilityRefresher.isInteractive("codex")) {
                 codexCapabilityPublicationPending = false;
                 publishCodexVerifiedSelection();
               }
@@ -441,7 +458,13 @@ export function registerDaemonStartCommand(daemon: Command): void {
             currentEntry: (provider) => capabilityRefresher.currentEntry(provider),
             setProviderEntry: (provider, entry) => capabilityRefresher.setProviderEntry(provider, entry),
             log: (symbol, msg) => writeStatus(symbol, msg),
-          }).finally(() => capabilityRefresher.endInteractive(command.provider));
+          }).finally(() => {
+            capabilityRefresher.endInteractive(command.provider);
+            if (command.provider === "codex" && codexCapabilityPublicationPending) {
+              codexCapabilityPublicationPending = false;
+              publishCodexVerifiedSelection();
+            }
+          });
         });
 
         // Host-local model catalog: web opens Model settings → server asks this

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -11,6 +11,8 @@ import {
   discoverProviderModels,
   flushClientSentry,
   initClientSentry,
+  onCodexVerifiedAutomaticCandidateChange,
+  probeCodexCapability,
 } from "@first-tree/client";
 import {
   agentConfigSchema,
@@ -126,6 +128,8 @@ export function registerDaemonStartCommand(daemon: Command): void {
 
       let unregisterRuntimeMarker: (() => void) | null = null;
       let releaseRuntimeOwnership: (() => void) | null = null;
+      let unregisterCodexCandidateChange: (() => void) | null = null;
+      let codexCapabilityPublicationStarted = false;
       try {
         // Service-mode delegation. We split four cases so the user gets a
         // single coherent command:
@@ -375,8 +379,8 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // Runtime-capability refresh as a single probing model. The refresher
         // owns startup, WS-reconnect, and bounded background probes. Startup is
         // deliberately post-registration and fire-and-forget: capability rows
-        // still come from launch-verified full probes, but slow provider smokes
-        // must not delay `Connecting...`, WS registration, or agent bind.
+        // come from install-only probes, and publication latency must not delay
+        // `Connecting...`, WS registration, or agent bind.
         const capabilityRefresher = new CapabilityRefresher({
           upload: async (capabilities) => {
             const accessToken = await ensureFreshAccessToken();
@@ -389,6 +393,29 @@ export function registerDaemonStartCommand(daemon: Command): void {
           },
           log: (symbol, msg) => writeStatus(symbol, msg),
         });
+        let codexCapabilityPublicationInFlight = false;
+        let codexCapabilityPublicationPending = false;
+        const publishCodexVerifiedSelection = (): void => {
+          if (!codexCapabilityPublicationStarted || codexCapabilityPublicationInFlight) {
+            codexCapabilityPublicationPending = true;
+            return;
+          }
+          codexCapabilityPublicationInFlight = true;
+          void probeCodexCapability()
+            .then((entry) => capabilityRefresher.setProviderEntry("codex", entry))
+            .catch((err) => {
+              const message = err instanceof Error ? err.message : String(err);
+              writeStatus("⚠️", `codex capability provenance update skipped: ${message}`);
+            })
+            .finally(() => {
+              codexCapabilityPublicationInFlight = false;
+              if (codexCapabilityPublicationPending) {
+                codexCapabilityPublicationPending = false;
+                publishCodexVerifiedSelection();
+              }
+            });
+        };
+        unregisterCodexCandidateChange = onCodexVerifiedAutomaticCandidateChange(publishCodexVerifiedSelection);
         runtime.onReconnect(() => capabilityRefresher.onReconnect());
 
         // In-product runtime-auth: the server pushes `runtime-auth:start` when a
@@ -447,6 +474,11 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // transient failure logs and moves on; agents still bind, and the poll
         // (or a later restart) retries.
         void capabilityRefresher.start();
+        codexCapabilityPublicationStarted = true;
+        if (codexCapabilityPublicationPending) {
+          codexCapabilityPublicationPending = false;
+          publishCodexVerifiedSelection();
+        }
 
         // Post-register slash-command skill upload. Phase 1B scope is
         // user-global Claude Code skills — every claude-code agent on this
@@ -511,6 +543,9 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // Graceful shutdown
         const shutdown = async () => {
           writeLine("\n  Shutting down...\n");
+          codexCapabilityPublicationStarted = false;
+          unregisterCodexCandidateChange?.();
+          unregisterCodexCandidateChange = null;
           capabilityRefresher.stop();
           runtime.unwatchAgentsDir();
           await runtime.stop(resolveClientRuntimeStopReason());
@@ -581,6 +616,8 @@ export function registerDaemonStartCommand(daemon: Command): void {
         }
         writeErrorAndExit(`Error: ${msg}`);
       } finally {
+        codexCapabilityPublicationStarted = false;
+        unregisterCodexCandidateChange?.();
         unregisterRuntimeMarker?.();
         releaseRuntimeOwnership?.();
         // Reset singleton so other commands can reinit

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -418,7 +418,14 @@ export function registerDaemonStartCommand(daemon: Command): void {
                 codexCapabilityPublicationPending = true;
                 return;
               }
-              await capabilityRefresher.setProviderEntry("codex", entry);
+              // A failed login has already published its terminal marker by
+              // the time interactive ownership is released. Provenance is an
+              // additive refresh, so retain that verdict while updating the
+              // verified runtime path instead of resetting the UI to a login
+              // that appears never attempted.
+              const current = capabilityRefresher.currentEntry("codex");
+              const published = current?.lastAuthError ? { ...entry, lastAuthError: current.lastAuthError } : entry;
+              await capabilityRefresher.setProviderEntry("codex", published);
             })
             .catch((err) => {
               const message = err instanceof Error ? err.message : String(err);

--- a/apps/cli/src/core/capability-refresh.ts
+++ b/apps/cli/src/core/capability-refresh.ts
@@ -45,7 +45,7 @@ export type CapabilityRefresherDeps = {
   /** Status logger (symbol + message), e.g. `print.status`. */
   log: (symbol: string, message: string) => void;
   /** Optional initial snapshot from a caller-owned probe. Daemon startup normally
-   * omits this so full launch probes run only after WS registration. */
+   * omits this so the full install-only probe runs after WS registration. */
   initial?: ClientCapabilities | null;
   /** Override the backoff base (test seam). */
   baseMs?: number;
@@ -64,7 +64,7 @@ export type CapabilityRefresherDeps = {
  * probing model, so the refresh triggers never overlap or fight:
  *
  *   1. Startup (`start`) — if no caller supplied an initial snapshot, immediately
- *      launch a full probe in the background after the Client has registered.
+ *      run a full probe in the background after the Client has registered.
  *   2. WS reconnect (`onReconnect`) — TTL-aware full-or-revalidate via
  *      {@link reprobeOnReconnect}, preserving the existing reconnect behavior.
  *   3. A bounded, backoff-scheduled background poll (`start`) that fires *while
@@ -76,7 +76,7 @@ export type CapabilityRefresherDeps = {
  *      itself once every built-in provider is `ok`.
  *
  * Both triggers share one in-flight guard, so a reconnect re-probe and a poll
- * can never launch providers concurrently, and uploads are deduped against the
+ * can never overlap, and uploads are deduped against the
  * last snapshot actually sent.
  */
 export class CapabilityRefresher {

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -20,7 +20,10 @@ import {
 } from "../providers/claude/capability.js";
 import { probeClaudeCodeTuiCapability } from "../providers/claude/capability-tui.js";
 import type { ClaudeExecutableResolution } from "../providers/claude/executable.js";
-import type { CodexExecutableVerification } from "../providers/codex/binary.js";
+import {
+  type CodexExecutableVerification,
+  createCodexAutomaticResolutionFailureTracker,
+} from "../providers/codex/binary.js";
 import {
   probeCodexCapability,
   resolveBundledBinaryInPackageRoot,
@@ -659,6 +662,47 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
     });
   });
 
+  it("bundle NOT found → skips a broken PATH candidate and resolves the healthy Desktop path for login", async () => {
+    const pathBinary = "/Users/test/.npm-global/bin/codex";
+    const desktopBinary = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const verifyPath = vi.fn(
+      (path: string): CodexExecutableVerification =>
+        path === pathBinary
+          ? { ok: false, transient: false, reason: "`codex --version` exited 1: revoked" }
+          : { ok: true, output: "codex 0.146.0-alpha.3" },
+    );
+    const res = await resolveCodexRuntimeBinary(
+      {},
+      { resolveBundled: notFound, findCandidates: () => [pathBinary, desktopBinary], verifyPath },
+    );
+
+    expect(res).toMatchObject({
+      ok: true,
+      runtimeSource: "path",
+      binary: desktopBinary,
+      runtimePath: desktopBinary,
+      version: "0.146.0",
+    });
+    expect(verifyPath.mock.calls.map(([path]) => path)).toEqual([pathBinary, desktopBinary]);
+  });
+
+  it("bundle NOT found → a transient first-candidate flake still falls through to a healthy later path", async () => {
+    const first = "/daemon/bin/codex";
+    const desktop = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const res = await resolveCodexRuntimeBinary(
+      {},
+      {
+        resolveBundled: notFound,
+        findCandidates: () => [first, desktop],
+        verifyPath: (path) =>
+          path === first
+            ? { ok: false, transient: true, reason: "`codex --version` timed out" }
+            : { ok: true, output: "codex 0.146.0" },
+      },
+    );
+    expect(res).toMatchObject({ ok: true, binary: desktop, runtimePath: desktop });
+  });
+
   it("keeps a validated PATH codex available when its version output has no semantic version", async () => {
     const verifyPath = (): CodexExecutableVerification => ({ ok: true, output: "codex dev build" });
     const res = await resolveCodexRuntimeBinary(
@@ -674,7 +718,7 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
     });
   });
 
-  it("bundle NOT found + PATH codex non-transient validation failure → binary-missing", async () => {
+  it("bundle NOT found + PATH codex non-transient validation failure → path-bearing unusable error", async () => {
     const verifyPath = (): CodexExecutableVerification => ({
       ok: false,
       transient: false,
@@ -685,7 +729,12 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
       { resolveBundled: notFound, findOnPath: () => "/usr/local/bin/codex", verifyPath },
     );
     expect(res.ok).toBe(false);
-    if (!res.ok) expect(res.error).toContain("Codex runtime binary is missing");
+    if (!res.ok) {
+      expect(res.error).toContain("binary candidates are installed but unusable");
+      expect(res.error).toContain("/usr/local/bin/codex");
+      expect(res.error).toContain("Upgrade or replace");
+      expect(res.error).not.toContain("binary is missing");
+    }
   });
 
   it("bundle NOT found + PATH codex TRANSIENT validation flake → NOT binary-missing", async () => {
@@ -704,6 +753,35 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
     if (!res.ok) {
       expect(res.error).not.toContain("Codex runtime binary is missing");
       expect(res.error).toContain("transient host condition");
+    }
+  });
+
+  it("bounds repeated identical runtime-resolver failures for forced app-server startup", async () => {
+    const tracker = createCodexAutomaticResolutionFailureTracker();
+    const pathBinary = "/Users/test/.npm-global/bin/codex";
+    const deps = {
+      resolveBundled: notFound,
+      findCandidates: () => [pathBinary],
+      verifyPath: (): CodexExecutableVerification => ({
+        ok: false,
+        transient: true,
+        reason: "`codex --version` killed by SIGKILL",
+      }),
+      failureTracker: tracker,
+    };
+
+    const first = await resolveCodexRuntimeBinary({ FIRST_TREE_CHAT_ID: "chat-app-server-bounded" }, deps);
+    const second = await resolveCodexRuntimeBinary({ FIRST_TREE_CHAT_ID: "chat-app-server-bounded" }, deps);
+    const third = await resolveCodexRuntimeBinary({ FIRST_TREE_CHAT_ID: "chat-app-server-bounded" }, deps);
+    expect(first).toMatchObject({ ok: false, error: expect.stringContaining("transient host condition") });
+    expect(second).toMatchObject({ ok: false, error: expect.stringContaining("transient host condition") });
+    expect(third).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("same automatic-candidate launch result repeated 3 times"),
+    });
+    if (!third.ok) {
+      expect(third.error).toContain(pathBinary);
+      expect(third.error).toContain("Upgrade or replace");
     }
   });
 

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -425,6 +425,7 @@ describe("probeCodexCapability (install-only)", () => {
     const entry = await probeCodexCapability({
       resolveBundled: bundledMissing,
       findOnPath: () => "/usr/local/bin/codex",
+      verifyPath: () => ({ ok: true, output: "codex 0.146.0" }),
       env: {},
     });
     expect(entry).toMatchObject({
@@ -433,6 +434,38 @@ describe("probeCodexCapability (install-only)", () => {
       runtimeSource: "path",
       runtimePath: "/usr/local/bin/codex",
     });
+  });
+
+  it("reports the same healthy later Desktop candidate selected by execution and login", async () => {
+    const staleGlobal = "/Users/test/.npm-global/bin/codex";
+    const desktop = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const candidates = () => [staleGlobal, desktop];
+    const verifyPath = vi.fn(
+      (path: string): CodexExecutableVerification =>
+        path === staleGlobal
+          ? { ok: false, transient: false, reason: "`codex --version` killed by SIGILL" }
+          : { ok: true, output: "codex 0.146.0" },
+    );
+
+    const entry = await probeCodexCapability({
+      resolveBundled: bundledMissing,
+      findCandidates: candidates,
+      verifyPath,
+      env: {},
+    });
+    const runtime = await resolveCodexRuntimeBinary(
+      {},
+      { resolveBundled: bundledMissing, findCandidates: candidates, verifyPath },
+    );
+
+    expect(entry).toMatchObject({
+      state: "ok",
+      available: true,
+      runtimeSource: "path",
+      runtimePath: desktop,
+    });
+    expect(runtime).toMatchObject({ ok: true, binary: desktop, runtimePath: desktop });
+    expect(verifyPath.mock.calls.map(([path]) => path)).toEqual([staleGlobal, desktop, staleGlobal, desktop]);
   });
 
   it("`missing` when neither the bundle nor a PATH codex resolves, with the binary-missing message", async () => {
@@ -753,6 +786,8 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
     if (!res.ok) {
       expect(res.error).not.toContain("Codex runtime binary is missing");
       expect(res.error).toContain("transient host condition");
+      expect(res.cause).toBeInstanceOf(Error);
+      expect(res.cause?.name).toBe("CodexBinaryVerifyTransientError");
     }
   });
 
@@ -782,6 +817,7 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
     if (!third.ok) {
       expect(third.error).toContain(pathBinary);
       expect(third.error).toContain("Upgrade or replace");
+      expect(third.cause?.name).toBe("CodexBinaryUnusableError");
     }
   });
 

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -23,6 +23,7 @@ import type { ClaudeExecutableResolution } from "../providers/claude/executable.
 import {
   type CodexExecutableVerification,
   createCodexAutomaticResolutionFailureTracker,
+  createCodexVerifiedAutomaticCandidateTracker,
 } from "../providers/codex/binary.js";
 import {
   probeCodexCapability,
@@ -422,24 +423,35 @@ describe("probeCodexCapability (install-only)", () => {
   });
 
   it("`ok` (runtimeSource path) when the bundle is missing but a system codex is on PATH", async () => {
-    const entry = await probeCodexCapability({
-      resolveBundled: bundledMissing,
-      findOnPath: () => "/usr/local/bin/codex",
-      verifyPath: () => ({ ok: true, output: "codex 0.146.0" }),
-      env: {},
-    });
-    expect(entry).toMatchObject({
-      state: "ok",
-      available: true,
-      runtimeSource: "path",
-      runtimePath: "/usr/local/bin/codex",
-    });
+    const root = mkdtempSync(join(tmpdir(), "ft-codex-install-only-"));
+    try {
+      const candidate = join(root, "codex");
+      const launchMarker = `${candidate}.launched`;
+      writeFileSync(candidate, '#!/bin/sh\ntouch "$0.launched"\n');
+      chmodSync(candidate, 0o755);
+
+      const entry = await probeCodexCapability({
+        resolveBundled: bundledMissing,
+        findOnPath: () => candidate,
+        env: {},
+      });
+      expect(entry).toMatchObject({
+        state: "ok",
+        available: true,
+        runtimeSource: "path",
+      });
+      expect(entry).not.toHaveProperty("runtimePath");
+      expect(existsSync(launchMarker)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
-  it("reports the same healthy later Desktop candidate selected by execution and login", async () => {
+  it("never launch-verifies during probing and later reports the runtime-verified Desktop candidate", async () => {
     const staleGlobal = "/Users/test/.npm-global/bin/codex";
     const desktop = "/Applications/ChatGPT.app/Contents/Resources/codex";
     const candidates = () => [staleGlobal, desktop];
+    const verifiedCandidateTracker = createCodexVerifiedAutomaticCandidateTracker();
     const verifyPath = vi.fn(
       (path: string): CodexExecutableVerification =>
         path === staleGlobal
@@ -447,25 +459,40 @@ describe("probeCodexCapability (install-only)", () => {
           : { ok: true, output: "codex 0.146.0" },
     );
 
-    const entry = await probeCodexCapability({
+    const beforeRuntime = await probeCodexCapability({
       resolveBundled: bundledMissing,
       findCandidates: candidates,
-      verifyPath,
+      verifiedCandidateTracker,
       env: {},
     });
+    expect(beforeRuntime).toMatchObject({ state: "ok", available: true, runtimeSource: "path" });
+    expect(beforeRuntime).not.toHaveProperty("runtimePath");
+    expect(verifyPath).not.toHaveBeenCalled();
+
     const runtime = await resolveCodexRuntimeBinary(
       {},
-      { resolveBundled: bundledMissing, findCandidates: candidates, verifyPath },
+      {
+        resolveBundled: bundledMissing,
+        findCandidates: candidates,
+        verifyPath,
+        verifiedCandidateTracker,
+      },
     );
+    const afterRuntime = await probeCodexCapability({
+      resolveBundled: bundledMissing,
+      findCandidates: candidates,
+      verifiedCandidateTracker,
+      env: {},
+    });
 
-    expect(entry).toMatchObject({
+    expect(afterRuntime).toMatchObject({
       state: "ok",
       available: true,
       runtimeSource: "path",
       runtimePath: desktop,
     });
     expect(runtime).toMatchObject({ ok: true, binary: desktop, runtimePath: desktop });
-    expect(verifyPath.mock.calls.map(([path]) => path)).toEqual([staleGlobal, desktop, staleGlobal, desktop]);
+    expect(verifyPath.mock.calls.map(([path]) => path)).toEqual([staleGlobal, desktop]);
   });
 
   it("`missing` when neither the bundle nor a PATH codex resolves, with the binary-missing message", async () => {

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -818,6 +818,38 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
     }
   });
 
+  it("clears a rejected verified path even when a later candidate keeps the aggregate result transient", async () => {
+    const staleGlobal = "/Users/test/.npm-global/bin/codex";
+    const desktop = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const verifiedCandidateTracker = createCodexVerifiedAutomaticCandidateTracker();
+    verifiedCandidateTracker.record(staleGlobal);
+    const candidates = () => [staleGlobal, desktop];
+
+    const resolution = await resolveCodexRuntimeBinary(
+      { FIRST_TREE_CHAT_ID: "chat-runtime-mixed-rejection" },
+      {
+        resolveBundled: notFound,
+        findCandidates: candidates,
+        verifyPath: (path) =>
+          path === staleGlobal
+            ? { ok: false, transient: false, reason: "revoked binary" }
+            : { ok: false, transient: true, reason: "Desktop cold-start timeout" },
+        verifiedCandidateTracker,
+      },
+    );
+    const capability = await probeCodexCapability({
+      resolveBundled: notFound,
+      findCandidates: candidates,
+      verifiedCandidateTracker,
+      env: {},
+    });
+
+    expect(resolution).toMatchObject({ ok: false, cause: { name: "CodexBinaryVerifyTransientError" } });
+    expect(verifiedCandidateTracker.get()).toBeNull();
+    expect(capability).toMatchObject({ state: "ok", available: true, runtimeSource: "path" });
+    expect(capability).not.toHaveProperty("runtimePath");
+  });
+
   it("bounds repeated identical runtime-resolver failures for forced app-server startup", async () => {
     const tracker = createCodexAutomaticResolutionFailureTracker();
     const pathBinary = "/Users/test/.npm-global/bin/codex";

--- a/packages/client/src/__tests__/error-taxonomy.test.ts
+++ b/packages/client/src/__tests__/error-taxonomy.test.ts
@@ -167,6 +167,26 @@ describe("error-taxonomy.classify", () => {
       expect(c.strategy.kind).toBe("exponentialBackoff");
     });
 
+    it("a bounded all-candidate Codex launch failure is permanent and distinct from missing", () => {
+      const err = new Error(
+        "Codex runtime binary candidates are installed but unusable. Checked: `/Users/test/.npm-global/bin/codex`.",
+      );
+      err.name = "CodexBinaryUnusableError";
+      const c = classify(err, { source: "session" });
+      expect(c.kind).toBe(ERROR_KINDS.PERMANENT);
+      expect(c.reasonCode).toBe("codex_binary_unusable");
+      expect(c.strategy.kind).toBe("none");
+
+      const wrapped = classify(new Error(`codex app-server startup failed at resolve-binary: ${err.message}`), {
+        source: "session",
+      });
+      expect(wrapped).toMatchObject({
+        kind: ERROR_KINDS.PERMANENT,
+        reasonCode: "codex_binary_unusable",
+        strategy: { kind: "none" },
+      });
+    });
+
     it("same-provider verify-transient still wins over that provider's missing patterns", () => {
       // Cursor verify name + Cursor missing text: verify is checked first for
       // Cursor, so the busy-host flake stays transient (not permanent missing).

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -232,6 +232,34 @@ describe("classifyProviderFailure", () => {
     ).toMatchObject({ action: "retry" });
   });
 
+  it("a bounded all-candidate Codex launch failure stops as a user-actionable capability error", () => {
+    const err = new Error(
+      "Codex runtime binary candidates are installed but unusable. Checked: `/Users/test/.npm-global/bin/codex` (`codex --version` killed by SIGKILL). Upgrade or replace the failing Codex installation.",
+    );
+    err.name = "CodexBinaryUnusableError";
+    const classification = classifyProviderFailure(err, {
+      provider: "codex",
+      scope: "session_start",
+      source: "session",
+    });
+    expect(classification).toMatchObject({
+      category: "capability",
+      reasonCode: "codex_binary_unusable",
+    });
+    expect(
+      decideProviderRetry({
+        classification,
+        scope: "session_start",
+        attempt: 3,
+        replaySafety: "pre_provider",
+      }),
+    ).toMatchObject({
+      action: "stop",
+      reasonCode: "codex_binary_unusable",
+      terminalKind: "needs_operator",
+    });
+  });
+
   it("classifies Grok Build logged-out phrasings as credential, grok-gated", () => {
     for (const message of [
       "Error: not logged in. Run `grok login` to authenticate.",

--- a/packages/client/src/__tests__/session-manager-retry.test.ts
+++ b/packages/client/src/__tests__/session-manager-retry.test.ts
@@ -9,6 +9,10 @@ import {
 } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
 import { type FirstTreeHubSDK, SdkError } from "../cloud/sdk.js";
+import {
+  createCodexAutomaticResolutionFailureTracker,
+  createCodexClientWithBinaryFallback,
+} from "../providers/codex/binary.js";
 import type { ContextSource } from "../runtime/context-source.js";
 import type {
   AgentHandler,
@@ -119,6 +123,70 @@ describe("SessionRuntime: transient session retry", () => {
     expect(sm.totalCount).toBe(1);
 
     await sm.shutdown();
+  });
+
+  it("bounds identical Codex candidate launch failures and stops scheduling provider retries", async () => {
+    vi.useFakeTimers();
+    try {
+      const tracker = createCodexAutomaticResolutionFailureTracker();
+      const candidate = "/Users/test/.npm-global/bin/codex";
+      const boundedHandler = (): AgentHandler => ({
+        start: vi.fn(async () => {
+          createCodexClientWithBinaryFallback(
+            { env: { FIRST_TREE_CHAT_ID: "chat-codex-bounded" } },
+            () => {
+              throw new Error("Unable to locate Codex CLI binaries");
+            },
+            {
+              resolveCandidates: () => [candidate],
+              verifyPath: () => ({
+                ok: false,
+                transient: true,
+                reason: "`codex --version` killed by SIGKILL",
+              }),
+              failureTracker: tracker,
+            },
+          );
+          throw new Error("unreachable");
+        }),
+        resume: vi.fn(),
+        inject: vi.fn(),
+        suspend: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      });
+      const events: SessionEvent[] = [];
+      const sm = makeRuntime({
+        handlers: [boundedHandler(), boundedHandler(), boundedHandler()],
+        onSessionEvent: (_chatId, event) => events.push(event),
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-codex-bounded" }));
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      const retryEvents = events
+        .filter((event): event is Extract<SessionEvent, { kind: "error" }> => event.kind === "error")
+        .map((event) => parseProviderRetryEventMessage(event.payload.message))
+        .filter((event) => event !== null);
+      expect(retryEvents.filter((event) => event.event === "provider_retry_scheduled")).toHaveLength(2);
+      expect(retryEvents).toContainEqual(
+        expect.objectContaining({
+          event: "provider_failure_terminal",
+          category: "capability",
+          reasonCode: "codex_binary_unusable",
+          scope: "session_start",
+        }),
+      );
+      expect(retryEvents.some((event) => event.event === "provider_retry_exhausted")).toBe(false);
+      expect(sm.totalCount).toBe(0);
+
+      const eventCount = events.length;
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(events).toHaveLength(eventCount);
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("permanent error still removes the entry (legacy F2 path)", async () => {

--- a/packages/client/src/__tests__/session-manager-retry.test.ts
+++ b/packages/client/src/__tests__/session-manager-retry.test.ts
@@ -9,7 +9,9 @@ import {
 } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
 import { type FirstTreeHubSDK, SdkError } from "../cloud/sdk.js";
+import { CodexAppServerStartupError } from "../providers/codex/app-server/index.js";
 import {
+  CodexBinaryVerifyTransientError,
   createCodexAutomaticResolutionFailureTracker,
   createCodexClientWithBinaryFallback,
 } from "../providers/codex/binary.js";
@@ -183,6 +185,55 @@ describe("SessionRuntime: transient session retry", () => {
       const eventCount = events.length;
       await vi.advanceTimersByTimeAsync(120_000);
       expect(events).toHaveLength(eventCount);
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps non-identical forced app-server binary smoke failures on the Codex transient schedule", async () => {
+    vi.useFakeTimers();
+    try {
+      const transientAppServerHandler = (detail: string): AgentHandler => ({
+        start: vi
+          .fn()
+          .mockRejectedValue(
+            new CodexAppServerStartupError("resolve-binary", new CodexBinaryVerifyTransientError(detail)),
+          ),
+        resume: vi.fn(),
+        inject: vi.fn(),
+        suspend: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      });
+      const events: SessionEvent[] = [];
+      const sm = makeRuntime({
+        handlers: [
+          transientAppServerHandler("candidate A timed out"),
+          transientAppServerHandler("candidate A was killed by SIGKILL"),
+          transientAppServerHandler("candidate B timed out"),
+          transientAppServerHandler("candidate B was killed by SIGTERM"),
+        ],
+        onSessionEvent: (_chatId, event) => events.push(event),
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-app-server-varying-transient" }));
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(4_000);
+
+      const retryEvents = events
+        .filter((event): event is Extract<SessionEvent, { kind: "error" }> => event.kind === "error")
+        .map((event) => parseProviderRetryEventMessage(event.payload.message))
+        .filter((event) => event !== null);
+      const scheduled = retryEvents.filter((event) => event.event === "provider_retry_scheduled");
+      expect(scheduled).toHaveLength(4);
+      expect(scheduled.every((event) => event.category === "transient_transport")).toBe(true);
+      expect(scheduled.every((event) => event.reasonCode === "codex_verify_transient")).toBe(true);
+      expect(scheduled.at(-1)).toMatchObject({ attempt: 4, retryMode: "background" });
+      expect(retryEvents.some((event) => event.event === "provider_retry_exhausted")).toBe(false);
+      expect(retryEvents.some((event) => event.event === "provider_failure_terminal")).toBe(false);
+      expect(sm.totalCount).toBe(1);
+
       await sm.shutdown();
     } finally {
       vi.useRealTimers();

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -63,6 +63,7 @@ export {
   resolveClaudeLoginInvocation,
   runClaudeBrowserLogin,
 } from "./providers/claude/login.js";
+export { onCodexVerifiedAutomaticCandidateChange } from "./providers/codex/binary.js";
 export {
   type CodexBinaryResolution,
   probeCodexCapability,

--- a/packages/client/src/providers/capabilities/detect.ts
+++ b/packages/client/src/providers/capabilities/detect.ts
@@ -37,7 +37,7 @@ export type DetectOutcome =
       version?: string | null;
       /** Which artifact backs the runtime (bundled binary vs external path). */
       runtimeSource?: CapabilityRuntimeSource;
-      /** Absolute path of the resolved binary, when `runtimeSource: "path"`. */
+      /** Last runtime-verified external path, when one is known and still discoverable. */
       runtimePath?: string | null;
     }
   | { installed: false; error: string };

--- a/packages/client/src/providers/codex/__tests__/app-server/extra-coverage.test.ts
+++ b/packages/client/src/providers/codex/__tests__/app-server/extra-coverage.test.ts
@@ -11,6 +11,7 @@ import type { AgentConfigCache } from "../../../../runtime/agent-config-cache.js
 import { setCliBinding } from "../../../../runtime/cli-binding.js";
 import type { DeliveryToken, SessionContext, SessionMessage } from "../../../../runtime/handler.js";
 import { noopDeliveryToken } from "../../../../runtime/handler.js";
+import { classifyProviderFailure } from "../../../../runtime/provider-retry-policy.js";
 import {
   CodexAppServerClient,
   type CodexAppServerClientOptions,
@@ -25,6 +26,7 @@ import {
   createWorkspaceOnlySpawnProcess,
   landingCodexDenyPaths,
 } from "../../app-server/workspace-sandbox.js";
+import { CodexBinaryVerifyTransientError } from "../../binary.js";
 
 vi.mock("../../../../runtime/bootstrap.js", () => ({
   FIRST_TREE_RUNTIME_DIR: ".first-tree-workspace",
@@ -578,14 +580,31 @@ describe("codex app-server handler extra branches", () => {
       message: expect.stringContaining("resolver exploded"),
     });
 
+    const transientCause = new CodexBinaryVerifyTransientError("candidate A timed out");
     const resolveFailure = makeHandler(new FakeAppServerClient(), {
-      codexRuntimeBinaryResolver: async () => ({ ok: false, error: "missing codex binary" }),
+      codexRuntimeBinaryResolver: async () => ({
+        ok: false,
+        error: transientCause.message,
+        cause: transientCause,
+      }),
     });
-    await expect(
-      resolveFailure.start(makeMessage("m1", "first"), makeContext(), noopDeliveryToken()),
-    ).rejects.toMatchObject({
+    const resolveFailureError = await resolveFailure
+      .start(makeMessage("m1", "first"), makeContext(), noopDeliveryToken())
+      .catch((err) => err);
+    expect(resolveFailureError).toMatchObject({
       stage: "resolve-binary",
-      message: expect.stringContaining("missing codex binary"),
+      message: expect.stringContaining("candidate A timed out"),
+      cause: transientCause,
+    });
+    expect(
+      classifyProviderFailure(resolveFailureError, {
+        provider: "codex",
+        scope: "session_start",
+        source: "session",
+      }),
+    ).toMatchObject({
+      category: "transient_transport",
+      reasonCode: "codex_verify_transient",
     });
 
     const initializeFailure = makeHandler(new FakeAppServerClient(), {

--- a/packages/client/src/providers/codex/__tests__/binary.test.ts
+++ b/packages/client/src/providers/codex/__tests__/binary.test.ts
@@ -162,6 +162,31 @@ describe("codex binary resolution", () => {
     expect(verifyPath.mock.calls.map(([path]) => path)).toEqual([first, desktop]);
   });
 
+  it("forgets a previously verified SDK fallback path when that path is deterministically rejected", () => {
+    const staleGlobal = "/Users/test/.npm-global/bin/codex";
+    const desktop = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const verifiedCandidateTracker = createCodexVerifiedAutomaticCandidateTracker();
+    verifiedCandidateTracker.record(staleGlobal);
+
+    expect(() =>
+      createCodexClientWithBinaryFallback(
+        { env: { FIRST_TREE_CHAT_ID: "chat-mixed-rejection" } },
+        () => {
+          throw new Error("Unable to locate Codex CLI binaries");
+        },
+        {
+          resolveCandidates: () => [staleGlobal, desktop],
+          verifyPath: (path) =>
+            path === staleGlobal
+              ? { ok: false, transient: false, reason: "revoked binary" }
+              : { ok: false, transient: true, reason: "Desktop cold-start timeout" },
+          verifiedCandidateTracker,
+        },
+      ),
+    ).toThrow(CodexBinaryVerifyTransientError);
+    expect(verifiedCandidateTracker.get()).toBeNull();
+  });
+
   it("bounds repeated identical all-candidate transient failures with an actionable terminal error", () => {
     const tracker = createCodexAutomaticResolutionFailureTracker();
     const first = "/Users/test/.npm-global/bin/codex";

--- a/packages/client/src/providers/codex/__tests__/binary.test.ts
+++ b/packages/client/src/providers/codex/__tests__/binary.test.ts
@@ -3,9 +3,12 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  CodexBinaryUnusableError,
   CodexBinaryVerifyTransientError,
+  createCodexAutomaticResolutionFailureTracker,
   createCodexClientWithBinaryFallback,
   type FindCodexExecutableDeps,
+  findCodexExecutableCandidates,
   findCodexExecutableOnPath,
   formatCodexBinaryMissingMessage,
   isCodexBinaryMissingError,
@@ -63,8 +66,9 @@ describe("codex binary resolution", () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining("falling back to codex"));
   });
 
-  it("does not fall back to a PATH codex executable that cannot start", () => {
-    expect(() =>
+  it("reports a deterministically broken automatic candidate as unusable", () => {
+    let thrown: unknown;
+    try {
       createCodexClientWithBinaryFallback(
         { env: { PATH: "/usr/local/bin" } },
         () => {
@@ -74,8 +78,120 @@ describe("codex binary resolution", () => {
           resolvePath: () => "/usr/local/bin/codex",
           verifyPath: () => ({ ok: false, transient: false, reason: "`codex --version` exited 1: broken shim" }),
         },
-      ),
-    ).toThrow(/Resolved codex failed validation: `codex --version` exited 1: broken shim/);
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(CodexBinaryUnusableError);
+    expect((thrown as Error).message).toContain("/usr/local/bin/codex");
+    expect((thrown as Error).message).toContain("broken shim");
+    expect((thrown as Error).message).toContain("npm install -g @openai/codex");
+  });
+
+  it("launch-verifies automatic candidates in priority order and reaches ChatGPT Desktop", () => {
+    tmp = mkdtempSync(join(tmpdir(), "ft-codex-ordered-fallback-"));
+    const daemonDir = join(tmp, "daemon-bin");
+    const wellKnownDir = join(tmp, "well-known-bin");
+    const loginDir = join(tmp, "login-bin");
+    const desktopDir = join(tmp, "ChatGPT.app", "Contents", "Resources");
+    for (const dir of [daemonDir, wellKnownDir, loginDir, desktopDir]) mkdirSync(dir, { recursive: true });
+    const candidates = [daemonDir, wellKnownDir, loginDir, desktopDir].map((dir) => join(dir, "codex"));
+    for (const candidate of candidates) {
+      writeFileSync(candidate, "#!/bin/sh\nexit 0\n");
+      chmodSync(candidate, 0o755);
+    }
+    const loginShellPathDirs = vi.fn(() => [loginDir]);
+    const desktopAppDirs = vi.fn(() => [desktopDir]);
+    const verifyPath = vi.fn((path: string) =>
+      path === candidates[3]
+        ? ({ ok: true as const, output: "codex 0.146.0-alpha.3" } as const)
+        : ({ ok: false as const, transient: false, reason: "candidate cannot launch" } as const),
+    );
+
+    const result = createCodexClientWithBinaryFallback(
+      { env: { PATH: daemonDir, HOME: tmp, FIRST_TREE_CHAT_ID: "chat-desktop-fallback" } },
+      (options) => {
+        if (!("codexPathOverride" in options) || typeof options.codexPathOverride !== "string") {
+          throw new Error("Unable to locate Codex CLI binaries for x86_64-apple-darwin");
+        }
+        return options;
+      },
+      {
+        resolveCandidates: (env) =>
+          findCodexExecutableCandidates(env, {
+            platform: "linux",
+            pathDelimiter: delimiter,
+            wellKnownDirs: () => [wellKnownDir],
+            loginShellPathDirs,
+            desktopAppDirs,
+          }),
+        verifyPath,
+      },
+    );
+
+    expect(result.codexPathOverride).toBe(candidates[3]);
+    expect(verifyPath.mock.calls.map(([path]) => path)).toEqual(candidates);
+    expect(loginShellPathDirs).toHaveBeenCalledTimes(1);
+    expect(desktopAppDirs).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through a transient first-candidate smoke flake when a later Desktop candidate is healthy", () => {
+    const first = "/daemon/path/codex";
+    const desktop = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const verifyPath = vi.fn((path: string) =>
+      path === first
+        ? ({ ok: false as const, transient: true, reason: "`codex --version` killed by SIGKILL" } as const)
+        : ({ ok: true as const, output: "codex 0.146.0-alpha.3" } as const),
+    );
+    const result = createCodexClientWithBinaryFallback(
+      { env: { FIRST_TREE_CHAT_ID: "chat-transient-fallback" } },
+      (options) => {
+        if (!("codexPathOverride" in options) || typeof options.codexPathOverride !== "string") {
+          throw new Error("Unable to locate Codex CLI binaries");
+        }
+        return options;
+      },
+      { resolveCandidates: () => [first, desktop], verifyPath },
+    );
+
+    expect(result.codexPathOverride).toBe(desktop);
+    expect(verifyPath.mock.calls.map(([path]) => path)).toEqual([first, desktop]);
+  });
+
+  it("bounds repeated identical all-candidate transient failures with an actionable terminal error", () => {
+    const tracker = createCodexAutomaticResolutionFailureTracker();
+    const first = "/Users/test/.npm-global/bin/codex";
+    const desktop = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const attempt = () =>
+      createCodexClientWithBinaryFallback(
+        { env: { FIRST_TREE_CHAT_ID: "chat-bounded" } },
+        () => {
+          throw new Error("Unable to locate Codex CLI binaries");
+        },
+        {
+          resolveCandidates: () => [first, desktop],
+          verifyPath: (path) => ({
+            ok: false,
+            transient: true,
+            reason: path === first ? "`codex --version` killed by SIGKILL" : "`codex --version` timed out",
+          }),
+          failureTracker: tracker,
+        },
+      );
+
+    expect(attempt).toThrow(CodexBinaryVerifyTransientError);
+    expect(attempt).toThrow(CodexBinaryVerifyTransientError);
+    let terminal: unknown;
+    try {
+      attempt();
+    } catch (err) {
+      terminal = err;
+    }
+    expect(terminal).toBeInstanceOf(CodexBinaryUnusableError);
+    expect((terminal as Error).message).toContain("repeated 3 times");
+    expect((terminal as Error).message).toContain(first);
+    expect((terminal as Error).message).toContain(desktop);
+    expect((terminal as Error).message).toContain("Upgrade or replace");
   });
 
   it("treats a transient PATH-codex verify flake as retryable, NOT a missing binary", () => {
@@ -125,6 +241,20 @@ describe("codex binary resolution", () => {
         { resolvePath: () => "/usr/local/bin/codex" },
       ),
     ).toThrow("config exploded");
+  });
+
+  it("never replaces an explicit codexPathOverride with an automatic candidate", () => {
+    const resolveCandidates = vi.fn(() => ["/automatic/codex"]);
+    expect(() =>
+      createCodexClientWithBinaryFallback(
+        { codexPathOverride: "/configured/codex" },
+        () => {
+          throw new Error("Unable to locate Codex CLI binaries at configured override");
+        },
+        { resolveCandidates },
+      ),
+    ).toThrow("configured override");
+    expect(resolveCandidates).not.toHaveBeenCalled();
   });
 
   it("finds an executable codex on PATH", () => {

--- a/packages/client/src/providers/codex/__tests__/binary.test.ts
+++ b/packages/client/src/providers/codex/__tests__/binary.test.ts
@@ -192,6 +192,12 @@ describe("codex binary resolution", () => {
     expect((terminal as Error).message).toContain(first);
     expect((terminal as Error).message).toContain(desktop);
     expect((terminal as Error).message).toContain("Upgrade or replace");
+
+    // The terminal settlement closes that sequence. A later user-initiated
+    // retry for the same chat gets a fresh initial attempt plus two retries.
+    expect(attempt).toThrow(CodexBinaryVerifyTransientError);
+    expect(attempt).toThrow(CodexBinaryVerifyTransientError);
+    expect(attempt).toThrow(CodexBinaryUnusableError);
   });
 
   it("treats a transient PATH-codex verify flake as retryable, NOT a missing binary", () => {

--- a/packages/client/src/providers/codex/__tests__/binary.test.ts
+++ b/packages/client/src/providers/codex/__tests__/binary.test.ts
@@ -7,6 +7,7 @@ import {
   CodexBinaryVerifyTransientError,
   createCodexAutomaticResolutionFailureTracker,
   createCodexClientWithBinaryFallback,
+  createCodexVerifiedAutomaticCandidateTracker,
   type FindCodexExecutableDeps,
   findCodexExecutableCandidates,
   findCodexExecutableOnPath,
@@ -107,6 +108,7 @@ describe("codex binary resolution", () => {
         ? ({ ok: true as const, output: "codex 0.146.0-alpha.3" } as const)
         : ({ ok: false as const, transient: false, reason: "candidate cannot launch" } as const),
     );
+    const verifiedCandidateTracker = createCodexVerifiedAutomaticCandidateTracker();
 
     const result = createCodexClientWithBinaryFallback(
       { env: { PATH: daemonDir, HOME: tmp, FIRST_TREE_CHAT_ID: "chat-desktop-fallback" } },
@@ -126,10 +128,12 @@ describe("codex binary resolution", () => {
             desktopAppDirs,
           }),
         verifyPath,
+        verifiedCandidateTracker,
       },
     );
 
     expect(result.codexPathOverride).toBe(candidates[3]);
+    expect(verifiedCandidateTracker.get()).toBe(candidates[3]);
     expect(verifyPath.mock.calls.map(([path]) => path)).toEqual(candidates);
     expect(loginShellPathDirs).toHaveBeenCalledTimes(1);
     expect(desktopAppDirs).toHaveBeenCalledTimes(1);

--- a/packages/client/src/providers/codex/app-server/index.ts
+++ b/packages/client/src/providers/codex/app-server/index.ts
@@ -176,7 +176,9 @@ export class CodexAppServerStartupError extends Error {
   readonly stage: string;
 
   constructor(stage: string, cause: unknown) {
-    super(`codex app-server startup failed at ${stage}: ${cause instanceof Error ? cause.message : String(cause)}`);
+    super(`codex app-server startup failed at ${stage}: ${cause instanceof Error ? cause.message : String(cause)}`, {
+      cause,
+    });
     this.name = "CodexAppServerStartupError";
     this.stage = stage;
   }
@@ -472,7 +474,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     } catch (err) {
       throw new CodexAppServerStartupError("resolve-binary", err);
     }
-    if (!resolution.ok) throw new CodexAppServerStartupError("resolve-binary", resolution.error);
+    if (!resolution.ok) throw new CodexAppServerStartupError("resolve-binary", resolution.cause ?? resolution.error);
     try {
       const appServerArgs =
         workspaceOnly && workspaceOnlyCodexHome && workspaceOnlyHostHome

--- a/packages/client/src/providers/codex/binary.ts
+++ b/packages/client/src/providers/codex/binary.ts
@@ -31,6 +31,7 @@ export type CodexBinaryFallbackDeps = {
   resolvePath?: (env?: Record<string, string>) => string | null;
   verifyPath?: (path: string, env?: Record<string, string | undefined>) => CodexExecutableVerification;
   failureTracker?: CodexAutomaticResolutionFailureTracker;
+  verifiedCandidateTracker?: CodexVerifiedAutomaticCandidateTracker;
   log?: (message: string) => void;
 };
 
@@ -58,7 +59,13 @@ export type CodexAutomaticResolutionFailureTracker = {
   reset(scope: string): void;
 };
 
-export type CodexAutomaticFailureBoundary = "probe" | "runtime" | "sdk";
+export type CodexVerifiedAutomaticCandidateTracker = {
+  get(): string | null;
+  record(path: string): void;
+  reset(): void;
+};
+
+export type CodexAutomaticFailureBoundary = "runtime" | "sdk";
 
 /**
  * `codex --version` smoke-check ceiling. A cold `codex` behind a version-manager
@@ -114,6 +121,21 @@ export function createCodexAutomaticResolutionFailureTracker(): CodexAutomaticRe
 }
 
 const defaultAutomaticResolutionFailureTracker = createCodexAutomaticResolutionFailureTracker();
+
+export function createCodexVerifiedAutomaticCandidateTracker(): CodexVerifiedAutomaticCandidateTracker {
+  let path: string | null = null;
+  return {
+    get: () => path,
+    record(nextPath: string): void {
+      path = nextPath;
+    },
+    reset(): void {
+      path = null;
+    },
+  };
+}
+
+export const codexVerifiedAutomaticCandidateTracker = createCodexVerifiedAutomaticCandidateTracker();
 
 const WINDOWS_CODEX_PLATFORM_PACKAGE_BY_ARCH: Readonly<Record<string, { triple: string; packageName: string }>> = {
   x64: { triple: "x86_64-pc-windows-msvc", packageName: "@openai/codex-win32-x64" },
@@ -242,8 +264,11 @@ export function createCodexClientWithBinaryFallback<TOptions extends CodexOption
   construct: (options: TOptions) => TClient,
   deps: CodexBinaryFallbackDeps = {},
 ): CodexBinaryFallbackResult<TClient> {
+  const verifiedCandidateTracker = deps.verifiedCandidateTracker ?? codexVerifiedAutomaticCandidateTracker;
   try {
-    return { client: construct(options), runtimeSource: "bundled" };
+    const client = construct(options);
+    verifiedCandidateTracker.reset();
+    return { client, runtimeSource: "bundled" };
   } catch (err) {
     if (!isCodexBinaryMissingError(err)) throw err;
 
@@ -262,16 +287,19 @@ export function createCodexClientWithBinaryFallback<TOptions extends CodexOption
     });
     if (!resolved.ok && resolved.failures.length === 0) {
       resetCodexAutomaticCandidateFailures(options.env ?? process.env, "sdk", deps.failureTracker);
+      verifiedCandidateTracker.reset();
       throw new Error(formatCodexBinaryMissingMessage(err));
     }
 
     if (!resolved.ok) {
-      throw codexAutomaticCandidateFailureError(
+      const failure = codexAutomaticCandidateFailureError(
         resolved.failures,
         options.env ?? process.env,
         "sdk",
         deps.failureTracker,
       );
+      if (failure instanceof CodexBinaryUnusableError) verifiedCandidateTracker.reset();
+      throw failure;
     }
 
     resetCodexAutomaticCandidateFailures(options.env ?? process.env, "sdk", deps.failureTracker);
@@ -279,8 +307,10 @@ export function createCodexClientWithBinaryFallback<TOptions extends CodexOption
       `Codex SDK bundled binary missing; falling back to codex at ${resolved.path}. ` +
         `Original error: ${errorText(err)}`,
     );
+    const client = construct({ ...options, codexPathOverride: resolved.path });
+    verifiedCandidateTracker.record(resolved.path);
     return {
-      client: construct({ ...options, codexPathOverride: resolved.path }),
+      client,
       runtimeSource: "path",
       codexPathOverride: resolved.path,
       fallbackReason: errorText(err),

--- a/packages/client/src/providers/codex/binary.ts
+++ b/packages/client/src/providers/codex/binary.ts
@@ -58,7 +58,7 @@ export type CodexAutomaticResolutionFailureTracker = {
   reset(scope: string): void;
 };
 
-export type CodexAutomaticFailureBoundary = "runtime" | "sdk";
+export type CodexAutomaticFailureBoundary = "probe" | "runtime" | "sdk";
 
 /**
  * `codex --version` smoke-check ceiling. A cold `codex` behind a version-manager
@@ -194,8 +194,13 @@ export function codexAutomaticCandidateFailureError(
     if (identicalAttempts < CODEX_IDENTICAL_AUTOMATIC_FAILURE_LIMIT) {
       return new CodexBinaryVerifyTransientError(formatCandidateFailureDetails(failures));
     }
+    // A terminal result ends this retry sequence. A later explicit user retry
+    // for the same chat must receive a fresh initial attempt plus two retries,
+    // and completed chat scopes must not remain in the process-global map.
+    failureTracker.reset(failureScope);
     return new CodexBinaryUnusableError(formatCodexBinaryUnusableMessage(failures, identicalAttempts));
   }
+  failureTracker.reset(failureScope);
   return new CodexBinaryUnusableError(formatCodexBinaryUnusableMessage(failures));
 }
 

--- a/packages/client/src/providers/codex/binary.ts
+++ b/packages/client/src/providers/codex/binary.ts
@@ -63,6 +63,7 @@ export type CodexVerifiedAutomaticCandidateTracker = {
   get(): string | null;
   record(path: string): void;
   reset(): void;
+  subscribe(listener: () => void): () => void;
 };
 
 export type CodexAutomaticFailureBoundary = "runtime" | "sdk";
@@ -124,18 +125,49 @@ const defaultAutomaticResolutionFailureTracker = createCodexAutomaticResolutionF
 
 export function createCodexVerifiedAutomaticCandidateTracker(): CodexVerifiedAutomaticCandidateTracker {
   let path: string | null = null;
+  const listeners = new Set<() => void>();
+  const notify = (): void => {
+    for (const listener of listeners) {
+      try {
+        listener();
+      } catch {
+        // Runtime selection must not fail because a diagnostic publisher did.
+      }
+    }
+  };
   return {
     get: () => path,
     record(nextPath: string): void {
+      if (path === nextPath) return;
       path = nextPath;
+      notify();
     },
     reset(): void {
+      if (path === null) return;
       path = null;
+      notify();
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
     },
   };
 }
 
 export const codexVerifiedAutomaticCandidateTracker = createCodexVerifiedAutomaticCandidateTracker();
+
+export function onCodexVerifiedAutomaticCandidateChange(listener: () => void): () => void {
+  return codexVerifiedAutomaticCandidateTracker.subscribe(listener);
+}
+
+export function resetCodexVerifiedAutomaticCandidateIfRejected(
+  failures: readonly CodexAutomaticCandidateFailure[],
+  tracker: CodexVerifiedAutomaticCandidateTracker = codexVerifiedAutomaticCandidateTracker,
+): void {
+  const verifiedPath = tracker.get();
+  if (!verifiedPath) return;
+  if (failures.some((failure) => failure.path === verifiedPath && !failure.transient)) tracker.reset();
+}
 
 const WINDOWS_CODEX_PLATFORM_PACKAGE_BY_ARCH: Readonly<Record<string, { triple: string; packageName: string }>> = {
   x64: { triple: "x86_64-pc-windows-msvc", packageName: "@openai/codex-win32-x64" },
@@ -292,6 +324,7 @@ export function createCodexClientWithBinaryFallback<TOptions extends CodexOption
     }
 
     if (!resolved.ok) {
+      resetCodexVerifiedAutomaticCandidateIfRejected(resolved.failures, verifiedCandidateTracker);
       const failure = codexAutomaticCandidateFailureError(
         resolved.failures,
         options.env ?? process.env,

--- a/packages/client/src/providers/codex/binary.ts
+++ b/packages/client/src/providers/codex/binary.ts
@@ -26,14 +26,39 @@ export type CodexOptionsLike = {
 };
 
 export type CodexBinaryFallbackDeps = {
+  resolveCandidates?: (env?: Record<string, string>) => Iterable<string>;
+  /** Legacy single-candidate seam. Prefer resolveCandidates for new tests. */
   resolvePath?: (env?: Record<string, string>) => string | null;
   verifyPath?: (path: string, env?: Record<string, string | undefined>) => CodexExecutableVerification;
+  failureTracker?: CodexAutomaticResolutionFailureTracker;
   log?: (message: string) => void;
 };
 
 export type CodexExecutableVerification =
   | { ok: true; output?: string }
   | { ok: false; reason: string; transient: boolean };
+
+export type CodexAutomaticCandidateFailure = {
+  path: string;
+  reason: string;
+  transient: boolean;
+};
+
+export type CodexVerifiedAutomaticCandidate =
+  | {
+      ok: true;
+      path: string;
+      verification: Extract<CodexExecutableVerification, { ok: true }>;
+      failures: readonly CodexAutomaticCandidateFailure[];
+    }
+  | { ok: false; failures: readonly CodexAutomaticCandidateFailure[] };
+
+export type CodexAutomaticResolutionFailureTracker = {
+  record(scope: string, fingerprint: string): number;
+  reset(scope: string): void;
+};
+
+export type CodexAutomaticFailureBoundary = "runtime" | "sdk";
 
 /**
  * `codex --version` smoke-check ceiling. A cold `codex` behind a version-manager
@@ -70,6 +95,26 @@ const DETERMINISTIC_CRASH_SIGNALS: ReadonlySet<NodeJS.Signals> = new Set([
   "SIGFPE",
 ]);
 
+/** Initial attempt plus two retries preserves cold-start recovery without an infinite schedule. */
+const CODEX_IDENTICAL_AUTOMATIC_FAILURE_LIMIT = 3;
+
+export function createCodexAutomaticResolutionFailureTracker(): CodexAutomaticResolutionFailureTracker {
+  const failuresByScope = new Map<string, { fingerprint: string; count: number }>();
+  return {
+    record(scope: string, fingerprint: string): number {
+      const previous = failuresByScope.get(scope);
+      const next = previous?.fingerprint === fingerprint ? previous.count + 1 : 1;
+      failuresByScope.set(scope, { fingerprint, count: next });
+      return next;
+    },
+    reset(scope: string): void {
+      failuresByScope.delete(scope);
+    },
+  };
+}
+
+const defaultAutomaticResolutionFailureTracker = createCodexAutomaticResolutionFailureTracker();
+
 const WINDOWS_CODEX_PLATFORM_PACKAGE_BY_ARCH: Readonly<Record<string, { triple: string; packageName: string }>> = {
   x64: { triple: "x86_64-pc-windows-msvc", packageName: "@openai/codex-win32-x64" },
   arm64: { triple: "aarch64-pc-windows-msvc", packageName: "@openai/codex-win32-arm64" },
@@ -94,6 +139,19 @@ export class CodexBinaryVerifyTransientError extends Error {
   }
 }
 
+/**
+ * Automatic candidates were present but deterministically unusable, or the
+ * exact same all-candidate transient result reached its narrow retry bound.
+ * The provider taxonomy maps this named error to a terminal capability reason
+ * instead of the generic unknown/transient retry path.
+ */
+export class CodexBinaryUnusableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodexBinaryUnusableError";
+  }
+}
+
 import { isCodexBinaryMissingError } from "../../runtime/provider-support/index.js";
 
 /** Single-owner match rules live in provider-support; re-export for call sites. */
@@ -110,6 +168,70 @@ export function formatCodexBinaryMissingMessage(input: unknown): string {
   );
 }
 
+export function formatCodexBinaryUnusableMessage(
+  failures: readonly CodexAutomaticCandidateFailure[],
+  identicalAttempts?: number,
+): string {
+  const checked = failures.map((failure) => `\`${failure.path.replaceAll("`", "'")}\` (${failure.reason})`).join("; ");
+  const repeated = identicalAttempts
+    ? ` The same automatic-candidate launch result repeated ${identicalAttempts} times.`
+    : "";
+  return (
+    `Codex runtime binary candidates are installed but unusable. Checked: ${checked}.${repeated} ` +
+    `Upgrade or replace the failing Codex installation(s) (for example \`${runtimeProviderInstallCommand("codex")}\`), remove stale candidate paths if needed, then run \`${runtimeProviderLoginCommand("codex")}\` and retry.`
+  );
+}
+
+export function codexAutomaticCandidateFailureError(
+  failures: readonly CodexAutomaticCandidateFailure[],
+  env: Record<string, string | undefined>,
+  boundary: CodexAutomaticFailureBoundary,
+  failureTracker: CodexAutomaticResolutionFailureTracker = defaultAutomaticResolutionFailureTracker,
+): CodexBinaryVerifyTransientError | CodexBinaryUnusableError {
+  const failureScope = codexAutomaticFailureScope(env, boundary);
+  if (failures.some((failure) => failure.transient)) {
+    const identicalAttempts = failureTracker.record(failureScope, JSON.stringify(failures));
+    if (identicalAttempts < CODEX_IDENTICAL_AUTOMATIC_FAILURE_LIMIT) {
+      return new CodexBinaryVerifyTransientError(formatCandidateFailureDetails(failures));
+    }
+    return new CodexBinaryUnusableError(formatCodexBinaryUnusableMessage(failures, identicalAttempts));
+  }
+  return new CodexBinaryUnusableError(formatCodexBinaryUnusableMessage(failures));
+}
+
+export function resetCodexAutomaticCandidateFailures(
+  env: Record<string, string | undefined>,
+  boundary: CodexAutomaticFailureBoundary,
+  failureTracker: CodexAutomaticResolutionFailureTracker = defaultAutomaticResolutionFailureTracker,
+): void {
+  failureTracker.reset(codexAutomaticFailureScope(env, boundary));
+}
+
+function codexAutomaticFailureScope(
+  env: Record<string, string | undefined>,
+  boundary: CodexAutomaticFailureBoundary,
+): string {
+  return `${env.FIRST_TREE_CHAT_ID ?? "__process__"}:${boundary}`;
+}
+
+export function resolveVerifiedCodexAutomaticCandidate(
+  env: Record<string, string | undefined> = process.env,
+  deps: {
+    candidates?: Iterable<string>;
+    verifyPath?: (path: string, env?: Record<string, string | undefined>) => CodexExecutableVerification;
+  } = {},
+): CodexVerifiedAutomaticCandidate {
+  const failures: CodexAutomaticCandidateFailure[] = [];
+  const candidates = deps.candidates ?? findCodexExecutableCandidates(env);
+  const verifyPath = deps.verifyPath ?? verifyCodexExecutable;
+  for (const path of candidates) {
+    const verification = verifyPath(path, env);
+    if (verification.ok) return { ok: true, path, verification, failures };
+    failures.push({ path, reason: verification.reason, transient: verification.transient });
+  }
+  return { ok: false, failures };
+}
+
 export function createCodexClientWithBinaryFallback<TOptions extends CodexOptionsLike, TClient>(
   options: TOptions,
   construct: (options: TOptions) => TClient,
@@ -120,36 +242,53 @@ export function createCodexClientWithBinaryFallback<TOptions extends CodexOption
   } catch (err) {
     if (!isCodexBinaryMissingError(err)) throw err;
 
-    const fallbackPath = (deps.resolvePath ?? findCodexExecutableOnPath)(options.env);
-    if (!fallbackPath) {
+    // An explicit SDK/config override is authoritative. Automatic discovery
+    // must never silently replace a path the caller deliberately selected.
+    if (options.codexPathOverride) throw err;
+
+    const candidateSource = deps.resolveCandidates
+      ? deps.resolveCandidates(options.env)
+      : deps.resolvePath
+        ? singleCandidate(deps.resolvePath(options.env))
+        : findCodexExecutableCandidates(options.env);
+    const resolved = resolveVerifiedCodexAutomaticCandidate(options.env, {
+      candidates: candidateSource,
+      verifyPath: deps.verifyPath,
+    });
+    if (!resolved.ok && resolved.failures.length === 0) {
+      resetCodexAutomaticCandidateFailures(options.env ?? process.env, "sdk", deps.failureTracker);
       throw new Error(formatCodexBinaryMissingMessage(err));
     }
-    const verification = (deps.verifyPath ?? verifyCodexExecutable)(fallbackPath, options.env);
-    if (!verification.ok) {
-      // The binary EXISTS (resolution found it at `fallbackPath`) — only the
-      // smoke check failed. A transient flake (timeout / machine pressure) must
-      // stay transient so the session bring-up is retried; only a genuine
-      // non-transient failure (broken / incompatible binary) is reported as
-      // missing, which classifies permanent and terminates the session.
-      if (verification.transient) {
-        throw new CodexBinaryVerifyTransientError(verification.reason);
-      }
-      throw new Error(
-        formatCodexBinaryMissingMessage(`${errorText(err)} Resolved codex failed validation: ${verification.reason}`),
+
+    if (!resolved.ok) {
+      throw codexAutomaticCandidateFailureError(
+        resolved.failures,
+        options.env ?? process.env,
+        "sdk",
+        deps.failureTracker,
       );
     }
 
+    resetCodexAutomaticCandidateFailures(options.env ?? process.env, "sdk", deps.failureTracker);
     deps.log?.(
-      `Codex SDK bundled binary missing; falling back to codex at ${fallbackPath}. ` +
+      `Codex SDK bundled binary missing; falling back to codex at ${resolved.path}. ` +
         `Original error: ${errorText(err)}`,
     );
     return {
-      client: construct({ ...options, codexPathOverride: fallbackPath }),
+      client: construct({ ...options, codexPathOverride: resolved.path }),
       runtimeSource: "path",
-      codexPathOverride: fallbackPath,
+      codexPathOverride: resolved.path,
       fallbackReason: errorText(err),
     };
   }
+}
+
+function singleCandidate(path: string | null): Iterable<string> {
+  return path ? [path] : [];
+}
+
+function formatCandidateFailureDetails(failures: readonly CodexAutomaticCandidateFailure[]): string {
+  return failures.map((failure) => `\`${failure.path.replaceAll("`", "'")}\`: ${failure.reason}`).join("; ");
 }
 
 export function verifyCodexExecutable(
@@ -215,6 +354,20 @@ export function findCodexExecutableOnPath(
   env: Record<string, string | undefined> = process.env,
   deps: FindCodexExecutableDeps = {},
 ): string | null {
+  for (const candidate of findCodexExecutableCandidates(env, deps)) return candidate;
+  return null;
+}
+
+/**
+ * Lazily enumerate automatic external candidates in runtime priority order.
+ * Laziness preserves the cheap-source short circuit: login-shell PATH and the
+ * desktop-app locations are consulted only when every earlier candidate is
+ * absent or fails launch verification.
+ */
+export function* findCodexExecutableCandidates(
+  env: Record<string, string | undefined> = process.env,
+  deps: FindCodexExecutableDeps = {},
+): Generator<string> {
   const platform = deps.platform ?? process.platform;
   const arch = deps.arch ?? process.arch;
   const pathDelimiter = deps.pathDelimiter ?? (platform === "win32" ? ";" : delimiter);
@@ -224,8 +377,9 @@ export function findCodexExecutableOnPath(
   const desktopAppDirs = deps.desktopAppDirs ?? (() => codexDesktopAppBinDirs(home));
   const names = codexExecutableNames(env, platform);
   const seen = new Set<string>();
+  const yielded = new Set<string>();
 
-  const search = (dirs: readonly string[]): string | null => {
+  function* search(dirs: readonly string[]): Generator<string> {
     for (const dir of dirs) {
       if (!dir) continue;
       const base = isAbsolute(dir) ? dir : resolve(dir);
@@ -234,11 +388,13 @@ export function findCodexExecutableOnPath(
       for (const name of names) {
         const candidate = join(base, name);
         const executable = resolveSpawnableCodexCandidate(candidate, { platform, arch });
-        if (executable) return executable;
+        if (executable && !yielded.has(executable)) {
+          yielded.add(executable);
+          yield executable;
+        }
       }
     }
-    return null;
-  };
+  }
 
   // Priority: daemon PATH → curated install dirs → login-shell PATH → macOS
   // desktop-app Resources. The login-shell probe may spawn a shell, so cheap
@@ -247,13 +403,10 @@ export function findCodexExecutableOnPath(
   // a custom export must keep its selected version and credential context.
   // Codex resolution is never on the daemon's pre-connect path.
   const pathValue = readPathValue(env, platform);
-  const fromDaemon = search(pathValue ? pathValue.split(pathDelimiter) : []);
-  if (fromDaemon) return fromDaemon;
-  const fromWellKnown = search(wellKnownDirs());
-  if (fromWellKnown) return fromWellKnown;
-  const fromLoginShell = search(loginShellPathDirs());
-  if (fromLoginShell) return fromLoginShell;
-  return search(desktopAppDirs());
+  yield* search(pathValue ? pathValue.split(pathDelimiter) : []);
+  yield* search(wellKnownDirs());
+  yield* search(loginShellPathDirs());
+  yield* search(desktopAppDirs());
 }
 
 function errorText(input: unknown): string {

--- a/packages/client/src/providers/codex/capability.ts
+++ b/packages/client/src/providers/codex/capability.ts
@@ -6,9 +6,14 @@ import type { CapabilityEntry, CapabilityRuntimeSource } from "@first-tree/share
 import { type DetectOutcome, runDetect } from "../capabilities/detect.js";
 import { verifyLaunchable } from "../capabilities/launch-probe.js";
 import {
+  type CodexAutomaticResolutionFailureTracker,
   type CodexExecutableVerification,
+  codexAutomaticCandidateFailureError,
+  findCodexExecutableCandidates,
   findCodexExecutableOnPath,
   formatCodexBinaryMissingMessage,
+  resetCodexAutomaticCandidateFailures,
+  resolveVerifiedCodexAutomaticCandidate,
   verifyCodexExecutable,
 } from "./binary.js";
 
@@ -155,8 +160,11 @@ export type CodexBinaryResolution =
 export type CodexRuntimeResolveDeps = {
   resolveBundled?: () => Promise<{ ok: true; binary: string } | { ok: false; error: string }>;
   verifyBundled?: (binary: string) => Promise<{ ok: true; version: string | null } | { ok: false; error: string }>;
+  findCandidates?: (env?: Record<string, string | undefined>) => Iterable<string>;
+  /** Legacy single-candidate seam. Prefer findCandidates for new tests. */
   findOnPath?: (env?: Record<string, string | undefined>) => string | null;
   verifyPath?: (path: string, env?: Record<string, string | undefined>) => CodexExecutableVerification;
+  failureTracker?: CodexAutomaticResolutionFailureTracker;
 };
 
 /**
@@ -175,7 +183,6 @@ export async function resolveCodexRuntimeBinary(
 ): Promise<CodexBinaryResolution> {
   const resolveBundled = deps.resolveBundled ?? resolveBundledCodexBinary;
   const verifyBundled = deps.verifyBundled ?? ((binary: string) => verifyLaunchable("codex", binary));
-  const findOnPath = deps.findOnPath ?? findCodexExecutableOnPath;
   const verifyPath = deps.verifyPath ?? verifyCodexExecutable;
 
   const bundled = await resolveBundled();
@@ -187,6 +194,7 @@ export async function resolveCodexRuntimeBinary(
         error: `the SDK-bundled codex binary at ${bundled.binary} could not be launched (${verified.error})`,
       };
     }
+    resetCodexAutomaticCandidateFailures(env, "runtime", deps.failureTracker);
     return {
       ok: true,
       binary: bundled.binary,
@@ -196,35 +204,34 @@ export async function resolveCodexRuntimeBinary(
     };
   }
 
-  const pathBinary = findOnPath(env);
-  if (pathBinary) {
-    const verification = verifyPath(pathBinary, env);
-    if (verification.ok) {
-      const match = (verification.output ?? "").match(/\d+\.\d+(?:\.\d+)?/);
-      return {
-        ok: true,
-        binary: pathBinary,
-        runtimeSource: "path",
-        runtimePath: pathBinary,
-        version: match ? match[0] : null,
-      };
-    }
-    // A present binary that only flaked its smoke check (timeout / host
-    // pressure) is NOT missing — say so honestly instead of telling the
-    // operator to reinstall codex.
-    if (verification.transient) {
-      return {
-        ok: false,
-        error: `codex resolved at ${pathBinary} but \`codex --version\` did not complete (transient host condition): ${verification.reason}`,
-      };
-    }
+  const candidates = deps.findCandidates
+    ? deps.findCandidates(env)
+    : deps.findOnPath
+      ? singleCandidate(deps.findOnPath(env))
+      : findCodexExecutableCandidates(env);
+  const resolved = resolveVerifiedCodexAutomaticCandidate(env, { candidates, verifyPath });
+  if (resolved.ok) {
+    resetCodexAutomaticCandidateFailures(env, "runtime", deps.failureTracker);
+    const match = (resolved.verification.output ?? "").match(/\d+\.\d+(?:\.\d+)?/);
     return {
-      ok: false,
-      error: formatCodexBinaryMissingMessage(`resolved codex failed validation: ${verification.reason}`),
+      ok: true,
+      binary: resolved.path,
+      runtimeSource: "path",
+      runtimePath: resolved.path,
+      version: match ? match[0] : null,
     };
   }
+  if (resolved.failures.length > 0) {
+    const failure = codexAutomaticCandidateFailureError(resolved.failures, env, "runtime", deps.failureTracker);
+    return { ok: false, error: failure.message };
+  }
 
+  resetCodexAutomaticCandidateFailures(env, "runtime", deps.failureTracker);
   return { ok: false, error: formatCodexBinaryMissingMessage(bundled.error) };
+}
+
+function singleCandidate(path: string | null): Iterable<string> {
+  return path ? [path] : [];
 }
 
 /** Injectable seams — production callers pass nothing. */

--- a/packages/client/src/providers/codex/capability.ts
+++ b/packages/client/src/providers/codex/capability.ts
@@ -14,6 +14,7 @@ import {
   findCodexExecutableCandidates,
   formatCodexBinaryMissingMessage,
   resetCodexAutomaticCandidateFailures,
+  resetCodexVerifiedAutomaticCandidateIfRejected,
   resolveVerifiedCodexAutomaticCandidate,
   verifyCodexExecutable,
 } from "./binary.js";
@@ -227,6 +228,7 @@ export async function resolveCodexRuntimeBinary(
     };
   }
   if (resolved.failures.length > 0) {
+    resetCodexVerifiedAutomaticCandidateIfRejected(resolved.failures, verifiedCandidateTracker);
     const failure = codexAutomaticCandidateFailureError(resolved.failures, env, "runtime", deps.failureTracker);
     if (failure.name === "CodexBinaryUnusableError") verifiedCandidateTracker.reset();
     return { ok: false, error: failure.message, cause: failure };

--- a/packages/client/src/providers/codex/capability.ts
+++ b/packages/client/src/providers/codex/capability.ts
@@ -9,8 +9,8 @@ import {
   type CodexAutomaticResolutionFailureTracker,
   type CodexExecutableVerification,
   codexAutomaticCandidateFailureError,
+  createCodexAutomaticResolutionFailureTracker,
   findCodexExecutableCandidates,
-  findCodexExecutableOnPath,
   formatCodexBinaryMissingMessage,
   resetCodexAutomaticCandidateFailures,
   resolveVerifiedCodexAutomaticCandidate,
@@ -154,7 +154,7 @@ export type CodexBinaryResolution =
       runtimePath: string | null;
       version: string | null;
     }
-  | { ok: false; error: string };
+  | { ok: false; error: string; cause?: Error };
 
 /** Injectable seams for `resolveCodexRuntimeBinary` (tests only). */
 export type CodexRuntimeResolveDeps = {
@@ -172,10 +172,10 @@ export type CodexRuntimeResolveDeps = {
  * contract as the handler (`createCodexClientWithBinaryFallback`): SDK-bundled
  * vendor binary first (launch-verified), else a validated external `codex`
  * resolved from PATH / known install locations. This is a RUNTIME/handler + login helper — it DOES launch-verify the
- * binary it is about to spawn. The capability probe does NOT use it (see
- * `probeCodexCapability`, which is install-only / existence-only); they share
- * the same `resolveBundledCodexBinary` + `findCodexExecutableOnPath`
- * primitives, so the probe's verdict is a strict subset of this resolution.
+ * binary it is about to spawn. The capability probe shares the external
+ * automatic-candidate launch-verification path so its reported artifact stays
+ * consistent, but retains its separate existence-only bundled probe and does
+ * not check login, provider reachability, or a real session.
  */
 export async function resolveCodexRuntimeBinary(
   env: NodeJS.ProcessEnv = process.env,
@@ -223,7 +223,7 @@ export async function resolveCodexRuntimeBinary(
   }
   if (resolved.failures.length > 0) {
     const failure = codexAutomaticCandidateFailureError(resolved.failures, env, "runtime", deps.failureTracker);
-    return { ok: false, error: failure.message };
+    return { ok: false, error: failure.message, cause: failure };
   }
 
   resetCodexAutomaticCandidateFailures(env, "runtime", deps.failureTracker);
@@ -237,6 +237,9 @@ function singleCandidate(path: string | null): Iterable<string> {
 /** Injectable seams — production callers pass nothing. */
 export type CodexProbeDeps = {
   resolveBundled?: () => Promise<{ ok: true; binary: string } | { ok: false; error: string }>;
+  findCandidates?: (env?: Record<string, string | undefined>) => Iterable<string>;
+  verifyPath?: (path: string, env?: Record<string, string | undefined>) => CodexExecutableVerification;
+  /** Legacy single-candidate seam. Prefer findCandidates for new tests. */
   findOnPath?: (env?: Record<string, string | undefined>) => string | null;
   env?: NodeJS.ProcessEnv;
 };
@@ -244,11 +247,13 @@ export type CodexProbeDeps = {
 /**
  * Install-only probe for the `codex` runtime.
  *
- * Installed when the binary the runtime would spawn EXISTS — the SDK-bundled
+ * Installed when the binary the runtime would spawn exists — the SDK-bundled
  * vendor binary (per the SDK's own `resolveNativePackage` layout check), or a
- * external `codex` from PATH / known install locations — without launching it (`--version`), checking
- * `codex login status`, or running `codex doctor`. Reports `runtimeSource` /
- * `runtimePath` so diagnostics still show which artifact backs the runtime.
+ * external `codex` from PATH / known install locations. External automatic
+ * candidates are launch-verified only to select the exact artifact whose path
+ * is reported and later executed; the probe still does not check login,
+ * provider reachability, or a real session. Reports `runtimeSource` /
+ * `runtimePath` so diagnostics show the same artifact the runtime selects.
  * Authentication and reachability are no longer probed; a logged-out or
  * unreachable codex is discovered at session run time and surfaced as an
  * in-chat credential failure.
@@ -256,16 +261,34 @@ export type CodexProbeDeps = {
 export async function probeCodexCapability(deps: CodexProbeDeps = {}): Promise<CapabilityEntry> {
   const env = deps.env ?? process.env;
   const resolveBundled = deps.resolveBundled ?? resolveBundledCodexBinary;
-  const findOnPath = deps.findOnPath ?? findCodexExecutableOnPath;
 
   return runDetect(async (): Promise<DetectOutcome> => {
     const bundled = await resolveBundled();
     if (bundled.ok) {
       return { installed: true, runtimeSource: "bundled", runtimePath: null };
     }
-    const pathBinary = findOnPath(env);
-    if (pathBinary) {
-      return { installed: true, runtimeSource: "path", runtimePath: pathBinary };
+    const candidates = deps.findCandidates
+      ? deps.findCandidates(env)
+      : deps.findOnPath
+        ? singleCandidate(deps.findOnPath(env))
+        : findCodexExecutableCandidates(env);
+    const resolved = resolveVerifiedCodexAutomaticCandidate(env, {
+      candidates,
+      verifyPath: deps.verifyPath,
+    });
+    if (resolved.ok) {
+      return { installed: true, runtimeSource: "path", runtimePath: resolved.path };
+    }
+    if (resolved.failures.length > 0) {
+      // Capability polling must never consume the session-start retry budget.
+      // A fresh local tracker preserves a one-off transient verdict while the
+      // non-ok capability entry remains eligible for the normal re-probe loop.
+      throw codexAutomaticCandidateFailureError(
+        resolved.failures,
+        env,
+        "probe",
+        createCodexAutomaticResolutionFailureTracker(),
+      );
     }
     return { installed: false, error: formatCodexBinaryMissingMessage(bundled.error) };
   });

--- a/packages/client/src/providers/codex/capability.ts
+++ b/packages/client/src/providers/codex/capability.ts
@@ -8,8 +8,9 @@ import { verifyLaunchable } from "../capabilities/launch-probe.js";
 import {
   type CodexAutomaticResolutionFailureTracker,
   type CodexExecutableVerification,
+  type CodexVerifiedAutomaticCandidateTracker,
   codexAutomaticCandidateFailureError,
-  createCodexAutomaticResolutionFailureTracker,
+  codexVerifiedAutomaticCandidateTracker,
   findCodexExecutableCandidates,
   formatCodexBinaryMissingMessage,
   resetCodexAutomaticCandidateFailures,
@@ -165,6 +166,7 @@ export type CodexRuntimeResolveDeps = {
   findOnPath?: (env?: Record<string, string | undefined>) => string | null;
   verifyPath?: (path: string, env?: Record<string, string | undefined>) => CodexExecutableVerification;
   failureTracker?: CodexAutomaticResolutionFailureTracker;
+  verifiedCandidateTracker?: CodexVerifiedAutomaticCandidateTracker;
 };
 
 /**
@@ -172,10 +174,9 @@ export type CodexRuntimeResolveDeps = {
  * contract as the handler (`createCodexClientWithBinaryFallback`): SDK-bundled
  * vendor binary first (launch-verified), else a validated external `codex`
  * resolved from PATH / known install locations. This is a RUNTIME/handler + login helper — it DOES launch-verify the
- * binary it is about to spawn. The capability probe shares the external
- * automatic-candidate launch-verification path so its reported artifact stays
- * consistent, but retains its separate existence-only bundled probe and does
- * not check login, provider reachability, or a real session.
+ * binary it is about to spawn. It records a successful automatic selection so
+ * the separate install-only capability probe can report that last verified
+ * artifact without launching provider binaries itself.
  */
 export async function resolveCodexRuntimeBinary(
   env: NodeJS.ProcessEnv = process.env,
@@ -184,17 +185,20 @@ export async function resolveCodexRuntimeBinary(
   const resolveBundled = deps.resolveBundled ?? resolveBundledCodexBinary;
   const verifyBundled = deps.verifyBundled ?? ((binary: string) => verifyLaunchable("codex", binary));
   const verifyPath = deps.verifyPath ?? verifyCodexExecutable;
+  const verifiedCandidateTracker = deps.verifiedCandidateTracker ?? codexVerifiedAutomaticCandidateTracker;
 
   const bundled = await resolveBundled();
   if (bundled.ok) {
     const verified = await verifyBundled(bundled.binary);
     if (!verified.ok) {
+      verifiedCandidateTracker.reset();
       return {
         ok: false,
         error: `the SDK-bundled codex binary at ${bundled.binary} could not be launched (${verified.error})`,
       };
     }
     resetCodexAutomaticCandidateFailures(env, "runtime", deps.failureTracker);
+    verifiedCandidateTracker.reset();
     return {
       ok: true,
       binary: bundled.binary,
@@ -212,6 +216,7 @@ export async function resolveCodexRuntimeBinary(
   const resolved = resolveVerifiedCodexAutomaticCandidate(env, { candidates, verifyPath });
   if (resolved.ok) {
     resetCodexAutomaticCandidateFailures(env, "runtime", deps.failureTracker);
+    verifiedCandidateTracker.record(resolved.path);
     const match = (resolved.verification.output ?? "").match(/\d+\.\d+(?:\.\d+)?/);
     return {
       ok: true,
@@ -223,10 +228,12 @@ export async function resolveCodexRuntimeBinary(
   }
   if (resolved.failures.length > 0) {
     const failure = codexAutomaticCandidateFailureError(resolved.failures, env, "runtime", deps.failureTracker);
+    if (failure.name === "CodexBinaryUnusableError") verifiedCandidateTracker.reset();
     return { ok: false, error: failure.message, cause: failure };
   }
 
   resetCodexAutomaticCandidateFailures(env, "runtime", deps.failureTracker);
+  verifiedCandidateTracker.reset();
   return { ok: false, error: formatCodexBinaryMissingMessage(bundled.error) };
 }
 
@@ -238,9 +245,9 @@ function singleCandidate(path: string | null): Iterable<string> {
 export type CodexProbeDeps = {
   resolveBundled?: () => Promise<{ ok: true; binary: string } | { ok: false; error: string }>;
   findCandidates?: (env?: Record<string, string | undefined>) => Iterable<string>;
-  verifyPath?: (path: string, env?: Record<string, string | undefined>) => CodexExecutableVerification;
   /** Legacy single-candidate seam. Prefer findCandidates for new tests. */
   findOnPath?: (env?: Record<string, string | undefined>) => string | null;
+  verifiedCandidateTracker?: CodexVerifiedAutomaticCandidateTracker;
   env?: NodeJS.ProcessEnv;
 };
 
@@ -249,11 +256,11 @@ export type CodexProbeDeps = {
  *
  * Installed when the binary the runtime would spawn exists — the SDK-bundled
  * vendor binary (per the SDK's own `resolveNativePackage` layout check), or a
- * external `codex` from PATH / known install locations. External automatic
- * candidates are launch-verified only to select the exact artifact whose path
- * is reported and later executed; the probe still does not check login,
- * provider reachability, or a real session. Reports `runtimeSource` /
- * `runtimePath` so diagnostics show the same artifact the runtime selects.
+ * external `codex` from PATH / known install locations. The probe never
+ * launch-verifies external candidates. `runtimePath` is reported only when a
+ * still-discoverable path was previously selected and verified by the runtime;
+ * otherwise the installed external capability intentionally omits it rather
+ * than claiming that the first existence-only candidate is the executed one.
  * Authentication and reachability are no longer probed; a logged-out or
  * unreachable codex is discovered at session run time and surfaced as an
  * in-chat credential failure.
@@ -261,34 +268,27 @@ export type CodexProbeDeps = {
 export async function probeCodexCapability(deps: CodexProbeDeps = {}): Promise<CapabilityEntry> {
   const env = deps.env ?? process.env;
   const resolveBundled = deps.resolveBundled ?? resolveBundledCodexBinary;
+  const verifiedCandidateTracker = deps.verifiedCandidateTracker ?? codexVerifiedAutomaticCandidateTracker;
 
   return runDetect(async (): Promise<DetectOutcome> => {
     const bundled = await resolveBundled();
     if (bundled.ok) {
       return { installed: true, runtimeSource: "bundled", runtimePath: null };
     }
-    const candidates = deps.findCandidates
-      ? deps.findCandidates(env)
-      : deps.findOnPath
-        ? singleCandidate(deps.findOnPath(env))
-        : findCodexExecutableCandidates(env);
-    const resolved = resolveVerifiedCodexAutomaticCandidate(env, {
-      candidates,
-      verifyPath: deps.verifyPath,
-    });
-    if (resolved.ok) {
-      return { installed: true, runtimeSource: "path", runtimePath: resolved.path };
-    }
-    if (resolved.failures.length > 0) {
-      // Capability polling must never consume the session-start retry budget.
-      // A fresh local tracker preserves a one-off transient verdict while the
-      // non-ok capability entry remains eligible for the normal re-probe loop.
-      throw codexAutomaticCandidateFailureError(
-        resolved.failures,
-        env,
-        "probe",
-        createCodexAutomaticResolutionFailureTracker(),
-      );
+    const candidates = [
+      ...(deps.findCandidates
+        ? deps.findCandidates(env)
+        : deps.findOnPath
+          ? singleCandidate(deps.findOnPath(env))
+          : findCodexExecutableCandidates(env)),
+    ];
+    if (candidates.length > 0) {
+      const verifiedPath = verifiedCandidateTracker.get();
+      if (verifiedPath && candidates.includes(verifiedPath)) {
+        return { installed: true, runtimeSource: "path", runtimePath: verifiedPath };
+      }
+      if (verifiedPath) verifiedCandidateTracker.reset();
+      return { installed: true, runtimeSource: "path" };
     }
     return { installed: false, error: formatCodexBinaryMissingMessage(bundled.error) };
   });

--- a/packages/client/src/runtime/error-taxonomy.ts
+++ b/packages/client/src/runtime/error-taxonomy.ts
@@ -271,10 +271,10 @@ export function classify(err: unknown, context?: { source?: ErrorSource }): Clas
       message: shape.message ?? "Claude Code CLI requires re-authentication (run /login)",
     };
   }
-  // Provider binary missing / verify-transient: consume the normalized signal
+  // Provider binary missing / unusable / verify-transient: consume the normalized signal
   // from provider-support. That seam owns the match rules, reason codes, and
-  // the historical interleaved order (Codex→Cursor→Grok→Pi, verify-then-missing
-  // within each provider) so this generic taxonomy never imports concrete
+  // the historical interleaved order (Codex→Cursor→Grok→Pi, with Codex's
+  // unusable outcome between verify and missing) so this generic taxonomy never imports concrete
   // *-binary modules. Cross-provider ambiguity keeps the earlier provider.
   const binaryFailure = recognizeProviderBinaryFailure(err);
   if (binaryFailure) {

--- a/packages/client/src/runtime/provider-retry-policy.ts
+++ b/packages/client/src/runtime/provider-retry-policy.ts
@@ -588,7 +588,11 @@ function credentialReason(base: Classification): string {
 }
 
 function isCapability(text: string, base: Classification): boolean {
-  return base.reasonCode.includes("binary_missing") || /binary missing|executable missing|unable to locate/.test(text);
+  return (
+    base.reasonCode.includes("binary_missing") ||
+    base.reasonCode.includes("binary_unusable") ||
+    /binary missing|binary candidates are installed but unusable|executable missing|unable to locate/.test(text)
+  );
 }
 
 function isPiProtocolError(name: string | undefined, text: string): boolean {

--- a/packages/client/src/runtime/provider-support/binary-failure.ts
+++ b/packages/client/src/runtime/provider-support/binary-failure.ts
@@ -11,6 +11,7 @@
 
 export const PROVIDER_BINARY_FAILURE_REASON_CODES = {
   CODEX_VERIFY_TRANSIENT: "codex_verify_transient",
+  CODEX_BINARY_UNUSABLE: "codex_binary_unusable",
   CODEX_BINARY_MISSING: "codex_binary_missing",
   CURSOR_VERIFY_TRANSIENT: "cursor_verify_transient",
   CURSOR_BINARY_MISSING: "cursor_binary_missing",
@@ -24,8 +25,8 @@ export type ProviderBinaryFailureReasonCode =
   (typeof PROVIDER_BINARY_FAILURE_REASON_CODES)[keyof typeof PROVIDER_BINARY_FAILURE_REASON_CODES];
 
 export type ProviderBinaryFailureSignal = {
-  /** Present-but-flaky smoke check vs genuinely-missing / unresolved binary. */
-  outcome: "verify_transient" | "binary_missing";
+  /** Present-but-flaky, present-but-unusable, or genuinely missing/unresolved. */
+  outcome: "verify_transient" | "binary_unusable" | "binary_missing";
   reasonCode: ProviderBinaryFailureReasonCode;
   /** Fallback human summary when the thrown value carries no message. */
   defaultMessage: string;
@@ -177,6 +178,20 @@ function verifyTransientSignal(
   };
 }
 
+function codexUnusableSignal(err: unknown): ProviderBinaryFailureSignal | null {
+  if (
+    readErrorName(err) !== "CodexBinaryUnusableError" &&
+    !/codex runtime binary candidates are installed but unusable/i.test(codexErrorSearchText(err))
+  ) {
+    return null;
+  }
+  return {
+    outcome: "binary_unusable",
+    reasonCode: PROVIDER_BINARY_FAILURE_REASON_CODES.CODEX_BINARY_UNUSABLE,
+    defaultMessage: "Codex runtime binary candidates are unusable",
+  };
+}
+
 function missingSignal(
   match: (input: unknown) => boolean,
   reasonCode: ProviderBinaryFailureReasonCode,
@@ -191,15 +206,17 @@ function missingSignal(
  * Normalize a thrown value into a binary-failure signal, or `null` when the
  * error is unrelated.
  *
- * Order matches the historical `error-taxonomy` classifier exactly — per
- * provider interleaved as verify-transient then missing, walking Codex →
- * Cursor → Grok → Pi. "Verify beats missing" is only within the same provider;
+ * Order keeps the historical `error-taxonomy` classifier, with Codex's narrow
+ * unusable outcome inserted after verify-transient and before missing — then
+ * walks Cursor → Grok → Pi as verify-transient then missing. "Verify beats
+ * missing" is only within the same provider;
  * a later provider's verify name must not preempt an earlier provider's missing
  * match (cross-provider ambiguity keeps the earlier provider's outcome).
  */
 export function recognizeProviderBinaryFailure(err: unknown): ProviderBinaryFailureSignal | null {
   return (
     verifyTransientSignal(err, "CodexBinaryVerifyTransientError") ??
+    codexUnusableSignal(err) ??
     missingSignal(
       isCodexBinaryMissingError,
       PROVIDER_BINARY_FAILURE_REASON_CODES.CODEX_BINARY_MISSING,

--- a/packages/client/src/runtime/provider-support/binary-failure.ts
+++ b/packages/client/src/runtime/provider-support/binary-failure.ts
@@ -213,7 +213,7 @@ function missingSignal(
  * a later provider's verify name must not preempt an earlier provider's missing
  * match (cross-provider ambiguity keeps the earlier provider's outcome).
  */
-export function recognizeProviderBinaryFailure(err: unknown): ProviderBinaryFailureSignal | null {
+function recognizeDirectProviderBinaryFailure(err: unknown): ProviderBinaryFailureSignal | null {
   return (
     verifyTransientSignal(err, "CodexBinaryVerifyTransientError") ??
     codexUnusableSignal(err) ??
@@ -245,4 +245,22 @@ export function recognizeProviderBinaryFailure(err: unknown): ProviderBinaryFail
       err,
     )
   );
+}
+
+function readErrorCause(err: unknown): unknown {
+  if (!err || typeof err !== "object") return undefined;
+  return (err as { cause?: unknown }).cause;
+}
+
+export function recognizeProviderBinaryFailure(err: unknown): ProviderBinaryFailureSignal | null {
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  for (let depth = 0; current !== undefined && current !== null && depth < 8; depth += 1) {
+    if ((typeof current === "object" || typeof current === "function") && seen.has(current)) return null;
+    if (typeof current === "object" || typeof current === "function") seen.add(current);
+    const direct = recognizeDirectProviderBinaryFailure(current);
+    if (direct) return direct;
+    current = readErrorCause(current);
+  }
+  return null;
 }

--- a/packages/qa/cases/runtime/daemon-probe-capability.md
+++ b/packages/qa/cases/runtime/daemon-probe-capability.md
@@ -44,8 +44,9 @@ entry rather than only checking process exit status:
 - the result is successful for the provider selected by the plan;
 - the provider capability includes availability/state detail;
 - `runtimeSource` explains whether the provider came from a bundled runtime or a binary found on `PATH`;
-- `runtimePath` is consistent with `runtimeSource` (for example, a path string for `runtimeSource: "path"`, or `null`/omitted
-  when a bundled runtime does not expose a host path);
+- `runtimePath` is consistent with `runtimeSource`: it is a path string only for a still-discoverable external artifact
+  that the runtime previously launch-verified, and is omitted when an install-only probe has found external candidates
+  but no current verified selection; bundled runtimes may report `null`/omitted when they do not expose a host path;
 - the no-upload run does not fail because server auth, upload credentials, or an active First Tree session is missing.
 
 If the output shape changes during product work, follow the product's current typed schema, but keep the evidence focused
@@ -55,10 +56,11 @@ upload.
 ## Expected Result
 
 `PASS` means the probe completed in the run cell, the selected provider's capability entry showed a usable runtime source
-and matching path/provenance detail, and the no-upload mode did not require server credentials.
+without claiming an unverified path (and included the matching path when a prior verified selection exists), and the
+no-upload mode did not require server credentials.
 
-`FAIL` means the CLI reproducibly returned incorrect provider provenance, required upload/auth despite `--no-upload`, or
-reported success while omitting the source/path detail needed to debug provider selection.
+`FAIL` means the CLI reproducibly returned incorrect provider provenance, presented an existence-only path as a verified
+selection, required upload/auth despite `--no-upload`, or omitted a previously verified path that is still discoverable.
 
 `BLOCKED` means the run cell could not expose any provider or the CLI under test could not be built/launched.
 

--- a/packages/shared/src/schemas/client-capabilities.ts
+++ b/packages/shared/src/schemas/client-capabilities.ts
@@ -68,7 +68,13 @@ export const capabilityEntrySchema = z.object({
   sdkVersion: z.string().nullable().optional(),
   /** Which artifact backs the runtime (bundled binary vs external-path fallback). */
   runtimeSource: capabilityRuntimeSourceSchema.optional(),
-  /** Absolute path of the resolved binary, when `runtimeSource: "path"`. */
+  /**
+   * Absolute path of the runtime-verified external binary, when known. An
+   * install-only probe may report `runtimeSource: "path"` without this field
+   * before the runtime has selected a candidate, or after that selection was
+   * invalidated; probes must not present an existence-only candidate as if it
+   * had already been launch-verified.
+   */
   runtimePath: z.string().nullable().optional(),
   /**
    * Human-readable failure reason for a non-`ok` state — for `missing`, which


### PR DESCRIPTION
## Summary

- launch-verify automatic Codex candidates in the existing daemon PATH → well-known dirs → login-shell PATH → macOS Desktop order, falling through unusable candidates to a later healthy binary
- keep capability detection existence-only and launch-free; runtime/login/SDK selection changes actively publish the exact still-discoverable verified artifact through the daemon capability refresher
- defer and coalesce targeted Codex provenance publication while browser login owns the provider entry, preserving `pendingAuth` until the interactive flow completes
- invalidate remembered provenance as soon as that exact path is deterministically rejected, even when a later candidate has a transient verification failure
- preserve one-off transient smoke failures, including through forced app-server startup, while bounding and resetting identical all-candidate failures with path-bearing `codex_binary_unusable` remediation
- preserve explicit `codexPathOverride` authority

## Tests

- `pnpm exec vitest run src/providers/codex/__tests__/binary.test.ts src/providers/codex/__tests__/app-server/extra-coverage.test.ts src/__tests__/capability-probes.test.ts src/__tests__/error-taxonomy.test.ts src/__tests__/provider-retry-policy.test.ts src/__tests__/provider-boundary-guard.test.ts src/__tests__/session-manager-retry.test.ts src/__tests__/session-start-error-signaling.test.ts` — 8 files, 263 tests passed
- `pnpm exec vitest run src/__tests__/daemon-start-command.test.ts` — 1 file, 37 tests passed
- `pnpm --filter first-tree-dev test` — 27/27 batches passed
- `pnpm --filter @first-tree/client test` — 214 files passed, 2 skipped; 2758 tests passed, 7 skipped
- `pnpm check` — passed; only pre-existing warnings/info outside the changed files
- `pnpm typecheck` — 9/9 tasks passed
- `git diff --check` — passed

## QA

- Tier: `test-only`
- Scope: Codex binary resolution, capability provenance publication, provider failure taxonomy, and session-start retry scheduling
- Case disposition: `candidate-case-update`; clarified the existing daemon-probe case so an install-only probe cannot claim an unverified path, while deterministic behavior remains covered by product tests
- Agent-run QA was not run because it was not requested
- No database, wire-schema-shape, migration, persistence, or Context Tree changes

Related to #2038