### PR TITLE
test(server): poll Feishu registration terminal states

### DIFF
--- a/packages/server/src/__tests__/feishu-registration.test.ts
+++ b/packages/server/src/__tests__/feishu-registration.test.ts
@@ -1446,7 +1446,15 @@ describe("official Feishu QR registration", () => {
     expect(providerSignal?.aborted).toBe(true);
 
     completion.resolve({ client_id: "cli_after_timeout", client_secret: "late-secret" });
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    // The request rejects synchronously at the QR timeout, but the DB
+    // terminal transition is launched fire-and-forget
+    // (`void transitionCurrentAttemptToError(...)`): poll the database
+    // postcondition instead of sleeping a fixed interval and hoping the
+    // transition landed.
+    await waitFor(async () => {
+      const [row] = await app.db.select().from(imBotBindings).where(eq(imBotBindings.agentId, a.agent.uuid));
+      return row?.status === "error";
+    });
     const [stored] = await app.db.select().from(imBotBindings).where(eq(imBotBindings.agentId, a.agent.uuid));
     expect(stored).toMatchObject({ status: "error", appId: null, appSecretCipher: null });
   });
@@ -1481,7 +1489,14 @@ describe("official Feishu QR registration", () => {
       }),
     ).rejects.toThrow("Timed out waiting for Feishu registration QR code");
     onQRCodeReady?.({ url: "https://open.feishu.cn/register?code=too-late", expireIn: 120 });
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    // Same async boundary: the QR timeout rejects the request now, while
+    // the row's terminal transition settles afterwards. Poll the database
+    // postcondition (error state with the stale URL cleared) rather than
+    // assuming a fixed sleep is enough.
+    await waitFor(async () => {
+      const [row] = await app.db.select().from(imBotBindings).where(eq(imBotBindings.agentId, a.agent.uuid));
+      return row?.status === "error" && row.registrationExpiresAt === null;
+    });
 
     const [stored] = await app.db.select().from(imBotBindings).where(eq(imBotBindings.agentId, a.agent.uuid));
     expect(stored).toMatchObject({ status: "error", registrationExpiresAt: null });
@@ -1535,7 +1550,19 @@ describe("official Feishu QR registration", () => {
     ).rejects.toThrow("Timed out waiting for Feishu registration QR code");
     lateQr?.({ url: "https://open.feishu.cn/register?code=too-late-update", expireIn: 120 });
     completion.resolve({ client_id: "cli_existing", client_secret: "late-secret" });
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    // The QR timeout rejects the request synchronously, but the restore of
+    // the pre-existing binding is an async fire-and-forget transition
+    // (`void transitionCurrentAttemptToError(...)`): poll the database
+    // postcondition instead of asserting after a fixed sleep.
+    await waitFor(async () => {
+      const [row] = await app.db.select().from(imBotBindings).where(eq(imBotBindings.id, before.id));
+      return (
+        row?.status === "active" &&
+        row.connectionStatus === "connected" &&
+        row.registrationStateCipher === null &&
+        row.registrationExpiresAt === null
+      );
+    });
 
     const [restored] = await app.db.select().from(imBotBindings).where(eq(imBotBindings.id, before.id));
     expect(restored).toMatchObject({


### PR DESCRIPTION
## Summary

- Replace three fixed 25 ms waits in the Feishu registration timeout cluster with bounded polling of the actual database terminal postconditions.
- Preserve every existing final-state assertion and the negative late-callback/provider race coverage.
- Keep the change test-only: no production manager, schema, migration, package, lockfile, Skill payload, or persistence behavior changes.

## Why

The registration manager intentionally rejects a timed-out request before its fire-and-forget terminal database transition completes. A fixed 25 ms delay is therefore not a completion proof under a busy runner.

This surfaced twice in PR #2354's Server CI run `32447112939`:

- attempt 1 left both a new timed-out registration and an existing-Bot reauthorization in `provisioning` at assertion time;
- attempt 2 again observed the existing-Bot row before restoration completed.

The affected test and production manager blobs were byte-identical to main, and the PR that exposed the timing did not touch Feishu registration paths.

## Contract preserved

- Abort timeout still requires `status=error` with null `appId` and `appSecretCipher`.
- Late QR callback still requires `status=error` with the stale registration expiry cleared.
- Existing-Bot restoration still requires `active + connected`, the original encrypted credentials, cleared registration state/expiry, and exactly one connect call.
- Retained sleeps are intentionally different: they either allow the private in-memory registration finalizer to clear after an already-polled DB state or provide a negative race window proving that late provider completion cannot mutate an already-proven terminal row.

## Validation

Independent `test-only` QA passed on exact clean head `75e168e91e80ca9724c03fd1d86c141a919a06be`:

- Three timeout cases across 10 fresh Vitest processes: 30/30 passed.
- Complete `feishu-registration.test.ts`: 29/29 passed.
- CI-equivalent two-fork Server suite: 294 files and 3,459/3,459 tests passed.
- Server typecheck passed.
- Changed-file Biome and `git diff --check` passed.
- Exact delta: one test file, +30/-3.

## Limits

This is deterministic product-test stabilization. It does not claim live Feishu provider or release-wide qualification.
