### PR TITLE
fix(client): keep Grok tool names across ACP tool_call_update patches

### DIFF
--- a/packages/client/src/providers/grok/__tests__/events.test.ts
+++ b/packages/client/src/providers/grok/__tests__/events.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  GROK_UNKNOWN_TOOL_NAME,
+  mergeGrokToolInfo,
   normalizeGrokSessionUpdate,
   normalizeGrokXaiNotification,
   parseGrokModelChangedEcho,
@@ -115,6 +117,19 @@ describe("normalizeGrokSessionUpdate", () => {
     if (event?.kind !== "tool_completed") throw new Error("expected tool_completed");
     expect(event.ok).toBe(false);
     expect(event.resultPreview).toBe("boom");
+    expect(event.tool.name).toBe(GROK_UNKNOWN_TOOL_NAME);
+  });
+
+  it("reads ACP top-level kind when x.ai/tool metadata is absent", () => {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "sess-1",
+      update: { sessionUpdate: "tool_call", toolCallId: "tc-k", kind: "execute", rawInput: { command: "cat NODE.md" } },
+    });
+    const event = normalized?.event;
+    if (event?.kind !== "tool_started") throw new Error("expected tool_started");
+    expect(event.tool.kind).toBe("execute");
+    expect(event.tool.isShell).toBe(true);
+    expect(event.tool.name).toBe(GROK_UNKNOWN_TOOL_NAME);
   });
 
   it("ignores in-progress tool_call_update statuses", () => {
@@ -161,6 +176,57 @@ describe("normalizeGrokSessionUpdate", () => {
     ).toBe("ignored");
     expect(normalizeGrokSessionUpdate("not an object")).toBeNull();
     expect(normalizeGrokSessionUpdate({ sessionId: "s" })).toBeNull();
+  });
+});
+
+describe("mergeGrokToolInfo — ACP tool_call_update patch semantics", () => {
+  function started(over: Record<string, unknown> = {}) {
+    const normalized = normalizeGrokSessionUpdate({
+      sessionId: "s",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-1",
+        title: "read_file",
+        rawInput: { path: "NODE.md" },
+        _meta: { "x.ai/tool": { name: "read_file", kind: "read", read_only: true, input: { path: "NODE.md" } } },
+        ...over,
+      },
+    });
+    if (normalized?.event.kind !== "tool_started") throw new Error("expected tool_started");
+    return normalized.event.tool;
+  }
+
+  it("keeps the start name when a completed update omits title and x.ai/tool meta", () => {
+    const completed = normalizeGrokSessionUpdate({
+      sessionId: "s",
+      update: { sessionUpdate: "tool_call_update", toolCallId: "tc-1", status: "completed", rawOutput: "ok" },
+    });
+    if (completed?.event.kind !== "tool_completed") throw new Error("expected tool_completed");
+    expect(completed.event.tool.name).toBe(GROK_UNKNOWN_TOOL_NAME);
+    const merged = mergeGrokToolInfo(started(), completed.event.tool);
+    expect(merged.name).toBe("read_file");
+    expect(merged.kind).toBe("read");
+    expect(merged.readOnly).toBe(true);
+    expect(merged.paths).toEqual(["NODE.md"]);
+    expect(merged.argsSummary).toEqual({ path: "NODE.md" });
+  });
+
+  it("lets a concrete incoming name replace the previous one", () => {
+    const incoming = normalizeGrokSessionUpdate({
+      sessionId: "s",
+      update: { sessionUpdate: "tool_call_update", toolCallId: "tc-1", title: "read_file_v2", status: "completed" },
+    });
+    if (incoming?.event.kind !== "tool_completed") throw new Error("expected tool_completed");
+    expect(mergeGrokToolInfo(started(), incoming.event.tool).name).toBe("read_file_v2");
+  });
+
+  it("leaves grok:unknown when this toolCallId has never had a name", () => {
+    const completed = normalizeGrokSessionUpdate({
+      sessionId: "s",
+      update: { sessionUpdate: "tool_call_update", toolCallId: "tc-orphan", status: "failed", rawOutput: "boom" },
+    });
+    if (completed?.event.kind !== "tool_completed") throw new Error("expected tool_completed");
+    expect(mergeGrokToolInfo(undefined, completed.event.tool).name).toBe(GROK_UNKNOWN_TOOL_NAME);
   });
 });
 

--- a/packages/client/src/providers/grok/__tests__/handler.test.ts
+++ b/packages/client/src/providers/grok/__tests__/handler.test.ts
@@ -56,10 +56,15 @@ function logRequest(req) {
 }
 function emitToolUpdates(sid) {
   if (!toolName) return;
+  const patchComplete = process.env.GROK_FAKE_TOOL_PATCH_COMPLETE === "1";
   const meta = { version: 1, name: toolName, kind: toolName === "read_file" ? "read" : toolName === "run_terminal_cmd" ? "execute" : "edit", namespace: "grok_build", label: toolName, read_only: toolName !== "search_replace" };
   const rawInput = toolName === "run_terminal_cmd" ? { command: "cat " + toolPath } : { path: toolPath };
   meta.input = rawInput;
   notify("session/update", { sessionId: sid, update: { sessionUpdate: "tool_call", toolCallId: "tc-1", title: toolName, rawInput: rawInput, _meta: { "x.ai/tool": meta } } });
+  if (patchComplete) {
+    notify("session/update", { sessionId: sid, update: { sessionUpdate: "tool_call_update", toolCallId: "tc-1", status: "completed", rawOutput: toolName + " done" } });
+    return;
+  }
   notify("session/update", { sessionId: sid, update: { sessionUpdate: "tool_call_update", toolCallId: "tc-1", title: toolName, status: "completed", content: toolName === "search_replace" ? [{ type: "diff", path: toolPath, oldText: "a", newText: "b" }] : [], locations: [{ path: toolPath }], rawInput: rawInput, rawOutput: toolName + " done", _meta: { "x.ai/tool": meta } } });
 }
 function emitPromptNotifications(sid, pid) {
@@ -1655,6 +1660,43 @@ describe("grok handler — per-turn ACP transport", () => {
     const completed = events.find((e) => e.kind === "tool_call" && e.payload.status === "ok");
     if (completed?.kind !== "tool_call") throw new Error("expected an ok tool_call event");
     expect(completed.payload.name).toBe("run_terminal_cmd");
+    expect(completed.payload.toolFileRefs).toMatchObject([
+      { origin: "tool_arg", repoUrl: "https://github.com/acme/tree.git", repoRelativePath: "NODE.md" },
+    ]);
+  });
+
+  it("a title-less completed tool_call_update keeps the start name and args", async () => {
+    const events: SessionEvent[] = [];
+    const specs: ProviderProcessSpec[] = [];
+    const contextTreePath = join(workspaceRoot, "context-tree");
+    const fakeEnv = fakeEnvFor("tool-patch-complete", {
+      GROK_FAKE_TOOL: "run_terminal_cmd",
+      GROK_FAKE_TOOL_PATH: join(contextTreePath, "NODE.md"),
+      GROK_FAKE_TOOL_PATCH_COMPLETE: "1",
+    });
+    const handler = makeHandler(createFakeAcpSupervisor(specs, fakeEnv), {
+      contextTreePath,
+      contextTreeRepoUrl: "https://github.com/acme/tree.git",
+      contextTreeBranch: "main",
+    });
+
+    await handler.start(
+      makeMessage("m1", "read the node"),
+      makeContext({ events, contextTreeRepoUrl: "https://github.com/acme/tree.git" }),
+      makeToken(),
+    );
+
+    const pending = events.find((e) => e.kind === "tool_call" && e.payload.status === "pending");
+    expect(pending).toMatchObject({
+      kind: "tool_call",
+      payload: { toolUseId: "tc-1", name: "run_terminal_cmd", status: "pending" },
+    });
+    const completed = events.find((e) => e.kind === "tool_call" && e.payload.status === "ok");
+    if (completed?.kind !== "tool_call") throw new Error("expected an ok tool_call event");
+    expect(completed.payload.name).toBe("run_terminal_cmd");
+    expect(completed.payload.name).not.toBe("grok:unknown");
+    expect(completed.payload.args).toEqual({ command: `cat ${join(contextTreePath, "NODE.md")}` });
+    expect(completed.payload.resultPreview).toBe("run_terminal_cmd done");
     expect(completed.payload.toolFileRefs).toMatchObject([
       { origin: "tool_arg", repoUrl: "https://github.com/acme/tree.git", repoRelativePath: "NODE.md" },
     ]);

--- a/packages/client/src/providers/grok/events.ts
+++ b/packages/client/src/providers/grok/events.ts
@@ -42,6 +42,9 @@ export type GrokTurnCompleted = {
  * absent, malformed) is unproven and must count as a side effect on the
  * replay-safety ladder.
  */
+/** Display fallback when one ACP payload has no `_meta["x.ai/tool"].name` and no `title`. */
+export const GROK_UNKNOWN_TOOL_NAME = "grok:unknown";
+
 export type GrokToolInfo = {
   toolCallId: string;
   /** `_meta["x.ai/tool"].name` when present, else the raw `title`, else a tagged unknown. */
@@ -60,6 +63,41 @@ export type GrokToolInfo = {
   paths: string[];
   argsSummary: Record<string, unknown>;
 };
+
+/** Shell detection keys on name/kind — NOT on the presence of a command. */
+export function grokToolIsShell(name: string, kind: string | null): boolean {
+  return name === "run_terminal_cmd" || kind === "execute";
+}
+
+/**
+ * ACP `tool_call_update` is a patch: omitted fields leave the previous tool
+ * call unchanged. Merge one extracted payload onto the last known info for
+ * the same `toolCallId` so a completed/failed update that only carries
+ * `status` + `rawOutput` cannot replace a real name with `grok:unknown`.
+ *
+ * Concrete incoming values replace; `null`/empty extracted fields are treated
+ * as omitted (the extractor cannot see JSON `null` vs absent). Keep
+ * `grok:unknown` only when this id has never had a name or title.
+ */
+export function mergeGrokToolInfo(previous: GrokToolInfo | undefined, incoming: GrokToolInfo): GrokToolInfo {
+  if (!previous) return incoming;
+  const name = incoming.name !== GROK_UNKNOWN_TOOL_NAME ? incoming.name : previous.name;
+  const kind = incoming.kind ?? previous.kind;
+  const command = incoming.command ?? previous.command;
+  const paths = incoming.paths.length > 0 ? incoming.paths : previous.paths;
+  const readOnly = incoming.readOnly ?? previous.readOnly;
+  const argsSummary = Object.keys(incoming.argsSummary).length > 0 ? incoming.argsSummary : previous.argsSummary;
+  return {
+    toolCallId: incoming.toolCallId,
+    name,
+    kind,
+    isShell: grokToolIsShell(name, kind),
+    readOnly,
+    command,
+    paths,
+    argsSummary,
+  };
+}
 
 export type GrokNormalizedEvent =
   | { kind: "assistant_chunk"; text: string }
@@ -138,15 +176,15 @@ function extractTool(update: Record<string, unknown>): GrokToolInfo | null {
   const command = asString(rawInput?.command) ?? asString(metaInput?.command);
   const title = asString(update.title);
   const metaName = meta ? asString(meta.name) : null;
-  const kind = meta ? asString(meta.kind) : null;
-  const name = metaName ?? title ?? "grok:unknown";
+  const kind = (meta ? asString(meta.kind) : null) ?? asString(update.kind);
+  const name = metaName ?? title ?? GROK_UNKNOWN_TOOL_NAME;
   const readOnly = meta && typeof meta.read_only === "boolean" ? meta.read_only : null;
   const paths = extractToolPaths(update, meta);
   return {
     toolCallId,
     name,
     kind,
-    isShell: name === "run_terminal_cmd" || kind === "execute",
+    isShell: grokToolIsShell(name, kind),
     readOnly,
     command,
     paths,

--- a/packages/client/src/providers/grok/index.ts
+++ b/packages/client/src/providers/grok/index.ts
@@ -57,6 +57,7 @@ import {
   type GrokNormalizedEvent,
   type GrokToolInfo,
   type GrokTurnCompleted,
+  mergeGrokToolInfo,
   normalizeGrokSessionUpdate,
   normalizeGrokXaiNotification,
 } from "./events.js";
@@ -166,6 +167,8 @@ type TurnAcpState = {
   assistantText: string;
   turnCompleted: GrokTurnCompleted | null;
   ignoredCount: number;
+  /** Last known tool info per ACP `toolCallId` — `tool_call_update` is a patch. */
+  tools: Map<string, GrokToolInfo>;
 };
 
 export const createGrokHandler: HandlerFactory = (config) => {
@@ -418,36 +421,40 @@ export const createGrokHandler: HandlerFactory = (config) => {
       case "user_echo":
         break;
       case "tool_started": {
-        if (!grokToolIsReadOnly(event.tool)) state.toolEffectStarted = true;
+        const tool = mergeGrokToolInfo(state.tools.get(event.tool.toolCallId), event.tool);
+        state.tools.set(tool.toolCallId, tool);
+        if (!grokToolIsReadOnly(tool)) state.toolEffectStarted = true;
         sessionCtx.emitEvent({
           kind: "tool_call",
           payload: {
-            toolUseId: event.tool.toolCallId,
-            name: event.tool.name,
-            args: event.tool.argsSummary,
+            toolUseId: tool.toolCallId,
+            name: tool.name,
+            args: tool.argsSummary,
             status: "pending",
           },
         });
         break;
       }
       case "tool_completed": {
+        const tool = mergeGrokToolInfo(state.tools.get(event.tool.toolCallId), event.tool);
+        state.tools.set(tool.toolCallId, tool);
         const ok = event.ok;
-        const readOnly = grokToolIsReadOnly(event.tool);
+        const readOnly = grokToolIsReadOnly(tool);
         if (!readOnly) state.toolEffectStarted = true;
-        const providerRefs = ok ? providerRefsForTool(event.tool) : [];
+        const providerRefs = ok ? providerRefsForTool(tool) : [];
         const toolFileRefs = refsForCompletedTool({
           ok,
           readOnly,
           providerRefs,
-          toolName: event.tool.name,
-          toolUseId: event.tool.toolCallId,
+          toolName: tool.name,
+          toolUseId: tool.toolCallId,
         });
         sessionCtx.emitEvent({
           kind: "tool_call",
           payload: {
-            toolUseId: event.tool.toolCallId,
-            name: event.tool.name,
-            args: event.tool.argsSummary,
+            toolUseId: tool.toolCallId,
+            name: tool.name,
+            args: tool.argsSummary,
             status: ok ? "ok" : "error",
             ...(event.resultPreview ? { resultPreview: event.resultPreview } : {}),
             ...(toolFileRefs ? { toolFileRefs } : {}),
@@ -617,6 +624,7 @@ export const createGrokHandler: HandlerFactory = (config) => {
           assistantText: "",
           turnCompleted: null,
           ignoredCount: 0,
+          tools: new Map(),
         };
         consumedErrorReason = null;
         retryReason = null;


### PR DESCRIPTION
## Summary

- Grok ACP `tool_call_update` is a patch: later completed/failed updates often send only `status` + `rawOutput` and omit `title` / `_meta["x.ai/tool"]`.
- The Grok adapter treated each payload as a full snapshot and labeled the missing name `grok:unknown`. The Working lane then kept the latest row per `toolUseId`, so a nameless completion overwrote a good start name.
- Merge last-known `GrokToolInfo` by `toolCallId` before emitting session events. Keep `grok:unknown` only when that id has never had a name or title.

This replaces #2387. Same exact head `785dc09b099777d8b54908e0f5712125b9feeb25`; the previous PR was blocked because `jeremy/grok-unknown-tool-merge` is not a required branch prefix.

## Validation

- [x] `biome check` on the four changed Grok files
- [x] Independent exact-head review of #2387: `git diff --check`, `pnpm check`, build (5/5), typecheck (9/9), 91 focused Grok tests, full client suite (2,898 passed, 7 skipped)
- [x] `pnpm --filter @first-tree/client exec vitest run src/providers/grok/__tests__/events.test.ts src/providers/grok/__tests__/handler.test.ts` (91 passed)

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: Grok events + handler coverage for title-less completed updates, including preserved shell args/refs
- follow-up work: optional Working-lane `TOOL_VERBS` mapping for Grok names (`run_terminal_cmd` / `run_terminal_command`) so shells render as `run <command>` instead of `use <title>`
