### PR TITLE
fix(client): admit schema v1 Managed Skills state in publication preflight

### DIFF
--- a/packages/client/src/__tests__/prepare-managed-session.test.ts
+++ b/packages/client/src/__tests__/prepare-managed-session.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionContext } from "../runtime/contracts.js";
+import { MANAGED_STATE_REL } from "../runtime/managed-state.js";
 import type { PrepareManagedSessionParams } from "../runtime/provider-support/preparation.js";
 import { INIT_COMPLETE_SENTINEL_REL } from "../runtime/workspace.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
@@ -877,6 +878,110 @@ describe("prepareManagedSession", () => {
 
     expect(callOrder).toEqual(["acquire", "chatContext", "sourceRepos", "skills"]);
     expect(ensureAgentBootstrap).not.toHaveBeenCalled();
+    expect(markWorkspaceInitComplete).not.toHaveBeenCalled();
+  });
+
+  function writeManagedState(record: Record<string, unknown>): void {
+    const statePath = join(workspaceRoot, MANAGED_STATE_REL);
+    mkdirSync(join(workspaceRoot, ".first-tree-workspace"), { recursive: true });
+    writeFileSync(statePath, JSON.stringify(record));
+  }
+
+  function boundSessionCtx(): SessionContext {
+    const ctx = sessionCtx();
+    (ctx.sdk as unknown as { getAgentContextTreeConfig: ReturnType<typeof vi.fn> }).getAgentContextTreeConfig = vi.fn(
+      async () => ({
+        bindingState: "bound",
+        repo: "https://example.test/tree",
+        branch: "main",
+        provider: null,
+      }),
+    );
+    return ctx;
+  }
+
+  const boundPayload = {
+    kind: "cursor" as const,
+    prompt: { append: "" },
+    model: "",
+    mcpServers: [],
+    env: [],
+    gitRepos: [{ url: "https://example.test/widget", localPath: "widget" }],
+    resourceSkills: [],
+  };
+
+  it("admits a schema v1 Managed Skills state so reconcile can migrate it", async () => {
+    const prepareManagedSession = await loadPrepare();
+    writeManagedState({
+      schemaVersion: 1,
+      cliVersion: "0.5.17",
+      updatedAt: "2026-07-23T23:24:32.393Z",
+      skills: [],
+    });
+
+    const result = await prepareManagedSession({
+      sessionCtx: boundSessionCtx(),
+      workspaceRoot,
+      agentName: "prep-agent",
+      runtimeProvider: "cursor",
+      providerSkillRoots: TEST_PROVIDER_SKILL_ROOTS,
+      runtimeConfig: {
+        agentId: "019d9a97-90b0-716b-8317-a8c0be8430d7",
+        version: 1,
+        payload: boundPayload,
+        updatedAt: new Date().toISOString(),
+        updatedBy: "test",
+      } as never,
+      payload: boundPayload,
+      payloadResolved: true,
+      contextTree: {
+        path: join(workspaceRoot, "context-tree"),
+        repoUrl: "https://example.test/tree",
+        branch: "main",
+      },
+    });
+
+    expect(callOrder).toContain("skills");
+    expect(reconcileManagedSkillsForConfig).toHaveBeenCalledTimes(1);
+    expect(result.resourceConfigVersion).toBe(3);
+    expect(markWorkspaceInitComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a future-schema Managed Skills state before reconcile", async () => {
+    const prepareManagedSession = await loadPrepare();
+    writeManagedState({
+      schemaVersion: 3,
+      resourceConfigVersion: 99,
+      updatedAt: new Date().toISOString(),
+      skills: [],
+    });
+
+    await expect(
+      prepareManagedSession({
+        sessionCtx: boundSessionCtx(),
+        workspaceRoot,
+        agentName: "prep-agent",
+        runtimeProvider: "cursor",
+        providerSkillRoots: TEST_PROVIDER_SKILL_ROOTS,
+        runtimeConfig: {
+          agentId: "019d9a97-90b0-716b-8317-a8c0be8430d7",
+          version: 1,
+          payload: boundPayload,
+          updatedAt: new Date().toISOString(),
+          updatedBy: "test",
+        } as never,
+        payload: boundPayload,
+        payloadResolved: true,
+        contextTree: {
+          path: join(workspaceRoot, "context-tree"),
+          repoUrl: "https://example.test/tree",
+          branch: "main",
+        },
+      }),
+    ).rejects.toThrow(/unreadable or from an unsupported version/);
+
+    expect(callOrder).not.toContain("skills");
+    expect(reconcileManagedSkillsForConfig).not.toHaveBeenCalled();
     expect(markWorkspaceInitComplete).not.toHaveBeenCalled();
   });
 

--- a/packages/client/src/__tests__/prepare-managed-session.test.ts
+++ b/packages/client/src/__tests__/prepare-managed-session.test.ts
@@ -947,6 +947,38 @@ describe("prepareManagedSession", () => {
     expect(markWorkspaceInitComplete).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the null-config guard for a schema v1 Managed Skills state", async () => {
+    const prepareManagedSession = await loadPrepare();
+    writeManagedState({
+      schemaVersion: 1,
+      cliVersion: "0.5.17",
+      updatedAt: "2026-07-23T23:24:32.393Z",
+      skills: [],
+    });
+
+    await expect(
+      prepareManagedSession({
+        sessionCtx: boundSessionCtx(),
+        workspaceRoot,
+        agentName: "prep-agent",
+        runtimeProvider: "cursor",
+        providerSkillRoots: TEST_PROVIDER_SKILL_ROOTS,
+        runtimeConfig: null,
+        payload: boundPayload,
+        payloadResolved: true,
+        contextTree: {
+          path: join(workspaceRoot, "context-tree"),
+          repoUrl: "https://example.test/tree",
+          branch: "main",
+        },
+      }),
+    ).rejects.toThrow(/runtime config is unavailable/);
+
+    expect(callOrder).not.toContain("skills");
+    expect(reconcileManagedSkillsForConfig).not.toHaveBeenCalled();
+    expect(markWorkspaceInitComplete).not.toHaveBeenCalled();
+  });
+
   it("refuses a future-schema Managed Skills state before reconcile", async () => {
     const prepareManagedSession = await loadPrepare();
     writeManagedState({

--- a/packages/client/src/runtime/provider-support/preparation.ts
+++ b/packages/client/src/runtime/provider-support/preparation.ts
@@ -272,12 +272,17 @@ function assertRuntimeConfigCanPublish(
       );
     }
     const state = readManagedStateResult(root);
-    if (state.kind !== "current") {
+    // Schema v1 state predates the Team Resource fence, so it publishes at
+    // version 0; reconcile migrates it in place once the session is admitted.
+    // Only future/invalid state is unsafe to mutate.
+    const publishedVersion =
+      state.kind === "current" ? state.state.resourceConfigVersion : state.kind === "legacy" ? 0 : null;
+    if (publishedVersion === null) {
       throw new ManagedSkillsUnsafeDiscoveryError(
         "Managed Skills state is unreadable or from an unsupported version; preserving the existing projection",
       );
     }
-    highestPublishedVersion = Math.max(highestPublishedVersion ?? 0, state.state.resourceConfigVersion);
+    highestPublishedVersion = Math.max(highestPublishedVersion ?? 0, publishedVersion);
   }
   if (highestPublishedVersion === null) return;
   if (runtimeConfig === null && !hasCapturedPayload) {


### PR DESCRIPTION
## Problem

Since #2338, `assertRuntimeConfigCanPublish` in `packages/client/src/runtime/provider-support/preparation.ts` runs before Managed Skills reconcile and throws `ManagedSkillsUnsafeDiscoveryError` for any `managed.json` whose read result is not `kind: "current"`. That includes the schema v1 (`legacy`) state that `loadOrMigrateManagedState` already migrates in place.

Any agent workspace that was last projected before the v2 state shipped can therefore never start a session: every retry fails with

```
Managed Skills state is unreadable or from an unsupported version; preserving the existing projection
```

classified as `transient_transport` / `managed_skills_unsafe_discovery`, so the slot retries forever and the chat shows `Retrying provider · attempt N`.

Observed on staging (`0.5.22-staging.1215.1`): `liuchao-fable` hit this on the first message after 07‑23; four more agents on the same host (`liuchao-codex`, `fire-fable-dev`, `fire-fable-reviewer`, one unnamed) carried the same v1 file and would have failed on their next wake-up.

## Fix

Treat v1 state as a projection published at Team Resource fence `0` (which is what `emptyManagedState()` produces after migration) instead of unsafe. The existing `runtimeConfig === null && !hasCapturedPayload` and version-fence checks still apply; `future` / `invalid` state is still refused.

## Tests

- `prepare-managed-session.test.ts`: new case writes a v1 `managed.json` and asserts the session is admitted and reconcile runs (fails on `main` with the error above); new case writes a `schemaVersion: 3` file and asserts it is still refused before reconcile.
- `pnpm check`, `pnpm typecheck`, `pnpm --filter @first-tree/client test` green locally.

## Operator note

Workspaces already stuck in the retry loop recover on the next retry once this ships. Until then, moving the v1 `.first-tree-workspace/managed.json` aside has the same effect: with `skills: []` (the only shape the v1 writer produced for core-skill-only workspaces) the `missing` and `legacy` migration paths adopt the same symlink-pair-proven targets. That is how the five staging workspaces above were unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
