### PR TITLE
release: bump apps/cli to v0.5.22

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Release bump

Bumps `apps/cli/package.json` version from `0.5.21` to `0.5.22`. No other changes (package name, bin, build-info, lockfile untouched; no database changes).

This is a human-authorized stable production release bump under the `first-tree-prod-release` exception.

## Draft release

**Title:** `v0.5.22 — More runtime providers, Team Skills, guided installs`

**Notes:**

```markdown
## Highlights

- Adds Amp and DeepSeek Harness as first-class runtime providers.
- Makes configured Team Skills discoverable and safely invokable from the slash-command menu, including mention-prefixed commands in group chats, and adds an experimental meeting-to-tree skill.
- Adds clearer progress, timing, and service-readiness feedback to the portable and development installers.

## Notable fixes

- Improves Claude credential recovery and Codex binary fallback when a configured executable cannot be used.
- Surfaces recovery for blocked or stale in-flight agent runs and clears stale working state when sessions stop.
- Preserves mobile chat-list position, excludes hidden Skills from public copy counts, and retires manual commit follows while keeping webhook-delivered commit comments automatic.
```

## Verification

- Branched from `origin/main` head `07dd9f84ffd55b976c284c1d9890cb119b6fc58b`.
- `pnpm install --frozen-lockfile` — clean.
- `pnpm check` (biome) — 0 errors (36 warnings / 8 infos, pre-existing style notes).
- `pnpm typecheck` (turbo) — 9/9 tasks successful.

## Post-merge steps

1. Confirm final version/tag/target SHA/title/body with human.
2. Tag the merge commit as `v0.5.22` and create the GitHub Release from the notes above (final confirmation pending).
3. Publish via the release automation — do **not** use local `npm publish`.
