### PR TITLE
[Fix] kimi-code provider: register approval handler so hosted sessions can exit plan mode

### DIFF
--- a/packages/client/src/providers/kimi-code/__tests__/handler.test.ts
+++ b/packages/client/src/providers/kimi-code/__tests__/handler.test.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
+  ApprovalHandler,
   CreateSessionOptions,
   Event as KimiEvent,
   KimiHarnessOptions,
@@ -24,6 +25,7 @@ class FakeSession {
   readonly listeners = new Set<(event: KimiEvent) => void>();
   readonly setPermission = vi.fn().mockResolvedValue(undefined);
   readonly setModel = vi.fn().mockResolvedValue(undefined);
+  readonly setApprovalHandler = vi.fn();
   readonly cancel = vi.fn().mockResolvedValue(undefined);
   readonly close = vi.fn().mockResolvedValue(undefined);
   usage: SessionUsage = {
@@ -437,6 +439,60 @@ describe("Kimi Code handler", () => {
     expect(captures.resume?.roleAdditional).toContain("First Tree");
     expect(fakeSession.setPermission).toHaveBeenCalledWith("yolo");
     expect(fakeSession.setModel).toHaveBeenCalledWith("kimi-for-coding");
+  });
+
+  it("registers an approval handler that approves plan exits and cancels other requests", async () => {
+    const fakeSession = new FakeSession("kimi-session-approval", [
+      successfulTurn("kimi-session-approval"),
+      successfulTurn("kimi-session-approval"),
+    ]);
+    const payload = {
+      kind: "kimi-code" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const handler = createKimiCodeHandler({
+      workspaceRoot,
+      agentName: "kimi-test-agent",
+      runtimeProvider: "kimi-code",
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
+      kimiHarnessFactory: () => ({
+        createSession: async () => fakeSession,
+        resumeSession: async () => fakeSession,
+        close: async () => {},
+      }),
+    });
+
+    await handler.start(message("m1", "start work"), makeContext([]), makeToken());
+    await handler.resume(message("m2", "continue"), "kimi-session-approval", makeContext([]), makeToken());
+
+    expect(fakeSession.setApprovalHandler).toHaveBeenCalledTimes(2);
+    const approvalHandler = fakeSession.setApprovalHandler.mock.calls[0]?.[0] as ApprovalHandler;
+    expect(fakeSession.setApprovalHandler.mock.calls[1]?.[0]).toBe(approvalHandler);
+
+    const planApproval = await approvalHandler({
+      toolName: "ExitPlanMode",
+      toolCallId: "t1",
+      action: "exit plan mode",
+      display: { kind: "plan_review", plan: "x", path: "/tmp/p.md" },
+    });
+    expect(planApproval).toEqual({ decision: "approved" });
+
+    const otherApproval = await approvalHandler({
+      toolName: "Bash",
+      toolCallId: "t2",
+      action: "run a shell command",
+      display: { kind: "command", command: "ls" },
+    });
+    expect(otherApproval).toEqual({
+      decision: "cancelled",
+      feedback: "No interactive approval surface in hosted sessions.",
+    });
   });
 
   it("does not pass declared but unmaterialized workspace repos as SDK additional directories", async () => {

--- a/packages/client/src/providers/kimi-code/index.ts
+++ b/packages/client/src/providers/kimi-code/index.ts
@@ -1,6 +1,9 @@
 import { statSync } from "node:fs";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import {
+  type ApprovalHandler,
+  type ApprovalRequest,
+  type ApprovalResponse,
   type CreateSessionOptions,
   createKimiHarness,
   type Event as KimiEvent,
@@ -243,6 +246,23 @@ function additionalDirectories(workspaceCwd: string, contextTreePath: string | n
     return [];
   }
 }
+
+/**
+ * Hosted sessions have no interactive approval surface, so no human can
+ * answer an approval prompt. The SDK's ExitPlanMode review policy escalates
+ * plan exits to an approval request in every permission mode except "auto" —
+ * including "yolo" — and the headless RPC bridge cancels any request that has
+ * no registered handler. Without this handler a session that enters plan mode
+ * deadlocks: every ExitPlanMode is auto-dismissed and plan mode keeps denying
+ * all writes. Approve plan exits to restore the intended yolo posture; cancel
+ * every other request, matching the previous handler-less behavior.
+ */
+const hostedSessionApprovalHandler: ApprovalHandler = (request: ApprovalRequest): ApprovalResponse => {
+  if (request.toolName === "ExitPlanMode" || request.display?.kind === "plan_review") {
+    return { decision: "approved" };
+  }
+  return { decision: "cancelled", feedback: "No interactive approval surface in hosted sessions." };
+};
 
 /** Kimi Code handler backed by the direct Botiverse/Moonshot Node SDK. */
 export const createKimiCodeHandler: HandlerFactory = (config) => {
@@ -985,6 +1005,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
           },
         });
         session = await activeHarness.createSession(options);
+        session.setApprovalHandler(hostedSessionApprovalHandler);
         sessionId = session.id;
         sessionActive = true;
         initialTurnPreparing = true;
@@ -1029,6 +1050,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         });
         session = await activeHarness.resumeSession(input);
         sessionId = session.id;
+        session.setApprovalHandler(hostedSessionApprovalHandler);
         await session.setPermission("yolo");
         if (prepared.payload.model) await session.setModel(prepared.payload.model);
         sessionActive = true;


### PR DESCRIPTION
## Symptom

A hosted kimi-code agent session deadlocked in plan mode: the agent called `ExitPlanMode` 9 times and every call was dismissed with the synthetic result "Plan approval dismissed. Plan mode remains active." Plan mode then kept denying all writes (`CronCreate`, `Edit`, and every other write tool), so the hosted agent could make no progress at all.

## Root cause

- The First Tree kimi-code provider (`packages/client/src/providers/kimi-code/index.ts`) runs headless sessions with `permission: "yolo"` and never registers an approval handler.
- Inside `@botiverse/kimi-code-sdk`, `ExitPlanModeReviewAskPermissionPolicy` escalates `ExitPlanMode` to an approval request in every permission mode except `"auto"` — including `"yolo"`.
- The headless RPC `requestApproval` returns `{decision: "cancelled", feedback: "No approval handler registered."}` when no handler is registered.
- Result: plan exits are auto-cancelled forever, plan mode stays active, and plan mode keeps blocking writes — a permanent deadlock with no interactive surface to recover through.

## Fix

Register a module-level approval handler on every kimi-code session, on both the create and resume paths:

- If the request is a plan exit (`toolName === "ExitPlanMode"` or `display.kind === "plan_review"`), return `{ decision: "approved" }` — restoring the intended yolo posture for hosted sessions.
- Otherwise return `{ decision: "cancelled", feedback: "No interactive approval surface in hosted sessions." }` — matching the previous handler-less behavior for everything else.

First Tree code only; the SDK and `patches/` are untouched.

## Test coverage

`packages/client/src/providers/kimi-code/__tests__/handler.test.ts`:

- `FakeSession` gains a `setApprovalHandler` spy.
- New test: after `start` and `resume`, the handler is registered; invoking it with an `ExitPlanMode`/`plan_review` request returns `{ decision: "approved" }`; invoking it with a non-plan request (`Bash`) returns `cancelled` with the hosted-session feedback.

## Verification

- `pnpm --filter @first-tree/client exec vitest run src/providers/kimi-code/__tests__/handler.test.ts` — all tests pass (including the new one).
- `pnpm --filter @first-tree/client typecheck` — clean.
- `biome check` on the two touched files — clean.
