### PR TITLE
Improve OpenCode turn abort handling and failure messages

### DIFF
--- a/packages/client/src/providers/opencode/__tests__/handler.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/handler.test.ts
@@ -1865,6 +1865,116 @@ describe("OpenCode V1 handler", () => {
     await handlerB.shutdown();
   }, 30_000);
 
+  it("does not admit a stale OpenCode prompt when aborted before the runProcess abort listener", async () => {
+    const root = mkdtempSync(join(realpathSync(tmpdir()), "ft-opencode-admit-race-"));
+    roots.push(root);
+    const specs: ProviderProcessSpec[] = [];
+    const prompts: string[] = [];
+    let staleChildPid: number | undefined;
+    let handler: ReturnType<typeof createOpenCodeHandler>;
+    let abortedDuringSpawn = false;
+
+    const supervisor: ProviderProcessSupervisor = {
+      spawn(spec) {
+        specs.push(spec);
+        if (spec.args[0] === "--version") {
+          const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
+            ...spec.options,
+            env: {
+              ...spec.options.env,
+              FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from("1.18.9\n", "utf8").toString("base64"),
+              FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: "0",
+            },
+          });
+          return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+        }
+        if (spec.args[0] === "db") {
+          const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
+            ...spec.options,
+            env: {
+              ...spec.options.env,
+              FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from('[{"ready":1}]\n', "utf8").toString("base64"),
+              FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: "0",
+            },
+          });
+          return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+        }
+
+        const runIndex = specs.filter((entry) => entry.args[0] === "run").length - 1;
+        if (runIndex === 0) {
+          const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
+            ...spec.options,
+            env: {
+              ...spec.options.env,
+              FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from(`${successfulTurn()}\n`, "utf8").toString("base64"),
+              FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: "0",
+            },
+          });
+          return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+        }
+
+        const partialOutput = [
+          JSON.stringify({ type: "step_start", sessionID: "ses_new", part: { sessionID: "ses_new" } }),
+          JSON.stringify({ type: "text", sessionID: "ses_new", part: { text: "partial" } }),
+        ].join("\n");
+        const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
+          ...spec.options,
+          env: {
+            ...spec.options.env,
+            FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from(`${partialOutput}\n`, "utf8").toString("base64"),
+            FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: "1",
+          },
+          detached: true,
+        });
+        staleChildPid = child.pid;
+        if (child.stdin) {
+          const write = child.stdin.write.bind(child.stdin);
+          child.stdin.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+            prompts.push(String(chunk));
+            return Reflect.apply(write, child.stdin, [chunk, ...args]);
+          }) as typeof child.stdin.write;
+        }
+        // Abort while still inside spawn — before runProcess registers its abort listener.
+        // AbortSignal does not replay, so without the post-listener re-check the stale prompt
+        // would still be written and the child would keep running.
+        abortedDuringSpawn = true;
+        void handler.suspend("abort-before-listener");
+        return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+      },
+    };
+
+    handler = createOpenCodeHandler({
+      workspaceRoot: root,
+      agentName: "opencode-test-agent",
+      runtimeProvider: "opencode",
+      agentConfigCache: cache(runtimeConfig()),
+      opencodeBinaryResolver: () => ({ ok: true, binary: "/host/opencode" }),
+      providerProcessSupervisor: supervisor,
+      opencodeTurnTimeoutMs: 5_000,
+    });
+    const sessionCtx = context([], []);
+    const bootstrapToken = deliveryToken();
+    const { sessionId } = await handler.start(message("m-boot", "bootstrap"), sessionCtx, bootstrapToken);
+
+    const staleToken = deliveryToken();
+    await handler.resume(message("m-stale", "first"), sessionId, sessionCtx, staleToken);
+    expect(abortedDuringSpawn).toBe(true);
+    expect(prompts).toEqual([]);
+    expect(staleToken.complete).not.toHaveBeenCalled();
+    if (staleChildPid !== undefined) {
+      const pid = staleChildPid;
+      await vi.waitFor(() => {
+        try {
+          process.kill(pid, 0);
+          throw new Error("stale child still alive");
+        } catch (error) {
+          expect((error as NodeJS.ErrnoException).code).toBe("ESRCH");
+        }
+      });
+    }
+    await handler.shutdown();
+  }, 30_000);
+
   it("preserves the unsafe-effect fence when private-config cleanup fails after provider exit", async () => {
     const root = mkdtempSync(join(realpathSync(tmpdir()), "ft-opencode-cleanup-effect-"));
     roots.push(root);

--- a/packages/client/src/providers/opencode/__tests__/handler.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/handler.test.ts
@@ -1039,7 +1039,7 @@ describe("OpenCode V1 handler", () => {
     expect(inputs[0]).toContain("<first-tree-current-chat-context");
     expect(inputs[1]).not.toContain("<first-tree-current-chat-context");
     await handler.shutdown();
-  });
+  }, 15_000);
 
   it("fails closed on unknown JSONL even when it carries a valid session id, then preserves one-shot context", async () => {
     const root = mkdtempSync(join(realpathSync(tmpdir()), "ft-opencode-protocol-"));
@@ -1669,7 +1669,7 @@ describe("OpenCode V1 handler", () => {
       expect.objectContaining({ status: "error", completion: "consumed", reason: "unsafe_replay" }),
     );
     await handler.shutdown();
-  });
+  }, 15_000);
 
   it("does not settle a superseded turn on the old token when a newer start arrives", async () => {
     const root = mkdtempSync(join(realpathSync(tmpdir()), "ft-opencode-supersede-token-"));
@@ -1750,6 +1750,83 @@ describe("OpenCode V1 handler", () => {
     expect(firstToken.retry).not.toHaveBeenCalled();
     expect(secondToken.complete).toHaveBeenCalled();
     await handler.shutdown();
+  }, 30_000);
+
+  it("scopes abort records per handler so concurrent sessions cannot steal settlement", async () => {
+    const rootA = mkdtempSync(join(realpathSync(tmpdir()), "ft-opencode-abort-scope-a-"));
+    const rootB = mkdtempSync(join(realpathSync(tmpdir()), "ft-opencode-abort-scope-b-"));
+    roots.push(rootA, rootB);
+    const specsA: ProviderProcessSpec[] = [];
+    const partialOutput = [
+      JSON.stringify({ type: "step_start", sessionID: "ses_new", part: { sessionID: "ses_new" } }),
+      JSON.stringify({ type: "text", sessionID: "ses_new", part: { text: "partial" } }),
+    ].join("\n");
+    const handlerA = createOpenCodeHandler({
+      workspaceRoot: rootA,
+      agentName: "opencode-test-agent-a",
+      runtimeProvider: "opencode",
+      agentConfigCache: cache(runtimeConfig()),
+      opencodeBinaryResolver: () => ({ ok: true, binary: "/host/opencode" }),
+      providerProcessSupervisor: createSupersedeProtocolSupervisor(
+        specsA,
+        `${partialOutput}\n`,
+        `${successfulTurn("ses_new", "done")}\n`,
+      ),
+    });
+    const ctxA = context([], [], { agentId: "agent-a", chatId: "chat-a" });
+    const bootstrapToken = deliveryToken();
+    const { sessionId } = await handlerA.start(message("boot-a", "bootstrap"), ctxA, bootstrapToken);
+
+    const staleToken = deliveryToken();
+    const ownerToken = deliveryToken();
+    const staleTurn = handlerA.resume(message("stale-a", "first"), sessionId, ctxA, staleToken);
+    await vi.waitFor(() => expect(staleToken.processingStarted).toHaveBeenCalled(), {
+      timeout: 10_000,
+    });
+    const ownerTurn = handlerA.resume(message("owner-a", "second"), sessionId, ctxA, ownerToken);
+    await Promise.all([staleTurn, ownerTurn]);
+    expect(staleToken.complete).not.toHaveBeenCalled();
+    expect(staleToken.retry).not.toHaveBeenCalled();
+    expect(ownerToken.complete).toHaveBeenCalled();
+
+    const writeOutput = [
+      JSON.stringify({ type: "step_start", sessionID: "ses_new", part: { sessionID: "ses_new" } }),
+      JSON.stringify({
+        type: "tool_use",
+        sessionID: "ses_new",
+        part: {
+          id: "tool-1",
+          tool: "bash",
+          state: { status: "completed", input: { command: "touch effect" }, output: "done" },
+        },
+      }),
+    ].join("\n");
+    const handlerB = createOpenCodeHandler({
+      workspaceRoot: rootB,
+      agentName: "opencode-test-agent-b",
+      runtimeProvider: "opencode",
+      agentConfigCache: cache(runtimeConfig()),
+      opencodeBinaryResolver: () => ({ ok: true, binary: "/host/opencode" }),
+      providerProcessSupervisor: createProtocolSupervisor([], [`${writeOutput}\n`], [], true),
+      opencodeTurnTimeoutMs: 5_000,
+    });
+    const eventsB: Array<{ kind?: string }> = [];
+    const ctxB = context(eventsB, [], { agentId: "agent-b", chatId: "chat-b" });
+    const unsafeToken = deliveryToken();
+    const unsafeTurn = handlerB.start(message("unsafe-b", "first"), ctxB, unsafeToken);
+    await vi.waitFor(() => expect(eventsB.some((event) => event.kind === "tool_call")).toBe(true), {
+      timeout: 10_000,
+    });
+    await handlerB.suspend("cross-handler isolation");
+    await unsafeTurn;
+    expect(unsafeToken.retry).not.toHaveBeenCalled();
+    expect(unsafeToken.complete).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: "unsafe-b" })],
+      expect.objectContaining({ status: "error", completion: "consumed", reason: "unsafe_replay" }),
+    );
+
+    await handlerA.shutdown();
+    await handlerB.shutdown();
   }, 30_000);
 
   it("preserves the unsafe-effect fence when private-config cleanup fails after provider exit", async () => {

--- a/packages/client/src/providers/opencode/__tests__/handler.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/handler.test.ts
@@ -178,8 +178,16 @@ process.stdin.resume();
 process.stdin.on("end", () => {
   const encoded = process.env.FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64 ?? "";
   process.stdout.write(Buffer.from(encoded, "base64").toString("utf8"));
+  if (process.env.FIRST_TREE_TEST_PROVIDER_TRAP_SIGTERM === "1") {
+    process.on("SIGTERM", () => {});
+  }
   if (process.env.FIRST_TREE_TEST_PROVIDER_HOLD_OPEN === "1") {
-    setInterval(() => {}, 1000);
+    const holdMs = Number(process.env.FIRST_TREE_TEST_PROVIDER_HOLD_MS ?? "0");
+    if (holdMs > 0) {
+      setTimeout(() => process.exit(0), holdMs);
+    } else {
+      setInterval(() => {}, 1000);
+    }
   }
 });
 `;
@@ -219,50 +227,32 @@ function createSyntheticSupervisor(
   };
 }
 
+type ProtocolTurnSpec = {
+  output: string;
+  holdOpen?: boolean;
+  holdMs?: number;
+  trapSigterm?: boolean;
+};
+
 function createProtocolSupervisor(
   specs: ProviderProcessSpec[],
   turnOutputs: string[],
   capturedInputs: string[] = [],
   holdOpen = false,
 ): ProviderProcessSupervisor {
-  let turn = 0;
-  return {
-    spawn(spec) {
-      specs.push(spec);
-      const output =
-        spec.args[0] === "--version"
-          ? "1.18.9\n"
-          : spec.args[0] === "db"
-            ? '[{"ready":1}]\n'
-            : (turnOutputs[turn++] ?? "");
-      const isRun = spec.args[0] === "run";
-      const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
-        ...spec.options,
-        env: {
-          ...spec.options.env,
-          FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from(output, "utf8").toString("base64"),
-          FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: holdOpen && isRun ? "1" : "0",
-        },
-        detached: holdOpen && isRun,
-      });
-      if (isRun && child.stdin) {
-        const write = child.stdin.write.bind(child.stdin);
-        child.stdin.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
-          capturedInputs.push(String(chunk));
-          return Reflect.apply(write, child.stdin, [chunk, ...args]);
-        }) as typeof child.stdin.write;
-      }
-      return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
-    },
-  };
+  return createProtocolTurnSupervisor(
+    specs,
+    turnOutputs.map((output) => ({ output, holdOpen })),
+    capturedInputs,
+  );
 }
 
-function createSupersedeProtocolSupervisor(
+function createProtocolTurnSupervisor(
   specs: ProviderProcessSpec[],
-  partialOutput: string,
-  successOutput: string,
+  turns: ProtocolTurnSpec[],
+  capturedInputs: string[] = [],
 ): ProviderProcessSupervisor {
-  let run = 0;
+  let turn = 0;
   return {
     spawn(spec) {
       specs.push(spec);
@@ -288,26 +278,47 @@ function createSupersedeProtocolSupervisor(
         });
         return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
       }
-      const output = run === 0 ? successOutput : run === 1 ? partialOutput : successOutput;
-      const holdPartial = run === 1;
-      run += 1;
+      const turnSpec = turns[turn++] ?? { output: "" };
+      const holdOpen = Boolean(turnSpec.holdOpen);
       const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
         ...spec.options,
         env: {
           ...spec.options.env,
-          FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from(output, "utf8").toString("base64"),
-          FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: holdPartial ? "1" : "0",
+          FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from(turnSpec.output, "utf8").toString("base64"),
+          FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: holdOpen ? "1" : "0",
+          FIRST_TREE_TEST_PROVIDER_TRAP_SIGTERM: turnSpec.trapSigterm ? "1" : "0",
+          FIRST_TREE_TEST_PROVIDER_HOLD_MS: String(turnSpec.holdMs ?? 0),
         },
-        detached: holdPartial,
+        detached: holdOpen,
       });
       if (child.stdin) {
         const write = child.stdin.write.bind(child.stdin);
-        child.stdin.write = ((chunk: string | Uint8Array, ...args: unknown[]) =>
-          Reflect.apply(write, child.stdin, [chunk, ...args])) as typeof child.stdin.write;
+        child.stdin.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+          capturedInputs.push(String(chunk));
+          return Reflect.apply(write, child.stdin, [chunk, ...args]);
+        }) as typeof child.stdin.write;
       }
       return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
     },
   };
+}
+
+function createSupersedeProtocolSupervisor(
+  specs: ProviderProcessSpec[],
+  partialOutput: string,
+  successOutput: string,
+  options: { trapPartialSigterm?: boolean; partialHoldMs?: number } = {},
+): ProviderProcessSupervisor {
+  return createProtocolTurnSupervisor(specs, [
+    { output: successOutput },
+    {
+      output: partialOutput,
+      holdOpen: true,
+      trapSigterm: options.trapPartialSigterm,
+      holdMs: options.partialHoldMs,
+    },
+    { output: successOutput },
+  ]);
 }
 
 function context(
@@ -1720,6 +1731,7 @@ describe("OpenCode V1 handler", () => {
       JSON.stringify({ type: "step_start", sessionID: "ses_new", part: { sessionID: "ses_new" } }),
       JSON.stringify({ type: "text", sessionID: "ses_new", part: { text: "partial" } }),
     ].join("\n");
+    const turnTimeoutMs = 2_500;
     const handler = createOpenCodeHandler({
       workspaceRoot: root,
       agentName: "opencode-test-agent",
@@ -1730,8 +1742,11 @@ describe("OpenCode V1 handler", () => {
         specs,
         `${partialOutput}\n`,
         `${successfulTurn("ses_new", "done")}\n`,
+        // Trap SIGTERM and stay alive past the turn deadline so the timer callback
+        // really attempts to overwrite the first-writer-wins superseded record.
+        { trapPartialSigterm: true, partialHoldMs: turnTimeoutMs + 800 },
       ),
-      opencodeTurnTimeoutMs: 400,
+      opencodeTurnTimeoutMs: turnTimeoutMs,
     });
     const sessionCtx = context([], []);
     const bootstrapToken = deliveryToken();
@@ -1744,11 +1759,15 @@ describe("OpenCode V1 handler", () => {
       timeout: 10_000,
     });
     const second = handler.resume(message("m-race-owner", "second"), sessionId, sessionCtx, secondToken);
-    await Promise.all([first, second]);
-    await new Promise((resolve) => setTimeout(resolve, 600));
+    await vi.waitFor(() => expect(secondToken.processingStarted).toHaveBeenCalled(), {
+      timeout: 10_000,
+    });
+    // Owner must finish well before the shared deadline; the stale child holds past it.
+    await vi.waitFor(() => expect(secondToken.complete).toHaveBeenCalled(), { timeout: turnTimeoutMs });
+    await first;
     expect(firstToken.complete).not.toHaveBeenCalled();
     expect(firstToken.retry).not.toHaveBeenCalled();
-    expect(secondToken.complete).toHaveBeenCalled();
+    expect(secondToken.retry).not.toHaveBeenCalled();
     await handler.shutdown();
   }, 30_000);
 
@@ -1771,23 +1790,25 @@ describe("OpenCode V1 handler", () => {
         specsA,
         `${partialOutput}\n`,
         `${successfulTurn("ses_new", "done")}\n`,
+        // Keep the superseded generation draining while handler B aborts the same
+        // numeric generation — the process-global ledger race only appears then.
+        { trapPartialSigterm: true, partialHoldMs: 2_000 },
       ),
     });
     const ctxA = context([], [], { agentId: "agent-a", chatId: "chat-a" });
     const bootstrapToken = deliveryToken();
-    const { sessionId } = await handlerA.start(message("boot-a", "bootstrap"), ctxA, bootstrapToken);
+    const { sessionId: sessionIdA } = await handlerA.start(message("boot-a", "bootstrap"), ctxA, bootstrapToken);
 
     const staleToken = deliveryToken();
     const ownerToken = deliveryToken();
-    const staleTurn = handlerA.resume(message("stale-a", "first"), sessionId, ctxA, staleToken);
+    const staleTurn = handlerA.resume(message("stale-a", "first"), sessionIdA, ctxA, staleToken);
     await vi.waitFor(() => expect(staleToken.processingStarted).toHaveBeenCalled(), {
       timeout: 10_000,
     });
-    const ownerTurn = handlerA.resume(message("owner-a", "second"), sessionId, ctxA, ownerToken);
-    await Promise.all([staleTurn, ownerTurn]);
-    expect(staleToken.complete).not.toHaveBeenCalled();
-    expect(staleToken.retry).not.toHaveBeenCalled();
-    expect(ownerToken.complete).toHaveBeenCalled();
+    const ownerTurn = handlerA.resume(message("owner-a", "second"), sessionIdA, ctxA, ownerToken);
+    await vi.waitFor(() => expect(ownerToken.processingStarted).toHaveBeenCalled(), {
+      timeout: 10_000,
+    });
 
     const writeOutput = [
       JSON.stringify({ type: "step_start", sessionID: "ses_new", part: { sessionID: "ses_new" } }),
@@ -1801,19 +1822,29 @@ describe("OpenCode V1 handler", () => {
         },
       }),
     ].join("\n");
+    const specsB: ProviderProcessSpec[] = [];
     const handlerB = createOpenCodeHandler({
       workspaceRoot: rootB,
       agentName: "opencode-test-agent-b",
       runtimeProvider: "opencode",
       agentConfigCache: cache(runtimeConfig()),
       opencodeBinaryResolver: () => ({ ok: true, binary: "/host/opencode" }),
-      providerProcessSupervisor: createProtocolSupervisor([], [`${writeOutput}\n`], [], true),
+      // Bootstrap consumes generation 1; the unsafe turn reaches generation 2 —
+      // the same numeric key A's superseded record still occupies while draining.
+      providerProcessSupervisor: createProtocolTurnSupervisor(specsB, [
+        { output: `${successfulTurn("ses_new", "boot-b")}\n` },
+        { output: `${writeOutput}\n`, holdOpen: true },
+      ]),
       opencodeTurnTimeoutMs: 5_000,
     });
     const eventsB: Array<{ kind?: string }> = [];
     const ctxB = context(eventsB, [], { agentId: "agent-b", chatId: "chat-b" });
+    const bootBToken = deliveryToken();
+    const { sessionId: sessionIdB } = await handlerB.start(message("boot-b", "bootstrap"), ctxB, bootBToken);
+    expect(bootBToken.complete).toHaveBeenCalled();
+
     const unsafeToken = deliveryToken();
-    const unsafeTurn = handlerB.start(message("unsafe-b", "first"), ctxB, unsafeToken);
+    const unsafeTurn = handlerB.resume(message("unsafe-b", "first"), sessionIdB, ctxB, unsafeToken);
     await vi.waitFor(() => expect(eventsB.some((event) => event.kind === "tool_call")).toBe(true), {
       timeout: 10_000,
     });
@@ -1824,6 +1855,11 @@ describe("OpenCode V1 handler", () => {
       [expect.objectContaining({ id: "unsafe-b" })],
       expect.objectContaining({ status: "error", completion: "consumed", reason: "unsafe_replay" }),
     );
+
+    await Promise.all([staleTurn, ownerTurn]);
+    expect(staleToken.complete).not.toHaveBeenCalled();
+    expect(staleToken.retry).not.toHaveBeenCalled();
+    expect(ownerToken.complete).toHaveBeenCalled();
 
     await handlerA.shutdown();
     await handlerB.shutdown();

--- a/packages/client/src/providers/opencode/__tests__/handler.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/handler.test.ts
@@ -235,21 +235,75 @@ function createProtocolSupervisor(
           : spec.args[0] === "db"
             ? '[{"ready":1}]\n'
             : (turnOutputs[turn++] ?? "");
+      const isRun = spec.args[0] === "run";
       const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
         ...spec.options,
         env: {
           ...spec.options.env,
           FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from(output, "utf8").toString("base64"),
-          FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: holdOpen && spec.args[0] === "run" ? "1" : "0",
+          FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: holdOpen && isRun ? "1" : "0",
         },
-        detached: holdOpen,
+        detached: holdOpen && isRun,
       });
-      if (spec.args[0] === "run" && child.stdin) {
+      if (isRun && child.stdin) {
         const write = child.stdin.write.bind(child.stdin);
         child.stdin.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
           capturedInputs.push(String(chunk));
           return Reflect.apply(write, child.stdin, [chunk, ...args]);
         }) as typeof child.stdin.write;
+      }
+      return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+    },
+  };
+}
+
+function createSupersedeProtocolSupervisor(
+  specs: ProviderProcessSpec[],
+  partialOutput: string,
+  successOutput: string,
+): ProviderProcessSupervisor {
+  let run = 0;
+  return {
+    spawn(spec) {
+      specs.push(spec);
+      if (spec.args[0] === "--version") {
+        const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
+          ...spec.options,
+          env: {
+            ...spec.options.env,
+            FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from("1.18.9\n", "utf8").toString("base64"),
+            FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: "0",
+          },
+        });
+        return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+      }
+      if (spec.args[0] === "db") {
+        const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
+          ...spec.options,
+          env: {
+            ...spec.options.env,
+            FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from('[{"ready":1}]\n', "utf8").toString("base64"),
+            FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: "0",
+          },
+        });
+        return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
+      }
+      const output = run === 0 ? successOutput : run === 1 ? partialOutput : successOutput;
+      const holdPartial = run === 1;
+      run += 1;
+      const child = spawn(process.execPath, ["-e", PROTOCOL_PROVIDER_SCRIPT], {
+        ...spec.options,
+        env: {
+          ...spec.options.env,
+          FIRST_TREE_TEST_PROVIDER_OUTPUT_BASE64: Buffer.from(output, "utf8").toString("base64"),
+          FIRST_TREE_TEST_PROVIDER_HOLD_OPEN: holdPartial ? "1" : "0",
+        },
+        detached: holdPartial,
+      });
+      if (child.stdin) {
+        const write = child.stdin.write.bind(child.stdin);
+        child.stdin.write = ((chunk: string | Uint8Array, ...args: unknown[]) =>
+          Reflect.apply(write, child.stdin, [chunk, ...args])) as typeof child.stdin.write;
       }
       return { child, exited: new Promise<void>((resolve) => child.once("exit", () => resolve())) };
     },
@@ -1604,7 +1658,9 @@ describe("OpenCode V1 handler", () => {
     });
     const token = deliveryToken();
     const started = handler.start(message("m-abort", "first"), context(events, []), token);
-    await vi.waitFor(() => expect(events.some((event) => event.kind === "tool_call")).toBe(true));
+    await vi.waitFor(() => expect(events.some((event) => event.kind === "tool_call")).toBe(true), {
+      timeout: 10_000,
+    });
     await handler.suspend("test explicit abort");
     await started;
     expect(token.retry).not.toHaveBeenCalled();
@@ -1614,6 +1670,87 @@ describe("OpenCode V1 handler", () => {
     );
     await handler.shutdown();
   });
+
+  it("does not settle a superseded turn on the old token when a newer start arrives", async () => {
+    const root = mkdtempSync(join(realpathSync(tmpdir()), "ft-opencode-supersede-token-"));
+    roots.push(root);
+    const specs: ProviderProcessSpec[] = [];
+    const partialOutput = [
+      JSON.stringify({ type: "step_start", sessionID: "ses_new", part: { sessionID: "ses_new" } }),
+      JSON.stringify({ type: "text", sessionID: "ses_new", part: { text: "partial" } }),
+    ].join("\n");
+    const handler = createOpenCodeHandler({
+      workspaceRoot: root,
+      agentName: "opencode-test-agent",
+      runtimeProvider: "opencode",
+      agentConfigCache: cache(runtimeConfig()),
+      opencodeBinaryResolver: () => ({ ok: true, binary: "/host/opencode" }),
+      providerProcessSupervisor: createSupersedeProtocolSupervisor(
+        specs,
+        `${partialOutput}\n`,
+        `${successfulTurn("ses_new", "done")}\n`,
+      ),
+      opencodeTurnTimeoutMs: 5_000,
+    });
+    const sessionCtx = context([], []);
+    const bootstrapToken = deliveryToken();
+    const { sessionId } = await handler.start(message("m-bootstrap", "bootstrap"), sessionCtx, bootstrapToken);
+    expect(bootstrapToken.complete).toHaveBeenCalled();
+
+    const supersededToken = deliveryToken();
+    const ownerToken = deliveryToken();
+    const superseded = handler.resume(message("m-superseded", "first"), sessionId, sessionCtx, supersededToken);
+    await vi.waitFor(() => expect(supersededToken.processingStarted).toHaveBeenCalled(), {
+      timeout: 10_000,
+    });
+    const owner = handler.resume(message("m-owner", "second"), sessionId, sessionCtx, ownerToken);
+    await Promise.all([superseded, owner]);
+    expect(supersededToken.complete).not.toHaveBeenCalled();
+    expect(supersededToken.retry).not.toHaveBeenCalled();
+    expect(ownerToken.complete).toHaveBeenCalled();
+    expect(specs.filter((spec) => spec.args[0] === "run")).toHaveLength(3);
+    await handler.shutdown();
+  }, 30_000);
+
+  it("preserves a superseded abort cause when the turn timeout fires after supersession", async () => {
+    const root = mkdtempSync(join(realpathSync(tmpdir()), "ft-opencode-supersede-timeout-race-"));
+    roots.push(root);
+    const specs: ProviderProcessSpec[] = [];
+    const partialOutput = [
+      JSON.stringify({ type: "step_start", sessionID: "ses_new", part: { sessionID: "ses_new" } }),
+      JSON.stringify({ type: "text", sessionID: "ses_new", part: { text: "partial" } }),
+    ].join("\n");
+    const handler = createOpenCodeHandler({
+      workspaceRoot: root,
+      agentName: "opencode-test-agent",
+      runtimeProvider: "opencode",
+      agentConfigCache: cache(runtimeConfig()),
+      opencodeBinaryResolver: () => ({ ok: true, binary: "/host/opencode" }),
+      providerProcessSupervisor: createSupersedeProtocolSupervisor(
+        specs,
+        `${partialOutput}\n`,
+        `${successfulTurn("ses_new", "done")}\n`,
+      ),
+      opencodeTurnTimeoutMs: 400,
+    });
+    const sessionCtx = context([], []);
+    const bootstrapToken = deliveryToken();
+    const { sessionId } = await handler.start(message("m-bootstrap", "bootstrap"), sessionCtx, bootstrapToken);
+
+    const firstToken = deliveryToken();
+    const secondToken = deliveryToken();
+    const first = handler.resume(message("m-race", "first"), sessionId, sessionCtx, firstToken);
+    await vi.waitFor(() => expect(firstToken.processingStarted).toHaveBeenCalled(), {
+      timeout: 10_000,
+    });
+    const second = handler.resume(message("m-race-owner", "second"), sessionId, sessionCtx, secondToken);
+    await Promise.all([first, second]);
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(firstToken.complete).not.toHaveBeenCalled();
+    expect(firstToken.retry).not.toHaveBeenCalled();
+    expect(secondToken.complete).toHaveBeenCalled();
+    await handler.shutdown();
+  }, 30_000);
 
   it("preserves the unsafe-effect fence when private-config cleanup fails after provider exit", async () => {
     const root = mkdtempSync(join(realpathSync(tmpdir()), "ft-opencode-cleanup-effect-"));

--- a/packages/client/src/providers/opencode/__tests__/handler.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/handler.test.ts
@@ -1764,7 +1764,7 @@ describe("OpenCode V1 handler", () => {
     });
     // Owner must finish well before the shared deadline; the stale child holds past it.
     await vi.waitFor(() => expect(secondToken.complete).toHaveBeenCalled(), { timeout: turnTimeoutMs });
-    await first;
+    await Promise.all([first, second]);
     expect(firstToken.complete).not.toHaveBeenCalled();
     expect(firstToken.retry).not.toHaveBeenCalled();
     expect(secondToken.retry).not.toHaveBeenCalled();

--- a/packages/client/src/providers/opencode/__tests__/turn-abort.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/turn-abort.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { ProviderAttempt } from "../../../runtime/provider-attempt.js";
 import {
-  classificationErrorForOpenCodeTurnAbort,
   describeOpenCodeTurnAbortFailure,
-  OPENCODE_TURN_ABORT_CLASSIFICATION_MESSAGE,
+  dispositionForOpenCodeTurnAbort,
+  inferOpenCodeTurnAbortRecord,
+  OPENCODE_TURN_ABORT_TIMEOUT_CLASSIFICATION_MESSAGE,
   resolveOpenCodeTurnAbortCause,
+  settlementPolicyForOpenCodeTurnAbort,
 } from "../turn-abort.js";
 
 describe("resolveOpenCodeTurnAbortCause", () => {
@@ -45,6 +47,28 @@ describe("resolveOpenCodeTurnAbortCause", () => {
   });
 });
 
+describe("dispositionForOpenCodeTurnAbort", () => {
+  it("keeps superseded turns silent", () => {
+    expect(dispositionForOpenCodeTurnAbort("superseded")).toBe("silent");
+  });
+
+  it("settles lifecycle and timeout aborts", () => {
+    expect(dispositionForOpenCodeTurnAbort("lifecycle")).toBe("settle");
+    expect(dispositionForOpenCodeTurnAbort("timeout")).toBe("settle");
+    expect(dispositionForOpenCodeTurnAbort("session_inactive")).toBe("settle");
+  });
+});
+
+describe("settlementPolicyForOpenCodeTurnAbort", () => {
+  it("uses the stable timeout classifier only for timeout", () => {
+    expect(settlementPolicyForOpenCodeTurnAbort("timeout").classificationError).toBe(
+      OPENCODE_TURN_ABORT_TIMEOUT_CLASSIFICATION_MESSAGE,
+    );
+    expect(settlementPolicyForOpenCodeTurnAbort("session_inactive").classificationError).toContain("inactive");
+    expect(settlementPolicyForOpenCodeTurnAbort("lifecycle").classificationError).toContain("lifecycle");
+  });
+});
+
 describe("describeOpenCodeTurnAbortFailure", () => {
   it("names timeout duration and missing terminal events", () => {
     expect(
@@ -76,8 +100,16 @@ describe("describeOpenCodeTurnAbortFailure", () => {
       turnTimeoutMs: 60_000,
       state: { terminalReasons: [], sawProviderActivity: true, text: ["partial"] },
     });
-    const classificationError = classificationErrorForOpenCodeTurnAbort("superseded");
-    expect(classificationError).toBe(OPENCODE_TURN_ABORT_CLASSIFICATION_MESSAGE);
+    const record = inferOpenCodeTurnAbortRecord({
+      turnGeneration: 1,
+      currentGeneration: 2,
+      sessionActive: true,
+      timedOut: false,
+      abortSignal: AbortSignal.abort(),
+    });
+    expect(record.disposition).toBe("silent");
+    const classificationError = settlementPolicyForOpenCodeTurnAbort("timeout").classificationError;
+    expect(classificationError).toBe(OPENCODE_TURN_ABORT_TIMEOUT_CLASSIFICATION_MESSAGE);
     expect(classificationError).toContain("timed out");
     expect(displayMessage).toContain("superseded");
 

--- a/packages/client/src/providers/opencode/__tests__/turn-abort.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/turn-abort.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { describeOpenCodeTurnAbortFailure, resolveOpenCodeTurnAbortCause } from "../turn-abort.js";
+
+describe("resolveOpenCodeTurnAbortCause", () => {
+  it("prefers timeout over other abort signals", () => {
+    expect(
+      resolveOpenCodeTurnAbortCause({
+        turnGeneration: 2,
+        currentGeneration: 3,
+        sessionActive: false,
+        timedOut: true,
+        abortSignal: AbortSignal.abort(),
+      }),
+    ).toBe("timeout");
+  });
+
+  it("classifies inactive sessions", () => {
+    expect(
+      resolveOpenCodeTurnAbortCause({
+        turnGeneration: 2,
+        currentGeneration: 2,
+        sessionActive: false,
+        timedOut: false,
+        abortSignal: AbortSignal.abort(),
+      }),
+    ).toBe("session_inactive");
+  });
+
+  it("classifies superseded turns", () => {
+    expect(
+      resolveOpenCodeTurnAbortCause({
+        turnGeneration: 2,
+        currentGeneration: 3,
+        sessionActive: true,
+        timedOut: false,
+        abortSignal: AbortSignal.abort(),
+      }),
+    ).toBe("superseded");
+  });
+});
+
+describe("describeOpenCodeTurnAbortFailure", () => {
+  it("names timeout duration and missing terminal events", () => {
+    expect(
+      describeOpenCodeTurnAbortFailure({
+        cause: "timeout",
+        turnTimeoutMs: 60_000,
+        state: { terminalReasons: [], sawProviderActivity: true, text: [] },
+      }),
+    ).toBe(
+      "OpenCode turn timed out after 60s before a safe terminal event (step_finish). no step_finish event received; provider activity without assistant text.",
+    );
+  });
+
+  it("notes superseded deliveries and partial text", () => {
+    expect(
+      describeOpenCodeTurnAbortFailure({
+        cause: "superseded",
+        turnTimeoutMs: 1_200_000,
+        state: { terminalReasons: [], sawProviderActivity: true, text: ["partial"] },
+      }),
+    ).toBe(
+      "OpenCode turn was superseded by a newer delivery before a safe terminal event (step_finish). no step_finish event received; partial assistant text was captured.",
+    );
+  });
+});

--- a/packages/client/src/providers/opencode/__tests__/turn-abort.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/turn-abort.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { describeOpenCodeTurnAbortFailure, resolveOpenCodeTurnAbortCause } from "../turn-abort.js";
+import { ProviderAttempt } from "../../../runtime/provider-attempt.js";
+import {
+  classificationErrorForOpenCodeTurnAbort,
+  describeOpenCodeTurnAbortFailure,
+  OPENCODE_TURN_ABORT_CLASSIFICATION_MESSAGE,
+  resolveOpenCodeTurnAbortCause,
+} from "../turn-abort.js";
 
 describe("resolveOpenCodeTurnAbortCause", () => {
   it("prefers timeout over other abort signals", () => {
@@ -62,5 +68,35 @@ describe("describeOpenCodeTurnAbortFailure", () => {
     ).toBe(
       "OpenCode turn was superseded by a newer delivery before a safe terminal event (step_finish). no step_finish event received; partial assistant text was captured.",
     );
+  });
+
+  it("keeps transient settlement classification separate from cause-specific operator text", () => {
+    const displayMessage = describeOpenCodeTurnAbortFailure({
+      cause: "superseded",
+      turnTimeoutMs: 60_000,
+      state: { terminalReasons: [], sawProviderActivity: true, text: ["partial"] },
+    });
+    const classificationError = classificationErrorForOpenCodeTurnAbort("superseded");
+    expect(classificationError).toBe(OPENCODE_TURN_ABORT_CLASSIFICATION_MESSAGE);
+    expect(classificationError).toContain("timed out");
+    expect(displayMessage).toContain("superseded");
+
+    const attempt = new ProviderAttempt({ provider: "opencode", scope: "provider_turn", source: "stream" });
+    attempt.markUserVisibleOutput();
+    attempt.recordSignal({
+      kind: "provider_error",
+      error: new Error(classificationError),
+      messagePreview: classificationError,
+    });
+    attempt.recordSignal({
+      kind: "diagnostic",
+      error: new Error(displayMessage),
+      messagePreview: displayMessage,
+    });
+
+    const settled = attempt.settle({ attempt: 1 });
+    expect(settled?.classification.category).toBe("transient_transport");
+    expect(settled?.decision.action).toBe("retry");
+    expect(settled?.messagePreview).toContain("superseded");
   });
 });

--- a/packages/client/src/providers/opencode/index.ts
+++ b/packages/client/src/providers/opencode/index.ts
@@ -272,24 +272,10 @@ type ProviderTurnFailureWindow = {
 };
 
 const providerTurnFailureAttempts = new Map<string, ProviderTurnFailureWindow>();
-const turnAbortRecords = new Map<number, OpenCodeTurnAbortRecord>();
-
-function markTurnAborted(turnGeneration: number, record: OpenCodeTurnAbortRecord): void {
-  if (!turnAbortRecords.has(turnGeneration)) {
-    turnAbortRecords.set(turnGeneration, record);
-  }
-}
-
-function takeTurnAbortRecord(turnGeneration: number): OpenCodeTurnAbortRecord | null {
-  const record = turnAbortRecords.get(turnGeneration) ?? null;
-  turnAbortRecords.delete(turnGeneration);
-  return record;
-}
 
 export function clearOpenCodeDbGateCacheForTests(): void {
   dbGatePromises.clear();
   providerTurnFailureAttempts.clear();
-  turnAbortRecords.clear();
 }
 
 export function openCodeProviderAttemptWindowSizeForTests(): number {
@@ -371,6 +357,19 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
   const handlerGenerationId = randomUUID().replaceAll("-", "");
   let privateConfigLease: OpenCodePrivateConfigLease | null = null;
   const queue: QueuedDelivery[] = [];
+  const turnAbortRecords = new Map<number, OpenCodeTurnAbortRecord>();
+
+  function markTurnAborted(turnGeneration: number, record: OpenCodeTurnAbortRecord): void {
+    if (!turnAbortRecords.has(turnGeneration)) {
+      turnAbortRecords.set(turnGeneration, record);
+    }
+  }
+
+  function takeTurnAbortRecord(turnGeneration: number): OpenCodeTurnAbortRecord | null {
+    const record = turnAbortRecords.get(turnGeneration) ?? null;
+    turnAbortRecords.delete(turnGeneration);
+    return record;
+  }
 
   function deliveryAttemptKey(sessionCtx: SessionContext, messages: readonly SessionMessage[]): string {
     const deliveryHead = messages[0];
@@ -1205,6 +1204,7 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
         turnGeneration,
       });
     } finally {
+      turnAbortRecords.delete(turnGeneration);
       if (generation === turnGeneration) {
         currentAbort = null;
         currentTurnPromise = null;

--- a/packages/client/src/providers/opencode/index.ts
+++ b/packages/client/src/providers/opencode/index.ts
@@ -57,6 +57,7 @@ import {
 } from "./binary.js";
 import { type OpenCodeStreamEvent, OpenCodeStreamParser, type OpenCodeUsage } from "./parser.js";
 import { acquireOpenCodePrivateConfigLease, type OpenCodePrivateConfigLease } from "./private-config.js";
+import { describeOpenCodeTurnAbortFailure, resolveOpenCodeTurnAbortCause } from "./turn-abort.js";
 
 export const OPENCODE_PENDING_SESSION_PREFIX = "opencode-pending-";
 
@@ -336,6 +337,7 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
   let initialTurnPreparing = false;
   let currentAbort: AbortController | null = null;
   let currentTurnPromise: Promise<void> | null = null;
+  let turnTimedOutGeneration: number | null = null;
   let versionReady = false;
   let generation = 0;
   let drainScheduled = false;
@@ -927,8 +929,10 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       return false;
     }
     const turnGeneration = ++generation;
+    const previousAbort = currentAbort;
     const abort = new AbortController();
     currentAbort = abort;
+    previousAbort?.abort();
     let observedState: TurnState | null = null;
     const promise = (async () => {
       const { payload } = await refreshProjection(sessionCtx);
@@ -978,7 +982,10 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       };
       observedState = state;
       token.processingStarted(messages);
-      const timeout = setTimeout(() => abort.abort(), turnTimeoutMs);
+      const timeout = setTimeout(() => {
+        turnTimedOutGeneration = turnGeneration;
+        abort.abort();
+      }, turnTimeoutMs);
       timeout.unref?.();
       let outcome: ProcessOutcome;
       try {
@@ -1018,9 +1025,23 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       }
 
       if (abort.signal.aborted || generation !== turnGeneration || !sessionActive) {
+        const timedOut = turnTimedOutGeneration === turnGeneration;
+        if (timedOut) turnTimedOutGeneration = null;
+        const abortCause = resolveOpenCodeTurnAbortCause({
+          turnGeneration,
+          currentGeneration: generation,
+          sessionActive,
+          timedOut,
+          abortSignal: abort.signal,
+        });
+        const failure = describeOpenCodeTurnAbortFailure({
+          cause: abortCause,
+          turnTimeoutMs,
+          state,
+        });
         return settleFailure({
-          failure: "OpenCode turn aborted or timed out before a safe terminal event",
-          spawnError: new Error("OpenCode turn aborted or timed out"),
+          failure,
+          spawnError: new Error(failure),
           state,
           sessionCtx,
           messages,

--- a/packages/client/src/providers/opencode/index.ts
+++ b/packages/client/src/providers/opencode/index.ts
@@ -493,6 +493,17 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
     label: string;
   }): Promise<ProcessOutcome> {
     return new Promise((resolveOutcome) => {
+      const abortedBeforeSpawn = input.abortSignal.aborted || generation !== input.turnGeneration || !sessionActive;
+      if (abortedBeforeSpawn) {
+        resolveOutcome({
+          exitCode: null,
+          signal: "SIGTERM",
+          stdoutTail: "",
+          stderrTail: "",
+        });
+        return;
+      }
+
       let supervised: ReturnType<ProviderProcessSupervisor["spawn"]>;
       try {
         supervised = processSupervisor.spawn({
@@ -605,6 +616,16 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       child.stdin?.on("error", () => {
         // EPIPE is classified from close + stderr.
       });
+      // Abort that won during spawn (before this listener) does not replay — close that race.
+      if (input.abortSignal.aborted || generation !== input.turnGeneration || !sessionActive) {
+        terminate();
+        try {
+          child.stdin?.end();
+        } catch {
+          // stdin may already be closed.
+        }
+        return;
+      }
       if (input.prompt !== undefined) child.stdin?.write(input.prompt);
       child.stdin?.end();
     });

--- a/packages/client/src/providers/opencode/index.ts
+++ b/packages/client/src/providers/opencode/index.ts
@@ -57,7 +57,7 @@ import {
 } from "./binary.js";
 import { type OpenCodeStreamEvent, OpenCodeStreamParser, type OpenCodeUsage } from "./parser.js";
 import { acquireOpenCodePrivateConfigLease, type OpenCodePrivateConfigLease } from "./private-config.js";
-import { describeOpenCodeTurnAbortFailure, resolveOpenCodeTurnAbortCause } from "./turn-abort.js";
+import { describeOpenCodeTurnAbortFailure, resolveOpenCodeTurnAbortCause, classificationErrorForOpenCodeTurnAbort } from "./turn-abort.js";
 
 export const OPENCODE_PENDING_SESSION_PREFIX = "opencode-pending-";
 
@@ -830,6 +830,7 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
 
   async function settleFailure(input: {
     failure: string;
+    classificationError?: string;
     spawnError?: Error;
     state: Pick<TurnState, "sawProviderActivity" | "sawUnsafeTool" | "text">;
     sessionCtx: SessionContext;
@@ -837,6 +838,9 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
     token: DeliveryToken;
     turnGeneration: number;
   }): Promise<boolean> {
+    if (generation !== input.turnGeneration) {
+      return false;
+    }
     const attemptKey = deliveryAttemptKey(input.sessionCtx, input.messages);
     const replaySafety = input.state.sawUnsafeTool
       ? "unsafe"
@@ -845,6 +849,7 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
         : input.state.sawProviderActivity
           ? "pre_visible"
           : "pre_provider";
+    const classificationError = input.classificationError ?? input.failure;
     const displayMessage = isOpenCodeAuthError(input.failure)
       ? formatAuthHint("opencode", input.failure)
       : input.failure;
@@ -856,9 +861,16 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
     });
     attempt.recordSignal({
       kind: input.spawnError ? "local_error" : "provider_error",
-      error: input.spawnError ?? input.failure,
-      messagePreview: displayMessage,
+      error: input.spawnError ?? new Error(classificationError),
+      messagePreview: classificationError,
     });
+    if (displayMessage !== classificationError) {
+      attempt.recordSignal({
+        kind: "diagnostic",
+        error: new Error(displayMessage),
+        messagePreview: displayMessage,
+      });
+    }
     const attemptNumber = nextProviderAttempt(
       attemptKey,
       () => input.sessionCtx.hasPendingDelivery?.(input.messages) ?? true,
@@ -1025,6 +1037,9 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       }
 
       if (abort.signal.aborted || generation !== turnGeneration || !sessionActive) {
+        if (generation !== turnGeneration) {
+          return false;
+        }
         const timedOut = turnTimedOutGeneration === turnGeneration;
         if (timedOut) turnTimedOutGeneration = null;
         const abortCause = resolveOpenCodeTurnAbortCause({
@@ -1039,9 +1054,11 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
           turnTimeoutMs,
           state,
         });
+        const classificationError = classificationErrorForOpenCodeTurnAbort(abortCause);
         return settleFailure({
           failure,
-          spawnError: new Error(failure),
+          classificationError,
+          spawnError: new Error(classificationError),
           state,
           sessionCtx,
           messages,

--- a/packages/client/src/providers/opencode/index.ts
+++ b/packages/client/src/providers/opencode/index.ts
@@ -57,7 +57,12 @@ import {
 } from "./binary.js";
 import { type OpenCodeStreamEvent, OpenCodeStreamParser, type OpenCodeUsage } from "./parser.js";
 import { acquireOpenCodePrivateConfigLease, type OpenCodePrivateConfigLease } from "./private-config.js";
-import { describeOpenCodeTurnAbortFailure, resolveOpenCodeTurnAbortCause, classificationErrorForOpenCodeTurnAbort } from "./turn-abort.js";
+import {
+  describeOpenCodeTurnAbortFailure,
+  inferOpenCodeTurnAbortRecord,
+  type OpenCodeTurnAbortRecord,
+  settlementPolicyForOpenCodeTurnAbort,
+} from "./turn-abort.js";
 
 export const OPENCODE_PENDING_SESSION_PREFIX = "opencode-pending-";
 
@@ -267,10 +272,24 @@ type ProviderTurnFailureWindow = {
 };
 
 const providerTurnFailureAttempts = new Map<string, ProviderTurnFailureWindow>();
+const turnAbortRecords = new Map<number, OpenCodeTurnAbortRecord>();
+
+function markTurnAborted(turnGeneration: number, record: OpenCodeTurnAbortRecord): void {
+  if (!turnAbortRecords.has(turnGeneration)) {
+    turnAbortRecords.set(turnGeneration, record);
+  }
+}
+
+function takeTurnAbortRecord(turnGeneration: number): OpenCodeTurnAbortRecord | null {
+  const record = turnAbortRecords.get(turnGeneration) ?? null;
+  turnAbortRecords.delete(turnGeneration);
+  return record;
+}
 
 export function clearOpenCodeDbGateCacheForTests(): void {
   dbGatePromises.clear();
   providerTurnFailureAttempts.clear();
+  turnAbortRecords.clear();
 }
 
 export function openCodeProviderAttemptWindowSizeForTests(): number {
@@ -337,7 +356,6 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
   let initialTurnPreparing = false;
   let currentAbort: AbortController | null = null;
   let currentTurnPromise: Promise<void> | null = null;
-  let turnTimedOutGeneration: number | null = null;
   let versionReady = false;
   let generation = 0;
   let drainScheduled = false;
@@ -838,9 +856,6 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
     token: DeliveryToken;
     turnGeneration: number;
   }): Promise<boolean> {
-    if (generation !== input.turnGeneration) {
-      return false;
-    }
     const attemptKey = deliveryAttemptKey(input.sessionCtx, input.messages);
     const replaySafety = input.state.sawUnsafeTool
       ? "unsafe"
@@ -942,9 +957,12 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
     }
     const turnGeneration = ++generation;
     const previousAbort = currentAbort;
+    if (previousAbort) {
+      markTurnAborted(generation - 1, { cause: "superseded", disposition: "silent" });
+      previousAbort.abort();
+    }
     const abort = new AbortController();
     currentAbort = abort;
-    previousAbort?.abort();
     let observedState: TurnState | null = null;
     const promise = (async () => {
       const { payload } = await refreshProjection(sessionCtx);
@@ -995,7 +1013,7 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       observedState = state;
       token.processingStarted(messages);
       const timeout = setTimeout(() => {
-        turnTimedOutGeneration = turnGeneration;
+        markTurnAborted(turnGeneration, { cause: "timeout", disposition: "settle" });
         abort.abort();
       }, turnTimeoutMs);
       timeout.unref?.();
@@ -1037,24 +1055,24 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       }
 
       if (abort.signal.aborted || generation !== turnGeneration || !sessionActive) {
-        if (generation !== turnGeneration) {
+        const record =
+          takeTurnAbortRecord(turnGeneration) ??
+          inferOpenCodeTurnAbortRecord({
+            turnGeneration,
+            currentGeneration: generation,
+            sessionActive,
+            timedOut: false,
+            abortSignal: abort.signal,
+          });
+        if (record.disposition === "silent") {
           return false;
         }
-        const timedOut = turnTimedOutGeneration === turnGeneration;
-        if (timedOut) turnTimedOutGeneration = null;
-        const abortCause = resolveOpenCodeTurnAbortCause({
-          turnGeneration,
-          currentGeneration: generation,
-          sessionActive,
-          timedOut,
-          abortSignal: abort.signal,
-        });
         const failure = describeOpenCodeTurnAbortFailure({
-          cause: abortCause,
+          cause: record.cause,
           turnTimeoutMs,
           state,
         });
-        const classificationError = classificationErrorForOpenCodeTurnAbort(abortCause);
+        const { classificationError } = settlementPolicyForOpenCodeTurnAbort(record.cause);
         return settleFailure({
           failure,
           classificationError,
@@ -1469,6 +1487,9 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       const recoveryReason = reason ?? "opencode_suspend_before_terminal";
       sessionActive = false;
       drainCancellationReason = recoveryReason;
+      if (currentAbort) {
+        markTurnAborted(generation, { cause: "lifecycle", disposition: "settle" });
+      }
       generation++;
       currentAbort?.abort();
       unsafeDiscoveryWaitAbort?.abort();
@@ -1486,6 +1507,9 @@ export const createOpenCodeHandler: HandlerFactory = (config) => {
       const recoveryReason = reason ?? "opencode_shutdown_before_terminal";
       sessionActive = false;
       drainCancellationReason = recoveryReason;
+      if (currentAbort) {
+        markTurnAborted(generation, { cause: "lifecycle", disposition: "settle" });
+      }
       generation++;
       currentAbort?.abort();
       unsafeDiscoveryWaitAbort?.abort();

--- a/packages/client/src/providers/opencode/turn-abort.ts
+++ b/packages/client/src/providers/opencode/turn-abort.ts
@@ -1,5 +1,9 @@
 export type OpenCodeTurnAbortCause = "timeout" | "superseded" | "session_inactive" | "lifecycle";
 
+/** Stable classifier input — must stay aligned with shared transient-transport matching. */
+export const OPENCODE_TURN_ABORT_CLASSIFICATION_MESSAGE =
+  "OpenCode turn aborted or timed out before a safe terminal event";
+
 export type OpenCodeTurnAbortState = {
   terminalReasons: readonly string[];
   sawProviderActivity: boolean;
@@ -50,4 +54,8 @@ export function describeOpenCodeTurnAbortFailure(input: {
   }
 
   return `${lead}. ${hints.join("; ")}.`;
+}
+
+export function classificationErrorForOpenCodeTurnAbort(_cause: OpenCodeTurnAbortCause): string {
+  return OPENCODE_TURN_ABORT_CLASSIFICATION_MESSAGE;
 }

--- a/packages/client/src/providers/opencode/turn-abort.ts
+++ b/packages/client/src/providers/opencode/turn-abort.ts
@@ -1,7 +1,14 @@
 export type OpenCodeTurnAbortCause = "timeout" | "superseded" | "session_inactive" | "lifecycle";
 
-/** Stable classifier input — must stay aligned with shared transient-transport matching. */
-export const OPENCODE_TURN_ABORT_CLASSIFICATION_MESSAGE =
+export type OpenCodeTurnAbortDisposition = "silent" | "settle";
+
+export type OpenCodeTurnAbortRecord = {
+  cause: OpenCodeTurnAbortCause;
+  disposition: OpenCodeTurnAbortDisposition;
+};
+
+/** Stable classifier input for timeout retries — must match shared transient-transport matching. */
+export const OPENCODE_TURN_ABORT_TIMEOUT_CLASSIFICATION_MESSAGE =
   "OpenCode turn aborted or timed out before a safe terminal event";
 
 export type OpenCodeTurnAbortState = {
@@ -9,6 +16,14 @@ export type OpenCodeTurnAbortState = {
   sawProviderActivity: boolean;
   text: readonly string[];
 };
+
+export type OpenCodeTurnAbortSettlementPolicy = {
+  classificationError: string;
+};
+
+export function dispositionForOpenCodeTurnAbort(cause: OpenCodeTurnAbortCause): OpenCodeTurnAbortDisposition {
+  return cause === "superseded" ? "silent" : "settle";
+}
 
 export function resolveOpenCodeTurnAbortCause(input: {
   turnGeneration: number;
@@ -22,6 +37,17 @@ export function resolveOpenCodeTurnAbortCause(input: {
   if (input.currentGeneration !== input.turnGeneration) return "superseded";
   if (input.abortSignal.aborted) return "lifecycle";
   return "lifecycle";
+}
+
+export function inferOpenCodeTurnAbortRecord(input: {
+  turnGeneration: number;
+  currentGeneration: number;
+  sessionActive: boolean;
+  timedOut: boolean;
+  abortSignal: AbortSignal;
+}): OpenCodeTurnAbortRecord {
+  const cause = resolveOpenCodeTurnAbortCause(input);
+  return { cause, disposition: dispositionForOpenCodeTurnAbort(cause) };
 }
 
 export function describeOpenCodeTurnAbortFailure(input: {
@@ -56,6 +82,19 @@ export function describeOpenCodeTurnAbortFailure(input: {
   return `${lead}. ${hints.join("; ")}.`;
 }
 
-export function classificationErrorForOpenCodeTurnAbort(_cause: OpenCodeTurnAbortCause): string {
-  return OPENCODE_TURN_ABORT_CLASSIFICATION_MESSAGE;
+export function settlementPolicyForOpenCodeTurnAbort(cause: OpenCodeTurnAbortCause): OpenCodeTurnAbortSettlementPolicy {
+  switch (cause) {
+    case "timeout":
+      return { classificationError: OPENCODE_TURN_ABORT_TIMEOUT_CLASSIFICATION_MESSAGE };
+    case "superseded":
+      return { classificationError: OPENCODE_TURN_ABORT_TIMEOUT_CLASSIFICATION_MESSAGE };
+    case "session_inactive":
+      return {
+        classificationError: "OpenCode session became inactive before a safe terminal event",
+      };
+    case "lifecycle":
+      return {
+        classificationError: "OpenCode turn aborted by runtime lifecycle before a safe terminal event",
+      };
+  }
 }

--- a/packages/client/src/providers/opencode/turn-abort.ts
+++ b/packages/client/src/providers/opencode/turn-abort.ts
@@ -1,0 +1,53 @@
+export type OpenCodeTurnAbortCause = "timeout" | "superseded" | "session_inactive" | "lifecycle";
+
+export type OpenCodeTurnAbortState = {
+  terminalReasons: readonly string[];
+  sawProviderActivity: boolean;
+  text: readonly string[];
+};
+
+export function resolveOpenCodeTurnAbortCause(input: {
+  turnGeneration: number;
+  currentGeneration: number;
+  sessionActive: boolean;
+  timedOut: boolean;
+  abortSignal: AbortSignal;
+}): OpenCodeTurnAbortCause {
+  if (input.timedOut) return "timeout";
+  if (!input.sessionActive) return "session_inactive";
+  if (input.currentGeneration !== input.turnGeneration) return "superseded";
+  if (input.abortSignal.aborted) return "lifecycle";
+  return "lifecycle";
+}
+
+export function describeOpenCodeTurnAbortFailure(input: {
+  cause: OpenCodeTurnAbortCause;
+  turnTimeoutMs: number;
+  state: OpenCodeTurnAbortState;
+}): string {
+  const timeoutSeconds = Math.round(input.turnTimeoutMs / 1000);
+  const lead = {
+    timeout: `OpenCode turn timed out after ${timeoutSeconds}s before a safe terminal event (step_finish)`,
+    superseded: "OpenCode turn was superseded by a newer delivery before a safe terminal event (step_finish)",
+    session_inactive:
+      "OpenCode turn ended because the session became inactive before a safe terminal event (step_finish)",
+    lifecycle: "OpenCode turn was aborted by runtime lifecycle before a safe terminal event (step_finish)",
+  }[input.cause];
+
+  const hints: string[] = [];
+  if (input.state.terminalReasons.length === 0) {
+    hints.push("no step_finish event received");
+  } else {
+    hints.push(
+      `observed ${input.state.terminalReasons.length} terminal event${input.state.terminalReasons.length === 1 ? "" : "s"}`,
+    );
+  }
+  if (input.state.sawProviderActivity && input.state.text.length === 0) {
+    hints.push("provider activity without assistant text");
+  }
+  if (input.state.text.length > 0) {
+    hints.push("partial assistant text was captured");
+  }
+
+  return `${lead}. ${hints.join("; ")}.`;
+}


### PR DESCRIPTION
## Summary
- Abort the previous OpenCode subprocess when a newer turn starts, so superseded review runs do not keep competing for CPU.
- Replace the generic `turn aborted or timed out before a safe terminal event` message with specific causes: timeout, superseded delivery, inactive session, or lifecycle abort.
- Include lightweight progress hints (missing `step_finish`, partial assistant text) in the failure card.

## Context
Review agents on OpenCode were failing with an opaque timeout message while multiple `opencode run` processes stacked on a loaded host. The handler incremented generation for new turns but did not abort the prior subprocess, and all abort paths collapsed to one message.

## Test plan
- [x] `pnpm exec vitest run src/providers/opencode/__tests__/turn-abort.test.ts`
- [ ] Manual: trigger a Review OpenCode timeout/supersede and confirm the failure card names the specific abort cause

Made with [Cursor](https://cursor.com)