### PR TITLE
docs(qa): add shared-component copy across callers QA case

### DIFF
--- a/packages/qa/cases/web/shared-component-copy-across-callers.md
+++ b/packages/qa/cases/web/shared-component-copy-across-callers.md
@@ -1,0 +1,98 @@
+---
+id: shared-component-copy-across-callers
+description: Copy removed from a shared UI component because it duplicated a neighbouring line must still leave every other caller able to state its own remedy.
+areas: [web]
+surfaces: [web]
+---
+
+# Shared component copy across callers
+
+## Goal
+
+Validate that a change to a copy slot inside a **shared** UI component leaves every screen that
+mounts that component still saying what the reader needs. The specific risk is a deletion justified
+by local redundancy — "this repeats the sentence directly above it" — when the sentence that made it
+redundant is contributed by one caller and not by the others. On those other callers the deleted
+line was the only statement of the remedy, and both the diff and the screen the author was asked to
+fix read as correct.
+
+The same question applies in the other direction: copy added at one caller can duplicate a line that
+the shared component already renders for a different caller.
+
+Deterministic caller-level rendering tests own the sentence once it is known to belong to a given
+caller. This case owns the discovery step that precedes them — deciding which callers lose meaning,
+which are genuinely unaffected, and whether the surrounding frame still tells the truth — which
+requires reading assembled screens rather than the component in isolation.
+
+## Trigger
+
+Select this case when a change removes, moves, or narrows a copy slot, lead line, empty-state
+sentence, helper text, or its reserved layout row inside a component that has more than one
+importer, and the stated rationale is duplication, redundancy, density, or spacing.
+
+## Preconditions
+
+- A run cell that can build and serve the real web bundle for two refs — the change under test and
+  its merge base — against the same seeded data. Reusing one warm environment across both builds is
+  preferred so the only difference is the ref.
+- Seeded state that actually reaches the affected component state on **each** caller. Callers often
+  differ in how the state is entered, and a state that is trivial to seed on one screen may require
+  a different fixture on another.
+- Every supported locale the copy exists in, and at least one narrow viewport, when the slot also
+  carried layout.
+
+## Operate and observe
+
+- Enumerate the importers of the component from source, then for each caller read what it renders
+  **around** the slot — not merely that it renders the component. Record, per caller, whether the
+  neighbouring sentence that made the slot redundant is present. Treat a caller that does not render
+  it as losing content until a live observation says otherwise.
+- Drive each caller to the affected state in a real browser and capture the rendered text of the
+  region, not a source reading. A caller that cannot be reached with the available fixtures is an
+  unverified caller; say so rather than reasoning about it from the diff.
+- Check the **mode or variant** each caller passes. A component may expose states one caller can
+  never enter — for example a create-style mode whose initial state skips the state whose copy was
+  removed. That is a genuine exemption, but it must be verified live on that caller, not assumed by
+  symmetry with the caller that was fixed.
+- Read the surrounding frame after the removal. A step footer, progress hint, or heading that
+  instructs the reader to "complete the action above" becomes false when the only remaining content
+  above it is an escape hatch such as a reinstall or support link. Judge the assembled step, not the
+  removed line.
+- When the change instead adds caller-local copy, revisit the other states of that same caller: two
+  sentences that previously shared one slot can now appear together. Decide whether the resulting
+  pair reads as complementary or as a duplicate, and record the judgement so a later reader does not
+  file it as a regression.
+- If the fix is accompanied by a regression test that asserts the restored copy, confirm the guard
+  is not vacuous: remove the restored element, re-run the suite, and check that the failure names
+  the missing sentence. Restore the source and confirm the tree is clean at the exact target before
+  reporting.
+
+## Evidence
+
+- A per-caller table: caller, entry path, mode/variant, state reached, and the rendered text of the
+  affected region, at base and at the target.
+- Base-versus-target screenshots of the **same** seeded state on each affected caller, plus the
+  narrow-viewport and non-default-locale captures when the slot carried layout or localized copy.
+- The base control must be a real build of the merge base driven through the product, never a diff
+  reading. Verify the base build actually rendered base copy before trusting it: a cached SPA shell,
+  a stale bundle, or a compiled message catalog that was not regenerated from its source strings will
+  silently serve target copy from a base checkout, which reads as "no change" and hides the finding.
+- The mutation-check output when a guard was verified, and the clean-tree confirmation afterwards.
+- Browser console and page errors for each observed state.
+
+## Expected result
+
+`PASS`: every caller was reached live, each one either still states its own remedy or was shown to be
+unable to enter the affected state, the surrounding frame remains truthful, and any accompanying
+guard was shown to bite.
+
+`FAIL`: a caller renders the affected state with no statement of the remedy, a frame instructs the
+reader toward content that no longer exists, an added line duplicates existing copy on another
+caller, or a guard passes with its subject removed.
+
+`BLOCKED`: the base build, a caller's entry path, or the seeded state required to reach the affected
+state on some caller is unavailable, so the comparison cannot be made.
+
+`INCONCLUSIVE`: some callers were verified and others only reasoned about from source, the base
+control cannot be shown to have rendered base copy, or the observations cannot be attributed to the
+exact refs.


### PR DESCRIPTION
## What

Adds one reusable QA case: `packages/qa/cases/web/shared-component-copy-across-callers.md`.

It comes out of a two-round independent QA run whose disposition was `candidate-new-case`. Per
`cases/README.md`, committed-case maintenance is a separate task from the run — this is that task.

## The pattern it captures

When a change removes a copy slot from a **shared** UI component with the rationale "it repeated the
sentence directly above it word for word", that duplication is usually **caller-local**. The screen
the author was asked to fix renders the neighbouring sentence; another caller of the same component
does not, so on that screen the deleted line was the only statement of what the reader should do —
and the remaining content is an escape hatch under a frame still saying "complete the action above".
Both the diff and the fixed screen read as correct.

Two sub-rules the case also carries:

- **Modes are not symmetric by assumption.** A caller may pass a mode whose initial state can never
  reach the state whose copy was removed. That is a real exemption, but it has to be verified live on
  that caller, not inferred from the caller that was fixed.
- **Prove the delta with a real base control.** Build the merge base, drive the same seeded state,
  and compare rendered text — not a diff reading. The case names the failure mode that makes a base
  control lie (cached shell / stale bundle / compiled message catalog not regenerated from source
  strings), because that silently renders target copy from a base checkout and reads as "no change".

It also covers the inverse direction (caller-local copy added on top of shared copy) and the
vacuous-guard check when a fix ships with a regression test.

## Placement

New case rather than an update: no existing case owns "shared component / multiple callers". The
nearest neighbour, `people-picker-long-identities`, answers a geometry question about identity
rendering, not a per-caller meaning question.

Filed under `web/` per `cases/README.md` ("put it where the primary validation question lives"). It
is deliberately repository-neutral and product-neutral prose so it applies to any shared component
with more than one importer.

## Scope

Docs only. One added file. No product code, no case-library restructuring, nothing removed.
