### PR TITLE
fix(server): encode Unicode attachment filenames in response headers

### DIFF
--- a/packages/server/src/__tests__/attachments-route.test.ts
+++ b/packages/server/src/__tests__/attachments-route.test.ts
@@ -1,3 +1,4 @@
+import { validateHeaderValue } from "node:http";
 import { Readable } from "node:stream";
 import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER, MAX_ATTACHMENT_BYTES } from "@first-tree/shared";
 import { eq, sql } from "drizzle-orm";
@@ -85,6 +86,30 @@ describe("attachments route — upload + capability download", () => {
       lifecycleState: "ready",
       data: bytes,
     });
+  });
+
+  it("serves Unicode filenames through an ASCII-safe Content-Disposition header", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `up-unicode-${crypto.randomUUID().slice(0, 6)}` });
+    const filename = "\u4f1a\u8bdd\u9644\u4ef6 100%\uff08\u7ec8\u7248\uff09.docx";
+    const encodedFilename = encodeURIComponent(filename);
+    const bytes = Buffer.from("unicode filename payload");
+
+    const upload = await postAttachment(app, admin, bytes, {
+      filename: encodedFilename,
+      mime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    expect(upload.statusCode).toBe(201);
+    const body = upload.json() as { id: string; filename: string };
+    expect(body.filename).toBe(filename);
+
+    const download = await getAttachment(app, admin, body.id);
+    expect(download.statusCode).toBe(200);
+    expect(download.rawPayload.equals(bytes)).toBe(true);
+    const contentDisposition = download.headers["content-disposition"];
+    expect(contentDisposition).toBe(`inline; filename="${encodedFilename}"`);
+    if (typeof contentDisposition !== "string") throw new Error("Content-Disposition header is missing");
+    expect(() => validateHeaderValue("Content-Disposition", contentDisposition)).not.toThrow();
   });
 
   it("dual-reads and reverse-backfills a pre-existing S3-only row", async () => {

--- a/packages/server/src/api/attachments.ts
+++ b/packages/server/src/api/attachments.ts
@@ -58,11 +58,13 @@ export async function attachmentRoutes(app: FastifyInstance): Promise<void> {
 }
 
 /**
- * RFC 6266 percent-encoding for the `filename` directive — `inline; filename="..."`.
- * Only percent-encodes characters that would break the quoted-string parser
- * (CR/LF, quote, backslash). Browsers tolerate non-ASCII inside the quoted
- * form, but raw quotes / control chars would smuggle headers.
+ * Encode the filename into an ASCII-only quoted `Content-Disposition`
+ * `filename` parameter.
+ * Node rejects non-Latin-1 response-header characters, and the client already
+ * decodes this percent-encoded wire form when it reads attachment metadata.
+ * Encoding the whole value also protects quotes, slashes, control characters,
+ * and literal percent signs without introducing an ambiguous partial encoding.
  */
 function encodeRfc6266Filename(name: string): string {
-  return name.replace(/[\r\n"\\]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`);
+  return encodeURIComponent(name);
 }


### PR DESCRIPTION
# PR: Encode Unicode attachment filenames in response headers

## Suggested title

`fix(server): encode Unicode attachment filenames in response headers`

## Summary

- Percent-encode the complete attachment filename before placing it in the
  `Content-Disposition` response header.
- Preserve the existing quoted `filename="..."` wire shape and the current
  client-side `decodeURIComponent` behavior.
- Add an upload-to-download regression test covering Unicode, spaces, a
  literal percent sign, and full-width punctuation.
- Validate the generated header with Node's own `validateHeaderValue` API.

## Root cause

The attachment download route only percent-encoded CR, LF, quotes, and
backslashes. A filename containing characters outside Latin-1 was therefore
passed directly to Node's HTTP response implementation. Node rejects that
header value with `ERR_INVALID_CHAR` while Fastify is sending the attachment
stream, which can terminate the server process.

The upload path already transports filenames with `encodeURIComponent`, and
the client already decodes percent-encoded `filename="..."` values. Applying
the same encoding to the complete download filename fixes the invalid header
without changing the wire contract or requiring a client upgrade.

## Scope

The issue is not specific to attachment size or MIME type. It affects any
consumer of `GET /api/v1/attachments/:id` when the stored filename contains
non-ASCII characters. That includes chat files and images as well as other
features backed by the shared attachment store, such as Team Skill bundles.

## Verification

- `biome check` for the two changed files: passed.
- `tsc --noEmit -p packages/server/tsconfig.json`: passed.
- Server `tsdown` build: passed.
- `git diff --check`: passed.
- Node header reproduction: old implementation raises `ERR_INVALID_CHAR`;
  patched implementation is ASCII-only and round-trips the original filename.
- The equivalent built Server bundle was exercised against an isolated
  database clone: multiple Unicode filenames and an ASCII control file all
  returned HTTP 200 with matching decoded names, byte lengths, and SHA-256
  content hashes, with zero Server restarts or severe errors.
- The focused Vitest route test is included but was not executed locally
  because no Docker/PostgreSQL test runtime was available. It should run in CI.
