### PR TITLE
fix(cli): exclude hidden skills from public copy count

### DIFF
--- a/apps/cli/tests/copy-skill-payloads.test.ts
+++ b/apps/cli/tests/copy-skill-payloads.test.ts
@@ -882,6 +882,28 @@ describe("verified copies", () => {
     });
   });
 
+  it("copies hidden dot-directories verbatim but never counts them as public skills", () => {
+    const parent = tempDir("first-tree-skill-target-hidden-");
+
+    withTrustedSkillsTarget({ trustedParentDir: parent }, (capability) => {
+      const result = copyAllSkillPayloads({ target: capability, clean: true });
+      const sourceNames = readdirSync(capability.sourceSkillsRoot, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+      const hidden = sourceNames.filter((name) => name.startsWith("."));
+      // The count is exactly the non-hidden source directories, whatever the
+      // repo currently carries — no hidden directory may inflate it.
+      expect(result.publicCount).toBe(sourceNames.length - hidden.length);
+      // Hidden directories still ride the verbatim copy (e.g. `.experimental`)
+      // — excluded from the count, never from the payload.
+      for (const name of hidden) {
+        expect(existsSync(join(capability.targetSkillsRoot, name)), `hidden directory ${name} must be copied`).toBe(
+          true,
+        );
+      }
+    });
+  });
+
   it("supports resetSkillsTarget plus a variants-only copy", () => {
     const parent = tempDir("first-tree-skill-target-variants-");
 

--- a/scripts/copy-skill-payloads.mjs
+++ b/scripts/copy-skill-payloads.mjs
@@ -473,7 +473,12 @@ export function copyAllSkillPayloads(options = {}) {
   }
   if (clean) rmSync(targetSkillsRoot, { recursive: true, force: true });
   cpSync(sourceSkillsRoot, targetSkillsRoot, { recursive: true });
-  const publicCount = directoryNames(sourceSkillsRoot).length;
+  // Hidden dot-directories (e.g. `.experimental`) are copied verbatim like
+  // any other source content, but they are not PUBLIC Skills, so they must
+  // not inflate the public count. Filter only here at the count site —
+  // `directoryNames` itself stays unfiltered because the private variant
+  // registry's exact-name assertions rely on its complete listing.
+  const publicCount = directoryNames(sourceSkillsRoot).filter((name) => !name.startsWith(".")).length;
   const variantCount = copyPrivateSkillVariants({ target });
   return { publicCount, variantCount };
 }


### PR DESCRIPTION
## Summary

- Exclude dot-prefixed Skill directories from `copyAllSkillPayloads().publicCount` while continuing to copy them verbatim into the target.
- Keep `directoryNames()` unfiltered so private-variant registry and variant-name exactness checks remain strict.
- Add a deterministic regression test covering both the public count and hidden-directory payload preservation.

## Context

Current `main` added `skills/.experimental/`, exposing a mismatch between the copy helper's reported public count and the target-side public-directory definition. The CLI shard then failed with `expected 9 / received 8` in `copy-skill-payloads.test.ts:875`.

This is an independent mainline fix so [#2354](https://github.com/first-tree-ai/first-tree/pull/2354) does not carry an unrelated CLI change.

## Validation

Independent `test-only` QA passed on exact head `ec068a1ae6d9f0e03b6aa1d9fa665d3b6a3ad369` with a clean worktree before and after:

- Parent `d48aacb523d50e037a17cf3a00ee75f623267ae5` reproduced the original failure.
- Focused `copy-skill-payloads` suite: 63/63 passed.
- CLI typecheck passed.
- Biome passed both changed files; `git diff --check` passed.
- A read-only semantic probe confirmed `.experimental` source/target recursive paths and file hashes are identical.
- A temporary `.rogue` private variant directory remained rejected by the unchanged exact-name validator.

## Change surface

- [x] `scripts/copy-skill-payloads.mjs`
- [x] `apps/cli/tests/copy-skill-payloads.test.ts`
- [ ] database, schema, migration, persistence semantics, package version, lockfile, or Skill payload content

## QA limits

This is localized deterministic `test-only` validation. It does not claim live CLI installation, cross-platform behavior, or release qualification.
