### PR TITLE
fix(runtime): revoke stopped session status

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -143,6 +143,7 @@ function makeSdk(options?: {
   /** Throw `error` on the first `times` config fetches, then succeed — models a transient blip. */
   configErrorsThenSucceed?: { error: unknown; times: number };
   activeRuntimeChatIds?: string[];
+  activeSessionChatIds?: string[];
   activeRuntimeChatIdsError?: unknown;
   runtimeSessionToken?: string;
 }): FirstTreeHubSDK {
@@ -176,7 +177,11 @@ function makeSdk(options?: {
     runtimeSessionToken: options?.runtimeSessionToken,
     listActiveRuntimeChatIds: vi.fn(async () => {
       if (options?.activeRuntimeChatIdsError) throw options.activeRuntimeChatIdsError;
-      return { chatIds: options?.activeRuntimeChatIds ?? ["chat-1", "chat-2", "chat-evicted"] };
+      const chatIds = options?.activeRuntimeChatIds ?? ["chat-1", "chat-2", "chat-evicted"];
+      return {
+        chatIds,
+        activeSessionChatIds: options?.activeSessionChatIds ?? chatIds,
+      };
     }),
   };
   // AgentSlot only uses this SDK subset; the concrete SDK type has many HTTP methods irrelevant here.
@@ -379,6 +384,7 @@ async function makeSlot(options?: {
   configError?: unknown;
   configErrorsThenSucceed?: { error: unknown; times: number };
   activeRuntimeChatIds?: string[];
+  activeSessionChatIds?: string[];
   activeRuntimeChatIdsError?: unknown;
   runtimeSessionToken?: string;
   runtimeType?: string;
@@ -405,6 +411,7 @@ async function makeSlot(options?: {
     configError: options?.configError,
     configErrorsThenSucceed: options?.configErrorsThenSucceed,
     activeRuntimeChatIds: options?.activeRuntimeChatIds,
+    activeSessionChatIds: options?.activeSessionChatIds,
     activeRuntimeChatIdsError: options?.activeRuntimeChatIdsError,
     runtimeSessionToken: options?.runtimeSessionToken,
   });
@@ -1219,9 +1226,10 @@ describe("AgentSlot", () => {
     await slot.stop();
   });
 
-  it("uses the active runtime chat set for full-state sync and revokes disappeared runtimes", async () => {
+  it("uses all active server sessions for runtime revocation but the human-scoped set for reconcile", async () => {
     const { slot, connection, sdk, state } = await makeSlot({
-      activeRuntimeChatIds: ["chat-1", "chat-disappeared"],
+      activeRuntimeChatIds: ["chat-1"],
+      activeSessionChatIds: ["chat-1", "chat-hidden-session"],
     });
 
     await slot.start();
@@ -1242,7 +1250,8 @@ describe("AgentSlot", () => {
     expect(connection.reportSessionState).not.toHaveBeenCalledWith("agent-1", "chat-evicted", "suspended");
     expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-1", "working");
     expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-2", "idle");
-    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-disappeared", "idle");
+    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-hidden-session", "idle");
+    expect(connection.reportSessionState).not.toHaveBeenCalledWith("agent-1", "chat-hidden-session", "suspended");
 
     const reconcile = Reflect.get(slot, "reconcileNow");
     if (typeof reconcile !== "function") throw new Error("private method missing");

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -1219,8 +1219,10 @@ describe("AgentSlot", () => {
     await slot.stop();
   });
 
-  it("uses the active runtime chat set for full-state sync and optimistic-adds delivered chats", async () => {
-    const { slot, connection, sdk, state } = await makeSlot({ activeRuntimeChatIds: ["chat-1"] });
+  it("uses the active runtime chat set for full-state sync and revokes disappeared runtimes", async () => {
+    const { slot, connection, sdk, state } = await makeSlot({
+      activeRuntimeChatIds: ["chat-1", "chat-disappeared"],
+    });
 
     await slot.start();
     const session = state.sessions[0];
@@ -1240,6 +1242,7 @@ describe("AgentSlot", () => {
     expect(connection.reportSessionState).not.toHaveBeenCalledWith("agent-1", "chat-evicted", "suspended");
     expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-1", "working");
     expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-2", "idle");
+    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-disappeared", "idle");
 
     const reconcile = Reflect.get(slot, "reconcileNow");
     if (typeof reconcile !== "function") throw new Error("private method missing");

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -152,17 +152,15 @@ describe("SessionRuntime: state notifications", () => {
     await sm.shutdown();
   });
 
-  it("does NOT emit a state notification when a session is LRU-evicted", async () => {
-    // LRU eviction is local-only: emitting any wire state on eviction would
-    // either accumulate stale rows in agent_chat_sessions (for `suspended`)
-    // or conflict with the server-authoritative `evicted` terminal. The row
-    // stays as last reported; local `evictedMappings` handles resume.
+  it("withdraws runtime and reports suspended when a session is LRU-evicted", async () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const runtimeChanges: Array<{ chatId: string; state: RuntimeState }> = [];
     const capturing = createCapturingFactory();
     const sm = createSessionRuntime({
       session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       handlerFactory: capturing.factory,
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, state) => runtimeChanges.push({ chatId, state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -172,8 +170,48 @@ describe("SessionRuntime: state notifications", () => {
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" }));
 
     const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
-    // Only the initial `active` for chat-a should appear — no wire event on LRU.
-    expect(chatAChanges).toEqual([{ chatId: "chat-a", state: "active" }]);
+    expect(chatAChanges).toEqual([
+      { chatId: "chat-a", state: "active" },
+      { chatId: "chat-a", state: "suspended" },
+    ]);
+    // The prior projection was already idle. Removing it must still produce
+    // an observable, idempotent idle revocation instead of silently deleting
+    // the local map entry.
+    expect(runtimeChanges.filter((c) => c.chatId === "chat-a").at(-1)).toEqual({
+      chatId: "chat-a",
+      state: "idle",
+    });
+
+    await sm.shutdown();
+  });
+
+  it("emits idle before suspended when preemption removes a working projection", async () => {
+    const emissions: Array<{ chatId: string; kind: "state" | "runtime"; value: string }> = [];
+    const handlers = [
+      createMockHandler({
+        async start(message, _ctx, token) {
+          token.processingStarted(message);
+          return { sessionId: "session-chat-a", route: { kind: "owned" as const, mode: "queued" as const } };
+        },
+      }),
+      createMockHandler(),
+    ];
+    const sm = createSessionRuntime({
+      concurrency: 1,
+      handlerFactory: () => handlers.shift() ?? createMockHandler(),
+      onStateChange: (chatId, state) => emissions.push({ chatId, kind: "state", value: state }),
+      onSessionRuntimeChange: (chatId, state) => emissions.push({ chatId, kind: "runtime", value: state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    expect(emissions).toContainEqual({ chatId: "chat-a", kind: "runtime", value: "working" });
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+
+    expect(emissions.filter((event) => event.chatId === "chat-a").slice(-2)).toEqual([
+      { chatId: "chat-a", kind: "runtime", value: "idle" },
+      { chatId: "chat-a", kind: "state", value: "suspended" },
+    ]);
 
     await sm.shutdown();
   });
@@ -375,23 +413,26 @@ describe("SessionRuntime: getEvictedChatIds()", () => {
 });
 
 describe("SessionRuntime: shutdown state reporting", () => {
-  it("reports active sessions as 'suspended' on shutdown", async () => {
-    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+  it("withdraws runtime before reporting active sessions as suspended on shutdown", async () => {
+    const emissions: Array<{ chatId: string; kind: "state" | "runtime"; value: string }> = [];
     const sm = createSessionRuntime({
-      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+      onStateChange: (chatId, state) => emissions.push({ chatId, kind: "state", value: state }),
+      onSessionRuntimeChange: (chatId, state) => emissions.push({ chatId, kind: "runtime", value: state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
 
-    // Clear state changes from start phase
-    stateChanges.length = 0;
+    emissions.length = 0;
 
     await sm.shutdown();
 
-    // Both active sessions should be reported as suspended
-    expect(stateChanges).toContainEqual({ chatId: "chat-a", state: "suspended" });
-    expect(stateChanges).toContainEqual({ chatId: "chat-b", state: "suspended" });
+    for (const chatId of ["chat-a", "chat-b"]) {
+      expect(emissions.filter((event) => event.chatId === chatId).slice(0, 2)).toEqual([
+        { chatId, kind: "runtime", value: "idle" },
+        { chatId, kind: "state", value: "suspended" },
+      ]);
+    }
   });
 
   it("does not report already-suspended sessions on shutdown", async () => {
@@ -420,20 +461,24 @@ describe("SessionRuntime: shutdown state reporting", () => {
 });
 
 describe("SessionRuntime: terminate + reconcile", () => {
-  it("handleCommand('session:terminate') deletes local state and does NOT emit any state notification", async () => {
+  it("handleCommand('session:terminate') withdraws runtime without inventing a client-owned terminal state", async () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const runtimeChanges: Array<{ chatId: string; state: RuntimeState }> = [];
     const sm = createSessionRuntime({
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, state) => runtimeChanges.push({ chatId, state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
     stateChanges.length = 0;
+    runtimeChanges.length = 0;
 
     await sm.handleCommand("chat-a", "session:terminate");
     // Direct SessionRuntime callers simulate server-confirmed Reset finalization.
     sm.releaseParkedResetFenceRecovery("chat-a");
 
     expect(stateChanges).toHaveLength(0); // server is authoritative
+    expect(runtimeChanges).toEqual([{ chatId: "chat-a", state: "idle" }]);
     expect(sm.getSessionStates()).toEqual([]);
     expect(sm.getHeldChatIds()).toEqual([]);
 

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -139,7 +139,10 @@ export class AgentSlot {
   private logger: pino.Logger;
   private agentConfigCache: AgentConfigCache | null = null;
   private sdk: FirstTreeHubSDK | null = null;
+  /** Managing human's visible/active chat set, used only for lifecycle reconcile. */
   private activeRuntimeChatIds: Set<string> | null = null;
+  /** Server-active session rows, used to revoke disappeared per-chat runtime. */
+  private activeSessionChatIds: Set<string> | null = null;
   private activeRuntimeChatIdsRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private activeRuntimeChatIdsRefreshInFlight: Promise<void> | null = null;
   private activeRuntimeChatIdsRefreshGeneration = 0;
@@ -812,6 +815,7 @@ export class AgentSlot {
       this.agentConfigCache = null;
       this.sdk = null;
       this.activeRuntimeChatIds = null;
+      this.activeSessionChatIds = null;
       this.activeRuntimeChatIdsRefreshInFlight = null;
       this.inboxId = null;
     }
@@ -859,6 +863,7 @@ export class AgentSlot {
       this.agentConfigCache = null;
       this.sdk = null;
       this.activeRuntimeChatIds = null;
+      this.activeSessionChatIds = null;
       this.activeRuntimeChatIdsRefreshInFlight = null;
       this.inboxId = null;
       this.runtimeSessionTokenMutationError = null;
@@ -888,6 +893,7 @@ export class AgentSlot {
   private fullStateSync(): void {
     if (!this.sessionRuntime) return;
     const activeChatIds = this.activeRuntimeChatIds;
+    const activeSessionChatIds = this.activeSessionChatIds;
     // ORDERING IS LOAD-BEARING: `session:state` frames flush before any
     // `session:runtime` frame so the server's `setSessionRuntime` (gated
     // on `state='active'`) can't fail-close because the state write
@@ -925,14 +931,17 @@ export class AgentSlot {
       reportedRuntimeChatIds.add(chatId);
       this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, runtimeState);
     }
-    // The server's active-chat set is the reconnect catch-up scope. An active
-    // server row omitted from the local runtime snapshot means the old local
-    // projection disappeared (for example after process restart or registry
-    // loss), so revoke it explicitly instead of waiting for stale recovery.
+    // The server's complete active-session set is the reconnect catch-up scope.
+    // It is deliberately separate from `activeChatIds`, which is filtered by
+    // the managing human's workspace visibility and remains lifecycle-only.
+    // An active server row omitted from the local runtime snapshot means the
+    // old local projection disappeared (for example after process restart or
+    // registry loss), so revoke it explicitly instead of waiting for stale
+    // recovery.
     // The server's active-row gate makes idle reports for chats without a
     // current session harmless and idempotent.
-    if (activeChatIds) {
-      for (const chatId of activeChatIds) {
+    if (activeSessionChatIds) {
+      for (const chatId of activeSessionChatIds) {
         if (!reportedRuntimeChatIds.has(chatId)) {
           this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, "idle");
         }
@@ -1013,10 +1022,18 @@ export class AgentSlot {
 
     const refresh = sdk
       .listActiveRuntimeChatIds()
-      .then(({ chatIds }) => {
+      .then(({ chatIds, activeSessionChatIds }) => {
         if (this.sdk !== sdk || !this.isActiveRuntimeChatIdsRefreshLive(generation)) return;
         this.activeRuntimeChatIds = new Set(chatIds);
-        this.logger.info({ count: chatIds.length, reason }, "active runtime chat ids refreshed");
+        // Older servers return only `chatIds`; keep their visible-set repair
+        // behavior during a rolling deployment, then widen automatically once
+        // the complete active-session field is available.
+        const revocationChatIds = activeSessionChatIds ?? chatIds;
+        this.activeSessionChatIds = new Set(revocationChatIds);
+        this.logger.info(
+          { count: chatIds.length, activeSessionCount: revocationChatIds.length, reason },
+          "active runtime chat ids refreshed",
+        );
       })
       .catch((err) => {
         if (this.sdk !== sdk || !this.isActiveRuntimeChatIdsRefreshLive(generation)) return;
@@ -1057,6 +1074,7 @@ export class AgentSlot {
 
   private noteActiveRuntimeChat(chatId: string): void {
     this.activeRuntimeChatIds?.add(chatId);
+    this.activeSessionChatIds?.add(chatId);
   }
 }
 

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -919,8 +919,24 @@ export class AgentSlot {
     // stay filtered to the user's active working set, while runtime rows are
     // cheap idempotent repairs for any chat the local SessionRuntime still
     // holds.
-    for (const { chatId, runtimeState } of this.sessionRuntime.getSessionRuntimeStates(null)) {
+    const runtimeStates = this.sessionRuntime.getSessionRuntimeStates(null);
+    const reportedRuntimeChatIds = new Set<string>();
+    for (const { chatId, runtimeState } of runtimeStates) {
+      reportedRuntimeChatIds.add(chatId);
       this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, runtimeState);
+    }
+    // The server's active-chat set is the reconnect catch-up scope. An active
+    // server row omitted from the local runtime snapshot means the old local
+    // projection disappeared (for example after process restart or registry
+    // loss), so revoke it explicitly instead of waiting for stale recovery.
+    // The server's active-row gate makes idle reports for chats without a
+    // current session harmless and idempotent.
+    if (activeChatIds) {
+      for (const chatId of activeChatIds) {
+        if (!reportedRuntimeChatIds.has(chatId)) {
+          this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, "idle");
+        }
+      }
     }
     // Explicit "idle" clears any stale `working`/`blocked` on the server:
     // any in-flight work owned by the previous process died with its SDK

--- a/packages/client/src/runtime/session-projection-authority.ts
+++ b/packages/client/src/runtime/session-projection-authority.ts
@@ -177,7 +177,7 @@ export class SessionProjectionAuthority<
   forgetChat(chatId: string): void {
     this.sessions.delete(chatId);
     this.evictedMappings.delete(chatId);
-    this.sessionRuntimeStates.delete(chatId);
+    this.withdrawSessionRuntime(chatId);
     this.lastReportedStates.delete(chatId);
     this.currentTrigger.delete(chatId);
   }
@@ -188,7 +188,7 @@ export class SessionProjectionAuthority<
    */
   dropLiveSession(chatId: string): void {
     this.sessions.delete(chatId);
-    this.sessionRuntimeStates.delete(chatId);
+    this.withdrawSessionRuntime(chatId);
     this.currentTrigger.delete(chatId);
   }
 
@@ -200,14 +200,14 @@ export class SessionProjectionAuthority<
   dropLiveSessionIfCurrent(chatId: string, entry: TSession): boolean {
     if (this.sessions.get(chatId) !== entry) return false;
     this.sessions.delete(chatId);
+    this.withdrawSessionRuntime(chatId);
     this.currentTrigger.delete(chatId);
     return true;
   }
 
   /** Session is no longer active for runtime projection (suspend / retry window). */
   clearActiveRuntimeProjection(chatId: string): void {
-    this.sessionRuntimeStates.delete(chatId);
-    this.recomputeRuntimeState();
+    this.withdrawSessionRuntime(chatId);
   }
 
   getSessionRuntimeState(chatId: string): RuntimeState | undefined {
@@ -237,6 +237,9 @@ export class SessionProjectionAuthority<
 
   /** Clear live session + evicted maps (shutdown / destructive registry flush). */
   clearLiveMapsOnShutdown(): void {
+    for (const chatId of [...this.sessionRuntimeStates.keys()]) {
+      this.withdrawSessionRuntime(chatId);
+    }
     this.sessions.clear();
     this.evictedMappings.clear();
   }
@@ -366,7 +369,7 @@ export class SessionProjectionAuthority<
     const session = this.sessions.get(chatId);
     const state = this.projectedRuntimeState(chatId, session ?? null);
     if (!state) {
-      if (this.sessionRuntimeStates.delete(chatId)) this.recomputeRuntimeState();
+      this.withdrawSessionRuntime(chatId);
       return;
     }
     const previous = this.sessionRuntimeStates.get(chatId);
@@ -384,6 +387,20 @@ export class SessionProjectionAuthority<
     if (session.status === "errored") return "error";
     if (session.status !== "active") return null;
     return this.deps.hasProcessingOwnedWork(chatId) ? "working" : "idle";
+  }
+
+  /**
+   * Removal is a projection transition, not a silent bookkeeping detail.
+   * Emit an explicit idle before forgetting the local value so a working
+   * edge cannot remain authoritative on the server until freshness expiry.
+   * Repeated removals are idempotent because an absent map entry emits
+   * nothing; removing a recorded idle still emits once so deletion itself is
+   * observable even without an ordinary value change.
+   */
+  private withdrawSessionRuntime(chatId: string): void {
+    if (!this.sessionRuntimeStates.delete(chatId)) return;
+    this.deps.onSessionRuntimeChange()?.(chatId, "idle");
+    this.recomputeRuntimeState();
   }
 
   /**

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -1282,9 +1282,12 @@ export class SessionRuntime {
 
     const reportSuspendedSessions = opts.reportSuspendedSessions ?? true;
     if (reportSuspendedSessions) {
-      // Report active sessions as suspended before clearing.
+      // Withdraw runtime before lifecycle so the server's active-gated idle
+      // write lands in-order; the lifecycle write is the server-side fallback
+      // if the connection drops between the two frames.
       for (const [chatId, session] of this.projection.sessionsEntries()) {
         if (session.status === "active") {
+          this.projection.clearActiveRuntimeProjection(chatId);
           this.projection.notifySessionState(chatId, "suspended");
         }
       }

--- a/packages/client/src/runtime/slot-scheduler-authority.ts
+++ b/packages/client/src/runtime/slot-scheduler-authority.ts
@@ -1067,14 +1067,12 @@ export class SlotSchedulerAuthority {
         // semantics), but its stop is unconfirmed — record the debt.
         this.deps.routeTeardown.registerPendingTeardown(candidate.key, candidate.session.handler);
       }
-      // LRU eviction is local memory-management, not operator intent — do
-      // NOT emit a wire state here. The chat now lives in `evictedMappings`
-      // and the next `agent:bound` (initial bind or reconnect) will pick it
-      // up via `getEvictedChatIds()` in `agent-slot.fullStateSync` and
-      // advertise it as `suspended`, so the server's `agent_chat_sessions.state`
-      // converges to "handler is gone" on the next sync without churn on
-      // every eviction.
+      // LRU eviction is local memory-management, not terminal operator intent,
+      // so the wire state is `suspended` rather than `evicted`. Report it now:
+      // waiting for a future bind leaves both lifecycle and runtime projections
+      // stale when the socket stays healthy and this chat remains quiet.
       this.deps.dropLiveSession(candidate.key);
+      this.deps.notifySessionState(candidate.key, "suspended");
       this.deps.inbox.prepareEvict(candidate.key, "session_evicted");
       this.deps.recomputeRuntimeState();
       this.deps.persistRegistry();

--- a/packages/server/src/__tests__/activity.test.ts
+++ b/packages/server/src/__tests__/activity.test.ts
@@ -221,6 +221,7 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
   it("DOES NOTIFY when state actually transitions", async () => {
     const { app, admin, agent, chat } = await setup();
     await upsertSessionState(app.db, agent.uuid, chat.id, "active", admin.organizationId);
+    await setSessionRuntime(app.db, agent.uuid, chat.id, "working", admin.organizationId);
 
     const notifier = {
       subscribe: vi.fn(),
@@ -267,6 +268,41 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       "suspended",
       admin.organizationId,
     );
+    expect(notifier.notifySessionRuntime).toHaveBeenCalledTimes(1);
+    expect(notifier.notifySessionRuntime).toHaveBeenCalledWith(agent.uuid, chat.id, "idle", admin.organizationId);
+
+    const [row] = await app.db
+      .select({ runtimeState: agentChatSessions.runtimeState, runtimeStateAt: agentChatSessions.runtimeStateAt })
+      .from(agentChatSessions)
+      .where(and(eq(agentChatSessions.agentId, agent.uuid), eq(agentChatSessions.chatId, chat.id)));
+    expect(row?.runtimeState).toBe("idle");
+    expect(row?.runtimeStateAt).toBeInstanceOf(Date);
+  });
+
+  it("repairs and notifies a same-state inactive row that retained working", async () => {
+    const { app, admin, agent, chat } = await setup();
+    await upsertSessionState(app.db, agent.uuid, chat.id, "suspended", admin.organizationId);
+    await app.db
+      .update(agentChatSessions)
+      .set({ runtimeState: "working", runtimeStateAt: new Date() })
+      .where(and(eq(agentChatSessions.agentId, agent.uuid), eq(agentChatSessions.chatId, chat.id)));
+    const notifier = makeNotifier();
+
+    await upsertSessionState(app.db, agent.uuid, chat.id, "suspended", admin.organizationId, notifier);
+
+    const [row] = await app.db
+      .select({ runtimeState: agentChatSessions.runtimeState })
+      .from(agentChatSessions)
+      .where(and(eq(agentChatSessions.agentId, agent.uuid), eq(agentChatSessions.chatId, chat.id)));
+    expect(row?.runtimeState).toBe("idle");
+    expect(notifier.notifySessionStateChange).toHaveBeenCalledTimes(1);
+    expect(notifier.notifySessionRuntime).toHaveBeenCalledWith(agent.uuid, chat.id, "idle", admin.organizationId);
+
+    vi.mocked(notifier.notifySessionStateChange).mockClear();
+    vi.mocked(notifier.notifySessionRuntime).mockClear();
+    await upsertSessionState(app.db, agent.uuid, chat.id, "suspended", admin.organizationId, notifier);
+    expect(notifier.notifySessionStateChange).not.toHaveBeenCalled();
+    expect(notifier.notifySessionRuntime).not.toHaveBeenCalled();
   });
 });
 
@@ -365,8 +401,32 @@ describe("setSessionRuntime — per-(agent,chat) D-axis writer", () => {
 
     const row = await readRuntime(app, agent.uuid, chat.id);
     expect(row?.runtimeState).toBe("idle"); // untouched
-    expect(row?.runtimeStateAt).toBeNull();
+    expect(row?.runtimeStateAt).toBeInstanceOf(Date);
     expect(notifier.notifySessionRuntime).not.toHaveBeenCalled();
+  });
+
+  it("suspend racing an idle report always converges to suspended idle", async () => {
+    const { app, admin, agent, chat } = await setupActive();
+    await setSessionRuntime(app.db, agent.uuid, chat.id, "working", admin.organizationId);
+    const notifier = makeNotifier();
+
+    await Promise.all([
+      setSessionRuntime(app.db, agent.uuid, chat.id, "idle", admin.organizationId, notifier),
+      upsertSessionState(app.db, agent.uuid, chat.id, "suspended", admin.organizationId, notifier),
+    ]);
+
+    const [row] = await app.db
+      .select({ state: agentChatSessions.state, runtimeState: agentChatSessions.runtimeState })
+      .from(agentChatSessions)
+      .where(and(eq(agentChatSessions.agentId, agent.uuid), eq(agentChatSessions.chatId, chat.id)));
+    expect(row).toMatchObject({ state: "suspended", runtimeState: "idle" });
+    expect(notifier.notifySessionStateChange).toHaveBeenCalledWith(
+      agent.uuid,
+      chat.id,
+      "suspended",
+      admin.organizationId,
+    );
+    expect(notifier.notifySessionRuntime).toHaveBeenCalledWith(agent.uuid, chat.id, "idle", admin.organizationId);
   });
 
   it("missing session row: no write, no notify, no throw", async () => {

--- a/packages/server/src/__tests__/admin-sessions-suspend-terminate.test.ts
+++ b/packages/server/src/__tests__/admin-sessions-suspend-terminate.test.ts
@@ -43,6 +43,24 @@ describe("Admin sessions — Suspend / Terminate (server-authoritative)", () => 
     return row?.state ?? null;
   }
 
+  async function setRuntimeState(app: FastifyInstance, agentId: string, chatId: string, runtimeState: string) {
+    const { and, eq } = await import("drizzle-orm");
+    await app.db
+      .update(agentChatSessions)
+      .set({ runtimeState, runtimeStateAt: new Date() })
+      .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
+  }
+
+  async function readRuntimeState(app: FastifyInstance, agentId: string, chatId: string): Promise<string | null> {
+    const { and, eq } = await import("drizzle-orm");
+    const [row] = await app.db
+      .select({ runtimeState: agentChatSessions.runtimeState })
+      .from(agentChatSessions)
+      .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)))
+      .limit(1);
+    return row?.runtimeState ?? null;
+  }
+
   it("Suspend on an active row transitions to suspended and returns 200 { transitioned: true }", async () => {
     const app = getApp();
     const admin = await createAdminContext(app, { username: `suspend-a-${crypto.randomUUID().slice(0, 6)}` });
@@ -55,6 +73,8 @@ describe("Admin sessions — Suspend / Terminate (server-authoritative)", () => 
     });
     const chat = await createChat(app.db, admin.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
     await seedSession(app, agent.uuid, chat.id, "active");
+    await setRuntimeState(app, agent.uuid, chat.id, "working");
+    const runtimeNotify = vi.spyOn(app.notifier, "notifySessionRuntime");
 
     const res = await app.inject({
       method: "POST",
@@ -66,6 +86,9 @@ describe("Admin sessions — Suspend / Terminate (server-authoritative)", () => 
     expect(body).toMatchObject({ agentId: agent.uuid, chatId: chat.id, state: "suspended", transitioned: true });
 
     expect(await readState(app, agent.uuid, chat.id)).toBe("suspended");
+    expect(await readRuntimeState(app, agent.uuid, chat.id)).toBe("idle");
+    expect(runtimeNotify).toHaveBeenCalledWith(agent.uuid, chat.id, "idle", admin.organizationId);
+    runtimeNotify.mockRestore();
   });
 
   it("Suspend on an already-suspended row is a no-op 200 { transitioned: false }", async () => {
@@ -80,6 +103,8 @@ describe("Admin sessions — Suspend / Terminate (server-authoritative)", () => 
     });
     const chat = await createChat(app.db, admin.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
     await seedSession(app, agent.uuid, chat.id, "suspended");
+    await setRuntimeState(app, agent.uuid, chat.id, "working");
+    const runtimeNotify = vi.spyOn(app.notifier, "notifySessionRuntime");
 
     const res = await app.inject({
       method: "POST",
@@ -88,6 +113,9 @@ describe("Admin sessions — Suspend / Terminate (server-authoritative)", () => 
     });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ state: "suspended", transitioned: false });
+    expect(await readRuntimeState(app, agent.uuid, chat.id)).toBe("idle");
+    expect(runtimeNotify).toHaveBeenCalledWith(agent.uuid, chat.id, "idle", admin.organizationId);
+    runtimeNotify.mockRestore();
   });
 
   it("Suspend reports delivered: true and sends session:suspend when the client is connected", async () => {
@@ -160,6 +188,7 @@ describe("Admin sessions — Suspend / Terminate (server-authoritative)", () => 
     });
     const chat = await createChat(app.db, admin.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
     await seedSession(app, agent.uuid, chat.id, "suspended");
+    await setRuntimeState(app, agent.uuid, chat.id, "working");
 
     const ws = { readyState: 1, send: vi.fn(), close: vi.fn() };
     setClientConnection(admin.clientId, ws as unknown as WebSocket);
@@ -192,6 +221,7 @@ describe("Admin sessions — Suspend / Terminate (server-authoritative)", () => 
     });
     const chat = await createChat(app.db, admin.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
     await seedSession(app, agent.uuid, chat.id, "suspended");
+    await setRuntimeState(app, agent.uuid, chat.id, "working");
     await sessionEventService.appendEvent(app.db, agent.uuid, chat.id, {
       kind: "error",
       payload: { source: "sdk", message: "pre-terminate event" },
@@ -206,6 +236,7 @@ describe("Admin sessions — Suspend / Terminate (server-authoritative)", () => 
     expect(res.json()).toMatchObject({ state: "evicted", transitioned: true });
 
     expect(await readState(app, agent.uuid, chat.id)).toBe("evicted");
+    expect(await readRuntimeState(app, agent.uuid, chat.id)).toBe("idle");
 
     // clearEvents is awaited before the success response, so by the time the
     // client can react (and refetch) the live trace is already gone.
@@ -696,6 +727,24 @@ describe("Terminate with apply-ack (?waitForApply=true) — the Web Reset path",
     return row?.state ?? null;
   }
 
+  async function setRuntimeState(app: FastifyInstance, agentId: string, chatId: string, runtimeState: string) {
+    const { and, eq } = await import("drizzle-orm");
+    await app.db
+      .update(agentChatSessions)
+      .set({ runtimeState, runtimeStateAt: new Date() })
+      .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
+  }
+
+  async function readRuntimeState(app: FastifyInstance, agentId: string, chatId: string): Promise<string | null> {
+    const { and, eq } = await import("drizzle-orm");
+    const [row] = await app.db
+      .select({ runtimeState: agentChatSessions.runtimeState })
+      .from(agentChatSessions)
+      .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)))
+      .limit(1);
+    return row?.runtimeState ?? null;
+  }
+
   const LOCAL_INSTANCE = "test-instance";
   const REMOTE_INSTANCE = "remote-instance";
 
@@ -868,6 +917,7 @@ describe("Terminate with apply-ack (?waitForApply=true) — the Web Reset path",
 
   it("holds the request until the ack, then atomically evicts and clears events", async () => {
     const { app, admin, agent, chat, ws } = await setup("suspended");
+    await setRuntimeState(app, agent.uuid, chat.id, "working");
     await sessionEventService.appendEvent(app.db, agent.uuid, chat.id, {
       kind: "error",
       payload: { source: "sdk", message: "pre-reset event" },
@@ -887,6 +937,7 @@ describe("Terminate with apply-ack (?waitForApply=true) — the Web Reset path",
       expect(res.statusCode).toBe(200);
       expect(res.json()).toMatchObject({ state: "evicted", transitioned: true, delivered: true, applied: true });
       expect(await readState(app, agent.uuid, chat.id)).toBe("evicted");
+      expect(await readRuntimeState(app, agent.uuid, chat.id)).toBe("idle");
       // Cleanup committed with the transition — no polling.
       expect((await sessionEventService.listEvents(app.db, agent.uuid, chat.id, { limit: 10 })).items).toEqual([]);
     } finally {
@@ -925,11 +976,13 @@ describe("Terminate with apply-ack (?waitForApply=true) — the Web Reset path",
     // waitForApply path must NOT fast-path success: it re-sends a ref'd
     // terminate, waits for a real ack, and only then reports evicted.
     const { app, admin, agent, chat, ws } = await setup("evicted");
+    await setRuntimeState(app, agent.uuid, chat.id, "working");
     await sessionEventService.appendEvent(app.db, agent.uuid, chat.id, {
       kind: "error",
       payload: { source: "sdk", message: "leftover trace" },
     });
     const notifySpy = vi.spyOn(app.notifier, "notifySessionStateChange");
+    const runtimeNotifySpy = vi.spyOn(app.notifier, "notifySessionRuntime");
     try {
       const pending = terminateReq(app, admin, agent.uuid, chat.id);
       await vi.waitFor(() => expect(ws.send).toHaveBeenCalled());
@@ -939,6 +992,7 @@ describe("Terminate with apply-ack (?waitForApply=true) — the Web Reset path",
       const res = await pending;
       expect(res.statusCode).toBe(200);
       expect(res.json()).toMatchObject({ state: "evicted", transitioned: false, applied: true });
+      expect(await readRuntimeState(app, agent.uuid, chat.id)).toBe("idle");
       // The idempotent finalize re-cleared the leftover trace.
       expect((await sessionEventService.listEvents(app.db, agent.uuid, chat.id, { limit: 10 })).items).toEqual([]);
       // …and still broadcast the eviction so every other open viewer drops
@@ -946,8 +1000,10 @@ describe("Terminate with apply-ack (?waitForApply=true) — the Web Reset path",
       await vi.waitFor(() =>
         expect(notifySpy).toHaveBeenCalledWith(agent.uuid, chat.id, "evicted", admin.organizationId),
       );
+      expect(runtimeNotifySpy).toHaveBeenCalledWith(agent.uuid, chat.id, "idle", admin.organizationId);
     } finally {
       notifySpy.mockRestore();
+      runtimeNotifySpy.mockRestore();
       cleanup(admin, ws);
     }
   });
@@ -955,8 +1011,10 @@ describe("Terminate with apply-ack (?waitForApply=true) — the Web Reset path",
   it("an evicted row produced by archiveAllSessionsForAgent also requires a fresh ack", async () => {
     const { app, admin, agent, chat, ws } = await setup("suspended");
     // Runtime-switch style eviction: no apply-ack was ever involved.
+    await setRuntimeState(app, agent.uuid, chat.id, "working");
     await sessionService.archiveAllSessionsForAgent(app.db, agent.uuid, admin.organizationId, app.notifier);
     expect(await readState(app, agent.uuid, chat.id)).toBe("evicted");
+    expect(await readRuntimeState(app, agent.uuid, chat.id)).toBe("idle");
     try {
       const pending = terminateReq(app, admin, agent.uuid, chat.id);
       await vi.waitFor(() => expect(ws.send).toHaveBeenCalled());

--- a/packages/server/src/__tests__/agent-chats.test.ts
+++ b/packages/server/src/__tests__/agent-chats.test.ts
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chatUserState } from "../db/schema/chat-user-state.js";
 import { chats } from "../db/schema/chats.js";
@@ -35,7 +36,7 @@ describe("Agent Chats API", () => {
     expect(getRes.json().id).toBe(chat.id);
   });
 
-  it("lists active runtime chat ids for the current human scope", async () => {
+  it("lists the human runtime set separately from every active server session", async () => {
     const app = getApp();
     const runtime = await createTestAgent(app, { name: "active-runtime-route" });
     const active = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
@@ -47,16 +48,36 @@ describe("Agent Chats API", () => {
     const deleted = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
       participantIds: [runtime.agent.uuid],
     });
+    const outsider = await createTestAdmin(app, { username: `runtime-outsider-${crypto.randomUUID().slice(0, 6)}` });
+    const hidden = await createMeChat(app.db, outsider.humanAgentUuid, runtime.organizationId, {
+      participantIds: [runtime.agent.uuid],
+    });
+    await app.db
+      .delete(chatMembership)
+      .where(and(eq(chatMembership.chatId, hidden.chatId), eq(chatMembership.agentId, runtime.humanAgentUuid)));
     await setChatEngagement(app.db, archived.chatId, runtime.humanAgentUuid, "archived");
     await setChatEngagement(app.db, deleted.chatId, runtime.humanAgentUuid, "deleted");
+    await app.db.insert(agentChatSessions).values(
+      [active.chatId, archived.chatId, deleted.chatId, hidden.chatId].map((chatId) => ({
+        agentId: runtime.agent.uuid,
+        chatId,
+        state: "active",
+        runtimeState: "working",
+        runtimeStateAt: new Date(),
+      })),
+    );
 
     const res = await runtime.request("GET", "/api/v1/agent/chats/active-runtime-ids");
 
     expect(res.statusCode).toBe(200);
-    const body = res.json<{ chatIds: string[] }>();
+    const body = res.json<{ chatIds: string[]; activeSessionChatIds: string[] }>();
     expect(body.chatIds).toContain(active.chatId);
     expect(body.chatIds).not.toContain(archived.chatId);
     expect(body.chatIds).not.toContain(deleted.chatId);
+    expect(body.chatIds).not.toContain(hidden.chatId);
+    expect(body.activeSessionChatIds).toEqual(
+      expect.arrayContaining([active.chatId, archived.chatId, deleted.chatId, hidden.chatId]),
+    );
   });
 
   it("creates a task chat with an initial message, woken recipients, and silent context participants", async () => {

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -26,10 +26,12 @@
  * See first-tree-context:agent-hub/web-console.md for the contract under test.
  */
 
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { users } from "../db/schema/users.js";
-import { listActiveRuntimeChatIds } from "../services/chat/conversation.js";
+import { listActiveRuntimeChatIds, listActiveSessionChatIds } from "../services/chat/conversation.js";
 import { recomputeChatWatchers } from "../services/chat/membership/participants.js";
 import { sendMessage } from "../services/chat/message.js";
 import {
@@ -997,6 +999,36 @@ describe("chat-first workspace service layer", () => {
     expect(ids).toContain(active.chatId);
     expect(ids).not.toContain(archived.chatId);
     expect(ids).not.toContain(deleted.chatId);
+  });
+
+  it("listActiveSessionChatIds returns active server sessions outside the manager's workspace scope", async () => {
+    const app = getApp();
+    const runtime = await createTestAgent(app, { name: "active-session-set" });
+    const outsider = await createTestAdmin(app, { username: `session-outsider-${crypto.randomUUID().slice(0, 6)}` });
+    const hidden = await createMeChat(app.db, outsider.humanAgentUuid, runtime.organizationId, {
+      participantIds: [runtime.agent.uuid],
+    });
+    await app.db
+      .delete(chatMembership)
+      .where(and(eq(chatMembership.chatId, hidden.chatId), eq(chatMembership.agentId, runtime.humanAgentUuid)));
+    await app.db.insert(agentChatSessions).values({
+      agentId: runtime.agent.uuid,
+      chatId: hidden.chatId,
+      state: "active",
+      runtimeState: "working",
+      runtimeStateAt: new Date(),
+    });
+
+    const visibleIds = await listActiveRuntimeChatIds(
+      app.db,
+      runtime.agent.uuid,
+      runtime.humanAgentUuid,
+      runtime.organizationId,
+    );
+    const sessionIds = await listActiveSessionChatIds(app.db, runtime.agent.uuid, runtime.organizationId);
+
+    expect(visibleIds).not.toContain(hidden.chatId);
+    expect(sessionIds).toContain(hidden.chatId);
   });
 
   it("listMeChats ?engagement=archived shows only archived rows", async () => {

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -131,13 +131,11 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
 
     const humanAgentId = await requireCallerHumanAgentId(app, user.userId, identity.organizationId);
 
-    const chatIds = await chatService.listActiveRuntimeChatIds(
-      app.db,
-      identity.uuid,
-      humanAgentId,
-      identity.organizationId,
-    );
-    return activeRuntimeChatIdsResponseSchema.parse({ chatIds });
+    const [chatIds, activeSessionChatIds] = await Promise.all([
+      chatService.listActiveRuntimeChatIds(app.db, identity.uuid, humanAgentId, identity.organizationId),
+      chatService.listActiveSessionChatIds(app.db, identity.uuid, identity.organizationId),
+    ]);
+    return activeRuntimeChatIdsResponseSchema.parse({ chatIds, activeSessionChatIds });
   });
 
   /**

--- a/packages/server/src/services/chat/conversation.ts
+++ b/packages/server/src/services/chat/conversation.ts
@@ -13,6 +13,7 @@ import {
 } from "@first-tree/shared";
 import { and, asc, desc, eq, inArray, lt, type SQL, sql } from "drizzle-orm";
 import type { Database } from "../../db/connection.js";
+import { agentChatSessions } from "../../db/schema/agent-chat-sessions.js";
 import { agents } from "../../db/schema/agents.js";
 import { chatMembership } from "../../db/schema/chat-membership.js";
 import { chatUserState } from "../../db/schema/chat-user-state.js";
@@ -906,6 +907,32 @@ export async function listActiveRuntimeChatIds(
      ORDER BY agent_membership.chat_id ASC
   `);
   return rows.map((row) => row.chat_id);
+}
+
+/**
+ * Runtime-revocation catch-up scope for one agent. Unlike the human-scoped
+ * workspace active set above, this reads the server session projection itself:
+ * an active session remains revocation-relevant even when the managing human
+ * is not a chat member or has archived/deleted the chat from their own view.
+ */
+export async function listActiveSessionChatIds(
+  db: Database,
+  agentId: string,
+  organizationId: string,
+): Promise<string[]> {
+  const rows = await db
+    .select({ chatId: agentChatSessions.chatId })
+    .from(agentChatSessions)
+    .innerJoin(chats, eq(chats.id, agentChatSessions.chatId))
+    .where(
+      and(
+        eq(agentChatSessions.agentId, agentId),
+        eq(agentChatSessions.state, "active"),
+        eq(chats.organizationId, organizationId),
+      ),
+    )
+    .orderBy(asc(agentChatSessions.chatId));
+  return rows.map((row) => row.chatId);
 }
 
 async function resolveViewerMembershipKind(

--- a/packages/server/src/services/chat/sessions/activity.ts
+++ b/packages/server/src/services/chat/sessions/activity.ts
@@ -1,5 +1,5 @@
 import { RUNTIME_STALE_MS, type RuntimeState, type SessionState } from "@first-tree/shared";
-import { and, eq, isNotNull, ne, sql } from "drizzle-orm";
+import { and, eq, isNotNull, ne, or, sql } from "drizzle-orm";
 import type { Database } from "../../../db/connection.js";
 import { agentChatSessions } from "../../../db/schema/agent-chat-sessions.js";
 import { agentPresence } from "../../../db/schema/agent-presence.js";
@@ -37,16 +37,18 @@ export async function upsertSessionState(
   options?: { touchPresenceLastSeen?: boolean },
 ) {
   const now = new Date();
-  let stateChanged = false;
+  const revokesRuntime = state !== "active";
+  let projectionChanged = false;
   await db.transaction(async (tx) => {
     // Short-circuit when the row is already at the target state: skip the
     // updatedAt refresh so steady-state messaging doesn't churn the row.
-    // Insertions and any state transition (evicted → active, active →
-    // suspended, etc.) still take the UPDATE branch.
+    // Insertions, lifecycle transitions (evicted → active, active →
+    // suspended, etc.), and one-time repair of a non-idle runtime retained by
+    // an already-inactive row still take the UPDATE branch.
     //
     // We use `.returning()` to detect whether INSERT/UPDATE actually fired —
     // PostgreSQL omits returning rows when the ON CONFLICT DO UPDATE's
-    // `setWhere` predicate is false (same-state no-op). Zero rows back ⇒
+    // `setWhere` predicate is false (same-state, already-revoked no-op). Zero rows back ⇒
     // skip the downstream presence refresh + NOTIFY. This keeps
     // `session:state` frames off the wire when an already-active session
     // receives a burst of steady-state messages (e.g. an agent emitting
@@ -59,19 +61,31 @@ export async function upsertSessionState(
     // side-effect here is safe.
     const rows = await tx
       .insert(agentChatSessions)
-      .values({ agentId, chatId, state, updatedAt: now })
+      .values(
+        revokesRuntime
+          ? { agentId, chatId, state, runtimeState: "idle", runtimeStateAt: now, updatedAt: now }
+          : { agentId, chatId, state, updatedAt: now },
+      )
       .onConflictDoUpdate({
         target: [agentChatSessions.agentId, agentChatSessions.chatId],
-        set: { state, updatedAt: now },
-        setWhere: ne(agentChatSessions.state, state),
+        set: revokesRuntime
+          ? { state, runtimeState: "idle", runtimeStateAt: now, updatedAt: now }
+          : { state, updatedAt: now },
+        // An inactive row retaining a non-idle runtime is also a real
+        // projection change even when its lifecycle value is already equal.
+        // Repair it once, then keep duplicate inactive frames as no-ops.
+        setWhere: revokesRuntime
+          ? or(ne(agentChatSessions.state, state), ne(agentChatSessions.runtimeState, "idle"))
+          : ne(agentChatSessions.state, state),
       })
       .returning({ agentId: agentChatSessions.agentId });
 
     if (rows.length === 0) return;
-    stateChanged = true;
+    projectionChanged = true;
 
-    // runtimeState is owned by the client's `runtime:state` frame — do not
-    // write it here to avoid dual-write conflicts.
+    // Active runtime values are owned by `session:runtime`. Lifecycle
+    // inactivation is the revocation authority and atomically writes idle so
+    // a dropped/reordered client edge cannot leave working behind.
     const [counts] = await tx
       .select({
         active: sql<number>`count(*) FILTER (WHERE ${agentChatSessions.state} = 'active')::int`,
@@ -103,8 +117,11 @@ export async function upsertSessionState(
       });
   });
 
-  if (stateChanged && notifier) {
+  if (projectionChanged && notifier) {
     notifier.notifySessionStateChange(agentId, chatId, state, organizationId).catch(() => {});
+    if (revokesRuntime) {
+      notifier.notifySessionRuntime(agentId, chatId, "idle", organizationId).catch(() => {});
+    }
   }
 }
 

--- a/packages/server/src/services/chat/sessions/lifecycle.ts
+++ b/packages/server/src/services/chat/sessions/lifecycle.ts
@@ -413,7 +413,7 @@ export async function finalizeTerminatedSession(
 
   await db.transaction(async (tx) => {
     const [existing] = await tx
-      .select({ state: agentChatSessions.state })
+      .select({ state: agentChatSessions.state, runtimeState: agentChatSessions.runtimeState })
       .from(agentChatSessions)
       .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)))
       .for("update");
@@ -440,6 +440,12 @@ export async function finalizeTerminatedSession(
     }
 
     if (current === "evicted") {
+      if (existing.runtimeState !== "idle") {
+        await tx
+          .update(agentChatSessions)
+          .set({ runtimeState: "idle", runtimeStateAt: now, updatedAt: now })
+          .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
+      }
       await sessionEventService.clearEvents(tx as unknown as Database, agentId, chatId);
       return;
     }
@@ -447,7 +453,7 @@ export async function finalizeTerminatedSession(
 
     await tx
       .update(agentChatSessions)
-      .set({ state: "evicted", updatedAt: now })
+      .set({ state: "evicted", runtimeState: "idle", runtimeStateAt: now, updatedAt: now })
       .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
 
     await sessionEventService.clearEvents(tx as unknown as Database, agentId, chatId);
@@ -483,6 +489,7 @@ export async function finalizeTerminatedSession(
   // cache; the state itself changing is not the point.
   if (finalState === "evicted" && notifier) {
     notifier.notifySessionStateChange(agentId, chatId, "evicted", organizationId).catch(() => {});
+    notifier.notifySessionRuntime(agentId, chatId, "idle", organizationId).catch(() => {});
   }
 
   return { state: finalState, transitioned };
@@ -550,6 +557,7 @@ export async function archiveAllSessionsForAgent(
   if (notifier) {
     for (const row of rows) {
       notifier.notifySessionStateChange(agentId, row.chatId, "evicted", organizationId).catch(() => {});
+      notifier.notifySessionRuntime(agentId, row.chatId, "idle", organizationId).catch(() => {});
     }
   }
 
@@ -568,10 +576,11 @@ async function transitionSessionState(
   const now = new Date();
   let finalState: SessionState | null = null;
   let transitioned = false;
+  let projectionChanged = false;
 
   await db.transaction(async (tx) => {
     const [existing] = await tx
-      .select({ state: agentChatSessions.state })
+      .select({ state: agentChatSessions.state, runtimeState: agentChatSessions.runtimeState })
       .from(agentChatSessions)
       .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)))
       .for("update");
@@ -580,40 +589,51 @@ async function transitionSessionState(
     const current = existing.state as SessionState;
     finalState = current;
 
-    if (!from.includes(current)) return;
+    const canTransition = from.includes(current);
+    const resolvedState = canTransition ? target : current;
+    const mustRevokeRuntime = resolvedState !== "active" && existing.runtimeState !== "idle";
+    if (!canTransition && !mustRevokeRuntime) return;
 
     await tx
       .update(agentChatSessions)
-      .set({ state: target, updatedAt: now })
+      .set(
+        canTransition
+          ? { state: target, runtimeState: "idle", runtimeStateAt: now, updatedAt: now }
+          : { runtimeState: "idle", runtimeStateAt: now, updatedAt: now },
+      )
       .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
 
-    const [counts] = await tx
-      .select({
-        active: sql<number>`count(*) FILTER (WHERE ${agentChatSessions.state} = 'active')::int`,
-        total: sql<number>`count(*) FILTER (WHERE ${agentChatSessions.state} != 'evicted')::int`,
-      })
-      .from(agentChatSessions)
-      .where(eq(agentChatSessions.agentId, agentId));
+    if (canTransition) {
+      const [counts] = await tx
+        .select({
+          active: sql<number>`count(*) FILTER (WHERE ${agentChatSessions.state} = 'active')::int`,
+          total: sql<number>`count(*) FILTER (WHERE ${agentChatSessions.state} != 'evicted')::int`,
+        })
+        .from(agentChatSessions)
+        .where(eq(agentChatSessions.agentId, agentId));
 
-    await tx
-      .update(agentPresence)
-      .set({
-        activeSessions: counts?.active ?? 0,
-        totalSessions: counts?.total ?? 0,
-        lastSeenAt: now,
-      })
-      .where(eq(agentPresence.agentId, agentId));
+      await tx
+        .update(agentPresence)
+        .set({
+          activeSessions: counts?.active ?? 0,
+          totalSessions: counts?.total ?? 0,
+          lastSeenAt: now,
+        })
+        .where(eq(agentPresence.agentId, agentId));
+    }
 
-    finalState = target;
-    transitioned = true;
+    finalState = resolvedState;
+    transitioned = canTransition;
+    projectionChanged = true;
   });
 
   if (finalState === null) {
     throw new NotFoundError(`Session (${agentId}, ${chatId}) not found`);
   }
 
-  if (transitioned && notifier) {
-    notifier.notifySessionStateChange(agentId, chatId, target, organizationId).catch(() => {});
+  if (projectionChanged && notifier) {
+    notifier.notifySessionStateChange(agentId, chatId, finalState, organizationId).catch(() => {});
+    notifier.notifySessionRuntime(agentId, chatId, "idle", organizationId).catch(() => {});
   }
 
   return { state: finalState, transitioned };

--- a/packages/shared/src/schemas/active-runtime-chats.ts
+++ b/packages/shared/src/schemas/active-runtime-chats.ts
@@ -2,5 +2,12 @@ import { z } from "zod";
 
 export const activeRuntimeChatIdsResponseSchema = z.object({
   chatIds: z.array(z.string().min(1)),
+  /**
+   * Every server-side session row that is currently active for this agent,
+   * independent of the managing human's workspace visibility/engagement.
+   * Optional for rolling compatibility with servers that only return the
+   * human-scoped runtime working set.
+   */
+  activeSessionChatIds: z.array(z.string().min(1)).optional(),
 });
 export type ActiveRuntimeChatIdsResponse = z.infer<typeof activeRuntimeChatIdsResponseSchema>;


### PR DESCRIPTION
## Summary

- Implements the confirmed B1-only scope for #1455: reliably revoke per-chat working/busy authority when a local runtime projection is removed or a session becomes inactive.
- Emits explicit idle before local projection deletion, reports LRU/shutdown suspension immediately, and atomically pairs server lifecycle inactivation with runtime idle plus lifecycle/runtime invalidation.
- Repairs disappeared runtime records on reconnect/catch-up from the complete server active-session projection.

## Scope

- Preserves the status model merged in #2355: fresh working is busy; stale in-flight is recovery/failed; stale idle stays quiet. Stale runtime is never restored as working authority.
- Does not add a second Web status authority or change the existing refetch/reconnect behavior.
- No database migration, unrelated refactor, or Context Tree change.

## Review resolution

- Keeps the managing human visible/active `chatIds` set only for lifecycle reconcile.
- Adds a distinct `activeSessionChatIds` snapshot from `agent_chat_sessions.state = active`, organization-scoped but independent of manager membership or archive/delete engagement, for runtime-disappearance revocation.
- Keeps rolling compatibility with older servers by falling back to `chatIds` until the complete active-session field is available.

## Deterministic coverage

- Turn completion and prevention of permanent idle-while-working.
- Projection deletion, LRU eviction, shutdown, suspend, terminate/finalize, and runtime-switch archive.
- Runtime disappearance plus reconnect/catch-up, including a server-active chat hidden from the managing human.
- Repeated inactive notifications and suspend/runtime races.

## Validation

- Focused client AgentSlot suite: 47 passed.
- Focused server affected suites: 180 passed.
- Shared typecheck passed.
- `pnpm check` passed; repository-existing warnings only.
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`: 10/10 monorepo tasks passed on the final head; client 2,745 passed / 7 skipped, Web 2,380 passed, CLI 27/27 batches passed.
- One unrelated Grok ACP pid-file timing flake occurred on the first full run; the exact test then passed 9/9 standalone and passed inside the successful full rerun.
- `git diff --check`

## Context Tree impact

The per-chat active-session authority and stale fail-closed rules require reconnect revocation to use the complete server Session projection, not the managing human workspace projection. Sources: [Sessions and Status](https://github.com/agent-team-foundation/first-tree-context/blob/65e6334788122bb83298ea8cd5edd82be1fe5243/first-tree/system/cloud/chat/sessions-and-status.md) and [Client Runtime](https://github.com/agent-team-foundation/first-tree-context/blob/65e6334788122bb83298ea8cd5edd82be1fe5243/first-tree/system/cloud/runtime/client-runtime.md).

## Remaining risk

Runtime notifications remain best-effort transport signals as before; the durable server write is committed first, and reconnect/catch-up plus existing Web refetch repair dropped notifications. The expanded HTTP response is optional for rolling compatibility. No live deployment or manual UI QA was performed.

Related to #1455