### PR TITLE
fix(runtime): report working for a provider turn the inbox does not own

### DIFF
--- a/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
+++ b/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
@@ -142,6 +142,7 @@ function buildSessionCtx(chatId: string): SessionContext {
     chatId,
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, chatId),
   };

--- a/packages/client/src/__tests__/prepare-managed-session.test.ts
+++ b/packages/client/src/__tests__/prepare-managed-session.test.ts
@@ -234,6 +234,7 @@ describe("prepareManagedSession", () => {
         logs.push(message);
       },
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
     } as SessionContext;
@@ -1424,6 +1425,7 @@ describe("projectManagedWorkspace", () => {
       chatId: "chat-1",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
     } as SessionContext;

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -158,7 +158,7 @@ describe("SessionRuntime runtime projection from inbox coordinator work", () => 
 
     // The background task completes and the provider starts a fresh turn on
     // its own: no delivery, no ownership, but real work.
-    capturedCtx.recordProviderActivity();
+    capturedCtx.emitEvent({ kind: "tool_call", payload: { toolUseId: "t1", name: "Bash", args: null, status: "ok" } });
     expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "working" });
     expect(sm.getAggregateRuntimeState()).toBe("working");
 
@@ -191,7 +191,7 @@ describe("SessionRuntime runtime projection from inbox coordinator work", () => 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
     if (!capturedCtx || !capturedMessage) throw new Error("expected captured session context");
     capturedCtx.markMessagesConsumed(capturedMessage);
-    capturedCtx.recordProviderActivity();
+    capturedCtx.emitEvent({ kind: "thinking", payload: {} });
     expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "working" });
 
     // Turn liveness ends, but the owned delivery is still being processed —
@@ -201,6 +201,50 @@ describe("SessionRuntime runtime projection from inbox coordinator work", () => 
     expect(sm.getAggregateRuntimeState()).toBe("working");
 
     ack.resolve();
+    await sm.shutdown();
+  });
+
+  it("does not resurrect working from out-of-turn provider traffic after a turn closes", async () => {
+    // `recordProviderActivity` is broader than turn liveness on purpose: the
+    // Codex app-server samples it above its own thread/turn filter, so a late
+    // `thread/tokenUsage/updated` for an already-closed turn reaches it and is
+    // then recorded as historical usage — with no `turn_end` to follow. Turn
+    // liveness must come from in-turn evidence only, or that sample would
+    // strand `working` on an idle chat.
+    const events: Array<{ chatId: string; state: string }> = [];
+    let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      async start(msg, ctx) {
+        capturedCtx = ctx;
+        capturedMessage = msg;
+        return { sessionId: "session-1", route: { kind: "owned" as const, mode: "queued" as const } };
+      },
+    });
+    const sm = createSessionRuntime({
+      handler,
+      onRuntimeStateChange: vi.fn(),
+      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    if (!capturedCtx || !capturedMessage) throw new Error("expected captured session context");
+    capturedCtx.markMessagesConsumed(capturedMessage);
+    capturedCtx.emitEvent({ kind: "thinking", payload: {} });
+    await capturedCtx.finishTurn(capturedMessage, { status: "success", terminal: true });
+    capturedCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "idle" });
+
+    // Late traffic for the closed turn: an activity sample and the usage event
+    // it carries. Neither is evidence of an open turn.
+    capturedCtx.recordProviderActivity();
+    capturedCtx.emitEvent({
+      kind: "token_usage",
+      payload: { provider: "codex", model: "gpt-5", inputTokens: 10, cachedInputTokens: 0, outputTokens: 5 },
+    });
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "idle" });
+    expect(sm.getAggregateRuntimeState()).toBe("idle");
+
     await sm.shutdown();
   });
 

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -129,6 +129,81 @@ describe("SessionRuntime runtime projection from inbox coordinator work", () => 
     await sm.shutdown();
   });
 
+  it("projects a provider turn as working when no inbox delivery owns it", async () => {
+    // A provider re-invoked by its own background-task completion runs a full
+    // turn with no owned inbox entry. Projecting that as idle is what made a
+    // busy agent read as "Idle" on every chat surface.
+    const events: Array<{ chatId: string; state: string }> = [];
+    let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      async start(msg, ctx) {
+        capturedCtx = ctx;
+        capturedMessage = msg;
+        return { sessionId: "session-1", route: { kind: "owned" as const, mode: "queued" as const } };
+      },
+    });
+    const sm = createSessionRuntime({
+      handler,
+      onRuntimeStateChange: vi.fn(),
+      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    if (!capturedCtx || !capturedMessage) throw new Error("expected captured session context");
+    capturedCtx.markMessagesConsumed(capturedMessage);
+    await capturedCtx.finishTurn(capturedMessage, { status: "success", terminal: true });
+    capturedCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "idle" });
+
+    // The background task completes and the provider starts a fresh turn on
+    // its own: no delivery, no ownership, but real work.
+    capturedCtx.recordProviderActivity();
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "working" });
+    expect(sm.getAggregateRuntimeState()).toBe("working");
+
+    capturedCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "idle" });
+    expect(sm.getAggregateRuntimeState()).toBe("idle");
+
+    await sm.shutdown();
+  });
+
+  it("keeps a delivery working when the provider closes one turn but the delivery is unsettled", async () => {
+    const events: Array<{ chatId: string; state: string }> = [];
+    let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const ack = deferred();
+    const handler = createMockHandler({
+      async start(msg, ctx) {
+        capturedCtx = ctx;
+        capturedMessage = msg;
+        return { sessionId: "session-1", route: { kind: "owned" as const, mode: "queued" as const } };
+      },
+    });
+    const sm = createSessionRuntime({
+      handler,
+      ackEntry: vi.fn().mockReturnValue(ack.promise),
+      onRuntimeStateChange: vi.fn(),
+      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    if (!capturedCtx || !capturedMessage) throw new Error("expected captured session context");
+    capturedCtx.markMessagesConsumed(capturedMessage);
+    capturedCtx.recordProviderActivity();
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "working" });
+
+    // Turn liveness ends, but the owned delivery is still being processed —
+    // ownership alone must keep the chat working.
+    capturedCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "working" });
+    expect(sm.getAggregateRuntimeState()).toBe("working");
+
+    ack.resolve();
+    await sm.shutdown();
+  });
+
   it("keeps ACK failure unsettled and recovers before routing later delivery", async () => {
     const events: Array<{ chatId: string; state: string }> = [];
     const recovery = deferred();

--- a/packages/client/src/__tests__/source-publication-lock.test.ts
+++ b/packages/client/src/__tests__/source-publication-lock.test.ts
@@ -103,6 +103,7 @@ describe("source-publication lock", () => {
       chatId: "chat-1",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
     } as SessionContext;

--- a/packages/client/src/providers/amp/__tests__/handler.test.ts
+++ b/packages/client/src/providers/amp/__tests__/handler.test.ts
@@ -214,6 +214,7 @@ function makeContext(opts: {
     chatId: "chat-amp",
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: (event) => {
       opts.events.push(event);
     },

--- a/packages/client/src/providers/claude/__tests__/inject-materialize.test.ts
+++ b/packages/client/src/providers/claude/__tests__/inject-materialize.test.ts
@@ -224,6 +224,7 @@ function makeContext(fetchAttachment = vi.fn(), log: (message: string) => void =
     chatId: "chat-materialize",
     log,
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: () => {},
     ...plumbing,
     publishTeamSkillCommands: (commands) => {

--- a/packages/client/src/providers/claude/__tests__/inject-startup-race.test.ts
+++ b/packages/client/src/providers/claude/__tests__/inject-startup-race.test.ts
@@ -210,6 +210,7 @@ function makeContext(
     chatId: "chat-claude-startup-race",
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, "chat-claude-startup-race"),
     ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),

--- a/packages/client/src/providers/claude/__tests__/provider-error-result.test.ts
+++ b/packages/client/src/providers/claude/__tests__/provider-error-result.test.ts
@@ -210,6 +210,7 @@ async function startSingleResultTurn() {
     chatId: "chat-claude-provider-error",
     log: (m) => logs.push(m),
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: (e) => {
       const retryEvent = e.kind === "error" ? parseProviderRetryEventMessage(e.payload.message) : null;
       if (retryEvent?.event === "provider_failure_terminal") settlementOrder.push("terminal-notice");

--- a/packages/client/src/providers/claude/__tests__/sdk-options.test.ts
+++ b/packages/client/src/providers/claude/__tests__/sdk-options.test.ts
@@ -102,6 +102,7 @@ function buildSessionCtx(chatId: string, buildAgentEnv?: SessionContext["buildAg
     chatId,
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: () => {},
     ...plumbing,
     ...(buildAgentEnv ? { buildAgentEnv } : {}),

--- a/packages/client/src/providers/claude/__tests__/session-limit-result.test.ts
+++ b/packages/client/src/providers/claude/__tests__/session-limit-result.test.ts
@@ -110,6 +110,7 @@ describe("claude-code handler — session-limit success result", () => {
       chatId: "chat-claude-session-limit",
       log: (m) => logs.push(m),
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-claude-session-limit"),
       forwardResult,

--- a/packages/client/src/providers/claude/__tests__/stream-error-retry-replay.test.ts
+++ b/packages/client/src/providers/claude/__tests__/stream-error-retry-replay.test.ts
@@ -193,6 +193,7 @@ describe("claude-code handler — transient stream-error retry replays user mess
       chatId: "chat-stream-retry",
       log: (m) => logs.push(m),
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-stream-retry"),
       finishTurn: async () => {
@@ -319,6 +320,7 @@ describe("claude-code handler — transient stream-error retry replays user mess
       chatId: "chat-stream-source-flip",
       log: (message) => logs.push(message),
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-stream-source-flip"),
       failSessionForRecovery,
@@ -387,6 +389,7 @@ describe("claude-code handler — transient stream-error retry replays user mess
       chatId: "chat-stream-retry",
       log: (m) => logs.push(m),
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-stream-retry"),
       finishTurn: async (messages) => {
@@ -490,6 +493,7 @@ describe("claude-code handler — transient stream-error retry replays user mess
       chatId: "chat-stream-retry",
       log: (m) => logs.push(m),
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...plumbing,
       formatInboundContent: async (message) => {

--- a/packages/client/src/providers/claude/__tests__/tui/suspend-queued-recovery.test.ts
+++ b/packages/client/src/providers/claude/__tests__/tui/suspend-queued-recovery.test.ts
@@ -179,6 +179,7 @@ function makeContext(
     chatId: CHAT_ID,
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: () => {},
     ...plumbing,
     ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),

--- a/packages/client/src/providers/claude/__tests__/turn-end-auto-resume-fail.test.ts
+++ b/packages/client/src/providers/claude/__tests__/turn-end-auto-resume-fail.test.ts
@@ -174,6 +174,7 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       chatId: "chat-resume-fail",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-resume-fail"),
       finishTurn: async () => {
@@ -272,6 +273,7 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       chatId: "chat-resume-fail",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-resume-fail"),
       finishTurn: async () => {},
@@ -361,6 +363,7 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       chatId: "chat-resume-fail",
       log: (m) => logs.push(m),
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...plumbing,
       formatInboundContent: async (message) => {

--- a/packages/client/src/providers/claude/__tests__/turn-end-retry-exhausted.test.ts
+++ b/packages/client/src/providers/claude/__tests__/turn-end-retry-exhausted.test.ts
@@ -163,6 +163,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       chatId: "chat-retry",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-retry"),
       finishTurn: async () => {
@@ -282,6 +283,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       chatId: "chat-retry",
       log: (m) => logs.push(m),
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...plumbing,
       formatInboundContent: async (message) => {
@@ -380,6 +382,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       chatId: "chat-retry-emit-throw",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: () => {
         throw new Error("event sink down");
       },

--- a/packages/client/src/providers/claude/__tests__/turn-end-sdk-error.test.ts
+++ b/packages/client/src/providers/claude/__tests__/turn-end-sdk-error.test.ts
@@ -101,6 +101,7 @@ describe("claude-code handler — turn_end on SDK-reported subtype error", () =>
       chatId: "chat-1",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
     };

--- a/packages/client/src/providers/claude/__tests__/turn-end-serialization.test.ts
+++ b/packages/client/src/providers/claude/__tests__/turn-end-serialization.test.ts
@@ -134,6 +134,7 @@ describe("claude-code handler — turn_end serialization (race guard)", () => {
       chatId: "chat-1",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: (e: SessionEvent) => {
         emitted.push({ kind: e.kind, at: Date.now() - start });
       },

--- a/packages/client/src/providers/claude/__tests__/turn-end.test.ts
+++ b/packages/client/src/providers/claude/__tests__/turn-end.test.ts
@@ -99,6 +99,7 @@ describe("claude-code handler — turn_end emission", () => {
       chatId: "chat-1",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
       emitEvent: (e) => emitted.push(e),
     };
@@ -143,6 +144,7 @@ describe("claude-code handler — turn_end emission", () => {
       chatId: "chat-1",
       log: () => {},
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
       // Production-faithful: forwardResult delivers nothing; record the call so
       // we can assert turn_end is emitted only after it resolves.

--- a/packages/client/src/providers/claude/__tests__/turn-liveness-boundary.test.ts
+++ b/packages/client/src/providers/claude/__tests__/turn-liveness-boundary.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEvent } from "@first-tree/shared";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * Turn liveness must follow the SDK's own turn lifecycle, not the arrival of
+ * messages.
+ *
+ * The stream does not end at `result`: `sdk.d.ts` documents
+ * `session_state_changed: idle` as the authoritative turn-over signal, fired
+ * once the held-back result flushes and the background-agent loop exits. A
+ * hook that treats every frame as turn-entering therefore runs again on that
+ * trailing frame and re-opens the turn it just closed — leaving the chat
+ * Working, with no `turn_end` left to clear it, until the idle sweep's hard
+ * cap (~12h with shipped defaults).
+ *
+ * The script below is that exact ordering: running -> result -> idle.
+ */
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+  const fakeQuery = {
+    [Symbol.asyncIterator]() {
+      let step = 0;
+      return {
+        next: async () => {
+          step += 1;
+          if (step === 1) {
+            return {
+              done: false,
+              value: {
+                type: "system",
+                subtype: "session_state_changed",
+                state: "running",
+                uuid: "u1",
+                session_id: "s",
+              },
+            };
+          }
+          if (step === 2) {
+            return {
+              done: false,
+              value: { type: "result", subtype: "success", result: "done", num_turns: 1, duration_ms: 5 },
+            };
+          }
+          if (step === 3) {
+            return {
+              done: false,
+              value: { type: "system", subtype: "session_state_changed", state: "idle", uuid: "u2", session_id: "s" },
+            };
+          }
+          return { done: true, value: undefined };
+        },
+      };
+    },
+    close: () => {},
+    setModel: async () => {},
+  };
+  return { query: () => fakeQuery };
+});
+
+import { mockCtxPlumbing } from "../../../__tests__/test-helpers.js";
+import { createAgentConfigCache } from "../../../runtime/agent-config-cache.js";
+import type { SessionContext } from "../../../runtime/handler.js";
+import { deliveryTokenFromSessionContext } from "../../../runtime/handler.js";
+import { createClaudeCodeHandler } from "../index.js";
+
+const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430d9";
+
+let workspaceRoot: string;
+
+beforeAll(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ftt-turn-liveness-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+function buildCache() {
+  const stubSdk = {
+    fetchAgentConfig: async () => ({
+      agentId: AGENT_ID,
+      version: 1,
+      payload: { prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos: [] },
+      updatedAt: new Date().toISOString(),
+      updatedBy: "test",
+    }),
+  } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
+  return createAgentConfigCache({ sdk: stubSdk });
+}
+
+describe("claude-code handler — turn liveness boundary", () => {
+  it("opens on the running frame and does not reopen on the post-result idle frame", async () => {
+    const sendMessage = vi.fn();
+    const order: string[] = [];
+
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+
+    const handler = createClaudeCodeHandler({
+      runtimeProvider: "claude-code",
+      workspaceRoot,
+      agentName: "test-agent",
+      agentConfigCache: cache,
+    });
+    const ctx: SessionContext = {
+      agent: {
+        agentId: AGENT_ID,
+        inboxId: "inbox-test",
+        displayName: "test",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+      chatId: "chat-1",
+      log: () => {},
+      recordProviderActivity: () => {},
+      noteTurnStart: () => order.push("turn_start"),
+      noteTurnEnd: () => order.push("turn_end_hook"),
+      emitEvent: (e: SessionEvent) => {
+        if (e.kind === "turn_end") order.push("turn_end_event");
+      },
+      ...mockCtxPlumbing({ sendMessage }, "chat-1"),
+      forwardResult: async () => {},
+    };
+
+    try {
+      await handler.start(
+        { id: "m1", chatId: "chat-1", senderId: "u", format: "text", content: "hi", metadata: null },
+        ctx,
+        deliveryTokenFromSessionContext(ctx),
+      );
+      await vi.waitFor(() => expect(order).toContain("turn_end_hook"));
+
+      // The whole point: exactly one open, and the trailing authoritative
+      // idle frame closes rather than reopens.
+      expect(order).toEqual(["turn_start", "turn_end_event", "turn_end_hook"]);
+      expect(order.lastIndexOf("turn_start")).toBe(0);
+    } finally {
+      await handler.suspend().catch(() => {});
+      await new Promise((r) => setImmediate(r));
+    }
+  });
+});

--- a/packages/client/src/providers/claude/index.ts
+++ b/packages/client/src/providers/claude/index.ts
@@ -1452,6 +1452,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           for await (const message of query) {
             // Every message refreshes lastActivity to prevent idle timeout
             sessionCtx.recordProviderActivity();
+            // Unlike providers that sample activity above a thread/turn
+            // filter, every message on this stream belongs to the turn that
+            // is currently streaming — including the first one, which arrives
+            // before any assistant text. So the stream head IS the turn
+            // boundary here, and a background-task wake-up lights up at once
+            // rather than at its first displayable output.
+            sessionCtx.noteTurnStart();
 
             toolCallProcessor.onMessage(message);
 

--- a/packages/client/src/providers/claude/index.ts
+++ b/packages/client/src/providers/claude/index.ts
@@ -296,6 +296,19 @@ type ClaudeModelUsageCounters = {
   cacheCreationInputTokens: number;
 };
 
+/**
+ * The SDK's own turn-lifecycle frame. Its `sdk.d.ts` calls `idle` the
+ * "authoritative turn-over signal" — it fires after the held-back result
+ * flushes and the background-agent do-while exits — which also makes `running`
+ * the authoritative turn-entering signal, earlier than any model output.
+ */
+function sessionStateChange(message: unknown): "idle" | "running" | "requires_action" | null {
+  if (!message || typeof message !== "object") return null;
+  const m = message as Record<string, unknown>;
+  if (m.type !== "system" || m.subtype !== "session_state_changed") return null;
+  return m.state === "idle" || m.state === "running" || m.state === "requires_action" ? m.state : null;
+}
+
 function isResultMessage(message: unknown): message is ResultMessage {
   if (!message || typeof message !== "object") return false;
   const m = message as Record<string, unknown>;
@@ -1452,13 +1465,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           for await (const message of query) {
             // Every message refreshes lastActivity to prevent idle timeout
             sessionCtx.recordProviderActivity();
-            // Unlike providers that sample activity above a thread/turn
-            // filter, every message on this stream belongs to the turn that
-            // is currently streaming — including the first one, which arrives
-            // before any assistant text. So the stream head IS the turn
-            // boundary here, and a background-task wake-up lights up at once
-            // rather than at its first displayable output.
-            sessionCtx.noteTurnStart();
+            // Turn liveness follows the SDK's own lifecycle frame, not the
+            // arrival of any message. The stream does NOT end at `result`:
+            // `session_state_changed: idle` fires afterwards, once the
+            // background-agent loop settles, so treating every frame as
+            // turn-entering would re-open the turn after its own end and leave
+            // the chat Working until the idle sweep's hard cap.
+            const stateChange = sessionStateChange(message);
+            if (stateChange === "running") sessionCtx.noteTurnStart();
+            else if (stateChange === "idle") sessionCtx.noteTurnEnd?.();
 
             toolCallProcessor.onMessage(message);
 

--- a/packages/client/src/providers/codex/__tests__/app-server/extra-coverage.test.ts
+++ b/packages/client/src/providers/codex/__tests__/app-server/extra-coverage.test.ts
@@ -331,6 +331,7 @@ function makeContext(
     chatId: "chat-app-server-extra",
     log: opts.log ?? (() => {}),
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-app-server-extra"),
     ...(opts.failSessionForRecovery ? { failSessionForRecovery: opts.failSessionForRecovery } : {}),

--- a/packages/client/src/providers/codex/__tests__/app-server/handler.test.ts
+++ b/packages/client/src/providers/codex/__tests__/app-server/handler.test.ts
@@ -307,6 +307,7 @@ function makeContext(
     chatId: "chat-app-server",
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...(opts.emitEventConfirmed ? { emitEventConfirmed: opts.emitEventConfirmed } : {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-app-server"),

--- a/packages/client/src/providers/codex/__tests__/inject-startup-race.test.ts
+++ b/packages/client/src/providers/codex/__tests__/inject-startup-race.test.ts
@@ -230,6 +230,7 @@ function makeContext(
     chatId: "chat-startup-race",
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-startup-race"),
     ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),

--- a/packages/client/src/providers/codex/__tests__/retry-abort.test.ts
+++ b/packages/client/src/providers/codex/__tests__/retry-abort.test.ts
@@ -188,6 +188,7 @@ function makeContext(
     chatId: "chat-retry-abort",
     log: opts.log ?? (() => {}),
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-retry-abort"),
     finishTurn: async (messages) => {

--- a/packages/client/src/providers/codex/__tests__/stale-rollout.test.ts
+++ b/packages/client/src/providers/codex/__tests__/stale-rollout.test.ts
@@ -173,6 +173,7 @@ function makeContext(
     chatId: "chat-stale-rollout",
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, "chat-stale-rollout"),
     ...(opts.replaceSessionId ? { replaceSessionId: opts.replaceSessionId } : {}),

--- a/packages/client/src/providers/codex/__tests__/usage-limit.test.ts
+++ b/packages/client/src/providers/codex/__tests__/usage-limit.test.ts
@@ -162,6 +162,7 @@ function makeContext(
   opts: {
     sendMessage?: SendMessageMock;
     emitEvent?: SessionContext["emitEvent"];
+    noteTurnStart?: SessionContext["noteTurnStart"];
     emitEventConfirmed?: SessionContext["emitEventConfirmed"];
     failSessionForRecovery?: SessionContext["failSessionForRecovery"];
     log?: SessionContext["log"];
@@ -186,6 +187,7 @@ function makeContext(
     chatId: "chat-usage-limit",
     log: opts.log ?? (() => {}),
     recordProviderActivity: () => {},
+    noteTurnStart: opts.noteTurnStart ?? (() => {}),
     emitEvent: opts.emitEvent ?? (() => {}),
     ...(opts.emitEventConfirmed ? { emitEventConfirmed: opts.emitEventConfirmed } : {}),
     ...(opts.failSessionForRecovery ? { failSessionForRecovery: opts.failSessionForRecovery } : {}),
@@ -212,6 +214,39 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("codex turn liveness at the provider boundary", () => {
+  it("marks the turn started at turn.started, before any displayable event", async () => {
+    // The chat must read Working from the turn boundary, not from the first
+    // thing the model happens to say. `turn.started` is followed here by a
+    // completion with no item events at all — the extreme case of the head of
+    // a turn being pure latency — and the boundary signal still has to fire.
+    // Anything weaker leaves a provider-owned turn (no inbox custody to fall
+    // back on) reading Idle for as long as the model takes to produce output.
+    state.turns = [[{ type: "turn.started" }, { type: "turn.completed", usage: zeroUsage }]];
+
+    const order: string[] = [];
+    const handler = createCodexHandler({
+      runtimeProvider: "codex",
+      workspaceRoot,
+      agentName: "test-agent",
+    });
+    const ctx = makeContext(() => {}, {
+      noteTurnStart: () => order.push("turn_start"),
+      emitEvent: (event) => order.push(`event:${event.kind}`),
+      sendMessage: vi
+        .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+        .mockResolvedValue(undefined),
+    });
+    await handler.start(makeMessage("msg-boundary", "hello"), ctx, deliveryTokenFromSessionContext(ctx));
+    await vi.waitFor(() => expect(order).toContain("event:turn_end"));
+
+    // Started first, ended last, and nothing displayable in between.
+    expect(order[0]).toBe("turn_start");
+    expect(order[order.length - 1]).toBe("event:turn_end");
+    expect(order.filter((e) => e === "event:assistant_text" || e === "event:tool_call")).toEqual([]);
+  });
 });
 
 describe("codex usage-limit empty-turn (issue #971)", () => {

--- a/packages/client/src/providers/codex/app-server/index.ts
+++ b/packages/client/src/providers/codex/app-server/index.ts
@@ -1312,6 +1312,9 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       resolveTerminal,
     };
     currentTurn = turn;
+    // Turn boundary: from here notifications for this turn are applied, so the
+    // chat is working even before the first displayable item arrives.
+    sessionCtx.noteTurnStart();
     if (providerRetryChain) providerRetryFence = false;
     token.processingStarted(messages);
     currentTurnPromise = terminalPromise.finally(() => {

--- a/packages/client/src/providers/codex/sdk.ts
+++ b/packages/client/src/providers/codex/sdk.ts
@@ -924,7 +924,12 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
               if (event.type === "thread.started") {
                 threadId = event.thread_id;
               } else if (event.type === "turn.started") {
-                // No-op — runtime state already "working".
+                // The turn boundary itself. For an inbox-owned turn the
+                // delivery already projects working, but a provider-owned
+                // turn has no such custody: without this the chat would read
+                // Idle through the model latency that precedes the first
+                // displayable item.
+                sessionCtx.noteTurnStart();
               } else if (event.type === "item.completed") {
                 if (event.item.type === "error" && isUnsupportedCodexServiceTierWarning(event.item.message)) {
                   providerAttempt.recordSignal({

--- a/packages/client/src/providers/cursor/__tests__/handler-engine.test.ts
+++ b/packages/client/src/providers/cursor/__tests__/handler-engine.test.ts
@@ -173,6 +173,7 @@ function makeContext(opts: {
     chatId: "chat-cursor",
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: (event) => {
       opts.events.push(event);
     },

--- a/packages/client/src/providers/cursor/index.ts
+++ b/packages/client/src/providers/cursor/index.ts
@@ -872,6 +872,10 @@ export const createCursorHandler: HandlerFactory = (config) => {
     switch (event.kind) {
       case "init": {
         state.sawInit = true;
+        // Stream open = turn boundary; `thinking_delta` and `user_echo` below
+        // are deliberately not emitted as events, so without this the chat
+        // would stay Idle until the first completed block.
+        sessionCtx.noteTurnStart();
         adoptProviderSessionId(sessionCtx, event.sessionId);
         break;
       }

--- a/packages/client/src/providers/deepseek-harness/__tests__/handler.test.ts
+++ b/packages/client/src/providers/deepseek-harness/__tests__/handler.test.ts
@@ -131,6 +131,7 @@ function makeContext(opts: {
       opts.events.push(event);
     },
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     ...(opts.replaceSessionId ? { replaceSessionId: opts.replaceSessionId } : {}),
   };
 }

--- a/packages/client/src/providers/grok/__tests__/handler.test.ts
+++ b/packages/client/src/providers/grok/__tests__/handler.test.ts
@@ -348,6 +348,7 @@ function makeContext(opts: {
       opts.logs?.push(msg);
     },
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: (event) => {
       opts.events.push(event);
     },

--- a/packages/client/src/providers/kimi-code/__tests__/handler.test.ts
+++ b/packages/client/src/providers/kimi-code/__tests__/handler.test.ts
@@ -229,6 +229,7 @@ function makeContext(
     chatId: "chat-kimi",
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: (value) => void events.push(value),
     ...mockCtxPlumbing({ sendMessage }, "chat-kimi"),
   };

--- a/packages/client/src/providers/kimi-code/__tests__/sdk-authorize-hook.test.ts
+++ b/packages/client/src/providers/kimi-code/__tests__/sdk-authorize-hook.test.ts
@@ -306,6 +306,7 @@ function handlerContext(): SessionContext {
     chatId: "chat-e2e",
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, "chat-e2e"),
   };

--- a/packages/client/src/providers/opencode/__tests__/handler.test.ts
+++ b/packages/client/src/providers/opencode/__tests__/handler.test.ts
@@ -296,6 +296,7 @@ function context(
     log: vi.fn(),
     chatId,
     recordProviderActivity: vi.fn(),
+    noteTurnStart: vi.fn(),
     emitEvent: (event) => events.push(event),
     forwardResult: async (text) => {
       forwarded.push(text);

--- a/packages/client/src/providers/pi/__tests__/handler.test.ts
+++ b/packages/client/src/providers/pi/__tests__/handler.test.ts
@@ -507,6 +507,7 @@ function makeContext(
     chatId: "chat-pi",
     log: (line) => void logs.push(line),
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: (value) => void events.push(value),
     ...mockCtxPlumbing({ sendMessage }, "chat-pi"),
   };

--- a/packages/client/src/providers/pi/__tests__/host-smoke.test.ts
+++ b/packages/client/src/providers/pi/__tests__/host-smoke.test.ts
@@ -135,6 +135,7 @@ function makeContext(events: SessionEvent[]): SessionContext {
     chatId: "chat-pi-smoke",
     log: () => {},
     recordProviderActivity: () => {},
+    noteTurnStart: () => {},
     emitEvent: (value) => void events.push(value),
     ...mockCtxPlumbing({ sendMessage }, "chat-pi-smoke"),
   };

--- a/packages/client/src/providers/pi/__tests__/lifecycle-preparation-fence.test.ts
+++ b/packages/client/src/providers/pi/__tests__/lifecycle-preparation-fence.test.ts
@@ -82,6 +82,7 @@ describe("Pi lifecycle fence during managed-session preparation", () => {
       chatId: "chat-pi",
       log: (m: string) => logs.push(m),
       recordProviderActivity: () => {},
+      noteTurnStart: () => {},
       emitEvent: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-pi"),
     } as SessionContext;

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -180,6 +180,15 @@ export type SessionContext = HandlerContext & {
    */
   noteTurnStart: () => void;
   /**
+   * The provider closed a turn for this chat. Optional: closure normally rides
+   * the `turn_end` session event, which every provider emits. Call this only
+   * where a provider has an authoritative turn-over frame *after* that event —
+   * the Claude SDK's `session_state_changed: idle`, which fires once the
+   * background-agent loop settles — so a post-result frame cannot leave a turn
+   * open behind it.
+   */
+  noteTurnEnd?: () => void;
+  /**
    * Persist a structured session event (tool_call / error / assistant_text /
    * thinking / turn_end / usage) to the server. Assistant text DOES go through
    * here: handlers emit it as `assistant_text` events (chunked when long — see

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -166,6 +166,20 @@ export type SessionContext = HandlerContext & {
   /** Refresh `lastActivity` timestamp when the provider produces activity. */
   recordProviderActivity: () => void;
   /**
+   * The provider is opening a turn for this chat. Marks the chat `working`
+   * from the turn boundary itself rather than from its first displayable
+   * output, so the model/tool latency at the head of a turn does not read as
+   * Idle. Cleared by the turn's `turn_end` event.
+   *
+   * Distinct from `recordProviderActivity`, which is deliberately broader:
+   * some providers sample activity above their own thread/turn filter, where
+   * late traffic for an already-closed turn arrives. Call this only where the
+   * provider genuinely opens a turn. A provider that does not call it still
+   * reads as working from its first in-turn session event (assistant text,
+   * thinking, or a tool call) — later, but never wrong.
+   */
+  noteTurnStart: () => void;
+  /**
    * Persist a structured session event (tool_call / error / assistant_text /
    * thinking / turn_end / usage) to the server. Assistant text DOES go through
    * here: handlers emit it as `assistant_text` events (chunked when long — see

--- a/packages/client/src/runtime/session-projection-authority.ts
+++ b/packages/client/src/runtime/session-projection-authority.ts
@@ -100,6 +100,13 @@ export class SessionProjectionAuthority<
   private readonly registry: SessionRegistry | null;
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
+  /**
+   * Chats whose provider is currently inside a turn. Set from the first
+   * provider message of a turn and cleared at `turn_end`, so a turn the inbox
+   * does not own — a provider re-invoked by its own background-task
+   * completion, for instance — still projects `working`.
+   */
+  private readonly providerTurnInFlight = new Set<string>();
   /** Chats held specifically for a fresh bind, never same-socket recovery. */
   private readonly runtimeProofRecoveryChats = new Set<string>();
   private lastReportedRuntimeState: RuntimeState | null = null;
@@ -365,6 +372,37 @@ export class SessionProjectionAuthority<
     onStateChange(chatId, state);
   }
 
+  /**
+   * The provider produced a message for `chatId`, so a turn is running there.
+   *
+   * Inbox delivery ownership alone is NOT sufficient to detect a running turn:
+   * a provider that re-invokes itself when a background task completes runs a
+   * full turn — tool calls, output, token spend — with no owned inbox entry,
+   * and projecting `idle` for it made a busy agent read as "Idle" on every
+   * chat surface. Turn liveness is therefore tracked from the provider stream
+   * itself, which every provider reports through `recordProviderActivity`.
+   */
+  noteProviderTurnStart(chatId: string): void {
+    if (this.providerTurnInFlight.has(chatId)) return;
+    this.providerTurnInFlight.add(chatId);
+    this.projectSessionRuntime(chatId);
+  }
+
+  /**
+   * The provider closed a turn for `chatId` (its `turn_end` event). The chat
+   * falls back to inbox-ownership projection, so it stays `working` when an
+   * owned delivery is still being processed and goes `idle` otherwise.
+   *
+   * A provider that dies mid-turn without emitting `turn_end` cannot pin
+   * `working` forever: `lastActivity` stops advancing, so the idle sweep
+   * suspends the session at the `idle_timeout + working_grace` hard cap and
+   * the projection is withdrawn.
+   */
+  noteProviderTurnEnd(chatId: string): void {
+    if (!this.providerTurnInFlight.delete(chatId)) return;
+    this.projectSessionRuntime(chatId);
+  }
+
   projectSessionRuntime(chatId: string, opts: { drainPendingOnIdle?: boolean } = {}): void {
     const session = this.sessions.get(chatId);
     const state = this.projectedRuntimeState(chatId, session ?? null);
@@ -386,7 +424,7 @@ export class SessionProjectionAuthority<
     if (!session) return null;
     if (session.status === "errored") return "error";
     if (session.status !== "active") return null;
-    return this.deps.hasProcessingOwnedWork(chatId) ? "working" : "idle";
+    return this.deps.hasProcessingOwnedWork(chatId) || this.providerTurnInFlight.has(chatId) ? "working" : "idle";
   }
 
   /**
@@ -398,6 +436,10 @@ export class SessionProjectionAuthority<
    * observable even without an ordinary value change.
    */
   private withdrawSessionRuntime(chatId: string): void {
+    // Drop turn liveness first: a withdrawn projection means the session is
+    // gone, suspended, or not active, and none of those may leave a stale
+    // in-flight turn behind for the next session on this chat.
+    this.providerTurnInFlight.delete(chatId);
     if (!this.sessionRuntimeStates.delete(chatId)) return;
     this.deps.onSessionRuntimeChange()?.(chatId, "idle");
     this.recomputeRuntimeState();

--- a/packages/client/src/runtime/session-projection-authority.ts
+++ b/packages/client/src/runtime/session-projection-authority.ts
@@ -373,14 +373,15 @@ export class SessionProjectionAuthority<
   }
 
   /**
-   * The provider produced a message for `chatId`, so a turn is running there.
+   * The provider emitted in-turn evidence for `chatId`, so a turn is running
+   * there. The host decides what counts as evidence (see
+   * `noteTurnLivenessFromEvent`); this owns only the ledger.
    *
    * Inbox delivery ownership alone is NOT sufficient to detect a running turn:
    * a provider that re-invokes itself when a background task completes runs a
    * full turn — tool calls, output, token spend — with no owned inbox entry,
    * and projecting `idle` for it made a busy agent read as "Idle" on every
-   * chat surface. Turn liveness is therefore tracked from the provider stream
-   * itself, which every provider reports through `recordProviderActivity`.
+   * chat surface.
    */
   noteProviderTurnStart(chatId: string): void {
     if (this.providerTurnInFlight.has(chatId)) return;

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -1593,6 +1593,12 @@ export class SessionRuntime {
    * in-turn path, so they are self-proving evidence that a turn is open; the
    * out-of-turn traffic that caused the problem (`token_usage`,
    * `context_tree_usage`, runtime `error`) is excluded.
+   *
+   * This is the floor, not the primary signal: a provider that reports its own
+   * turn boundary through `noteTurnStart` lights up at the boundary instead,
+   * which matters because the head of a turn is model latency with nothing
+   * displayable in it yet. A provider that reports neither stays idle, which
+   * is the correct failure direction.
    */
   private noteTurnLivenessFromEvent(chatId: string, event: SessionEvent): void {
     if (event.kind === "turn_end") {
@@ -3281,6 +3287,10 @@ export class SessionRuntime {
         if (entry && entry.status === "active") {
           entry.lastActivity = Date.now();
         }
+      },
+      noteTurnStart: () => {
+        if (mutationValid && !mutationValid()) return;
+        this.projection.noteProviderTurnStart(chatId);
       },
       emitEvent: (event) => {
         // During graceful drain, only structured terminal provider-failure events

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -3253,6 +3253,11 @@ export class SessionRuntime {
         const entry = this.projection.getSession(chatId);
         if (entry && entry.status === "active") {
           entry.lastActivity = Date.now();
+          // A provider message means a turn is running here, whoever started
+          // it. Inbox ownership does not cover a turn the provider re-invokes
+          // itself for (a completed background task, for instance), and such a
+          // turn must not read as "Idle" while it burns tools and tokens.
+          this.projection.noteProviderTurnStart(chatId);
         }
       },
       emitEvent: (event) => {
@@ -3267,6 +3272,7 @@ export class SessionRuntime {
           return;
         }
         if (mutationValid && !mutationValid()) return;
+        if (event.kind === "turn_end") this.projection.noteProviderTurnEnd(chatId);
         this.config.onSessionEvent?.(chatId, event);
         if (mutationValid && !mutationValid()) return;
         this.captureRuntimeFailureNotice(chatId, event, mutationValid);
@@ -3275,6 +3281,11 @@ export class SessionRuntime {
         if (mutationValid && !mutationValid()) {
           return Promise.reject(new Error("route transition invalidated"));
         }
+        // `turn_end` also reaches the server through this confirmed channel
+        // (the Codex landing trial awaits it), so turn liveness must clear
+        // here too or that turn would stay `working` until the session is
+        // suspended.
+        if (event.kind === "turn_end") this.projection.noteProviderTurnEnd(chatId);
         return this.confirmSessionEventOrThrow(chatId, event, mutationValid);
       },
       forwardResult: (text) => {

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -3292,6 +3292,10 @@ export class SessionRuntime {
         if (mutationValid && !mutationValid()) return;
         this.projection.noteProviderTurnStart(chatId);
       },
+      noteTurnEnd: () => {
+        if (mutationValid && !mutationValid()) return;
+        this.projection.noteProviderTurnEnd(chatId);
+      },
       emitEvent: (event) => {
         // During graceful drain, only structured terminal provider-failure events
         // may cross the settlement lease (durable notice capture). All other

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -1577,6 +1577,33 @@ export class SessionRuntime {
     return parsed.data;
   }
 
+  /**
+   * Turn liveness for the D-axis, derived from the session events a provider
+   * emits *inside* a turn.
+   *
+   * Raw provider activity is deliberately NOT the signal. `recordProviderActivity`
+   * is broader than turn liveness by design — the Codex app-server samples it
+   * above its own thread/turn filter, so a late `thread/tokenUsage/updated` for
+   * an already-closed turn reaches it and is then recorded as historical usage
+   * or buffered, without ever producing a `turn_end`. Treating that sample as a
+   * turn start would strand `working` on an idle chat, kept fresh by the
+   * re-affirm loop until an unrelated turn ends or the session is suspended.
+   *
+   * Assistant text, thinking, and tool calls are only emitted from a provider's
+   * in-turn path, so they are self-proving evidence that a turn is open; the
+   * out-of-turn traffic that caused the problem (`token_usage`,
+   * `context_tree_usage`, runtime `error`) is excluded.
+   */
+  private noteTurnLivenessFromEvent(chatId: string, event: SessionEvent): void {
+    if (event.kind === "turn_end") {
+      this.projection.noteProviderTurnEnd(chatId);
+      return;
+    }
+    if (event.kind === "assistant_text" || event.kind === "thinking" || event.kind === "tool_call") {
+      this.projection.noteProviderTurnStart(chatId);
+    }
+  }
+
   private captureRuntimeFailureNotice(
     chatId: string,
     event: SessionEvent,
@@ -3253,11 +3280,6 @@ export class SessionRuntime {
         const entry = this.projection.getSession(chatId);
         if (entry && entry.status === "active") {
           entry.lastActivity = Date.now();
-          // A provider message means a turn is running here, whoever started
-          // it. Inbox ownership does not cover a turn the provider re-invokes
-          // itself for (a completed background task, for instance), and such a
-          // turn must not read as "Idle" while it burns tools and tokens.
-          this.projection.noteProviderTurnStart(chatId);
         }
       },
       emitEvent: (event) => {
@@ -3272,7 +3294,7 @@ export class SessionRuntime {
           return;
         }
         if (mutationValid && !mutationValid()) return;
-        if (event.kind === "turn_end") this.projection.noteProviderTurnEnd(chatId);
+        this.noteTurnLivenessFromEvent(chatId, event);
         this.config.onSessionEvent?.(chatId, event);
         if (mutationValid && !mutationValid()) return;
         this.captureRuntimeFailureNotice(chatId, event, mutationValid);
@@ -3285,7 +3307,7 @@ export class SessionRuntime {
         // (the Codex landing trial awaits it), so turn liveness must clear
         // here too or that turn would stay `working` until the session is
         // suspended.
-        if (event.kind === "turn_end") this.projection.noteProviderTurnEnd(chatId);
+        this.noteTurnLivenessFromEvent(chatId, event);
         return this.confirmSessionEventOrThrow(chatId, event, mutationValid);
       },
       forwardResult: (text) => {

--- a/packages/qa/cases/runtime/provider-owned-turn-status.md
+++ b/packages/qa/cases/runtime/provider-owned-turn-status.md
@@ -1,0 +1,65 @@
+---
+id: provider-owned-turn-status
+description: A turn the provider starts on its own reads as Working from its boundary and returns to Idle when it closes.
+areas: [runtime]
+surfaces: [client, server, web]
+---
+
+# Provider-owned turn status
+
+Validate that an agent reads as **Working** for a turn nobody sent it a message
+for, and returns to **Idle** when that turn closes.
+
+Not every turn begins with a delivery. A provider re-invokes itself when work
+it launched finishes — a background task completing is the common case — and
+that turn runs tools, produces output, and spends tokens with no inbox entry
+behind it. The failure this case exists to catch is silent and looks like
+nothing: the agent works normally while every status surface says Idle, so a
+human watching concludes it stalled.
+
+## Preconditions
+
+An isolated test agent with a live client, and a provider that can be driven
+to start a turn without an inbound message. Deliver one ordinary message, have
+the agent launch background work inside that turn, and let the turn close
+while the background work continues. The wake-up that follows is the turn
+under test. Do not simulate it by sending a second message — that restores the
+inbox custody whose absence is the whole point, and the case would pass
+against the bug.
+
+## What to observe
+
+Watch the chat right-sidebar row, the compose status bar, and the chat-list row
+across the whole sequence. Read them against the server's composite status for
+the same `(agent, chat)` rather than against the timeline alone, since live
+activity and composite status come from different paths.
+
+The turn is Working from its **boundary**, not from its first visible output.
+The head of a turn is model latency with nothing displayable in it, and a row
+that only lights up once text or a tool call appears will look correct in a
+quick smoke test while still being wrong for exactly the turns this case
+covers. If the provider exposes a turn-start event, check the window between
+that event and the first assistant output specifically.
+
+When the turn closes, the row returns to Idle without needing another message,
+and stays Idle through whatever out-of-turn traffic the provider emits
+afterwards. Late token-usage accounting for a closed turn is the known
+instance: it must not resurrect Working, and a chat left Working after its turn
+ended is a failure even though the transient display looked right earlier.
+
+## Credible evidence
+
+A result is credible when the composite status is sampled at each edge — before
+the wake-up, during the woken turn, and after it closes — and the samples are
+tied to the same chat and agent as the observed turn. A single screenshot of a
+Working badge proves nothing about the boundary or the return to Idle.
+
+Report `BLOCKED` or `INCONCLUSIVE` rather than `PASS` when the provider cannot
+be made to start a turn on its own, or when composite status cannot be observed
+independently of the live-activity timeline.
+
+## Related
+
+`sessions-and-status` in the Context Tree carries the durable rule: turn
+liveness follows the provider producing for the chat, whoever triggered it, and
+delivery bookkeeping is not a substitute.


### PR DESCRIPTION
## What was wrong

An agent that was actively working showed as **Idle** on every chat surface.

Per-chat runtime state was projected from one thing only — whether an inbox delivery was currently being processed:

```ts
// session-projection-authority.ts
return this.deps.hasProcessingOwnedWork(chatId) ? "working" : "idle";
```

That equates "a turn is running" with "a message is being handled". A provider that re-invokes itself when a background task completes runs a full turn — tool calls, output, token spend — with **no owned inbox entry**. The client reported `idle` for that entire turn, the server's `computeWorking` therefore derived `working: false` → `main: "ready"`, and the sidebar, the compose bar and the chat row all rendered "Idle" while the agent ran tools. Because the composite carries `activity: working ? activity : null`, the "Using Bash · 12s" detail was dropped with it.

The client already contradicted itself about this. From a real client log, repeated for 25 minutes on the same chat:

```
runtimeState:"idle", reason:"live_subprocess",
msg:"session idle threshold reached but work is still in flight — skipping suspend"
```

The idle sweep refused to suspend the session *because work was in flight*, while the projection told the server the same chat was idle. Two subsystems, two definitions of "working".

This is also a regression window that widens with client version: before per-chat runtime existed, the server fell back to "a fresh `session_events` row means working", which covered these turns. Once a client reports per-chat runtime even once, the server stops consulting events — so newer clients are the ones that go dark.

## The fix

Turn liveness has two sources, and the split is the point:

- **The provider's own turn boundary** (`SessionContext.noteTurnStart`), called where each provider genuinely opens a turn: `turn.started` (Codex SDK), the turn becoming current (Codex app-server), `init` (Cursor), and `session_state_changed: running` (Claude, the SDK's own turn-entering frame). This is what makes a row Working through the model latency at the head of a turn, where nothing displayable exists yet.

  Closure is normally the `turn_end` event, but Claude also gets the optional `noteTurnEnd` hook, driven by `session_state_changed: idle` — the SDK documents that frame as the authoritative turn-over signal, and it arrives *after* the result. Without treating it as closure, a per-message start hook reopens the turn it just closed.
- **In-turn session events** (`assistant_text` / `thinking` / `tool_call`) as the floor, for a provider that reports no boundary — later, but never wrong. A provider that reports neither stays idle, which is the correct failure direction.

`turn_end` closes liveness, through both the plain and the confirmed event channel (the Codex landing trial awaits it through the latter).

Raw provider activity is deliberately **not** a source. `recordProviderActivity` is broader than turn liveness on purpose: the Codex app-server samples it above its own thread/turn filter, so a late `thread/tokenUsage/updated` for an already-closed turn reaches it and is then recorded as historical usage or buffered — returning before `applyNotification`, and therefore before any `turn_end` that could clear it. An earlier revision of this PR used that signal and would have stranded `working` on an idle chat.

Inbox ownership still projects `working` on its own, so an unsettled delivery does not flicker to idle when one turn closes.

**A stuck flag cannot pin "Working" indefinitely.** If a provider dies mid-turn without emitting `turn_end`, `lastActivity` stops advancing, the idle sweep suspends the session at the existing `idle_timeout + working_grace` hard cap, and the withdrawal path drops turn liveness with the projection. To be precise about the bound rather than reassuring: with shipped defaults (`idle_timeout` 300s, `working_grace_seconds` 43200s) that cap is about 12 hours, so this bounds the failure — it does not make it short.

## Tests

- **regression** — a provider turn with no owned inbox delivery projects `working`, then returns to `idle` at `turn_end`. Verified to fail on the old inbox-only one-liner.
- **out-of-turn traffic** — after a turn closes, a late `recordProviderActivity()` plus the `token_usage` event it carries leaves the chat idle. Verified to fail on the superseded activity-based signal.
- **provider boundary** — an adapter-backed test drives the real Codex `runTurn` state machine through `turn.started` → `turn.completed` with no item events at all: the boundary signal fires first, and nothing displayable follows it. Verified to fail when the `turn.started` call is removed.
- **post-result ordering** — the Claude handler is driven through `running` → `result(success)` → `idle`, asserting exactly one turn opening. Verified to reproduce `turn_start → turn_end → turn_start` when the per-message hook is restored.
- **guard** — `turn_end` while an owned delivery is still unsettled keeps the chat `working`.

`packages/qa/cases/runtime/provider-owned-turn-status.md` covers the live path per the AGENTS.md testing rule.

`pnpm check` and client `typecheck` exit 0 (real exit codes); client suite green.

## Scope

Client-only. No schema, wire-format or server change; the server already reads the per-chat runtime it is now told the truth about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
