### PR TITLE
fix(client): tolerate empty OpenCode text events from tool-only steps

### DIFF
--- a/packages/client/src/providers/opencode/__tests__/parser.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/parser.test.ts
@@ -50,10 +50,31 @@ describe("OpenCode JSONL parser", () => {
     );
   });
 
-  it("skips empty text events (stored by tool-only steps and re-emitted on resume)", () => {
-    const events = parseOpenCodeStreamLine(JSON.stringify({ type: "text", sessionID: "ses_1", part: {} }));
+  it("skips explicitly empty text events stored by tool-only steps", () => {
+    const events = parseOpenCodeStreamLine(JSON.stringify({ type: "text", sessionID: "ses_1", part: { text: "" } }));
     expect(events).toContainEqual({ kind: "session", sessionId: "ses_1" });
     expect(events).not.toContainEqual(expect.objectContaining({ kind: "unknown" }));
     expect(events).not.toContainEqual(expect.objectContaining({ kind: "text" }));
+  });
+
+  it("keeps malformed text fields as protocol violations", () => {
+    for (const part of [{}, { text: 123 }]) {
+      expect(parseOpenCodeStreamLine(JSON.stringify({ type: "text", sessionID: "ses_1", part }))).toContainEqual({
+        kind: "unknown",
+        note: "text event missing text",
+      });
+    }
+  });
+
+  it("uses the row-level text fallback only when the part has no text field", () => {
+    expect(
+      parseOpenCodeStreamLine(JSON.stringify({ type: "text", sessionID: "ses_1", text: "legacy" })),
+    ).toContainEqual({ kind: "text", text: "legacy" });
+    expect(
+      parseOpenCodeStreamLine(JSON.stringify({ type: "text", sessionID: "ses_1", text: "legacy", part: {} })),
+    ).toContainEqual({ kind: "text", text: "legacy" });
+    expect(
+      parseOpenCodeStreamLine(JSON.stringify({ type: "text", sessionID: "ses_1", text: "legacy", part: { text: "" } })),
+    ).not.toContainEqual(expect.objectContaining({ kind: "text" }));
   });
 });

--- a/packages/client/src/providers/opencode/__tests__/parser.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/parser.test.ts
@@ -48,8 +48,12 @@ describe("OpenCode JSONL parser", () => {
     expect(parseOpenCodeStreamLine(JSON.stringify({ type: "future", sessionID: "ses_1" }))).toContainEqual(
       expect.objectContaining({ kind: "unknown" }),
     );
-    expect(parseOpenCodeStreamLine(JSON.stringify({ type: "text", sessionID: "ses_1", part: {} }))).toContainEqual(
-      expect.objectContaining({ kind: "unknown" }),
-    );
+  });
+
+  it("skips empty text events (stored by tool-only steps and re-emitted on resume)", () => {
+    const events = parseOpenCodeStreamLine(JSON.stringify({ type: "text", sessionID: "ses_1", part: {} }));
+    expect(events).toContainEqual({ kind: "session", sessionId: "ses_1" });
+    expect(events).not.toContainEqual(expect.objectContaining({ kind: "unknown" }));
+    expect(events).not.toContainEqual(expect.objectContaining({ kind: "text" }));
   });
 });

--- a/packages/client/src/providers/opencode/parser.ts
+++ b/packages/client/src/providers/opencode/parser.ts
@@ -89,8 +89,11 @@ export function parseOpenCodeStreamLine(line: string): OpenCodeStreamEvent[] {
   switch (string(row.type)) {
     case "text": {
       const text = string(part?.text) ?? string(row.text);
-      if (!text) events.push({ kind: "unknown", note: "text event missing text" });
-      else events.push({ kind: "text", text });
+      // OpenCode stores an empty text part for assistant steps that only call
+      // tools, and re-emits stored parts (including empty ones) when a session
+      // is resumed. An empty text event is therefore normal, not a protocol
+      // violation — skip it instead of failing the turn.
+      if (text) events.push({ kind: "text", text });
       break;
     }
     case "tool_use": {

--- a/packages/client/src/providers/opencode/parser.ts
+++ b/packages/client/src/providers/opencode/parser.ts
@@ -31,6 +31,13 @@ function string(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+type TextField = { kind: "missing" } | { kind: "invalid" } | { kind: "value"; text: string };
+
+function textField(value: Record<string, unknown> | null): TextField {
+  if (!value || !Object.hasOwn(value, "text")) return { kind: "missing" };
+  return typeof value.text === "string" ? { kind: "value", text: value.text } : { kind: "invalid" };
+}
+
 function number(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
@@ -88,12 +95,16 @@ export function parseOpenCodeStreamLine(line: string): OpenCodeStreamEvent[] {
 
   switch (string(row.type)) {
     case "text": {
-      const text = string(part?.text) ?? string(row.text);
       // OpenCode stores an empty text part for assistant steps that only call
       // tools, and re-emits stored parts (including empty ones) when a session
-      // is resumed. An empty text event is therefore normal, not a protocol
-      // violation — skip it instead of failing the turn.
-      if (text) events.push({ kind: "text", text });
+      // is resumed. An explicitly empty string is therefore normal, not a
+      // protocol violation — skip it instead of failing the turn. Missing or
+      // non-string fields remain protocol violations. The row-level text
+      // fallback is retained only when the part has no text field.
+      const partText = textField(part);
+      const text = partText.kind === "missing" ? textField(row) : partText;
+      if (text.kind !== "value") events.push({ kind: "unknown", note: "text event missing text" });
+      else if (text.text) events.push({ kind: "text", text: text.text });
       break;
     }
     case "tool_use": {


### PR DESCRIPTION
## Summary

- `parseOpenCodeStreamLine` flagged `text` JSONL events with an empty/missing `part.text` as `unknown` protocol violations, and any diagnostic fails the whole OpenCode turn (`unsupported or malformed OpenCode JSONL`).
- OpenCode legitimately stores an **empty text part** for assistant steps that only call tools, and re-emits stored parts when a session is resumed — so any agent turn containing a tool-only step poisons its session: every subsequent resumed turn fails. Observed in production with a DeepSeek (Responses API) backend where tool-only steps are common.
- Fix: skip empty `text` events instead of flagging them. Session-id extraction is preserved.

## Test plan

- Updated `parser.test.ts`: empty-text line now yields only the session event (no `unknown` diagnostic); added explicit regression test.
- `vitest run src/providers/opencode/` — 56/56 tests pass.
- Same change applied to a deployed staging client: previously failing resumed turns now complete.
