### PR TITLE
fix(client): retire Claude query after credential failure

### DIFF
--- a/packages/client/src/__tests__/runtime-notice.test.ts
+++ b/packages/client/src/__tests__/runtime-notice.test.ts
@@ -102,9 +102,12 @@ describe("runtime notice formatting", () => {
         }),
       ),
     ).toContain("usually NOT a login problem");
-    expect(formatProviderFailureRuntimeNotice(payload({ provider: "claude-code", category: "credential" }))).toContain(
-      "Run `claude auth login`",
+    const credentialNotice = formatProviderFailureRuntimeNotice(
+      payload({ provider: "claude-code", category: "credential" }),
     );
+    expect(credentialNotice).toContain("Run `claude auth login`");
+    expect(credentialNotice).toContain("send your message again in this chat");
+    expect(credentialNotice).not.toContain("then retry");
     expect(
       formatProviderFailureRuntimeNotice(
         payload({ provider: "claude-code", category: "provider_capacity", reasonCode: "provider_billing_limit" }),

--- a/packages/client/src/providers/claude/__tests__/provider-error-result.test.ts
+++ b/packages/client/src/providers/claude/__tests__/provider-error-result.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type ProviderRetryEventPayload, parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
@@ -458,6 +458,85 @@ describe("claude-code handler — structured provider error result", () => {
     recoveredTurnGate.resolve();
     await waitForCondition(() => result.completed.length === 2, "recovered turn settlement");
     expect(result.forwardResult).toHaveBeenCalledWith("Recovered after login");
+    expect(result.failSessionForRecovery).not.toHaveBeenCalled();
+
+    await result.handler.suspend();
+    expect(mockState.closeCalls).toEqual([1, 2]);
+  });
+
+  it("projects config updated during credential wait before the fresh resume query", async () => {
+    const failedTurnGate = deferred();
+    const recoveredTurnGate = deferred();
+    mockState.promptAppend = "credential recovery prompt v1";
+    mockState.messagesByAttempt = [
+      [
+        {
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          api_error_status: 401,
+          result: "authentication_failed",
+        },
+      ],
+      [
+        {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          result: "Recovered with current briefing",
+        },
+      ],
+    ];
+    mockState.inputDrainLimitByAttempt = [1, 1];
+    mockState.resultGateByAttempt = [failedTurnGate.promise, recoveredTurnGate.promise];
+
+    const result = await startSingleResultTurn();
+    await waitForCondition(
+      () => mockState.observedInputMessages.filter((input) => input.attempt === 1).length === 1,
+      "failed query input",
+    );
+    failedTurnGate.resolve();
+    await waitForCondition(() => result.completed.length === 1, "credential settlement");
+
+    const briefingPath = join(workspaceRoot, "CLAUDE.md");
+    expect(readFileSync(briefingPath, "utf8")).toContain("credential recovery prompt v1");
+    expect(mockState.queryCalls).toBe(1);
+
+    mockState.configVersion = 2;
+    mockState.promptAppend = "credential recovery prompt v2";
+    await result.cache.refresh(AGENT_ID);
+    result.handler.inject(
+      {
+        id: "m2",
+        chatId: "chat-claude-provider-error",
+        senderId: "user-1",
+        format: "text",
+        content: "continue after login with the new briefing",
+        metadata: null,
+      },
+      deliveryTokenFromSessionContext(result.ctx),
+    );
+
+    await waitForCondition(() => mockState.queryCalls === 2, "fresh credential-recovery query");
+    await waitForCondition(
+      () => mockState.observedInputMessages.filter((input) => input.attempt === 2).length === 1,
+      "fresh query input",
+    );
+
+    const projectedBriefing = readFileSync(briefingPath, "utf8");
+    expect(projectedBriefing).toContain("credential recovery prompt v2");
+    expect(projectedBriefing).not.toContain("credential recovery prompt v1");
+    expect(mockState.observedQueryOptions[1]).toEqual({ attempt: 2, resume: result.sessionId });
+    expect(mockState.queryCalls).toBe(2);
+    expect(result.logs).toContain("[configHotSwitch] path=credential-recovery fromVersion=1 toVersion=2");
+    const recoveredInput = mockState.observedInputMessages.find((input) => input.attempt === 2)?.content ?? "";
+    expect(recoveredInput).toContain("CLAUDE.md");
+    expect(recoveredInput).toContain("continue after login with the new briefing");
+    expect(recoveredInput).not.toContain("hello");
+
+    recoveredTurnGate.resolve();
+    await waitForCondition(() => result.completed.length === 2, "recovered turn settlement");
+    expect(result.forwardResult).toHaveBeenCalledWith("Recovered with current briefing");
     expect(result.failSessionForRecovery).not.toHaveBeenCalled();
 
     await result.handler.suspend();

--- a/packages/client/src/providers/claude/__tests__/provider-error-result.test.ts
+++ b/packages/client/src/providers/claude/__tests__/provider-error-result.test.ts
@@ -12,6 +12,9 @@ const mockState = vi.hoisted(() => ({
   messagesByAttempt: [] as unknown[][],
   queryCalls: 0,
   observedInputMessages: [] as Array<{ attempt: number; content: string }>,
+  observedQueryOptions: [] as Array<{ attempt: number; sessionId?: string; resume?: string }>,
+  inputDrainLimitByAttempt: [] as number[],
+  resultGateByAttempt: [] as Array<Promise<void> | undefined>,
   configVersion: 1,
   promptAppend: "",
   configModel: "",
@@ -22,7 +25,11 @@ const mockState = vi.hoisted(() => ({
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => {
-  const drainPrompt = async (prompt: AsyncIterable<{ message?: { content?: unknown } }>, attempt: number) => {
+  const drainPrompt = async (
+    prompt: AsyncIterable<{ message?: { content?: unknown } }>,
+    attempt: number,
+    limit: number,
+  ) => {
     let drained = 0;
     for await (const sdkMsg of prompt) {
       const content = sdkMsg.message?.content;
@@ -31,23 +38,34 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
         content: typeof content === "string" ? content : JSON.stringify(content),
       });
       drained += 1;
-      if (drained >= 1) break;
+      if (drained >= limit) break;
     }
   };
   return {
-    query: (args: { prompt: AsyncIterable<{ message?: { content?: unknown } }> }) => {
+    query: (args: {
+      prompt: AsyncIterable<{ message?: { content?: unknown } }>;
+      options?: { sessionId?: string; resume?: string };
+    }) => {
       mockState.queryCalls += 1;
       const attempt = mockState.queryCalls;
       if (attempt === mockState.throwQueryOnCall) {
         throw new Error("config restart query construction failed");
       }
       const messages = (mockState.messagesByAttempt[attempt - 1] ?? mockState.nextMessages).slice();
-      void drainPrompt(args.prompt, attempt);
+      const sessionId = args.options?.sessionId;
+      const resume = args.options?.resume;
+      mockState.observedQueryOptions.push({
+        attempt,
+        ...(typeof sessionId === "string" ? { sessionId } : {}),
+        ...(typeof resume === "string" ? { resume } : {}),
+      });
+      void drainPrompt(args.prompt, attempt, mockState.inputDrainLimitByAttempt[attempt - 1] ?? 1);
       return {
         [Symbol.asyncIterator]() {
           let idx = 0;
           return {
             next: async () => {
+              if (idx === 0) await mockState.resultGateByAttempt[attempt - 1];
               if (idx < messages.length) {
                 const value = messages[idx];
                 idx += 1;
@@ -88,6 +106,9 @@ beforeEach(() => {
   if (workspaceRoot) rmSync(workspaceRoot, { recursive: true, force: true });
   workspaceRoot = mkdtempSync(join(realpathSync(tmpdir()), "ftt-claude-provider-error-"));
   mockState.messagesByAttempt.length = 0;
+  mockState.observedQueryOptions.length = 0;
+  mockState.inputDrainLimitByAttempt.length = 0;
+  mockState.resultGateByAttempt.length = 0;
   mockState.configVersion = 1;
   mockState.promptAppend = "";
   mockState.configModel = "";
@@ -142,6 +163,14 @@ async function waitForCondition(predicate: () => boolean, description: string): 
   throw new Error(`timed out waiting for ${description}`);
 }
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = (): void => {};
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 async function startSingleResultTurn() {
   mockState.queryCalls = 0;
   mockState.observedInputMessages.length = 0;
@@ -149,6 +178,7 @@ async function startSingleResultTurn() {
   const forwardResult = vi.fn<SessionContext["forwardResult"]>().mockResolvedValue(undefined);
   const emitted: SessionEvent[] = [];
   const completed: Array<{ count: number; outcome: TurnOutcome }> = [];
+  const settlementOrder: string[] = [];
   const logs: string[] = [];
   const retryTurn = vi.fn<SessionContext["retryTurn"]>(() => {
     mockState.lifecycleEvents.push("retry:entered");
@@ -180,17 +210,22 @@ async function startSingleResultTurn() {
     chatId: "chat-claude-provider-error",
     log: (m) => logs.push(m),
     recordProviderActivity: () => {},
-    emitEvent: (e) => emitted.push(e),
+    emitEvent: (e) => {
+      const retryEvent = e.kind === "error" ? parseProviderRetryEventMessage(e.payload.message) : null;
+      if (retryEvent?.event === "provider_failure_terminal") settlementOrder.push("terminal-notice");
+      emitted.push(e);
+    },
     ...mockCtxPlumbing({ sendMessage }, "chat-claude-provider-error"),
     forwardResult,
     retryTurn,
     failSessionForRecovery,
     finishTurn: async (messages, outcome) => {
+      settlementOrder.push("complete");
       completed.push({ count: Array.isArray(messages) ? messages.length : 1, outcome });
     },
   };
 
-  await handler.start(
+  const started = await handler.start(
     {
       id: "m1",
       chatId: "chat-claude-provider-error",
@@ -205,12 +240,14 @@ async function startSingleResultTurn() {
 
   return {
     handler,
+    sessionId: started.sessionId,
     cache,
     ctx,
     sendMessage,
     forwardResult,
     emitted,
     completed,
+    settlementOrder,
     logs,
     retryTurn,
     failSessionForRecovery,
@@ -309,6 +346,122 @@ describe("claude-code handler — structured provider error result", () => {
       completion: "consumed",
       reason: "provider_credential_required",
     });
+  });
+
+  it("retires a credential-failed query and lazily resumes only recovered new input", async () => {
+    const failedTurnGate = deferred();
+    const recoveredTurnGate = deferred();
+    mockState.messagesByAttempt = [
+      [
+        {
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          api_error_status: 401,
+          result: "authentication_failed",
+        },
+      ],
+      [
+        {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          result: "Recovered after login",
+        },
+      ],
+    ];
+    mockState.inputDrainLimitByAttempt = [1, 2];
+    mockState.resultGateByAttempt = [failedTurnGate.promise, recoveredTurnGate.promise];
+
+    const result = await startSingleResultTurn();
+    await waitForCondition(
+      () => mockState.observedInputMessages.filter((input) => input.attempt === 1).length === 1,
+      "failed query input",
+    );
+
+    const tailRecoveryOrder: string[] = [];
+    const makeTailToken = (id: string) => ({
+      processingStarted: vi.fn(),
+      complete: vi.fn().mockResolvedValue(undefined),
+      retry: vi.fn(() => tailRecoveryOrder.push(id)),
+      terminalRejected: vi.fn().mockResolvedValue(undefined),
+    });
+    const tail2 = makeTailToken("m2");
+    const tail3 = makeTailToken("m3");
+    const message2 = {
+      id: "m2",
+      chatId: "chat-claude-provider-error",
+      senderId: "user-1",
+      format: "text" as const,
+      content: "second message",
+      metadata: null,
+    };
+    const message3 = {
+      id: "m3",
+      chatId: "chat-claude-provider-error",
+      senderId: "user-1",
+      format: "text" as const,
+      content: "third message",
+      metadata: null,
+    };
+    result.handler.inject(message2, tail2);
+    result.handler.inject(message3, tail3);
+
+    failedTurnGate.resolve();
+    await waitForCondition(() => result.completed.length === 1, "credential settlement");
+    await waitForCondition(() => tailRecoveryOrder.length === 2, "unentered tail recovery");
+
+    expect(mockState.queryCalls).toBe(1);
+    expect(mockState.closeCalls).toEqual([1]);
+    expect(result.settlementOrder).toEqual(["terminal-notice", "complete"]);
+    expect(result.completed[0]).toMatchObject({
+      count: 1,
+      outcome: {
+        status: "error",
+        terminal: true,
+        completion: "consumed",
+        reason: "provider_credential_required",
+      },
+    });
+    expect(tailRecoveryOrder).toEqual(["m2", "m3"]);
+    expect(tail2.processingStarted).not.toHaveBeenCalled();
+    expect(tail3.processingStarted).not.toHaveBeenCalled();
+    expect(tail2.complete).not.toHaveBeenCalled();
+    expect(tail3.complete).not.toHaveBeenCalled();
+
+    const redelivered2 = deliveryTokenFromSessionContext(result.ctx);
+    const redelivered3 = deliveryTokenFromSessionContext(result.ctx);
+    result.handler.inject(message2, redelivered2);
+    result.handler.inject(message3, redelivered3);
+
+    await waitForCondition(() => mockState.queryCalls === 2, "fresh credential-recovery query");
+    await waitForCondition(
+      () => mockState.observedInputMessages.filter((input) => input.attempt === 2).length === 2,
+      "fresh query inputs",
+    );
+
+    expect(mockState.queryCalls).toBe(2);
+    expect(mockState.observedQueryOptions[0]).toEqual({ attempt: 1, sessionId: result.sessionId });
+    expect(mockState.observedQueryOptions[1]).toEqual({ attempt: 2, resume: result.sessionId });
+    const recoveredInput = mockState.observedInputMessages
+      .filter((input) => input.attempt === 2)
+      .map((input) => input.content);
+    expect(recoveredInput).toHaveLength(2);
+    expect(recoveredInput[0]).toContain("second message");
+    expect(recoveredInput[1]).toContain("third message");
+    expect(
+      mockState.observedInputMessages
+        .filter((input) => input.attempt === 2)
+        .some((input) => input.content.includes("hello")),
+    ).toBe(false);
+
+    recoveredTurnGate.resolve();
+    await waitForCondition(() => result.completed.length === 2, "recovered turn settlement");
+    expect(result.forwardResult).toHaveBeenCalledWith("Recovered after login");
+    expect(result.failSessionForRecovery).not.toHaveBeenCalled();
+
+    await result.handler.suspend();
+    expect(mockState.closeCalls).toEqual([1, 2]);
   });
 
   it("retries a transient structured failure after assistant text was emitted", async () => {

--- a/packages/client/src/providers/claude/index.ts
+++ b/packages/client/src/providers/claude/index.ts
@@ -1001,6 +1001,74 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     }
   }
 
+  async function spawnCredentialRecoveryQuery(sessionCtx: SessionContext, sessionId: string): Promise<void> {
+    await assertQuerySpawnCurrent(sessionCtx);
+    if (ctx !== sessionCtx || claudeSessionId !== sessionId || !credentialResumeRequired || inputController) {
+      return;
+    }
+
+    // A config event may land while the credential-failed query is retired.
+    // Project every newer non-model payload before the only recovery spawn so
+    // buildQuery cannot record that version as applied while CLAUDE.md still
+    // carries the old briefing. Keep this local projection baseline separate
+    // from appliedPayload: only spawnQuery may advance the applied snapshot,
+    // after the projection and SDK constructor both succeed.
+    let projectedPayload = appliedPayload;
+    while (true) {
+      const cached = agentConfigCache?.get(sessionCtx.agent.agentId);
+      const onlyModelChangedSinceProjection =
+        cached !== undefined &&
+        projectedPayload !== null &&
+        JSON.stringify({ ...projectedPayload, model: "" }) === JSON.stringify({ ...cached.payload, model: "" }) &&
+        projectedPayload.model !== cached.payload.model;
+      const needsBriefingProjection =
+        cached !== undefined && cached.version > appliedConfigVersion && !onlyModelChangedSinceProjection;
+
+      if (needsBriefingProjection) {
+        if (!cwd) throw new Error("credential recovery has no managed workspace to project");
+        sessionCtx.log(
+          `[configHotSwitch] path=credential-recovery fromVersion=${appliedConfigVersion} toVersion=${cached.version}`,
+        );
+        const legacyProjection = cwd !== workspaceRoot;
+        const projected = await projectManagedWorkspace({
+          sessionCtx,
+          workspace: cwd,
+          sourceAuthorityRoot: legacyProjection ? workspaceRoot : cwd,
+          agentName,
+          runtimeProvider,
+          providerSkillRoots: PROVIDER_SKILL_ROOTS,
+          runtimeConfig: cached,
+          payload: cached.payload,
+          payloadResolved: true,
+          existingPayload: projectedPayload ?? undefined,
+          contextTree: {
+            kind: contextTree.kind,
+            path: contextTree.path,
+            repoUrl: contextTree.repoUrl,
+            branch: contextTree.branch,
+          },
+          reresolveSource: true,
+          markInitComplete: false,
+          writeIdentityAndManifest: !legacyProjection,
+          suppressSourceRepos: legacyProjection,
+        });
+        currentBriefingFingerprint = computeBriefingFingerprint(projected.briefing);
+        projectedPayload = cached.payload;
+
+        if (ctx !== sessionCtx || claudeSessionId !== sessionId || !credentialResumeRequired || inputController) {
+          return;
+        }
+        const latest = agentConfigCache?.get(sessionCtx.agent.agentId);
+        if (!latest) throw new Error("credential recovery runtime config disappeared during projection");
+        if (latest.version !== cached.version) continue;
+      }
+
+      sessionCtx.log(`Credential recovery: resuming session in a fresh Claude query (${sessionId})`);
+      spawnQuery(sessionId, sessionCtx, sessionId, buildEnv(sessionCtx));
+      return;
+    }
+  }
+
   function scheduleInjectedMessagesDrain(sessionCtx: SessionContext, sessionId: string): void {
     if (injectDrainInProgress || (!inputController && !credentialResumeRequired)) return;
     void (async () => {
@@ -1008,12 +1076,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       try {
         if (!inputController && credentialResumeRequired) {
           try {
-            await assertQuerySpawnCurrent(sessionCtx);
-            if (ctx !== sessionCtx || claudeSessionId !== sessionId || !credentialResumeRequired || inputController) {
-              return;
-            }
-            sessionCtx.log(`Credential recovery: resuming session in a fresh Claude query (${sessionId})`);
-            spawnQuery(sessionId, sessionCtx, sessionId, buildEnv(sessionCtx));
+            await spawnCredentialRecoveryQuery(sessionCtx, sessionId);
           } catch (err) {
             sessionCtx.log(`Credential recovery resume failed: ${err instanceof Error ? err.message : String(err)}`);
             credentialResumeRequired = false;

--- a/packages/client/src/providers/claude/index.ts
+++ b/packages/client/src/providers/claude/index.ts
@@ -419,6 +419,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   let inputController: InputController<PendingSdkInput> | null = null;
   let providerRetryBackoffAbort: AbortController | null = null;
   let consumerDone: Promise<void> | null = null;
+  /**
+   * A terminal credential result retires the current SDK query because Claude
+   * caches authentication state in its native process. Keep the logical
+   * Session and claudeSessionId, then lazily create one fresh resume query
+   * when the next delivered message arrives.
+   */
+  let credentialResumeRequired = false;
   let retryCount = 0;
   let ctx: SessionContext | null = null;
   /** Snapshot of the runtime config the *current* sub-process was launched with. */
@@ -995,10 +1002,26 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   function scheduleInjectedMessagesDrain(sessionCtx: SessionContext, sessionId: string): void {
-    if (!inputController || injectDrainInProgress) return;
+    if (injectDrainInProgress || (!inputController && !credentialResumeRequired)) return;
     void (async () => {
       injectDrainInProgress = true;
       try {
+        if (!inputController && credentialResumeRequired) {
+          try {
+            await assertQuerySpawnCurrent(sessionCtx);
+            if (ctx !== sessionCtx || claudeSessionId !== sessionId || !credentialResumeRequired || inputController) {
+              return;
+            }
+            sessionCtx.log(`Credential recovery: resuming session in a fresh Claude query (${sessionId})`);
+            spawnQuery(sessionId, sessionCtx, sessionId, buildEnv(sessionCtx));
+          } catch (err) {
+            sessionCtx.log(`Credential recovery resume failed: ${err instanceof Error ? err.message : String(err)}`);
+            credentialResumeRequired = false;
+            retryBufferedMessages("claude_credential_resume_failed_recovery");
+            failFatalSessionForRecovery(sessionCtx, "claude_credential_resume_failed");
+            return;
+          }
+        }
         while (
           queuedInjectedMessages.length > 0 &&
           inputController &&
@@ -1019,14 +1042,19 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         }
       } finally {
         injectDrainInProgress = false;
-        if (queuedInjectedMessages.length > 0 && inputController && ctx && claudeSessionId) {
+        if (
+          queuedInjectedMessages.length > 0 &&
+          (inputController || credentialResumeRequired) &&
+          ctx &&
+          claudeSessionId
+        ) {
           scheduleInjectedMessagesDrain(ctx, claudeSessionId);
         }
       }
     })();
   }
 
-  function retryBufferedMessages(reason: string): void {
+  function retryBufferedMessages(reason: string, preserveFifo = false): void {
     inputRecoveryReason = reason;
     unclosedSdkInputs.length = 0;
     const pending = pendingAckMessages.splice(0);
@@ -1037,8 +1065,22 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           pendingItem.message === drainingInjectedMessage?.message &&
           pendingItem.token === drainingInjectedMessage.token,
       );
-    if (drainingInjectedMessage && !drainingIsPending) retryInjectedItem(drainingInjectedMessage, reason);
     const queued = queuedInjectedMessages.splice(0);
+    if (preserveFifo) {
+      // pending inputs reached the controller before the currently formatting
+      // item, which in turn precedes the untouched handler queue. Credential
+      // settlement must return that exact unentered tail order to runtime
+      // recovery after removing the consumed prefix.
+      for (const item of pending) {
+        item.token.retry(item.message, reason);
+      }
+      if (drainingInjectedMessage && !drainingIsPending) retryInjectedItem(drainingInjectedMessage, reason);
+      for (const item of queued) {
+        retryInjectedItem(item, reason);
+      }
+      return;
+    }
+    if (drainingInjectedMessage && !drainingIsPending) retryInjectedItem(drainingInjectedMessage, reason);
     for (const item of queued) {
       retryInjectedItem(item, reason);
     }
@@ -1185,6 +1227,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     inputController = nextInputController;
     currentQuery = nextQuery;
     activeProviderEnv = childEnv;
+    credentialResumeRequired = false;
   }
 
   /**
@@ -1457,8 +1500,31 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                   }
                   sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
                   retryCount = 0;
+                  const retireCredentialGeneration =
+                    settlement.classification.category === "credential" &&
+                    settlement.decision.action === "stop" &&
+                    settlement.decision.terminalKind === "needs_operator";
+                  if (retireCredentialGeneration) {
+                    // Prevent messages delivered while the durable runtime
+                    // notice / exact-prefix ACK is in flight from reaching
+                    // the stale native process. The logical Session and
+                    // claudeSessionId remain intact for lazy exact resume.
+                    retireProviderTransport();
+                  }
                   await ackTurnClose("error", consumedReasonForProviderSettlement(settlement), providerEnteredPrefix);
                   resetTurnReplaySafety();
+                  if (retireCredentialGeneration) {
+                    // The consumed prefix is now settled and removed from the
+                    // replay buffer. Return only the unentered tail to the
+                    // existing ordered recovery path, then wait for a newly
+                    // delivered message before creating a fresh query.
+                    retryBufferedMessages("claude_credential_terminal_tail_recovery", true);
+                    credentialResumeRequired = true;
+                    if (queuedInjectedMessages.length > 0 && claudeSessionId) {
+                      scheduleInjectedMessagesDrain(sessionCtx, claudeSessionId);
+                    }
+                    return;
+                  }
                   continue;
                 }
               }
@@ -2025,6 +2091,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
     async suspend(reason?: string) {
       ctx?.log("Suspending session");
+      credentialResumeRequired = false;
       retireProviderTransport();
 
       // Wait for consumer loop to finish

--- a/packages/client/src/runtime/runtime-notice.ts
+++ b/packages/client/src/runtime/runtime-notice.ts
@@ -94,7 +94,7 @@ function isClaudeProvider(provider: RuntimeProvider): boolean {
 function claudeProviderTurnNoticeLead(payload: ProviderRetryEventPayload): string {
   if (payload.category === "credential") {
     if (isEgressForbiddenText(payload.messagePreview ?? "")) return claudeEgressForbiddenLead();
-    return "Claude Code could not run this turn: Anthropic rejected the local Claude authentication. Run `claude auth login` on this machine, then retry.";
+    return "Claude Code could not run this turn: Anthropic rejected the local Claude authentication. Run `claude auth login` on this machine. After sign-in completes, send your message again in this chat.";
   }
   if (payload.category === "provider_capacity") {
     if (payload.reasonCode === "provider_billing_limit") {


### PR DESCRIPTION
## Summary

- settle Claude credential failures as terminal `needs_operator` turns, publish the runtime failure event before the exact consumed-prefix settlement, and retire the failed SDK query/native generation
- preserve the logical chat and persisted Claude session id, then lazily create one fresh exact-resume query when a newly delivered message arrives
- project the latest non-model managed config before that recovery query, repeating projection if the cache advances so the applied snapshot cannot outrun the generated `CLAUDE.md`
- keep the settled failed input out of replay while returning only unentered tail messages through the existing FIFO recovery path
- tell the operator to sign in and send a message again; login completion itself does not restart affected chats
- keep non-credential terminal handling and transient automatic retry/replay paths unchanged

Relates to #2362. This PR intentionally does not auto-close the issue.

## Context Tree coordination

- Draft Tree PR: https://github.com/first-tree-ai/first-tree-context/pull/974
- The Tree PR records the durable generation-retirement and lazy exact-resume boundary and remains draft under the code-first flow.

## Verification

- `pnpm --filter @first-tree/client exec vitest run src/providers/claude/__tests__/provider-error-result.test.ts src/__tests__/runtime-notice.test.ts` — 22 tests passed
- adjacent Claude/retry/runtime-notice suite — 93 tests passed
- `pnpm --filter @first-tree/client typecheck` — passed
- `pnpm --filter @first-tree/client test` — 216 files passed, 2 skipped; 2,840 tests passed, 7 skipped
- `pnpm check` — passed with no errors (existing repository warnings/info only)
- `pnpm typecheck` — 9/9 tasks passed
- `pnpm test` — 10/10 tasks passed
- `git diff --check` — passed

## QA self-check

- Status: PASS
- Tier: `test-only`
- Scope: Claude handler lifecycle at the SDK query seam, exact terminal settlement ordering, lazy same-session resume, latest-config projection before recovery, failed-input exclusion, queued-tail FIFO, stale-query closure, duplicate-query prevention, and runtime notice wording
- Case disposition: `move-to-product-test` — the deterministic regressions are committed in the provider lifecycle and runtime-notice product suites
- Limitations: no live Anthropic login was performed; credential state and SDK/native lifecycle are controlled at the real handler seam

No database schema, migration, or persistence-semantic changes are included.
