### PR TITLE
fix: reduce session event query load

### DIFF
--- a/packages/client/src/providers/antigravity/__tests__/handler.test.ts
+++ b/packages/client/src/providers/antigravity/__tests__/handler.test.ts
@@ -114,6 +114,7 @@ function context(
     log: vi.fn(),
     chatId,
     recordProviderActivity: vi.fn(),
+    noteTurnStart: vi.fn(),
     emitEvent: (event) => events.push(event),
     forwardResult: async (text) => {
       forwarded.push(text);

--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -2,15 +2,18 @@ import { randomUUID } from "node:crypto";
 import {
   agentChatStatusSchema,
   encodeProviderRetryEventMessage,
+  LIVE_ACTIVITY_STALE_MS,
   type LiveActivity,
   RUNTIME_STALE_MS,
 } from "@first-tree/shared";
 import { sql } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it, vi } from "vitest";
 import { createAgent } from "../services/agents/identity.js";
 import {
   computeErrored,
   computeWorking,
+  getChatAgentStatus,
   getChatAgentStatuses,
   isRuntimeFresh,
   previewAssistantTextFull,
@@ -708,6 +711,376 @@ describe("agent-chat-status", () => {
       expect(byChat.get(a.chatId)?.find((s) => s.agentId === peer.agent.uuid)?.main).toBe("working");
       expect(byChat.get(b.chatId)?.find((s) => s.agentId === peer.agent.uuid)?.main).toBe("working");
       expect(byChat.get(c.chatId)?.find((s) => s.agentId === peer.agent.uuid)?.main).toBe("ready");
+    });
+  });
+
+  describe("resolveAgentChatStatuses target workset / getChatAgentStatus", () => {
+    type CapturedStatement = { sql: string; params: unknown[] };
+
+    /**
+     * Capture every statement the resolve flow executes by intercepting the
+     * Drizzle session's `prepareQuery` chokepoint (both query-builder selects
+     * and raw `db.execute` SQL arrive here as `{ sql, params }`). Pure
+     * pass-through — execution is untouched.
+     */
+    async function captureStatements(app: FastifyInstance, run: () => Promise<unknown>): Promise<CapturedStatement[]> {
+      const session = (app.db as unknown as { session: { prepareQuery: (...args: unknown[]) => unknown } }).session;
+      const originalPrepareQuery = session.prepareQuery.bind(session);
+      const captured: CapturedStatement[] = [];
+      const spy = vi.spyOn(session, "prepareQuery").mockImplementation(((query: unknown, ...rest: unknown[]) => {
+        const q = query as { sql?: unknown; params?: unknown } | null;
+        if (q && typeof q.sql === "string" && Array.isArray(q.params)) {
+          captured.push({ sql: q.sql, params: q.params as unknown[] });
+        }
+        return originalPrepareQuery(query, ...rest);
+      }) satisfies (...args: unknown[]) => unknown);
+      try {
+        await run();
+      } finally {
+        spy.mockRestore();
+      }
+      return captured;
+    }
+
+    /**
+     * The (agentId, chatId) pairs carried by a statement's parameters, from
+     * the row-value pair predicates `(col, col) IN ((a1,c1),(a2,c2),…)`.
+     * Only meaningful for statements whose parameters are exactly the pair
+     * list; non-identifier literal params (e.g. `speaker` / `human` filter
+     * values on the membership read) are skipped.
+     */
+    const statementPairs = (statement: CapturedStatement): Array<readonly [string, string]> => {
+      const pairs: Array<readonly [string, string]> = [];
+      for (let i = 0; i + 1 < statement.params.length; i += 2) {
+        const agentId = statement.params[i];
+        const chatId = statement.params[i + 1];
+        if (
+          typeof agentId === "string" &&
+          typeof chatId === "string" &&
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(agentId) &&
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(chatId)
+        ) {
+          pairs.push([agentId, chatId] as const);
+        }
+      }
+      return pairs;
+    };
+
+    const pairList = (pairs: ReadonlyArray<readonly [string, string]>): string =>
+      [...pairs]
+        .sort()
+        .map(([a, c]) => `${a}/${c}`)
+        .join(",");
+
+    /** Insert a session event with an explicit ISO timestamp (raw Date
+     *  binding is unsupported by the installed driver — always ISO text). */
+    async function insertEventAtMs(
+      app: FastifyInstance,
+      agentId: string,
+      chatId: string,
+      seq: number,
+      kind: string,
+      payload: unknown,
+      createdAtIso: string,
+    ): Promise<void> {
+      await app.db.execute(sql`
+        INSERT INTO session_events (id, agent_id, chat_id, seq, kind, payload, created_at)
+        VALUES (${randomUUID()}, ${agentId}, ${chatId}, ${seq}, ${kind},
+                ${JSON.stringify(payload)}::jsonb, ${createdAtIso}::timestamptz)
+      `);
+    }
+
+    it("downpushes the target workset into every executed query (no sibling pair parameters)", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const first = await createTestAgent(app, { name: `tgt-a-${randomUUID().slice(0, 6)}` });
+      const second = await createTestAgent(app, { name: `tgt-b-${randomUUID().slice(0, 6)}` });
+      const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+        participantIds: [first.agent.uuid, second.agent.uuid],
+      });
+      for (const peer of [first, second]) {
+        await bindPresence(peer.agent.uuid, peer.clientId);
+        await setSession(peer.agent.uuid, chatId, "active");
+        await setRuntime(peer.agent.uuid, chatId, "idle");
+        await insertEvent(peer.agent.uuid, chatId, 1, "tool_call", {
+          toolUseId: "t1",
+          name: "Bash",
+          args: null,
+          status: "pending",
+        });
+      }
+
+      const single = await captureStatements(app, () =>
+        resolveAgentChatStatuses(app.db, [chatId], {
+          targets: new Map([[chatId, new Set([first.agent.uuid])]]),
+        }),
+      );
+      // Membership read + session-row read + Q3 + Q2 all ran, and every one
+      // of them carries only the (first, chat) pair.
+      const singleWorkset = single.filter(
+        (s) => s.sql.includes("agent_chat_sessions") || s.sql.includes("chat_membership"),
+      );
+      expect(singleWorkset.length).toBeGreaterThanOrEqual(3);
+      for (const statement of singleWorkset) {
+        expect(pairList(statementPairs(statement))).toBe(pairList([[first.agent.uuid, chatId]]));
+      }
+      const singleParams = singleWorkset.flatMap((s) => s.params);
+      expect(singleParams).not.toContain(second.agent.uuid);
+
+      const full = await captureStatements(app, () => resolveAgentChatStatuses(app.db, [chatId]));
+      const fullWorkset = full.filter((s) => s.sql.includes("agent_chat_sessions"));
+      expect(fullWorkset.some((s) => s.params.includes(second.agent.uuid))).toBe(true);
+    });
+
+    it("multi-chat targets execute pair-exact SQL — crossed pairs are never fetched", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const peerX = await createTestAgent(app, { name: `cross-x-${randomUUID().slice(0, 6)}` });
+      const peerY = await createTestAgent(app, { name: `cross-y-${randomUUID().slice(0, 6)}` });
+      // Both agents speak in BOTH chats and hold session rows in BOTH chats —
+      // the exact scenario where a chat × agent cross product would fetch
+      // (X, chatB) / (Y, chatA) rows the workset never asked for.
+      const chatA = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+        participantIds: [peerX.agent.uuid, peerY.agent.uuid],
+        topic: "A",
+      });
+      const chatB = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+        participantIds: [peerX.agent.uuid, peerY.agent.uuid],
+        topic: "B",
+      });
+      for (const peer of [peerX, peerY]) {
+        await bindPresence(peer.agent.uuid, peer.clientId);
+        await setSession(peer.agent.uuid, chatA.chatId, "active");
+        await setSession(peer.agent.uuid, chatB.chatId, "active");
+      }
+      await setRuntime(peerX.agent.uuid, chatA.chatId, "working");
+      await setRuntime(peerY.agent.uuid, chatB.chatId, "working");
+
+      const captured = await captureStatements(app, () =>
+        resolveAgentChatStatuses(app.db, [chatA.chatId, chatB.chatId], {
+          targets: new Map([
+            [chatA.chatId, new Set([peerX.agent.uuid])],
+            [chatB.chatId, new Set([peerY.agent.uuid])],
+          ]),
+        }),
+      );
+
+      // Every statement touching a session- or membership-bearing table is
+      // parameterised by EXACTLY the two requested pairs — the crossed pairs
+      // (X, B) and (Y, A) exist as real session rows here, so an independent
+      // chat IN + agent IN filter would have fetched them.
+      const worksetStatements = captured.filter(
+        (s) => s.sql.includes("agent_chat_sessions") || s.sql.includes("chat_membership"),
+      );
+      expect(worksetStatements.length).toBeGreaterThanOrEqual(3);
+      const expected = pairList([
+        [peerX.agent.uuid, chatA.chatId],
+        [peerY.agent.uuid, chatB.chatId],
+      ]);
+      for (const statement of worksetStatements) {
+        expect(pairList(statementPairs(statement))).toBe(expected);
+      }
+
+      const byChat = await resolveAgentChatStatuses(app.db, [chatA.chatId, chatB.chatId], {
+        targets: new Map([
+          [chatA.chatId, new Set([peerX.agent.uuid])],
+          [chatB.chatId, new Set([peerY.agent.uuid])],
+        ]),
+      });
+      expect(byChat.get(chatA.chatId)?.map((s) => s.agentId)).toEqual([peerX.agent.uuid]);
+      expect(byChat.get(chatB.chatId)?.map((s) => s.agentId)).toEqual([peerY.agent.uuid]);
+    });
+
+    it("single-target status equals the full projection's entry for the same pair (working + narration preserved)", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await setRuntime(peer.agent.uuid, chatId, "working");
+      await insertEvent(peer.agent.uuid, chatId, 1, "assistant_text", { text: "narration text" });
+
+      const single = await getChatAgentStatus(app.db, chatId, peer.agent.uuid);
+      const full = (await getChatAgentStatuses(app.db, chatId)).find((s) => s.agentId === peer.agent.uuid);
+      expect(single).toEqual(full);
+      expect(single?.main).toBe("working");
+      expect(single?.activity?.kind).toBe("assistant_text");
+      expect(single?.activity?.turnText).toBe("narration text");
+      expect(single?.sessionResetSupported).toBe(full?.sessionResetSupported);
+    });
+
+    it("same agent across chats: per-chat target pairs stay exact and independent", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const peer = await createTestAgent(app, { name: `pair-a-${randomUUID().slice(0, 6)}` });
+      const sibling = await createTestAgent(app, { name: `pair-b-${randomUUID().slice(0, 6)}` });
+      const chatA = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+        participantIds: [peer.agent.uuid],
+        topic: "A",
+      });
+      const chatB = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+        participantIds: [peer.agent.uuid, sibling.agent.uuid],
+        topic: "B",
+      });
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await bindPresence(sibling.agent.uuid, sibling.clientId);
+      await setSession(peer.agent.uuid, chatA.chatId, "active");
+      await setRuntime(peer.agent.uuid, chatA.chatId, "working");
+      await setSession(peer.agent.uuid, chatB.chatId, "suspended");
+      await setSession(sibling.agent.uuid, chatB.chatId, "active");
+      await setRuntime(sibling.agent.uuid, chatB.chatId, "idle");
+
+      const byChat = await resolveAgentChatStatuses(app.db, [chatA.chatId, chatB.chatId], {
+        targets: new Map([
+          [chatA.chatId, new Set([peer.agent.uuid])],
+          [chatB.chatId, new Set([sibling.agent.uuid])],
+        ]),
+      });
+      expect(byChat.get(chatA.chatId)?.map((s) => s.agentId)).toEqual([peer.agent.uuid]);
+      expect(byChat.get(chatA.chatId)?.[0]?.main).toBe("working");
+      // chat B targets only the sibling: the peer speaks there too, but the
+      // pair-exact workset must not widen to it.
+      expect(byChat.get(chatB.chatId)?.map((s) => s.agentId)).toEqual([sibling.agent.uuid]);
+      expect(byChat.get(chatB.chatId)?.map((s) => s.agentId)).not.toContain(peer.agent.uuid);
+
+      // The single-target getter reads each chat's own row for the same agent.
+      const inA = await getChatAgentStatus(app.db, chatA.chatId, peer.agent.uuid);
+      const inB = await getChatAgentStatus(app.db, chatB.chatId, peer.agent.uuid);
+      expect(inA?.main).toBe("working");
+      expect(inB?.main).toBe("paused");
+    });
+
+    it("non-speaker targets resolve to nothing and never widen to the chat's speakers", async () => {
+      const { app, admin, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      const outsider = await createTestAgent(app, { name: `outsider-${randomUUID().slice(0, 6)}` });
+      // A member of the same org, but no membership row in this chat.
+      const otherChat = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+        participantIds: [outsider.agent.uuid],
+      });
+
+      await expect(getChatAgentStatus(app.db, chatId, outsider.agent.uuid)).resolves.toBeUndefined();
+      // The outsider speaks in a DIFFERENT chat — targeting it for this chat
+      // must not pull the peer in either.
+      const byChat = await resolveAgentChatStatuses(app.db, [chatId], {
+        targets: new Map([[chatId, new Set([outsider.agent.uuid])]]),
+      });
+      expect(byChat.size).toBe(0);
+
+      // Sanity: the same target in its own chat resolves.
+      const own = await getChatAgentStatus(app.db, otherChat.chatId, outsider.agent.uuid);
+      expect(own?.agentId).toBe(outsider.agent.uuid);
+    });
+
+    it("empty target sets and absent chat keys never mean all agents — and skip the pair reads entirely", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+
+      const emptySet = await captureStatements(app, () =>
+        resolveAgentChatStatuses(app.db, [chatId], {
+          targets: new Map([[chatId, new Set()]]),
+        }),
+      );
+      expect(
+        emptySet.filter((s) => s.sql.includes("agent_chat_sessions") || s.sql.includes("chat_membership")),
+      ).toHaveLength(0);
+
+      const absentKey = await captureStatements(app, () =>
+        resolveAgentChatStatuses(app.db, [chatId], {
+          targets: new Map([[`chat-${crypto.randomUUID()}`, new Set([peer.agent.uuid])]]),
+        }),
+      );
+      expect(
+        absentKey.filter((s) => s.sql.includes("agent_chat_sessions") || s.sql.includes("chat_membership")),
+      ).toHaveLength(0);
+    });
+
+    it("holds the exact LIVE_ACTIVITY_STALE_MS boundary on activity + narration (frozen application clock)", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const justFresh = await createTestAgent(app, { name: `bound-f-${randomUUID().slice(0, 6)}` });
+      const justStale = await createTestAgent(app, { name: `bound-s-${randomUUID().slice(0, 6)}` });
+      const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+        participantIds: [justFresh.agent.uuid, justStale.agent.uuid],
+      });
+      for (const peer of [justFresh, justStale]) {
+        await bindPresence(peer.agent.uuid, peer.clientId);
+        await setSession(peer.agent.uuid, chatId, "active");
+        await setRuntime(peer.agent.uuid, chatId, "working");
+      }
+
+      // Freeze the application clock so the JS stale check and the SQL-side
+      // narration cutoff share one reference instant; DB timestamps are
+      // inserted explicitly relative to it (ISO text params — raw Date
+      // binding is not supported by the installed driver).
+      const frozenNow = Date.now();
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(frozenNow);
+      try {
+        await insertEventAtMs(
+          app,
+          justFresh.agent.uuid,
+          chatId,
+          1,
+          "assistant_text",
+          { text: "one millisecond fresh" },
+          new Date(frozenNow - LIVE_ACTIVITY_STALE_MS + 1).toISOString(),
+        );
+        await insertEventAtMs(
+          app,
+          justStale.agent.uuid,
+          chatId,
+          1,
+          "tool_call",
+          { toolUseId: "t1", name: "Bash", args: null, status: "pending" },
+          new Date(frozenNow - LIVE_ACTIVITY_STALE_MS - 1).toISOString(),
+        );
+
+        const byChat = await resolveAgentChatStatuses(app.db, [chatId], { withTurnText: true });
+        const fresh = byChat.get(chatId)?.find((s) => s.agentId === justFresh.agent.uuid);
+        const stale = byChat.get(chatId)?.find((s) => s.agentId === justStale.agent.uuid);
+        // Age 59,999 ms: kept by the JS stale check AND the SQL narration
+        // guard — narration rides along.
+        expect(fresh?.activity?.kind).toBe("assistant_text");
+        expect(fresh?.activity?.turnText).toBe("one millisecond fresh");
+        // Age 60,001 ms: dropped by the JS stale check; the guarded narration
+        // may not keep it alive (nothing resurrects across the boundary). The
+        // schema carries `activity: null` when working without a live
+        // activity descriptor.
+        expect(stale?.activity).toBeNull();
+        expect(stale?.activity?.turnText).toBeUndefined();
+        expect(fresh?.working).toBe(true);
+        expect(stale?.working).toBe(true); // runtime axis is independent of activity
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it("terminal / stale latest events never resurrect older narration or activity", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await setRuntime(peer.agent.uuid, chatId, "working");
+      await insertEvent(peer.agent.uuid, chatId, 1, "assistant_text", { text: "old narration" });
+
+      // A fresh terminal event as the latest row: no activity descriptor
+      // (null when working without one), no narration.
+      await insertEvent(peer.agent.uuid, chatId, 2, "turn_end", { status: "success" });
+      let s = await getChatAgentStatus(app.db, chatId, peer.agent.uuid);
+      expect(s?.working).toBe(true); // runtime axis unaffected
+      expect(s?.activity).toBeNull();
+
+      // A stale activity-kind latest event (older than LIVE_ACTIVITY_STALE_MS):
+      // dropped by the JS stale check — the guarded narration may not keep it
+      // alive either.
+      await getApp().db.execute(sql`
+        INSERT INTO session_events (id, agent_id, chat_id, seq, kind, payload, created_at)
+        VALUES (${randomUUID()}, ${peer.agent.uuid}, ${chatId}, 3, 'tool_call',
+                ${JSON.stringify({ toolUseId: "t1", name: "Bash", args: null, status: "pending" })}::jsonb,
+                NOW() - (${LIVE_ACTIVITY_STALE_MS + 5_000}::int * interval '1 millisecond'))
+      `);
+      s = await getChatAgentStatus(app.db, chatId, peer.agent.uuid);
+      expect(s?.activity).toBeNull();
+      expect(s?.activity?.turnText).toBeUndefined();
     });
   });
 

--- a/packages/server/src/__tests__/session-event.test.ts
+++ b/packages/server/src/__tests__/session-event.test.ts
@@ -701,3 +701,309 @@ async function humanAgentIdFor(app: FastifyInstance, memberId: string): Promise<
   if (!row) throw new Error("member row missing");
   return row.agentId;
 }
+
+describe("listChatSpeakerEvents — bounded per-speaker windows and current-turn metadata", () => {
+  const getApp = useTestApp();
+  const chatId = () => `chat-${crypto.randomUUID()}`;
+
+  async function seedChatWithSpeakers(agentUuids: string[], organizationId: string): Promise<string> {
+    const c = chatId();
+    await getApp().db.insert(chats).values({ id: c, organizationId, type: "group" });
+    await getApp()
+      .db.insert(chatMembership)
+      .values(agentUuids.map((agentId) => ({ chatId: c, agentId, accessMode: "speaker" })));
+    return c;
+  }
+
+  async function insertEventAt(
+    agentId: string,
+    c: string,
+    seq: number,
+    kind: string,
+    payload: unknown,
+    createdAt: Date,
+  ): Promise<void> {
+    await getApp().db.insert(sessionEvents).values({ id: uuidv7(), agentId, chatId: c, seq, kind, payload, createdAt });
+  }
+
+  it("keeps per-speaker windows capped while turn metadata spans the whole history (>200 rows, start outside window)", async () => {
+    const app = getApp();
+    const speaker = await createTestAgent(app, { name: `q1-a-${crypto.randomUUID().slice(0, 6)}` });
+    const sibling = await createTestAgent(app, { name: `q1-b-${crypto.randomUUID().slice(0, 6)}` });
+    const c = await seedChatWithSpeakers([speaker.agent.uuid, sibling.agent.uuid], speaker.organizationId);
+
+    const base = new Date("2026-09-03T08:00:00.000Z");
+    // Speaker history: 205 tool_calls, then a turn_end, then a fresh turn of
+    // three activity events whose first row falls OUTSIDE a limit=2 window.
+    for (let i = 1; i <= 205; i++) {
+      await insertEventAt(
+        speaker.agent.uuid,
+        c,
+        i,
+        "tool_call",
+        { toolUseId: `t${i}`, name: "Bash", args: null, status: "ok" },
+        new Date(base.getTime() + i),
+      );
+    }
+    const turnEndAt = new Date(base.getTime() + 100_000);
+    const currentTurnStartAt = new Date(base.getTime() + 200_000);
+    await insertEventAt(speaker.agent.uuid, c, 206, "turn_end", { status: "success" }, turnEndAt);
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      207,
+      "tool_call",
+      { toolUseId: "t207", name: "Read", args: null, status: "pending" },
+      currentTurnStartAt,
+    );
+    await insertEventAt(speaker.agent.uuid, c, 208, "thinking", {}, new Date(base.getTime() + 201_000));
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      209,
+      "assistant_text",
+      { text: "almost done" },
+      new Date(base.getTime() + 202_000),
+    );
+    // Sibling: three events, no turn_end.
+    for (let i = 1; i <= 3; i++) {
+      await insertEventAt(
+        sibling.agent.uuid,
+        c,
+        i,
+        "assistant_text",
+        { text: `s${i}` },
+        new Date(base.getTime() + 10_000 + i),
+      );
+    }
+
+    const desc = await sessionEventService.listChatSpeakerEvents(app.db, c, { limit: 2, direction: "desc" });
+    const speakerFeed = desc.feeds.find((f) => f.agentId === speaker.agent.uuid);
+    const siblingFeed = desc.feeds.find((f) => f.agentId === sibling.agent.uuid);
+    expect(desc.feeds.map((f) => f.agentId).sort()).toEqual([sibling.agent.uuid, speaker.agent.uuid].sort());
+    expect(speakerFeed?.items.map((e) => e.seq)).toEqual([209, 208]);
+    expect(speakerFeed?.nextCursor).toBe(208);
+    // The turn started at seq 207 — outside the returned window — and the
+    // metadata must still report it.
+    expect(speakerFeed?.turnStartedAt).toBe(currentTurnStartAt.toISOString());
+    expect(siblingFeed?.items.map((e) => e.seq)).toEqual([3, 2]);
+    expect(siblingFeed?.nextCursor).toBe(2);
+
+    // Direction-independent metadata: asc window walks the oldest events but
+    // reports the same current-turn start.
+    const asc = await sessionEventService.listChatSpeakerEvents(app.db, c, { limit: 2 });
+    expect(asc.feeds.find((f) => f.agentId === speaker.agent.uuid)?.items.map((e) => e.seq)).toEqual([1, 2]);
+    expect(asc.feeds.find((f) => f.agentId === speaker.agent.uuid)?.nextCursor).toBe(2);
+    expect(asc.feeds.find((f) => f.agentId === speaker.agent.uuid)?.turnStartedAt).toBe(
+      currentTurnStartAt.toISOString(),
+    );
+
+    // Default limit (200) with >200 history: capped window + cursor, same turn start.
+    const page = await sessionEventService.listChatSpeakerEvents(app.db, c, { direction: "desc" });
+    const pageFeed = page.feeds.find((f) => f.agentId === speaker.agent.uuid);
+    expect(pageFeed?.items).toHaveLength(200);
+    expect(pageFeed?.items[0]?.seq).toBe(209);
+    expect(pageFeed?.items[199]?.seq).toBe(10);
+    expect(pageFeed?.nextCursor).toBe(10);
+    expect(pageFeed?.turnStartedAt).toBe(currentTurnStartAt.toISOString());
+  });
+
+  it("computes the turn start as MIN(created_at) over the current turn — not seq order, window head, or error rows", async () => {
+    const app = getApp();
+    const speaker = await createTestAgent(app, { name: `q1-min-${crypto.randomUUID().slice(0, 6)}` });
+    const c = await seedChatWithSpeakers([speaker.agent.uuid], speaker.organizationId);
+
+    // Timestamps are deliberately non-monotonic with seq: seq 4 (created
+    // 11:59:59) is OLDER than the turn_end at seq 2 (12:00:01) yet still part
+    // of the current turn, and seq 3 is an error created even earlier — it
+    // must never become the turn start.
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      1,
+      "assistant_text",
+      { text: "one" },
+      new Date("2026-09-03T12:00:00.000Z"),
+    );
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      2,
+      "turn_end",
+      { status: "success" },
+      new Date("2026-09-03T12:00:01.000Z"),
+    );
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      3,
+      "error",
+      { source: "sdk", message: "boom" },
+      new Date("2026-09-03T11:59:30.000Z"),
+    );
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      4,
+      "assistant_text",
+      { text: "two" },
+      new Date("2026-09-03T11:59:59.000Z"),
+    );
+    await insertEventAt(speaker.agent.uuid, c, 5, "thinking", {}, new Date("2026-09-03T12:00:02.000Z"));
+
+    const desc = await sessionEventService.listChatSpeakerEvents(app.db, c, { limit: 1, direction: "desc" });
+    const feed = desc.feeds.find((f) => f.agentId === speaker.agent.uuid);
+    if (!feed) throw new Error("feed missing");
+    expect(feed.items.map((e) => e.seq)).toEqual([5]);
+    expect(feed.nextCursor).toBe(5);
+    // MIN(created_at) over the current turn (seq > 2, activity kinds) = seq 4,
+    // even though seq 4 is outside the window and its timestamp predates the
+    // turn_end.
+    expect(feed.turnStartedAt).toBe("2026-09-03T11:59:59.000Z");
+  });
+
+  it("reports the earliest activity-kind event as the turn start when no turn_end exists yet", async () => {
+    const app = getApp();
+    const speaker = await createTestAgent(app, { name: `q1-open-${crypto.randomUUID().slice(0, 6)}` });
+    const c = await seedChatWithSpeakers([speaker.agent.uuid], speaker.organizationId);
+
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      1,
+      "error",
+      { source: "sdk", message: "x" },
+      new Date("2026-09-03T11:58:00.000Z"),
+    );
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      2,
+      "assistant_text",
+      { text: "first" },
+      new Date("2026-09-03T11:59:00.000Z"),
+    );
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      3,
+      "tool_call",
+      { toolUseId: "t1", name: "Bash", args: null, status: "pending" },
+      new Date("2026-09-03T12:00:00.000Z"),
+    );
+
+    const desc = await sessionEventService.listChatSpeakerEvents(app.db, c, { limit: 2, direction: "desc" });
+    const feed = desc.feeds.find((f) => f.agentId === speaker.agent.uuid);
+    if (!feed) throw new Error("feed missing");
+    expect(feed.items.map((e) => e.seq)).toEqual([3, 2]);
+    expect(feed.nextCursor).toBe(2);
+    // Whole history is the current turn; the pre-history error is not an
+    // activity kind, so the earliest eligible event (seq 2, 11:59) starts it.
+    expect(feed.turnStartedAt).toBe("2026-09-03T11:59:00.000Z");
+  });
+
+  it("emits a feed only for speakers with events and never mixes a second chat's events into the window", async () => {
+    const app = getApp();
+    const withEvents = await createTestAgent(app, { name: `q1-feed-${crypto.randomUUID().slice(0, 6)}` });
+    const silent = await createTestAgent(app, { name: `q1-silent-${crypto.randomUUID().slice(0, 6)}` });
+    const c = await seedChatWithSpeakers([withEvents.agent.uuid, silent.agent.uuid], withEvents.organizationId);
+    const otherChat = await seedChatWithSpeakers([withEvents.agent.uuid], withEvents.organizationId);
+
+    await insertEventAt(
+      withEvents.agent.uuid,
+      c,
+      1,
+      "tool_call",
+      { toolUseId: "t1", name: "Bash", args: null, status: "ok" },
+      new Date("2026-09-03T10:00:00.000Z"),
+    );
+    await insertEventAt(
+      withEvents.agent.uuid,
+      otherChat,
+      1,
+      "assistant_text",
+      { text: "other chat" },
+      new Date("2026-09-03T10:00:01.000Z"),
+    );
+
+    const feeds = (await sessionEventService.listChatSpeakerEvents(app.db, c, { direction: "desc" })).feeds;
+    expect(feeds).toHaveLength(1);
+    expect(feeds[0]?.agentId).toBe(withEvents.agent.uuid);
+    expect(feeds[0]?.items.map((e) => e.seq)).toEqual([1]);
+    expect(feeds[0]?.items.map((e) => e.payload)).toEqual([
+      { toolUseId: "t1", name: "Bash", args: null, status: "ok" },
+    ]);
+    expect(feeds[0]?.turnStartedAt).toBe("2026-09-03T10:00:00.000Z");
+  });
+
+  it("reports turnStartedAt null when the latest row is a turn_end — even though the window shows earlier activity", async () => {
+    const app = getApp();
+    const speaker = await createTestAgent(app, { name: `q1-end-${crypto.randomUUID().slice(0, 6)}` });
+    const c = await seedChatWithSpeakers([speaker.agent.uuid], speaker.organizationId);
+
+    // A finished turn whose activity rows predate the turn_end: the window
+    // still returns those rows (desc), but no event AFTER the last turn_end
+    // can start a current turn — turnStartedAt must be null, not the earlier
+    // activity's timestamp.
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      1,
+      "assistant_text",
+      { text: "finished work" },
+      new Date("2026-09-03T09:00:00.000Z"),
+    );
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      2,
+      "turn_end",
+      { status: "success" },
+      new Date("2026-09-03T09:00:01.000Z"),
+    );
+    // Only non-activity events (error) follow the turn_end.
+    await insertEventAt(
+      speaker.agent.uuid,
+      c,
+      3,
+      "error",
+      { source: "sdk", message: "late noise" },
+      new Date("2026-09-03T09:00:02.000Z"),
+    );
+
+    const feeds = (await sessionEventService.listChatSpeakerEvents(app.db, c, { limit: 3, direction: "desc" })).feeds;
+    const feed = feeds.find((f) => f.agentId === speaker.agent.uuid);
+    if (!feed) throw new Error("feed missing");
+    // The returned window includes the earlier activity row (seq 1).
+    expect(feed.items.map((e) => e.seq)).toEqual([3, 2, 1]);
+    expect(feed.items.some((e) => e.kind === "assistant_text")).toBe(true);
+    expect(feed.nextCursor).toBeNull();
+    // No current-turn activity exists after the latest turn_end → null.
+    expect(feed.turnStartedAt).toBeNull();
+
+    // Same contract without the trailing error: the window is [2, 1] and the
+    // latest row is the turn_end itself.
+    const c2 = await seedChatWithSpeakers([speaker.agent.uuid], speaker.organizationId);
+    await insertEventAt(
+      speaker.agent.uuid,
+      c2,
+      1,
+      "tool_call",
+      { toolUseId: "t1", name: "Bash", args: null, status: "ok" },
+      new Date("2026-09-03T09:00:00.000Z"),
+    );
+    await insertEventAt(
+      speaker.agent.uuid,
+      c2,
+      2,
+      "turn_end",
+      { status: "success" },
+      new Date("2026-09-03T09:00:01.000Z"),
+    );
+    const secondFeed = (
+      await sessionEventService.listChatSpeakerEvents(app.db, c2, { limit: 2, direction: "desc" })
+    ).feeds.find((f) => f.agentId === speaker.agent.uuid);
+    expect(secondFeed?.items.map((e) => e.seq)).toEqual([2, 1]);
+    expect(secondFeed?.turnStartedAt).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/ws-admin-edge.test.ts
+++ b/packages/server/src/__tests__/ws-admin-edge.test.ts
@@ -101,6 +101,8 @@ function makeDb(options: {
   humanRows?: unknown[];
   audienceRows?: unknown[][];
   finalMemberRows?: unknown[];
+  /** Rows for chat-status selects (speaker membership / session rows share the chatId-keyed projection). */
+  statusRows?: unknown[];
   liveMembershipError?: Error;
   handshakeMembershipError?: Error;
   visibleAgentError?: Error;
@@ -141,6 +143,7 @@ function makeDb(options: {
       }
       if (keys.has("organizationId")) return makeSelectBuilder(memberRows);
       if (keys.has("uuid")) return makeSelectBuilder(humanRows);
+      if (keys.has("chatId")) return makeSelectBuilder(options.statusRows ?? []);
       return makeSelectBuilder(visibleRows);
     }),
   } as unknown as Database;
@@ -381,6 +384,83 @@ describe("Admin WS route edge paths", () => {
     expect(sentPayloads(own.send).map((payload) => payload.type)).toEqual(["admin:connected", "me-chats:changed"]);
     // The other-org socket (same user) never sees org-1's pin.
     expect(sentPayloads(otherOrg.send).map((payload) => payload.type)).toEqual(["admin:connected"]);
+  });
+
+  it("skips session-frame status enrichment when no connected socket is in the chat audience (performance gate)", async () => {
+    const handlers: CapturedHandlers = {};
+    // The only admitted socket's human agent is human-1; the cached audience
+    // names human-2 only, so no enriched frame could be delivered — the
+    // audience query is the ONLY execute (no derive scans follow).
+    const db = makeDb({ audienceRows: [[{ agent_id: "human-2" }]] });
+    const { app, getRoute } = makeApp(db);
+    await orgWsRoutes(makeNotifier(handlers), JWT_SECRET)(app as never);
+    const route = getRoute();
+    const socket = makeSocket();
+    await route(socket.socket, request(await signToken({ sub: "user-1", type: "access" })));
+    const dbExecuteMock = (db as unknown as { execute: ReturnType<typeof vi.fn> }).execute;
+    dbExecuteMock.mockClear();
+
+    handlers.sessionState?.({ agentId: "agent-1", chatId: "chat-gate-skip", organizationId: "org-1" });
+    await waitForAsyncDispatch();
+
+    // Bare frame still delivered to the live org socket (delivery contract).
+    const frame = sentPayloads(socket.send).find((p) => p.type === "session:state");
+    expect(frame).toBeDefined();
+    expect(frame).not.toHaveProperty("status");
+    // Audience resolution ran; the status compute (2 derive executes) did not.
+    expect(dbExecuteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips session-frame status enrichment for an empty audience", async () => {
+    const handlers: CapturedHandlers = {};
+    const db = makeDb({ audienceRows: [[]] });
+    const { app, getRoute } = makeApp(db);
+    await orgWsRoutes(makeNotifier(handlers), JWT_SECRET)(app as never);
+    const route = getRoute();
+    const socket = makeSocket();
+    await route(socket.socket, request(await signToken({ sub: "user-1", type: "access" })));
+    const dbExecuteMock = (db as unknown as { execute: ReturnType<typeof vi.fn> }).execute;
+    dbExecuteMock.mockClear();
+
+    handlers.sessionEvent?.({ agentId: "agent-1", chatId: "chat-gate-empty", organizationId: "org-1" });
+    await waitForAsyncDispatch();
+
+    expect(dbExecuteMock).toHaveBeenCalledTimes(1);
+    const frame = sentPayloads(socket.send).find((p) => p.type === "session:event");
+    expect(frame).not.toHaveProperty("status");
+  });
+
+  it("enriches a session frame via single-target status resolution when an audience socket is connected", async () => {
+    const handlers: CapturedHandlers = {};
+    // The admitted socket (human-1) IS in the cached audience, so the gate
+    // passes and the event's own agent status is resolved (audience + 2
+    // derive executes) — scoped to (chat-enrich-1, agent-1).
+    const db = makeDb({
+      audienceRows: [[{ agent_id: "human-1" }]],
+      statusRows: [
+        {
+          chatId: "chat-enrich-1",
+          agentId: "agent-1",
+          state: "active",
+          runtimeState: "idle",
+          runtimeStateAt: null,
+        },
+      ],
+    });
+    const { app, getRoute } = makeApp(db);
+    await orgWsRoutes(makeNotifier(handlers), JWT_SECRET)(app as never);
+    const route = getRoute();
+    const socket = makeSocket();
+    await route(socket.socket, request(await signToken({ sub: "user-1", type: "access" })));
+    const dbExecuteMock = (db as unknown as { execute: ReturnType<typeof vi.fn> }).execute;
+    dbExecuteMock.mockClear();
+
+    handlers.sessionState?.({ agentId: "agent-1", chatId: "chat-enrich-1", organizationId: "org-1" });
+    await waitForAsyncDispatch();
+
+    expect(dbExecuteMock).toHaveBeenCalledTimes(3); // audience + deriveActivities + deriveStatusReasons
+    const frame = sentPayloads(socket.send).find((p) => p.type === "session:state");
+    expect(frame?.status).toMatchObject({ agentId: "agent-1" });
   });
 
   it("closes affected sockets with 1013 when live authorization cannot be revalidated", async () => {

--- a/packages/server/src/api/orgs/ws.ts
+++ b/packages/server/src/api/orgs/ws.ts
@@ -15,7 +15,7 @@ import {
 } from "../../observability/index.js";
 import { registerAdminBroadcaster } from "../../services/admin-broadcast.js";
 import { getCachedAudience } from "../../services/chat/membership/audience-cache.js";
-import { getChatAgentStatuses } from "../../services/chat/sessions/status.js";
+import { getChatAgentStatus } from "../../services/chat/sessions/status.js";
 import type { Notifier } from "../../services/notifier.js";
 
 const log = createLogger("OrgWs");
@@ -78,6 +78,26 @@ export function orgWsRoutes(notifier: Notifier, jwtSecret: string): (app: Fastif
       }
     }
     ws.close(4403, "Membership changed");
+  }
+
+  /**
+   * Local, in-memory pre-gate for session-frame enrichment: is there any
+   * currently open + admitted socket in `organizationId` whose human agent
+   * is in `audience`? No DB revalidation here (cheap by design) — the
+   * delivery loop's `liveSocketEntries` stays the DB-backed authority.
+   */
+  function hasAudienceSocket(organizationId: string, audience: ReadonlySet<string>): boolean {
+    for (const [ws, meta] of adminSockets) {
+      if (
+        ws.readyState === 1 &&
+        meta.admitted &&
+        meta.organizationId === organizationId &&
+        audience.has(meta.humanAgentId)
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   function closeAuthorizationUnavailable(ws: WebSocket): void {
@@ -217,6 +237,13 @@ export function orgWsRoutes(notifier: Notifier, jwtSecret: string): (app: Fastif
    * composite axis flipped", just on different axes (lifecycle vs D-axis
    * runtime). Sharing the path keeps the web cache reconciliation
    * deterministic (one in-place patch, no invalidate races).
+   *
+   * The enrichment is resolved for the frame's OWN agent only
+   * (`getChatAgentStatus`), never for the whole chat — and only when at
+   * least one currently connected + admitted socket in this org belongs to
+   * the chat audience. The latter is a performance gate, not authorization:
+   * the DB-backed liveSocketEntries revalidation and the per-socket
+   * audience filter below remain the delivery authority.
    */
   async function dispatchSessionFrame(
     type: "session:state" | "session:event" | "session:runtime",
@@ -228,8 +255,12 @@ export function orgWsRoutes(notifier: Notifier, jwtSecret: string): (app: Fastif
     try {
       const db = getDbForChatLookup();
       audience = await getCachedAudience(db, payload.chatId);
-      if (audience && audience.size > 0) {
-        status = (await getChatAgentStatuses(db, payload.chatId)).find((s) => s.agentId === payload.agentId);
+      // Performance gate (not authorization): when no currently ready +
+      // admitted socket in the event's org has a human agent in the cached
+      // audience, no enriched frame can be delivered — skip the whole status
+      // computation (bare frames below still reach every live org socket).
+      if (audience && audience.size > 0 && hasAudienceSocket(payload.organizationId, audience)) {
+        status = await getChatAgentStatus(db, payload.chatId, payload.agentId);
       }
     } catch (err) {
       // Best-effort enrichment: on any failure fall back to the bare frame

--- a/packages/server/src/services/chat/sessions/events.ts
+++ b/packages/server/src/services/chat/sessions/events.ts
@@ -6,7 +6,7 @@ import type {
   SessionEventKind,
 } from "@first-tree/shared";
 import { sessionEventSchema } from "@first-tree/shared";
-import { and, asc, desc, eq, gt, gte, inArray, lt, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, lt, sql } from "drizzle-orm";
 import type { Database } from "../../../db/connection.js";
 import { agentChatSessions } from "../../../db/schema/agent-chat-sessions.js";
 import { agents } from "../../../db/schema/agents.js";
@@ -273,8 +273,21 @@ export async function listEvents(
  * The caller-facing route gates the viewer with `requireChatAccess`; this
  * query independently constrains event owners to current speaker membership.
  * That makes chat membership the disclosure boundary without broadening the
- * agent's org-level discoverability. A window function applies `limit` per
- * agent, so one noisy speaker cannot crowd every sibling out of the response.
+ * agent's org-level discoverability.
+ *
+ * Query shape (one SQL statement / snapshot):
+ *   - `authorized_speakers`: the chat's current speaker membership with the
+ *     agent type / same-org constraints — the disclosure boundary.
+ *   - Per speaker, a `CROSS JOIN LATERAL` event window that uses the unique
+ *     `(agent_id, chat_id, seq)` index (`ORDER BY seq` + `LIMIT limit + 1`,
+ *     asc or desc). Payloads are carried ONLY for these returned rows.
+ *   - Per speaker, current-turn metadata (last `turn_end` seq + `MIN(created_at)`
+ *     of the eligible kinds after it) is computed ONCE per speaker in a
+ *     MATERIALIZED CTE over seq/kind/created_at only — never once per
+ *     returned event, and never over full-history window sorts. It stays
+ *     independent of the capped event window, so a limit=2 desc page still
+ *     reports a turn that started outside the window. `MIN(created_at)` is
+ *     kept exactly — seq order does not prove monotonic timestamps.
  */
 export async function listChatSpeakerEvents(
   db: Database,
@@ -285,75 +298,65 @@ export async function listChatSpeakerEvents(
   const direction = options?.direction ?? "asc";
   const orderFragment = direction === "desc" ? sql`DESC` : sql`ASC`;
 
-  const scoped = db
-    .select({
-      id: sessionEvents.id,
-      agentId: sessionEvents.agentId,
-      chatId: sessionEvents.chatId,
-      seq: sessionEvents.seq,
-      kind: sessionEvents.kind,
-      payload: sessionEvents.payload,
-      createdAt: sessionEvents.createdAt,
-      lastTurnEndSeq: sql<number>`coalesce(
-        max(${sessionEvents.seq}) filter (where ${sessionEvents.kind} = 'turn_end')
-          over (partition by ${sessionEvents.agentId}),
-        0
-      )`.as("last_turn_end_seq"),
-    })
-    .from(sessionEvents)
-    .innerJoin(
-      chatMembership,
-      and(eq(chatMembership.chatId, sessionEvents.chatId), eq(chatMembership.agentId, sessionEvents.agentId)),
+  const rows = await db.execute<SpeakerWindowRow>(sql`
+    WITH authorized_speakers AS MATERIALIZED (
+      SELECT cm.agent_id AS agent_id
+        FROM chat_membership cm
+        INNER JOIN agents a ON a.uuid = cm.agent_id
+        INNER JOIN chats ch ON ch.id = cm.chat_id
+       WHERE cm.chat_id = ${chatId}
+         AND cm.access_mode = 'speaker'
+         AND a.type = 'agent'
+         AND a.organization_id = ch.organization_id
+    ),
+    -- Per-speaker current-turn metadata, computed once per speaker from
+    -- seq/kind/created_at only (never full payloads): the last turn_end seq
+    -- and the earliest created_at of the eligible current-turn kinds after
+    -- it. Materialized so the planner cannot inline it per returned row.
+    speaker_meta AS MATERIALIZED (
+      SELECT sp.agent_id                    AS agent_id,
+             coalesce(last_end.last_turn_end_seq, 0) AS last_turn_end_seq,
+             turn_start.turn_started_at     AS turn_started_at
+        FROM authorized_speakers sp
+        LEFT JOIN LATERAL (
+          SELECT max(se.seq) AS last_turn_end_seq
+            FROM session_events se
+           WHERE se.agent_id = sp.agent_id
+             AND se.chat_id  = ${chatId}
+             AND se.kind     = 'turn_end'
+        ) last_end ON TRUE
+        LEFT JOIN LATERAL (
+          SELECT min(se.created_at) AS turn_started_at
+            FROM session_events se
+           WHERE se.agent_id = sp.agent_id
+             AND se.chat_id  = ${chatId}
+             AND se.kind     IN ('tool_call', 'thinking', 'assistant_text')
+             AND se.seq > coalesce(last_end.last_turn_end_seq, 0)
+        ) turn_start ON TRUE
     )
-    .innerJoin(agents, eq(agents.uuid, sessionEvents.agentId))
-    .innerJoin(chats, eq(chats.id, sessionEvents.chatId))
-    .where(
-      and(
-        eq(sessionEvents.chatId, chatId),
-        eq(chatMembership.accessMode, "speaker"),
-        eq(agents.type, "agent"),
-        eq(agents.organizationId, chats.organizationId),
-      ),
-    )
-    .as("scoped_chat_session_events");
+    SELECT sp.agent_id       AS "agentId",
+           w.id              AS id,
+           w.chat_id         AS "chatId",
+           w.seq             AS seq,
+           w.kind            AS kind,
+           w.payload         AS payload,
+           w.created_at      AS "createdAt",
+           m.turn_started_at AS "turnStartedAt"
+      FROM authorized_speakers sp
+      CROSS JOIN LATERAL (
+        SELECT se.id AS id, se.chat_id AS chat_id, se.seq AS seq, se.kind AS kind,
+               se.payload AS payload, se.created_at AS created_at
+          FROM session_events se
+         WHERE se.agent_id = sp.agent_id
+           AND se.chat_id  = ${chatId}
+         ORDER BY se.seq ${orderFragment}
+         LIMIT ${limit + 1}
+      ) w
+      LEFT JOIN speaker_meta m ON m.agent_id = sp.agent_id
+     ORDER BY sp.agent_id, w.seq ${orderFragment}
+  `);
 
-  const ranked = db
-    .select({
-      id: scoped.id,
-      agentId: scoped.agentId,
-      chatId: scoped.chatId,
-      seq: scoped.seq,
-      kind: scoped.kind,
-      payload: scoped.payload,
-      createdAt: scoped.createdAt,
-      turnStartedAt: sql<Date | string | null>`min(${scoped.createdAt}) filter (
-        where ${scoped.seq} > ${scoped.lastTurnEndSeq}
-          and ${scoped.kind} in ('tool_call', 'thinking', 'assistant_text')
-      ) over (partition by ${scoped.agentId})`.as("turn_started_at"),
-      rank: sql<number>`row_number() over (
-        partition by ${scoped.agentId}
-        order by ${scoped.seq} ${orderFragment}
-      )`.as("event_rank"),
-    })
-    .from(scoped)
-    .as("ranked_chat_session_events");
-
-  const rows = await db
-    .select({
-      id: ranked.id,
-      agentId: ranked.agentId,
-      chatId: ranked.chatId,
-      seq: ranked.seq,
-      kind: ranked.kind,
-      payload: ranked.payload,
-      createdAt: ranked.createdAt,
-      turnStartedAt: ranked.turnStartedAt,
-    })
-    .from(ranked)
-    .where(lte(ranked.rank, limit + 1))
-    .orderBy(asc(ranked.agentId), direction === "desc" ? desc(ranked.seq) : asc(ranked.seq));
-
-  const rowsByAgent = new Map<string, typeof rows>();
+  const rowsByAgent = new Map<string, SpeakerWindowRow[]>();
   for (const row of rows) {
     const feedRows = rowsByAgent.get(row.agentId);
     if (feedRows) feedRows.push(row);
@@ -363,7 +366,7 @@ export async function listChatSpeakerEvents(
   return {
     feeds: [...rowsByAgent].map(([agentId, feedRows]) => {
       const hasMore = feedRows.length > limit;
-      const items = (hasMore ? feedRows.slice(0, limit) : feedRows).map(rowToEvent);
+      const items = (hasMore ? feedRows.slice(0, limit) : feedRows).map(toEventRow).map(rowToEvent);
       const last = items[items.length - 1];
       const turnStartedAt = feedRows[0]?.turnStartedAt ?? null;
       const turnStartedAtIso =
@@ -379,6 +382,41 @@ export async function listChatSpeakerEvents(
         turnStartedAt: turnStartedAtIso,
       };
     }),
+  };
+}
+
+/** Raw row shape returned by `listChatSpeakerEvents` (snake_case columns
+ *  aliased to camelCase in SQL). Timestamp values may arrive as JS `Date` or
+ *  as ISO/format strings depending on the driver's timestamp parsing, so
+ *  `createdAt` / `turnStartedAt` are normalized defensively before use. */
+type SpeakerWindowRow = {
+  agentId: string;
+  id: string;
+  chatId: string;
+  seq: number;
+  kind: string;
+  payload: unknown;
+  createdAt: Date | string;
+  turnStartedAt: Date | string | null;
+};
+
+function toEventRow(row: SpeakerWindowRow): {
+  id: string;
+  agentId: string;
+  chatId: string;
+  seq: number;
+  kind: string;
+  payload: unknown;
+  createdAt: Date;
+} {
+  return {
+    id: row.id,
+    agentId: row.agentId,
+    chatId: row.chatId,
+    seq: row.seq,
+    kind: row.kind,
+    payload: row.payload,
+    createdAt: row.createdAt instanceof Date ? row.createdAt : new Date(row.createdAt),
   };
 }
 

--- a/packages/server/src/services/chat/sessions/status.ts
+++ b/packages/server/src/services/chat/sessions/status.ts
@@ -198,56 +198,120 @@ export function withTurnNarration(base: LiveActivity | null, narrationText: unkn
 // ---------------------------------------------------------------------------
 
 /**
- * Per-(agent,chat) live activity for `chatIds`: the latest `session_events`
- * row per pair, mapped through `toLiveActivity` (terminal kinds → absent) and
- * dropped when older than the stale threshold. Per-pair LATERAL seek on the
- * unique `(agent_id, chat_id, seq)` index — a single B-tree descent per pair,
- * independent of `session_events` table size.
+ * The exact (chatId, agentId) workset whose statuses the caller assembles.
+ * Every query below is restricted to these pairs (row-value conditions on
+ * the driving `agent_chat_sessions` rows), never to the chats alone — a
+ * single-agent WS dispatch therefore runs the Q2/Q3 LATERAL loops for that
+ * pair only, instead of every session holder in the chat.
+ */
+type StatusWorkset = ReadonlyMap<string, ReadonlySet<string>>;
+
+/**
+ * `(agent_id, chat_id) IN (…pair rows…)` clause over a workset. Values are
+ * inlined individually (the postgres-js string[] binding caveat below); the
+ * row-value IN keeps the correspondence pair-exact for multi-chat batches so
+ * a chat set × agent set cross product can never widen the drive rows.
+ */
+function statusWorksetInClause(workset: StatusWorkset): ReturnType<typeof sql.join> {
+  const pairs: ReturnType<typeof sql>[] = [];
+  for (const [chatId, agents] of workset) {
+    for (const agentId of agents) {
+      pairs.push(sql`(${agentId}, ${chatId})`);
+    }
+  }
+  return sql.join(pairs, sql`, `);
+}
+
+/**
+ * The subset of a target workset whose chats are in `chatIds`, dropping
+ * empty agent sets. An empty result means "no exact pairs to read" — never
+ * an implicit widening to all agents / chats.
+ */
+function restrictWorksetToChatIds(workset: StatusWorkset, chatIds: string[]): StatusWorkset {
+  const chatIdSet = new Set(chatIds);
+  const restricted = new Map<string, ReadonlySet<string>>();
+  for (const [chatId, agents] of workset) {
+    if (chatIdSet.has(chatId) && agents.size > 0) {
+      restricted.set(chatId, agents);
+    }
+  }
+  return restricted;
+}
+
+/**
+ * Per-(agent,chat) live activity for the exact (chatId, agentId) workset:
+ * the latest `session_events` row per pair, mapped through `toLiveActivity`
+ * (terminal kinds → absent) and dropped when older than the stale threshold.
+ * Per-pair LATERAL seek on the unique `(agent_id, chat_id, seq)` index — a
+ * single B-tree descent per pair, independent of `session_events` table size.
  *
  * When `withTurnText`, a second `LEFT JOIN LATERAL` seeks the current turn's
  * latest `assistant_text` (`seq` past the last `turn_end`); `withTurnNarration`
  * rides it along as `turnText` so the compose status bar can show the running
  * narration even while a tool runs. Only the per-agent `/agent-status` path
  * pays for the extra seek; the chat-list passes `withTurnText: false`.
+ *
+ * The narration seek runs ONLY when the (unfiltered) latest event row is an
+ * activity kind fresh enough to survive the JS stale check — a terminal /
+ * unknown / stale latest event would drop the whole activity in JS, so the
+ * text subquery would be pure waste. The guard is a `CASE` around a scalar
+ * subquery: SQL evaluates only the taken branch, so the narration scan does
+ * not execute at all for guarded-out pairs. The cutoff is the application
+ * clock (`Date.now()` minus LIVE_ACTIVITY_STALE_MS), not the DB clock, and
+ * the final JS stale check below stays authoritative — the guard can only
+ * skip work JS would discard anyway, never resurrect or lose activity at the
+ * 60-second boundary.
  */
 async function deriveActivities(
   db: Database,
-  chatIds: string[],
+  workset: StatusWorkset,
   opts?: { withTurnText?: boolean },
 ): Promise<Map<string, Map<string, LiveActivity>>> {
   const out = new Map<string, Map<string, LiveActivity>>();
-  if (chatIds.length === 0) return out;
+  if (workset.size === 0) return out;
 
   const withTurn = opts?.withTurnText === true;
   // `IN (${...})` rather than `= ANY($1::text[])`: postgres-js binds string[]
   // as a flat string when the driver type hint resolves to text[], which PG
   // rejects. Inlining each value sidesteps the binding mismatch.
-  const chatIdInClause = sql.join(
-    chatIds.map((id) => sql`${id}`),
-    sql`, `,
-  );
+  const worksetInClause = statusWorksetInClause(workset);
   const turnTextSelect = withTurn ? sql`, t.text AS turn_text` : sql`, NULL::text AS turn_text`;
+  // App-clock cutoff for the SQL-side narration guard (see the docblock).
+  // Serialized explicitly to ISO text: the installed postgres-js driver binds
+  // a raw JS Date through identity serializers, which fails the query — see
+  // the driver probe in query-investigation/date-binding-probe.json. The
+  // explicit `::timestamptz` cast keeps the comparison against the
+  // timestamptz column unambiguous.
+  const narrationCutoff = withTurn ? new Date(Date.now() - LIVE_ACTIVITY_STALE_MS).toISOString() : null;
   const turnTextJoin = withTurn
     ? sql`
       LEFT JOIN LATERAL (
-        -- Raw prefix cap: bounds the bytes pulled from PG while leaving margin
-        -- above ASSISTANT_TEXT_FULL_MAX (2000) — the newline-preserving
-        -- previewAssistantTextFull is the widest consumer, and margin keeps
-        -- pathological leading whitespace from starving the final value.
-        SELECT LEFT(se.payload->>'text', ${sql.raw(String(ASSISTANT_TEXT_FULL_MAX + 200))}) AS text
-          FROM session_events se
-         WHERE se.agent_id = acs.agent_id
-           AND se.chat_id  = acs.chat_id
-           AND se.kind     = 'assistant_text'
-           AND se.seq > COALESCE((
-             SELECT MAX(se2.seq)
-               FROM session_events se2
-              WHERE se2.agent_id = acs.agent_id
-                AND se2.chat_id  = acs.chat_id
-                AND se2.kind     = 'turn_end'
-           ), 0)
-         ORDER BY se.seq DESC
-         LIMIT 1
+        SELECT CASE
+          WHEN e.kind IN ('tool_call', 'thinking', 'assistant_text')
+           AND e.created_at >= ${narrationCutoff}::timestamptz THEN (
+            -- Raw prefix cap: LEFT(text, n) caps CHARACTERS, not bytes; the
+            -- bound stays above ASSISTANT_TEXT_FULL_MAX (2000) — the
+            -- newline-preserving previewAssistantTextFull is the widest
+            -- consumer, and margin keeps pathological leading whitespace from
+            -- starving the final value. Scalar subquery inside CASE: it only
+            -- executes when the guard above passes.
+            SELECT LEFT(se.payload->>'text', ${sql.raw(String(ASSISTANT_TEXT_FULL_MAX + 200))})
+              FROM session_events se
+             WHERE se.agent_id = acs.agent_id
+               AND se.chat_id  = acs.chat_id
+               AND se.kind     = 'assistant_text'
+               AND se.seq > COALESCE((
+                 SELECT MAX(se2.seq)
+                   FROM session_events se2
+                  WHERE se2.agent_id = acs.agent_id
+                    AND se2.chat_id  = acs.chat_id
+                    AND se2.kind     = 'turn_end'
+               ), 0)
+             ORDER BY se.seq DESC
+             LIMIT 1
+          )
+          ELSE NULL::text
+        END AS text
       ) t ON TRUE`
     : sql``;
 
@@ -270,7 +334,7 @@ async function deriveActivities(
          LIMIT 1
       ) e
       ${turnTextJoin}
-     WHERE acs.chat_id IN (${chatIdInClause})
+     WHERE (acs.agent_id, acs.chat_id) IN (${worksetInClause})
        AND acs.state <> 'evicted'
   `)) as unknown as Array<{
     agent_id: string;
@@ -307,15 +371,15 @@ async function deriveActivities(
 
 async function deriveStatusReasons(
   db: Database,
-  chatIds: string[],
+  workset: StatusWorkset,
 ): Promise<Map<string, Map<string, AgentStatusReason>>> {
   const out = new Map<string, Map<string, AgentStatusReason>>();
-  if (chatIds.length === 0) return out;
+  if (workset.size === 0) return out;
 
-  const chatIdInClause = sql.join(
-    chatIds.map((id) => sql`${id}`),
-    sql`, `,
-  );
+  // Same pair-exact drive restriction as deriveActivities: only the workset
+  // pairs' recent error/turn_end windows are sought, so a single-agent WS
+  // dispatch does not scan sibling sessions.
+  const worksetInClause = statusWorksetInClause(workset);
   const rawRows = (await db.execute(sql`
     SELECT acs.agent_id AS agent_id,
            acs.chat_id  AS chat_id,
@@ -331,7 +395,7 @@ async function deriveStatusReasons(
          ORDER BY se.seq DESC
          LIMIT 10
       ) e
-     WHERE acs.chat_id IN (${chatIdInClause})
+     WHERE (acs.agent_id, acs.chat_id) IN (${worksetInClause})
      ORDER BY acs.chat_id, acs.agent_id, e.seq DESC
   `)) as unknown as Array<{
     agent_id: string;
@@ -397,6 +461,16 @@ export async function resolveAgentChatStatuses(
     withTurnText?: boolean;
     includeStatusReason?: boolean;
     nonHumanSpeakersByChat?: ReadonlyMap<string, ReadonlySet<string>>;
+    /**
+     * Internal target workset: only the given per-chat agent targets are
+     * resolved, intersected with the actual non-human speaker membership so a
+     * non-speaker target yields nothing. A chat absent from the map — or an
+     * empty set — resolves to NO statuses (never the full speaker set), and
+     * pair correspondence stays exact per chat for multi-chat batches. Used
+     * by the admin-WS single-agent dispatch; every other caller omits it and
+     * keeps the full speaker-set contract.
+     */
+    targets?: ReadonlyMap<string, ReadonlySet<string>>;
   },
 ): Promise<Map<string, AgentChatStatus[]>> {
   const out = new Map<string, AgentChatStatus[]>();
@@ -417,25 +491,52 @@ export async function resolveAgentChatStatuses(
   // its participant chips. Let that caller provide the same canonical set so a
   // list request does not immediately repeat the membership query. Detail
   // surfaces omit the map and retain the self-contained resolver path.
+  //
+  // When a target workset is present, the membership read itself is bounded
+  // by the EXACT (chatId, agentId) target pairs (speaker + non-human filters
+  // still apply) — never a chat set × agent set cross product; the JS
+  // intersection below then closes the correspondence defensively.
+  const targetWorkset = opts?.targets ? restrictWorksetToChatIds(opts.targets, chatIds) : null;
   if (opts?.nonHumanSpeakersByChat) {
     for (const chatId of chatIds) {
       for (const agentId of opts.nonHumanSpeakersByChat.get(chatId) ?? []) {
         addUnion(chatId, agentId);
       }
     }
-  } else {
+  } else if (targetWorkset === null || targetWorkset.size > 0) {
     const speakerRows = await db
       .select({ chatId: chatMembership.chatId, agentId: chatMembership.agentId })
       .from(chatMembership)
       .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
       .where(
         and(
-          inArray(chatMembership.chatId, chatIds),
           eq(chatMembership.accessMode, "speaker"),
           ne(agents.type, "human"),
+          ...(targetWorkset !== null
+            ? [sql`(${chatMembership.agentId}, ${chatMembership.chatId}) IN (${statusWorksetInClause(targetWorkset)})`]
+            : [inArray(chatMembership.chatId, chatIds)]),
         ),
       );
     for (const r of speakerRows) addUnion(r.chatId, r.agentId);
+  }
+
+  // Intersect the resolved speaker union with the explicit target workset.
+  // Absent or empty targets for a chat drop it entirely — an empty target set
+  // must never mean "all agents".
+  if (opts?.targets) {
+    for (const chatId of chatIds) {
+      const targetsForChat = opts.targets.get(chatId);
+      if (!targetsForChat || targetsForChat.size === 0) {
+        unionByChat.delete(chatId);
+        continue;
+      }
+      const union = unionByChat.get(chatId);
+      if (!union) continue;
+      for (const agentId of [...union]) {
+        if (!targetsForChat.has(agentId)) union.delete(agentId);
+      }
+      if (union.size === 0) unionByChat.delete(chatId);
+    }
   }
   if (unionByChat.size === 0) return out;
 
@@ -445,6 +546,10 @@ export async function resolveAgentChatStatuses(
   // `runtime_state` / `runtime_state_at` feed `computeWorking` / `computeErrored`
   // — the per-chat authoritative source replacing the legacy event-proxy
   // (which only knew "fresh event = working" and missed codex no-events).
+  //
+  // The read is bounded by the exact workset pairs — never a chat set × agent
+  // set cross product — so a session an agent holds in a chat it was NOT
+  // targeted for is not fetched.
   const sessionRows = await db
     .select({
       agentId: agentChatSessions.agentId,
@@ -454,7 +559,7 @@ export async function resolveAgentChatStatuses(
       runtimeStateAt: agentChatSessions.runtimeStateAt,
     })
     .from(agentChatSessions)
-    .where(and(inArray(agentChatSessions.chatId, chatIds), inArray(agentChatSessions.agentId, allAgentIds)));
+    .where(sql`(${agentChatSessions.agentId}, ${agentChatSessions.chatId}) IN (${statusWorksetInClause(unionByChat)})`);
   const sessionByPair = new Map(sessionRows.map((s) => [pairKey(s.chatId, s.agentId), s]));
 
   // -- Reachability (A) + legacy presence runtime (for the old-client
@@ -525,8 +630,10 @@ export async function resolveAgentChatStatuses(
   // -- Activity (D): per-(agent,chat) live activity (+ turnText when asked).
   //    Pure description: 60s drop here means "5-min-old tool_call is not the
   //    current activity description", not "agent is not working" (which is
-  //    decided by `computeWorking` above).
-  const activityByChat = await deriveActivities(db, chatIds, { withTurnText: opts?.withTurnText });
+  //    decided by `computeWorking` above). Both derives are driven by the
+  //    exact union workset — the Q2/Q3 LATERAL loops never scan session
+  //    holders outside the pairs being assembled.
+  const activityByChat = await deriveActivities(db, unionByChat, { withTurnText: opts?.withTurnText });
   // The list DTO consumes working / errored / activity only. Provider retry
   // reasons belong to the chat-detail agent-status surface, so list hydration
   // explicitly skips this LATERAL session-event seek while the default detail
@@ -534,7 +641,7 @@ export async function resolveAgentChatStatuses(
   const statusReasonByChat =
     opts?.includeStatusReason === false
       ? new Map<string, Map<string, AgentStatusReason>>()
-      : await deriveStatusReasons(db, chatIds);
+      : await deriveStatusReasons(db, unionByChat);
 
   const now = Date.now();
   for (const [chatId, agentSet] of unionByChat) {
@@ -719,4 +826,27 @@ export function computeErrored(session: RuntimeSessionRow, presenceRuntimeState:
 export async function getChatAgentStatuses(db: Database, chatId: string): Promise<AgentChatStatus[]> {
   const byChat = await resolveAgentChatStatuses(db, [chatId], { withTurnText: true });
   return byChat.get(chatId) ?? [];
+}
+
+/**
+ * Composite status for ONE (agent, chat) pair — the single-target path used
+ * by the admin-WS session-frame dispatch, where only the event's own agent
+ * needs enrichment. Thin projection over `resolveAgentChatStatuses` with the
+ * internal `targets` workset: the pair is intersected with actual non-human
+ * speaker membership, so a target that is not a current non-human speaker of
+ * the chat — a human, a non-speaker, or an agent with no membership row —
+ * resolves to `undefined` and no sibling speaker is ever computed. Session
+ * lifecycle state (including `evicted`) is a status axis, not a membership
+ * gate: an evicted session whose agent is still a speaker resolves normally.
+ */
+export async function getChatAgentStatus(
+  db: Database,
+  chatId: string,
+  agentId: string,
+): Promise<AgentChatStatus | undefined> {
+  const byChat = await resolveAgentChatStatuses(db, [chatId], {
+    withTurnText: true,
+    targets: new Map([[chatId, new Set([agentId])]]),
+  });
+  return byChat.get(chatId)?.find((s) => s.agentId === agentId);
 }

--- a/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
@@ -563,3 +563,303 @@ describe("useAdminWs", () => {
     expect(FakeWebSocket.instances).toHaveLength(1);
   });
 });
+
+describe("useAdminWs session:event timeline throttling", () => {
+  function countInvalidations(
+    spy: { mock: { calls: Array<readonly unknown[]> } },
+    queryKey: readonly string[],
+  ): number {
+    return spy.mock.calls.filter(([options]) => {
+      const filters = options as { queryKey?: readonly unknown[] } | undefined;
+      return JSON.stringify(filters?.queryKey) === JSON.stringify(queryKey);
+    }).length;
+  }
+
+  const eventPairKey = ["session-events", "agent-1", "chat-1"];
+  const eventChatKey = ["chat-session-events", "chat-1"];
+
+  function emitEvent(socket: FakeWebSocket, agentId: string, chatId: string, main: "working" | "ready" = "working") {
+    socket.emit({ type: "session:event", agentId, chatId, status: makeStatus({ agentId, main }) });
+  }
+
+  it("folds a session:event burst on one chat into one leading + one trailing refresh, patching status every frame", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    await renderHook();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+    vi.useFakeTimers();
+    invalidateSpy.mockClear();
+
+    queryClient.setQueryData(
+      ["chat-agent-status", "chat-1"],
+      [makeStatus({ agentId: "agent-1", main: "ready", working: false })],
+    );
+
+    // 10 frames of one tool-call burst, all inside the same throttle window.
+    await act(async () => {
+      for (let i = 0; i < 10; i++) {
+        emitEvent(socket, "agent-1", "chat-1", i % 2 === 0 ? "ready" : "working");
+      }
+    });
+
+    // Leading edge fired exactly once per key for the whole burst (10 frames
+    // → 1 refetch per key instead of 10).
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(1);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(1);
+    // The per-frame status patch is immediate even while invalidations are
+    // folded — the last frame's status must already be cached.
+    const cached = queryClient.getQueryData<AgentChatStatus[]>(["chat-agent-status", "chat-1"]);
+    expect(cached?.[0]?.main).toBe("working");
+
+    // Nothing refetches mid-window…
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(1);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(1);
+
+    // …then the burst collapses into exactly one trailing refresh.
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(2);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(2);
+
+    // And nothing more fires afterwards.
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(2);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(2);
+  });
+
+  it("keeps per-chat and per-(agent, chat) windows independent", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    await renderHook();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+    vi.useFakeTimers();
+    invalidateSpy.mockClear();
+
+    // A burst on chat-1 opens chat-1's window…
+    await act(async () => {
+      for (let i = 0; i < 5; i++) {
+        emitEvent(socket, "agent-1", "chat-1");
+      }
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(1);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(1);
+
+    // …but a frame for another chat still refreshes that chat immediately,
+    // and a second agent streaming into chat-1 still gets its own pair
+    // refresh instead of being starved by agent-1's window.
+    await act(async () => {
+      emitEvent(socket, "agent-2", "chat-2");
+      emitEvent(socket, "agent-3", "chat-1");
+    });
+    expect(countInvalidations(invalidateSpy, ["session-events", "agent-2", "chat-2"])).toBe(1);
+    expect(countInvalidations(invalidateSpy, ["chat-session-events", "chat-2"])).toBe(1);
+    expect(countInvalidations(invalidateSpy, ["session-events", "agent-3", "chat-1"])).toBe(1);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(1);
+
+    // Each window that saw a burst trails exactly once; single-frame bursts
+    // need no trailing refresh.
+    await act(async () => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(2);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(2);
+    expect(countInvalidations(invalidateSpy, ["session-events", "agent-2", "chat-2"])).toBe(1);
+    expect(countInvalidations(invalidateSpy, ["chat-session-events", "chat-2"])).toBe(1);
+    expect(countInvalidations(invalidateSpy, ["session-events", "agent-3", "chat-1"])).toBe(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(2);
+  });
+
+  it("guarantees a trailing refresh after a long burst and refreshes the next burst immediately", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    await renderHook();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+    vi.useFakeTimers();
+    invalidateSpy.mockClear();
+
+    // A 20-frame burst at ~10 fps spans two cooldown windows (t=0…1900ms).
+    // The fires land at t=0 (leading), t=1000 (trailing) and t=2000 (trailing)
+    // — the frame at t=1000 must fold into the next trailing refresh instead
+    // of re-firing a leading one at the boundary.
+    await act(async () => {
+      for (let i = 0; i < 20; i++) {
+        emitEvent(socket, "agent-1", "chat-1");
+        if (i < 19) vi.advanceTimersByTime(100);
+      }
+    });
+    // Loop ended at t=1900 with t=0 + t=1000 fired; the burst's last refresh
+    // (t=2000) is still pending.
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(2);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(2);
+
+    // The burst ended at t=1900; the guaranteed last refresh fires after it.
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(3);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(3);
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(3);
+
+    // A later isolated frame is a fresh burst: it refetches immediately
+    // (the idle sweep dropped the entry once the cooldown elapsed).
+    await act(async () => {
+      emitEvent(socket, "agent-1", "chat-1");
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(4);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(4);
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(4);
+  });
+
+  it("does not re-fire a leading invalidation when a frame lands on a fire boundary", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    await renderHook();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+    vi.useFakeTimers();
+    invalidateSpy.mockClear();
+
+    await act(async () => {
+      for (let i = 0; i < 10; i++) {
+        emitEvent(socket, "agent-1", "chat-1");
+        if (i < 9) vi.advanceTimersByTime(100);
+      }
+    });
+    // Frames t=0…900: leading fired at t=0; the trailing (due t=1000) is
+    // still pending.
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(1);
+
+    // Advance onto the boundary: the trailing fires at t=1000…
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(2);
+
+    // …and a frame landing at exactly that moment must fold into the next
+    // trailing refresh (t=2000), not re-fire a leading one at t=1000.
+    await act(async () => {
+      emitEvent(socket, "agent-1", "chat-1");
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(2);
+    await act(async () => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(3);
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(3);
+  });
+
+  it("drops pending session:event throttle timers when the workspace unmounts", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    await renderHook();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+    vi.useFakeTimers();
+    invalidateSpy.mockClear();
+
+    await act(async () => {
+      for (let i = 0; i < 3; i++) {
+        emitEvent(socket, "agent-1", "chat-1");
+      }
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(1);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(1);
+
+    // Release (last subscriber unmounts): the pending trailing timers must
+    // not survive to fire against a later scope.
+    await act(async () => root?.unmount());
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(1);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(1);
+  });
+
+  it("resets session:event throttle state on org switch so old-scope timers cannot fire", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    await renderHook();
+    const first = FakeWebSocket.instances[0];
+    if (!first) throw new Error("socket missing");
+    vi.useFakeTimers();
+    invalidateSpy.mockClear();
+
+    await act(async () => {
+      for (let i = 0; i < 3; i++) {
+        emitEvent(first, "agent-1", "chat-1");
+      }
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(1);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(1);
+
+    // Org switch drops the old socket's pending throttle timers.
+    clientMocks.getApiSelectedOrganizationId.mockReturnValue("org-2");
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("admin-ws:org-changed"));
+    });
+    const second = FakeWebSocket.instances[1];
+    if (!second) throw new Error("replacement socket missing");
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(1);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(1);
+
+    // The new org starts with a clean throttle: the same chat id refreshes
+    // immediately instead of inheriting the old scope's open window.
+    await act(async () => {
+      emitEvent(second, "agent-1", "chat-1");
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(2);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(2);
+  });
+
+  it("keeps session:state eviction invalidations immediate during an event burst", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    await renderHook();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+    vi.useFakeTimers();
+    invalidateSpy.mockClear();
+
+    await act(async () => {
+      for (let i = 0; i < 5; i++) {
+        emitEvent(socket, "agent-1", "chat-1");
+      }
+      // Terminal eviction lands mid-burst: its timeline invalidations are
+      // NOT folded into the session:event throttle — every viewer must learn
+      // about the server-side trace deletion immediately.
+      socket.emit({ type: "session:state", agentId: "agent-1", chatId: "chat-1", state: "evicted" });
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(2);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(2);
+
+    // The pre-eviction burst's pending trailing still settles exactly once…
+    await act(async () => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(3);
+    expect(countInvalidations(invalidateSpy, eventChatKey)).toBe(3);
+    // …then nothing else fires.
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(countInvalidations(invalidateSpy, eventPairKey)).toBe(3);
+  });
+});

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -51,9 +51,9 @@ let refCount = 0;
 // 1s is the long-enough-to-fold-a-burst, short-enough-to-feel-live
 // trade-off — `liveActivity` (WorkingChip / chat-list dot) updates with at
 // most ~1s lag, well inside the 60s server-side `liveActivity` window. Also
-// applied to `chat:message`
-// to fold storm-of-messages flurries (formerly invalidated every frame
-// without a throttle).
+// applied to `chat:message` to fold storm-of-messages flurries, and to the
+// `session:event` timeline keys (per-chat / per-pair throttle below) — all
+// formerly invalidated every frame without a throttle.
 //
 // Each cache key gets its OWN leading + trailing pair via the factory
 // below so bursts in one channel don't starve another. The server's
@@ -171,6 +171,129 @@ function disposeSessionPairThrottle(): void {
   sessionPairThrottle.clear();
 }
 
+// `session:event` frames stream once per tool_call / thinking /
+// assistant_text / turn_end. ChatView mounts two reads off that stream — the
+// per-(agent, chat) agent feed `["session-events", agentId, chatId]` and the
+// per-chat aggregate `["chat-session-events", chatId]` — and every frame used
+// to invalidate both: one invalidation per frame per mounted timeline while
+// an agent ticks through a burst (each invalidation is a potential refetch;
+// the query library may coalesce concurrent requests). Same window as
+// everything above (INVALIDATE_THROTTLE_MS): a leading fire keeps the
+// timeline feeling live, a trailing fire folds the burst into at most one
+// extra refresh once it settles.
+//
+// The window is keyed per (agentId, chatId) pair for the agent feed and per
+// chatId for the aggregate, so concurrent chats — and concurrent agents
+// streaming into the same chat — never block one another (same per-pair
+// reasoning as `sessionPairThrottle` above).
+//
+// Unlike the fixed invalidators, these keys arrive for arbitrary chats, so
+// the maps self-clean instead of accumulating one entry per chat ever seen:
+// every actual fire (leading or trailing) keeps `lastAt` for a full cooldown
+// — so a frame landing right on a fire boundary schedules the next trailing
+// refresh instead of re-firing a leading one — and an idle sweep drops the
+// entry once the cooldown elapses with no pending trailing refresh.
+type SessionEventThrottleEntry = {
+  lastAt: number;
+  trailingTimer: ReturnType<typeof setTimeout> | null;
+  sweepTimer: ReturnType<typeof setTimeout> | null;
+};
+
+const chatSessionEventsThrottle = new Map<string, SessionEventThrottleEntry>();
+const sessionEventPairThrottle = new Map<string, SessionEventThrottleEntry>();
+
+function armSessionEventThrottleSweep(
+  map: Map<string, SessionEventThrottleEntry>,
+  key: string,
+  entry: SessionEventThrottleEntry,
+): void {
+  if (entry.sweepTimer !== null) {
+    clearTimeout(entry.sweepTimer);
+  }
+  entry.sweepTimer = setTimeout(() => {
+    entry.sweepTimer = null;
+    // Idle cleanup only: a pending trailing refresh still owns the entry, and
+    // a re-armed entry (fresh `lastAt`) must not be deleted by a stale sweep
+    // that fires late.
+    if (map.get(key) !== entry || entry.trailingTimer !== null) return;
+    if (Date.now() - entry.lastAt >= INVALIDATE_THROTTLE_MS) {
+      map.delete(key);
+    }
+  }, INVALIDATE_THROTTLE_MS);
+}
+
+/**
+ * Leading + trailing throttle for one keyed timeline invalidation. Fires
+ * `fire` immediately on the first frame of a burst (or once the previous
+ * cooldown fully elapsed), then at most once more via a trailing timer while
+ * frames keep arriving inside the cooldown. `lastAt` is retained for a full
+ * cooldown after every actual fire so frames at the fire boundary fold into
+ * the next trailing refresh; entries are swept once idle, keeping the maps
+ * bounded. Note a fire is a cache-invalidation request, not a promise that
+ * exactly one HTTP/DB execution follows — query libraries coalesce.
+ */
+function scheduleSessionEventInvalidation(
+  map: Map<string, SessionEventThrottleEntry>,
+  key: string,
+  fire: () => void,
+): void {
+  const now = Date.now();
+  let entry = map.get(key);
+  if (!entry) {
+    // Fresh key (map self-cleans, so absence means idle). Seed `lastAt` a
+    // full window back so the first-ever frame fires immediately even when
+    // `Date.now()` is 0 under a fake clock.
+    entry = { lastAt: now - INVALIDATE_THROTTLE_MS, trailingTimer: null, sweepTimer: null };
+    map.set(key, entry);
+  }
+  if (entry.trailingTimer !== null) {
+    // A trailing refresh for this key is already pending and will refetch at
+    // the end of the cooldown — this frame is folded into it.
+    return;
+  }
+  const elapsed = now - entry.lastAt;
+  if (elapsed >= INVALIDATE_THROTTLE_MS) {
+    // Leading edge of a fresh burst (or the previous cooldown elapsed):
+    // refresh immediately and keep the entry for the full cooldown.
+    entry.lastAt = now;
+    armSessionEventThrottleSweep(map, key, entry);
+    fire();
+    return;
+  }
+  // Inside the cooldown with no trailing pending: guarantee exactly one
+  // refresh once the burst settles. The entry (with the refreshed `lastAt`)
+  // stays in place for the next cooldown.
+  entry.trailingTimer = setTimeout(() => {
+    entry.trailingTimer = null;
+    if (map.get(key) !== entry) return;
+    entry.lastAt = Date.now();
+    armSessionEventThrottleSweep(map, key, entry);
+    fire();
+  }, INVALIDATE_THROTTLE_MS - elapsed);
+}
+
+function invalidateChatSessionEvents(chatId: string): void {
+  scheduleSessionEventInvalidation(chatSessionEventsThrottle, chatId, () => {
+    if (latestQc) latestQc.invalidateQueries({ queryKey: ["chat-session-events", chatId] });
+  });
+}
+
+function invalidateSessionEventPair(agentId: string, chatId: string): void {
+  scheduleSessionEventInvalidation(sessionEventPairThrottle, `${agentId}:${chatId}`, () => {
+    if (latestQc) latestQc.invalidateQueries({ queryKey: ["session-events", agentId, chatId] });
+  });
+}
+
+function disposeSessionEventThrottles(): void {
+  for (const map of [chatSessionEventsThrottle, sessionEventPairThrottle]) {
+    for (const entry of map.values()) {
+      if (entry.trailingTimer) clearTimeout(entry.trailingTimer);
+      if (entry.sweepTimer) clearTimeout(entry.sweepTimer);
+    }
+    map.clear();
+  }
+}
+
 /**
  * Apply a session frame's per-agent status delta. When the server attached the
  * recomputed `status` (only for sockets whose viewer can access the chat),
@@ -254,14 +377,18 @@ function broadcast(msg: WsMessage) {
       meChatsInvalidator.invalidate(latestQc);
       patchOrInvalidateAgentStatus(latestQc, msg);
       // Frame carries `chatId` (api/orgs/ws.ts:82 spreads the notifier
-      // payload), so target the single chat-scoped batch ChatView reads.
+      // payload), so target the two timeline reads ChatView mounts — the
+      // per-(agent, chat) agent feed and the per-chat aggregate. Both ride
+      // the leading + trailing per-key throttle above: a tool-call burst
+      // otherwise fires one invalidation per frame per timeline (each a
+      // potential refetch, not a guaranteed SQL execution).
       const agentId = typeof msg.agentId === "string" ? msg.agentId : null;
       const chatId = typeof msg.chatId === "string" ? msg.chatId : null;
-      if (agentId && chatId) {
-        latestQc.invalidateQueries({ queryKey: ["session-events", agentId, chatId] });
-      }
       if (chatId) {
-        latestQc.invalidateQueries({ queryKey: ["chat-session-events", chatId] });
+        invalidateChatSessionEvents(chatId);
+        if (agentId) {
+          invalidateSessionEventPair(agentId, chatId);
+        }
       }
     } else if (msg.type === "chat:message") {
       // Best-effort realtime nudge for the chat-first workspace. The frame
@@ -486,6 +613,7 @@ function teardown() {
   sessionsInvalidator.dispose();
   chatAgentStatusInvalidator.dispose();
   disposeSessionPairThrottle();
+  disposeSessionEventThrottles();
   if (ws) {
     ws.close(1000, "unmount");
     ws = null;
@@ -508,6 +636,11 @@ function reconnectForOrgChange(): void {
   }
   reconnectAttempt = 0;
   cancelCurrentAdmissionTimer?.();
+  // A user-driven org switch clears the React-Query cache (auth-context
+  // selectOrganization) and swaps this socket to the new org. Drop in-flight
+  // session-event throttle state so a pending trailing timer from the
+  // previous org cannot fire against the new org's cache.
+  disposeSessionEventThrottles();
   const previous = ws;
   // Detach before closing so the stale socket's onclose (`socket !== ws`)
   // no-ops instead of scheduling a backoff reconnect to the previous org.


### PR DESCRIPTION
## Summary

A session notification currently recomputes whole-chat agent status and invalidates both event timelines on every frame. The chat event query also processes historical payloads through window functions before enforcing the per-speaker page limit. This change reduces that repeated work while preserving status, pagination, and authorization behavior.

- Throttle event timeline invalidations independently by chat and agent/chat pair, with an immediate leading refresh, a one-second window, and a trailing refresh. Clear timers on org changes and teardown; keep immediate status cache patches.
- Enrich WS session frames only when this process has an eligible audience socket, and resolve only the frame's agent. Intersect targets with speaker membership and push exact pair predicates into the relevant database reads. Keep the existing delivery-time authorization checks.
- Read each speaker's bounded event window separately from current-turn metadata within one SQL statement. Preserve `MIN(created_at)`, window-independent `turnStartedAt`, ordering, and cursors.
- Skip Q3 narration and turn-end lookups when the actual latest event cannot produce a fresh activity. Preserve application-clock freshness and provider retry semantics.

## Validation

- [x] `pnpm check` — exit 0; existing repository diagnostics remain. Touched-file checks are clean.
- [x] `pnpm typecheck` — all 9 Turbo tasks pass after completing the Antigravity test fixture with its required `noteTurnStart` mock. The original CI failure was a baseline fixture omission; the interface and runtime implementation remain unchanged.
- [x] `env -u CI_DATABASE_URL -u DATABASE_URL VITEST_MAX_FORKS=1 pnpm test` — exit 0, 10/10 Turbo tasks successful (4 cached). Server: 3,507 passed; Web: 2,434 passed; Client: 2,893 passed and 7 skipped. Remaining package and CLI batches pass. This full local run was on `75752f5ac`; the fixture-only follow-up passes its 14 Antigravity handler tests, and [the complete GitHub CI run](https://github.com/first-tree-ai/first-tree/actions/runs/33738741174) passes on `f99e588d5` (lint/typecheck, Server, Client/Web, both CLI shards, and smoke checks). CodeQL also passes.
- [x] Focused regression: 115 server tests across six files and 26 Web WS tests across two files. Covers event pagination/turn metadata, target pair scope, retry recovery, freshness, audience/membership isolation, burst/trailing invalidations, eviction, and org changes.
- [x] Real PostgreSQL comparison: invoke the baseline and candidate service functions through Drizzle/postgres.js on identical synthetic fixtures, compare complete DTOs, and capture actual `EXPLAIN (ANALYZE, BUFFERS)` plans. All comparisons pass for DESC 200, ASC 2, full status, and targeted status projection.

Local PostgreSQL 17.10, 2 CPUs, 1 GiB RAM, 256 MiB shared buffers, 4 MiB work_mem, existing repository migrations/indexes. One warmup plus seven measured executions per version, alternating order. Median database execution times for eight agents with 12,000 events each:

| Query | Before | After | Evidence |
| --- | ---: | ---: | --- |
| Q1 chat event window | 292.594 ms | 20.158 ms | Temp read/write blocks fall to zero |
| Q2 WS target status reason | 18.445 ms | 2.423 ms | Shared hits: 17,236 → 2,154 |
| Q3 WS target activity | 1.900 ms | 0.232 ms | Shared hits: 3,185 → 399 |

In a separate fixture with an old narration and latest `error`, full Q3 drops from 26.620 ms to 0.071 ms; both narration and turn-end subplans have zero execution loops in every candidate sample. All three Q1 fixtures have zero candidate temp I/O. Full-chat Q2 remains approximately unchanged; Q1's timestamp metadata seek still filters historical rows and can increase shared-buffer hits despite the lower execution time. Synthetic local results do not establish production CPU savings.

## Change Surface

- [x] Server chat event/status services and admin WS enrichment
- [x] Web WS event timeline cache invalidation
- [ ] Public CLI, tree onboarding, skills, packaging, or release behavior
- [ ] Database schema, indexes, migrations, or persistence semantics

## Notes

- No package/install changes or new database indexes. Also complete the existing Antigravity `SessionContext` test fixture so the repository typecheck gate can pass.
- QA scope: focused local queries and deterministic product regressions. Related cross-surface case: `packages/qa/cases/runtime/provider-owned-turn-status.md`; live provider/browser validation was not run, and this is not deployment qualification.
- Follow-up: evaluate kind-filtered access paths and Q1 metadata scans using representative plans. Consider WS computation coalescing only if residual notification rates justify the additional ordering and trailing-update logic.

## Adversarial verification

Reviewed head: `f99e588d591619d0ea5fd729d2a90a82d6c4c28c`. No blocking regression found in the changed paths.

- Real PostgreSQL differential checks across 20 deterministic randomized fixtures: 400 Q1 comparisons against both the baseline and an independent in-memory oracle; 520 full/targeted/batch status comparisons. Covered both sort directions, clamped limits, more than 1,000 events, sequence gaps, nonmonotonic timestamps, two database time zones, unknown/terminal events, stale/future timestamps, missing/evicted sessions, speaker/watcher/human membership, cross-org Q1 exclusion, and absent/empty target sets.
- Adversarial Web probes passed with a real QueryClient/QueryObserver: a slow older request cannot overwrite the trailing refresh result, and old-socket late frames plus old event-timeline timers do not affect the replacement org connection. The matching Web run passes 28 tests; the focused PostgreSQL/WS regression run passes 115 tests.
- Production source remained unchanged and matches the recorded query benchmark hashes. Temporary test files were removed and synthetic database rows reset.
- Residual performance costs remain as described above: full-chat Q2 scans and Q1 turn metadata still need separate access-path evaluation. These checks do not establish a production CPU reduction or replace live provider/browser acceptance.

Merge readiness is still gated by the repository's required Code Owner approval; no approval is claimed by this author-side adversarial verification.

