### PR TITLE
feat(status): explain an idle chat that is parked on background work

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -690,7 +690,10 @@ describe("AgentSlot", () => {
     expect(session.noteBindRecoveryComplete).not.toHaveBeenCalled();
     expect(connection.reportSessionState).toHaveBeenCalledWith("agent-1", "chat-1", "active");
     expect(connection.reportSessionState).toHaveBeenCalledWith("agent-1", "chat-evicted", "suspended");
-    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-1", "working");
+    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-1", {
+      runtimeState: "working",
+      backgroundWork: false,
+    });
     expect(connection.reportRuntimeState).toHaveBeenCalledWith("agent-1", "working");
     expect(connection.sendSessionReconcile).toHaveBeenCalledWith("agent-1", ["chat-1", "chat-2"]);
 
@@ -717,7 +720,7 @@ describe("AgentSlot", () => {
     onRuntimeStateChange("blocked");
     onSessionEvent("chat-callback", { type: "error", message: "oops" });
     await confirmSessionEvent("chat-callback", { type: "error", message: "oops" });
-    onSessionRuntimeChange("chat-callback", "error");
+    onSessionRuntimeChange("chat-callback", { runtimeState: "error", backgroundWork: false });
 
     expect(connection.sendInboxAck).toHaveBeenCalledWith(123, "agent-1");
     expect(connection.reportSessionState).toHaveBeenCalledWith("agent-1", "chat-callback", "suspended");
@@ -730,7 +733,10 @@ describe("AgentSlot", () => {
       type: "error",
       message: "oops",
     });
-    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-callback", "error");
+    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-callback", {
+      runtimeState: "error",
+      backgroundWork: false,
+    });
 
     connection.emit("session:reconcile:result", {
       agentId: "other-agent",
@@ -1248,9 +1254,18 @@ describe("AgentSlot", () => {
     expect(vi.mocked(sdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(1);
     expect(connection.reportSessionState).toHaveBeenCalledWith("agent-1", "chat-1", "active");
     expect(connection.reportSessionState).not.toHaveBeenCalledWith("agent-1", "chat-evicted", "suspended");
-    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-1", "working");
-    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-2", "idle");
-    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-hidden-session", "idle");
+    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-1", {
+      runtimeState: "working",
+      backgroundWork: false,
+    });
+    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-2", {
+      runtimeState: "idle",
+      backgroundWork: false,
+    });
+    expect(connection.reportSessionRuntime).toHaveBeenCalledWith("agent-1", "chat-hidden-session", {
+      runtimeState: "idle",
+      backgroundWork: false,
+    });
     expect(connection.reportSessionState).not.toHaveBeenCalledWith("agent-1", "chat-hidden-session", "suspended");
 
     const reconcile = Reflect.get(slot, "reconcileNow");

--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -252,7 +252,7 @@ describe("ClientConnection — WebSocket edge coverage", () => {
 
     connection.reportSessionState("agent-1", "chat-1", "active");
     connection.reportRuntimeState("agent-1", "working");
-    connection.reportSessionRuntime("agent-1", "chat-1", "working");
+    connection.reportSessionRuntime("agent-1", "chat-1", { runtimeState: "working", backgroundWork: false });
     connection.reportSessionEvent("agent-1", "chat-1", {
       kind: "error",
       payload: { source: "runtime", message: "still handshaking" },
@@ -281,7 +281,7 @@ describe("ClientConnection — WebSocket edge coverage", () => {
 
     connection.reportSessionState("agent-1", "chat-1", "active");
     connection.reportRuntimeState("agent-1", "working");
-    connection.reportSessionRuntime("agent-1", "chat-1", "working");
+    connection.reportSessionRuntime("agent-1", "chat-1", { runtimeState: "working", backgroundWork: false });
     connection.reportSessionEvent("agent-1", "chat-1", {
       kind: "error",
       payload: { source: "runtime", message: "before bind" },
@@ -317,7 +317,7 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     const start = socket.sent.length;
     connection.reportSessionState("agent-1", "chat-1", "active");
     connection.reportRuntimeState("agent-1", "working");
-    connection.reportSessionRuntime("agent-1", "chat-1", "working");
+    connection.reportSessionRuntime("agent-1", "chat-1", { runtimeState: "working", backgroundWork: false });
     connection.reportSessionEvent("agent-1", "chat-1", {
       kind: "error",
       payload: { source: "runtime", message: "after bind" },

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -55,6 +55,11 @@ describe("process-tree-probe pure helpers", () => {
   });
 });
 
+/** `sealBaseline` captures its snapshot fire-and-forget; drain that microtask. */
+async function flushBoundaryCapture(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("PsSubprocessProbe", () => {
   const daemonPid = 55;
   // chat-A provider (100) has a live watcher; chat-B provider (200) has none.
@@ -103,14 +108,13 @@ describe("PsSubprocessProbe", () => {
     // child. Reading that as "background task" would put the qualifier on
     // every idle chat on the machine — the opposite of what it is for.
     const mcpOnly = [`300  ${daemonPid} /opt/homebrew/bin/claude`, "301  300 npm exec momentic mcp --config /x.yaml"];
-    const env = async (): Promise<string> => "FIRST_TREE_CHAT_ID=chat-mcp /bin/claude";
     let rows = [...mcpOnly];
     const probe = new PsSubprocessProbe({
       log: silentLogger(),
       daemonPid,
       intervalMs: 1_000_000,
       runProcessSnapshot: async () => rows.join("\n"),
-      runEnvForPid: env,
+      runEnvForPid: async () => "FIRST_TREE_CHAT_ID=chat-mcp /bin/claude",
     });
 
     await probe.refresh();
@@ -119,8 +123,11 @@ describe("PsSubprocessProbe", () => {
     expect(probe.hasLiveSubprocess("chat-mcp")).toBe(true);
     expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(false);
 
-    // A turn launches a background watcher: a child the baseline never saw.
+    // A turn begins: the boundary snapshot records the MCP child as infrastructure.
     probe.sealBaseline("chat-mcp");
+    await flushBoundaryCapture();
+
+    // That turn launches a background watcher.
     rows = [...mcpOnly, "302  300 /bin/zsh", "303  302 sleep"];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(true);
@@ -132,14 +139,13 @@ describe("PsSubprocessProbe", () => {
     probe.stop();
   });
 
-  it("absorbs a startup MCP child that appears after the provider is first seen", async () => {
-    // The poll starts before any provider exists, so a scan can catch the
-    // `claude` process in the gap before its stdio MCP server spawns. Freezing
-    // the baseline on first sight would store nothing, and the MCP child
-    // arriving one scan later would read as background work for the rest of
-    // that provider's life — the very claim the baseline exists to prevent.
-    const chatId = "chat-startup-race";
-    let rows = [`600  ${daemonPid} /opt/homebrew/bin/claude`];
+  it("takes the baseline at the turn boundary, whenever the MCP child happened to start", async () => {
+    // The interleaving that defeats any scan-order rule: a scan lands while the
+    // provider is still alone, THEN its MCP server starts, and only then does a
+    // turn begin. "Observed before the turn" is true of that first scan and
+    // tells you nothing, because what it observed was incomplete.
+    const chatId = "chat-mcp-after-scan";
+    let rows = [`900  ${daemonPid} /opt/homebrew/bin/claude`];
     const probe = new PsSubprocessProbe({
       log: silentLogger(),
       daemonPid,
@@ -148,32 +154,25 @@ describe("PsSubprocessProbe", () => {
       runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
     });
 
-    // Scan 1: provider only, still starting up.
+    await probe.refresh(); // provider seen alone
+    rows = [`900  ${daemonPid} /opt/homebrew/bin/claude`, "901  900 npm exec momentic mcp"]; // MCP starts after
+    probe.sealBaseline(chatId); // …and only now does the first turn begin
+    await flushBoundaryCapture();
+
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
 
-    // Scan 2: the permanent MCP child has arrived, still before any turn.
-    rows = [`600  ${daemonPid} /opt/homebrew/bin/claude`, "601  600 npm exec momentic mcp"];
-    await probe.refresh();
-    expect(probe.hasLiveSubprocess(chatId)).toBe(true);
-    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
-
-    // The first turn closes the baseline: everything alive now is infrastructure.
-    probe.sealBaseline(chatId);
-    await probe.refresh();
-    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
-
-    // A task the turn launches is outside it.
-    rows = [`600  ${daemonPid} /opt/homebrew/bin/claude`, "601  600 npm exec momentic mcp", "602  600 /bin/zsh"];
+    // The boundary still lets real work through afterwards.
+    rows = [...rows, "902  900 /bin/zsh"];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
     probe.stop();
   });
 
   it("keeps reporting a background task that survives into a later turn", async () => {
-    // The baseline seals ONCE, at the first turn. Re-taking it at every turn
-    // start would absorb a task that outlived the previous turn and silence it
-    // — which is the exact case this feature exists to report.
+    // The boundary is taken once per provider. Re-taking it at every turn would
+    // absorb a task that outlived the previous turn and silence it — the exact
+    // case this feature exists to report.
     const chatId = "chat-survives";
     let rows = [`700  ${daemonPid} /opt/homebrew/bin/claude`, "701  700 npm exec momentic mcp"];
     const probe = new PsSubprocessProbe({
@@ -185,7 +184,7 @@ describe("PsSubprocessProbe", () => {
     });
     await probe.refresh();
     probe.sealBaseline(chatId);
-    await probe.refresh();
+    await flushBoundaryCapture();
 
     // Turn 1 launches a watcher that outlives it.
     rows = [...rows, "702  700 /bin/zsh"];
@@ -194,16 +193,16 @@ describe("PsSubprocessProbe", () => {
 
     // Turn 2 starts with that watcher still running: it must stay reported.
     probe.sealBaseline(chatId);
+    await flushBoundaryCapture();
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
     probe.stop();
   });
 
-  it("stays silent for a provider first observed after its session is already running", async () => {
-    // A provider whose first scan lands mid-turn cannot be told apart from one
-    // that always had those children, so its whole tree becomes the baseline.
-    // That under-reports until they exit — silence, not a false claim.
-    const chatId = "chat-late-first-scan";
+  it("claims nothing for a provider that has not reached a turn boundary", async () => {
+    // A replacement provider between turns has no boundary yet. Silence until
+    // its next turn, rather than guessing which of its children are its own.
+    const chatId = "chat-no-boundary-yet";
     const probe = new PsSubprocessProbe({
       log: silentLogger(),
       daemonPid,
@@ -214,69 +213,17 @@ describe("PsSubprocessProbe", () => {
         ),
       runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
     });
-    probe.sealBaseline(chatId);
     await probe.refresh();
     expect(probe.hasLiveSubprocess(chatId)).toBe(true);
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
     probe.stop();
   });
 
-  it("re-baselines when the provider process is replaced", async () => {
-    // Baselines are keyed by provider pid, so a restarted provider must not
-    // inherit the old one's children as its session infrastructure.
-    let rows = [`400  ${daemonPid} /opt/homebrew/bin/claude`, "401  400 npm exec momentic mcp"];
-    const probe = new PsSubprocessProbe({
-      log: silentLogger(),
-      daemonPid,
-      intervalMs: 1_000_000,
-      runProcessSnapshot: async () => rows.join("\n"),
-      runEnvForPid: async () => "FIRST_TREE_CHAT_ID=chat-restart /bin/claude",
-    });
-    await probe.refresh();
-    probe.sealBaseline("chat-restart");
-    await probe.refresh();
-    expect(probe.hasSessionSpawnedSubprocess("chat-restart")).toBe(false);
-
-    // New provider process for the same chat: its own startup window, so the
-    // replacement's MCP child must not be read as work the session launched.
-    rows = [`500  ${daemonPid} /opt/homebrew/bin/claude`, "501  500 npm exec momentic mcp"];
-    await probe.refresh();
-    expect(probe.hasSessionSpawnedSubprocess("chat-restart")).toBe(false);
-    probe.stop();
-  });
-
-  it("gives a provider first seen after the seal request its own startup window", async () => {
-    // The first turn can begin before any scan has seen the provider. Sealing
-    // on that first sighting stores whatever exists at that instant — possibly
-    // nothing — and the MCP child arriving a tick later then reads as work for
-    // the provider's whole life.
-    const chatId = "chat-turn-before-scan";
-    let rows = [`900  ${daemonPid} /opt/homebrew/bin/claude`];
-    const probe = new PsSubprocessProbe({
-      log: silentLogger(),
-      daemonPid,
-      intervalMs: 1_000_000,
-      runProcessSnapshot: async () => rows.join("\n"),
-      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
-    });
-
-    probe.sealBaseline(chatId); // the turn starts first
-    await probe.refresh(); // …and only now is the provider seen at all
-    rows = [`900  ${daemonPid} /opt/homebrew/bin/claude`, "901  900 npm exec momentic mcp"];
-    await probe.refresh(); // its MCP server appears during the grace interval
-    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
-
-    // The window is one interval, not forever: work after it still reports.
-    rows = [...rows, "902  900 /bin/zsh"];
-    await probe.refresh();
-    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
-    probe.stop();
-  });
-
-  it("gives a seamless replacement provider its own startup window", async () => {
-    // The chat stays sealed across a provider restart (it never loses a live
-    // provider), so a replacement pid would otherwise be created and sealed in
-    // the same scan — an empty baseline, and its startup MCP child outside it.
+  it("gives a seamless replacement provider its own boundary at the next turn", async () => {
+    // The chat never loses a live provider across a restart, so a chat-level
+    // seal would never re-arm. Baselines are per pid and taken at a boundary,
+    // so the replacement gets its own — including when it is seen before its
+    // MCP child exists.
     const chatId = "chat-seamless-replace";
     let rows = [`1000 ${daemonPid} /opt/homebrew/bin/claude`, "1001 1000 npm exec momentic mcp"];
     const probe = new PsSubprocessProbe({
@@ -288,13 +235,17 @@ describe("PsSubprocessProbe", () => {
     });
     await probe.refresh();
     probe.sealBaseline(chatId);
+    await flushBoundaryCapture();
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
 
-    // The provider is replaced between scans, seen before its MCP child.
+    // Replaced between scans, observed before its MCP child.
     rows = [`1100 ${daemonPid} /opt/homebrew/bin/claude`];
     await probe.refresh();
     rows = [`1100 ${daemonPid} /opt/homebrew/bin/claude`, "1101 1100 npm exec momentic mcp"];
+    probe.sealBaseline(chatId); // the next turn on the new provider
+    await flushBoundaryCapture();
+
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
 

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -242,6 +242,34 @@ describe("PsSubprocessProbe", () => {
     probe.stop();
   });
 
+  it("keeps work from turn 1 when a second turn opens before the next scan", async () => {
+    // Two turns can easily run inside one 10s poll interval. If a later
+    // candidate displaced the earlier one, the watcher turn 1 launched would
+    // predate the surviving boundary and read as infrastructure for its life.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const chatId = "chat-two-turns";
+    let rows = [proc(2100, daemonPid, 120, "/opt/homebrew/bin/claude"), proc(2101, 2100, 119, "npm exec momentic mcp")];
+    const probe = probeOver(() => rows, chatId);
+    await probe.refresh();
+
+    probe.noteTurnBoundary(chatId); // turn 1 at T0
+    vi.setSystemTime(T0 + 2_000);
+    rows = [...rows, proc(2102, 2100, 0, "/bin/zsh")]; // …which launches a watcher
+    vi.setSystemTime(T0 + 5_000);
+    probe.noteTurnBoundary(chatId); // turn 2, still before any scan
+
+    vi.setSystemTime(T0 + 30_000);
+    rows = [
+      proc(2100, daemonPid, 150, "/opt/homebrew/bin/claude"),
+      proc(2101, 2100, 149, "npm exec momentic mcp"),
+      proc(2102, 2100, 28, "/bin/zsh"),
+    ];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    probe.stop();
+  });
+
   it("takes a replacement provider's own first turn even before any scan sees it", async () => {
     // The ordering the poll cannot exclude: A leaves an unassigned candidate,
     // B replaces A, and B's first turn happens before any scan. If that turn

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -97,6 +97,60 @@ describe("PsSubprocessProbe", () => {
     probe.stop();
   });
 
+  it("does not call a long-lived stdio MCP server session-spawned work", async () => {
+    // The shape that made this distinction necessary: on a host running
+    // MCP-configured agents, EVERY provider has a permanent `npm exec … mcp`
+    // child. Reading that as "background task" would put the qualifier on
+    // every idle chat on the machine — the opposite of what it is for.
+    const mcpOnly = [`300  ${daemonPid} /opt/homebrew/bin/claude`, "301  300 npm exec momentic mcp --config /x.yaml"];
+    const env = async (): Promise<string> => "FIRST_TREE_CHAT_ID=chat-mcp /bin/claude";
+    let rows = [...mcpOnly];
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => rows.join("\n"),
+      runEnvForPid: env,
+    });
+
+    await probe.refresh();
+    // Broad predicate still true — the eviction deferral it feeds is meant to
+    // be conservative — but nothing this session started is running.
+    expect(probe.hasLiveSubprocess("chat-mcp")).toBe(true);
+    expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(false);
+
+    // A turn launches a background watcher: a child the baseline never saw.
+    rows = [...mcpOnly, "302  300 /bin/zsh", "303  302 sleep"];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(true);
+
+    // It finishes; the permanent MCP child alone must not keep the claim alive.
+    rows = [...mcpOnly];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(false);
+    probe.stop();
+  });
+
+  it("re-baselines when the provider process is replaced", async () => {
+    // Baselines are keyed by provider pid, so a restarted provider must not
+    // inherit the old one's children as its session infrastructure.
+    let rows = [`400  ${daemonPid} /opt/homebrew/bin/claude`, "401  400 npm exec momentic mcp"];
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => rows.join("\n"),
+      runEnvForPid: async () => "FIRST_TREE_CHAT_ID=chat-restart /bin/claude",
+    });
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess("chat-restart")).toBe(false);
+
+    rows = [`500  ${daemonPid} /opt/homebrew/bin/claude`, "501  500 npm exec momentic mcp"];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess("chat-restart")).toBe(false);
+    probe.stop();
+  });
+
   it("falls back to no-live-work when the process scan fails", async () => {
     const probe = new PsSubprocessProbe({
       log: silentLogger(),
@@ -109,6 +163,7 @@ describe("PsSubprocessProbe", () => {
     });
     await probe.refresh();
     expect(probe.hasLiveSubprocess("chat-A")).toBe(false);
+    expect(probe.hasSessionSpawnedSubprocess("chat-A")).toBe(false);
     probe.stop();
   });
 });

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -242,28 +242,34 @@ describe("PsSubprocessProbe", () => {
     probe.stop();
   });
 
-  it("keeps the first in-turn event's boundary when the same turn emits more", async () => {
-    // Every assistant/thinking/tool event reaches noteTurnBoundary, so a later
-    // event in the SAME turn must not move the boundary past a watcher an
-    // earlier one already launched.
+  it("takes a replacement provider's own first turn even before any scan sees it", async () => {
+    // The ordering the poll cannot exclude: A leaves an unassigned candidate,
+    // B replaces A, and B's first turn happens before any scan. If that turn
+    // could not supersede A's candidate, B would never get a boundary and all
+    // of its work would stay hidden for its life.
     vi.useFakeTimers();
     vi.setSystemTime(T0);
-    const chatId = "chat-repeat-events";
-    let rows = [proc(1200, daemonPid, 120, "/opt/homebrew/bin/claude"), proc(1201, 1200, 119, "npm exec momentic mcp")];
+    const chatId = "chat-b-first-turn";
+    let rows = [proc(1900, daemonPid, 300, "/opt/homebrew/bin/claude"), proc(1901, 1900, 299, "npm exec momentic mcp")];
     const probe = probeOver(() => rows, chatId);
     await probe.refresh();
-
-    probe.noteTurnBoundary(chatId); // first tool call of the turn, at T0
+    probe.noteTurnBoundary(chatId); // A's turn, assigned on the next scan
     vi.setSystemTime(T0 + 10_000);
-    rows = [...rows, proc(1202, 1200, 0, "/bin/zsh")]; // …which launches a watcher
+    await probe.refresh();
     vi.setSystemTime(T0 + 20_000);
-    probe.noteTurnBoundary(chatId); // a second event in the same turn
+    probe.noteTurnBoundary(chatId); // a later A turn, left unassigned
 
-    vi.setSystemTime(T0 + 60_000);
+    // B replaces A and takes its own first turn, with no scan in between.
+    vi.setSystemTime(T0 + 40_000);
+    probe.noteTurnBoundary(chatId);
+    rows = [proc(2000, daemonPid, 5, "/opt/homebrew/bin/claude"), proc(2001, 2000, 4, "npm exec momentic mcp")];
+
+    // B launches a watcher, and only now does a scan happen.
+    vi.setSystemTime(T0 + 80_000);
     rows = [
-      proc(1200, daemonPid, 180, "/opt/homebrew/bin/claude"),
-      proc(1201, 1200, 179, "npm exec momentic mcp"),
-      proc(1202, 1200, 50, "/bin/zsh"),
+      proc(2000, daemonPid, 45, "/opt/homebrew/bin/claude"),
+      proc(2001, 2000, 44, "npm exec momentic mcp"),
+      proc(2002, 2000, 30, "/bin/zsh"),
     ];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -245,6 +245,65 @@ describe("PsSubprocessProbe", () => {
     probe.stop();
   });
 
+  it("gives a provider first seen after the seal request its own startup window", async () => {
+    // The first turn can begin before any scan has seen the provider. Sealing
+    // on that first sighting stores whatever exists at that instant — possibly
+    // nothing — and the MCP child arriving a tick later then reads as work for
+    // the provider's whole life.
+    const chatId = "chat-turn-before-scan";
+    let rows = [`900  ${daemonPid} /opt/homebrew/bin/claude`];
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => rows.join("\n"),
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
+    });
+
+    probe.sealBaseline(chatId); // the turn starts first
+    await probe.refresh(); // …and only now is the provider seen at all
+    rows = [`900  ${daemonPid} /opt/homebrew/bin/claude`, "901  900 npm exec momentic mcp"];
+    await probe.refresh(); // its MCP server appears during the grace interval
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    // The window is one interval, not forever: work after it still reports.
+    rows = [...rows, "902  900 /bin/zsh"];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    probe.stop();
+  });
+
+  it("gives a seamless replacement provider its own startup window", async () => {
+    // The chat stays sealed across a provider restart (it never loses a live
+    // provider), so a replacement pid would otherwise be created and sealed in
+    // the same scan — an empty baseline, and its startup MCP child outside it.
+    const chatId = "chat-seamless-replace";
+    let rows = [`1000 ${daemonPid} /opt/homebrew/bin/claude`, "1001 1000 npm exec momentic mcp"];
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => rows.join("\n"),
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
+    });
+    await probe.refresh();
+    probe.sealBaseline(chatId);
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    // The provider is replaced between scans, seen before its MCP child.
+    rows = [`1100 ${daemonPid} /opt/homebrew/bin/claude`];
+    await probe.refresh();
+    rows = [`1100 ${daemonPid} /opt/homebrew/bin/claude`, "1101 1100 npm exec momentic mcp"];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    rows = [...rows, "1102 1100 /bin/zsh"];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    probe.stop();
+  });
+
   it("falls back to no-live-work when the process scan fails", async () => {
     const probe = new PsSubprocessProbe({
       log: silentLogger(),

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -1,40 +1,53 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildChildrenIndex,
   extractChatId,
   findProviderPids,
   hasDescendant,
   PsSubprocessProbe,
+  parseElapsedSeconds,
   parseProcessRows,
 } from "../runtime/process-tree-probe.js";
 import { silentLogger } from "./_logger-helpers.js";
 
 describe("process-tree-probe pure helpers", () => {
-  it("parses ps pid/ppid/comm rows and skips unparseable lines", () => {
-    const out = ["  100   55 /opt/homebrew/bin/claude", " 101  100 /bin/zsh", "garbage", "", "102 101 sleep"].join(
-      "\n",
-    );
+  it("parses ps pid/ppid/etime/comm rows and skips unparseable lines", () => {
+    const out = [
+      "  100   55 01:02:03 /opt/homebrew/bin/claude",
+      " 101  100    04:05 /bin/zsh",
+      "garbage",
+      "",
+      "102 101 2-03:04:05 sleep",
+      "103 101 not-a-time sleep",
+    ].join("\n");
     expect(parseProcessRows(out)).toEqual([
-      { pid: 100, ppid: 55, comm: "/opt/homebrew/bin/claude" },
-      { pid: 101, ppid: 100, comm: "/bin/zsh" },
-      { pid: 102, ppid: 101, comm: "sleep" },
+      { pid: 100, ppid: 55, elapsedSec: 3723, comm: "/opt/homebrew/bin/claude" },
+      { pid: 101, ppid: 100, elapsedSec: 245, comm: "/bin/zsh" },
+      { pid: 102, ppid: 101, elapsedSec: 183_845, comm: "sleep" },
     ]);
+  });
+
+  it("rejects an elapsed field that is not an elapsed time", () => {
+    expect(parseElapsedSeconds("04:05")).toBe(245);
+    expect(parseElapsedSeconds("2-03:04:05")).toBe(183_845);
+    expect(parseElapsedSeconds("/bin/zsh")).toBeNull();
+    expect(parseElapsedSeconds("")).toBeNull();
   });
 
   it("finds claude providers that are direct children of the daemon (macOS path + linux basename)", () => {
     const rows = [
-      { pid: 100, ppid: 55, comm: "/opt/homebrew/bin/claude" },
-      { pid: 200, ppid: 55, comm: "claude" },
-      { pid: 300, ppid: 55, comm: "/usr/bin/codex" },
-      { pid: 400, ppid: 99, comm: "claude" }, // not a direct child of the daemon
+      { pid: 100, ppid: 55, elapsedSec: 10, comm: "/opt/homebrew/bin/claude" },
+      { pid: 200, ppid: 55, elapsedSec: 10, comm: "claude" },
+      { pid: 300, ppid: 55, elapsedSec: 10, comm: "/usr/bin/codex" },
+      { pid: 400, ppid: 99, elapsedSec: 10, comm: "claude" }, // not a direct child of the daemon
     ];
     expect(findProviderPids(rows, 55).sort((a, b) => a - b)).toEqual([100, 200]);
   });
 
   it("detects a live descendant via a direct child, and its absence", () => {
     const idx = buildChildrenIndex([
-      { pid: 101, ppid: 100, comm: "/bin/zsh" },
-      { pid: 102, ppid: 101, comm: "sleep" },
+      { pid: 101, ppid: 100, elapsedSec: 5, comm: "/bin/zsh" },
+      { pid: 102, ppid: 101, elapsedSec: 5, comm: "sleep" },
     ]);
     expect(hasDescendant(100, idx)).toBe(true);
     expect(hasDescendant(999, idx)).toBe(false);
@@ -55,30 +68,45 @@ describe("process-tree-probe pure helpers", () => {
   });
 });
 
-/** `sealBaseline` captures its snapshot fire-and-forget; drain that microtask. */
-async function flushBoundaryCapture(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 describe("PsSubprocessProbe", () => {
   const daemonPid = 55;
-  // chat-A provider (100) has a live watcher; chat-B provider (200) has none.
-  const snapshot = [
-    `100  ${daemonPid} /opt/homebrew/bin/claude`,
-    "101  100 /bin/zsh",
-    "102  101 sleep",
-    `200  ${daemonPid} /opt/homebrew/bin/claude`,
-  ].join("\n");
-  const envForPid = async (pid: number): Promise<string> =>
-    pid === 100 ? "FIRST_TREE_CHAT_ID=chat-A /bin/claude" : "FIRST_TREE_CHAT_ID=chat-B /bin/claude";
+  const T0 = new Date("2026-09-02T00:00:00Z").getTime();
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * A `pid ppid etime comm` row. `ageSec` is the process's age at the moment of
+   * the scan — the datum the probe classifies on, so every case here states it
+   * explicitly rather than letting wall-clock timing decide.
+   */
+  const proc = (pid: number, ppid: number, ageSec: number, comm: string): string =>
+    `${pid} ${ppid} ${Math.floor(ageSec / 60)}:${String(ageSec % 60).padStart(2, "0")} ${comm}`;
+
+  function probeOver(rows: () => string[], chatId: string): PsSubprocessProbe {
+    return new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => rows().join("\n"),
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
+    });
+  }
 
   it("marks only providers that currently have a live descendant", async () => {
+    const rows = [
+      proc(100, daemonPid, 60, "/opt/homebrew/bin/claude"),
+      proc(101, 100, 50, "/bin/zsh"),
+      proc(200, daemonPid, 60, "/opt/homebrew/bin/claude"),
+    ];
     const probe = new PsSubprocessProbe({
       log: silentLogger(),
       daemonPid,
       intervalMs: 1_000_000,
-      runProcessSnapshot: async () => snapshot,
-      runEnvForPid: envForPid,
+      runProcessSnapshot: async () => rows.join("\n"),
+      runEnvForPid: async (pid) =>
+        pid === 100 ? "FIRST_TREE_CHAT_ID=chat-A /bin/claude" : "FIRST_TREE_CHAT_ID=chat-B /bin/claude",
     });
     await probe.refresh();
     expect(probe.hasLiveSubprocess("chat-A")).toBe(true);
@@ -87,171 +115,180 @@ describe("PsSubprocessProbe", () => {
     probe.stop();
   });
 
-  it("attributes providers from NUL-separated env (Linux /proc form)", async () => {
-    const probe = new PsSubprocessProbe({
-      log: silentLogger(),
-      daemonPid,
-      intervalMs: 1_000_000,
-      runProcessSnapshot: async () => snapshot,
-      runEnvForPid: async (pid) =>
-        ["FIRST_TREE_HOME=/x", `FIRST_TREE_CHAT_ID=${pid === 100 ? "chat-A" : "chat-B"}`, ""].join("\0"),
-    });
-    await probe.refresh();
-    expect(probe.hasLiveSubprocess("chat-A")).toBe(true);
-    expect(probe.hasLiveSubprocess("chat-B")).toBe(false);
-    probe.stop();
-  });
-
   it("does not call a long-lived stdio MCP server session-spawned work", async () => {
-    // The shape that made this distinction necessary: on a host running
-    // MCP-configured agents, EVERY provider has a permanent `npm exec … mcp`
-    // child. Reading that as "background task" would put the qualifier on
-    // every idle chat on the machine — the opposite of what it is for.
-    const mcpOnly = [`300  ${daemonPid} /opt/homebrew/bin/claude`, "301  300 npm exec momentic mcp --config /x.yaml"];
-    let rows = [...mcpOnly];
-    const probe = new PsSubprocessProbe({
-      log: silentLogger(),
-      daemonPid,
-      intervalMs: 1_000_000,
-      runProcessSnapshot: async () => rows.join("\n"),
-      runEnvForPid: async () => "FIRST_TREE_CHAT_ID=chat-mcp /bin/claude",
-    });
+    // Every provider on an MCP-configured host has a permanent `npm exec … mcp`
+    // child. Reading that as "background task" would put the qualifier on every
+    // idle chat on the machine — the opposite of what it is for.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const chatId = "chat-mcp";
+    let rows = [proc(300, daemonPid, 120, "/opt/homebrew/bin/claude"), proc(301, 300, 119, "npm exec momentic mcp")];
+    const probe = probeOver(() => rows, chatId);
 
     await probe.refresh();
-    // Broad predicate still true — the eviction deferral it feeds is meant to
-    // be conservative — but nothing this session started is running.
-    expect(probe.hasLiveSubprocess("chat-mcp")).toBe(true);
-    expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(false);
-
-    // A turn begins: the boundary snapshot records the MCP child as infrastructure.
-    probe.sealBaseline("chat-mcp");
-    await flushBoundaryCapture();
-
-    // That turn launches a background watcher.
-    rows = [...mcpOnly, "302  300 /bin/zsh", "303  302 sleep"];
-    await probe.refresh();
-    expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(true);
-
-    // It finishes; the permanent MCP child alone must not keep the claim alive.
-    rows = [...mcpOnly];
-    await probe.refresh();
-    expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(false);
-    probe.stop();
-  });
-
-  it("takes the baseline at the turn boundary, whenever the MCP child happened to start", async () => {
-    // The interleaving that defeats any scan-order rule: a scan lands while the
-    // provider is still alone, THEN its MCP server starts, and only then does a
-    // turn begin. "Observed before the turn" is true of that first scan and
-    // tells you nothing, because what it observed was incomplete.
-    const chatId = "chat-mcp-after-scan";
-    let rows = [`900  ${daemonPid} /opt/homebrew/bin/claude`];
-    const probe = new PsSubprocessProbe({
-      log: silentLogger(),
-      daemonPid,
-      intervalMs: 1_000_000,
-      runProcessSnapshot: async () => rows.join("\n"),
-      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
-    });
-
-    await probe.refresh(); // provider seen alone
-    rows = [`900  ${daemonPid} /opt/homebrew/bin/claude`, "901  900 npm exec momentic mcp"]; // MCP starts after
-    probe.sealBaseline(chatId); // …and only now does the first turn begin
-    await flushBoundaryCapture();
-
-    await probe.refresh();
+    expect(probe.hasLiveSubprocess(chatId)).toBe(true);
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
 
-    // The boundary still lets real work through afterwards.
-    rows = [...rows, "902  900 /bin/zsh"];
+    probe.noteTurnBoundary(chatId); // a turn begins at T0
+    vi.setSystemTime(T0 + 30_000); // the next scan is 30s later
+    rows = [
+      proc(300, daemonPid, 150, "/opt/homebrew/bin/claude"),
+      proc(301, 300, 149, "npm exec momentic mcp"),
+      proc(302, 300, 20, "/bin/zsh"), // the watcher the turn launched
+      proc(303, 302, 20, "sleep"),
+    ];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+
+    // The watcher exits; the permanent MCP child must not keep the claim alive.
+    vi.setSystemTime(T0 + 60_000);
+    rows = [proc(300, daemonPid, 180, "/opt/homebrew/bin/claude"), proc(301, 300, 179, "npm exec momentic mcp")];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+    probe.stop();
+  });
+
+  it("classifies by process age, not by when the scan happens to run", async () => {
+    // The interleaving that defeats every observation-order rule: a scan lands
+    // while the provider is still alone, its MCP child starts afterwards, and
+    // only then does the first turn begin. Ages settle it whatever the scans did.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const chatId = "chat-late-mcp";
+    let rows = [proc(900, daemonPid, 2, "/opt/homebrew/bin/claude")];
+    const probe = probeOver(() => rows, chatId);
+
+    await probe.refresh(); // provider observed alone — an incomplete picture
+    vi.setSystemTime(T0 + 5_000);
+    rows = [proc(900, daemonPid, 7, "/opt/homebrew/bin/claude"), proc(901, 900, 4, "npm exec momentic mcp")];
+    probe.noteTurnBoundary(chatId); // MCP is up by the time the turn begins
+    vi.setSystemTime(T0 + 40_000);
+    rows = [proc(900, daemonPid, 42, "/opt/homebrew/bin/claude"), proc(901, 900, 39, "npm exec momentic mcp")];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+    probe.stop();
+  });
+
+  it("reports a watcher even when the scan proving it runs long afterwards", async () => {
+    // Nothing about the boundary is captured asynchronously, so a scan that
+    // completes well after the work began still classifies it correctly — the
+    // false negative a fire-and-forget snapshot had.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const chatId = "chat-late-scan";
+    let rows = [proc(950, daemonPid, 120, "/opt/homebrew/bin/claude"), proc(951, 950, 119, "npm exec momentic mcp")];
+    const probe = probeOver(() => rows, chatId);
+    await probe.refresh();
+    probe.noteTurnBoundary(chatId);
+
+    vi.setSystemTime(T0 + 120_000); // two minutes of no scans at all
+    rows = [
+      proc(950, daemonPid, 240, "/opt/homebrew/bin/claude"),
+      proc(951, 950, 239, "npm exec momentic mcp"),
+      proc(952, 950, 118, "/bin/zsh"), // started right after the boundary
+    ];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
     probe.stop();
   });
 
   it("keeps reporting a background task that survives into a later turn", async () => {
-    // The boundary is taken once per provider. Re-taking it at every turn would
-    // absorb a task that outlived the previous turn and silence it — the exact
-    // case this feature exists to report.
+    // The provider keeps its first boundary, so a task that outlived turn 1 is
+    // not reclassified as infrastructure when turn 2 opens.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
     const chatId = "chat-survives";
-    let rows = [`700  ${daemonPid} /opt/homebrew/bin/claude`, "701  700 npm exec momentic mcp"];
-    const probe = new PsSubprocessProbe({
-      log: silentLogger(),
-      daemonPid,
-      intervalMs: 1_000_000,
-      runProcessSnapshot: async () => rows.join("\n"),
-      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
-    });
+    let rows = [proc(700, daemonPid, 120, "/opt/homebrew/bin/claude"), proc(701, 700, 119, "npm exec momentic mcp")];
+    const probe = probeOver(() => rows, chatId);
     await probe.refresh();
-    probe.sealBaseline(chatId);
-    await flushBoundaryCapture();
+    probe.noteTurnBoundary(chatId);
 
-    // Turn 1 launches a watcher that outlives it.
-    rows = [...rows, "702  700 /bin/zsh"];
+    vi.setSystemTime(T0 + 30_000);
+    rows = [
+      proc(700, daemonPid, 150, "/opt/homebrew/bin/claude"),
+      proc(701, 700, 149, "npm exec momentic mcp"),
+      proc(702, 700, 20, "/bin/zsh"),
+    ];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
 
-    // Turn 2 starts with that watcher still running: it must stay reported.
-    probe.sealBaseline(chatId);
-    await flushBoundaryCapture();
+    vi.setSystemTime(T0 + 90_000);
+    probe.noteTurnBoundary(chatId); // turn 2, with the watcher still running
+    rows = [
+      proc(700, daemonPid, 210, "/opt/homebrew/bin/claude"),
+      proc(701, 700, 209, "npm exec momentic mcp"),
+      proc(702, 700, 80, "/bin/zsh"),
+    ];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
     probe.stop();
   });
 
   it("claims nothing for a provider that has not reached a turn boundary", async () => {
-    // A replacement provider between turns has no boundary yet. Silence until
-    // its next turn, rather than guessing which of its children are its own.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
     const chatId = "chat-no-boundary-yet";
-    const probe = new PsSubprocessProbe({
-      log: silentLogger(),
-      daemonPid,
-      intervalMs: 1_000_000,
-      runProcessSnapshot: async () =>
-        [`800  ${daemonPid} /opt/homebrew/bin/claude`, "801  800 npm exec momentic mcp", "802  800 /bin/zsh"].join(
-          "\n",
-        ),
-      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
-    });
+    const probe = probeOver(
+      () => [
+        proc(800, daemonPid, 60, "/opt/homebrew/bin/claude"),
+        proc(801, 800, 59, "npm exec momentic mcp"),
+        proc(802, 800, 5, "/bin/zsh"),
+      ],
+      chatId,
+    );
     await probe.refresh();
     expect(probe.hasLiveSubprocess(chatId)).toBe(true);
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
     probe.stop();
   });
 
-  it("gives a seamless replacement provider its own boundary at the next turn", async () => {
-    // The chat never loses a live provider across a restart, so a chat-level
-    // seal would never re-arm. Baselines are per pid and taken at a boundary,
-    // so the replacement gets its own — including when it is seen before its
-    // MCP child exists.
-    const chatId = "chat-seamless-replace";
-    let rows = [`1000 ${daemonPid} /opt/homebrew/bin/claude`, "1001 1000 npm exec momentic mcp"];
+  it("gives a replacement provider its own boundary, with no scan in between", async () => {
+    // The chat keeps a live provider across the swap, so a chat-level seal
+    // would never re-arm. A boundary older than the process cannot belong to
+    // it, so the replacement waits for its own turn.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const chatId = "chat-replace";
+    let rows = [proc(1000, daemonPid, 300, "/opt/homebrew/bin/claude"), proc(1001, 1000, 299, "npm exec momentic mcp")];
+    const probe = probeOver(() => rows, chatId);
+    await probe.refresh();
+    probe.noteTurnBoundary(chatId);
+    vi.setSystemTime(T0 + 30_000);
+    rows = [proc(1000, daemonPid, 330, "/opt/homebrew/bin/claude"), proc(1001, 1000, 329, "npm exec momentic mcp")];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    // Replaced with no scan in between: the new pid is younger than the old
+    // boundary, so it does not adopt it and claims nothing yet.
+    vi.setSystemTime(T0 + 60_000);
+    rows = [proc(1100, daemonPid, 2, "/opt/homebrew/bin/claude"), proc(1101, 1100, 1, "npm exec momentic mcp")];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    // Its own first turn, then a watcher it launches.
+    probe.noteTurnBoundary(chatId);
+    vi.setSystemTime(T0 + 120_000);
+    rows = [
+      proc(1100, daemonPid, 62, "/opt/homebrew/bin/claude"),
+      proc(1101, 1100, 61, "npm exec momentic mcp"),
+      proc(1102, 1100, 30, "/bin/zsh"),
+    ];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    probe.stop();
+  });
+
+  it("attributes providers from NUL-separated env (Linux /proc form)", async () => {
     const probe = new PsSubprocessProbe({
       log: silentLogger(),
       daemonPid,
       intervalMs: 1_000_000,
-      runProcessSnapshot: async () => rows.join("\n"),
-      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
+      runProcessSnapshot: async () =>
+        [proc(100, daemonPid, 60, "/opt/homebrew/bin/claude"), proc(101, 100, 50, "/bin/zsh")].join("\n"),
+      runEnvForPid: async () => ["FIRST_TREE_HOME=/x", "FIRST_TREE_CHAT_ID=chat-A", ""].join("\0"),
     });
     await probe.refresh();
-    probe.sealBaseline(chatId);
-    await flushBoundaryCapture();
-    await probe.refresh();
-    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
-
-    // Replaced between scans, observed before its MCP child.
-    rows = [`1100 ${daemonPid} /opt/homebrew/bin/claude`];
-    await probe.refresh();
-    rows = [`1100 ${daemonPid} /opt/homebrew/bin/claude`, "1101 1100 npm exec momentic mcp"];
-    probe.sealBaseline(chatId); // the next turn on the new provider
-    await flushBoundaryCapture();
-
-    await probe.refresh();
-    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
-
-    rows = [...rows, "1102 1100 /bin/zsh"];
-    await probe.refresh();
-    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    expect(probe.hasLiveSubprocess("chat-A")).toBe(true);
     probe.stop();
   });
 
@@ -263,7 +300,7 @@ describe("PsSubprocessProbe", () => {
       runProcessSnapshot: async () => {
         throw new Error("ps unavailable");
       },
-      runEnvForPid: envForPid,
+      runEnvForPid: async () => "FIRST_TREE_CHAT_ID=chat-A /bin/claude",
     });
     await probe.refresh();
     expect(probe.hasLiveSubprocess("chat-A")).toBe(false);

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -270,6 +270,92 @@ describe("PsSubprocessProbe", () => {
     probe.stop();
   });
 
+  it("classifies against the window ps was actually sampled in, not the scan's start", async () => {
+    // `ps` can take seconds to return. Deriving both start bounds from one
+    // timestamp taken BEFORE the command runs shifts them backwards by that
+    // delay — enough for a replacement to accept a boundary that predates it
+    // and then report its own permanent MCP child as work.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const chatId = "chat-slow-ps";
+    let rows: string[] = [];
+    let holdNext: { promise: Promise<string>; resolve: () => void } | null = null;
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => {
+        if (!holdNext) return rows.join("\n");
+        const held = holdNext;
+        holdNext = null;
+        return held.promise;
+      },
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
+    });
+
+    rows = [proc(1500, daemonPid, 300, "/opt/homebrew/bin/claude"), proc(1501, 1500, 299, "npm exec momentic mcp")];
+    await probe.refresh();
+    probe.noteTurnBoundary(chatId); // predecessor boundary at T0
+
+    // A scan starts at T0+6s; its `ps` does not return until T0+16s, by which
+    // point the replacement provider (started at T0+5s) is 11s old.
+    vi.setSystemTime(T0 + 6_000);
+    let resolveHeld!: (value: string) => void;
+    const heldPromise = new Promise<string>((resolve) => {
+      resolveHeld = resolve;
+    });
+    holdNext = { promise: heldPromise, resolve: () => resolveHeld("") };
+    const pending = probe.refresh();
+    vi.setSystemTime(T0 + 16_000);
+    resolveHeld(
+      [proc(1600, daemonPid, 11, "/opt/homebrew/bin/claude"), proc(1601, 1600, 10, "npm exec momentic mcp")].join("\n"),
+    );
+    await pending;
+
+    // Measured from the scan's start the provider looks born at T0-5s and the
+    // predecessor's boundary looks valid for it; measured from when `ps`
+    // actually sampled, it does not. The damage shows on the NEXT ordinary
+    // scan, where a wrongly adopted boundary turns the replacement's permanent
+    // MCP child into "work" — so the assertion has to look one scan further.
+    vi.setSystemTime(T0 + 20_000);
+    rows = [proc(1600, daemonPid, 15, "/opt/homebrew/bin/claude"), proc(1601, 1600, 14, "npm exec momentic mcp")];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+    probe.stop();
+  });
+
+  it("lets a replacement recover with its own turn after rejecting a stale boundary", async () => {
+    // A pending timestamp a provider rejects as older than itself must not
+    // linger: it would block every later turn from being recorded, and the
+    // replacement's work would stay hidden for its whole life.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const chatId = "chat-recover";
+    let rows = [proc(1700, daemonPid, 300, "/opt/homebrew/bin/claude"), proc(1701, 1700, 299, "npm exec momentic mcp")];
+    const probe = probeOver(() => rows, chatId);
+    await probe.refresh();
+    probe.noteTurnBoundary(chatId); // predecessor boundary at T0
+
+    // Replaced; the scan rejects the stale boundary for the new provider.
+    vi.setSystemTime(T0 + 5_000);
+    rows = [proc(1800, daemonPid, 2, "/opt/homebrew/bin/claude"), proc(1801, 1800, 1, "npm exec momentic mcp")];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    // Its own first turn, then a watcher it launches: both must register.
+    vi.setSystemTime(T0 + 20_000);
+    probe.noteTurnBoundary(chatId);
+    vi.setSystemTime(T0 + 60_000);
+    rows = [
+      proc(1800, daemonPid, 57, "/opt/homebrew/bin/claude"),
+      proc(1801, 1800, 56, "npm exec momentic mcp"),
+      proc(1802, 1800, 30, "/bin/zsh"),
+    ];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    probe.stop();
+  });
+
   it("does not let a same-second replacement adopt its predecessor's boundary", async () => {
     // One-second resolution means a provider born in the same second as the
     // previous boundary cannot prove the boundary came after it started. Fail

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildChildrenIndex,
+  defaultProcessSnapshot,
   extractChatId,
   findProviderPids,
   hasDescendant,
@@ -65,6 +66,23 @@ describe("process-tree-probe pure helpers", () => {
     );
     // The value must not bleed into the next NUL-separated entry.
     expect(extractChatId(environ)).toBe("f93566d9-00c8");
+  });
+});
+
+describe("the real ps adapter", () => {
+  it("produces rows this parser accepts, including our own process", async () => {
+    // Every other test here injects a fixture, so none of them can see the
+    // adapter and the parser disagreeing about columns. That mismatch is
+    // silent and total: no row parses, both result sets publish empty, and the
+    // idle-suspend protection that predates this feature dies with it. This
+    // runs the actual command instead.
+    const rows = parseProcessRows(await defaultProcessSnapshot());
+    expect(rows.length).toBeGreaterThan(0);
+    const self = rows.find((row) => row.pid === process.pid);
+    expect(self, "this process should appear in its own ps output").toBeTruthy();
+    expect(self?.ppid).toBe(process.ppid);
+    expect(self?.elapsedSec).toBeGreaterThanOrEqual(0);
+    expect(self?.comm.length).toBeGreaterThan(0);
   });
 });
 
@@ -221,6 +239,55 @@ describe("PsSubprocessProbe", () => {
     ];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    probe.stop();
+  });
+
+  it("keeps the first in-turn event's boundary when the same turn emits more", async () => {
+    // Every assistant/thinking/tool event reaches noteTurnBoundary, so a later
+    // event in the SAME turn must not move the boundary past a watcher an
+    // earlier one already launched.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const chatId = "chat-repeat-events";
+    let rows = [proc(1200, daemonPid, 120, "/opt/homebrew/bin/claude"), proc(1201, 1200, 119, "npm exec momentic mcp")];
+    const probe = probeOver(() => rows, chatId);
+    await probe.refresh();
+
+    probe.noteTurnBoundary(chatId); // first tool call of the turn, at T0
+    vi.setSystemTime(T0 + 10_000);
+    rows = [...rows, proc(1202, 1200, 0, "/bin/zsh")]; // …which launches a watcher
+    vi.setSystemTime(T0 + 20_000);
+    probe.noteTurnBoundary(chatId); // a second event in the same turn
+
+    vi.setSystemTime(T0 + 60_000);
+    rows = [
+      proc(1200, daemonPid, 180, "/opt/homebrew/bin/claude"),
+      proc(1201, 1200, 179, "npm exec momentic mcp"),
+      proc(1202, 1200, 50, "/bin/zsh"),
+    ];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    probe.stop();
+  });
+
+  it("does not let a same-second replacement adopt its predecessor's boundary", async () => {
+    // One-second resolution means a provider born in the same second as the
+    // previous boundary cannot prove the boundary came after it started. Fail
+    // closed: wait for a boundary that definitely does.
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const chatId = "chat-same-second";
+    let rows = [proc(1300, daemonPid, 300, "/opt/homebrew/bin/claude"), proc(1301, 1300, 299, "npm exec momentic mcp")];
+    const probe = probeOver(() => rows, chatId);
+    await probe.refresh();
+    probe.noteTurnBoundary(chatId); // predecessor boundary at T0
+
+    // Replacement starts ~0.5s later, its MCP child ~0.6s later; first scan at
+    // T0+1.5s reports ages of 1s and 0s.
+    vi.setSystemTime(T0 + 1_500);
+    rows = [proc(1400, daemonPid, 1, "/opt/homebrew/bin/claude"), proc(1401, 1400, 0, "npm exec momentic mcp")];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
     probe.stop();
   });
 

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -120,6 +120,7 @@ describe("PsSubprocessProbe", () => {
     expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(false);
 
     // A turn launches a background watcher: a child the baseline never saw.
+    probe.sealBaseline("chat-mcp");
     rows = [...mcpOnly, "302  300 /bin/zsh", "303  302 sleep"];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(true);
@@ -128,6 +129,95 @@ describe("PsSubprocessProbe", () => {
     rows = [...mcpOnly];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess("chat-mcp")).toBe(false);
+    probe.stop();
+  });
+
+  it("absorbs a startup MCP child that appears after the provider is first seen", async () => {
+    // The poll starts before any provider exists, so a scan can catch the
+    // `claude` process in the gap before its stdio MCP server spawns. Freezing
+    // the baseline on first sight would store nothing, and the MCP child
+    // arriving one scan later would read as background work for the rest of
+    // that provider's life — the very claim the baseline exists to prevent.
+    const chatId = "chat-startup-race";
+    let rows = [`600  ${daemonPid} /opt/homebrew/bin/claude`];
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => rows.join("\n"),
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
+    });
+
+    // Scan 1: provider only, still starting up.
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    // Scan 2: the permanent MCP child has arrived, still before any turn.
+    rows = [`600  ${daemonPid} /opt/homebrew/bin/claude`, "601  600 npm exec momentic mcp"];
+    await probe.refresh();
+    expect(probe.hasLiveSubprocess(chatId)).toBe(true);
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    // The first turn closes the baseline: everything alive now is infrastructure.
+    probe.sealBaseline(chatId);
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    // A task the turn launches is outside it.
+    rows = [`600  ${daemonPid} /opt/homebrew/bin/claude`, "601  600 npm exec momentic mcp", "602  600 /bin/zsh"];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    probe.stop();
+  });
+
+  it("keeps reporting a background task that survives into a later turn", async () => {
+    // The baseline seals ONCE, at the first turn. Re-taking it at every turn
+    // start would absorb a task that outlived the previous turn and silence it
+    // — which is the exact case this feature exists to report.
+    const chatId = "chat-survives";
+    let rows = [`700  ${daemonPid} /opt/homebrew/bin/claude`, "701  700 npm exec momentic mcp"];
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => rows.join("\n"),
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
+    });
+    await probe.refresh();
+    probe.sealBaseline(chatId);
+    await probe.refresh();
+
+    // Turn 1 launches a watcher that outlives it.
+    rows = [...rows, "702  700 /bin/zsh"];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+
+    // Turn 2 starts with that watcher still running: it must stay reported.
+    probe.sealBaseline(chatId);
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    probe.stop();
+  });
+
+  it("stays silent for a provider first observed after its session is already running", async () => {
+    // A provider whose first scan lands mid-turn cannot be told apart from one
+    // that always had those children, so its whole tree becomes the baseline.
+    // That under-reports until they exit — silence, not a false claim.
+    const chatId = "chat-late-first-scan";
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () =>
+        [`800  ${daemonPid} /opt/homebrew/bin/claude`, "801  800 npm exec momentic mcp", "802  800 /bin/zsh"].join(
+          "\n",
+        ),
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /bin/claude`,
+    });
+    probe.sealBaseline(chatId);
+    await probe.refresh();
+    expect(probe.hasLiveSubprocess(chatId)).toBe(true);
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
     probe.stop();
   });
 
@@ -143,8 +233,12 @@ describe("PsSubprocessProbe", () => {
       runEnvForPid: async () => "FIRST_TREE_CHAT_ID=chat-restart /bin/claude",
     });
     await probe.refresh();
+    probe.sealBaseline("chat-restart");
+    await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess("chat-restart")).toBe(false);
 
+    // New provider process for the same chat: its own startup window, so the
+    // replacement's MCP child must not be read as work the session launched.
     rows = [`500  ${daemonPid} /opt/homebrew/bin/claude`, "501  500 npm exec momentic mcp"];
     await probe.refresh();
     expect(probe.hasSessionSpawnedSubprocess("chat-restart")).toBe(false);

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -7794,6 +7794,74 @@ describe("SessionRuntime edge coverage", () => {
     await sm.shutdown();
   });
 
+  it("seals through a real turn and then reports a watcher that turn launched", async () => {
+    // The positive direction, end to end, with nothing about the answer stubbed:
+    // a real PsSubprocessProbe fed a real process tree, a real SessionRuntime,
+    // and the seal reached ONLY through a turn — never by calling
+    // `sealBaseline` directly. Every other runtime-level test here is either a
+    // negative (a dead feature also emits no frame) or hands the runtime a
+    // stubbed `hasSessionSpawnedSubprocess`, so replacing the one-line seal
+    // wiring with a no-op leaves them all green while the qualifier can never
+    // appear on any host.
+    const chatId = "chat-seal-wiring";
+    const withMcp = ["4242 1 node", "7000 4242 /opt/homebrew/bin/claude", "7001 7000 npm exec momentic mcp"];
+    let rows = [...withMcp];
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid: 4242,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => rows.join("\n"),
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /opt/homebrew/bin/claude`,
+    });
+    await probe.refresh(); // startup scan: the MCP child becomes the baseline
+
+    const frames: Array<{ chatId: string; report: { runtimeState: string; backgroundWork: boolean } }> = [];
+    let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const sm = makeRuntime({
+      subprocessProbe: probe,
+      onSessionRuntimeChange: (id, report) => frames.push({ chatId: id, report }),
+      handlers: [
+        handler({
+          start: vi.fn(async (msg: SessionMessage, ctx: SessionContext) => {
+            capturedCtx = ctx;
+            capturedMessage = msg;
+            return { sessionId: "session-seal", route: { kind: "owned" as const, mode: "queued" as const } };
+          }) as unknown as AgentHandler["start"],
+        }),
+      ],
+    });
+    const i = internals(sm);
+
+    await sm.dispatch(mockEntry({ id: 1, chatId }));
+    if (!capturedCtx || !capturedMessage) throw new Error("expected captured session context");
+
+    // A turn runs. This event is the only thing that seals the baseline.
+    capturedCtx.emitEvent({
+      kind: "tool_call",
+      payload: { toolUseId: "t1", name: "Bash", args: null, status: "ok" },
+    });
+    // …and it launches a watcher that outlives it.
+    rows = [...withMcp, "7002 7000 /bin/zsh", "7003 7002 sleep"];
+    await capturedCtx.finishTurn(capturedMessage, { status: "success", terminal: true });
+    capturedCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
+
+    await probe.refresh();
+    frames.length = 0;
+    i.projection.reaffirmRuntimeStates();
+    expect(frames).toContainEqual({ chatId, report: { runtimeState: "idle", backgroundWork: true } });
+
+    // The watcher exits; the permanent MCP child must not keep the claim alive.
+    rows = [...withMcp];
+    await probe.refresh();
+    frames.length = 0;
+    i.projection.reaffirmRuntimeStates();
+    expect(frames).toContainEqual({ chatId, report: { runtimeState: "idle", backgroundWork: false } });
+
+    probe.stop();
+    await sm.shutdown();
+  });
+
   it("never asserts background work for a session whose only child is its MCP server", async () => {
     // End to end against the REAL probe rather than a stubbed boolean: this is
     // the shape that would have shipped the qualifier onto every idle chat of

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -7911,6 +7911,69 @@ describe("SessionRuntime edge coverage", () => {
     await sm.shutdown();
   });
 
+  it("gives a provider that respawns inside an open turn its own boundary", async () => {
+    // Claude's transient retry rebuilds the native process mid-turn without a
+    // `turn_end`, so chat-level turn liveness is still in flight when the
+    // replacement generation reports its own boundary. That boundary has to
+    // reach the probe anyway, or the new process's startup MCP child and every
+    // task it launches stay unclassifiable until some later turn.
+    const chatId = "chat-respawn";
+    const T0 = new Date("2026-09-02T00:00:00Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    let rows = ["4242 1 20:00 node", "8000 4242 02:00 /opt/homebrew/bin/claude", "8001 8000 01:59 npm exec mcp"];
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid: 4242,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => rows.join("\n"),
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /opt/homebrew/bin/claude`,
+    });
+    await probe.refresh();
+
+    let capturedCtx: SessionContext | undefined;
+    const sm = makeRuntime({
+      subprocessProbe: probe,
+      handlers: [
+        handler({
+          start: vi.fn(async (_msg: SessionMessage, ctx: SessionContext) => {
+            capturedCtx = ctx;
+            return { sessionId: "session-respawn", route: { kind: "owned" as const, mode: "queued" as const } };
+          }) as unknown as AgentHandler["start"],
+        }),
+      ],
+    });
+    await sm.dispatch(mockEntry({ id: 1, chatId }));
+    if (!capturedCtx) throw new Error("expected captured session context");
+
+    capturedCtx.noteTurnStart(); // the first generation's turn opens
+
+    // The provider respawns mid-turn: new pid, no `turn_end` in between, and
+    // the replacement reports its own boundary.
+    vi.setSystemTime(T0 + 30_000);
+    rows = ["4242 1 20:30 node", "8100 4242 00:03 /opt/homebrew/bin/claude", "8101 8100 00:02 npm exec mcp"];
+    capturedCtx.noteTurnStart();
+
+    // It then launches a watcher, and a scan follows.
+    vi.setSystemTime(T0 + 90_000);
+    rows = [
+      "4242 1 21:30 node",
+      "8100 4242 01:03 /opt/homebrew/bin/claude",
+      "8101 8100 01:02 npm exec mcp",
+      "8102 8100 00:30 /bin/zsh",
+    ];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(true);
+    // …and the replacement's own permanent MCP child is not the reason.
+    rows = ["4242 1 21:30 node", "8100 4242 01:03 /opt/homebrew/bin/claude", "8101 8100 01:02 npm exec mcp"];
+    await probe.refresh();
+    expect(probe.hasSessionSpawnedSubprocess(chatId)).toBe(false);
+
+    probe.stop();
+    await sm.shutdown();
+    vi.useRealTimers();
+  });
+
   it("never asserts background work for a session whose only child is its MCP server", async () => {
     // End to end against the REAL probe rather than a stubbed boolean: this is
     // the shape that would have shipped the qualifier onto every idle chat of

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -7841,6 +7841,10 @@ describe("SessionRuntime edge coverage", () => {
       kind: "tool_call",
       payload: { toolUseId: "t1", name: "Bash", args: null, status: "ok" },
     });
+    // The seal captures its snapshot asynchronously; drain it so this test
+    // pins the real ordering (boundary first, then the turn's work) instead of
+    // depending on which microtask happens to win.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     // …and it launches a watcher that outlives it.
     rows = [...withMcp, "7002 7000 /bin/zsh", "7003 7002 sleep"];
     await capturedCtx.finishTurn(capturedMessage, { status: "success", terminal: true });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -7,6 +7,7 @@ import type {
   ProviderRetryEventPayload,
   RuntimeState,
   SessionEvent,
+  SessionRuntimeReport,
   SessionState,
 } from "@first-tree/shared";
 import { encodeProviderRetryEventMessage, parseProviderRetryEventMessage } from "@first-tree/shared";
@@ -21,6 +22,7 @@ import type {
 } from "../runtime/handler.js";
 import type { DeliveryDecision, DeliveryRouteOwnership, DeliveryWork } from "../runtime/inbox-delivery-coordinator.js";
 import type { SubprocessProbe } from "../runtime/process-tree-probe.js";
+import { PsSubprocessProbe } from "../runtime/process-tree-probe.js";
 import { SessionRegistry } from "../runtime/session-registry.js";
 import { SessionRuntime } from "../runtime/session-runtime.js";
 import { recordingLogger, silentLogger } from "./_logger-helpers.js";
@@ -65,6 +67,8 @@ type SessionRuntimeInternals = {
     projectSessionRuntime(chatId: string, opts?: { drainPendingOnIdle?: boolean }): void;
     recomputeRuntimeState(): void;
     reaffirmRuntimeStates(): void;
+    hasBackgroundWork(chatId: string): boolean;
+    noteProviderTurnStart(chatId: string): void;
     persistRegistry(): void;
     recordHandlerSource(entry: SessionRecord, sourceKey: string): void;
   };
@@ -265,7 +269,7 @@ function makeRuntime(
     subprocessProbe?: SubprocessProbe;
     onStateChange?: (chatId: string, state: SessionState) => void;
     onRuntimeStateChange?: (state: TestRuntimeState) => void;
-    onSessionRuntimeChange?: (chatId: string, state: TestRuntimeState) => void;
+    onSessionRuntimeChange?: (chatId: string, report: SessionRuntimeReport) => void;
     onSessionEvent?: (chatId: string, event: SessionEvent) => void;
     confirmSessionEvent?: (chatId: string, event: SessionEvent) => Promise<void>;
     workspaceRoot?: string;
@@ -7212,7 +7216,9 @@ describe("SessionRuntime edge coverage", () => {
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-runtime" }));
-    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-runtime", runtimeState: "working" }]);
+    expect(sm.getSessionRuntimeStates()).toEqual([
+      { chatId: "chat-runtime", runtimeState: "working", backgroundWork: false },
+    ]);
     if (!captured) throw new Error("context was not captured");
     runtimeChanges.length = 0;
     await sm.handleCommand("chat-runtime", "session:suspend");
@@ -7303,7 +7309,7 @@ describe("SessionRuntime edge coverage", () => {
     const sessionRuntimeChanges: Array<{ chatId: string; state: RuntimeState }> = [];
     const aggregateChanges: RuntimeState[] = [];
     const sm = makeRuntime({
-      onSessionRuntimeChange: (chatId, state) => sessionRuntimeChanges.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, { runtimeState }) => sessionRuntimeChanges.push({ chatId, state: runtimeState }),
       onRuntimeStateChange: (state) => aggregateChanges.push(state),
     });
     const i = internals(sm);
@@ -7726,9 +7732,130 @@ describe("SessionRuntime edge coverage", () => {
     await sm.shutdown();
   });
 
+  it("qualifies an idle chat with background work and keeps re-affirming it", async () => {
+    // A provider parked on a task it started itself burns no tokens, so the
+    // chat is genuinely idle — but it wakes itself up, which plain "Idle"
+    // cannot say. The marker rides the runtime frame it qualifies.
+    const onSessionRuntimeChange = vi.fn();
+    const subprocessProbe: SubprocessProbe = {
+      hasLiveSubprocess: vi.fn(() => true),
+      hasSessionSpawnedSubprocess: vi.fn((chatId: string) => chatId === "chat-parked"),
+      stop: vi.fn(),
+    };
+    const sm = makeRuntime({ subprocessProbe, onSessionRuntimeChange });
+    const i = internals(sm);
+    bindSeededSession(i, makeSessionRecord("chat-parked", { status: "active", lastActivity: Date.now() }));
+    i.projection.projectSessionRuntime("chat-parked");
+    onSessionRuntimeChange.mockClear();
+
+    i.projection.reaffirmRuntimeStates();
+    expect(onSessionRuntimeChange).toHaveBeenCalledWith("chat-parked", { runtimeState: "idle", backgroundWork: true });
+    expect(i.projection.hasBackgroundWork("chat-parked")).toBe(true);
+
+    // The server only trusts the marker while the runtime stamp is fresh, so
+    // the re-affirm must keep coming for as long as the provider is parked.
+    onSessionRuntimeChange.mockClear();
+    i.projection.reaffirmRuntimeStates();
+    expect(onSessionRuntimeChange).toHaveBeenCalledWith("chat-parked", { runtimeState: "idle", backgroundWork: true });
+
+    await sm.shutdown();
+  });
+
+  it("never asserts background work while a turn is running", async () => {
+    // The probe answers "the provider has a live child process", which an
+    // ordinary foreground tool call satisfies too. Only an idle chat may
+    // carry the marker, or a `Bash` step would flap it every turn.
+    const onSessionRuntimeChange = vi.fn();
+    const subprocessProbe: SubprocessProbe = {
+      hasLiveSubprocess: vi.fn(() => true),
+      hasSessionSpawnedSubprocess: vi.fn(() => true),
+      stop: vi.fn(),
+    };
+    const sm = makeRuntime({ subprocessProbe, onSessionRuntimeChange });
+    const i = internals(sm);
+    const chatId = "chat-running-turn";
+    bindSeededSession(i, makeSessionRecord(chatId, { status: "active", lastActivity: Date.now() }));
+    i.projection.projectSessionRuntime(chatId);
+    i.projection.reaffirmRuntimeStates();
+    expect(i.projection.hasBackgroundWork(chatId)).toBe(true);
+
+    // A turn starts: the marker retires with the transition, and the frame
+    // carrying `working` carries the cleared value with it.
+    onSessionRuntimeChange.mockClear();
+    i.projection.noteProviderTurnStart(chatId);
+    expect(onSessionRuntimeChange).toHaveBeenCalledWith(chatId, { runtimeState: "working", backgroundWork: false });
+    expect(i.projection.hasBackgroundWork(chatId)).toBe(false);
+
+    i.projection.reaffirmRuntimeStates();
+    expect(i.projection.hasBackgroundWork(chatId)).toBe(false);
+
+    await sm.shutdown();
+  });
+
+  it("never asserts background work for a session whose only child is its MCP server", async () => {
+    // End to end against the REAL probe rather than a stubbed boolean: this is
+    // the shape that would have shipped the qualifier onto every idle chat of
+    // every MCP-configured agent, and a boolean stub cannot see it because it
+    // assumes the probe already answers the product question.
+    const chatId = "chat-mcp-only";
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid: 4242,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () =>
+        ["4242 1 node", "7000 4242 /opt/homebrew/bin/claude", "7001 7000 npm exec momentic mcp --config /x.yaml"].join(
+          "\n",
+        ),
+      runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /opt/homebrew/bin/claude`,
+    });
+    await probe.refresh();
+
+    const onSessionRuntimeChange = vi.fn();
+    const sm = makeRuntime({ subprocessProbe: probe, onSessionRuntimeChange });
+    const i = internals(sm);
+    bindSeededSession(i, makeSessionRecord(chatId, { status: "active", lastActivity: Date.now() }));
+    i.projection.projectSessionRuntime(chatId);
+    onSessionRuntimeChange.mockClear();
+
+    i.projection.reaffirmRuntimeStates();
+    expect(i.projection.hasBackgroundWork(chatId)).toBe(false);
+    expect(onSessionRuntimeChange).not.toHaveBeenCalled();
+
+    probe.stop();
+    await sm.shutdown();
+  });
+
+  it("stops asserting background work past the idle-sweep hard cap", async () => {
+    // A forgotten background watcher must not leave "background task" on an
+    // agent forever: past `idle_timeout + working_grace` the sweep reclaims
+    // the slot anyway, so the assertion stops at the same boundary.
+    const onSessionRuntimeChange = vi.fn();
+    const subprocessProbe: SubprocessProbe = {
+      hasLiveSubprocess: vi.fn(() => true),
+      hasSessionSpawnedSubprocess: vi.fn(() => true),
+      stop: vi.fn(),
+    };
+    const sm = makeRuntime({ subprocessProbe, onSessionRuntimeChange });
+    const i = internals(sm);
+    const pastCapMs = (sessionConfig.idle_timeout + sessionConfig.working_grace_seconds) * 1000 + 1_000;
+    bindSeededSession(
+      i,
+      makeSessionRecord("chat-forgotten-watcher", { status: "active", lastActivity: Date.now() - pastCapMs }),
+    );
+    i.projection.projectSessionRuntime("chat-forgotten-watcher");
+    onSessionRuntimeChange.mockClear();
+
+    i.projection.reaffirmRuntimeStates();
+    expect(i.projection.hasBackgroundWork("chat-forgotten-watcher")).toBe(false);
+    expect(onSessionRuntimeChange).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
   it("evicts idle active sessions with live subprocesses only after no better candidate exists", async () => {
     const subprocessProbe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn((chatId: string) => chatId === "chat-live-subprocess"),
+      hasSessionSpawnedSubprocess: vi.fn(() => false),
       stop: vi.fn(),
     };
     const sm = makeRuntime({ maxSessions: 1, subprocessProbe });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -69,6 +69,7 @@ type SessionRuntimeInternals = {
     reaffirmRuntimeStates(): void;
     hasBackgroundWork(chatId: string): boolean;
     noteProviderTurnStart(chatId: string): void;
+    noteProviderTurnEnd(chatId: string): void;
     persistRegistry(): void;
     recordHandlerSource(entry: SessionRecord, sourceKey: string): void;
   };
@@ -7878,6 +7879,36 @@ describe("SessionRuntime edge coverage", () => {
     probe.stop();
     await sm.shutdown();
     vi.useRealTimers();
+  });
+
+  it("signals one turn boundary per turn, not one per in-turn event", async () => {
+    // The probe treats each boundary call as a newer candidate, so this guard
+    // is what stops a turn's second tool call from moving the boundary past a
+    // watcher its first one already launched. It lives here rather than in the
+    // probe because only the projection knows where a turn begins and ends.
+    const chatId = "chat-one-boundary-per-turn";
+    const boundaries: string[] = [];
+    const probe: SubprocessProbe = {
+      hasLiveSubprocess: vi.fn(() => true),
+      hasSessionSpawnedSubprocess: vi.fn(() => false),
+      noteTurnBoundary: vi.fn((id: string) => boundaries.push(id)),
+      stop: vi.fn(),
+    };
+    const sm = makeRuntime({ subprocessProbe: probe });
+    const i = internals(sm);
+    bindSeededSession(i, makeSessionRecord(chatId, { status: "active", lastActivity: Date.now() }));
+
+    i.projection.noteProviderTurnStart(chatId);
+    i.projection.noteProviderTurnStart(chatId);
+    i.projection.noteProviderTurnStart(chatId);
+    expect(boundaries).toEqual([chatId]);
+
+    // A distinct turn must be able to supersede the previous candidate.
+    i.projection.noteProviderTurnEnd(chatId);
+    i.projection.noteProviderTurnStart(chatId);
+    expect(boundaries).toEqual([chatId, chatId]);
+
+    await sm.shutdown();
   });
 
   it("never asserts background work for a session whose only child is its MCP server", async () => {

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -7740,6 +7740,7 @@ describe("SessionRuntime edge coverage", () => {
     const subprocessProbe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn(() => true),
       hasSessionSpawnedSubprocess: vi.fn((chatId: string) => chatId === "chat-parked"),
+      sealBaseline: vi.fn(),
       stop: vi.fn(),
     };
     const sm = makeRuntime({ subprocessProbe, onSessionRuntimeChange });
@@ -7769,6 +7770,7 @@ describe("SessionRuntime edge coverage", () => {
     const subprocessProbe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn(() => true),
       hasSessionSpawnedSubprocess: vi.fn(() => true),
+      sealBaseline: vi.fn(),
       stop: vi.fn(),
     };
     const sm = makeRuntime({ subprocessProbe, onSessionRuntimeChange });
@@ -7833,6 +7835,7 @@ describe("SessionRuntime edge coverage", () => {
     const subprocessProbe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn(() => true),
       hasSessionSpawnedSubprocess: vi.fn(() => true),
+      sealBaseline: vi.fn(),
       stop: vi.fn(),
     };
     const sm = makeRuntime({ subprocessProbe, onSessionRuntimeChange });
@@ -7856,6 +7859,7 @@ describe("SessionRuntime edge coverage", () => {
     const subprocessProbe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn((chatId: string) => chatId === "chat-live-subprocess"),
       hasSessionSpawnedSubprocess: vi.fn(() => false),
+      sealBaseline: vi.fn(),
       stop: vi.fn(),
     };
     const sm = makeRuntime({ maxSessions: 1, subprocessProbe });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -7740,7 +7740,7 @@ describe("SessionRuntime edge coverage", () => {
     const subprocessProbe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn(() => true),
       hasSessionSpawnedSubprocess: vi.fn((chatId: string) => chatId === "chat-parked"),
-      sealBaseline: vi.fn(),
+      noteTurnBoundary: vi.fn(),
       stop: vi.fn(),
     };
     const sm = makeRuntime({ subprocessProbe, onSessionRuntimeChange });
@@ -7770,7 +7770,7 @@ describe("SessionRuntime edge coverage", () => {
     const subprocessProbe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn(() => true),
       hasSessionSpawnedSubprocess: vi.fn(() => true),
-      sealBaseline: vi.fn(),
+      noteTurnBoundary: vi.fn(),
       stop: vi.fn(),
     };
     const sm = makeRuntime({ subprocessProbe, onSessionRuntimeChange });
@@ -7804,7 +7804,14 @@ describe("SessionRuntime edge coverage", () => {
     // wiring with a no-op leaves them all green while the qualifier can never
     // appear on any host.
     const chatId = "chat-seal-wiring";
-    const withMcp = ["4242 1 node", "7000 4242 /opt/homebrew/bin/claude", "7001 7000 npm exec momentic mcp"];
+    const T0 = new Date("2026-09-02T00:00:00Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const withMcp = [
+      "4242 1 20:00 node",
+      "7000 4242 02:00 /opt/homebrew/bin/claude",
+      "7001 7000 01:59 npm exec momentic mcp",
+    ];
     let rows = [...withMcp];
     const probe = new PsSubprocessProbe({
       log: silentLogger(),
@@ -7813,7 +7820,7 @@ describe("SessionRuntime edge coverage", () => {
       runProcessSnapshot: async () => rows.join("\n"),
       runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /opt/homebrew/bin/claude`,
     });
-    await probe.refresh(); // startup scan: the MCP child becomes the baseline
+    await probe.refresh(); // startup scan
 
     const frames: Array<{ chatId: string; report: { runtimeState: string; backgroundWork: boolean } }> = [];
     let capturedCtx: SessionContext | undefined;
@@ -7836,27 +7843,33 @@ describe("SessionRuntime edge coverage", () => {
     await sm.dispatch(mockEntry({ id: 1, chatId }));
     if (!capturedCtx || !capturedMessage) throw new Error("expected captured session context");
 
-    // A turn runs. This event is the only thing that seals the baseline.
+    // A turn runs. This event is the only thing that records the boundary —
+    // no test-imposed ordering around it, because the runtime does not provide
+    // one: the boundary is an instant, and the scan proving it can run late.
     capturedCtx.emitEvent({
       kind: "tool_call",
       payload: { toolUseId: "t1", name: "Bash", args: null, status: "ok" },
     });
-    // The seal captures its snapshot asynchronously; drain it so this test
-    // pins the real ordering (boundary first, then the turn's work) instead of
-    // depending on which microtask happens to win.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    // …and it launches a watcher that outlives it.
-    rows = [...withMcp, "7002 7000 /bin/zsh", "7003 7002 sleep"];
+    // …and the turn launches a watcher that outlives it.
     await capturedCtx.finishTurn(capturedMessage, { status: "success", terminal: true });
     capturedCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
 
+    vi.setSystemTime(T0 + 30_000);
+    rows = [
+      "4242 1 20:30 node",
+      "7000 4242 02:30 /opt/homebrew/bin/claude",
+      "7001 7000 02:29 npm exec momentic mcp",
+      "7002 7000 00:20 /bin/zsh",
+      "7003 7002 00:20 sleep",
+    ];
     await probe.refresh();
     frames.length = 0;
     i.projection.reaffirmRuntimeStates();
     expect(frames).toContainEqual({ chatId, report: { runtimeState: "idle", backgroundWork: true } });
 
     // The watcher exits; the permanent MCP child must not keep the claim alive.
-    rows = [...withMcp];
+    vi.setSystemTime(T0 + 60_000);
+    rows = ["4242 1 21:00 node", "7000 4242 03:00 /opt/homebrew/bin/claude", "7001 7000 02:59 npm exec momentic mcp"];
     await probe.refresh();
     frames.length = 0;
     i.projection.reaffirmRuntimeStates();
@@ -7864,6 +7877,7 @@ describe("SessionRuntime edge coverage", () => {
 
     probe.stop();
     await sm.shutdown();
+    vi.useRealTimers();
   });
 
   it("never asserts background work for a session whose only child is its MCP server", async () => {
@@ -7877,9 +7891,11 @@ describe("SessionRuntime edge coverage", () => {
       daemonPid: 4242,
       intervalMs: 1_000_000,
       runProcessSnapshot: async () =>
-        ["4242 1 node", "7000 4242 /opt/homebrew/bin/claude", "7001 7000 npm exec momentic mcp --config /x.yaml"].join(
-          "\n",
-        ),
+        [
+          "4242 1 20:00 node",
+          "7000 4242 02:00 /opt/homebrew/bin/claude",
+          "7001 7000 01:59 npm exec momentic mcp --config /x.yaml",
+        ].join("\n"),
       runEnvForPid: async () => `FIRST_TREE_CHAT_ID=${chatId} /opt/homebrew/bin/claude`,
     });
     await probe.refresh();
@@ -7907,7 +7923,7 @@ describe("SessionRuntime edge coverage", () => {
     const subprocessProbe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn(() => true),
       hasSessionSpawnedSubprocess: vi.fn(() => true),
-      sealBaseline: vi.fn(),
+      noteTurnBoundary: vi.fn(),
       stop: vi.fn(),
     };
     const sm = makeRuntime({ subprocessProbe, onSessionRuntimeChange });
@@ -7931,7 +7947,7 @@ describe("SessionRuntime edge coverage", () => {
     const subprocessProbe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn((chatId: string) => chatId === "chat-live-subprocess"),
       hasSessionSpawnedSubprocess: vi.fn(() => false),
-      sealBaseline: vi.fn(),
+      noteTurnBoundary: vi.fn(),
       stop: vi.fn(),
     };
     const sm = makeRuntime({ maxSessions: 1, subprocessProbe });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -68,7 +68,7 @@ type SessionRuntimeInternals = {
     recomputeRuntimeState(): void;
     reaffirmRuntimeStates(): void;
     hasBackgroundWork(chatId: string): boolean;
-    noteProviderTurnStart(chatId: string): void;
+    noteProviderTurnStart(chatId: string): boolean;
     noteProviderTurnEnd(chatId: string): void;
     persistRegistry(): void;
     recordHandlerSource(entry: SessionRecord, sourceKey: string): void;
@@ -7882,10 +7882,9 @@ describe("SessionRuntime edge coverage", () => {
   });
 
   it("signals one turn boundary per turn, not one per in-turn event", async () => {
-    // The probe treats each boundary call as a newer candidate, so this guard
-    // is what stops a turn's second tool call from moving the boundary past a
-    // watcher its first one already launched. It lives here rather than in the
-    // probe because only the projection knows where a turn begins and ends.
+    // Only the projection knows where a turn begins and ends, so it owns the
+    // "did this open a turn" answer; the runtime turns that into at most one
+    // boundary candidate per turn from the noisy event floor.
     const chatId = "chat-one-boundary-per-turn";
     const boundaries: string[] = [];
     const probe: SubprocessProbe = {
@@ -7898,15 +7897,17 @@ describe("SessionRuntime edge coverage", () => {
     const i = internals(sm);
     bindSeededSession(i, makeSessionRecord(chatId, { status: "active", lastActivity: Date.now() }));
 
-    i.projection.noteProviderTurnStart(chatId);
-    i.projection.noteProviderTurnStart(chatId);
-    i.projection.noteProviderTurnStart(chatId);
-    expect(boundaries).toEqual([chatId]);
+    // The projection reports whether a call actually opened a turn; that
+    // boolean is what the runtime gates the probe boundary on, so repeated
+    // in-turn events cannot each become a candidate.
+    expect(i.projection.noteProviderTurnStart(chatId)).toBe(true);
+    expect(i.projection.noteProviderTurnStart(chatId)).toBe(false);
+    expect(i.projection.noteProviderTurnStart(chatId)).toBe(false);
 
-    // A distinct turn must be able to supersede the previous candidate.
+    // A distinct turn is a new candidate.
     i.projection.noteProviderTurnEnd(chatId);
-    i.projection.noteProviderTurnStart(chatId);
-    expect(boundaries).toEqual([chatId, chatId]);
+    expect(i.projection.noteProviderTurnStart(chatId)).toBe(true);
+    expect(boundaries).toEqual([]);
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3316,6 +3316,7 @@ describe("SessionRuntime subprocess-aware suspend/eviction", () => {
       const probe: SubprocessProbe = {
         hasLiveSubprocess: hasLive,
         hasSessionSpawnedSubprocess: vi.fn(() => false),
+        sealBaseline: vi.fn(),
         stop: vi.fn(),
       };
       const sm = createSessionRuntime({
@@ -3356,6 +3357,7 @@ describe("SessionRuntime subprocess-aware suspend/eviction", () => {
       const probe: SubprocessProbe = {
         hasLiveSubprocess: vi.fn().mockReturnValue(true),
         hasSessionSpawnedSubprocess: vi.fn(() => false),
+        sealBaseline: vi.fn(),
         stop: vi.fn(),
       };
       const sm = createSessionRuntime({
@@ -3397,6 +3399,7 @@ describe("SessionRuntime subprocess-aware suspend/eviction", () => {
     const probe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn((chatId: string) => chatId === "chat-1"),
       hasSessionSpawnedSubprocess: vi.fn(() => false),
+      sealBaseline: vi.fn(),
       stop: vi.fn(),
     };
     const sm = createSessionRuntime({ handlerFactory: factory, concurrency: 2, subprocessProbe: probe });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1,6 +1,7 @@
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { SessionRuntimeReport } from "@first-tree/shared";
 import {
   AGENT_RUNTIME_SESSION_ERROR_CODES,
   type AgentRuntimeConfig,
@@ -239,7 +240,7 @@ function createSessionRuntime(opts: {
   probeFencedSettlement?: (chatId: string, messageIds: readonly string[]) => Promise<readonly string[]>;
   recoverRuntimeSessionProof?: (reasonCode: string) => Promise<void>;
   onSessionEvent?: (chatId: string, event: SessionEvent) => void;
-  onSessionRuntimeChange?: (chatId: string, state: RuntimeState) => void;
+  onSessionRuntimeChange?: (chatId: string, report: SessionRuntimeReport) => void;
   confirmSessionEvent?: (chatId: string, event: SessionEvent) => Promise<void>;
   subprocessProbe?: SubprocessProbe;
   registryPath?: string;
@@ -3312,7 +3313,11 @@ describe("SessionRuntime subprocess-aware suspend/eviction", () => {
         },
       });
       const hasLive = vi.fn().mockReturnValue(true);
-      const probe: SubprocessProbe = { hasLiveSubprocess: hasLive, stop: vi.fn() };
+      const probe: SubprocessProbe = {
+        hasLiveSubprocess: hasLive,
+        hasSessionSpawnedSubprocess: vi.fn(() => false),
+        stop: vi.fn(),
+      };
       const sm = createSessionRuntime({
         handler,
         subprocessProbe: probe,
@@ -3348,7 +3353,11 @@ describe("SessionRuntime subprocess-aware suspend/eviction", () => {
           return { sessionId: "sid", route: { kind: "owned" as const, mode: "queued" as const } };
         },
       });
-      const probe: SubprocessProbe = { hasLiveSubprocess: vi.fn().mockReturnValue(true), stop: vi.fn() };
+      const probe: SubprocessProbe = {
+        hasLiveSubprocess: vi.fn().mockReturnValue(true),
+        hasSessionSpawnedSubprocess: vi.fn(() => false),
+        stop: vi.fn(),
+      };
       const sm = createSessionRuntime({
         handler,
         subprocessProbe: probe,
@@ -3387,6 +3396,7 @@ describe("SessionRuntime subprocess-aware suspend/eviction", () => {
     // chat-1 has a live watcher; chat-2 does not.
     const probe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn((chatId: string) => chatId === "chat-1"),
+      hasSessionSpawnedSubprocess: vi.fn(() => false),
       stop: vi.fn(),
     };
     const sm = createSessionRuntime({ handlerFactory: factory, concurrency: 2, subprocessProbe: probe });
@@ -3437,7 +3447,7 @@ describe("SessionRuntime replay fence gate", () => {
         handler,
         ackEntry,
         replayFencePath: fencePath,
-        onSessionRuntimeChange: (chatId, state) => runtimeStates.push({ chatId, state }),
+        onSessionRuntimeChange: (chatId, { runtimeState }) => runtimeStates.push({ chatId, state: runtimeState }),
       });
 
       // The crashed delivery is redelivered after restart: it must NOT be

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3316,7 +3316,7 @@ describe("SessionRuntime subprocess-aware suspend/eviction", () => {
       const probe: SubprocessProbe = {
         hasLiveSubprocess: hasLive,
         hasSessionSpawnedSubprocess: vi.fn(() => false),
-        sealBaseline: vi.fn(),
+        noteTurnBoundary: vi.fn(),
         stop: vi.fn(),
       };
       const sm = createSessionRuntime({
@@ -3357,7 +3357,7 @@ describe("SessionRuntime subprocess-aware suspend/eviction", () => {
       const probe: SubprocessProbe = {
         hasLiveSubprocess: vi.fn().mockReturnValue(true),
         hasSessionSpawnedSubprocess: vi.fn(() => false),
-        sealBaseline: vi.fn(),
+        noteTurnBoundary: vi.fn(),
         stop: vi.fn(),
       };
       const sm = createSessionRuntime({
@@ -3399,7 +3399,7 @@ describe("SessionRuntime subprocess-aware suspend/eviction", () => {
     const probe: SubprocessProbe = {
       hasLiveSubprocess: vi.fn((chatId: string) => chatId === "chat-1"),
       hasSessionSpawnedSubprocess: vi.fn(() => false),
-      sealBaseline: vi.fn(),
+      noteTurnBoundary: vi.fn(),
       stop: vi.fn(),
     };
     const sm = createSessionRuntime({ handlerFactory: factory, concurrency: 2, subprocessProbe: probe });

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -1,3 +1,4 @@
+import type { SessionRuntimeReport } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { FirstTreeHubSDK } from "../cloud/sdk.js";
@@ -44,7 +45,7 @@ function createSessionRuntime(opts: {
   concurrency?: number;
   log?: pino.Logger;
   onRuntimeStateChange?: (state: "idle" | "working" | "blocked" | "error") => void;
-  onSessionRuntimeChange?: (chatId: string, state: "idle" | "working" | "blocked" | "error") => void;
+  onSessionRuntimeChange?: (chatId: string, report: SessionRuntimeReport) => void;
 }): SessionRuntime {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
@@ -105,7 +106,7 @@ describe("SessionRuntime runtime projection from inbox coordinator work", () => 
       handler,
       ackEntry: vi.fn().mockReturnValue(ack.promise),
       onRuntimeStateChange: vi.fn(),
-      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, { runtimeState }) => events.push({ chatId, state: runtimeState }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -146,7 +147,7 @@ describe("SessionRuntime runtime projection from inbox coordinator work", () => 
     const sm = createSessionRuntime({
       handler,
       onRuntimeStateChange: vi.fn(),
-      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, { runtimeState }) => events.push({ chatId, state: runtimeState }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -185,7 +186,7 @@ describe("SessionRuntime runtime projection from inbox coordinator work", () => 
       handler,
       ackEntry: vi.fn().mockReturnValue(ack.promise),
       onRuntimeStateChange: vi.fn(),
-      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, { runtimeState }) => events.push({ chatId, state: runtimeState }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -224,7 +225,7 @@ describe("SessionRuntime runtime projection from inbox coordinator work", () => 
     const sm = createSessionRuntime({
       handler,
       onRuntimeStateChange: vi.fn(),
-      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, { runtimeState }) => events.push({ chatId, state: runtimeState }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -265,7 +266,7 @@ describe("SessionRuntime runtime projection from inbox coordinator work", () => 
       recoverChat,
       ackEntry: vi.fn().mockRejectedValue(new Error("prefix_gap")),
       onRuntimeStateChange: vi.fn(),
-      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, { runtimeState }) => events.push({ chatId, state: runtimeState }),
     });
 
     const first = mockEntry({ id: 1, chatId: "chat-a" });

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -1,4 +1,4 @@
-import type { RuntimeState, SessionState } from "@first-tree/shared";
+import type { RuntimeState, SessionRuntimeReport, SessionState } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { FirstTreeHubSDK } from "../cloud/sdk.js";
@@ -79,7 +79,7 @@ function createSessionRuntime(opts: {
   concurrency?: number;
   log?: pino.Logger;
   onStateChange?: (chatId: string, state: SessionState) => void;
-  onSessionRuntimeChange?: (chatId: string, state: RuntimeState) => void;
+  onSessionRuntimeChange?: (chatId: string, report: SessionRuntimeReport) => void;
   recoverChat?: (chatId: string) => Promise<void>;
 }) {
   const handler = opts.handler ?? createMockHandler();
@@ -160,7 +160,7 @@ describe("SessionRuntime: state notifications", () => {
       session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       handlerFactory: capturing.factory,
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
-      onSessionRuntimeChange: (chatId, state) => runtimeChanges.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, { runtimeState: state }) => runtimeChanges.push({ chatId, state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -200,7 +200,8 @@ describe("SessionRuntime: state notifications", () => {
       concurrency: 1,
       handlerFactory: () => handlers.shift() ?? createMockHandler(),
       onStateChange: (chatId, state) => emissions.push({ chatId, kind: "state", value: state }),
-      onSessionRuntimeChange: (chatId, state) => emissions.push({ chatId, kind: "runtime", value: state }),
+      onSessionRuntimeChange: (chatId, { runtimeState: state }) =>
+        emissions.push({ chatId, kind: "runtime", value: state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -301,7 +302,7 @@ describe("SessionRuntime: state-before-runtime ordering (codex review P2)", () =
     const sm = createSessionRuntime({
       handler,
       onStateChange: (_chatId, state) => emissions.push({ kind: "state", value: state }),
-      onSessionRuntimeChange: (_chatId, state) => emissions.push({ kind: "runtime", value: state }),
+      onSessionRuntimeChange: (_chatId, { runtimeState }) => emissions.push({ kind: "runtime", value: runtimeState }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-codex" }));
@@ -417,7 +418,8 @@ describe("SessionRuntime: shutdown state reporting", () => {
     const emissions: Array<{ chatId: string; kind: "state" | "runtime"; value: string }> = [];
     const sm = createSessionRuntime({
       onStateChange: (chatId, state) => emissions.push({ chatId, kind: "state", value: state }),
-      onSessionRuntimeChange: (chatId, state) => emissions.push({ chatId, kind: "runtime", value: state }),
+      onSessionRuntimeChange: (chatId, { runtimeState: state }) =>
+        emissions.push({ chatId, kind: "runtime", value: state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -466,7 +468,7 @@ describe("SessionRuntime: terminate + reconcile", () => {
     const runtimeChanges: Array<{ chatId: string; state: RuntimeState }> = [];
     const sm = createSessionRuntime({
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
-      onSessionRuntimeChange: (chatId, state) => runtimeChanges.push({ chatId, state }),
+      onSessionRuntimeChange: (chatId, { runtimeState: state }) => runtimeChanges.push({ chatId, state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeState,
   SessionCommandAbortReason,
   SessionEvent,
+  SessionRuntimeReport,
   SessionState,
 } from "@first-tree/shared";
 import { runtimeProviderSchema } from "@first-tree/shared";
@@ -414,7 +415,7 @@ export class AgentSlot {
         onRuntimeStateChange: (state) => this.reportRuntimeState(state),
         onSessionEvent: (chatId, event) => this.reportSessionEvent(chatId, event),
         confirmSessionEvent: (chatId, event) => this.confirmSessionEvent(chatId, event),
-        onSessionRuntimeChange: (chatId, state) => this.reportSessionRuntime(chatId, state),
+        onSessionRuntimeChange: (chatId, report) => this.reportSessionRuntime(chatId, report),
       });
 
       const onCommand = (cmd: {
@@ -886,8 +887,8 @@ export class AgentSlot {
     return this.clientConnection.reportSessionEventConfirmed(this.config.agentId, chatId, event);
   }
 
-  private reportSessionRuntime(chatId: string, state: RuntimeState): void {
-    this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, state);
+  private reportSessionRuntime(chatId: string, report: SessionRuntimeReport): void {
+    this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, report);
   }
 
   private fullStateSync(): void {
@@ -927,9 +928,15 @@ export class AgentSlot {
     // holds.
     const runtimeStates = this.sessionRuntime.getSessionRuntimeStates(null);
     const reportedRuntimeChatIds = new Set<string>();
-    for (const { chatId, runtimeState } of runtimeStates) {
+    for (const { chatId, runtimeState, backgroundWork } of runtimeStates) {
       reportedRuntimeChatIds.add(chatId);
-      this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, runtimeState);
+      // Normalize at the boundary: the snapshot is the reconnect repair path,
+      // and a missing marker must go on the wire as an explicit `false` rather
+      // than as `undefined`.
+      this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, {
+        runtimeState,
+        backgroundWork: backgroundWork === true,
+      });
     }
     // The server's complete active-session set is the reconnect catch-up scope.
     // It is deliberately separate from `activeChatIds`, which is filtered by
@@ -943,7 +950,11 @@ export class AgentSlot {
     if (activeSessionChatIds) {
       for (const chatId of activeSessionChatIds) {
         if (!reportedRuntimeChatIds.has(chatId)) {
-          this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, "idle");
+          // Revocation: no local session, therefore nothing parked either.
+          this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, {
+            runtimeState: "idle",
+            backgroundWork: false,
+          });
         }
       }
     }

--- a/packages/client/src/runtime/client-connection.ts
+++ b/packages/client/src/runtime/client-connection.ts
@@ -32,6 +32,7 @@ import {
   type SessionCommandAbortedFrame,
   type SessionCommandFinalizedFrame,
   type SessionEvent,
+  type SessionRuntimeReport,
   type SessionState,
   serverWelcomeFrameSchema,
   sessionCommandAbortedFrameSchema,
@@ -1362,9 +1363,20 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * the agent-global runtime is double-written and kept around for the
    * admin overview / fault notification path until that consumer migrates.
    */
-  reportSessionRuntime(agentId: string, chatId: string, runtimeState: RuntimeState): void {
+  reportSessionRuntime(agentId: string, chatId: string, report: SessionRuntimeReport): void {
     if (!this.canSendAgentFrame(agentId) || !this.ws) return;
-    this.ws.send(JSON.stringify({ type: "session:runtime", agentId, chatId, runtimeState }));
+    // Omitted rather than sent as `false`: an absent field and an explicit
+    // `false` mean the same thing to the server, and omitting keeps the
+    // common frame byte-identical to what older clients send.
+    this.ws.send(
+      JSON.stringify({
+        type: "session:runtime",
+        agentId,
+        chatId,
+        runtimeState: report.runtimeState,
+        ...(report.backgroundWork ? { backgroundWork: true } : {}),
+      }),
+    );
   }
 
   reportSessionEvent(agentId: string, chatId: string, event: SessionEvent): void {

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -92,6 +92,15 @@ function earliestStartMs(row: ProcessRow, nowMs: number): number {
   return nowMs - (row.elapsedSec + 1) * 1_000;
 }
 
+/**
+ * The latest instant a process with this elapsed time could have started.
+ * Pairs with {@link earliestStartMs}: each comparison picks whichever end of
+ * the one-second uncertainty makes the claim harder to prove.
+ */
+function latestStartMs(row: ProcessRow, nowMs: number): number {
+  return nowMs - row.elapsedSec * 1_000;
+}
+
 /** Build a parent-pid -> child-pids adjacency index. */
 export function buildChildrenIndex(rows: readonly ProcessRow[]): Map<number, number[]> {
   const byParent = new Map<number, number[]>();
@@ -168,14 +177,23 @@ type PsSubprocessProbeOptions = {
   daemonPid?: number;
   /** Refresh cadence; defaults to 10s (matches the idle-eviction tick). */
   intervalMs?: number;
-  /** Injectable for tests: returns `ps -axo pid=,ppid=,comm=` stdout. */
+  /** Injectable for tests: returns {@link PROCESS_SNAPSHOT_PS_ARGS} stdout. */
   runProcessSnapshot?: () => Promise<string>;
   /** Injectable for tests: returns `ps -Eww -p <pid> -o command=` stdout. */
   runEnvForPid?: (pid: number) => Promise<string>;
 };
 
-async function defaultProcessSnapshot(): Promise<string> {
-  const { stdout } = await execFileAsync("ps", ["-axo", "pid=,ppid=,comm="]);
+/**
+ * The columns {@link parseProcessRows} expects, in order. Exported so a test
+ * can run the real command and prove the adapter and the parser still agree —
+ * an injected fixture cannot, and a mismatch here is silent: every row fails to
+ * parse, both result sets publish empty, and the idle-suspend protection that
+ * predates any of this goes with them.
+ */
+export const PROCESS_SNAPSHOT_PS_ARGS = ["-axo", "pid=,ppid=,etime=,comm="] as const;
+
+export async function defaultProcessSnapshot(): Promise<string> {
+  const { stdout } = await execFileAsync("ps", [...PROCESS_SNAPSHOT_PS_ARGS]);
   return stdout;
 }
 
@@ -201,8 +219,17 @@ async function defaultEnvForPid(pid: number): Promise<string> {
 export class PsSubprocessProbe implements SubprocessProbe {
   private chatIdsWithLiveWork = new Set<string>();
   private chatIdsWithSessionSpawnedWork = new Set<string>();
-  /** Most recent turn-start instant per chat. Written synchronously, no I/O. */
-  private readonly turnBoundaryMsByChat = new Map<string, number>();
+  /**
+   * The earliest not-yet-assigned turn-start instant per chat. Written
+   * synchronously, no I/O.
+   *
+   * Earliest, not latest: every in-turn event reaches this, so overwriting
+   * would let the second tool call of a turn move the boundary past a watcher
+   * the first one already launched, hiding it for the provider's life. Once a
+   * scan assigns it to a provider the entry is consumed, so a later turn can
+   * still supply a boundary to a provider that appears afterwards.
+   */
+  private readonly pendingTurnBoundaryMsByChat = new Map<string, number>();
   /**
    * Per provider pid: the instant its first turn began. Assigned once — from a
    * chat boundary that is not older than the provider itself — and never
@@ -235,7 +262,8 @@ export class PsSubprocessProbe implements SubprocessProbe {
   }
 
   noteTurnBoundary(chatId: string): void {
-    this.turnBoundaryMsByChat.set(chatId, Date.now());
+    if (this.pendingTurnBoundaryMsByChat.has(chatId)) return;
+    this.pendingTurnBoundaryMsByChat.set(chatId, Date.now());
   }
 
   stop(): void {
@@ -276,13 +304,17 @@ export class PsSubprocessProbe implements SubprocessProbe {
         const providerRow = rowsByPid.get(providerPid);
         let boundaryMs = this.boundaryMsByProviderPid.get(providerPid);
         if (boundaryMs === undefined && chatId && providerRow) {
-          const chatBoundary = this.turnBoundaryMsByChat.get(chatId);
-          // Only a turn that began at or after this provider started belongs to
-          // it. A replacement provider therefore ignores the boundary of the
-          // process it replaced and waits for its own first turn.
-          if (chatBoundary !== undefined && chatBoundary >= earliestStartMs(providerRow, now)) {
+          const chatBoundary = this.pendingTurnBoundaryMsByChat.get(chatId);
+          // Adopt only a boundary that is DEFINITELY at or after this provider
+          // started — the latest instant its age allows. Comparing against the
+          // earliest instead would let a replacement born in the same second
+          // adopt its predecessor's boundary, and then read its own startup MCP
+          // child as work. A replacement that cannot prove it waits for its own
+          // turn instead.
+          if (chatBoundary !== undefined && chatBoundary >= latestStartMs(providerRow, now)) {
             boundaryMs = chatBoundary;
             this.boundaryMsByProviderPid.set(providerPid, chatBoundary);
+            this.pendingTurnBoundaryMsByChat.delete(chatId);
           }
         }
         const live = hasDescendant(providerPid, childrenByParent);

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -190,6 +190,13 @@ type PsSubprocessProbeOptions = {
  * parse, both result sets publish empty, and the idle-suspend protection that
  * predates any of this goes with them.
  */
+/**
+ * Cap on unassigned boundary candidates held per chat. A provider that never
+ * appears in a scan would otherwise accumulate one per turn forever; the
+ * oldest are the ones no live provider can still claim.
+ */
+const MAX_PENDING_TURN_BOUNDARIES = 32;
+
 export const PROCESS_SNAPSHOT_PS_ARGS = ["-axo", "pid=,ppid=,etime=,comm="] as const;
 
 export async function defaultProcessSnapshot(): Promise<string> {
@@ -220,16 +227,19 @@ export class PsSubprocessProbe implements SubprocessProbe {
   private chatIdsWithLiveWork = new Set<string>();
   private chatIdsWithSessionSpawnedWork = new Set<string>();
   /**
-   * The latest unassigned turn-start instant per chat. Written synchronously,
-   * no I/O.
+   * Unassigned turn-start instants per chat, oldest first. Written
+   * synchronously, no I/O.
    *
-   * Its caller fires once per distinct turn, so overwriting is what a newer
-   * turn is *for*: a replacement provider's own first turn must supersede a
-   * candidate left over from the process it replaced, even when that turn
-   * happens before any scan has seen the replacement. Repeated events inside
-   * one turn cannot move it, because they never reach here.
+   * A list rather than one slot, because collapsing it forces a choice that
+   * loses real cases either way: keeping only the newest discards turn 1's
+   * boundary when two turns run between scans, so work turn 1 launched reads
+   * as infrastructure; keeping only the oldest discards a replacement
+   * provider's own first turn. Neither is a property of the timestamps — it is
+   * an artifact of throwing candidates away before any provider has had a
+   * chance to claim one. A provider adopts the earliest candidate that
+   * postdates it, so both cases are answered from the same list.
    */
-  private readonly pendingTurnBoundaryMsByChat = new Map<string, number>();
+  private readonly pendingTurnBoundariesMsByChat = new Map<string, number[]>();
   /**
    * Per provider pid: the instant its first turn began. Assigned once — from a
    * chat boundary that is not older than the provider itself — and never
@@ -262,7 +272,17 @@ export class PsSubprocessProbe implements SubprocessProbe {
   }
 
   noteTurnBoundary(chatId: string): void {
-    this.pendingTurnBoundaryMsByChat.set(chatId, Date.now());
+    const now = Date.now();
+    const pending = this.pendingTurnBoundariesMsByChat.get(chatId);
+    if (!pending) {
+      this.pendingTurnBoundariesMsByChat.set(chatId, [now]);
+      return;
+    }
+    // Same-instant duplicates carry no information: the explicit provider hook
+    // and the event floor can both report one turn's boundary.
+    if (pending[pending.length - 1] === now) return;
+    pending.push(now);
+    if (pending.length > MAX_PENDING_TURN_BOUNDARIES) pending.shift();
   }
 
   stop(): void {
@@ -309,17 +329,29 @@ export class PsSubprocessProbe implements SubprocessProbe {
         const providerRow = rowsByPid.get(providerPid);
         let boundaryMs = this.boundaryMsByProviderPid.get(providerPid);
         if (boundaryMs === undefined && chatId && providerRow) {
-          const chatBoundary = this.pendingTurnBoundaryMsByChat.get(chatId);
+          // The earliest candidate this provider could own. Earliest, so a
+          // second turn cannot bury work the first one launched; "could own",
+          // so a replacement skips its predecessor's leftovers.
+          const providerLatestStart = latestStartMs(providerRow, scanEndMs);
+          const chatBoundary = (this.pendingTurnBoundariesMsByChat.get(chatId) ?? []).find(
+            (candidate) => candidate >= providerLatestStart,
+          );
           // Adopt only a boundary DEFINITELY at or after this provider started:
           // the latest instant its age allows, measured from the latest instant
           // `ps` could have sampled. Comparing against the earliest instead
           // would let a replacement born in the same second adopt its
           // predecessor's boundary and then read its own startup MCP child as
           // work.
-          if (chatBoundary !== undefined && chatBoundary >= latestStartMs(providerRow, scanEndMs)) {
+          if (chatBoundary !== undefined) {
             boundaryMs = chatBoundary;
             this.boundaryMsByProviderPid.set(providerPid, chatBoundary);
-            this.pendingTurnBoundaryMsByChat.delete(chatId);
+            // Everything up to and including the adopted candidate is spent:
+            // older ones can never be owned by a later provider either.
+            const remaining = (this.pendingTurnBoundariesMsByChat.get(chatId) ?? []).filter(
+              (candidate) => candidate > chatBoundary,
+            );
+            if (remaining.length > 0) this.pendingTurnBoundariesMsByChat.set(chatId, remaining);
+            else this.pendingTurnBoundariesMsByChat.delete(chatId);
           }
         }
         const live = hasDescendant(providerPid, childrenByParent);

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -176,23 +176,13 @@ export class PsSubprocessProbe implements SubprocessProbe {
   private chatIdsWithLiveWork = new Set<string>();
   private chatIdsWithSessionSpawnedWork = new Set<string>();
   /**
-   * Per provider pid: the infrastructure children, and whether that set is
-   * still growing. Keyed by pid, so a restarted provider re-baselines for free
-   * and a dead one is pruned on the next scan.
+   * Per provider pid: the children it was running at its first turn boundary.
+   * Written once, from a snapshot taken at that instant, and never revised —
+   * so a later turn cannot absorb a watcher an earlier turn left running.
    */
-  private readonly baselineChildrenByProvider = new Map<
-    number,
-    {
-      pids: Set<number>;
-      sealed: boolean;
-      /** This pid was observed growing before any turn asked to seal it. */
-      grownBeforeSealRequest: boolean;
-      /** The one grace scan given to a pid first seen after the seal request. */
-      graceScanUsed: boolean;
-    }
-  >();
-  /** Chats whose first turn has begun; their provider's baseline is closed. */
-  private readonly sealedChats = new Set<string>();
+  private readonly baselineChildrenByProvider = new Map<number, Set<number>>();
+  /** Last known provider pid -> chat, so a boundary capture can skip a scan. */
+  private readonly chatIdByProviderPid = new Map<number, string>();
   private timer: ReturnType<typeof setInterval> | null = null;
   private inflight: Promise<void> | null = null;
   private readonly daemonPid: number;
@@ -218,7 +208,53 @@ export class PsSubprocessProbe implements SubprocessProbe {
   }
 
   sealBaseline(chatId: string): void {
-    this.sealedChats.add(chatId);
+    // Skip the scan when every provider known for this chat already has its
+    // boundary, so the extra `ps` costs one turn per session, not every turn.
+    let known = false;
+    for (const [pid, mapped] of this.chatIdByProviderPid) {
+      if (mapped !== chatId) continue;
+      known = true;
+      if (!this.baselineChildrenByProvider.has(pid)) break;
+    }
+    const allBaselined =
+      known &&
+      [...this.chatIdByProviderPid].every(
+        ([pid, mapped]) => mapped !== chatId || this.baselineChildrenByProvider.has(pid),
+      );
+    if (allBaselined) return;
+    void this.captureBaselineAtBoundary(chatId);
+  }
+
+  /**
+   * Record what this chat's provider is running *right now*, at a turn
+   * boundary, for any provider pid that does not have a baseline yet.
+   *
+   * The snapshot is the whole point. Deriving the boundary from scan order
+   * cannot work: a periodic scan lands wherever it lands, so "the provider was
+   * observed before the turn" is true even for a scan that ran before the
+   * provider's MCP server existed, and any grace window bought against that
+   * has the mirror defect of absorbing a watcher that is already running. A
+   * turn boundary is a real instant — the provider is initialized, so its
+   * infrastructure is up, and the turn has not yet launched anything.
+   *
+   * A pid with no baseline claims nothing until its next turn boundary, which
+   * is the safe direction for a provider that appears between turns.
+   */
+  private async captureBaselineAtBoundary(chatId: string): Promise<void> {
+    try {
+      const rows = parseProcessRows(await this.runProcessSnapshot());
+      const childrenByParent = buildChildrenIndex(rows);
+      for (const providerPid of findProviderPids(rows, this.daemonPid)) {
+        if (this.baselineChildrenByProvider.has(providerPid)) continue;
+        const owner = extractChatId(await this.runEnvForPid(providerPid));
+        if (owner !== chatId) continue;
+        this.chatIdByProviderPid.set(providerPid, owner);
+        this.baselineChildrenByProvider.set(providerPid, new Set(childrenByParent.get(providerPid) ?? []));
+      }
+    } catch (err) {
+      // No baseline means no claim, so a failed capture degrades to silence.
+      this.opts.log.debug({ err }, "subprocess probe boundary capture failed; leaving this provider unbaselined");
+    }
   }
 
   stop(): void {
@@ -254,44 +290,13 @@ export class PsSubprocessProbe implements SubprocessProbe {
         // exists: baseline growth has to happen during provider startup, which
         // is exactly the window where there may be no children yet.
         const chatId = extractChatId(await this.runEnvForPid(providerPid));
-        const children = childrenByParent.get(providerPid) ?? [];
-        let baseline = this.baselineChildrenByProvider.get(providerPid);
-        if (!baseline) {
-          baseline = { pids: new Set(), sealed: false, grownBeforeSealRequest: false, graceScanUsed: false };
-          this.baselineChildrenByProvider.set(providerPid, baseline);
-        }
-        const grow = (): void => {
-          for (const child of children) baseline.pids.add(child);
-        };
-        if (!baseline.sealed) {
-          if (!(chatId && this.sealedChats.has(chatId))) {
-            // Startup: no turn has asked to close this chat's baseline yet.
-            grow();
-            baseline.grownBeforeSealRequest = true;
-          } else if (baseline.grownBeforeSealRequest) {
-            // The startup window was observed before the turn, so everything
-            // infrastructure could be is already in. Closing WITHOUT growing is
-            // what keeps a task this turn just launched outside the baseline.
-            baseline.sealed = true;
-          } else if (!baseline.graceScanUsed) {
-            // This provider was first seen only after the seal request — a
-            // restarted provider, or a first turn that began before any scan.
-            // It has had no startup window at all, and sealing an empty
-            // baseline is what makes a permanent MCP child look like work. Give
-            // it one full interval to show its infrastructure.
-            baseline.graceScanUsed = true;
-            grow();
-          } else {
-            // End of that interval: absorb whatever appeared during it, then
-            // close. Work started inside the grace window is absorbed too —
-            // silence, which is the error direction this whole signal prefers.
-            grow();
-            baseline.sealed = true;
-          }
-        }
+        const baseline = this.baselineChildrenByProvider.get(providerPid);
         const live = hasDescendant(providerPid, childrenByParent);
-        const sessionSpawned = baseline.sealed && hasNonBaselineChild(providerPid, childrenByParent, baseline.pids);
+        // No boundary captured yet — this provider has not reached a turn since
+        // it appeared, so nothing here is known to be work.
+        const sessionSpawned = baseline !== undefined && hasNonBaselineChild(providerPid, childrenByParent, baseline);
         if (!chatId) continue;
+        this.chatIdByProviderPid.set(providerPid, chatId);
         chatsWithLiveProvider.add(chatId);
         if (live) next.add(chatId);
         if (sessionSpawned) nextSessionSpawned.add(chatId);
@@ -302,10 +307,8 @@ export class PsSubprocessProbe implements SubprocessProbe {
       for (const pid of this.baselineChildrenByProvider.keys()) {
         if (!alive.has(pid)) this.baselineChildrenByProvider.delete(pid);
       }
-      // A chat with no live provider has no baseline to keep closed; the next
-      // provider for it starts its own startup window.
-      for (const chatId of this.sealedChats) {
-        if (!chatsWithLiveProvider.has(chatId)) this.sealedChats.delete(chatId);
+      for (const pid of this.chatIdByProviderPid.keys()) {
+        if (!alive.has(pid)) this.chatIdByProviderPid.delete(pid);
       }
       this.chatIdsWithLiveWork = next;
       this.chatIdsWithSessionSpawnedWork = nextSessionSpawned;

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -36,6 +36,20 @@ export interface SubprocessProbe {
    * idle chat on the host.
    */
   hasSessionSpawnedSubprocess(chatId: string): boolean;
+  /**
+   * A turn has begun for `chatId`, so whatever the provider is running now is
+   * its startup infrastructure and nothing more. Until this is called, the
+   * probe keeps absorbing newly observed children into that provider's
+   * baseline; after it, new children are session-spawned work.
+   *
+   * The seal needs a lifecycle point rather than a scan count: the poll starts
+   * before any provider exists, so a scan can catch a `claude` process in the
+   * window before its stdio MCP server appears. Freezing on first sight would
+   * baseline nothing, and the MCP child arriving one scan later would read as
+   * background work for the rest of that provider's life — the exact false
+   * claim the baseline exists to prevent.
+   */
+  sealBaseline(chatId: string): void;
   /** Stop the background refresh loop (called on SessionRuntime shutdown). */
   stop(): void;
 }
@@ -88,19 +102,20 @@ export function hasDescendant(pid: number, childrenByParent: ReadonlyMap<number,
 }
 
 /**
- * True if `pid` has a direct child outside `baseline` — the children it had
- * when this provider process was first observed.
+ * True if `pid` has a direct child outside `baseline` — the children this
+ * provider was running before its first turn.
  *
  * The baseline is what a provider starts a session with and keeps: stdio MCP
  * servers, most visibly. Work the session itself launches appears as a pid the
  * baseline has never seen, which is exactly the distinction the plain
  * descendant check cannot draw.
  *
- * Both error directions are deliberate. A provider first observed mid-turn
- * baselines that turn's children and under-reports until they exit — silence
- * rather than a false claim. An MCP server that crashes and respawns takes a
- * new pid and over-reports for the rest of that provider process; that is a
- * rare, self-limiting case, unlike the permanent misreading it replaces.
+ * Both error directions are deliberate. A provider whose baseline seals mid-turn
+ * absorbs that turn's children and under-reports until they exit — silence
+ * rather than a false claim. An MCP server that crashes and respawns after the
+ * seal takes a new pid and over-reports for the rest of that provider process;
+ * that is a rare, self-limiting case, unlike the permanent misreading it
+ * replaces.
  */
 export function hasNonBaselineChild(
   pid: number,
@@ -161,11 +176,13 @@ export class PsSubprocessProbe implements SubprocessProbe {
   private chatIdsWithLiveWork = new Set<string>();
   private chatIdsWithSessionSpawnedWork = new Set<string>();
   /**
-   * Direct children each provider pid had when first observed. Keyed by pid,
-   * so a restarted provider re-baselines for free and a dead one is pruned on
-   * the next scan.
+   * Per provider pid: the infrastructure children, and whether that set is
+   * still growing. Keyed by pid, so a restarted provider re-baselines for free
+   * and a dead one is pruned on the next scan.
    */
-  private readonly baselineChildrenByProvider = new Map<number, Set<number>>();
+  private readonly baselineChildrenByProvider = new Map<number, { pids: Set<number>; sealed: boolean }>();
+  /** Chats whose first turn has begun; their provider's baseline is closed. */
+  private readonly sealedChats = new Set<string>();
   private timer: ReturnType<typeof setInterval> | null = null;
   private inflight: Promise<void> | null = null;
   private readonly daemonPid: number;
@@ -188,6 +205,10 @@ export class PsSubprocessProbe implements SubprocessProbe {
 
   hasSessionSpawnedSubprocess(chatId: string): boolean {
     return this.chatIdsWithSessionSpawnedWork.has(chatId);
+  }
+
+  sealBaseline(chatId: string): void {
+    this.sealedChats.add(chatId);
   }
 
   stop(): void {
@@ -216,18 +237,27 @@ export class PsSubprocessProbe implements SubprocessProbe {
       const childrenByParent = buildChildrenIndex(rows);
       const next = new Set<string>();
       const nextSessionSpawned = new Set<string>();
+      const chatsWithLiveProvider = new Set<string>();
       const providerPids = findProviderPids(rows, this.daemonPid);
       for (const providerPid of providerPids) {
+        // The chat is resolved every scan now, not only when a descendant
+        // exists: baseline growth has to happen during provider startup, which
+        // is exactly the window where there may be no children yet.
+        const chatId = extractChatId(await this.runEnvForPid(providerPid));
+        const children = childrenByParent.get(providerPid) ?? [];
         let baseline = this.baselineChildrenByProvider.get(providerPid);
         if (!baseline) {
-          baseline = new Set(childrenByParent.get(providerPid) ?? []);
+          baseline = { pids: new Set(children), sealed: false };
           this.baselineChildrenByProvider.set(providerPid, baseline);
         }
+        if (!baseline.sealed) {
+          if (chatId && this.sealedChats.has(chatId)) baseline.sealed = true;
+          else for (const child of children) baseline.pids.add(child);
+        }
         const live = hasDescendant(providerPid, childrenByParent);
-        const sessionSpawned = hasNonBaselineChild(providerPid, childrenByParent, baseline);
-        if (!live && !sessionSpawned) continue;
-        const chatId = extractChatId(await this.runEnvForPid(providerPid));
+        const sessionSpawned = baseline.sealed && hasNonBaselineChild(providerPid, childrenByParent, baseline.pids);
         if (!chatId) continue;
+        chatsWithLiveProvider.add(chatId);
         if (live) next.add(chatId);
         if (sessionSpawned) nextSessionSpawned.add(chatId);
       }
@@ -236,6 +266,11 @@ export class PsSubprocessProbe implements SubprocessProbe {
       const alive = new Set(providerPids);
       for (const pid of this.baselineChildrenByProvider.keys()) {
         if (!alive.has(pid)) this.baselineChildrenByProvider.delete(pid);
+      }
+      // A chat with no live provider has no baseline to keep closed; the next
+      // provider for it starts its own startup window.
+      for (const chatId of this.sealedChats) {
+        if (!chatsWithLiveProvider.has(chatId)) this.sealedChats.delete(chatId);
       }
       this.chatIdsWithLiveWork = next;
       this.chatIdsWithSessionSpawnedWork = nextSessionSpawned;

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -220,14 +220,14 @@ export class PsSubprocessProbe implements SubprocessProbe {
   private chatIdsWithLiveWork = new Set<string>();
   private chatIdsWithSessionSpawnedWork = new Set<string>();
   /**
-   * The earliest not-yet-assigned turn-start instant per chat. Written
-   * synchronously, no I/O.
+   * The latest unassigned turn-start instant per chat. Written synchronously,
+   * no I/O.
    *
-   * Earliest, not latest: every in-turn event reaches this, so overwriting
-   * would let the second tool call of a turn move the boundary past a watcher
-   * the first one already launched, hiding it for the provider's life. Once a
-   * scan assigns it to a provider the entry is consumed, so a later turn can
-   * still supply a boundary to a provider that appears afterwards.
+   * Its caller fires once per distinct turn, so overwriting is what a newer
+   * turn is *for*: a replacement provider's own first turn must supersede a
+   * candidate left over from the process it replaced, even when that turn
+   * happens before any scan has seen the replacement. Repeated events inside
+   * one turn cannot move it, because they never reach here.
    */
   private readonly pendingTurnBoundaryMsByChat = new Map<string, number>();
   /**
@@ -262,7 +262,6 @@ export class PsSubprocessProbe implements SubprocessProbe {
   }
 
   noteTurnBoundary(chatId: string): void {
-    if (this.pendingTurnBoundaryMsByChat.has(chatId)) return;
     this.pendingTurnBoundaryMsByChat.set(chatId, Date.now());
   }
 
@@ -301,8 +300,6 @@ export class PsSubprocessProbe implements SubprocessProbe {
       const next = new Set<string>();
       const nextSessionSpawned = new Set<string>();
       const chatsWithLiveProvider = new Set<string>();
-      /** Pending boundaries a provider rejected as older than itself. */
-      const supersededPendingChats = new Set<string>();
       const providerPids = findProviderPids(rows, this.daemonPid);
       for (const providerPid of providerPids) {
         // The chat is resolved every scan now, not only when a descendant
@@ -323,12 +320,6 @@ export class PsSubprocessProbe implements SubprocessProbe {
             boundaryMs = chatBoundary;
             this.boundaryMsByProviderPid.set(providerPid, chatBoundary);
             this.pendingTurnBoundaryMsByChat.delete(chatId);
-          } else if (chatBoundary !== undefined) {
-            // It predates this provider, so it can never become its boundary.
-            // Dropping it is what lets this provider's OWN next turn be
-            // recorded — holding it would make one stale timestamp swallow
-            // every later turn and hide this provider's work for good.
-            supersededPendingChats.add(chatId);
           }
         }
         const live = hasDescendant(providerPid, childrenByParent);
@@ -344,9 +335,6 @@ export class PsSubprocessProbe implements SubprocessProbe {
       }
       // Drop baselines for providers that are gone, so a recycled pid cannot
       // inherit a previous provider's session infrastructure.
-      for (const chatId of supersededPendingChats) {
-        if (!nextSessionSpawned.has(chatId)) this.pendingTurnBoundaryMsByChat.delete(chatId);
-      }
       const alive = new Set(providerPids);
       for (const pid of this.boundaryMsByProviderPid.keys()) {
         if (!alive.has(pid)) this.boundaryMsByProviderPid.delete(pid);

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -22,6 +22,20 @@ const execFileAsync = promisify(execFile);
 export interface SubprocessProbe {
   /** True if the provider for `chatId` currently has at least one live descendant. */
   hasLiveSubprocess(chatId: string): boolean;
+  /**
+   * True if the provider for `chatId` has a live child it did NOT start the
+   * session with — the closest available reading of "a task this session
+   * launched is still running".
+   *
+   * `hasLiveSubprocess` cannot answer that question. Its predicate is "the
+   * provider has any direct child", and a stdio MCP server is a direct child
+   * for the whole life of the session, so for any MCP-configured agent it is
+   * unconditionally true. That is harmless for the deferral it was built for
+   * (over-deferring a suspend is conservative and invisible) but wrong for
+   * anything a user reads, which would then say "background task" about every
+   * idle chat on the host.
+   */
+  hasSessionSpawnedSubprocess(chatId: string): boolean;
   /** Stop the background refresh loop (called on SessionRuntime shutdown). */
   stop(): void;
 }
@@ -74,6 +88,29 @@ export function hasDescendant(pid: number, childrenByParent: ReadonlyMap<number,
 }
 
 /**
+ * True if `pid` has a direct child outside `baseline` — the children it had
+ * when this provider process was first observed.
+ *
+ * The baseline is what a provider starts a session with and keeps: stdio MCP
+ * servers, most visibly. Work the session itself launches appears as a pid the
+ * baseline has never seen, which is exactly the distinction the plain
+ * descendant check cannot draw.
+ *
+ * Both error directions are deliberate. A provider first observed mid-turn
+ * baselines that turn's children and under-reports until they exit — silence
+ * rather than a false claim. An MCP server that crashes and respawns takes a
+ * new pid and over-reports for the rest of that provider process; that is a
+ * rare, self-limiting case, unlike the permanent misreading it replaces.
+ */
+export function hasNonBaselineChild(
+  pid: number,
+  childrenByParent: ReadonlyMap<number, number[]>,
+  baseline: ReadonlySet<number>,
+): boolean {
+  return (childrenByParent.get(pid) ?? []).some((childPid) => !baseline.has(childPid));
+}
+
+/**
  * Extract the `FIRST_TREE_CHAT_ID` value from a process's environment dump.
  * Handles both forms produced by {@link defaultEnvForPid}: space-separated
  * (Darwin `ps -Eww`) and NUL-separated (Linux `/proc/<pid>/environ`). The value
@@ -122,6 +159,13 @@ async function defaultEnvForPid(pid: number): Promise<string> {
  */
 export class PsSubprocessProbe implements SubprocessProbe {
   private chatIdsWithLiveWork = new Set<string>();
+  private chatIdsWithSessionSpawnedWork = new Set<string>();
+  /**
+   * Direct children each provider pid had when first observed. Keyed by pid,
+   * so a restarted provider re-baselines for free and a dead one is pruned on
+   * the next scan.
+   */
+  private readonly baselineChildrenByProvider = new Map<number, Set<number>>();
   private timer: ReturnType<typeof setInterval> | null = null;
   private inflight: Promise<void> | null = null;
   private readonly daemonPid: number;
@@ -140,6 +184,10 @@ export class PsSubprocessProbe implements SubprocessProbe {
 
   hasLiveSubprocess(chatId: string): boolean {
     return this.chatIdsWithLiveWork.has(chatId);
+  }
+
+  hasSessionSpawnedSubprocess(chatId: string): boolean {
+    return this.chatIdsWithSessionSpawnedWork.has(chatId);
   }
 
   stop(): void {
@@ -167,12 +215,30 @@ export class PsSubprocessProbe implements SubprocessProbe {
       const rows = parseProcessRows(await this.runProcessSnapshot());
       const childrenByParent = buildChildrenIndex(rows);
       const next = new Set<string>();
-      for (const providerPid of findProviderPids(rows, this.daemonPid)) {
-        if (!hasDescendant(providerPid, childrenByParent)) continue;
+      const nextSessionSpawned = new Set<string>();
+      const providerPids = findProviderPids(rows, this.daemonPid);
+      for (const providerPid of providerPids) {
+        let baseline = this.baselineChildrenByProvider.get(providerPid);
+        if (!baseline) {
+          baseline = new Set(childrenByParent.get(providerPid) ?? []);
+          this.baselineChildrenByProvider.set(providerPid, baseline);
+        }
+        const live = hasDescendant(providerPid, childrenByParent);
+        const sessionSpawned = hasNonBaselineChild(providerPid, childrenByParent, baseline);
+        if (!live && !sessionSpawned) continue;
         const chatId = extractChatId(await this.runEnvForPid(providerPid));
-        if (chatId) next.add(chatId);
+        if (!chatId) continue;
+        if (live) next.add(chatId);
+        if (sessionSpawned) nextSessionSpawned.add(chatId);
+      }
+      // Drop baselines for providers that are gone, so a recycled pid cannot
+      // inherit a previous provider's session infrastructure.
+      const alive = new Set(providerPids);
+      for (const pid of this.baselineChildrenByProvider.keys()) {
+        if (!alive.has(pid)) this.baselineChildrenByProvider.delete(pid);
       }
       this.chatIdsWithLiveWork = next;
+      this.chatIdsWithSessionSpawnedWork = nextSessionSpawned;
     } catch (err) {
       // A probe failure must never wedge the runtime: fall back to "no live
       // work", which simply lets suspend proceed exactly as it did before this
@@ -182,6 +248,7 @@ export class PsSubprocessProbe implements SubprocessProbe {
         "subprocess probe refresh failed; treating all sessions as having no live subprocess",
       );
       this.chatIdsWithLiveWork = new Set();
+      this.chatIdsWithSessionSpawnedWork = new Set();
     }
   }
 }

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -180,7 +180,17 @@ export class PsSubprocessProbe implements SubprocessProbe {
    * still growing. Keyed by pid, so a restarted provider re-baselines for free
    * and a dead one is pruned on the next scan.
    */
-  private readonly baselineChildrenByProvider = new Map<number, { pids: Set<number>; sealed: boolean }>();
+  private readonly baselineChildrenByProvider = new Map<
+    number,
+    {
+      pids: Set<number>;
+      sealed: boolean;
+      /** This pid was observed growing before any turn asked to seal it. */
+      grownBeforeSealRequest: boolean;
+      /** The one grace scan given to a pid first seen after the seal request. */
+      graceScanUsed: boolean;
+    }
+  >();
   /** Chats whose first turn has begun; their provider's baseline is closed. */
   private readonly sealedChats = new Set<string>();
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -247,12 +257,37 @@ export class PsSubprocessProbe implements SubprocessProbe {
         const children = childrenByParent.get(providerPid) ?? [];
         let baseline = this.baselineChildrenByProvider.get(providerPid);
         if (!baseline) {
-          baseline = { pids: new Set(children), sealed: false };
+          baseline = { pids: new Set(), sealed: false, grownBeforeSealRequest: false, graceScanUsed: false };
           this.baselineChildrenByProvider.set(providerPid, baseline);
         }
+        const grow = (): void => {
+          for (const child of children) baseline.pids.add(child);
+        };
         if (!baseline.sealed) {
-          if (chatId && this.sealedChats.has(chatId)) baseline.sealed = true;
-          else for (const child of children) baseline.pids.add(child);
+          if (!(chatId && this.sealedChats.has(chatId))) {
+            // Startup: no turn has asked to close this chat's baseline yet.
+            grow();
+            baseline.grownBeforeSealRequest = true;
+          } else if (baseline.grownBeforeSealRequest) {
+            // The startup window was observed before the turn, so everything
+            // infrastructure could be is already in. Closing WITHOUT growing is
+            // what keeps a task this turn just launched outside the baseline.
+            baseline.sealed = true;
+          } else if (!baseline.graceScanUsed) {
+            // This provider was first seen only after the seal request — a
+            // restarted provider, or a first turn that began before any scan.
+            // It has had no startup window at all, and sealing an empty
+            // baseline is what makes a permanent MCP child look like work. Give
+            // it one full interval to show its infrastructure.
+            baseline.graceScanUsed = true;
+            grow();
+          } else {
+            // End of that interval: absorb whatever appeared during it, then
+            // close. Work started inside the grace window is absorbed too —
+            // silence, which is the error direction this whole signal prefers.
+            grow();
+            baseline.sealed = true;
+          }
         }
         const live = hasDescendant(providerPid, childrenByParent);
         const sessionSpawned = baseline.sealed && hasNonBaselineChild(providerPid, childrenByParent, baseline.pids);

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -88,8 +88,8 @@ export function parseProcessRows(output: string): ProcessRow[] {
  * and a child too close to call reads as infrastructure — silence rather than
  * a false claim, the same bias as everywhere else in this signal.
  */
-function earliestStartMs(row: ProcessRow, nowMs: number): number {
-  return nowMs - (row.elapsedSec + 1) * 1_000;
+function earliestStartMs(row: ProcessRow, sampledAtLowerBoundMs: number): number {
+  return sampledAtLowerBoundMs - (row.elapsedSec + 1) * 1_000;
 }
 
 /**
@@ -97,8 +97,8 @@ function earliestStartMs(row: ProcessRow, nowMs: number): number {
  * Pairs with {@link earliestStartMs}: each comparison picks whichever end of
  * the one-second uncertainty makes the claim harder to prove.
  */
-function latestStartMs(row: ProcessRow, nowMs: number): number {
-  return nowMs - row.elapsedSec * 1_000;
+function latestStartMs(row: ProcessRow, sampledAtUpperBoundMs: number): number {
+  return sampledAtUpperBoundMs - row.elapsedSec * 1_000;
 }
 
 /** Build a parent-pid -> child-pids adjacency index. */
@@ -151,11 +151,11 @@ export function hasChildStartedAfter(
   childrenByParent: ReadonlyMap<number, number[]>,
   rowsByPid: ReadonlyMap<number, ProcessRow>,
   boundaryMs: number,
-  nowMs: number,
+  sampledAtLowerBoundMs: number,
 ): boolean {
   return (childrenByParent.get(pid) ?? []).some((childPid) => {
     const row = rowsByPid.get(childPid);
-    return row !== undefined && earliestStartMs(row, nowMs) > boundaryMs;
+    return row !== undefined && earliestStartMs(row, sampledAtLowerBoundMs) > boundaryMs;
   });
 }
 
@@ -288,13 +288,21 @@ export class PsSubprocessProbe implements SubprocessProbe {
 
   private async doRefresh(): Promise<void> {
     try {
-      const now = Date.now();
+      // `ps` samples somewhere inside [scanStartMs, scanEndMs], and the command
+      // can take a while. Each bound below is derived from whichever end of
+      // that window makes its claim harder to prove; collapsing them into one
+      // `Date.now()` taken before the await silently shifts both start bounds
+      // backwards by however long the command took.
+      const scanStartMs = Date.now();
       const rows = parseProcessRows(await this.runProcessSnapshot());
+      const scanEndMs = Date.now();
       const childrenByParent = buildChildrenIndex(rows);
       const rowsByPid = new Map(rows.map((row) => [row.pid, row]));
       const next = new Set<string>();
       const nextSessionSpawned = new Set<string>();
       const chatsWithLiveProvider = new Set<string>();
+      /** Pending boundaries a provider rejected as older than itself. */
+      const supersededPendingChats = new Set<string>();
       const providerPids = findProviderPids(rows, this.daemonPid);
       for (const providerPid of providerPids) {
         // The chat is resolved every scan now, not only when a descendant
@@ -305,23 +313,30 @@ export class PsSubprocessProbe implements SubprocessProbe {
         let boundaryMs = this.boundaryMsByProviderPid.get(providerPid);
         if (boundaryMs === undefined && chatId && providerRow) {
           const chatBoundary = this.pendingTurnBoundaryMsByChat.get(chatId);
-          // Adopt only a boundary that is DEFINITELY at or after this provider
-          // started — the latest instant its age allows. Comparing against the
-          // earliest instead would let a replacement born in the same second
-          // adopt its predecessor's boundary, and then read its own startup MCP
-          // child as work. A replacement that cannot prove it waits for its own
-          // turn instead.
-          if (chatBoundary !== undefined && chatBoundary >= latestStartMs(providerRow, now)) {
+          // Adopt only a boundary DEFINITELY at or after this provider started:
+          // the latest instant its age allows, measured from the latest instant
+          // `ps` could have sampled. Comparing against the earliest instead
+          // would let a replacement born in the same second adopt its
+          // predecessor's boundary and then read its own startup MCP child as
+          // work.
+          if (chatBoundary !== undefined && chatBoundary >= latestStartMs(providerRow, scanEndMs)) {
             boundaryMs = chatBoundary;
             this.boundaryMsByProviderPid.set(providerPid, chatBoundary);
             this.pendingTurnBoundaryMsByChat.delete(chatId);
+          } else if (chatBoundary !== undefined) {
+            // It predates this provider, so it can never become its boundary.
+            // Dropping it is what lets this provider's OWN next turn be
+            // recorded — holding it would make one stale timestamp swallow
+            // every later turn and hide this provider's work for good.
+            supersededPendingChats.add(chatId);
           }
         }
         const live = hasDescendant(providerPid, childrenByParent);
         // No boundary yet — this provider has not reached a turn since it
         // appeared, so nothing under it is known to be work.
         const sessionSpawned =
-          boundaryMs !== undefined && hasChildStartedAfter(providerPid, childrenByParent, rowsByPid, boundaryMs, now);
+          boundaryMs !== undefined &&
+          hasChildStartedAfter(providerPid, childrenByParent, rowsByPid, boundaryMs, scanStartMs);
         if (!chatId) continue;
         chatsWithLiveProvider.add(chatId);
         if (live) next.add(chatId);
@@ -329,6 +344,9 @@ export class PsSubprocessProbe implements SubprocessProbe {
       }
       // Drop baselines for providers that are gone, so a recycled pid cannot
       // inherit a previous provider's session infrastructure.
+      for (const chatId of supersededPendingChats) {
+        if (!nextSessionSpawned.has(chatId)) this.pendingTurnBoundaryMsByChat.delete(chatId);
+      }
       const alive = new Set(providerPids);
       for (const pid of this.boundaryMsByProviderPid.keys()) {
         if (!alive.has(pid)) this.boundaryMsByProviderPid.delete(pid);

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -37,36 +37,59 @@ export interface SubprocessProbe {
    */
   hasSessionSpawnedSubprocess(chatId: string): boolean;
   /**
-   * A turn has begun for `chatId`, so whatever the provider is running now is
-   * its startup infrastructure and nothing more. Until this is called, the
-   * probe keeps absorbing newly observed children into that provider's
-   * baseline; after it, new children are session-spawned work.
+   * A turn has begun for `chatId`. Records the instant, nothing more.
    *
-   * The seal needs a lifecycle point rather than a scan count: the poll starts
-   * before any provider exists, so a scan can catch a `claude` process in the
-   * window before its stdio MCP server appears. Freezing on first sight would
-   * baseline nothing, and the MCP child arriving one scan later would read as
-   * background work for the rest of that provider's life — the exact false
-   * claim the baseline exists to prevent.
+   * The instant is the whole mechanism: a child that started before its
+   * provider's first turn is startup infrastructure (a stdio MCP server), and
+   * one that started after it is work the session launched. Both facts are
+   * read from each process's own age, so this call does no I/O and the answer
+   * does not depend on when a scan happens to run, how many scans have run, or
+   * whether one is in flight — the failure modes of every version of this that
+   * inferred the boundary from observation order.
    */
-  sealBaseline(chatId: string): void;
+  noteTurnBoundary(chatId: string): void;
   /** Stop the background refresh loop (called on SessionRuntime shutdown). */
   stop(): void;
 }
 
-export type ProcessRow = { pid: number; ppid: number; comm: string };
+export type ProcessRow = { pid: number; ppid: number; elapsedSec: number; comm: string };
 
-/** Parse `ps -axo pid=,ppid=,comm=` output into rows. Unparseable lines are skipped. */
+/**
+ * Parse `[[dd-]hh:]mm:ss` elapsed time into seconds. Returns null when the
+ * field is not an elapsed time, which is how a row from an older column layout
+ * is rejected rather than silently misread as a pid.
+ */
+export function parseElapsedSeconds(field: string): number | null {
+  const match = field.match(/^(?:(\d+)-)?(?:(\d+):)?(\d{1,2}):(\d{2})$/);
+  if (!match) return null;
+  const [, days, hours, minutes, seconds] = match;
+  return Number(days ?? 0) * 86_400 + Number(hours ?? 0) * 3_600 + Number(minutes ?? 0) * 60 + Number(seconds ?? 0);
+}
+
+/** Parse `ps -axo pid=,ppid=,etime=,comm=` output into rows. Unparseable lines are skipped. */
 export function parseProcessRows(output: string): ProcessRow[] {
   const rows: ProcessRow[] = [];
   for (const line of output.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(.*)$/);
+    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/);
     if (!match) continue;
-    rows.push({ pid: Number(match[1]), ppid: Number(match[2]), comm: match[3] ?? "" });
+    const elapsedSec = parseElapsedSeconds(match[3] ?? "");
+    if (elapsedSec === null) continue;
+    rows.push({ pid: Number(match[1]), ppid: Number(match[2]), elapsedSec, comm: match[4] ?? "" });
   }
   return rows;
+}
+
+/**
+ * The earliest instant a process with this elapsed time could have started.
+ * `etime` has one-second resolution, so a whole extra second is subtracted:
+ * every comparison then asks "did this definitely start after the boundary",
+ * and a child too close to call reads as infrastructure — silence rather than
+ * a false claim, the same bias as everywhere else in this signal.
+ */
+function earliestStartMs(row: ProcessRow, nowMs: number): number {
+  return nowMs - (row.elapsedSec + 1) * 1_000;
 }
 
 /** Build a parent-pid -> child-pids adjacency index. */
@@ -102,27 +125,29 @@ export function hasDescendant(pid: number, childrenByParent: ReadonlyMap<number,
 }
 
 /**
- * True if `pid` has a direct child outside `baseline` — the children this
- * provider was running before its first turn.
+ * True if `pid` has a direct child that definitely started after `boundaryMs` —
+ * the instant its provider's first turn began.
  *
- * The baseline is what a provider starts a session with and keeps: stdio MCP
- * servers, most visibly. Work the session itself launches appears as a pid the
- * baseline has never seen, which is exactly the distinction the plain
- * descendant check cannot draw.
- *
- * Both error directions are deliberate. A provider whose baseline seals mid-turn
- * absorbs that turn's children and under-reports until they exit — silence
- * rather than a false claim. An MCP server that crashes and respawns after the
- * seal takes a new pid and over-reports for the rest of that provider process;
- * that is a rare, self-limiting case, unlike the permanent misreading it
- * replaces.
+ * This is the distinction the plain descendant check cannot draw. A stdio MCP
+ * server starts with the provider, so it predates that boundary for the whole
+ * session; a task the session launches starts after it. Reading each child's
+ * own age makes the answer independent of when the process scan runs, which is
+ * what every earlier version of this got wrong: they inferred the boundary
+ * from the order of observations, and an observation that lands in a startup
+ * gap, or a snapshot that completes after the work has begun, tells you
+ * nothing about what came first.
  */
-export function hasNonBaselineChild(
+export function hasChildStartedAfter(
   pid: number,
   childrenByParent: ReadonlyMap<number, number[]>,
-  baseline: ReadonlySet<number>,
+  rowsByPid: ReadonlyMap<number, ProcessRow>,
+  boundaryMs: number,
+  nowMs: number,
 ): boolean {
-  return (childrenByParent.get(pid) ?? []).some((childPid) => !baseline.has(childPid));
+  return (childrenByParent.get(pid) ?? []).some((childPid) => {
+    const row = rowsByPid.get(childPid);
+    return row !== undefined && earliestStartMs(row, nowMs) > boundaryMs;
+  });
 }
 
 /**
@@ -172,17 +197,19 @@ async function defaultEnvForPid(pid: number): Promise<string> {
  * synchronous `hasLiveSubprocess` lookup used inside `evictIdle` never blocks on
  * a process scan.
  */
+
 export class PsSubprocessProbe implements SubprocessProbe {
   private chatIdsWithLiveWork = new Set<string>();
   private chatIdsWithSessionSpawnedWork = new Set<string>();
+  /** Most recent turn-start instant per chat. Written synchronously, no I/O. */
+  private readonly turnBoundaryMsByChat = new Map<string, number>();
   /**
-   * Per provider pid: the children it was running at its first turn boundary.
-   * Written once, from a snapshot taken at that instant, and never revised —
-   * so a later turn cannot absorb a watcher an earlier turn left running.
+   * Per provider pid: the instant its first turn began. Assigned once — from a
+   * chat boundary that is not older than the provider itself — and never
+   * revised, so a later turn cannot reclassify a task an earlier turn left
+   * running. A pid with no boundary claims nothing.
    */
-  private readonly baselineChildrenByProvider = new Map<number, Set<number>>();
-  /** Last known provider pid -> chat, so a boundary capture can skip a scan. */
-  private readonly chatIdByProviderPid = new Map<number, string>();
+  private readonly boundaryMsByProviderPid = new Map<number, number>();
   private timer: ReturnType<typeof setInterval> | null = null;
   private inflight: Promise<void> | null = null;
   private readonly daemonPid: number;
@@ -207,54 +234,8 @@ export class PsSubprocessProbe implements SubprocessProbe {
     return this.chatIdsWithSessionSpawnedWork.has(chatId);
   }
 
-  sealBaseline(chatId: string): void {
-    // Skip the scan when every provider known for this chat already has its
-    // boundary, so the extra `ps` costs one turn per session, not every turn.
-    let known = false;
-    for (const [pid, mapped] of this.chatIdByProviderPid) {
-      if (mapped !== chatId) continue;
-      known = true;
-      if (!this.baselineChildrenByProvider.has(pid)) break;
-    }
-    const allBaselined =
-      known &&
-      [...this.chatIdByProviderPid].every(
-        ([pid, mapped]) => mapped !== chatId || this.baselineChildrenByProvider.has(pid),
-      );
-    if (allBaselined) return;
-    void this.captureBaselineAtBoundary(chatId);
-  }
-
-  /**
-   * Record what this chat's provider is running *right now*, at a turn
-   * boundary, for any provider pid that does not have a baseline yet.
-   *
-   * The snapshot is the whole point. Deriving the boundary from scan order
-   * cannot work: a periodic scan lands wherever it lands, so "the provider was
-   * observed before the turn" is true even for a scan that ran before the
-   * provider's MCP server existed, and any grace window bought against that
-   * has the mirror defect of absorbing a watcher that is already running. A
-   * turn boundary is a real instant — the provider is initialized, so its
-   * infrastructure is up, and the turn has not yet launched anything.
-   *
-   * A pid with no baseline claims nothing until its next turn boundary, which
-   * is the safe direction for a provider that appears between turns.
-   */
-  private async captureBaselineAtBoundary(chatId: string): Promise<void> {
-    try {
-      const rows = parseProcessRows(await this.runProcessSnapshot());
-      const childrenByParent = buildChildrenIndex(rows);
-      for (const providerPid of findProviderPids(rows, this.daemonPid)) {
-        if (this.baselineChildrenByProvider.has(providerPid)) continue;
-        const owner = extractChatId(await this.runEnvForPid(providerPid));
-        if (owner !== chatId) continue;
-        this.chatIdByProviderPid.set(providerPid, owner);
-        this.baselineChildrenByProvider.set(providerPid, new Set(childrenByParent.get(providerPid) ?? []));
-      }
-    } catch (err) {
-      // No baseline means no claim, so a failed capture degrades to silence.
-      this.opts.log.debug({ err }, "subprocess probe boundary capture failed; leaving this provider unbaselined");
-    }
+  noteTurnBoundary(chatId: string): void {
+    this.turnBoundaryMsByChat.set(chatId, Date.now());
   }
 
   stop(): void {
@@ -279,8 +260,10 @@ export class PsSubprocessProbe implements SubprocessProbe {
 
   private async doRefresh(): Promise<void> {
     try {
+      const now = Date.now();
       const rows = parseProcessRows(await this.runProcessSnapshot());
       const childrenByParent = buildChildrenIndex(rows);
+      const rowsByPid = new Map(rows.map((row) => [row.pid, row]));
       const next = new Set<string>();
       const nextSessionSpawned = new Set<string>();
       const chatsWithLiveProvider = new Set<string>();
@@ -290,13 +273,24 @@ export class PsSubprocessProbe implements SubprocessProbe {
         // exists: baseline growth has to happen during provider startup, which
         // is exactly the window where there may be no children yet.
         const chatId = extractChatId(await this.runEnvForPid(providerPid));
-        const baseline = this.baselineChildrenByProvider.get(providerPid);
+        const providerRow = rowsByPid.get(providerPid);
+        let boundaryMs = this.boundaryMsByProviderPid.get(providerPid);
+        if (boundaryMs === undefined && chatId && providerRow) {
+          const chatBoundary = this.turnBoundaryMsByChat.get(chatId);
+          // Only a turn that began at or after this provider started belongs to
+          // it. A replacement provider therefore ignores the boundary of the
+          // process it replaced and waits for its own first turn.
+          if (chatBoundary !== undefined && chatBoundary >= earliestStartMs(providerRow, now)) {
+            boundaryMs = chatBoundary;
+            this.boundaryMsByProviderPid.set(providerPid, chatBoundary);
+          }
+        }
         const live = hasDescendant(providerPid, childrenByParent);
-        // No boundary captured yet — this provider has not reached a turn since
-        // it appeared, so nothing here is known to be work.
-        const sessionSpawned = baseline !== undefined && hasNonBaselineChild(providerPid, childrenByParent, baseline);
+        // No boundary yet — this provider has not reached a turn since it
+        // appeared, so nothing under it is known to be work.
+        const sessionSpawned =
+          boundaryMs !== undefined && hasChildStartedAfter(providerPid, childrenByParent, rowsByPid, boundaryMs, now);
         if (!chatId) continue;
-        this.chatIdByProviderPid.set(providerPid, chatId);
         chatsWithLiveProvider.add(chatId);
         if (live) next.add(chatId);
         if (sessionSpawned) nextSessionSpawned.add(chatId);
@@ -304,11 +298,8 @@ export class PsSubprocessProbe implements SubprocessProbe {
       // Drop baselines for providers that are gone, so a recycled pid cannot
       // inherit a previous provider's session infrastructure.
       const alive = new Set(providerPids);
-      for (const pid of this.baselineChildrenByProvider.keys()) {
-        if (!alive.has(pid)) this.baselineChildrenByProvider.delete(pid);
-      }
-      for (const pid of this.chatIdByProviderPid.keys()) {
-        if (!alive.has(pid)) this.chatIdByProviderPid.delete(pid);
+      for (const pid of this.boundaryMsByProviderPid.keys()) {
+        if (!alive.has(pid)) this.boundaryMsByProviderPid.delete(pid);
       }
       this.chatIdsWithLiveWork = next;
       this.chatIdsWithSessionSpawnedWork = nextSessionSpawned;

--- a/packages/client/src/runtime/reset-replay-authority.ts
+++ b/packages/client/src/runtime/reset-replay-authority.ts
@@ -1,4 +1,4 @@
-import { INBOX_FENCE_PROBE_MAX_IDS, type RuntimeState } from "@first-tree/shared";
+import { INBOX_FENCE_PROBE_MAX_IDS, type SessionRuntimeReport } from "@first-tree/shared";
 import type { pino } from "../cloud/observability/logger.js";
 import type { SessionMessage } from "./handler.js";
 import { type ReplayFenceEntry, ReplayFenceStore, type ReplayFenceWriter } from "./replay-fence.js";
@@ -44,7 +44,7 @@ export type ResetReplayAuthorityDeps = {
   probeFencedSettlement: () =>
     | ((chatId: string, messageIds: readonly string[]) => Promise<readonly string[]>)
     | undefined;
-  onSessionRuntimeChange: () => ((chatId: string, state: RuntimeState) => void) | undefined;
+  onSessionRuntimeChange: () => ((chatId: string, report: SessionRuntimeReport) => void) | undefined;
   projectSessionRuntime: (chatId: string) => void;
   /**
    * SessionRegistry custody lives on SessionProjectionAuthority; these
@@ -417,7 +417,7 @@ export class ResetReplayAuthority {
           { err, chatId, messageId },
           "stale replay fence could not be cleared; the retry loop will redo the local clear",
         );
-        this.deps.onSessionRuntimeChange()?.(chatId, "error");
+        this.deps.onSessionRuntimeChange()?.(chatId, { runtimeState: "error", backgroundWork: false });
       }
     }
     if (proven.size === 0) this.provenSettledFences.delete(chatId);
@@ -541,7 +541,7 @@ export class ResetReplayAuthority {
           { err, chatId, messageId },
           "replay fence could not be cleared after confirmed ACK; the retry loop will redo the local clear",
         );
-        this.deps.onSessionRuntimeChange()?.(chatId, "error");
+        this.deps.onSessionRuntimeChange()?.(chatId, { runtimeState: "error", backgroundWork: false });
       }
     }
     if (transitioned && !this.replayFence.hasFenceForChat(chatId)) {

--- a/packages/client/src/runtime/session-projection-authority.ts
+++ b/packages/client/src/runtime/session-projection-authority.ts
@@ -402,9 +402,14 @@ export class SessionProjectionAuthority<
    * chat surface.
    */
   noteProviderTurnStart(chatId: string): void {
-    this.deps.onProviderTurnStarted(chatId);
     if (this.providerTurnInFlight.has(chatId)) return;
     this.providerTurnInFlight.add(chatId);
+    // Below the in-flight guard on purpose: this fires once per DISTINCT turn,
+    // never once per in-turn event. That is what lets the subprocess probe
+    // treat each call as a newer boundary candidate — a later turn supersedes
+    // an unassigned one — without a turn's own second tool call being able to
+    // move the boundary past work its first one already launched.
+    this.deps.onProviderTurnStarted(chatId);
     this.projectSessionRuntime(chatId);
   }
 

--- a/packages/client/src/runtime/session-projection-authority.ts
+++ b/packages/client/src/runtime/session-projection-authority.ts
@@ -62,12 +62,6 @@ export type SessionProjectionAuthorityDeps = {
    * owns both the probe and the cap).
    */
   hasReportableBackgroundWork: (chatId: string) => boolean;
-  /**
-   * A turn opened for this chat. The subprocess probe records the instant, and
-   * later reads each provider child's own age against it: what predates the
-   * first turn is startup infrastructure, what started after it is work.
-   */
-  onProviderTurnStarted: (chatId: string) => void;
   onRuntimeStateChange: () => ((state: RuntimeState) => void) | undefined;
   /** Inbox processing ownership still lives on InboxDeliveryCoordinator. */
   hasProcessingOwnedWork: (chatId: string) => boolean;
@@ -401,16 +395,12 @@ export class SessionProjectionAuthority<
    * and projecting `idle` for it made a busy agent read as "Idle" on every
    * chat surface.
    */
-  noteProviderTurnStart(chatId: string): void {
-    if (this.providerTurnInFlight.has(chatId)) return;
+  /** Returns true when this opened a turn, false when one was already in flight. */
+  noteProviderTurnStart(chatId: string): boolean {
+    if (this.providerTurnInFlight.has(chatId)) return false;
     this.providerTurnInFlight.add(chatId);
-    // Below the in-flight guard on purpose: this fires once per DISTINCT turn,
-    // never once per in-turn event. That is what lets the subprocess probe
-    // treat each call as a newer boundary candidate — a later turn supersedes
-    // an unassigned one — without a turn's own second tool call being able to
-    // move the boundary past work its first one already launched.
-    this.deps.onProviderTurnStarted(chatId);
     this.projectSessionRuntime(chatId);
+    return true;
   }
 
   /**

--- a/packages/client/src/runtime/session-projection-authority.ts
+++ b/packages/client/src/runtime/session-projection-authority.ts
@@ -63,9 +63,9 @@ export type SessionProjectionAuthorityDeps = {
    */
   hasReportableBackgroundWork: (chatId: string) => boolean;
   /**
-   * A turn opened for this chat. The subprocess probe uses it to close the
-   * provider's startup-infrastructure baseline: whatever is running when the
-   * first turn begins is infrastructure, and anything later is work.
+   * A turn opened for this chat. The subprocess probe records the instant, and
+   * later reads each provider child's own age against it: what predates the
+   * first turn is startup infrastructure, what started after it is work.
    */
   onProviderTurnStarted: (chatId: string) => void;
   onRuntimeStateChange: () => ((state: RuntimeState) => void) | undefined;

--- a/packages/client/src/runtime/session-projection-authority.ts
+++ b/packages/client/src/runtime/session-projection-authority.ts
@@ -62,6 +62,12 @@ export type SessionProjectionAuthorityDeps = {
    * owns both the probe and the cap).
    */
   hasReportableBackgroundWork: (chatId: string) => boolean;
+  /**
+   * A turn opened for this chat. The subprocess probe uses it to close the
+   * provider's startup-infrastructure baseline: whatever is running when the
+   * first turn begins is infrastructure, and anything later is work.
+   */
+  onProviderTurnStarted: (chatId: string) => void;
   onRuntimeStateChange: () => ((state: RuntimeState) => void) | undefined;
   /** Inbox processing ownership still lives on InboxDeliveryCoordinator. */
   hasProcessingOwnedWork: (chatId: string) => boolean;
@@ -396,6 +402,7 @@ export class SessionProjectionAuthority<
    * chat surface.
    */
   noteProviderTurnStart(chatId: string): void {
+    this.deps.onProviderTurnStarted(chatId);
     if (this.providerTurnInFlight.has(chatId)) return;
     this.providerTurnInFlight.add(chatId);
     this.projectSessionRuntime(chatId);

--- a/packages/client/src/runtime/session-projection-authority.ts
+++ b/packages/client/src/runtime/session-projection-authority.ts
@@ -1,4 +1,4 @@
-import type { RuntimeState, SessionState } from "@first-tree/shared";
+import type { RuntimeState, SessionRuntimeReport, SessionState } from "@first-tree/shared";
 import type { pino } from "../cloud/observability/logger.js";
 import type { SessionMessage } from "./handler.js";
 import type { Trigger } from "./result-sink.js";
@@ -55,7 +55,13 @@ export type EvictedMappingSnapshot = {
 export type SessionProjectionAuthorityDeps = {
   log: pino.Logger;
   onStateChange: () => ((chatId: string, state: SessionState) => void) | undefined;
-  onSessionRuntimeChange: () => ((chatId: string, state: RuntimeState) => void) | undefined;
+  onSessionRuntimeChange: () => ((chatId: string, report: SessionRuntimeReport) => void) | undefined;
+  /**
+   * The provider for this chat is parked on work it started itself and the
+   * assertion is still within the idle-sweep hard cap (SlotSchedulerAuthority
+   * owns both the probe and the cap).
+   */
+  hasReportableBackgroundWork: (chatId: string) => boolean;
   onRuntimeStateChange: () => ((state: RuntimeState) => void) | undefined;
   /** Inbox processing ownership still lives on InboxDeliveryCoordinator. */
   hasProcessingOwnedWork: (chatId: string) => boolean;
@@ -100,6 +106,12 @@ export class SessionProjectionAuthority<
   private readonly registry: SessionRegistry | null;
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
+  /**
+   * Chats whose provider is parked on its own background work. Descriptive
+   * only — it never changes the projected runtime state, it rides along with
+   * it so an idle chat can say why it is not finished.
+   */
+  private readonly backgroundWorkChats = new Set<string>();
   /**
    * Chats whose provider is currently inside a turn. Set from the first
    * provider message of a turn and cleared at `turn_end`, so a turn the inbox
@@ -404,6 +416,30 @@ export class SessionProjectionAuthority<
     this.projectSessionRuntime(chatId);
   }
 
+  hasBackgroundWork(chatId: string): boolean {
+    return this.backgroundWorkChats.has(chatId);
+  }
+
+  /**
+   * Re-sample the background-work marker for one chat and report the change
+   * immediately, so an idle chat starts (or stops) explaining itself without
+   * waiting for an unrelated runtime transition.
+   *
+   * Only an idle chat can carry the marker. The underlying probe answers
+   * "does the provider have a live child process", which is also true of an
+   * ordinary foreground tool call — asserting it during a turn would both
+   * flap the wire every time a `Bash` step starts and claim "parked on
+   * background work" about a provider that is plainly running.
+   */
+  syncBackgroundWork(chatId: string): void {
+    const state = this.sessionRuntimeStates.get(chatId);
+    const active = state === "idle" && this.deps.hasReportableBackgroundWork(chatId);
+    if (active === this.backgroundWorkChats.has(chatId)) return;
+    if (active) this.backgroundWorkChats.add(chatId);
+    else this.backgroundWorkChats.delete(chatId);
+    if (state) this.deps.onSessionRuntimeChange()?.(chatId, { runtimeState: state, backgroundWork: active });
+  }
+
   projectSessionRuntime(chatId: string, opts: { drainPendingOnIdle?: boolean } = {}): void {
     const session = this.sessions.get(chatId);
     const state = this.projectedRuntimeState(chatId, session ?? null);
@@ -411,10 +447,16 @@ export class SessionProjectionAuthority<
       this.withdrawSessionRuntime(chatId);
       return;
     }
+    // Leaving idle retires the marker: the chat is no longer explaining a
+    // pause, and the frame below carries the cleared value with the new state.
+    if (state !== "idle") this.backgroundWorkChats.delete(chatId);
     const previous = this.sessionRuntimeStates.get(chatId);
     if (previous === state) return;
     this.sessionRuntimeStates.set(chatId, state);
-    this.deps.onSessionRuntimeChange()?.(chatId, state);
+    this.deps.onSessionRuntimeChange()?.(chatId, {
+      runtimeState: state,
+      backgroundWork: this.backgroundWorkChats.has(chatId),
+    });
     this.recomputeRuntimeState();
     if (state === "idle" && opts.drainPendingOnIdle !== false) {
       this.deps.drainPendingOnIdle();
@@ -441,8 +483,9 @@ export class SessionProjectionAuthority<
     // gone, suspended, or not active, and none of those may leave a stale
     // in-flight turn behind for the next session on this chat.
     this.providerTurnInFlight.delete(chatId);
-    if (!this.sessionRuntimeStates.delete(chatId)) return;
-    this.deps.onSessionRuntimeChange()?.(chatId, "idle");
+    const hadBackgroundWork = this.backgroundWorkChats.delete(chatId);
+    if (!this.sessionRuntimeStates.delete(chatId) && !hadBackgroundWork) return;
+    this.deps.onSessionRuntimeChange()?.(chatId, { runtimeState: "idle", backgroundWork: false });
     this.recomputeRuntimeState();
   }
 
@@ -450,17 +493,30 @@ export class SessionProjectionAuthority<
    * Re-affirm working / blocked / error sessions so the server-side
    * freshness stamp doesn't lapse mid-turn. Reports only — does NOT
    * touch `lastActivity` (that governs idle eviction and must not be
-   * reset by a liveness ping). `idle` is deliberately omitted: the
+   * reset by a liveness ping). Plain `idle` is deliberately omitted: the
    * server treats it as the fail-closed default after the stale window
    * expires, so re-affirming idle is pure wire noise.
+   *
+   * `idle` WITH background work is the one exception, and it is not noise:
+   * the server trusts that marker only while the runtime stamp is fresh, so
+   * letting the stamp lapse would silently drop "background task" from a chat
+   * whose provider is still parked. This tick also re-samples the marker,
+   * which is what makes it decay honestly — a client that dies stops
+   * re-affirming and the server stops believing it.
    */
   reaffirmRuntimeStates(): void {
     if (!this.deps.onSessionRuntimeChange()) return;
     for (const [chatId, session] of this.sessions) {
       if (session.status !== "active" && session.status !== "errored") continue;
+      if (session.status === "active") this.syncBackgroundWork(chatId);
       const state = this.sessionRuntimeStates.get(chatId);
       if (state === "working" || state === "error") {
-        this.deps.onSessionRuntimeChange()?.(chatId, state);
+        this.deps.onSessionRuntimeChange()?.(chatId, {
+          runtimeState: state,
+          backgroundWork: this.backgroundWorkChats.has(chatId),
+        });
+      } else if (state === "idle" && this.backgroundWorkChats.has(chatId)) {
+        this.deps.onSessionRuntimeChange()?.(chatId, { runtimeState: state, backgroundWork: true });
       }
     }
   }
@@ -537,13 +593,16 @@ export class SessionProjectionAuthority<
    */
   getSessionRuntimeStates(
     activeChatIds: RuntimeSyncActiveSet = null,
-  ): Array<{ chatId: string; runtimeState: RuntimeState }> {
-    const out: Array<{ chatId: string; runtimeState: RuntimeState }> = [];
+  ): Array<{ chatId: string; runtimeState: RuntimeState; backgroundWork: boolean }> {
+    const out: Array<{ chatId: string; runtimeState: RuntimeState; backgroundWork: boolean }> = [];
     for (const [chatId, session] of this.sessions) {
       if (!this.shouldIncludeInRuntimeSync(chatId, activeChatIds)) continue;
       const runtimeState = this.projectedRuntimeState(chatId, session);
       if (!runtimeState) continue;
-      out.push({ chatId, runtimeState });
+      // The reconnect repair re-asserts the marker with the state it
+      // qualifies; dropping it here would leave the server showing a bare
+      // "Idle" for a provider that is still parked on background work.
+      out.push({ chatId, runtimeState, backgroundWork: this.backgroundWorkChats.has(chatId) });
     }
     return out;
   }

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -3295,6 +3295,16 @@ export class SessionRuntime {
       },
       noteTurnStart: () => {
         if (mutationValid && !mutationValid()) return;
+        // A provider reporting its OWN turn boundary is authoritative even
+        // inside an open logical turn, so it reaches the probe directly rather
+        // than through chat-level turn liveness. Claude's transient retry
+        // respawns the native process mid-turn without a `turn_end`, and that
+        // replacement generation needs its own instant — otherwise its startup
+        // MCP child and everything it launches stay unclassifiable until some
+        // later turn. Event-derived liveness keeps the one-call-per-turn guard
+        // below, because repeated in-turn events are noise, not a new
+        // generation.
+        this.config.subprocessProbe?.noteTurnBoundary(chatId);
         this.projection.noteProviderTurnStart(chatId);
       },
       noteTurnEnd: () => {

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -611,6 +611,7 @@ export class SessionRuntime {
         onRuntimeStateChange: () => this.config.onRuntimeStateChange,
         hasProcessingOwnedWork: (chatId) => this.inboxDelivery.hasProcessingOwnedWork(chatId),
         hasReportableBackgroundWork: (chatId) => this.slotScheduler.hasReportableBackgroundWork(chatId),
+        onProviderTurnStarted: (chatId) => this.config.subprocessProbe?.sealBaseline(chatId),
         drainPendingOnIdle: () => {
           this.slotScheduler.drainPendingQueue();
         },

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -611,7 +611,7 @@ export class SessionRuntime {
         onRuntimeStateChange: () => this.config.onRuntimeStateChange,
         hasProcessingOwnedWork: (chatId) => this.inboxDelivery.hasProcessingOwnedWork(chatId),
         hasReportableBackgroundWork: (chatId) => this.slotScheduler.hasReportableBackgroundWork(chatId),
-        onProviderTurnStarted: (chatId) => this.config.subprocessProbe?.sealBaseline(chatId),
+        onProviderTurnStarted: (chatId) => this.config.subprocessProbe?.noteTurnBoundary(chatId),
         drainPendingOnIdle: () => {
           this.slotScheduler.drainPendingQueue();
         },

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeProvider,
   RuntimeState,
   SessionEvent,
+  SessionRuntimeReport,
   SessionState,
 } from "@first-tree/shared";
 import {
@@ -397,7 +398,7 @@ type SessionRuntimeConfig = {
    * working / blocked / error sessions so a long turn keeps the
    * server-side freshness stamp current.
    */
-  onSessionRuntimeChange?: (chatId: string, state: RuntimeState) => void;
+  onSessionRuntimeChange?: (chatId: string, report: SessionRuntimeReport) => void;
 };
 
 /**
@@ -609,6 +610,7 @@ export class SessionRuntime {
         onSessionRuntimeChange: () => this.config.onSessionRuntimeChange,
         onRuntimeStateChange: () => this.config.onRuntimeStateChange,
         hasProcessingOwnedWork: (chatId) => this.inboxDelivery.hasProcessingOwnedWork(chatId),
+        hasReportableBackgroundWork: (chatId) => this.slotScheduler.hasReportableBackgroundWork(chatId),
         drainPendingOnIdle: () => {
           this.slotScheduler.drainPendingQueue();
         },
@@ -679,6 +681,8 @@ export class SessionRuntime {
       idleTimeoutSec: () => this.config.session.idle_timeout,
       workingGraceSec: () => this.config.session.working_grace_seconds,
       hasLiveSubprocessProbe: (chatId) => this.config.subprocessProbe?.hasLiveSubprocess(chatId) === true,
+      hasSessionSpawnedSubprocessProbe: (chatId) =>
+        this.config.subprocessProbe?.hasSessionSpawnedSubprocess(chatId) === true,
       isProviderRouteAdmissionFenced: (chatId) => this.resetReplay.isProviderRouteAdmissionFenced(chatId),
       getSession: (chatId) => this.projection.getSession(chatId),
       sessionsValues: () => this.projection.sessionsValues(),
@@ -2108,7 +2112,7 @@ export class SessionRuntime {
         { chatId, messageId: message.id },
         "withholding provider re-entry for replay-fenced chat; unsafe tool effect fenced before interruption",
       );
-      this.config.onSessionRuntimeChange?.(chatId, "error");
+      this.config.onSessionRuntimeChange?.(chatId, { runtimeState: "error", backgroundWork: false });
       this.inboxDelivery.markReplayFenceWithheld(chatId, [message.id]);
       this.resetReplay.ensureReplayFenceReconcileLoop(chatId);
       return;
@@ -3557,7 +3561,7 @@ export class SessionRuntime {
    */
   getSessionRuntimeStates(
     activeChatIds: RuntimeSyncActiveSet = null,
-  ): Array<{ chatId: string; runtimeState: RuntimeState }> {
+  ): Array<{ chatId: string; runtimeState: RuntimeState; backgroundWork: boolean }> {
     return this.projection.getSessionRuntimeStates(activeChatIds);
   }
 

--- a/packages/client/src/runtime/session-runtime.ts
+++ b/packages/client/src/runtime/session-runtime.ts
@@ -611,7 +611,6 @@ export class SessionRuntime {
         onRuntimeStateChange: () => this.config.onRuntimeStateChange,
         hasProcessingOwnedWork: (chatId) => this.inboxDelivery.hasProcessingOwnedWork(chatId),
         hasReportableBackgroundWork: (chatId) => this.slotScheduler.hasReportableBackgroundWork(chatId),
-        onProviderTurnStarted: (chatId) => this.config.subprocessProbe?.noteTurnBoundary(chatId),
         drainPendingOnIdle: () => {
           this.slotScheduler.drainPendingQueue();
         },
@@ -1611,7 +1610,11 @@ export class SessionRuntime {
       return;
     }
     if (event.kind === "assistant_text" || event.kind === "thinking" || event.kind === "tool_call") {
-      this.projection.noteProviderTurnStart(chatId);
+      // The event floor is noisy — several of these arrive per turn — so only
+      // the one that actually opens a turn becomes a boundary candidate.
+      if (this.projection.noteProviderTurnStart(chatId)) {
+        this.config.subprocessProbe?.noteTurnBoundary(chatId);
+      }
     }
   }
 

--- a/packages/client/src/runtime/slot-scheduler-authority.ts
+++ b/packages/client/src/runtime/slot-scheduler-authority.ts
@@ -101,6 +101,8 @@ export type SlotSchedulerAuthorityDeps = {
   idleTimeoutSec: () => number;
   workingGraceSec: () => number;
   hasLiveSubprocessProbe: (chatId: string) => boolean;
+  /** Live child the provider did not start the session with (see SubprocessProbe). */
+  hasSessionSpawnedSubprocessProbe: (chatId: string) => boolean;
   isProviderRouteAdmissionFenced: (chatId: string) => boolean;
   getSession: (chatId: string) => SlotSchedulerSessionEntry | undefined;
   sessionsValues: () => IterableIterator<SlotSchedulerSessionEntry>;
@@ -889,6 +891,32 @@ export class SlotSchedulerAuthority {
    */
   hasLiveSubprocess(chatId: string): boolean {
     return this.deps.hasLiveSubprocessProbe(chatId);
+  }
+
+  /**
+   * Background work this client is willing to *assert* to the server: the
+   * provider has a live child it did not start the session with, AND the
+   * session has not passed the `idle_timeout + working_grace` hard cap that
+   * `evictIdle` enforces.
+   *
+   * Deliberately NOT `hasLiveSubprocess`. That predicate is "any direct
+   * child", which a stdio MCP server satisfies for the whole session, so
+   * asserting on it would put "background task" on every idle chat of every
+   * MCP-configured agent — inverting a feature whose entire purpose is to stop
+   * Idle from lying. Deferring a suspend on the broader signal stays correct;
+   * telling a human something does not.
+   *
+   * The cap is the second guard. A forgotten `run_in_background` watcher that
+   * nobody will ever read would otherwise leave "background task" hanging on
+   * an agent; past the cap the sweep reclaims the slot anyway, so this stops
+   * asserting at the same boundary.
+   */
+  hasReportableBackgroundWork(chatId: string): boolean {
+    const session = this.deps.getSession(chatId);
+    if (!session || session.status !== "active") return false;
+    if (!this.deps.hasSessionSpawnedSubprocessProbe(chatId)) return false;
+    const capMs = (this.deps.idleTimeoutSec() + this.deps.workingGraceSec()) * 1000;
+    return Date.now() - session.lastActivity < capMs;
   }
 
   findOldestActiveSession(eligible: (session: SlotSchedulerSessionEntry) => boolean): SlotSchedulerSessionEntry | null {

--- a/packages/qa/cases/cross-surface/idle-background-task-qualifier.md
+++ b/packages/qa/cases/cross-surface/idle-background-task-qualifier.md
@@ -1,0 +1,69 @@
+---
+id: idle-background-task-qualifier
+description: An idle chat says why it is idle when its provider is parked on work it started, and stops saying so when that stops being true.
+areas: [cross-surface]
+surfaces: [client, server, web]
+---
+
+# Idle background-task qualifier
+
+Validate the `Idle · Background task` qualifier end to end: it appears when an
+agent is parked on work it launched, disappears when a turn starts, disappears
+when the work ends, and decays on its own when the client stops reporting.
+
+The qualifier exists because "Idle" alone reads as *finished, nothing happens
+unless you say something*, which is wrong for an agent that will wake itself
+up. That framing also sets the bar for failure: a qualifier that is on when
+nothing is running is worse than no qualifier at all, because it moves the lie
+rather than removing it, and it makes plain `Idle` the rare state.
+
+## The failure this case exists to catch
+
+Ask first whether the marker is on for the right reason. Take an ordinary
+agent, let it finish a turn with no background work outstanding, and read the
+row. It must say plain `Idle`.
+
+That check is not academic. The signal underneath is a process probe, and a
+provider keeps long-lived children that have nothing to do with a turn — a
+stdio MCP server is spawned at session start and lives for the whole session.
+A probe that answers "does the provider have any child" is therefore true for
+every MCP-configured agent, forever. Prefer a host where at least one agent has
+an MCP server configured; if none does, say so in the report rather than
+reporting `PASS` on a host that cannot see this class of defect.
+
+## The sequence to walk
+
+Give an agent a message that makes it launch background work and then finish
+its turn — the work outlives the turn. Then read the sidebar row, the compose
+bar and the chat row at each edge:
+
+- while the turn runs — `Working`, no qualifier;
+- after the turn closes with the work still running — `Idle · Background task`;
+- when a new turn starts — `Working`, qualifier gone;
+- once the work finishes and the agent settles — plain `Idle`.
+
+Then kill the client without a clean shutdown. The qualifier must disappear on
+its own within the runtime freshness window; a marker that survives a dead
+client is asserting local state nobody is maintaining.
+
+## Credible evidence
+
+Read the composite status the API returns, not only the rendered row, and tie
+each sample to the same `(agent, chat)` pair. A chat whose row shows the
+qualifier next to any state other than `Idle` is a failure — `Offline ·
+Background task` in particular means the qualifier escaped the state it is
+supposed to be a footnote on.
+
+Prefer a real provider with a real background task. A synthetic frame proves
+the wire, the persistence and the rendering, but it cannot tell you whether the
+client's own signal means what it claims, which is where this feature's
+interesting failure lives — say which of the two you did.
+
+Report `BLOCKED` or `INCONCLUSIVE` rather than `PASS` when background work
+cannot be launched on a real provider, or when the composite status cannot be
+observed apart from the timeline.
+
+## Related
+
+`packages/qa/cases/runtime/provider-owned-turn-status.md` covers the Working
+half of the same status contract.

--- a/packages/server/drizzle/0095_bent_dracula.sql
+++ b/packages/server/drizzle/0095_bent_dracula.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent_chat_sessions" ADD COLUMN "background_work" boolean DEFAULT false NOT NULL;

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0094_ambiguous_alex_wilder
+0095_bent_dracula

--- a/packages/server/drizzle/meta/0095_snapshot.json
+++ b/packages/server/drizzle/meta/0095_snapshot.json
@@ -1,0 +1,6731 @@
+{
+  "id": "82d3c109-e0fc-4d1c-a49f-4663490cbf62",
+  "prevId": "6abe1cef-064e-49f5-8135-fb58c1c3558d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_chat_sessions": {
+      "name": "agent_chat_sessions",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "runtime_state_at": {
+          "name": "runtime_state_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_work": {
+          "name": "background_work",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_chat_sessions_chat_agent": {
+          "name": "idx_agent_chat_sessions_chat_agent",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chat_sessions_agent_id_agents_uuid_fk": {
+          "name": "agent_chat_sessions_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_chat_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_chat_sessions_chat_id_chats_id_fk": {
+          "name": "agent_chat_sessions_chat_id_chats_id_fk",
+          "tableFrom": "agent_chat_sessions",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_chat_sessions_agent_id_chat_id_pk": {
+          "name": "agent_chat_sessions_agent_id_chat_id_pk",
+          "columns": [
+            "agent_id",
+            "chat_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_configs": {
+      "name": "agent_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_ids": {
+          "name": "template_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_configs_template_ids": {
+          "name": "idx_agent_configs_template_ids",
+          "columns": [
+            {
+              "expression": "template_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_agent_configs_template_ids_cardinality": {
+          "name": "ck_agent_configs_template_ids_cardinality",
+          "value": "cardinality(\"agent_configs\".\"template_ids\") <= 3"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_type": {
+          "name": "runtime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sessions": {
+          "name": "total_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_updated_at": {
+          "name": "runtime_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_presence_agent_id_agents_uuid_fk": {
+          "name": "agent_presence_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_presence_client_id_clients_id_fk": {
+          "name": "agent_presence_client_id_clients_id_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_resource_bindings": {
+      "name": "agent_resource_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaces_resource_id": {
+          "name": "replaces_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_prompt_body": {
+          "name": "inline_prompt_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_ref": {
+          "name": "repo_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_local_path": {
+          "name": "repo_local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "origin_template_id": {
+          "name": "origin_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_component_key": {
+          "name": "origin_component_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_resource_bindings_agent": {
+          "name": "idx_agent_resource_bindings_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_resource_bindings_resource": {
+          "name": "idx_agent_resource_bindings_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_resource_bindings_replaces": {
+          "name": "idx_agent_resource_bindings_replaces",
+          "columns": [
+            {
+              "expression": "replaces_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_resource_bindings_template_origin": {
+          "name": "idx_agent_resource_bindings_template_origin",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_resource_bindings\".\"origin_template_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_resource_bindings_organization_id_organizations_id_fk": {
+          "name": "agent_resource_bindings_organization_id_organizations_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_resource_bindings_agent_id_agents_uuid_fk": {
+          "name": "agent_resource_bindings_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_resource_bindings_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_resource_bindings_replaces_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_replaces_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "replaces_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_agent_resource_bindings_template_origin_consistency": {
+          "name": "ck_agent_resource_bindings_template_origin_consistency",
+          "value": "(\"agent_resource_bindings\".\"origin_template_id\" IS NULL AND \"agent_resource_bindings\".\"origin_component_key\" IS NULL) OR (\"agent_resource_bindings\".\"origin_template_id\" IS NOT NULL AND \"agent_resource_bindings\".\"origin_component_key\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_templates": {
+      "name": "agent_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_template_id": {
+          "name": "replacement_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agent_templates_slug": {
+          "name": "uq_agent_templates_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_templates_status": {
+          "name": "idx_agent_templates_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_templates_replacement_template_id_agent_templates_id_fk": {
+          "name": "agent_templates_replacement_template_id_agent_templates_id_fk",
+          "tableFrom": "agent_templates",
+          "tableTo": "agent_templates",
+          "columnsFrom": [
+            "replacement_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_agent_templates_status": {
+          "name": "ck_agent_templates_status",
+          "value": "\"agent_templates\".\"status\" IN ('draft', 'active', 'retired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_mention": {
+          "name": "delegate_mention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "avatar_color_token": {
+          "name": "avatar_color_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_data": {
+          "name": "avatar_image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_mime": {
+          "name": "avatar_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_updated_at": {
+          "name": "avatar_image_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_manager": {
+          "name": "idx_agents_manager",
+          "columns": [
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_visibility_org": {
+          "name": "idx_agents_visibility_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_client": {
+          "name": "idx_agents_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organizations_id_fk": {
+          "name": "agents_organization_id_organizations_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_client_id_clients_id_fk": {
+          "name": "agents_client_id_clients_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_inbox_id_unique": {
+          "name": "agents_inbox_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id"
+          ]
+        },
+        "uq_agents_org_name": {
+          "name": "uq_agents_org_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_state": {
+          "name": "lifecycle_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ready'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachments_org_state_idx": {
+          "name": "attachments_org_state_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_state_updated_idx": {
+          "name": "attachments_state_updated_idx",
+          "columns": [
+            {
+              "expression": "lifecycle_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_uploaded_by_idx": {
+          "name": "attachments_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_created_at_idx": {
+          "name": "attachments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attentions": {
+      "name": "attentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "origin_agent_id": {
+          "name": "origin_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_chat_id": {
+          "name": "origin_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_human_id": {
+          "name": "target_human_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "requires_response": {
+          "name": "requires_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by": {
+          "name": "responded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_reason": {
+          "name": "cancelled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_attentions_target_open": {
+          "name": "idx_attentions_target_open",
+          "columns": [
+            {
+              "expression": "target_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attentions_chat_open": {
+          "name": "idx_attentions_chat_open",
+          "columns": [
+            {
+              "expression": "origin_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attentions_origin": {
+          "name": "idx_attentions_origin",
+          "columns": [
+            {
+              "expression": "origin_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_payload": {
+          "name": "credential_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_identities_user": {
+          "name": "idx_auth_identities_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_identities_email": {
+          "name": "idx_auth_identities_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_auth_identities_provider_identifier": {
+          "name": "uq_auth_identities_provider_identifier",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "identifier"
+          ]
+        },
+        "uq_auth_identities_user_provider": {
+          "name": "uq_auth_identities_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_membership": {
+      "name": "chat_membership",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_membership_agent": {
+          "name": "idx_membership_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_membership_chat_role": {
+          "name": "idx_membership_chat_role",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_membership_chat_id_agent_id_pk": {
+          "name": "chat_membership_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_user_state": {
+      "name": "chat_user_state",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_mention_count": {
+          "name": "unread_mention_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "open_request_count": {
+          "name": "open_request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_status": {
+          "name": "engagement_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_state_agent": {
+          "name": "idx_user_state_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_state_unread": {
+          "name": "idx_user_state_unread",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "unread_mention_count > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_state_open_req": {
+          "name": "idx_user_state_open_req",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "open_request_count > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_state_pinned": {
+          "name": "idx_user_state_pinned",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "pinned_at IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_user_state_chat_id_agent_id_pk": {
+          "name": "chat_user_state_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_updated_at": {
+          "name": "description_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_policy": {
+          "name": "lifecycle_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'persistent'"
+        },
+        "parent_chat_id": {
+          "name": "parent_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_kickoff_key": {
+          "name": "onboarding_kickoff_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chats_org_last_message": {
+          "name": "idx_chats_org_last_message",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"last_message_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chats_org_activity": {
+          "name": "idx_chats_org_activity",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"activity_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_chats_onboarding_kickoff_key": {
+          "name": "uq_chats_onboarding_kickoff_key",
+          "columns": [
+            {
+              "expression": "onboarding_kickoff_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_organization_id_organizations_id_fk": {
+          "name": "chats_organization_id_organizations_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disconnected'"
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_reason": {
+          "name": "paused_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_user": {
+          "name": "idx_clients_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_org": {
+          "name": "idx_clients_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_user_id_users_id_fk": {
+          "name": "clients_user_id_users_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "clients_organization_id_organizations_id_fk": {
+          "name": "clients_organization_id_organizations_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_clients_paused_reason": {
+          "name": "ck_clients_paused_reason",
+          "value": "\"clients\".\"paused_reason\" IS NULL OR \"clients\".\"paused_reason\" IN ('auth_rejected', 'auth_refresh_failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connect_codes": {
+      "name": "connect_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connect_codes_user": {
+          "name": "idx_connect_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connect_codes_expires_at": {
+          "name": "idx_connect_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connect_codes_user_id_users_id_fk": {
+          "name": "connect_codes_user_id_users_id_fk",
+          "tableFrom": "connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connect_codes_code_hash_unique": {
+          "name": "connect_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context_tree_io_events": {
+      "name": "context_tree_io_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_event_id": {
+          "name": "source_session_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_index": {
+          "name": "source_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_repo_url": {
+          "name": "tree_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_branch": {
+          "name": "tree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_context_tree_io_source": {
+          "name": "uq_context_tree_io_source",
+          "columns": [
+            {
+              "expression": "source_session_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_recent": {
+          "name": "idx_context_tree_io_org_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_action_recent": {
+          "name": "idx_context_tree_io_org_action_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_agent_recent": {
+          "name": "idx_context_tree_io_org_agent_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_target_recent": {
+          "name": "idx_context_tree_io_org_target_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_tree_io_events_organization_id_organizations_id_fk": {
+          "name": "context_tree_io_events_organization_id_organizations_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "context_tree_io_events_agent_id_agents_uuid_fk": {
+          "name": "context_tree_io_events_agent_id_agents_uuid_fk",
+          "tableFrom": "context_tree_io_events",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "context_tree_io_events_chat_id_chats_id_fk": {
+          "name": "context_tree_io_events_chat_id_chats_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_context_tree_io_action": {
+          "name": "ck_context_tree_io_action",
+          "value": "\"context_tree_io_events\".\"action\" IN ('read', 'write')"
+        },
+        "ck_context_tree_io_target_kind": {
+          "name": "ck_context_tree_io_target_kind",
+          "value": "\"context_tree_io_events\".\"target_kind\" IN ('file', 'directory', 'repo')"
+        },
+        "ck_context_tree_io_target_path_nonempty": {
+          "name": "ck_context_tree_io_target_path_nonempty",
+          "value": "\"context_tree_io_events\".\"target_path\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_member_id": {
+          "name": "owner_member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "control_chat_id": {
+          "name": "control_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_mode": {
+          "name": "chat_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reuse_control_chat'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_reason": {
+          "name": "state_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_trigger_message_id": {
+          "name": "last_trigger_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cron_jobs_due": {
+          "name": "idx_cron_jobs_due",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cron_jobs\".\"state\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cron_jobs_control_created": {
+          "name": "idx_cron_jobs_control_created",
+          "columns": [
+            {
+              "expression": "control_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cron_jobs_owner_created": {
+          "name": "idx_cron_jobs_owner_created",
+          "columns": [
+            {
+              "expression": "owner_member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_jobs_owner_member_id_members_id_fk": {
+          "name": "cron_jobs_owner_member_id_members_id_fk",
+          "tableFrom": "cron_jobs",
+          "tableTo": "members",
+          "columnsFrom": [
+            "owner_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cron_jobs_control_chat_id_chats_id_fk": {
+          "name": "cron_jobs_control_chat_id_chats_id_fk",
+          "tableFrom": "cron_jobs",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "control_chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cron_jobs_agent_id_agents_uuid_fk": {
+          "name": "cron_jobs_agent_id_agents_uuid_fk",
+          "tableFrom": "cron_jobs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cron_jobs_last_trigger_message_id_messages_id_fk": {
+          "name": "cron_jobs_last_trigger_message_id_messages_id_fk",
+          "tableFrom": "cron_jobs",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "last_trigger_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_cron_jobs_control_agent_name": {
+          "name": "uq_cron_jobs_control_agent_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "control_chat_id",
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_cron_jobs_state": {
+          "name": "ck_cron_jobs_state",
+          "value": "\"cron_jobs\".\"state\" IN ('active', 'paused')"
+        },
+        "ck_cron_jobs_chat_mode": {
+          "name": "ck_cron_jobs_chat_mode",
+          "value": "\"cron_jobs\".\"chat_mode\" = 'reuse_control_chat'"
+        },
+        "ck_cron_jobs_revision_positive": {
+          "name": "ck_cron_jobs_revision_positive",
+          "value": "\"cron_jobs\".\"revision\" > 0"
+        },
+        "ck_cron_jobs_active_shape": {
+          "name": "ck_cron_jobs_active_shape",
+          "value": "(\"cron_jobs\".\"state\" = 'active' AND \"cron_jobs\".\"next_run_at\" IS NOT NULL AND \"cron_jobs\".\"state_reason\" IS NULL) OR (\"cron_jobs\".\"state\" = 'paused' AND \"cron_jobs\".\"next_run_at\" IS NULL AND \"cron_jobs\".\"state_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.doc_comments": {
+      "name": "doc_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_comments_document_status_idx": {
+          "name": "doc_comments_document_status_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_comments_parent_idx": {
+          "name": "doc_comments_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_comments_document_id_doc_documents_id_fk": {
+          "name": "doc_comments_document_id_doc_documents_id_fk",
+          "tableFrom": "doc_comments",
+          "tableTo": "doc_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "doc_comments_parent_id_doc_comments_id_fk": {
+          "name": "doc_comments_parent_id_doc_comments_id_fk",
+          "tableFrom": "doc_comments",
+          "tableTo": "doc_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_documents": {
+      "name": "doc_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_kind": {
+          "name": "created_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_name": {
+          "name": "created_by_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_documents_org_slug_unique": {
+          "name": "doc_documents_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_documents_org_updated_idx": {
+          "name": "doc_documents_org_updated_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_documents_organization_id_organizations_id_fk": {
+          "name": "doc_documents_organization_id_organizations_id_fk",
+          "tableFrom": "doc_documents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_versions": {
+      "name": "doc_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_versions_document_number_unique": {
+          "name": "doc_versions_document_number_unique",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "doc_versions_document_id_doc_documents_id_fk": {
+          "name": "doc_versions_document_id_doc_documents_id_fk",
+          "tableFrom": "doc_versions",
+          "tableTo": "doc_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_app_installations": {
+      "name": "github_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_github_id": {
+          "name": "account_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_github_id": {
+          "name": "installer_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester_github_id": {
+          "name": "requester_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_organization_id": {
+          "name": "hub_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_github_app_installations_installation_id": {
+          "name": "uq_github_app_installations_installation_id",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_github_app_installations_hub_org": {
+          "name": "uq_github_app_installations_hub_org",
+          "columns": [
+            {
+              "expression": "hub_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_app_installations_account": {
+          "name": "idx_github_app_installations_account",
+          "columns": [
+            {
+              "expression": "account_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_app_installations_installer": {
+          "name": "idx_github_app_installations_installer",
+          "columns": [
+            {
+              "expression": "installer_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_app_installations_requester": {
+          "name": "idx_github_app_installations_requester",
+          "columns": [
+            {
+              "expression": "requester_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_hub_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_hub_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "hub_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_github_app_installations_account_type": {
+          "name": "ck_github_app_installations_account_type",
+          "value": "\"github_app_installations\".\"account_type\" IN ('User', 'Organization')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_entity_chat_mappings": {
+      "name": "github_entity_chat_mappings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "human_agent_id": {
+          "name": "human_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_agent_id": {
+          "name": "delegate_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_key": {
+          "name": "entity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bound_via": {
+          "name": "bound_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_state": {
+          "name": "entity_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "entity_state_updated_at": {
+          "name": "entity_state_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_github_entity_chat_mappings_chat": {
+          "name": "idx_github_entity_chat_mappings_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_entity_chat_mappings_chat_state": {
+          "name": "idx_github_entity_chat_mappings_chat_state",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_entity_chat_mappings_organization_id_organizations_id_fk": {
+          "name": "github_entity_chat_mappings_organization_id_organizations_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "github_entity_chat_mappings_human_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_human_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "human_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "delegate_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_entity_chat_mappings_chat_id_chats_id_fk": {
+          "name": "github_entity_chat_mappings_chat_id_chats_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk": {
+          "name": "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk",
+          "columns": [
+            "organization_id",
+            "human_agent_id",
+            "delegate_agent_id",
+            "entity_type",
+            "entity_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab_connections": {
+      "name": "gitlab_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_origin": {
+          "name": "instance_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_first_seen_at": {
+          "name": "endpoint_first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_valid_inbound_at": {
+          "name": "last_valid_inbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_system_hook_inbound_at": {
+          "name": "last_system_hook_inbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_project_hook_inbound_at": {
+          "name": "last_project_hook_inbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_system_hook_merge_request_inbound_at": {
+          "name": "last_system_hook_merge_request_inbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processing_failure_at": {
+          "name": "last_processing_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processing_failure_code": {
+          "name": "last_processing_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stable_delivery_observed_at": {
+          "name": "stable_delivery_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_version": {
+          "name": "last_observed_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_mode": {
+          "name": "reviewer_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_reviewer_schema_anomaly_at": {
+          "name": "last_reviewer_schema_anomaly_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewer_schema_anomaly_code": {
+          "name": "last_reviewer_schema_anomaly_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_member_id": {
+          "name": "created_by_member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_member_id": {
+          "name": "updated_by_member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_gitlab_connections_org": {
+          "name": "uq_gitlab_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_gitlab_connections_token_hash": {
+          "name": "uq_gitlab_connections_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gitlab_connections_organization_id_organizations_id_fk": {
+          "name": "gitlab_connections_organization_id_organizations_id_fk",
+          "tableFrom": "gitlab_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gitlab_connections_created_by_member_id_members_id_fk": {
+          "name": "gitlab_connections_created_by_member_id_members_id_fk",
+          "tableFrom": "gitlab_connections",
+          "tableTo": "members",
+          "columnsFrom": [
+            "created_by_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gitlab_connections_updated_by_member_id_members_id_fk": {
+          "name": "gitlab_connections_updated_by_member_id_members_id_fk",
+          "tableFrom": "gitlab_connections",
+          "tableTo": "members",
+          "columnsFrom": [
+            "updated_by_member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_gitlab_connections_reviewer_mode": {
+          "name": "ck_gitlab_connections_reviewer_mode",
+          "value": "\"gitlab_connections\".\"reviewer_mode\" IN ('unknown', 'assignee', 'reviewers')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gitlab_entity_chat_mappings": {
+      "name": "gitlab_entity_chat_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_by_agent_id": {
+          "name": "declared_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_via": {
+          "name": "bound_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agent_declared'"
+        },
+        "identity_link_id": {
+          "name": "identity_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "human_agent_id": {
+          "name": "human_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_agent_id": {
+          "name": "delegate_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attention_mode": {
+          "name": "attention_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy_route_only'"
+        },
+        "attention_backfill_version": {
+          "name": "attention_backfill_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_iid": {
+          "name": "entity_iid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_path_normalized": {
+          "name": "project_path_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_url": {
+          "name": "entity_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_state": {
+          "name": "entity_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_gitlab_entity_pending_pair": {
+          "name": "uq_gitlab_entity_pending_pair",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "human_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delegate_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_path_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_gitlab_entity_observed_pair": {
+          "name": "uq_gitlab_entity_observed_pair",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "human_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delegate_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_gitlab_entity_pending_legacy_chat": {
+          "name": "uq_gitlab_entity_pending_legacy_chat",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_path_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_gitlab_entity_observed_legacy_chat": {
+          "name": "uq_gitlab_entity_observed_legacy_chat",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_gitlab_entity_identity_target": {
+          "name": "uq_gitlab_entity_identity_target",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identity_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" = 'identity_target'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gitlab_entity_observed_lookup": {
+          "name": "idx_gitlab_entity_observed_lookup",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gitlab_entity_pending_lookup": {
+          "name": "idx_gitlab_entity_pending_lookup",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_path_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gitlab_entity_chat": {
+          "name": "idx_gitlab_entity_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gitlab_entity_chat_mappings_organization_id_organizations_id_fk": {
+          "name": "gitlab_entity_chat_mappings_organization_id_organizations_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gitlab_entity_chat_mappings_connection_id_gitlab_connections_id_fk": {
+          "name": "gitlab_entity_chat_mappings_connection_id_gitlab_connections_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "tableTo": "gitlab_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gitlab_entity_chat_mappings_chat_id_chats_id_fk": {
+          "name": "gitlab_entity_chat_mappings_chat_id_chats_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gitlab_entity_chat_mappings_declared_by_agent_id_agents_uuid_fk": {
+          "name": "gitlab_entity_chat_mappings_declared_by_agent_id_agents_uuid_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "declared_by_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gitlab_entity_chat_mappings_identity_link_id_gitlab_identity_links_id_fk": {
+          "name": "gitlab_entity_chat_mappings_identity_link_id_gitlab_identity_links_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "tableTo": "gitlab_identity_links",
+          "columnsFrom": [
+            "identity_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gitlab_entity_chat_mappings_human_agent_id_agents_uuid_fk": {
+          "name": "gitlab_entity_chat_mappings_human_agent_id_agents_uuid_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "human_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gitlab_entity_chat_mappings_delegate_agent_id_agents_uuid_fk": {
+          "name": "gitlab_entity_chat_mappings_delegate_agent_id_agents_uuid_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "delegate_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_gitlab_entity_type": {
+          "name": "ck_gitlab_entity_type",
+          "value": "\"gitlab_entity_chat_mappings\".\"entity_type\" IN ('issue', 'pull_request')"
+        },
+        "ck_gitlab_entity_bound_via": {
+          "name": "ck_gitlab_entity_bound_via",
+          "value": "\"gitlab_entity_chat_mappings\".\"bound_via\" IN ('agent_declared', 'human_declared', 'identity_target')"
+        },
+        "ck_gitlab_entity_identity_owner": {
+          "name": "ck_gitlab_entity_identity_owner",
+          "value": "\"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' OR (\"gitlab_entity_chat_mappings\".\"identity_link_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL)"
+        },
+        "ck_gitlab_entity_attention_pair": {
+          "name": "ck_gitlab_entity_attention_pair",
+          "value": "(\"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NULL) OR (\"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL)"
+        },
+        "ck_gitlab_entity_attention_mode": {
+          "name": "ck_gitlab_entity_attention_mode",
+          "value": "\"gitlab_entity_chat_mappings\".\"attention_mode\" IN ('paired', 'legacy_route_only')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gitlab_identity_links": {
+      "name": "gitlab_identity_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_username": {
+          "name": "normalized_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_gitlab_identity_connection_membership": {
+          "name": "uq_gitlab_identity_connection_membership",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_gitlab_identity_connection_username": {
+          "name": "uq_gitlab_identity_connection_username",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gitlab_identity_org_state": {
+          "name": "idx_gitlab_identity_org_state",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gitlab_identity_membership_state": {
+          "name": "idx_gitlab_identity_membership_state",
+          "columns": [
+            {
+              "expression": "membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gitlab_identity_links_organization_id_organizations_id_fk": {
+          "name": "gitlab_identity_links_organization_id_organizations_id_fk",
+          "tableFrom": "gitlab_identity_links",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gitlab_identity_links_membership_id_members_id_fk": {
+          "name": "gitlab_identity_links_membership_id_members_id_fk",
+          "tableFrom": "gitlab_identity_links",
+          "tableTo": "members",
+          "columnsFrom": [
+            "membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "gitlab_identity_links_connection_id_gitlab_connections_id_fk": {
+          "name": "gitlab_identity_links_connection_id_gitlab_connections_id_fk",
+          "tableFrom": "gitlab_identity_links",
+          "tableTo": "gitlab_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_gitlab_identity_state": {
+          "name": "ck_gitlab_identity_state",
+          "value": "\"gitlab_identity_links\".\"state\" IN ('active', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_bot_bindings": {
+      "name": "im_bot_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_open_id": {
+          "name": "bot_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_name": {
+          "name": "bot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_key": {
+          "name": "tenant_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_secret_cipher": {
+          "name": "app_secret_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_state_cipher": {
+          "name": "registration_state_cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_expires_at": {
+          "name": "registration_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_scopes": {
+          "name": "granted_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "connection_status": {
+          "name": "connection_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disconnected'"
+        },
+        "connection_owner_instance_id": {
+          "name": "connection_owner_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_lease_expires_at": {
+          "name": "connection_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_epoch": {
+          "name": "connection_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_im_bot_bindings_current_agent": {
+          "name": "uq_im_bot_bindings_current_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bot_bindings\".\"status\" <> 'revoked'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_im_bot_bindings_current_app": {
+          "name": "uq_im_bot_bindings_current_app",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bot_bindings\".\"status\" <> 'revoked' AND \"im_bot_bindings\".\"app_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_im_bot_bindings_org_status": {
+          "name": "idx_im_bot_bindings_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_im_bot_bindings_connection_claim": {
+          "name": "idx_im_bot_bindings_connection_claim",
+          "columns": [
+            {
+              "expression": "connection_lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"im_bot_bindings\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_bot_bindings_organization_id_organizations_id_fk": {
+          "name": "im_bot_bindings_organization_id_organizations_id_fk",
+          "tableFrom": "im_bot_bindings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_bot_bindings_agent_id_agents_uuid_fk": {
+          "name": "im_bot_bindings_agent_id_agents_uuid_fk",
+          "tableFrom": "im_bot_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_im_bot_bindings_status": {
+          "name": "chk_im_bot_bindings_status",
+          "value": "\"im_bot_bindings\".\"status\" IN ('provisioning', 'active', 'error', 'revoked')"
+        },
+        "chk_im_bot_bindings_connection_status": {
+          "name": "chk_im_bot_bindings_connection_status",
+          "value": "\"im_bot_bindings\".\"connection_status\" IN ('disconnected', 'connecting', 'connected', 'error')"
+        },
+        "chk_im_bot_bindings_connection_epoch": {
+          "name": "chk_im_bot_bindings_connection_epoch",
+          "value": "\"im_bot_bindings\".\"connection_epoch\" >= 0"
+        },
+        "chk_im_bot_bindings_active": {
+          "name": "chk_im_bot_bindings_active",
+          "value": "\"im_bot_bindings\".\"status\" <> 'active' OR (\"im_bot_bindings\".\"app_id\" IS NOT NULL AND \"im_bot_bindings\".\"bot_open_id\" IS NOT NULL AND \"im_bot_bindings\".\"app_secret_cipher\" IS NOT NULL AND \"im_bot_bindings\".\"registration_state_cipher\" IS NULL)"
+        },
+        "chk_im_bot_bindings_revoked": {
+          "name": "chk_im_bot_bindings_revoked",
+          "value": "\"im_bot_bindings\".\"status\" <> 'revoked' OR (\"im_bot_bindings\".\"app_secret_cipher\" IS NULL AND \"im_bot_bindings\".\"registration_state_cipher\" IS NULL AND \"im_bot_bindings\".\"connection_owner_instance_id\" IS NULL AND \"im_bot_bindings\".\"connection_lease_expires_at\" IS NULL AND \"im_bot_bindings\".\"connection_status\" = 'disconnected' AND \"im_bot_bindings\".\"revoked_at\" IS NOT NULL)"
+        },
+        "chk_im_bot_bindings_lease_owner": {
+          "name": "chk_im_bot_bindings_lease_owner",
+          "value": "(\"im_bot_bindings\".\"connection_owner_instance_id\" IS NULL AND \"im_bot_bindings\".\"connection_lease_expires_at\" IS NULL) OR (\"im_bot_bindings\".\"connection_owner_instance_id\" IS NOT NULL AND \"im_bot_bindings\".\"connection_lease_expires_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_chat_bindings": {
+      "name": "im_chat_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_binding_id": {
+          "name": "bot_binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feishu_chat_id": {
+          "name": "feishu_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feishu_chat_type": {
+          "name": "feishu_chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_im_chat_bindings_bot_chat": {
+          "name": "uq_im_chat_bindings_bot_chat",
+          "columns": [
+            {
+              "expression": "bot_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feishu_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_im_chat_bindings_chat": {
+          "name": "uq_im_chat_bindings_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_chat_bindings_bot_binding_id_im_bot_bindings_id_fk": {
+          "name": "im_chat_bindings_bot_binding_id_im_bot_bindings_id_fk",
+          "tableFrom": "im_chat_bindings",
+          "tableTo": "im_bot_bindings",
+          "columnsFrom": [
+            "bot_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "im_chat_bindings_chat_id_chats_id_fk": {
+          "name": "im_chat_bindings_chat_id_chats_id_fk",
+          "tableFrom": "im_chat_bindings",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_im_chat_bindings_chat_type": {
+          "name": "chk_im_chat_bindings_chat_type",
+          "value": "\"im_chat_bindings\".\"feishu_chat_type\" IN ('p2p', 'group')"
+        },
+        "chk_im_chat_bindings_status": {
+          "name": "chk_im_chat_bindings_status",
+          "value": "\"im_chat_bindings\".\"status\" IN ('active', 'detached')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inbox_entries": {
+      "name": "inbox_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notify": {
+          "name": "notify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_pending": {
+          "name": "idx_inbox_pending",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_pending_notify": {
+          "name": "idx_inbox_pending_notify",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending' AND notify = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_chat_silent": {
+          "name": "idx_inbox_chat_silent",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notify",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_entries_message_status": {
+          "name": "idx_inbox_entries_message_status",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_entries_message_id_messages_id_fk": {
+          "name": "inbox_entries_message_id_messages_id_fk",
+          "tableFrom": "inbox_entries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_inbox_delivery": {
+          "name": "uq_inbox_delivery",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id",
+            "message_id",
+            "chat_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_inbox_entries_status": {
+          "name": "ck_inbox_entries_status",
+          "value": "\"inbox_entries\".\"status\" IN ('pending', 'delivered', 'acked')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation_redemptions": {
+      "name": "invitation_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invitation_redemptions_invitation": {
+          "name": "idx_invitation_redemptions_invitation",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_redemptions_user": {
+          "name": "idx_invitation_redemptions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_redemptions_invitation_id_invitations_id_fk": {
+          "name": "invitation_redemptions_invitation_id_invitations_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "tableTo": "invitations",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_redemptions_user_id_users_id_fk": {
+          "name": "invitation_redemptions_user_id_users_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitations_token": {
+          "name": "idx_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitations_org": {
+          "name": "idx_invitations_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_created_by_users_id_fk": {
+          "name": "invitations_created_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_suppressed_at": {
+          "name": "onboarding_suppressed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_suppressed_reason": {
+          "name": "onboarding_suppressed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_members_user": {
+          "name": "idx_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_members_org": {
+          "name": "idx_members_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "members_agent_id_agents_uuid_fk": {
+          "name": "members_agent_id_agents_uuid_fk",
+          "tableFrom": "members",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_agent_id_unique": {
+          "name": "members_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id"
+          ]
+        },
+        "uq_members_user_org": {
+          "name": "uq_members_user_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_members_completed_implies_suppressed": {
+          "name": "ck_members_completed_implies_suppressed",
+          "value": "\"members\".\"onboarding_completed_at\" IS NULL OR \"members\".\"onboarding_suppressed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_kind": {
+          "name": "sender_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "sender_provider": {
+          "name": "sender_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reply_to_inbox": {
+          "name": "reply_to_inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_chat": {
+          "name": "reply_to_chat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_chat_time": {
+          "name": "idx_messages_chat_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_in_reply_to": {
+          "name": "idx_messages_in_reply_to",
+          "columns": [
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_chat_source_time": {
+          "name": "idx_messages_chat_source_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_mentions": {
+          "name": "idx_messages_mentions",
+          "columns": [
+            {
+              "expression": "((\"metadata\" -> 'mentions')) jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_messages_attachment_image_id": {
+          "name": "idx_messages_attachment_image_id",
+          "columns": [
+            {
+              "expression": "(\"content\" ->> 'imageId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_content_attachments": {
+          "name": "idx_messages_content_attachments",
+          "columns": [
+            {
+              "expression": "((\"content\" -> 'attachments')) jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_messages_metadata_attachments": {
+          "name": "idx_messages_metadata_attachments",
+          "columns": [
+            {
+              "expression": "((\"metadata\" -> 'attachments')) jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "uq_messages_feishu_inbound_message": {
+          "name": "uq_messages_feishu_inbound_message",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"metadata\" -> 'feishu' -> 'reference' ->> 'messageId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"messages\".\"sender_kind\" = 'integration' AND \"messages\".\"sender_provider\" = 'feishu' AND \"messages\".\"metadata\" -> 'feishu' ->> 'direction' = 'inbound'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_messages_sender_identity": {
+          "name": "chk_messages_sender_identity",
+          "value": "(\"messages\".\"sender_kind\" = 'member' AND \"messages\".\"sender_provider\" IS NULL) OR (\"messages\".\"sender_kind\" = 'integration' AND \"messages\".\"sender_provider\" = 'feishu' AND \"messages\".\"sender_id\" = 'integration:feishu')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_org_created": {
+          "name": "idx_notifications_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_org_read": {
+          "name": "idx_notifications_org_read",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_notifications_org_dedup_unread": {
+          "name": "uq_notifications_org_dedup_unread",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "read = false AND dedup_key IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_settings_namespace": {
+          "name": "idx_org_settings_namespace",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_settings_organization_id_organizations_id_fk": {
+          "name": "organization_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_settings_updated_by_users_id_fk": {
+          "name": "organization_settings_updated_by_users_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_settings_organization_id_namespace_pk": {
+          "name": "organization_settings_organization_id_namespace_pk",
+          "columns": [
+            "organization_id",
+            "namespace"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_agents": {
+          "name": "max_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_messages_per_minute": {
+          "name": "max_messages_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_unique": {
+          "name": "organizations_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_questions": {
+      "name": "pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_questions_agent_status": {
+          "name": "idx_pending_questions_agent_status",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_questions_chat_status": {
+          "name": "idx_pending_questions_chat_status",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_agent_id": {
+          "name": "owner_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_canonical_key": {
+          "name": "repo_canonical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_attachment_id": {
+          "name": "bundle_attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_enabled": {
+          "name": "default_enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_template_id": {
+          "name": "origin_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_component_key": {
+          "name": "origin_component_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_content_digest": {
+          "name": "origin_content_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resources_org_type_scope": {
+          "name": "idx_resources_org_type_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_owner_agent": {
+          "name": "idx_resources_owner_agent",
+          "columns": [
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_repo_key": {
+          "name": "idx_resources_repo_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_bundle_attachment": {
+          "name": "idx_resources_bundle_attachment",
+          "columns": [
+            {
+              "expression": "bundle_attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_resources_team_repo_canonical_active": {
+          "name": "uq_resources_team_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'team' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_resources_agent_repo_canonical_active": {
+          "name": "uq_resources_agent_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'agent' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_resources_template_origin_active": {
+          "name": "uq_resources_template_origin_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_component_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"origin_template_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resources_organization_id_organizations_id_fk": {
+          "name": "resources_organization_id_organizations_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_owner_agent_id_agents_uuid_fk": {
+          "name": "resources_owner_agent_id_agents_uuid_fk",
+          "tableFrom": "resources",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "owner_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_resources_template_origin_consistency": {
+          "name": "ck_resources_template_origin_consistency",
+          "value": "(\"resources\".\"origin_template_id\" IS NULL AND \"resources\".\"origin_component_key\" IS NULL AND \"resources\".\"origin_content_digest\" IS NULL) OR (\"resources\".\"origin_template_id\" IS NOT NULL AND \"resources\".\"origin_component_key\" IS NOT NULL AND \"resources\".\"origin_content_digest\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.server_instances": {
+      "name": "server_instances",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_events": {
+      "name": "session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_session_events_chat_seq": {
+          "name": "uq_session_events_chat_seq",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_chat_created": {
+          "name": "idx_session_events_chat_created",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_context_tree_usage_recent": {
+          "name": "idx_session_events_context_tree_usage_recent",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_events\".\"kind\" = 'context_tree_usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_context_tree_io_agent_recent": {
+          "name": "idx_session_events_context_tree_io_agent_recent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_events\".\"kind\" IN ('context_tree_usage', 'tool_call')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_token_usage_agent_recent": {
+          "name": "idx_session_events_token_usage_agent_recent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_events\".\"kind\" = 'token_usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_token_usage_chat": {
+          "name": "idx_session_events_token_usage_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_events\".\"kind\" = 'token_usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -666,6 +666,13 @@
       "when": 1786593308966,
       "tag": "0094_ambiguous_alex_wilder",
       "breakpoints": true
+    },
+    {
+      "idx": 95,
+      "version": "7",
+      "when": 1788301396765,
+      "tag": "0095_bent_dracula",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -8,7 +8,9 @@ import {
 import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { createAgent } from "../services/agents/identity.js";
+import { upsertSessionState } from "../services/chat/sessions/activity.js";
 import {
+  computeBackgroundWork,
   computeErrored,
   computeWorking,
   getChatAgentStatuses,
@@ -50,6 +52,13 @@ describe("agent-chat-status", () => {
       UPDATE agent_chat_sessions
         SET runtime_state = ${runtimeState},
             runtime_state_at = NOW() + (${atOffsetMs}::int * interval '1 millisecond')
+        WHERE agent_id = ${agentId} AND chat_id = ${chatId}
+    `);
+  }
+
+  async function setBackgroundWork(agentId: string, chatId: string, value: boolean): Promise<void> {
+    await getApp().db.execute(sql`
+      UPDATE agent_chat_sessions SET background_work = ${value}
         WHERE agent_id = ${agentId} AND chat_id = ${chatId}
     `);
   }
@@ -137,6 +146,76 @@ describe("agent-chat-status", () => {
       expect(s?.working).toBe(true);
       expect(s?.main).toBe("working");
       expect(s?.activity?.label).toBe("Bash");
+    });
+
+    it("an idle chat whose provider is parked on background work stays ready and carries the marker", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await setRuntime(peer.agent.uuid, chatId, "idle");
+      await app.db.execute(sql`
+        UPDATE agent_chat_sessions SET background_work = true
+          WHERE agent_id = ${peer.agent.uuid} AND chat_id = ${chatId}
+      `);
+
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      // Descriptive only: the agent burns no tokens, so it is not working —
+      // the marker only explains why "idle" does not mean "finished".
+      expect(s?.working).toBe(false);
+      expect(s?.main).toBe("ready");
+      expect(s?.backgroundWork).toBe(true);
+    });
+
+    it("drops the background-work qualifier for every composite that is not ready", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await setRuntime(peer.agent.uuid, chatId, "idle");
+      await setBackgroundWork(peer.agent.uuid, chatId, true);
+
+      const marker = async (): Promise<{ main: string; backgroundWork: boolean | undefined }> => {
+        const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+        return { main: s?.main ?? "missing", backgroundWork: s?.backgroundWork };
+      };
+      expect(await marker()).toEqual({ main: "ready", backgroundWork: true });
+
+      // Disconnect. The runtime row stays active and fresh for the whole
+      // stale window, so without the ready gate this reads
+      // "Offline · Background task".
+      await app.db.execute(sql`UPDATE agent_presence SET client_id = NULL WHERE agent_id = ${peer.agent.uuid}`);
+      expect(await marker()).toEqual({ main: "offline", backgroundWork: undefined });
+      await bindPresence(peer.agent.uuid, peer.clientId);
+
+      // A turn is the more specific truth; the qualifier explains idleness.
+      await setRuntime(peer.agent.uuid, chatId, "working");
+      expect(await marker()).toEqual({ main: "working", backgroundWork: undefined });
+
+      // Runtime fault: attention belongs on the failure, not on a footnote.
+      await setRuntime(peer.agent.uuid, chatId, "error");
+      expect(await marker()).toEqual({ main: "failed", backgroundWork: undefined });
+    });
+
+    it("clears a stored background-work marker when the session is suspended and reactivated", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await setRuntime(peer.agent.uuid, chatId, "idle");
+      await setBackgroundWork(peer.agent.uuid, chatId, true);
+
+      // Suspension revokes runtime; the marker describes a provider session
+      // that no longer exists and must not survive into the next one.
+      await upsertSessionState(app.db, peer.agent.uuid, chatId, "suspended", peer.organizationId);
+      const [stored] = (await app.db.execute(sql`
+        SELECT background_work FROM agent_chat_sessions
+          WHERE agent_id = ${peer.agent.uuid} AND chat_id = ${chatId}
+      `)) as unknown as Array<{ background_work: boolean }>;
+      expect(stored?.background_work).toBe(false);
+
+      await upsertSessionState(app.db, peer.agent.uuid, chatId, "active", peer.organizationId);
+      await setRuntime(peer.agent.uuid, chatId, "idle");
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      expect(s?.main).toBe("ready");
+      expect(s?.backgroundWork).toBeUndefined();
     });
 
     // turnText (folds closed PR #558) — current-turn narration on the /agent-status path.
@@ -765,6 +844,21 @@ describe("agent-chat-status", () => {
       expect(computeWorking(active, null, now)).toBe(false);
       // Old-client fallback still gated on active.
       expect(computeWorking({ ...active, state: "suspended" }, activity, now)).toBe(false);
+    });
+
+    it("computeBackgroundWork — a fresh claim from a live client, nothing more", () => {
+      const parked = { state: "active", runtimeState: "idle", runtimeStateAt: recent(-1000), backgroundWork: true };
+      expect(computeBackgroundWork(parked, now)).toBe(true);
+
+      // Same freshness gate as `working`: a client that stopped reporting
+      // stops asserting background work rather than pinning it forever.
+      expect(computeBackgroundWork({ ...parked, runtimeStateAt: new Date(now - RUNTIME_STALE_MS - 1) }, now)).toBe(
+        false,
+      );
+      expect(computeBackgroundWork({ ...parked, runtimeStateAt: null }, now)).toBe(false);
+      expect(computeBackgroundWork({ ...parked, state: "suspended" }, now)).toBe(false);
+      expect(computeBackgroundWork({ ...parked, backgroundWork: false }, now)).toBe(false);
+      expect(computeBackgroundWork(undefined, now)).toBe(false);
     });
 
     it("computeErrored — new-client authoritative: state='errored' OR fresh error/blocked OR stale in-flight", () => {

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -1023,6 +1023,9 @@ describe("Agent client WS branch fakes", () => {
       "working",
       "org_1",
       expect.anything(),
+      // The descriptive background-work marker rides the same frame; a client
+      // that omits it asserts nothing, which persists as `false`.
+      false,
     );
     expect(presenceService.setRuntimeState).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/server/src/api/agent/ws-client/session-frames.ts
+++ b/packages/server/src/api/agent/ws-client/session-frames.ts
@@ -119,7 +119,7 @@ export function createSessionFrameHandler(
       }
       const boundInfo = boundAgents.get(agentId);
       if (!boundInfo) return;
-      const { chatId, runtimeState } = payloadResult.data;
+      const { chatId, runtimeState, backgroundWork } = payloadResult.data;
       // Same per-(agent,chat) FIFO as session:state / session:event —
       // setSessionRuntime gates on `state='active'`, so the upstream
       // state write must drain first.
@@ -132,6 +132,7 @@ export function createSessionFrameHandler(
             runtimeState,
             boundInfo.organizationId,
             notifier,
+            backgroundWork === true,
           );
         } catch (err) {
           socket.send(

--- a/packages/server/src/db/schema/agent-chat-sessions.ts
+++ b/packages/server/src/db/schema/agent-chat-sessions.ts
@@ -1,4 +1,4 @@
-import { index, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, index, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 import { chats } from "./chats.js";
 
@@ -34,6 +34,16 @@ export const agentChatSessions = pgTable(
      * would let the producer light up agents that never reported anything.
      */
     runtimeStateAt: timestamp("runtime_state_at", { withTimezone: true }),
+    /**
+     * Descriptive companion to `runtime_state`: the provider for this pair is
+     * parked on work it started itself (a background task) and will resume
+     * without anyone messaging it. Written by the same `session:runtime`
+     * frame and therefore governed by the same `runtime_state_at` freshness
+     * — a client that stops reporting stops asserting background work. It is
+     * NOT an input to the composite `main`; an agent carrying it is still
+     * `ready`, just not finished.
+     */
+    backgroundWork: boolean("background_work").notNull().default(false),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/packages/server/src/services/chat/sessions/activity.ts
+++ b/packages/server/src/services/chat/sessions/activity.ts
@@ -63,19 +63,26 @@ export async function upsertSessionState(
       .insert(agentChatSessions)
       .values(
         revokesRuntime
-          ? { agentId, chatId, state, runtimeState: "idle", runtimeStateAt: now, updatedAt: now }
+          ? { agentId, chatId, state, runtimeState: "idle", runtimeStateAt: now, backgroundWork: false, updatedAt: now }
           : { agentId, chatId, state, updatedAt: now },
       )
       .onConflictDoUpdate({
         target: [agentChatSessions.agentId, agentChatSessions.chatId],
         set: revokesRuntime
-          ? { state, runtimeState: "idle", runtimeStateAt: now, updatedAt: now }
+          ? { state, runtimeState: "idle", runtimeStateAt: now, backgroundWork: false, updatedAt: now }
           : { state, updatedAt: now },
         // An inactive row retaining a non-idle runtime is also a real
         // projection change even when its lifecycle value is already equal.
         // Repair it once, then keep duplicate inactive frames as no-ops.
         setWhere: revokesRuntime
-          ? or(ne(agentChatSessions.state, state), ne(agentChatSessions.runtimeState, "idle"))
+          ? or(
+              ne(agentChatSessions.state, state),
+              ne(agentChatSessions.runtimeState, "idle"),
+              // A leftover background-work marker is the same class of stale
+              // projection as a leftover non-idle runtime: repair it once so a
+              // later activation cannot revive a previous session's marker.
+              eq(agentChatSessions.backgroundWork, true),
+            )
           : ne(agentChatSessions.state, state),
       })
       .returning({ agentId: agentChatSessions.agentId });
@@ -158,6 +165,13 @@ export async function setSessionRuntime(
   runtimeState: RuntimeState,
   organizationId: string,
   notifier?: Notifier,
+  /**
+   * Descriptive marker riding the same frame: the provider is parked on work
+   * it started itself and will resume unprompted. Absent (old client) is
+   * written as `false` — the same fail-closed default a client that stopped
+   * reporting decays to.
+   */
+  backgroundWork = false,
 ): Promise<void> {
   // CTE captures the previous row before the UPDATE; the UPDATE's WHERE
   // additionally enforces `state='active'` so an inactive / missing row
@@ -169,19 +183,25 @@ export async function setSessionRuntime(
   const rows = (await db.execute(sql`
     WITH prev AS (
       SELECT runtime_state    AS prev_runtime_state,
-             runtime_state_at AS prev_runtime_state_at
+             runtime_state_at AS prev_runtime_state_at,
+             background_work  AS prev_background_work
         FROM agent_chat_sessions
        WHERE agent_id = ${agentId} AND chat_id = ${chatId}
     )
     UPDATE agent_chat_sessions
        SET runtime_state    = ${runtimeState},
-           runtime_state_at = NOW()
+           runtime_state_at = NOW(),
+           background_work  = ${backgroundWork}
       FROM prev
      WHERE agent_chat_sessions.agent_id = ${agentId}
        AND agent_chat_sessions.chat_id  = ${chatId}
        AND agent_chat_sessions.state    = 'active'
-    RETURNING prev.prev_runtime_state, prev.prev_runtime_state_at
-  `)) as unknown as Array<{ prev_runtime_state: string | null; prev_runtime_state_at: Date | string | null }>;
+    RETURNING prev.prev_runtime_state, prev.prev_runtime_state_at, prev.prev_background_work
+  `)) as unknown as Array<{
+    prev_runtime_state: string | null;
+    prev_runtime_state_at: Date | string | null;
+    prev_background_work: boolean | null;
+  }>;
 
   // No row returned = WHERE didn't match (row missing or not active). Either
   // way the runtime report is stale; nothing to notify. This replaces the
@@ -204,7 +224,10 @@ export async function setSessionRuntime(
   // a value change, OR a same-value report that crosses the fail-closed
   // boundary (NULL sentinel → fresh, OR stale → fresh). A fresh same-value
   // re-affirm changes nothing, so it stays silent.
-  const valueChanged = prevRuntimeState !== runtimeState;
+  // A background-work flip changes what the surfaces render ("Idle" vs
+  // "Idle · background task"), so it earns a notify on its own even when the
+  // runtime state itself is an unchanged, still-fresh `idle`.
+  const valueChanged = prevRuntimeState !== runtimeState || (row.prev_background_work ?? false) !== backgroundWork;
   const wasStale = prevRuntimeStateAt == null || Date.now() - prevRuntimeStateAt.getTime() > RUNTIME_STALE_MS;
   if ((valueChanged || wasStale) && notifier) {
     notifier.notifySessionRuntime(agentId, chatId, runtimeState, organizationId).catch(() => {});

--- a/packages/server/src/services/chat/sessions/lifecycle.ts
+++ b/packages/server/src/services/chat/sessions/lifecycle.ts
@@ -443,7 +443,7 @@ export async function finalizeTerminatedSession(
       if (existing.runtimeState !== "idle") {
         await tx
           .update(agentChatSessions)
-          .set({ runtimeState: "idle", runtimeStateAt: now, updatedAt: now })
+          .set({ runtimeState: "idle", runtimeStateAt: now, backgroundWork: false, updatedAt: now })
           .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
       }
       await sessionEventService.clearEvents(tx as unknown as Database, agentId, chatId);
@@ -453,7 +453,7 @@ export async function finalizeTerminatedSession(
 
     await tx
       .update(agentChatSessions)
-      .set({ state: "evicted", runtimeState: "idle", runtimeStateAt: now, updatedAt: now })
+      .set({ state: "evicted", runtimeState: "idle", runtimeStateAt: now, backgroundWork: false, updatedAt: now })
       .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
 
     await sessionEventService.clearEvents(tx as unknown as Database, agentId, chatId);
@@ -534,7 +534,7 @@ export async function archiveAllSessionsForAgent(
 
     const transitioned = await tx
       .update(agentChatSessions)
-      .set({ state: "evicted", runtimeState: "idle", runtimeStateAt: now, updatedAt: now })
+      .set({ state: "evicted", runtimeState: "idle", runtimeStateAt: now, backgroundWork: false, updatedAt: now })
       .where(and(eq(agentChatSessions.agentId, agentId), ne(agentChatSessions.state, "evicted")))
       .returning({ chatId: agentChatSessions.chatId });
 
@@ -598,8 +598,8 @@ async function transitionSessionState(
       .update(agentChatSessions)
       .set(
         canTransition
-          ? { state: target, runtimeState: "idle", runtimeStateAt: now, updatedAt: now }
-          : { runtimeState: "idle", runtimeStateAt: now, updatedAt: now },
+          ? { state: target, runtimeState: "idle", runtimeStateAt: now, backgroundWork: false, updatedAt: now }
+          : { runtimeState: "idle", runtimeStateAt: now, backgroundWork: false, updatedAt: now },
       )
       .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
 

--- a/packages/server/src/services/chat/sessions/status.ts
+++ b/packages/server/src/services/chat/sessions/status.ts
@@ -6,6 +6,7 @@ import {
   ASSISTANT_TEXT_PREVIEW_MAX,
   type AssistantTextEventPayload,
   buildAgentChatStatus,
+  deriveMainStatus,
   LIVE_ACTIVITY_STALE_MS,
   type LiveActivity,
   parseProviderRetryEventMessage,
@@ -452,6 +453,7 @@ export async function resolveAgentChatStatuses(
       state: agentChatSessions.state,
       runtimeState: agentChatSessions.runtimeState,
       runtimeStateAt: agentChatSessions.runtimeStateAt,
+      backgroundWork: agentChatSessions.backgroundWork,
     })
     .from(agentChatSessions)
     .where(and(inArray(agentChatSessions.chatId, chatIds), inArray(agentChatSessions.agentId, allAgentIds)));
@@ -548,6 +550,16 @@ export async function resolveAgentChatStatuses(
       const activity = perAgentActivity?.get(agentId) ?? null;
       const engagement: AgentEngagement = state === "active" ? "active" : state === "suspended" ? "suspended" : "none";
       const working = computeWorking(sess, activity, now);
+      const axes = {
+        reachable: p?.clientId != null,
+        errored: computeErrored(sess, p?.runtimeState ?? null, now),
+        working,
+        engagement,
+      };
+      // Only a chat that actually reduces to `ready` may carry the qualifier.
+      // A disconnect keeps the last runtime row fresh for the stale window, so
+      // gating on `!working` alone would render "Offline · Background task".
+      const backgroundWork = deriveMainStatus(axes) === "ready" && computeBackgroundWork(sess, now);
       // A `provider_turn`-scoped `terminal` reason (provider_retry_exhausted /
       // provider_failure_terminal) records that a *past* turn's provider attempts
       // gave up. Once the agent is `working` again it is on a NEW turn, so that
@@ -572,10 +584,7 @@ export async function resolveAgentChatStatuses(
       arr.push(
         buildAgentChatStatus({
           agentId,
-          reachable: p?.clientId != null,
-          errored: computeErrored(sess, p?.runtimeState ?? null, now),
-          working,
-          engagement,
+          ...axes,
           // The activity is a descriptor of in-flight work — carry it only
           // while working, matching the schema's "null when not working"
           // contract. Codex no-events case (new-client authoritative path):
@@ -590,6 +599,10 @@ export async function resolveAgentChatStatuses(
           // runtime frame self-heals.
           activity: working ? activity : null,
           statusReason,
+          // Why an idle chat is not finished. Descriptive only — `main` stays
+          // `ready` — and suppressed while working, where the running turn is
+          // the more specific truth.
+          backgroundWork,
           // Live-connection capability gate for the Web chat-session Reset:
           // only a client that negotiated the composite v1 protocol can both
           // prove the old provider mapping is gone and release the rows it
@@ -642,6 +655,7 @@ type RuntimeSessionRow =
       state: string;
       runtimeState: string;
       runtimeStateAt: Date | null;
+      backgroundWork?: boolean;
     }
   | undefined;
 
@@ -676,6 +690,24 @@ export function computeWorking(session: RuntimeSessionRow, activity: LiveActivit
     return activity != null;
   }
   return isRuntimeFresh(session, now) && session.runtimeState === ("working" satisfies RuntimeState);
+}
+
+/**
+ * Descriptive companion to `computeWorking`: the client last reported that the
+ * provider is parked on work it started itself and will resume unprompted.
+ *
+ * This answers only "did a live client recently say so", gated on the SAME
+ * freshness window as `working` — a client that dies or stops reporting stops
+ * asserting background work rather than leaving a permanent "background task"
+ * on a chat nobody is running. Whether that claim is worth *showing* is a
+ * separate question the caller answers, because the marker qualifies the word
+ * "Idle" specifically: an unreachable, failed, paused, or working chat is not
+ * idle, and appending "· Background task" to any of those states would state
+ * something the composite does not mean. Never an input to `main`.
+ */
+export function computeBackgroundWork(session: RuntimeSessionRow, now: number): boolean {
+  if (!isRuntimeFresh(session, now)) return false;
+  return session?.backgroundWork === true;
 }
 
 function isFaultRuntime(runtimeState: string): boolean {

--- a/packages/shared/src/__tests__/agent-status.test.ts
+++ b/packages/shared/src/__tests__/agent-status.test.ts
@@ -146,6 +146,33 @@ describe("buildAgentChatStatus", () => {
     expect(agentChatStatusSchema.safeParse(status).success).toBe(true);
   });
 
+  it("carries background work without letting it touch main", () => {
+    // The marker says "idle, but it wakes itself up" — a descriptive
+    // qualifier like `activity` / `statusReason`, never a fifth state.
+    const status = buildAgentChatStatus({
+      agentId: "agent-1",
+      reachable: true,
+      errored: false,
+      working: false,
+      engagement: "active",
+      backgroundWork: true,
+    });
+    expect(status.main).toBe("ready");
+    expect(status.backgroundWork).toBe(true);
+    expect(agentChatStatusSchema.safeParse(status).success).toBe(true);
+  });
+
+  it("omits background work when absent so the field never lands as false", () => {
+    const status = buildAgentChatStatus({
+      agentId: "agent-1",
+      reachable: true,
+      errored: false,
+      working: false,
+      engagement: "active",
+    });
+    expect(status.backgroundWork).toBeUndefined();
+  });
+
   it("an unreachable agent builds to offline regardless of other axes", () => {
     const status = buildAgentChatStatus({
       agentId: "agent-1",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1395,6 +1395,7 @@ export {
   runtimeStateSchema,
   SESSION_STATES,
   type SessionRuntimeMessage,
+  type SessionRuntimeReport,
   type SessionState,
   type SessionStateMessage,
   sessionRuntimeMessageSchema,

--- a/packages/shared/src/schemas/agent-status.ts
+++ b/packages/shared/src/schemas/agent-status.ts
@@ -148,6 +148,18 @@ export const agentChatStatusSchema = z
      */
     statusReason: agentStatusReasonSchema.optional(),
     /**
+     * The provider for this chat is parked on work it started itself (a
+     * background task) and will resume on its own when that work finishes.
+     *
+     * Descriptive only, exactly like `activity` and `statusReason`: it is NOT
+     * an input to `main`, and a chat carrying it stays `ready`. A parked
+     * provider burns no tokens and runs no turn, so calling it `working`
+     * would be a lie; but plain "Idle" is also a lie by omission, because it
+     * reads as "finished, nothing will happen without you" when in fact the
+     * agent wakes itself up. Surfaces render it as a qualifier on Idle.
+     */
+    backgroundWork: z.boolean().optional(),
+    /**
      * The agent's live client connection declares the composite Reset
      * capability `wsSessionResetV1` — i.e. it answers a ref'd terminate with
      * an apply-ack, parks intervening inbox rows behind the Reset fence, and
@@ -190,6 +202,7 @@ export type AgentChatStatusInput = DeriveMainStatusInput & {
   agentId: string;
   activity?: LiveActivity | null;
   statusReason?: AgentStatusReason;
+  backgroundWork?: boolean;
   sessionResetSupported?: boolean;
   teamSkillInvocationSupported?: boolean;
 };
@@ -209,6 +222,7 @@ export function buildAgentChatStatus(input: AgentChatStatusInput): AgentChatStat
     main: deriveMainStatus(input),
     activity: input.activity ?? null,
     ...(input.statusReason ? { statusReason: input.statusReason } : {}),
+    ...(input.backgroundWork ? { backgroundWork: true } : {}),
     ...(input.sessionResetSupported !== undefined ? { sessionResetSupported: input.sessionResetSupported } : {}),
     ...(input.teamSkillInvocationSupported !== undefined
       ? { teamSkillInvocationSupported: input.teamSkillInvocationSupported }

--- a/packages/shared/src/schemas/presence.ts
+++ b/packages/shared/src/schemas/presence.ts
@@ -82,8 +82,25 @@ export type RuntimeStateMessage = z.infer<typeof runtimeStateMessageSchema>;
 export const sessionRuntimeMessageSchema = z.object({
   chatId: z.string().min(1),
   runtimeState: runtimeStateSchema,
+  /**
+   * The provider for this chat is parked on work it started itself — a
+   * `run_in_background` task, for instance — and will resume on its own when
+   * that work finishes. Descriptive only: it never makes a chat `working`
+   * (the turn is not running and no tokens are burning), it explains why an
+   * idle chat is not finished. Optional so an older client that never sends
+   * it simply reads as "no background work".
+   */
+  backgroundWork: z.boolean().optional(),
 });
 export type SessionRuntimeMessage = z.infer<typeof sessionRuntimeMessageSchema>;
+
+/**
+ * One per-chat runtime report, named rather than threaded positionally. The
+ * report crosses four layers (projection -> slot -> connection -> frame), and
+ * every descriptive field added to it would otherwise be another positional
+ * parameter sweep through all of them.
+ */
+export type SessionRuntimeReport = Omit<SessionRuntimeMessage, "chatId"> & { backgroundWork: boolean };
 
 // -- Agent Bind Payload (client -> server) --
 // WS bind authorization derives from the WS-level JWT and the client_id pinned

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -1275,6 +1275,26 @@ describe("AgentStatusPanel extra DOM coverage", () => {
     expect(sessionApiMocks.suspendSession).not.toHaveBeenCalled();
   });
 
+  it("qualifies an Idle row whose provider is parked on a background task", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
+      status("agent-nova", { engagement: "active", backgroundWork: true }),
+    ]);
+
+    h.render(
+      withProviders(
+        <AgentStatusPanel chatId="chat-1" agents={[agent("agent-nova", "Nova")]} canManage={() => true} compact />,
+      ),
+    );
+
+    await waitForSettled(h, () => {
+      // Still Idle — no turn is running and no tokens are burning. The
+      // qualifier only says the agent will wake itself up, so "Idle" is not
+      // read as "finished, nothing happens without you".
+      expect(h.container.textContent).toContain("Idle");
+      expect(h.container.textContent).toContain("Background task");
+    });
+  });
+
   it("keeps working and failed roster statuses static and omits activity detail", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-worker", {

--- a/packages/web/src/components/chat/agent-status-panel.tsx
+++ b/packages/web/src/components/chat/agent-status-panel.tsx
@@ -314,6 +314,15 @@ function SecondLine({ status }: { status: AgentChatStatus | null }) {
   return (
     <div className="text-caption" style={{ color: view.colorVar }}>
       {view.label}
+      {/* Why this idle agent is not finished: its provider is parked on work
+          it started itself and wakes up on its own. Rendered as a quieter
+          qualifier, not a second state — the dot stays idle. The `ready`
+          check is defense in depth: the qualifier reads as a footnote on the
+          word "Idle", so it must never trail Offline or Paused even if the
+          server were to send it alongside one. */}
+      {status.main === "ready" && status.backgroundWork === true ? (
+        <span style={{ color: "var(--fg-4)" }}> · Background task</span>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Stacked on #2378 — review that one first; this branch contains its two commits.

## Why

With #2378, an agent that is running a turn reads as **Working**. This PR is about the other half of the same report: a provider that is parked on work it started itself — a `run_in_background` task — and will wake up on its own when that work finishes.

That chat is genuinely idle. No turn is running, no tokens are burning, and calling it "working" would be a lie. But plain **Idle** is a lie by omission: it reads as "finished, nothing more happens unless you say something", when in fact the agent resumes by itself. In the incident that prompted this, the gap was 25 minutes long.

The client already knows this state precisely — the idle sweep consults a live-subprocess probe and refuses to suspend such a session — it simply never told the server.

## What this is not

It is deliberately **not** a fifth `AgentMainStatus`. That enum is a cross-version wire contract parsed with `z.enum`, so a value an older reader has never seen doesn't degrade gracefully — it fails the parse and takes the whole chat's agent-status payload with it. The `RuntimeState` client→server enum has the same property. And "background task" is not a peer of offline/failed/working/paused/ready anyway: it is the *reason* a chat is idle, not a different kind of idle, so it would have no defensible slot in the `MAIN_STATUS_PRIORITY` ladder.

So it follows the pattern the codebase already has for exactly this: `activity` and `statusReason` are documented as descriptive, never inputs to `main`. `backgroundWork` joins them.

## How it flows

- **Client** — `SlotSchedulerAuthority.hasReportableBackgroundWork` = a live provider child *the session did not start with*, AND still inside the `idle_timeout + working_grace` cap the idle sweep already enforces. `SessionProjectionAuthority` re-samples it on the existing ~20s re-affirm tick and rides it on the `session:runtime` frame it already sends.
- **Wire** — one optional `backgroundWork` field, omitted when false so the common frame stays byte-identical to what older clients send.
- **Server** — `agent_chat_sessions.background_work` (migration `0095`), written by the same frame, read by `computeBackgroundWork` under the *same* freshness gate as `working`.
- **Web** — the sidebar row's second line becomes `Idle · Background task`. Same idle dot, same colour; the qualifier is dimmer than the state word.

## The signal, and why the obvious one is wrong

"Does the provider have a live child" — the predicate the idle sweep already uses — cannot carry this claim. A stdio MCP server is a direct child for the whole session, so on any host running MCP-configured agents it is unconditionally true: every idle chat would report a background task, forever, and plain `Idle` would become the rare state. A qualifier that is on when nothing is running does not remove the lie in "Idle", it relocates it.

So the probe baselines each provider's direct children when it first observes that process, and only pids outside the baseline count. A provider first seen mid-turn baselines that turn's children and under-reports until they exit — silence rather than a false claim; an MCP server that respawns takes a new pid and over-reports for that provider process only.

`hasLiveSubprocess` is untouched and still feeds `evictIdle`: over-triggering there defers a suspend, which is conservative and invisible. The same over-triggering behind a user-visible label is a false statement about the agent, made continuously — which is why these are now two predicates rather than one.

## Two more things that keep it honest

**It only ever qualifies an idle chat.** The underlying probe answers "does the provider have a live child process", which an ordinary foreground `Bash` step also satisfies. Asserting it during a turn would flap the wire every tool call and claim "parked" about a provider that is plainly running, so the marker is gated to idle and cleared on the transition out of idle — both client-side and again server-side.

**It decays on its own.** The marker is trusted only while the runtime stamp is fresh, and the client re-affirms `idle` *only* when it carries background work (plain idle stays off the wire, as before). A client that dies stops re-affirming and the server stops believing it within the freshness window; a forgotten background watcher stops being asserted at the idle hard cap, where the sweep reclaims the slot anyway.

## Tests

- probe — a process tree with an MCP-style permanent child reports `hasLiveSubprocess` true and session-spawned work false, flips true only while a turn-spawned child lives, and re-baselines when the provider pid changes. Plus an end-to-end case: the real probe fed that tree, wired into a real `SessionRuntime`, emits no frame at all after a completed turn.
- shared — the marker survives `buildAgentChatStatus` without touching `main`, and is omitted rather than written as `false`.
- server — `computeBackgroundWork` truth table (a fresh claim from a live client; false once stale, NULL-stamped, or suspended), a DB-backed case asserting `main: "ready"` with the marker set, a case dropping it for every non-ready composite (disconnect, working, error), and one proving suspend clears the stored column so a reactivated session cannot inherit it.
- client — the marker is reported and re-affirmed on the tick; it is dropped past the hard cap; it is never asserted while a turn runs.
- web — an idle row with the marker renders both "Idle" and "Background task".

**Requires explicit approval for the migration.** `AGENTS.md` requires human sign-off for a specific database change; I wrote the column before asking, which was my error. The question is open with the maintainer, and this should not merge on a green board alone.

`pnpm check` exit 0 and typecheck exit 0 for shared/server/client/web (real exit codes, not through a pipe). Full suites on this head: client 2855, server 3492, shared 956, qa 5, web 2427 (`TZ=UTC`) — all exit 0.

Two local failures that are **not** from this change, both verified:

- Four Web tests (`group-rows` recency + one CommandPalette case) fail in any timezone far enough behind UTC and pass under `TZ=UTC`. Reproduced on a branch with zero Web changes; filed as #2379.
- `providers/grok/__tests__/acp-session.test.ts` "times out and kills a child that never answers initialize" waits on a real spawned child's pid file and times out only inside a fully parallel run on a loaded machine (load average ~10 here). It passes standalone and in the full client suite when the machine is quieter; this diff touches no provider spawn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
