### PR TITLE
fix(github): retire manual commit follows

### DIFF
--- a/apps/cli/src/commands/github/follow.ts
+++ b/apps/cli/src/commands/github/follow.ts
@@ -14,8 +14,8 @@ export function registerGithubFollowCommand(github: Command): void {
   github
     .command("follow <entity>")
     .description(
-      "Follow a GitHub entity (PR / Issue / Discussion / Commit): route its webhook events into the current " +
-        "chat. <entity> is a GitHub URL, owner/repo#42, or owner/repo@<sha>. Creating a PR or issue never " +
+      "Follow a GitHub entity (PR / Issue / Discussion): route its webhook events into the current " +
+        "chat. <entity> is a GitHub URL or owner/repo#42. Creating a PR or issue never " +
         "follows it for you — declare the dependency yourself, immediately after creation.",
     )
     .option("--chat <chatId>", "Target chat (default: the session's FIRST_TREE_CHAT_ID)")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -785,7 +785,6 @@ first-tree github
 # Inside an agent session the chat is inferred from FIRST_TREE_CHAT_ID
 first-tree github follow https://github.com/acme/api/pull/42
 first-tree github follow acme/api#42        # issue vs PR resolved automatically
-first-tree github follow acme/api@3f2a91c   # commit
 first-tree github following
 first-tree github unfollow acme/api#42
 ```
@@ -808,7 +807,9 @@ terminal App reply carrying its valid hidden run marker remains an ordinary
 subscription event but cannot create another task run. This ordinary comment
 publisher does not grant Context Review verdict or merge authority.
 
-`<entity>` accepts a full GitHub URL, `owner/repo#N`, or `owner/repo@<sha>`.
+`<entity>` accepts a full GitHub PR / Issue / Discussion URL or `owner/repo#N`.
+Commits remain a webhook event surface but cannot be followed or unfollowed
+manually.
 A `409` means the same (human, delegate) line already lives in another chat
 — `--rebind` MOVES it here (a line is never duplicated). `unfollow` is
 idempotent: `removed: 0` is success, not an error. Requires the org's

--- a/docs/development/local-github-app.md
+++ b/docs/development/local-github-app.md
@@ -125,10 +125,15 @@ Subscribe the GitHub App to:
 - `issue_comment`
 - `pull_request`
 - `pull_request_review`
-- `push`
+- `pull_request_review_comment`
+- `discussion`
+- `discussion_comment`
+- `commit_comment`
 - `installation`
 - `installation_repositories`
-- `member`
+
+`push` and `member` may remain subscribed for future use, but the current
+normalizer intentionally produces no fanout for them.
 
 The server also accepts GitHub's `ping` event on the same webhook endpoint.
 

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -879,7 +879,7 @@ describe("small API route handlers", () => {
         params: { chatId: "chat_1" },
         query: {},
       }),
-    ).rejects.toThrow("Pass ?entity=<GitHub URL | owner/repo#N | owner/repo@sha> to unfollow.");
+    ).rejects.toThrow("Pass ?entity=<GitHub PR/Issue/Discussion URL | owner/repo#N> to unfollow.");
   });
 
   it("serializes organization identity reads and updates", async () => {

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -1351,7 +1351,6 @@ describe("POST /webhooks/github-app", () => {
       delegateMention: delegate,
       type: "human",
     });
-
     const res = await postWebhook(app, "pull_request", {
       action: "review_requested",
       pull_request: {
@@ -1434,6 +1433,100 @@ describe("POST /webhooks/github-app", () => {
       .where(eq(githubEntityChatMappings.entityKey, "owner/repo#829"))
       .limit(1);
     expect(mappingRow).toMatchObject({ humanAgentId: human, entityType: "issue", entityState: "closed" });
+  });
+
+  it("routes commit_comment mentions through attention, card, and notifying inbox delivery", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100048;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `commit-dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `commit-human-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+      type: "human",
+    });
+    const legacyChat = await createChat(app.db, human, {
+      type: "group",
+      participantIds: [delegate],
+    });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "commit",
+      entityKey: "owner/repo@abc1234",
+      chatId: legacyChat.id,
+      boundVia: "agent_declared",
+    });
+
+    const res = await postWebhook(app, "commit_comment", {
+      action: "created",
+      comment: {
+        body: `@${humanName} please inspect this commit`,
+        commit_id: "abc1234",
+        html_url: "https://github.com/owner/repo/commit/abc1234#commitcomment-1",
+        author_association: "MEMBER",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "external-author", type: "User" },
+      installation: { id: installationId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ delivered: 1, newChats: 1, failed: 0 });
+
+    const [mapping] = await app.db
+      .select({
+        humanAgentId: githubEntityChatMappings.humanAgentId,
+        delegateAgentId: githubEntityChatMappings.delegateAgentId,
+        entityType: githubEntityChatMappings.entityType,
+        entityKey: githubEntityChatMappings.entityKey,
+        boundVia: githubEntityChatMappings.boundVia,
+        chatId: githubEntityChatMappings.chatId,
+      })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo@abc1234"))
+      .limit(1);
+    expect(mapping).toMatchObject({
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "commit",
+      entityKey: "owner/repo@abc1234",
+      boundVia: "direct",
+    });
+    expect(mapping?.chatId).not.toBe(legacyChat.id);
+
+    const [message] = await app.db.select().from(messages).limit(1);
+    expect(message?.content).toMatchObject({
+      type: "github_event",
+      event: "commit_comment",
+      kind: "commit_commented",
+      reason: "mentioned",
+      entity: { type: "commit", key: "owner/repo@abc1234" },
+    });
+    expect(message?.metadata).toMatchObject({
+      event: "commit_comment",
+      entityType: "commit",
+      entityKey: "owner/repo@abc1234",
+      mentions: [delegate],
+    });
+    expect(message?.chatId).toBe(mapping?.chatId);
+
+    const [entry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.messageId, message?.id ?? ""), eq(inboxEntries.inboxId, `inbox_${delegate}`)))
+      .limit(1);
+    expect(entry?.notify).toBe(true);
   });
 
   it("issue_comment.created on a PR seeds a new closed PR mapping from the issue payload state", async () => {

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -831,6 +831,63 @@ describe("resolveAudience", () => {
     expect(resolution.appTaskBlocker).toBeNull();
   });
 
+  it("routes commit webhooks only through webhook-created rows, not legacy manual follows", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const declaredDelegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `declared-${randomUUID().slice(0, 6)}`,
+    });
+    const webhookDelegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `webhook-${randomUUID().slice(0, 6)}`,
+    });
+    const declaredChat = await seedChat(app, admin.organizationId, admin.humanAgentUuid);
+    const webhookChat = await seedChat(app, admin.organizationId, admin.humanAgentUuid);
+    const entityKey = "owner/repo@abc1234";
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: admin.humanAgentUuid,
+      delegateId: declaredDelegate,
+      entityType: "commit",
+      entityKey,
+      chatId: declaredChat,
+      boundVia: "agent_declared",
+    });
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: admin.humanAgentUuid,
+      delegateId: webhookDelegate,
+      entityType: "commit",
+      entityKey,
+      chatId: webhookChat,
+      boundVia: "direct",
+    });
+
+    const targets = await resolveAudience(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "commit",
+        entityKey,
+        eventType: "commit_comment",
+        actorLogin: "external",
+        kind: "commit_commented",
+      }),
+    );
+
+    expect(targets).toEqual([
+      expect.objectContaining({
+        kind: "existing",
+        chatId: webhookChat,
+        delegateAgentId: webhookDelegate,
+        provenance: "identity_target",
+      }),
+    ]);
+  });
+
   it("requires a configured App slug and preserves an independent subscription when it is missing", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/github-entities-agent-route.test.ts
+++ b/packages/server/src/__tests__/github-entities-agent-route.test.ts
@@ -53,7 +53,7 @@ describe("agent github-entities routes", () => {
         accountType: "Organization",
         accountLogin: `acme-${githubAccountId}`,
         accountGithubId: githubAccountId,
-        permissions: { contents: "read" },
+        permissions: { issues: "read", pull_requests: "read" },
         events: ["pull_request", "issues"],
         suspendedAt: null,
       },
@@ -70,7 +70,7 @@ describe("agent github-entities routes", () => {
         {
           token: "ghs_test_token",
           expires_at: "2099-01-01T00:00:00Z",
-          permissions: { contents: "read" },
+          permissions: { issues: "read", pull_requests: "read" },
           repository_selection: "selected",
         },
         201,
@@ -111,6 +111,20 @@ describe("agent github-entities routes", () => {
     });
     expect(res.statusCode).toBe(422);
     expect((res.json() as { error: string }).error).toContain("GitHub App");
+  });
+
+  it("rejects commit references at the agent API boundary", async () => {
+    const app = getApp();
+    const a = await createTestAgent(app, { name: `gh-commit-${randomUUID().slice(0, 6)}` });
+    const chatId = await createChatWith(a, [a.humanAgentUuid]);
+
+    const res = await a.request("POST", `/api/v1/agent/chats/${chatId}/github-entities`, {
+      entity: "https://github.com/acme/api/commit/3f2a91c0",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect((res.json() as { error: string }).error).toContain("Commit references are not supported");
+    expect(await app.db.select().from(githubEntityChatMappings)).toHaveLength(0);
   });
 
   it("follow in an agents-only chat still resolves a pair via the supervising human watcher", async () => {

--- a/packages/server/src/__tests__/github-entities-user-route.test.ts
+++ b/packages/server/src/__tests__/github-entities-user-route.test.ts
@@ -96,4 +96,17 @@ describe("user github-entities follow route", () => {
     expect(res.statusCode).toBe(422);
     expect((res.json() as { error: string }).error).toContain("GitHub App");
   });
+
+  it("rejects commit references at the user API boundary", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `u-${randomUUID().slice(0, 8)}` });
+    const delegate = await seedAgent(app, admin.organizationId, admin.memberId, "agent");
+    await app.db.update(agents).set({ delegateMention: delegate }).where(eq(agents.uuid, admin.humanAgentUuid));
+    const chatId = await seedChat(app, admin.organizationId, [admin.humanAgentUuid, delegate]);
+
+    const res = await follow(app, admin.accessToken, chatId, "acme/api@3f2a91c0");
+
+    expect(res.statusCode).toBe(400);
+    expect((res.json() as { error: string }).error).toContain("Commit references are not supported");
+  });
 });

--- a/packages/server/src/__tests__/github-entity-follow.test.ts
+++ b/packages/server/src/__tests__/github-entity-follow.test.ts
@@ -123,7 +123,7 @@ describe("github-entity-follow", () => {
         accountType: "Organization",
         accountLogin: `acme-${githubAccountId}`,
         accountGithubId: githubAccountId,
-        permissions: { contents: "read" },
+        permissions: { issues: "read", pull_requests: "read" },
         events: ["pull_request", "issues"],
         suspendedAt: null,
       },
@@ -143,7 +143,7 @@ describe("github-entity-follow", () => {
           JSON.stringify({
             token: "ghs_test_token",
             expires_at: "2099-01-01T00:00:00Z",
-            permissions: { contents: "read" },
+            permissions: { issues: "read", pull_requests: "read" },
             repository_selection: "selected",
           }),
           { status: 201, headers: { "content-type": "application/json" } },
@@ -232,14 +232,12 @@ describe("github-entity-follow", () => {
       expect(parseEntityReference("https://github.com/o/r/discussions/9")).toMatchObject({
         explicitType: "discussion",
       });
-      expect(parseEntityReference("https://github.com/o/r/commit/3F2A91C0")).toEqual({
-        kind: "commit",
-        owner: "o",
-        repo: "r",
-        sha: "3f2a91c0",
-      });
       expect(parseEntityReference("o/r#42")).toMatchObject({ kind: "numeric", explicitType: null, number: 42 });
-      expect(parseEntityReference("o/r@abcdef1")).toMatchObject({ kind: "commit", sha: "abcdef1" });
+    });
+
+    it("does not parse commit references as manual follow targets", () => {
+      expect(parseEntityReference("https://github.com/o/r/commit/3F2A91C0")).toBeNull();
+      expect(parseEntityReference("o/r@abcdef1")).toBeNull();
     });
 
     it("rejects garbage", () => {
@@ -247,6 +245,22 @@ describe("github-entity-follow", () => {
       expect(parseEntityReference("https://github.com/o/r")).toBeNull();
       expect(parseEntityReference("o/r#abc")).toBeNull();
     });
+  });
+
+  it("rejects commit follow and unfollow before minting a token or calling GitHub", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const fetcher = vi.fn<typeof fetch>().mockRejectedValue(new Error("unexpected GitHub request"));
+
+    await expect(
+      declareEntityFollow(app.db, deps(fetcher), followParams(s, "https://github.com/acme/api/commit/3f2a91c0")),
+    ).rejects.toThrow(/Commit references are not supported/);
+    await expect(removeEntityFollow(app.db, { chatId: s.chatId, entity: "acme/api@3f2a91c0" })).rejects.toThrow(
+      /Commit references are not supported/,
+    );
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(await app.db.select().from(githubEntityChatMappings)).toHaveLength(0);
   });
 
   it("follows a short-form entity: discriminates PR vs issue and canonicalises the key (R8/R9)", async () => {
@@ -467,79 +481,6 @@ describe("github-entity-follow", () => {
     expect(row?.entityState).toBe("draft");
   });
 
-  it("follows a commit URL and stores the full sha with its first-line title", async () => {
-    const app = getApp();
-    const s = await setup(app);
-    const fullSha = "3f2a91c0aaaabbbbccccddddeeeeffff00001111";
-    const fetcher = makeFetcher({
-      "/repos/Acme/Api/commits/3f2a91c0": () =>
-        json({
-          sha: fullSha,
-          html_url: `https://github.com/Acme/Api/commit/${fullSha}`,
-          commit: { message: "Fix inbox routing\n\nLonger body" },
-        }),
-      "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
-    });
-
-    const result = await declareEntityFollow(
-      app.db,
-      deps(fetcher),
-      followParams(s, "https://github.com/acme/api/commit/3F2A91C0"),
-    );
-
-    expect(result.outcome).toBe("created");
-    if (result.outcome !== "created") throw new Error("unreachable");
-    expect(result.entity).toMatchObject({
-      entityType: "commit",
-      entityKey: `Acme/Api@${fullSha}`,
-      htmlUrl: `https://github.com/Acme/Api/commit/${fullSha}`,
-      title: "Fix inbox routing",
-      state: null,
-      number: null,
-    });
-
-    const [row] = await app.db
-      .select({
-        entityType: githubEntityChatMappings.entityType,
-        entityKey: githubEntityChatMappings.entityKey,
-        title: githubEntityChatMappings.title,
-        entityState: githubEntityChatMappings.entityState,
-      })
-      .from(githubEntityChatMappings)
-      .where(eq(githubEntityChatMappings.chatId, s.chatId));
-    expect(row).toEqual({
-      entityType: "commit",
-      entityKey: `Acme/Api@${fullSha}`,
-      title: "Fix inbox routing",
-      entityState: "open",
-    });
-  });
-
-  it("allows commit payloads without a commit object and falls back to a null title", async () => {
-    const app = getApp();
-    const s = await setup(app);
-    const fullSha = "3f2a91c0aaaabbbbccccddddeeeeffff00001111";
-    const fetcher = makeFetcher({
-      "/repos/Acme/Api/commits/3f2a91c0": () =>
-        json({
-          sha: fullSha,
-          html_url: `https://github.com/Acme/Api/commit/${fullSha}`,
-          commit: null,
-        }),
-      "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
-    });
-
-    const result = await declareEntityFollow(
-      app.db,
-      deps(fetcher),
-      followParams(s, "https://github.com/acme/api/commit/3F2A91C0"),
-    );
-
-    expect(result.outcome).toBe("created");
-    if (result.outcome !== "created") throw new Error("unreachable");
-    expect(result.entity.title).toBeNull();
-  });
-
   it("falls back to a null live state when GitHub returns an unexpected PR state", async () => {
     const app = getApp();
     const s = await setup(app);
@@ -682,7 +623,7 @@ describe("github-entity-follow", () => {
         return json({
           token: "ghs_test_token",
           expires_at: "2099-01-01T00:00:00Z",
-          permissions: { contents: "read" },
+          permissions: { issues: "read", pull_requests: "read" },
           repository_selection: "selected",
         });
       }
@@ -1510,31 +1451,76 @@ describe("github-entity-follow", () => {
     ).resolves.toEqual({ removed: 1 });
   });
 
-  it("commit unfollow escapes LIKE metacharacters — an underscore repo cannot sweep a sibling", async () => {
+  it("keeps webhook commit rows readable while legacy manual commit rows stay inert", async () => {
     const app = getApp();
     const s = await setup(app);
-    const base = {
+    const webhookDelegate = await seedAgent(app, s.admin.organizationId, s.admin.memberId, "agent");
+    await seedPairMembership(app, s.chatId, s.human, webhookDelegate);
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: s.admin.organizationId,
+        humanAgentId: s.human,
+        delegateAgentId: s.delegate,
+        entityType: "commit",
+        entityKey: "Acme/Api@3f2a91c0aaaabbbbccccddddeeeeffff00001111",
+        chatId: s.chatId,
+        boundVia: "agent_declared",
+        boundAt: new Date("2026-08-20T10:00:00.000Z"),
+      },
+      {
+        organizationId: s.admin.organizationId,
+        humanAgentId: s.human,
+        delegateAgentId: webhookDelegate,
+        entityType: "commit",
+        entityKey: "Acme/Api@3f2a91c0aaaabbbbccccddddeeeeffff00001111",
+        chatId: s.chatId,
+        boundVia: "direct",
+        title: "Webhook-observed commit",
+        boundAt: new Date("2026-08-20T09:00:00.000Z"),
+      },
+    ]);
+
+    const list = await listChatGithubEntities(app.db, { chatId: s.chatId });
+    expect(list.items).toEqual([
+      {
+        entityType: "commit",
+        entityKey: "Acme/Api@3f2a91c0aaaabbbbccccddddeeeeffff00001111",
+        boundVia: "direct",
+        htmlUrl: "https://github.com/Acme/Api/commit/3f2a91c0aaaabbbbccccddddeeeeffff00001111",
+        title: "Webhook-observed commit",
+        state: null,
+        number: null,
+      },
+    ]);
+
+    const storedRows = await app.db
+      .select({ boundVia: githubEntityChatMappings.boundVia })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, s.chatId));
+    expect(storedRows).toHaveLength(2);
+  });
+
+  it("does not let a rejected commit unfollow mutate historical rows", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    await app.db.insert(githubEntityChatMappings).values({
       organizationId: s.admin.organizationId,
       humanAgentId: s.human,
       delegateAgentId: s.delegate,
       entityType: "commit",
+      entityKey: "acme/my_app@3f2a91c0aaaabbbbccccddddeeeeffff00001111",
       chatId: s.chatId,
       boundVia: "agent_declared",
-    };
-    await app.db.insert(githubEntityChatMappings).values([
-      { ...base, entityKey: "acme/my_app@3f2a91c0aaaabbbbccccddddeeeeffff00001111" },
-      // `_` as LIKE-any-char would also match this sibling repo's row.
-      { ...base, entityKey: "acme/myxapp@3f2a91c0aaaabbbbccccddddeeeeffff00001111" },
-    ]);
-
-    await expect(removeEntityFollow(app.db, { chatId: s.chatId, entity: "acme/my_app@3f2a91c0" })).resolves.toEqual({
-      removed: 1,
     });
+
+    await expect(removeEntityFollow(app.db, { chatId: s.chatId, entity: "acme/my_app@3f2a91c0" })).rejects.toThrow(
+      /Commit references are not supported/,
+    );
     const remaining = await app.db
       .select({ entityKey: githubEntityChatMappings.entityKey })
       .from(githubEntityChatMappings)
       .where(eq(githubEntityChatMappings.chatId, s.chatId));
-    expect(remaining).toEqual([{ entityKey: "acme/myxapp@3f2a91c0aaaabbbbccccddddeeeeffff00001111" }]);
+    expect(remaining).toEqual([{ entityKey: "acme/my_app@3f2a91c0aaaabbbbccccddddeeeeffff00001111" }]);
   });
 
   it("rebind whose conflicting row vanished concurrently falls back to a real insert (no ghost success)", async () => {
@@ -1806,76 +1792,6 @@ describe("github-entity-follow", () => {
       htmlUrl: "https://github.com/Acme/Api/discussions/42",
       number: 42,
     });
-  });
-
-  it("unfollow by short commit sha prefix removes the full-sha row", async () => {
-    const app = getApp();
-    const s = await setup(app);
-    await app.db.insert(githubEntityChatMappings).values({
-      organizationId: s.admin.organizationId,
-      humanAgentId: s.human,
-      delegateAgentId: s.delegate,
-      entityType: "commit",
-      entityKey: "Acme/Api@3f2a91c0aaaabbbbccccddddeeeeffff00001111",
-      chatId: s.chatId,
-      boundVia: "agent_declared",
-    });
-    await expect(removeEntityFollow(app.db, { chatId: s.chatId, entity: "acme/api@3f2a91c0" })).resolves.toEqual({
-      removed: 1,
-    });
-  });
-
-  it("uses commit resolver fallbacks for repo name, sha, html URL, and blank first-line title", async () => {
-    const app = getApp();
-    const s = await setup(app);
-    const fetcher = makeFetcher({
-      "/repos/acme/api/commits/3f2a91c0": () => json({ commit: { message: "\nbody" } }),
-      "/repos/acme/api": () => json({}),
-    });
-
-    const result = await declareEntityFollow(app.db, deps(fetcher), followParams(s, "acme/api@3f2a91c0"));
-
-    expect(result.outcome).toBe("created");
-    if (result.outcome !== "created") throw new Error("expected created");
-    expect(result.entity).toMatchObject({
-      entityType: "commit",
-      entityKey: "acme/api@3f2a91c0",
-      htmlUrl: "https://github.com/acme/api/commit/3f2a91c0",
-      title: "",
-      state: null,
-      number: null,
-    });
-  });
-
-  it("maps commit GitHub failures after repo resolution", async () => {
-    const app = getApp();
-    const unavailable = await setup(app);
-    await expect(
-      declareEntityFollow(
-        app.db,
-        deps(
-          makeFetcher({
-            "/repos/acme/api/commits/3f2a91c0": () => json({ message: "server error" }, 502),
-            "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
-          }),
-        ),
-        followParams(unavailable, "acme/api@3f2a91c0"),
-      ),
-    ).rejects.toBeInstanceOf(ServiceUnavailableError);
-
-    const missing = await setup(app);
-    await expect(
-      declareEntityFollow(
-        app.db,
-        deps(
-          makeFetcher({
-            "/repos/acme/api/commits/3f2a91c0": () => json({ message: "Not Found" }, 404),
-            "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
-          }),
-        ),
-        followParams(missing, "acme/api@3f2a91c0"),
-      ),
-    ).rejects.toBeInstanceOf(NotFoundError);
   });
 
   it("maps PR second-hop failures without writing a follow row", async () => {

--- a/packages/server/src/__tests__/github-entity-live.test.ts
+++ b/packages/server/src/__tests__/github-entity-live.test.ts
@@ -140,7 +140,7 @@ describe("fetchEntityLiveFields", () => {
     ).resolves.toEqual({ title: "", state: "closed" });
   });
 
-  it("fetches issue state and commit title", async () => {
+  it("fetches issue state", async () => {
     const issueFetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ title: "Bug", state: "closed" }));
     await expect(
       __testing.fetchEntityLiveFields(
@@ -150,21 +150,9 @@ describe("fetchEntityLiveFields", () => {
         issueFetcher,
       ),
     ).resolves.toEqual({ title: "Bug", state: "closed" });
-
-    const commitFetcher = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(jsonResponse({ commit: { message: "Fix startup\n\nBody" } }));
-    await expect(
-      __testing.fetchEntityLiveFields(
-        "commit",
-        { kind: "sha", owner: "owner", repo: "repo", sha: "abcdef1" },
-        "token",
-        commitFetcher,
-      ),
-    ).resolves.toEqual({ title: "Fix startup", state: null });
   });
 
-  it("normalizes issue and commit live field fallbacks", async () => {
+  it("normalizes issue live field fallbacks", async () => {
     await expect(
       __testing.fetchEntityLiveFields(
         "issue",
@@ -173,24 +161,19 @@ describe("fetchEntityLiveFields", () => {
         vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ state: "triaged" })),
       ),
     ).resolves.toEqual({ title: null, state: null });
+  });
 
+  it("never resolves commit fields through GitHub REST", async () => {
+    const fetcher = vi.fn<typeof fetch>();
     await expect(
       __testing.fetchEntityLiveFields(
         "commit",
         { kind: "sha", owner: "owner", repo: "repo", sha: "abcdef1" },
         "token",
-        vi.fn<typeof fetch>().mockResolvedValueOnce(new Response("nope", { status: 500 })),
+        fetcher,
       ),
     ).resolves.toEqual({ title: null, state: null });
-
-    await expect(
-      __testing.fetchEntityLiveFields(
-        "commit",
-        { kind: "sha", owner: "owner", repo: "repo", sha: "abcdef1" },
-        "token",
-        vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ commit: {} })),
-      ),
-    ).resolves.toEqual({ title: null, state: null });
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("returns empty live fields when fetch fails or entity type has no live endpoint", async () => {
@@ -285,7 +268,7 @@ describe("resolveChatGithubEntity", () => {
     });
   });
 
-  it("does not fetch live fields without a token", async () => {
+  it("keeps legacy manually followed commit rows inert and read-safe", async () => {
     const fetcher = vi.fn<typeof fetch>();
 
     await expect(
@@ -294,12 +277,44 @@ describe("resolveChatGithubEntity", () => {
         null,
         fetcher,
       ),
+    ).resolves.toBeNull();
+    await expect(
+      resolveChatGithubEntity(
+        { entityType: "commit", entityKey: "owner/repo@abcdef1", boundVia: "human_declared" },
+        "token",
+        fetcher,
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      resolveChatGithubEntity(
+        { entityType: "commit", entityKey: "owner/repo@abcdef1", boundVia: "agent_created" },
+        "token",
+        fetcher,
+      ),
+    ).resolves.toBeNull();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("materializes webhook commit rows without a live GitHub lookup", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(
+      resolveChatGithubEntity(
+        {
+          entityType: "commit",
+          entityKey: "owner/repo@abcdef1",
+          boundVia: "direct",
+          title: "Webhook projection",
+        },
+        "token",
+        fetcher,
+      ),
     ).resolves.toEqual({
       entityType: "commit",
       entityKey: "owner/repo@abcdef1",
-      boundVia: "agent_declared",
+      boundVia: "direct",
       htmlUrl: "https://github.com/owner/repo/commit/abcdef1",
-      title: null,
+      title: "Webhook projection",
       state: null,
       number: null,
     });

--- a/packages/server/src/__tests__/service-branch-sweeper.test.ts
+++ b/packages/server/src/__tests__/service-branch-sweeper.test.ts
@@ -56,12 +56,7 @@ describe("service branch contracts", () => {
       number: 42,
       explicitType: "pull_request",
     });
-    expect(parseEntityReference("acme/repo@ABCDEF123456")).toEqual({
-      kind: "commit",
-      owner: "acme",
-      repo: "repo",
-      sha: "abcdef123456",
-    });
+    expect(parseEntityReference("acme/repo@ABCDEF123456")).toBeNull();
     expect(parseEntityReference("not an entity")).toBeNull();
 
     expect(githubEntityKeyCandidates("discussion", "acme/repo#discussion-7")).toEqual([

--- a/packages/server/src/__tests__/setup-capabilities.test.ts
+++ b/packages/server/src/__tests__/setup-capabilities.test.ts
@@ -380,6 +380,20 @@ describe("Team setup capabilities", () => {
     });
   });
 
+  it("recognizes commit_comment as an active GitHub repository automation event", async () => {
+    const app = getApp();
+    const scenario = await createScenario(app);
+    await seedGithubInstallation(app, scenario, { events: ["commit_comment"] });
+
+    const projection = await project(app, scenario);
+    expect(projection.repositoryAutomation.providers[0]).toMatchObject({
+      provider: "github",
+      adoption: "enabled",
+      health: "ready",
+      blockers: [],
+    });
+  });
+
   it("fails closed for malformed, unresolved, and provider-mismatched Tree bindings", async () => {
     const app = getApp();
     const malformed = await createScenario(app);

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -329,7 +329,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
       const entity = request.query.entity;
       if (!entity) {
-        throw new BadRequestError("Pass ?entity=<GitHub URL | owner/repo#N | owner/repo@sha> to unfollow.");
+        throw new BadRequestError("Pass ?entity=<GitHub PR/Issue/Discussion URL | owner/repo#N> to unfollow.");
       }
       return removeEntityFollow(app.db, { chatId: request.params.chatId, entity });
     },

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -358,7 +358,7 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
       await assertWebMutableChat(chat.id);
       const entity = request.query.entity;
       if (!entity) {
-        throw new BadRequestError("Pass ?entity=<GitHub URL | owner/repo#N | owner/repo@sha> to unfollow.");
+        throw new BadRequestError("Pass ?entity=<GitHub PR/Issue/Discussion URL | owner/repo#N> to unfollow.");
       }
       return removeEntityFollow(app.db, { chatId: chat.id, entity });
     },

--- a/packages/server/src/db/schema/github-entity-chat-mappings.ts
+++ b/packages/server/src/db/schema/github-entity-chat-mappings.ts
@@ -14,9 +14,10 @@ import { organizations } from "./organizations.js";
  * `bound_via` records how the row came to exist — webhook first-touch
  * (`direct`), `Fixes #N` linker (`fixes_link`), human-scoped fallback
  * (`human_fallback`), or an explicit `github follow` (`agent_declared` /
- * `human_declared`). Routing logic ignores the distinction; it exists for
- * audit and the narrow `pull_request.opened` carve-out in
- * `services/scm/github/audience.ts`. Canonical value docs: `BoundVia` in
+ * `human_declared`). Routing generally ignores the distinction; it exists for
+ * audit, the narrow `pull_request.opened` carve-out in
+ * `services/scm/github/audience.ts`, and inert compatibility for historical
+ * declared commit rows. Canonical value docs: `BoundVia` in
  * `services/scm/github/entity-chat.ts`.
  *
  * `entity_state` (added 0048) tracks the upstream PR/Issue lifecycle so

--- a/packages/server/src/services/scm/github/audience.ts
+++ b/packages/server/src/services/scm/github/audience.ts
@@ -3,6 +3,7 @@ import {
   AGENT_TYPES,
   type GithubAppInstallationPermissions,
   type GithubTaskReplyErrorCode,
+  githubEntityBoundViaSchema,
   isDeclaredBoundVia,
   type NormalizedScmEvent,
   type ScmAudienceEntry,
@@ -272,6 +273,15 @@ export async function resolveGithubAudience(
       ),
     );
 
+  const activeSubscribedRows = subscribedRows.filter((row) => {
+    if (event.entity.type !== "commit") return true;
+    const boundVia = githubEntityBoundViaSchema.safeParse(row.boundVia);
+    // Commit attention remains webhook-only. Historical manual rows (including
+    // read-normalized `agent_created`) and unknown legacy provenance are inert,
+    // while direct/human_fallback webhook rows continue to route normally.
+    return boundVia.success && !isDeclaredBoundVia(boundVia.data);
+  });
+
   // Dedup subscribed rows by `(humanAgentId, delegateAgentId, chatId)` (keep
   // earliest `bound_at`). Alias entity keys can leave duplicate rows for the
   // same logical attention line, but distinct delegates are distinct wake
@@ -290,8 +300,8 @@ export async function resolveGithubAudience(
   // share the same fallback human and chat while carrying distinct wake
   // agents. "The chat follows, not the person", so the surviving unit is one
   // row per (human, delegate, chat).
-  const earliestByAttentionLine = new Map<string, (typeof subscribedRows)[number]>();
-  for (const row of subscribedRows) {
+  const earliestByAttentionLine = new Map<string, (typeof activeSubscribedRows)[number]>();
+  for (const row of activeSubscribedRows) {
     const key = `${row.humanAgentId}:${row.delegateAgentId}:${row.chatId}`;
     const current = earliestByAttentionLine.get(key);
     if (!current || row.boundAt < current.boundAt) {
@@ -319,7 +329,7 @@ export async function resolveGithubAudience(
   // comment, …) is a legitimately distinct subscribed signal.
   const isPullRequestOpened = event.eventType === "pull_request" && event.action === "opened";
   const involvedLogins = new Set(event.targets.map((target) => target.externalUsername.toLowerCase()));
-  const keepSubscribedOpened = (row: (typeof subscribedRows)[number]): boolean => {
+  const keepSubscribedOpened = (row: (typeof activeSubscribedRows)[number]): boolean => {
     if (!isPullRequestOpened) return true;
     if (isDeclaredBoundVia(row.boundVia)) return true;
     return row.humanAgentName !== null && involvedLogins.has(row.humanAgentName.toLowerCase());

--- a/packages/server/src/services/scm/github/entity-chat.ts
+++ b/packages/server/src/services/scm/github/entity-chat.ts
@@ -1,5 +1,5 @@
 import { chatMetadataSchema, type GithubEntityBoundVia, githubEntityBoundViaSchema } from "@first-tree/shared";
-import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
 import type { GithubEntity } from "../../../api/webhooks/github-entity.js";
 import { formatEntityTitle, refreshEntityTitle } from "../../../api/webhooks/github-entity.js";
 import type { Database } from "../../../db/connection.js";
@@ -20,6 +20,12 @@ import { canonicalizeGithubEntityKey, githubEntityKeyCandidates, githubEntityKey
 import type { EntityState, EntityStateSeed } from "./entity-state.js";
 
 const log = createLogger("GithubEntityChat");
+
+const ACTIVE_COMMIT_BOUND_VIA: readonly GithubEntityBoundVia[] = ["direct", "fixes_link", "human_fallback"];
+
+function activeMappingProvenance(entityType: GithubEntity["type"]) {
+  return entityType === "commit" ? inArray(githubEntityChatMappings.boundVia, [...ACTIVE_COMMIT_BOUND_VIA]) : undefined;
+}
 
 /**
  * `bound_via` audit values — the value set is owned by the shared
@@ -45,8 +51,10 @@ const log = createLogger("GithubEntityChat");
  *                         Surfaces in telemetry so both controlled reuse paths
  *                         remain auditable.
  *
- * Routing logic ignores the distinction; the column exists for audit and the
- * narrow `pull_request.opened` carve-out in `github-audience.ts`.
+ * Routing generally ignores the distinction. The exceptions are the narrow
+ * `pull_request.opened` carve-out in `github-audience.ts` and commit rows:
+ * historical declared commit follows are inert, while webhook-created commit
+ * rows remain active.
  */
 export type BoundVia = GithubEntityBoundVia;
 
@@ -127,6 +135,7 @@ export async function resolveGithubPersonnelTargetChat(
             eq(githubEntityChatMappings.organizationId, params.organizationId),
             eq(githubEntityChatMappings.entityType, params.entity.type),
             inArray(githubEntityChatMappings.entityKey, candidateKeys),
+            activeMappingProvenance(params.entity.type),
           ),
         );
       const candidateChatIds = candidateChats.map((row) => row.chatId);
@@ -376,6 +385,7 @@ async function lookupMapping(
         eq(githubEntityChatMappings.delegateAgentId, delegateAgentId),
         eq(githubEntityChatMappings.entityType, entity.type),
         inArray(githubEntityChatMappings.entityKey, candidateKeys),
+        activeMappingProvenance(entity.type),
       ),
     )
     .orderBy(desc(sql`${githubEntityChatMappings.entityKey} = ${canonicalKey}`))
@@ -410,6 +420,7 @@ async function lookupMappingByHuman(
         eq(githubEntityChatMappings.humanAgentId, humanAgentId),
         eq(githubEntityChatMappings.entityType, entity.type),
         inArray(githubEntityChatMappings.entityKey, candidateKeys),
+        activeMappingProvenance(entity.type),
       ),
     )
     .orderBy(
@@ -439,6 +450,40 @@ export async function insertMappingIfAbsent(
   const existing = await lookupMapping(db, params.organizationId, params.humanAgentId, params.delegateAgentId, entity);
   if (existing) {
     return { ...existing, inserted: false };
+  }
+
+  if (entity.type === "commit" && ACTIVE_COMMIT_BOUND_VIA.includes(params.boundVia)) {
+    // A real commit_comment target may collide with a historical manual row's
+    // primary key. Treat that row as absent during placement, then convert it
+    // in place into the webhook-created line instead of failing the delivery
+    // or requiring a migration.
+    const candidateKeys = githubEntityKeyCandidates(entity.type, entity.key);
+    const [reactivated] = await db
+      .update(githubEntityChatMappings)
+      .set({
+        chatId: params.chatId,
+        boundVia: params.boundVia,
+        boundAt: new Date(),
+        ...(params.entityState ? { entityState: params.entityState } : {}),
+        ...(entity.title && entity.title.length > 0 ? { title: entity.title } : {}),
+      })
+      .where(
+        and(
+          eq(githubEntityChatMappings.organizationId, params.organizationId),
+          eq(githubEntityChatMappings.humanAgentId, params.humanAgentId),
+          eq(githubEntityChatMappings.delegateAgentId, params.delegateAgentId),
+          eq(githubEntityChatMappings.entityType, "commit"),
+          inArray(githubEntityChatMappings.entityKey, candidateKeys),
+          notInArray(githubEntityChatMappings.boundVia, [...ACTIVE_COMMIT_BOUND_VIA]),
+        ),
+      )
+      .returning({
+        chatId: githubEntityChatMappings.chatId,
+        boundVia: githubEntityChatMappings.boundVia,
+      });
+    if (reactivated) {
+      return { chatId: reactivated.chatId, boundVia: asBoundVia(reactivated.boundVia), inserted: true };
+    }
   }
 
   const [inserted] = await db

--- a/packages/server/src/services/scm/github/entity-follow.ts
+++ b/packages/server/src/services/scm/github/entity-follow.ts
@@ -64,27 +64,27 @@ const GITHUB_FETCH_TIMEOUT_MS = 5_000;
 // usually has one); short forms match the stored entity-key syntax.
 const URL_NUMERIC_RE =
   /^https?:\/\/(?:www\.)?github\.com\/([^/\s]+)\/([^/\s]+)\/(pull|issues|discussions)\/(\d+)(?:[/?#].*)?$/;
-const URL_COMMIT_RE =
+const UNSUPPORTED_URL_COMMIT_RE =
   /^https?:\/\/(?:www\.)?github\.com\/([^/\s]+)\/([^/\s]+)\/commit\/([0-9a-fA-F]{6,40})(?:[/?#].*)?$/;
 const SHORT_NUMERIC_RE = /^([^/\s]+)\/([^/\s#@]+)#(\d+)$/;
-const SHORT_COMMIT_RE = /^([^/\s]+)\/([^/\s#@]+)@([0-9a-fA-F]{6,40})$/;
+const UNSUPPORTED_SHORT_COMMIT_RE = /^([^/\s]+)\/([^/\s#@]+)@([0-9a-fA-F]{6,40})$/;
 
-const URL_PATH_TYPE: Record<string, GithubEntityType> = {
+type FollowableGithubEntityType = Exclude<GithubEntityType, "commit">;
+
+const URL_PATH_TYPE: Record<string, FollowableGithubEntityType> = {
   pull: "pull_request",
   issues: "issue",
   discussions: "discussion",
 };
 
-export type EntityReference =
-  | {
-      kind: "numeric";
-      owner: string;
-      repo: string;
-      number: number;
-      /** Explicit type from a URL path; null for the short `owner/repo#N` form. */
-      explicitType: Exclude<GithubEntityType, "commit"> | null;
-    }
-  | { kind: "commit"; owner: string; repo: string; sha: string };
+export type EntityReference = {
+  kind: "numeric";
+  owner: string;
+  repo: string;
+  number: number;
+  /** Explicit type from a URL path; null for the short `owner/repo#N` form. */
+  explicitType: FollowableGithubEntityType | null;
+};
 
 /** Parse the raw `entity` argument. Returns null when no shape matches. */
 export function parseEntityReference(raw: string): EntityReference | null {
@@ -95,15 +95,8 @@ export function parseEntityReference(raw: string): EntityReference | null {
     const [, owner, repo, path, numberStr] = urlNumeric;
     if (!owner || !repo || !path || !numberStr) return null;
     const explicitType = URL_PATH_TYPE[path];
-    if (!explicitType || explicitType === "commit") return null;
+    if (!explicitType) return null;
     return { kind: "numeric", owner, repo, number: Number(numberStr), explicitType };
-  }
-
-  const urlCommit = URL_COMMIT_RE.exec(trimmed);
-  if (urlCommit) {
-    const [, owner, repo, sha] = urlCommit;
-    if (!owner || !repo || !sha) return null;
-    return { kind: "commit", owner, repo, sha: sha.toLowerCase() };
   }
 
   const shortNumeric = SHORT_NUMERIC_RE.exec(trimmed);
@@ -113,14 +106,12 @@ export function parseEntityReference(raw: string): EntityReference | null {
     return { kind: "numeric", owner, repo, number: Number(numberStr), explicitType: null };
   }
 
-  const shortCommit = SHORT_COMMIT_RE.exec(trimmed);
-  if (shortCommit) {
-    const [, owner, repo, sha] = shortCommit;
-    if (!owner || !repo || !sha) return null;
-    return { kind: "commit", owner, repo, sha: sha.toLowerCase() };
-  }
-
   return null;
+}
+
+function isUnsupportedCommitReference(raw: string): boolean {
+  const trimmed = raw.trim();
+  return UNSUPPORTED_URL_COMMIT_RE.test(trimmed) || UNSUPPORTED_SHORT_COMMIT_RE.test(trimmed);
 }
 
 /**
@@ -129,35 +120,33 @@ export function parseEntityReference(raw: string): EntityReference | null {
  * one copy.
  */
 function parseEntityReferenceOrThrow(raw: string): EntityReference {
+  if (isUnsupportedCommitReference(raw)) {
+    throw new BadRequestError(
+      "Commit references are not supported by `github follow` or `github unfollow`. " +
+        "Commit comments continue to arrive automatically through GitHub webhooks.",
+    );
+  }
   const ref = parseEntityReference(raw);
   if (!ref) {
     throw new BadRequestError(
       `Unrecognized entity reference "${raw}". Pass a GitHub URL ` +
-        `(https://github.com/owner/repo/pull/42), "owner/repo#42", or "owner/repo@<sha>".`,
+        `(https://github.com/owner/repo/pull/42), ` +
+        `(https://github.com/owner/repo/issues/42), ` +
+        `(https://github.com/owner/repo/discussions/42), or "owner/repo#42".`,
     );
   }
   return ref;
 }
 
-/**
- * Escape SQL LIKE metacharacters (`\`, `%`, `_`) in a literal that will be
- * embedded in a LIKE pattern. GitHub repo names legitimately contain `_`,
- * which LIKE would otherwise treat as match-any-one-char and over-delete
- * across sibling repos.
- */
-function escapeLikeLiteral(value: string): string {
-  return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
-}
-
 type ResolvedEntity = {
-  entityType: GithubEntityType;
-  /** Canonical key — GitHub's `full_name` casing, full commit sha. */
+  entityType: FollowableGithubEntityType;
+  /** Canonical key — GitHub's `full_name` casing plus entity number. */
   entityKey: string;
   htmlUrl: string;
   title: string | null;
   liveState: GithubEntityLiveState | null;
   entityState: EntityState;
-  /** Issue / PR / Discussion number; null for commits. Set where `entityKey` is built. */
+  /** Issue / PR / Discussion number. Set where `entityKey` is built. */
   number: number | null;
 };
 
@@ -233,30 +222,6 @@ async function resolveEntityOnGithub(
   // Canonical casing (and current name after a rename — the API follows the
   // redirect) so the written key always matches webhook-side keys. (R8)
   const fullName = readStr(repoRes.body.full_name) ?? `${ref.owner}/${ref.repo}`;
-
-  if (ref.kind === "commit") {
-    const res = await ghGet(`/repos/${fullName}/commits/${ref.sha}`, token, fetcher);
-    if (res.kind === "unavailable") return { ok: false, reason: "github-unavailable" };
-    if (res.kind !== "ok") return { ok: false, reason: "entity-not-found" };
-    const fullSha = readStr(res.body.sha) ?? ref.sha;
-    const commit =
-      typeof res.body.commit === "object" && res.body.commit !== null
-        ? (res.body.commit as Record<string, unknown>)
-        : null;
-    const message = readStr(commit?.message);
-    return {
-      ok: true,
-      entity: {
-        entityType: "commit",
-        entityKey: `${fullName}@${fullSha}`,
-        htmlUrl: readStr(res.body.html_url) ?? `https://github.com/${fullName}/commit/${fullSha}`,
-        title: message ? (message.split("\n", 1)[0]?.trim() ?? null) : null,
-        liveState: null,
-        entityState: "open",
-        number: null,
-      },
-    };
-  }
 
   if (ref.explicitType === "discussion") {
     return resolveDiscussion(fullName, ref.number, token, fetcher);
@@ -366,7 +331,7 @@ export type DeclareFollowParams = {
   humanAgentId: string;
   delegateAgentId: string;
   boundVia: DeclaredBoundVia;
-  /** Raw entity reference — URL, `owner/repo#N`, or `owner/repo@sha`. */
+  /** Raw entity reference — PR / Issue / Discussion URL or `owner/repo#N`. */
   entity: string;
   rebind: boolean;
 };
@@ -604,8 +569,7 @@ export async function declareEntityFollow(
  * succeeds (R4: `removed: 0` is terminal success).
  *
  * Matching is case-insensitive on the key (GitHub repo slugs are
- * case-insensitive) and prefix-based for commit shas so a short sha
- * unfollows the full-sha row. A repo renamed since the row was written
+ * case-insensitive). A repo renamed since the row was written
  * cannot be matched without the API — that is the known whole-table key
  * drift limitation, out of scope here (R8 note).
  */
@@ -620,8 +584,7 @@ export async function removeEntityFollow(
     .where(eq(chats.id, params.chatId))
     .limit(1);
   if (!chat) return { removed: 0 };
-  const entityLockKey =
-    ref.kind === "commit" ? `${ref.owner}/${ref.repo}@${ref.sha}` : `${ref.owner}/${ref.repo}#${ref.number}`;
+  const entityLockKey = `${ref.owner}/${ref.repo}#${ref.number}`;
 
   return withScmEntityAttentionTransaction(
     db,
@@ -632,53 +595,35 @@ export async function removeEntityFollow(
     },
     async (tx) => {
       const chatCond = eq(githubEntityChatMappings.chatId, params.chatId);
-      let removedRows: Array<{ entityKey: string }>;
-      if (ref.kind === "commit") {
-        // Prefix match so a short sha unfollows the full-sha row; LIKE
-        // metacharacters in owner/repo (GitHub allows `_`) are escaped so the
-        // pattern can't over-match sibling repos.
-        const prefix = escapeLikeLiteral(`${ref.owner}/${ref.repo}@${ref.sha}`.toLowerCase());
-        removedRows = await tx
-          .delete(githubEntityChatMappings)
-          .where(
-            and(
-              chatCond,
-              eq(githubEntityChatMappings.entityType, "commit"),
-              sql`lower(${githubEntityChatMappings.entityKey}) LIKE ${`${prefix}%`}`,
-            ),
-          )
-          .returning({ entityKey: githubEntityChatMappings.entityKey });
-      } else {
-        const key = `${ref.owner}/${ref.repo}#${ref.number}`.toLowerCase();
-        // Type matching without a GitHub call (unfollow must not depend on
-        // GitHub being up):
-        //   - Issues and PRs share one numbering space, and follow auto-corrects
-        //     a `/pull/N` URL that actually points at an issue (and vice versa)
-        //     — so an explicit issue/PR reference matches BOTH types, otherwise
-        //     the row created through the auto-corrected follow could never be
-        //     removed with the same reference the caller used to create it.
-        //   - Discussions number independently; an explicit `/discussions/N`
-        //     URL matches only discussions, and only the bare `owner/repo#N`
-        //     form sweeps all three ("make this chat quiet about #N").
-        const types: GithubEntityType[] =
-          ref.explicitType === "discussion"
-            ? ["discussion"]
-            : ref.explicitType !== null
-              ? ["issue", "pull_request"]
-              : ["issue", "pull_request", "discussion"];
-        const lowerKeys = new Set([key]);
-        if (types.includes("discussion")) {
-          const legacyKey = legacyDiscussionEntityKey(key);
-          if (legacyKey) lowerKeys.add(legacyKey);
-        }
-        const keyConditions = [...lowerKeys].map(
-          (lowerKey) => sql`lower(${githubEntityChatMappings.entityKey}) = ${lowerKey}`,
-        );
-        removedRows = await tx
-          .delete(githubEntityChatMappings)
-          .where(and(chatCond, inArray(githubEntityChatMappings.entityType, types), or(...keyConditions)))
-          .returning({ entityKey: githubEntityChatMappings.entityKey });
+      const key = `${ref.owner}/${ref.repo}#${ref.number}`.toLowerCase();
+      // Type matching without a GitHub call (unfollow must not depend on
+      // GitHub being up):
+      //   - Issues and PRs share one numbering space, and follow auto-corrects
+      //     a `/pull/N` URL that actually points at an issue (and vice versa)
+      //     — so an explicit issue/PR reference matches BOTH types, otherwise
+      //     the row created through the auto-corrected follow could never be
+      //     removed with the same reference the caller used to create it.
+      //   - Discussions number independently; an explicit `/discussions/N`
+      //     URL matches only discussions, and only the bare `owner/repo#N`
+      //     form sweeps all three ("make this chat quiet about #N").
+      const types: FollowableGithubEntityType[] =
+        ref.explicitType === "discussion"
+          ? ["discussion"]
+          : ref.explicitType !== null
+            ? ["issue", "pull_request"]
+            : ["issue", "pull_request", "discussion"];
+      const lowerKeys = new Set([key]);
+      if (types.includes("discussion")) {
+        const legacyKey = legacyDiscussionEntityKey(key);
+        if (legacyKey) lowerKeys.add(legacyKey);
       }
+      const keyConditions = [...lowerKeys].map(
+        (lowerKey) => sql`lower(${githubEntityChatMappings.entityKey}) = ${lowerKey}`,
+      );
+      const removedRows = await tx
+        .delete(githubEntityChatMappings)
+        .where(and(chatCond, inArray(githubEntityChatMappings.entityType, types), or(...keyConditions)))
+        .returning({ entityKey: githubEntityChatMappings.entityKey });
 
       if (removedRows.length > 0) {
         log.info({ chatId: params.chatId, entity: params.entity, removed: removedRows.length }, "github unfollow");
@@ -714,14 +659,17 @@ export async function listChatGithubEntities(
 
   if (rows.length === 0) return { items: [] };
 
-  const dedup = new Map<string, (typeof rows)[number]>();
+  const dedup = new Map<string, ChatGithubEntity>();
   for (const r of rows) {
-    const key = githubEntityDedupKey(r.entityType, r.entityKey);
+    // Materialize before deduplication so an inert legacy manual commit row
+    // cannot hide an older webhook-created row for the same commit.
+    const item = materializeChatGithubEntity(r);
+    if (!item) continue;
+    const key = githubEntityDedupKey(item.entityType, item.entityKey);
     // Rows arrive newest-first so the dedup keeps the most recent binding,
     // which carries the `boundVia` the user actually triggered last.
-    if (!dedup.has(key)) dedup.set(key, r);
+    if (!dedup.has(key)) dedup.set(key, item);
   }
 
-  const items = Array.from(dedup.values()).map((r) => materializeChatGithubEntity(r));
-  return { items: items.filter((x): x is NonNullable<typeof x> => x !== null) };
+  return { items: Array.from(dedup.values()) };
 }

--- a/packages/server/src/services/scm/github/entity-live.ts
+++ b/packages/server/src/services/scm/github/entity-live.ts
@@ -5,6 +5,7 @@ import {
   type GithubEntityLiveState,
   type GithubEntityType,
   githubEntityBoundViaSchema,
+  isDeclaredBoundVia,
 } from "@first-tree/shared";
 import { GITHUB_API_BASE } from "./api-base.js";
 import { canonicalizeGithubEntityKey } from "./entity-key.js";
@@ -138,17 +139,6 @@ async function fetchEntityLiveFields(
       const state: GithubEntityLiveState | null = body.state === "open" || body.state === "closed" ? body.state : null;
       return { title: body.title ?? null, state };
     }
-    if (entityType === "commit" && parsed.kind === "sha") {
-      const res = await fetcher(
-        `${GITHUB_API_BASE}/repos/${parsed.owner}/${parsed.repo}/commits/${parsed.sha}`,
-        fetchOpts,
-      );
-      if (!res.ok) return { title: null, state: null };
-      const body = (await res.json()) as { commit?: { message?: string } };
-      // First line of the commit message is its de-facto title.
-      const title = body.commit?.message?.split("\n", 1)[0]?.trim() ?? null;
-      return { title, state: null };
-    }
     return { title: null, state: null };
   } catch {
     // Network errors, AbortController timeouts, and JSON parse errors all
@@ -206,6 +196,10 @@ export function materializeChatGithubEntity(row: MappingRow): ChatGithubEntity |
   const boundViaParsed = githubEntityBoundViaSchema.safeParse(row.boundVia);
   if (!boundViaParsed.success) return null;
   const boundVia: GithubEntityBoundVia = boundViaParsed.data;
+  // Manual commit follows are retired. Keep the shared commit representation
+  // for webhook-created rows, but make historical declared rows inert on read
+  // without a migration or a GitHub lookup.
+  if (entityType === "commit" && isDeclaredBoundVia(boundVia)) return null;
   const parsed = parseEntityKey(entityType, row.entityKey);
   if (!parsed) return null;
   return {
@@ -231,6 +225,9 @@ export async function resolveChatGithubEntity(
 ): Promise<ChatGithubEntity | null> {
   const base = materializeChatGithubEntity(row);
   if (!base || !token) return base;
+  // Commit data is webhook-only/local-projection data. Never re-resolve it
+  // through the GitHub Contents-backed commit endpoint.
+  if (base.entityType === "commit") return base;
   const parsed = parseEntityKey(base.entityType, row.entityKey);
   if (!parsed) return base;
   const live = await fetchEntityLiveFields(base.entityType, parsed, token, fetcher);

--- a/packages/server/src/services/scm/shared/entity-attention-lock.ts
+++ b/packages/server/src/services/scm/shared/entity-attention-lock.ts
@@ -7,10 +7,8 @@ export type ScmEntityAttentionLock = {
   entityKey: string;
 };
 
-/** Commit refs may be abbreviated by unfollow, so serialize them per repo. */
 export function githubEntityAttentionLockKey(entityKey: string): string {
-  const commitSeparator = entityKey.lastIndexOf("@");
-  return commitSeparator > 0 ? `${entityKey.slice(0, commitSeparator)}@commit` : entityKey;
+  return entityKey;
 }
 
 export function gitlabPathEntityAttentionLockKey(

--- a/packages/shared/src/schemas/chat-github-entities.ts
+++ b/packages/shared/src/schemas/chat-github-entities.ts
@@ -85,7 +85,9 @@ export type ChatGithubEntityListResponse = z.infer<typeof chatGithubEntityListRe
  *
  * `entity` accepts a full GitHub URL (`https://github.com/o/r/pull/42`),
  * the short numeric form (`owner/repo#42` — issue vs PR resolved against
- * the GitHub API), or the commit form (`owner/repo@<sha>`).
+ * the GitHub API, with discussion fallback), or an explicit Discussion URL.
+ * Commit URLs and `owner/repo@<sha>` are webhook-only compatibility shapes
+ * and are rejected by the manual follow API.
  *
  * `rebind: true` MOVES the binding into the target chat when the same
  * (human, delegate) line already lives in another chat — the 409 outcome's

--- a/packages/shared/src/schemas/chat-metadata.ts
+++ b/packages/shared/src/schemas/chat-metadata.ts
@@ -59,8 +59,12 @@ export function withFirstChatOrientationChatState(
  */
 
 /**
- * Source of truth for which github entity types the workspace UI knows
- * how to render. Drives `MeChatRow.entityType` (per-row sub-type, drives
+ * Source of truth for which GitHub entity types webhook cards, legacy rows,
+ * and the workspace UI know how to render. `commit` remains here for the
+ * `commit_comment` webhook surface and stored-row compatibility; the manual
+ * follow parser accepts only PRs, Issues, and Discussions.
+ *
+ * Drives `MeChatRow.entityType` (per-row sub-type, drives
  * the leading icon) and the `Github*Schema` discriminator below. The
  * `ChatSource` enum below does NOT branch on these — Phase C collapsed
  * the conversation-list origin filter to a single `github` value, and


### PR DESCRIPTION
## Summary

- remove manual commit targets from CLI/API parsing, follow resolution, unfollow, and live REST lookup
- retain the production `commit_comment` subscription, setup capability, normalization, attention/routing, event cards, and notifications
- keep the shared/internal commit representation for webhook and stored-row compatibility
- make historical declared commit rows inert and read-safe with no migration or network re-resolution; a real webhook target can safely replace the inert line
- remove the entity-resolution consumer of `GET /repos/{owner}/{repo}/commits/{sha}` and its Contents-backed lookup path

## Compatibility

Manual follow is removed, `commit_comment` automation is retained, legacy rows are inert/read-safe, and there is no database migration. PR, Issue, and Discussion follow behavior remains supported. Repository-wide Contents permission is unchanged because Context Tree consumers remain outside this issue.

## Validation

- `pnpm check` (passes with pre-existing repository warnings)
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- focused server suite: 9 files / 236 tests
- `git diff --check`
- residual `/repos/.../commits/...` lookup search: clean

## Context Tree

Paired draft: https://github.com/agent-team-foundation/first-tree-context/pull/616

Related to #1301. This PR intentionally does not auto-close the issue.