### PR TITLE
fix: contain authentication failures and reconnect resource use

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -105,6 +105,7 @@
     "@types/ejs": "^3.1.5",
     "@types/node": "^22.16.0",
     "@types/semver": "^7.5.8",
+    "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "3.2.4",
     "postgres": "^3.4.0",
     "tsdown": "^0.21.4",

--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -528,3 +528,152 @@ describe("CapabilityRefresher", () => {
     refresher.stop();
   });
 });
+
+/**
+ * D5 (staging auth-failure storm): while the connection sits in auth paused
+ * mode the poll's uploads would keep firing doomed `/auth/refresh` 401s at
+ * the base cadence forever (a failed upload reset the backoff to 0, so the
+ * retry was always 15s away). `pause()`/`resume()` gate all probe/upload work
+ * on the existing auth events WITHOUT touching the terminal `stop()` state:
+ * resume must never revive a stopped refresher, and resume itself performs no
+ * work — the next registration-driven `onReconnect()` owns the catch-up.
+ */
+describe("CapabilityRefresher — auth pause gate (D5)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("pause() disarms the poll; resume() alone performs no work; the next onReconnect owns the catch-up", async () => {
+    const { refresher, upload, reprobe, revalidate } = makeRefresher({ initial: codexMissing() });
+    await refresher.start();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    refresher.pause();
+    // While paused nothing polls and nothing uploads, even well past the
+    // previous 15s-flat retry cadence.
+    await vi.advanceTimersByTimeAsync(MAX * 4);
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    // auth:resumed fires BEFORE the reconnect/registration completes —
+    // resume() must ungate without probing or uploading by itself.
+    refresher.resume();
+    await vi.advanceTimersByTimeAsync(MAX * 4);
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(reprobe).not.toHaveBeenCalled();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    // Successful re-registration drives the refresh through the existing
+    // reconnect path (TTL/interactive ownership untouched).
+    reprobe.mockResolvedValueOnce({ capabilities: allOk(), mode: "revalidate" as const });
+    refresher.onReconnect();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reprobe).toHaveBeenCalledTimes(1);
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(upload).toHaveBeenLastCalledWith(allOk());
+    refresher.stop();
+  });
+
+  it("a pause landing mid-probe blocks the late upload and does not re-arm — even after credentials resume, until registration", async () => {
+    const gate = deferred<ClientCapabilities>();
+    const { refresher, upload, reprobe, revalidate } = makeRefresher({ initial: codexMissing() });
+    revalidate.mockReturnValueOnce(gate.promise); // poll #1 hangs in flight
+
+    await refresher.start();
+    expect(upload).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+
+    refresher.pause();
+    // Credentials-resumed ONLY (no resume() call — the daemon now ungates
+    // exclusively on a completed registration). The old in-flight probe
+    // resolves inside this gap…
+    gate.resolve(allOk());
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // …and must NOT upload (a dead token would just 401 the server again)
+    // and must NOT re-arm the poll. The snapshot IS kept locally, so the
+    // post-registration refresh still publishes the recovery.
+    expect(upload).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(MAX * 4);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+
+    // Registration completed: the daemon wiring calls resume() then
+    // onReconnect() — exactly one catch-up upload.
+    refresher.resume();
+    refresher.onReconnect();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reprobe).toHaveBeenCalledTimes(1);
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(upload).toHaveBeenLastCalledWith(allOk());
+    refresher.stop();
+  });
+
+  it("stop() stays terminal across pause/resume and later reconnects", async () => {
+    const { refresher, upload, reprobe, revalidate } = makeRefresher({ initial: codexMissing() });
+    await refresher.start();
+    refresher.stop();
+
+    refresher.pause();
+    refresher.resume(); // must NOT revive a stopped refresher
+    refresher.onReconnect();
+    await vi.advanceTimersByTimeAsync(MAX * 4);
+
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(reprobe).not.toHaveBeenCalled();
+    expect(upload).toHaveBeenCalledTimes(1);
+  });
+
+  it("setProviderEntry keeps local state but does not upload while paused", async () => {
+    const { refresher, upload } = makeRefresher({ initial: codexPendingSnapshot() });
+    await refresher.start();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    refresher.pause();
+    // The credentials-resumed → registration gap: a login flow finishing
+    // inside it must not push anything onto the wire yet.
+    await refresher.setProviderEntry("codex", ok({ detectedAt: "2026-06-17T00:01:00.000Z" }));
+    // Local snapshot/provider-write bookkeeping still advances (the login
+    // flow must not lose its result)…
+    expect(refresher.currentEntry("codex")?.state).toBe("ok");
+    // …but nothing reaches the server while credentials are dead.
+    expect(upload).toHaveBeenCalledTimes(1);
+    refresher.stop();
+  });
+
+  it("start() after stop() performs no work — terminal stop is never revived by a late startup", async () => {
+    const { refresher, upload, reprobe, revalidate } = makeRefresher({ initial: codexMissing() });
+    refresher.stop();
+    await refresher.start();
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(reprobe).not.toHaveBeenCalled();
+    expect(revalidate).not.toHaveBeenCalled();
+
+    // resume() must not make a later start() work either.
+    refresher.resume();
+    await refresher.start();
+    expect(upload).not.toHaveBeenCalled();
+    expect(reprobe).not.toHaveBeenCalled();
+  });
+
+  it("start() respects the paused gate and works after resume()", async () => {
+    const { refresher, upload, reprobe } = makeRefresher({ initial: codexMissing() });
+    refresher.pause();
+    await refresher.start();
+    expect(upload).not.toHaveBeenCalled();
+    expect(reprobe).not.toHaveBeenCalled();
+
+    // The daemon calls resume() only after a successful registration, then
+    // start() — the normal startup upload follows.
+    refresher.resume();
+    await refresher.start();
+    expect(upload).toHaveBeenCalledTimes(1);
+    refresher.stop();
+  });
+});

--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -533,10 +533,8 @@ describe("CapabilityRefresher", () => {
  * D5 (staging auth-failure storm): while the connection sits in auth paused
  * mode the poll's uploads would keep firing doomed `/auth/refresh` 401s at
  * the base cadence forever (a failed upload reset the backoff to 0, so the
- * retry was always 15s away). `pause()`/`resume()` gate all probe/upload work
- * on the existing auth events WITHOUT touching the terminal `stop()` state:
- * resume must never revive a stopped refresher, and resume itself performs no
- * work — the next registration-driven `onReconnect()` owns the catch-up.
+ * retry was always 15s away). `pause()` gates probe/upload work until `onRegistered()` releases it.
+ * A credentials change alone never reopens work; `stop()` stays terminal.
  */
 describe("CapabilityRefresher — auth pause gate (D5)", () => {
   beforeEach(() => {
@@ -547,7 +545,7 @@ describe("CapabilityRefresher — auth pause gate (D5)", () => {
     vi.restoreAllMocks();
   });
 
-  it("pause() disarms the poll; resume() alone performs no work; the next onReconnect owns the catch-up", async () => {
+  it("pause disarms work until one registration notification performs the catch-up", async () => {
     const { refresher, upload, reprobe, revalidate } = makeRefresher({ initial: codexMissing() });
     await refresher.start();
     expect(upload).toHaveBeenCalledTimes(1);
@@ -559,9 +557,7 @@ describe("CapabilityRefresher — auth pause gate (D5)", () => {
     expect(revalidate).not.toHaveBeenCalled();
     expect(upload).toHaveBeenCalledTimes(1);
 
-    // auth:resumed fires BEFORE the reconnect/registration completes —
-    // resume() must ungate without probing or uploading by itself.
-    refresher.resume();
+    // Credentials may already be fresh, but registration has not completed.
     await vi.advanceTimersByTimeAsync(MAX * 4);
     expect(revalidate).not.toHaveBeenCalled();
     expect(reprobe).not.toHaveBeenCalled();
@@ -570,7 +566,7 @@ describe("CapabilityRefresher — auth pause gate (D5)", () => {
     // Successful re-registration drives the refresh through the existing
     // reconnect path (TTL/interactive ownership untouched).
     reprobe.mockResolvedValueOnce({ capabilities: allOk(), mode: "revalidate" as const });
-    refresher.onReconnect();
+    refresher.onRegistered(true);
     await vi.advanceTimersByTimeAsync(0);
     expect(reprobe).toHaveBeenCalledTimes(1);
     expect(upload).toHaveBeenCalledTimes(2);
@@ -589,8 +585,7 @@ describe("CapabilityRefresher — auth pause gate (D5)", () => {
     expect(revalidate).toHaveBeenCalledTimes(1);
 
     refresher.pause();
-    // Credentials-resumed ONLY (no resume() call — the daemon now ungates
-    // exclusively on a completed registration). The old in-flight probe
+    // Credentials changed, but registration is still pending. The old probe
     // resolves inside this gap…
     gate.resolve(allOk());
     await vi.advanceTimersByTimeAsync(0);
@@ -603,10 +598,8 @@ describe("CapabilityRefresher — auth pause gate (D5)", () => {
     await vi.advanceTimersByTimeAsync(MAX * 4);
     expect(revalidate).toHaveBeenCalledTimes(1);
 
-    // Registration completed: the daemon wiring calls resume() then
-    // onReconnect() — exactly one catch-up upload.
-    refresher.resume();
-    refresher.onReconnect();
+    // Registration completed: one notification owns the catch-up upload.
+    refresher.onRegistered(true);
     await vi.advanceTimersByTimeAsync(0);
     expect(reprobe).toHaveBeenCalledTimes(1);
     expect(upload).toHaveBeenCalledTimes(2);
@@ -614,14 +607,13 @@ describe("CapabilityRefresher — auth pause gate (D5)", () => {
     refresher.stop();
   });
 
-  it("stop() stays terminal across pause/resume and later reconnects", async () => {
+  it("stop stays terminal across pauses and later registrations", async () => {
     const { refresher, upload, reprobe, revalidate } = makeRefresher({ initial: codexMissing() });
     await refresher.start();
     refresher.stop();
 
     refresher.pause();
-    refresher.resume(); // must NOT revive a stopped refresher
-    refresher.onReconnect();
+    refresher.onRegistered(true); // must NOT revive a stopped refresher
     await vi.advanceTimersByTimeAsync(MAX * 4);
 
     expect(revalidate).not.toHaveBeenCalled();
@@ -655,24 +647,22 @@ describe("CapabilityRefresher — auth pause gate (D5)", () => {
     expect(reprobe).not.toHaveBeenCalled();
     expect(revalidate).not.toHaveBeenCalled();
 
-    // resume() must not make a later start() work either.
-    refresher.resume();
+    // A later registration must not revive a stopped refresher either.
+    refresher.onRegistered(false);
     await refresher.start();
     expect(upload).not.toHaveBeenCalled();
     expect(reprobe).not.toHaveBeenCalled();
   });
 
-  it("start() respects the paused gate and works after resume()", async () => {
+  it("start respects the paused gate; first registration releases it and uploads once", async () => {
     const { refresher, upload, reprobe } = makeRefresher({ initial: codexMissing() });
     refresher.pause();
     await refresher.start();
     expect(upload).not.toHaveBeenCalled();
     expect(reprobe).not.toHaveBeenCalled();
 
-    // The daemon calls resume() only after a successful registration, then
-    // start() — the normal startup upload follows.
-    refresher.resume();
-    await refresher.start();
+    refresher.onRegistered(false);
+    await vi.advanceTimersByTimeAsync(0);
     expect(upload).toHaveBeenCalledTimes(1);
     refresher.stop();
   });

--- a/apps/cli/src/__tests__/client-runtime-auth-recovery.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-auth-recovery.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -137,6 +137,8 @@ describe("ClientRuntime — paused-mode credential recovery", () => {
     saveCredentials({ serverUrl, accessToken: token("old"), refreshToken: "synthetic-old" });
 
     const runtime = new ClientRuntime(serverUrl, "synthetic-early-login", { output: silentOutput });
+    const registrations = vi.fn();
+    runtime.onRegistered(registrations);
     let pauses = 0;
     runtime.onAuthPaused(() => pauses++);
     const starting = runtime.start().then(
@@ -149,6 +151,7 @@ describe("ClientRuntime — paused-mode credential recovery", () => {
       expect(registered).toBe(1);
       expect(authFrames).toBe(2);
       expect(pauses).toBe(1);
+      expect(registrations).toHaveBeenCalledExactlyOnceWith(false);
     } finally {
       await runtime.stop("synthetic race complete");
       await starting;
@@ -331,6 +334,15 @@ describe("ClientRuntime — paused-mode credential recovery", () => {
       expect(runtime.pausedReason()).toBe("auth_refresh_failed");
       // Unchanged credentials: parked, and the 401 latch keeps the failed
       // authority from re-hitting the network.
+      await sleep(700);
+      expect(runtime.isPaused()).toBe(true);
+      expect(counts).toEqual({ refresh401: 1, refresh200: 0, sockets: 1, registrations: 0 });
+
+      // Formatting, field order, and unrelated metadata do not change auth identity.
+      writeFileSync(
+        join(home, "config", "credentials.json"),
+        JSON.stringify({ note: "edited", refreshToken: "synthetic-dead", accessToken: staleToken, serverUrl }, null, 2),
+      );
       await sleep(700);
       expect(runtime.isPaused()).toBe(true);
       expect(counts).toEqual({ refresh401: 1, refresh200: 0, sockets: 1, registrations: 0 });

--- a/apps/cli/src/__tests__/client-runtime-auth-recovery.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-auth-recovery.test.ts
@@ -1,0 +1,353 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type WebSocket, WebSocketServer } from "ws";
+import { saveCredentials } from "../core/bootstrap.js";
+import { ClientRuntime } from "../core/client-runtime.js";
+
+/**
+ * Paused-mode credential recovery, end-to-end at the ClientRuntime level with
+ * a real local WebSocket server and a real temp-home fs watcher.
+ *
+ * Regression: a login that landed BETWEEN the rejected auth frame and the
+ * server reply used to be lost — the credentials watcher was installed on
+ * auth:paused and baselined the ALREADY-new file, so with the parked initial
+ * connect nothing ever retried until a second credential write. Recovery is
+ * now anchored to the credential the rejected attempt actually used, checked
+ * immediately on pause and on every later file event.
+ */
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const token = (id: string) =>
+  `synthetic.${Buffer.from(
+    JSON.stringify({ sub: "synthetic-owner", jti: id, exp: Math.floor(Date.now() / 1000) + 3600 }),
+  ).toString("base64url")}.signature`;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("bounded condition timeout");
+    await sleep(10);
+  }
+}
+
+const silentOutput = {
+  blank() {},
+  status() {},
+  check() {},
+  line() {},
+};
+
+type Harness = {
+  serverUrl: string;
+  close: () => Promise<void>;
+};
+
+/** Start a loopback HTTP+WS server; `onFrame` answers auth/register frames. */
+async function serve(
+  onFrame: (frame: { type: string; token?: string }, ws: WebSocket) => void,
+  onSocket?: () => void,
+  onRequest?: (body: string, respond: (status: number, payload?: string) => void) => void,
+): Promise<Harness> {
+  const server = createServer((req, res) => {
+    if (!onRequest || req.method !== "POST") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () =>
+      onRequest(Buffer.concat(chunks).toString(), (status, payload) => {
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(payload);
+      }),
+    );
+  });
+  const wss = new WebSocketServer({ server, path: "/api/v1/agent/ws/client" });
+  wss.on("connection", (ws) => {
+    onSocket?.();
+    ws.on("message", (raw) => onFrame(JSON.parse(String(raw)) as { type: string; token?: string }, ws));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("missing local address");
+  return {
+    serverUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      for (const ws of wss.clients) ws.terminate();
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function acceptAuth(ws: WebSocket): void {
+  ws.send(
+    JSON.stringify({
+      type: "server:welcome",
+      serverCommandVersion: "0.0.0",
+      serverTimeMs: Date.now(),
+      capabilities: {},
+    }),
+  );
+  ws.send(JSON.stringify({ type: "auth:ok" }));
+}
+
+function rejectAuth(ws: WebSocket): void {
+  ws.send(JSON.stringify({ type: "auth:rejected", code: "invalid_token", message: "token rejected" }));
+  ws.close(4401, "authentication failed");
+}
+
+describe("ClientRuntime — paused-mode credential recovery", () => {
+  let home: string;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function stubHome(prefix: string): void {
+    home = mkdtempSync(join(tmpdir(), prefix));
+    vi.stubEnv("FIRST_TREE_HOME", home);
+    vi.stubEnv("FIRST_TREE_LOG_LEVEL", "error");
+  }
+
+  it("a login saved before the old handshake rejection still recovers without a second file change", async () => {
+    stubHome("ft-early-login-");
+    let authFrames = 0;
+    let registered = 0;
+    let serverUrl = "";
+    const harness = await serve((frame, ws) => {
+      if (frame.type === "auth" && ++authFrames === 1) {
+        // Operator login wins before the old server reply reaches the runtime.
+        saveCredentials({ serverUrl, accessToken: token("new"), refreshToken: "synthetic-new" });
+        setTimeout(() => rejectAuth(ws), 50);
+      } else if (frame.type === "auth") {
+        acceptAuth(ws);
+      } else if (frame.type === "client:register") {
+        registered++;
+        ws.send(JSON.stringify({ type: "client:registered" }));
+      }
+    });
+    serverUrl = harness.serverUrl;
+    saveCredentials({ serverUrl, accessToken: token("old"), refreshToken: "synthetic-old" });
+
+    const runtime = new ClientRuntime(serverUrl, "synthetic-early-login", { output: silentOutput });
+    let pauses = 0;
+    runtime.onAuthPaused(() => pauses++);
+    const starting = runtime.start().then(
+      () => "registered",
+      () => "rejected",
+    );
+    try {
+      const outcome = await Promise.race([starting, sleep(3_000).then(() => "still-pending")]);
+      expect(outcome).toBe("registered");
+      expect(registered).toBe(1);
+      expect(authFrames).toBe(2);
+      expect(pauses).toBe(1);
+    } finally {
+      await runtime.stop("synthetic race complete");
+      await starting;
+      await harness.close();
+    }
+  }, 15_000);
+
+  it("a login saved after the pause recovers through the real credentials watcher", async () => {
+    stubHome("ft-late-login-");
+    const oldToken = token("old");
+    const newToken = token("new");
+    let sockets = 0;
+    let authFrames = 0;
+    let registered = 0;
+    const harness = await serve(
+      (frame, ws) => {
+        if (frame.type === "auth") {
+          authFrames++;
+          if (frame.token === newToken) {
+            acceptAuth(ws);
+          } else {
+            rejectAuth(ws);
+          }
+        } else if (frame.type === "client:register") {
+          registered++;
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      },
+      () => sockets++,
+    );
+    const serverUrl = harness.serverUrl;
+    saveCredentials({ serverUrl, accessToken: oldToken, refreshToken: "synthetic-old" });
+
+    const runtime = new ClientRuntime(serverUrl, "synthetic-late-login", { output: silentOutput });
+    let pauses = 0;
+    runtime.onAuthPaused(() => pauses++);
+    const starting = runtime.start().then(
+      () => "registered",
+      () => "rejected",
+    );
+    try {
+      await waitFor(() => pauses === 1);
+      // The immediate post-pause reconciliation saw unchanged credentials:
+      // parked, with zero repeat socket/auth work.
+      await sleep(700);
+      expect(runtime.isPaused()).toBe(true);
+      expect(sockets).toBe(1);
+      expect(authFrames).toBe(1);
+
+      saveCredentials({ serverUrl, accessToken: newToken, refreshToken: "synthetic-new" });
+      const outcome = await Promise.race([starting, sleep(5_000).then(() => "still-pending")]);
+      expect(outcome).toBe("registered");
+      expect(registered).toBe(1);
+      expect(authFrames).toBe(2);
+      expect(pauses).toBe(1);
+    } finally {
+      await runtime.stop("synthetic test complete");
+      await starting;
+      await harness.close();
+    }
+  }, 15_000);
+
+  it("unchanged credentials stay parked across rejections until a real login arrives", async () => {
+    stubHome("ft-unchanged-parked-");
+    const goodToken = token("good");
+    let sockets = 0;
+    let authFrames = 0;
+    let registered = 0;
+    const harness = await serve(
+      (frame, ws) => {
+        if (frame.type === "auth") {
+          authFrames++;
+          if (frame.token === goodToken) {
+            acceptAuth(ws);
+          } else {
+            rejectAuth(ws);
+          }
+        } else if (frame.type === "client:register") {
+          registered++;
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      },
+      () => sockets++,
+    );
+    const serverUrl = harness.serverUrl;
+    const v1Creds = { serverUrl, accessToken: token("v1"), refreshToken: "synthetic-v1" };
+    const v2Creds = { serverUrl, accessToken: token("v2"), refreshToken: "synthetic-v2" };
+    saveCredentials(v1Creds);
+
+    const runtime = new ClientRuntime(serverUrl, "synthetic-unchanged-parked", { output: silentOutput });
+    let pauses = 0;
+    runtime.onAuthPaused(() => pauses++);
+    const starting = runtime.start().then(
+      () => "registered",
+      () => "rejected",
+    );
+    try {
+      await waitFor(() => pauses === 1);
+      await sleep(700);
+      expect(runtime.isPaused()).toBe(true);
+      expect(sockets).toBe(1);
+      expect(authFrames).toBe(1);
+
+      // Rewriting the identical file is not a credential change: still parked.
+      saveCredentials(v1Creds);
+      await sleep(700);
+      expect(sockets).toBe(1);
+      expect(authFrames).toBe(1);
+      expect(pauses).toBe(1);
+
+      // A login the server also rejects resumes exactly once, then parks again.
+      saveCredentials(v2Creds);
+      await waitFor(() => pauses === 2);
+      await sleep(700);
+      expect(runtime.isPaused()).toBe(true);
+      expect(sockets).toBe(2);
+      expect(authFrames).toBe(2);
+
+      // A file event matching the current failed authority cannot unpause it.
+      saveCredentials(v2Creds);
+      await sleep(700);
+      expect(sockets).toBe(2);
+      expect(authFrames).toBe(2);
+      expect(pauses).toBe(2);
+
+      // A genuine credential change recovers.
+      saveCredentials({ serverUrl, accessToken: goodToken, refreshToken: "synthetic-good" });
+      const outcome = await Promise.race([starting, sleep(5_000).then(() => "still-pending")]);
+      expect(outcome).toBe("registered");
+      expect(registered).toBe(1);
+      expect(sockets).toBe(3);
+      expect(authFrames).toBe(3);
+      expect(pauses).toBe(2);
+    } finally {
+      await runtime.stop("synthetic test complete");
+      await starting;
+      await harness.close();
+    }
+  }, 15_000);
+
+  it("a refresh-token failure parks and a later login recovers with the rotated token", async () => {
+    stubHome("ft-refresh-failed-");
+    const staleToken = `synthetic.${Buffer.from(
+      JSON.stringify({ sub: "synthetic-owner", jti: "stale", exp: 1 }),
+    ).toString("base64url")}.signature`;
+    const counts = { refresh401: 0, refresh200: 0, sockets: 0, registrations: 0 };
+    const harness = await serve(
+      (frame, ws) => {
+        if (frame.type === "auth") {
+          acceptAuth(ws);
+        } else if (frame.type === "client:register") {
+          counts.registrations++;
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      },
+      () => counts.sockets++,
+      (body, respond) => {
+        const refreshToken = (JSON.parse(body) as { refreshToken?: string }).refreshToken;
+        if (refreshToken === "synthetic-recovered") {
+          counts.refresh200++;
+          respond(200, JSON.stringify({ accessToken: token("rotated"), refreshToken: "synthetic-rotated" }));
+        } else {
+          counts.refresh401++;
+          respond(401);
+        }
+      },
+    );
+    const serverUrl = harness.serverUrl;
+    saveCredentials({ serverUrl, accessToken: staleToken, refreshToken: "synthetic-dead" });
+
+    const runtime = new ClientRuntime(serverUrl, "synthetic-refresh-failed", { output: silentOutput });
+    let pauses = 0;
+    runtime.onAuthPaused(() => pauses++);
+    const starting = runtime.start().then(
+      () => "registered",
+      () => "rejected",
+    );
+    try {
+      await waitFor(() => pauses === 1);
+      expect(runtime.pausedReason()).toBe("auth_refresh_failed");
+      // Unchanged credentials: parked, and the 401 latch keeps the failed
+      // authority from re-hitting the network.
+      await sleep(700);
+      expect(runtime.isPaused()).toBe(true);
+      expect(counts).toEqual({ refresh401: 1, refresh200: 0, sockets: 1, registrations: 0 });
+
+      saveCredentials({ serverUrl, accessToken: staleToken, refreshToken: "synthetic-recovered" });
+      const outcome = await Promise.race([starting, sleep(5_000).then(() => "still-pending")]);
+      expect(outcome).toBe("registered");
+      // The handshake used the token produced by the successful refresh —
+      // the refresh itself rotated and persisted the credentials first.
+      expect(counts.refresh200).toBe(1);
+      expect(counts.registrations).toBe(1);
+      expect(counts.sockets).toBe(2);
+      expect(pauses).toBe(1);
+    } finally {
+      await runtime.stop("synthetic test complete");
+      await starting;
+      await harness.close();
+    }
+  }, 15_000);
+});

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -414,9 +414,16 @@ describe("ClientRuntime context-tree wiring", () => {
     rt.onReconnect(reconnectStringBroken);
     const welcome = connectionListeners.get("server:welcome");
     if (!welcome) throw new Error("server:welcome listener missing");
+    const connected = connectionListeners.get("connected");
+    if (!connected) throw new Error("connected listener missing");
     welcome({ isReconnect: false });
+    connected();
     expect(reconnectOk).not.toHaveBeenCalled();
+    // A reconnect welcome only ARMS publication — the listeners fire on the
+    // registration boundary (`connected`), never on the welcome frame alone.
     welcome({ isReconnect: true });
+    expect(reconnectOk).not.toHaveBeenCalled();
+    connected();
     expect(reconnectOk).toHaveBeenCalled();
     expect(print.status).toHaveBeenCalledWith("⚠️", "reconnect handler error: probe failed");
     expect(print.status).toHaveBeenCalledWith("⚠️", "reconnect handler error: probe string failed");

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -69,6 +69,7 @@ const connectionMock = {
   emit: vi.fn(),
   isPaused: vi.fn(() => false),
   getPausedReason: vi.fn<() => ClientPausedReason | null>(() => null),
+  getAuthAttemptCredential: vi.fn<() => string | null>(() => null),
   clearPaused: vi.fn(),
   getMaxListeners: vi.fn(() => connectionMaxListeners),
   setMaxListeners: vi.fn((n: number) => {
@@ -119,6 +120,7 @@ vi.mock("@first-tree/client", () => {
       emit = connectionMock.emit;
       isPaused = connectionMock.isPaused;
       getPausedReason = connectionMock.getPausedReason;
+      getAuthAttemptCredential = connectionMock.getAuthAttemptCredential;
       clearPaused = connectionMock.clearPaused;
       getMaxListeners = connectionMock.getMaxListeners;
       setMaxListeners = connectionMock.setMaxListeners;
@@ -186,6 +188,8 @@ describe("ClientRuntime context-tree wiring", () => {
     connectionMock.isPaused.mockReturnValue(false);
     connectionMock.getPausedReason.mockReset();
     connectionMock.getPausedReason.mockReturnValue(null);
+    connectionMock.getAuthAttemptCredential.mockReset();
+    connectionMock.getAuthAttemptCredential.mockReturnValue(null);
     connectionMock.clearPaused.mockClear();
     connectionMaxListeners = 10;
     connectionMock.getMaxListeners.mockClear();
@@ -1220,9 +1224,13 @@ describe("ClientRuntime context-tree wiring", () => {
     expect(watchMockProbe).toBe(fsWatchMocks.watch);
     const { ClientRuntime } = await import("../core/client-runtime.js");
     mkdirSync(join(home, "config"), { recursive: true });
-    writeFileSync(join(home, "config", "credentials.json"), JSON.stringify({ refreshToken: "old" }));
+    const oldCredentials = JSON.stringify({ refreshToken: "old" });
+    writeFileSync(join(home, "config", "credentials.json"), oldCredentials);
     const rt = new ClientRuntime("https://hub.test", "client-test");
     connectionMock.isPaused.mockReturnValue(true);
+    connectionMock.getPausedReason.mockReturnValue("auth_refresh_failed");
+    // The paused attempt used the credentials currently on disk.
+    connectionMock.getAuthAttemptCredential.mockReturnValue(oldCredentials);
 
     const paused = connectionListeners.get("auth:paused");
     if (!paused) throw new Error("auth:paused listener missing");

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -1,6 +1,7 @@
 import { watch as importedWatch, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import type { AuthAttemptCredential } from "@first-tree/client";
 import type { ClientPausedReason } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -69,7 +70,7 @@ const connectionMock = {
   emit: vi.fn(),
   isPaused: vi.fn(() => false),
   getPausedReason: vi.fn<() => ClientPausedReason | null>(() => null),
-  getAuthAttemptCredential: vi.fn<() => string | null>(() => null),
+  getAuthAttemptCredential: vi.fn<() => AuthAttemptCredential | null>(() => null),
   clearPaused: vi.fn(),
   getMaxListeners: vi.fn(() => connectionMaxListeners),
   setMaxListeners: vi.fn((n: number) => {
@@ -144,7 +145,8 @@ vi.mock("@first-tree/client", () => {
   };
 });
 
-vi.mock("../core/bootstrap.js", () => ({
+vi.mock("../core/bootstrap.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../core/bootstrap.js")>()),
   ensureFreshAccessToken: vi.fn(async () => "tok-test"),
 }));
 
@@ -416,19 +418,18 @@ describe("ClientRuntime context-tree wiring", () => {
     rt.onReconnect(reconnectOk);
     rt.onReconnect(reconnectBroken);
     rt.onReconnect(reconnectStringBroken);
-    const welcome = connectionListeners.get("server:welcome");
-    if (!welcome) throw new Error("server:welcome listener missing");
+    const registered = vi.fn();
+    rt.onRegistered(registered);
     const connected = connectionListeners.get("connected");
     if (!connected) throw new Error("connected listener missing");
-    welcome({ isReconnect: false });
+    // Welcome is irrelevant to registration readiness, including failed handshakes.
+    expect(connectionListeners.has("server:welcome")).toBe(false);
     connected();
     expect(reconnectOk).not.toHaveBeenCalled();
-    // A reconnect welcome only ARMS publication — the listeners fire on the
-    // registration boundary (`connected`), never on the welcome frame alone.
-    welcome({ isReconnect: true });
-    expect(reconnectOk).not.toHaveBeenCalled();
+    expect(registered).toHaveBeenLastCalledWith(false);
     connected();
     expect(reconnectOk).toHaveBeenCalled();
+    expect(registered).toHaveBeenLastCalledWith(true);
     expect(print.status).toHaveBeenCalledWith("⚠️", "reconnect handler error: probe failed");
     expect(print.status).toHaveBeenCalledWith("⚠️", "reconnect handler error: probe string failed");
 
@@ -1224,20 +1225,30 @@ describe("ClientRuntime context-tree wiring", () => {
     expect(watchMockProbe).toBe(fsWatchMocks.watch);
     const { ClientRuntime } = await import("../core/client-runtime.js");
     mkdirSync(join(home, "config"), { recursive: true });
-    const oldCredentials = JSON.stringify({ refreshToken: "old" });
+    const oldCredentials = JSON.stringify({
+      serverUrl: "https://hub.test",
+      accessToken: "access",
+      refreshToken: "old",
+    });
     writeFileSync(join(home, "config", "credentials.json"), oldCredentials);
     const rt = new ClientRuntime("https://hub.test", "client-test");
     connectionMock.isPaused.mockReturnValue(true);
     connectionMock.getPausedReason.mockReturnValue("auth_refresh_failed");
     // The paused attempt used the credentials currently on disk.
-    connectionMock.getAuthAttemptCredential.mockReturnValue(oldCredentials);
+    connectionMock.getAuthAttemptCredential.mockReturnValue({
+      kind: "credential_snapshot",
+      value: JSON.stringify([join(home, "config", "credentials.json"), "https://hub.test", "access", "old"]),
+    });
 
     const paused = connectionListeners.get("auth:paused");
     if (!paused) throw new Error("auth:paused listener missing");
     paused("auth_refresh_failed", new Error("refresh rejected"));
     paused("auth_refresh_failed", new Error("refresh rejected again"));
     fsWatchMocks.state.callback("rename", "ignored.txt");
-    writeFileSync(join(home, "config", "credentials.json"), JSON.stringify({ refreshToken: "new" }));
+    writeFileSync(
+      join(home, "config", "credentials.json"),
+      JSON.stringify({ serverUrl: "https://hub.test", accessToken: "access", refreshToken: "new" }),
+    );
     if (!fsWatchMocks.state.registered) throw new Error("credentials watcher callback missing");
     fsWatchMocks.state.callback("change", "credentials.json");
     fsWatchMocks.state.callback("change", null);
@@ -1247,12 +1258,13 @@ describe("ClientRuntime context-tree wiring", () => {
 
     const runtimeProbe = rt as unknown as {
       credentialsDebounce: ReturnType<typeof setTimeout> | null;
-      readCredentialsSnapshot(path: string): string | null;
+      readCredentialsSnapshot(): string | null;
       readAgentYamlRecord(name: string): Record<string, unknown>;
       scanForNewAgents(agentsDir: string): void;
     };
     runtimeProbe.credentialsDebounce = setTimeout(() => undefined, 10_000);
-    expect(runtimeProbe.readCredentialsSnapshot(join(home, "config", "missing.json"))).toBeNull();
+    writeFileSync(join(home, "config", "credentials.json"), "invalid JSON");
+    expect(runtimeProbe.readCredentialsSnapshot()).toBeNull();
     expect(runtimeProbe.readAgentYamlRecord("missing")).toEqual({});
     mkdirSync(join(home, "config", "agents", "array-yaml"), { recursive: true });
     writeFileSync(join(home, "config", "agents", "array-yaml", "agent.yaml"), "[]\n");

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -104,7 +104,7 @@ let runtimeInstance: {
   stop: ReturnType<typeof vi.fn>;
   unwatchAgentsDir: ReturnType<typeof vi.fn>;
   watchAgentsDir: ReturnType<typeof vi.fn>;
-  onReconnect: ReturnType<typeof vi.fn>;
+  onRegistered: ReturnType<typeof vi.fn>;
   onAuthPaused: ReturnType<typeof vi.fn>;
   onRuntimeAuthStart: ReturnType<typeof vi.fn>;
   onProviderModelsList: ReturnType<typeof vi.fn>;
@@ -113,11 +113,9 @@ let runtimeInstance: {
   isPaused: ReturnType<typeof vi.fn>;
 };
 let refresherInstance: {
-  start: ReturnType<typeof vi.fn>;
-  onReconnect: ReturnType<typeof vi.fn>;
+  onRegistered: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
   pause: ReturnType<typeof vi.fn>;
-  resume: ReturnType<typeof vi.fn>;
   isInteractive: ReturnType<typeof vi.fn>;
   beginInteractive: ReturnType<typeof vi.fn>;
   endInteractive: ReturnType<typeof vi.fn>;
@@ -232,13 +230,13 @@ beforeEach(() => {
 
   runtimeInstance = {
     addAgent: vi.fn(),
-    start: vi.fn(async () => undefined),
+    start: vi.fn(async () => runtimeInstance.onRegistered.mock.calls[0]?.[0](false)),
     stop: vi.fn(async () => undefined),
     unwatchAgentsDir: vi.fn(),
     watchAgentsDir: vi.fn(() => {
       throw new Error("stop after watch");
     }),
-    onReconnect: vi.fn(),
+    onRegistered: vi.fn(),
     onAuthPaused: vi.fn(),
     onRuntimeAuthStart: vi.fn(),
     onProviderModelsList: vi.fn(),
@@ -249,11 +247,9 @@ beforeEach(() => {
   coreMocks.ClientRuntime.mockImplementation(() => runtimeInstance);
 
   refresherInstance = {
-    start: vi.fn(async () => undefined),
-    onReconnect: vi.fn(),
+    onRegistered: vi.fn(),
     stop: vi.fn(),
     pause: vi.fn(),
-    resume: vi.fn(),
     isInteractive: vi.fn(() => false),
     beginInteractive: vi.fn(),
     endInteractive: vi.fn(),
@@ -609,9 +605,9 @@ describe("daemon start command", () => {
       expect.objectContaining({ upload: expect.any(Function), log: expect.any(Function) }),
     );
     expect(coreMocks.CapabilityRefresher.mock.calls[0]?.[0]).not.toHaveProperty("initial");
-    expect(runtimeInstance.onReconnect).toHaveBeenCalledWith(expect.any(Function));
+    expect(runtimeInstance.onRegistered).toHaveBeenCalledWith(expect.any(Function));
     expect(runtimeInstance.onProviderModelsList).toHaveBeenCalledWith(expect.any(Function));
-    expect(refresherInstance.start).toHaveBeenCalled();
+    expect(refresherInstance.onRegistered).toHaveBeenCalledExactlyOnceWith(false);
     expect(coreMocks.listPinnedAgents).toHaveBeenCalledWith({
       serverUrl: "https://first-tree.example",
       accessToken: "access-token",
@@ -712,18 +708,15 @@ describe("daemon start command", () => {
     expect(output()).toContain("manual log check");
   });
 
-  it("routes the runtime's reconnect callback into the capability refresher", async () => {
+  it("routes initial and later registrations into the capability refresher", async () => {
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
 
-    // start.ts no longer re-probes inline; it hands the runtime's reconnect
-    // signal to the refresher (whose probe/upload/dedup behavior is covered by
-    // capability-refresh.test.ts).
-    const reconnect = runtimeInstance.onReconnect.mock.calls[0]?.[0];
-    if (typeof reconnect !== "function") throw new Error("Reconnect callback was not registered");
+    const registered = runtimeInstance.onRegistered.mock.calls[0]?.[0];
+    if (typeof registered !== "function") throw new Error("Registration callback was not registered");
 
-    expect(refresherInstance.onReconnect).not.toHaveBeenCalled();
-    reconnect();
-    expect(refresherInstance.onReconnect).toHaveBeenCalledTimes(1);
+    expect(refresherInstance.onRegistered).toHaveBeenCalledExactlyOnceWith(false);
+    registered(true);
+    expect(refresherInstance.onRegistered.mock.calls).toEqual([[false], [true]]);
   });
 
   it("serializes runtime-auth login requests per provider", async () => {
@@ -771,6 +764,7 @@ describe("daemon start command", () => {
 
   it("publishes a runtime-verified Codex selection through the live capability refresher", async () => {
     runtimeInstance.start.mockImplementationOnce(async () => {
+      runtimeInstance.onRegistered.mock.calls[0]?.[0](false);
       codexCandidateChangeListener?.();
     });
 
@@ -779,7 +773,7 @@ describe("daemon start command", () => {
 
     expect(clientMocks.onCodexVerifiedAutomaticCandidateChange).toHaveBeenCalledTimes(1);
     expect(clientMocks.probeCodexCapability).toHaveBeenCalledTimes(1);
-    expect(refresherInstance.start).toHaveBeenCalledTimes(1);
+    expect(refresherInstance.onRegistered).toHaveBeenCalledExactlyOnceWith(false);
     expect(refresherInstance.setProviderEntry).toHaveBeenCalledWith(
       "codex",
       expect.objectContaining({
@@ -1193,32 +1187,19 @@ describe("daemon start command", () => {
     onAuthPaused();
     expect(refresherInstance.pause).toHaveBeenCalledTimes(1);
 
-    // The gate opens only AFTER runtime.start() resolved (the initial
-    // registration): resume first, then start() — while gated, start() is a
-    // no-op by design.
-    expect(refresherInstance.resume).toHaveBeenCalledTimes(1);
-    expect(refresherInstance.start).toHaveBeenCalledTimes(1);
-    expect(refresherInstance.resume.mock.invocationCallOrder[0]).toBeGreaterThan(
-      runtimeInstance.start.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY,
+    expect(runtimeInstance.onRegistered.mock.invocationCallOrder[0]).toBeLessThan(
+      runtimeInstance.start.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
-    expect(refresherInstance.resume.mock.invocationCallOrder[0]).toBeLessThan(
-      refresherInstance.start.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    );
-
-    // Re-registration path: the onReconnect callback ungates THEN refreshes,
-    // in that order (an onReconnect on a still-gated refresher would no-op).
-    const onReconnect = runtimeInstance.onReconnect.mock.calls[0]?.[0] as () => void;
-    refresherInstance.resume.mockClear();
-    onReconnect();
-    expect(refresherInstance.resume).toHaveBeenCalledTimes(1);
-    expect(refresherInstance.onReconnect).toHaveBeenCalledTimes(1);
-    expect(refresherInstance.resume.mock.invocationCallOrder[0]).toBeLessThan(
-      refresherInstance.onReconnect.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    );
+    expect(refresherInstance.onRegistered).toHaveBeenCalledExactlyOnceWith(false);
+    const onRegistered = runtimeInstance.onRegistered.mock.calls[0]?.[0] as (isReconnect: boolean) => void;
+    onRegistered(true);
+    expect(refresherInstance.onRegistered.mock.calls).toEqual([[false], [true]]);
   });
 
   it("keeps capability work paused when authentication fails during startup", async () => {
     runtimeInstance.start.mockImplementationOnce(async () => {
+      // Registration completes, then auth fails while agents are starting.
+      runtimeInstance.onRegistered.mock.calls[0]?.[0](false);
       runtimeInstance.isPaused.mockReturnValue(true);
       const onAuthPaused = runtimeInstance.onAuthPaused.mock.calls[0]?.[0] as () => void;
       onAuthPaused();
@@ -1227,14 +1208,15 @@ describe("daemon start command", () => {
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
 
     expect(refresherInstance.pause).toHaveBeenCalledOnce();
-    expect(refresherInstance.resume).not.toHaveBeenCalled();
-    expect(refresherInstance.start).not.toHaveBeenCalled();
+    expect(refresherInstance.onRegistered).toHaveBeenCalledExactlyOnceWith(false);
+    expect(refresherInstance.onRegistered.mock.invocationCallOrder[0]).toBeLessThan(
+      refresherInstance.pause.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
 
     runtimeInstance.isPaused.mockReturnValue(false);
-    const onReconnect = runtimeInstance.onReconnect.mock.calls[0]?.[0] as () => void;
-    onReconnect();
-    expect(refresherInstance.resume).toHaveBeenCalledOnce();
-    expect(refresherInstance.onReconnect).toHaveBeenCalledOnce();
+    const onRegistered = runtimeInstance.onRegistered.mock.calls[0]?.[0] as (isReconnect: boolean) => void;
+    onRegistered(true);
+    expect(refresherInstance.onRegistered.mock.calls).toEqual([[false], [true]]);
   });
 
   it("runs graceful shutdown when SIGTERM arrives during the pending auth-paused initial start", async () => {

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -105,15 +105,19 @@ let runtimeInstance: {
   unwatchAgentsDir: ReturnType<typeof vi.fn>;
   watchAgentsDir: ReturnType<typeof vi.fn>;
   onReconnect: ReturnType<typeof vi.fn>;
+  onAuthPaused: ReturnType<typeof vi.fn>;
   onRuntimeAuthStart: ReturnType<typeof vi.fn>;
   onProviderModelsList: ReturnType<typeof vi.fn>;
   sendProviderModelsResult: ReturnType<typeof vi.fn>;
   emitConnectionResilienceEvent: ReturnType<typeof vi.fn>;
+  isPaused: ReturnType<typeof vi.fn>;
 };
 let refresherInstance: {
   start: ReturnType<typeof vi.fn>;
   onReconnect: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
   isInteractive: ReturnType<typeof vi.fn>;
   beginInteractive: ReturnType<typeof vi.fn>;
   endInteractive: ReturnType<typeof vi.fn>;
@@ -235,10 +239,12 @@ beforeEach(() => {
       throw new Error("stop after watch");
     }),
     onReconnect: vi.fn(),
+    onAuthPaused: vi.fn(),
     onRuntimeAuthStart: vi.fn(),
     onProviderModelsList: vi.fn(),
     sendProviderModelsResult: vi.fn(),
     emitConnectionResilienceEvent: vi.fn(),
+    isPaused: vi.fn(() => false),
   };
   coreMocks.ClientRuntime.mockImplementation(() => runtimeInstance);
 
@@ -246,6 +252,8 @@ beforeEach(() => {
     start: vi.fn(async () => undefined),
     onReconnect: vi.fn(),
     stop: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
     isInteractive: vi.fn(() => false),
     beginInteractive: vi.fn(),
     endInteractive: vi.fn(),
@@ -1166,6 +1174,106 @@ describe("daemon start command", () => {
 
     expect(output()).toContain("skills upload pin check skipped: pin check failed as string");
     expect(output()).toContain("skills upload for nova skipped: agent skill upload failed as string");
+  });
+
+  it("gates capability refresh on auth pause, ungating only after a successful registration", async () => {
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    // The pause wiring must be attached before `runtime.start()` — an auth
+    // pause during the initial connect (dead refresh token at boot) fires
+    // before start resolves, and a late-registered listener would miss it.
+    expect(runtimeInstance.onAuthPaused).toHaveBeenCalledWith(expect.any(Function));
+    expect(runtimeInstance.onAuthPaused.mock.invocationCallOrder[0]).toBeLessThan(
+      runtimeInstance.start.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    // NOTE: the mock has no `onAuthResumed` — if start.ts wired it, every
+    // test here would throw. Fresh credentials alone must not ungate.
+
+    const onAuthPaused = runtimeInstance.onAuthPaused.mock.calls[0]?.[0] as () => void;
+    onAuthPaused();
+    expect(refresherInstance.pause).toHaveBeenCalledTimes(1);
+
+    // The gate opens only AFTER runtime.start() resolved (the initial
+    // registration): resume first, then start() — while gated, start() is a
+    // no-op by design.
+    expect(refresherInstance.resume).toHaveBeenCalledTimes(1);
+    expect(refresherInstance.start).toHaveBeenCalledTimes(1);
+    expect(refresherInstance.resume.mock.invocationCallOrder[0]).toBeGreaterThan(
+      runtimeInstance.start.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY,
+    );
+    expect(refresherInstance.resume.mock.invocationCallOrder[0]).toBeLessThan(
+      refresherInstance.start.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+
+    // Re-registration path: the onReconnect callback ungates THEN refreshes,
+    // in that order (an onReconnect on a still-gated refresher would no-op).
+    const onReconnect = runtimeInstance.onReconnect.mock.calls[0]?.[0] as () => void;
+    refresherInstance.resume.mockClear();
+    onReconnect();
+    expect(refresherInstance.resume).toHaveBeenCalledTimes(1);
+    expect(refresherInstance.onReconnect).toHaveBeenCalledTimes(1);
+    expect(refresherInstance.resume.mock.invocationCallOrder[0]).toBeLessThan(
+      refresherInstance.onReconnect.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("runs graceful shutdown when SIGTERM arrives during the pending auth-paused initial start", async () => {
+    const signalHandlers = new Map<string, () => void>();
+    const onSpy = vi.spyOn(process, "on").mockImplementation((event, listener) => {
+      if (event === "SIGINT" || event === "SIGTERM") {
+        signalHandlers.set(event, listener as () => void);
+      }
+      return process;
+    });
+    // runtime.start() stays pending — the connection is parked on auth pause.
+    let rejectStart!: (err: Error) => void;
+    runtimeInstance.start.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectStart = reject;
+        }),
+    );
+    // In production stop() → disconnect() aborts the parked connect, which
+    // rejects start() with the auth error. Mirror that causal link here.
+    runtimeInstance.stop.mockImplementationOnce(async () => {
+      rejectStart(new Error("Refresh token rejected by server."));
+    });
+    exitSpy.mockImplementation((() => undefined) as never);
+
+    try {
+      const start = runStart(["--foreground"]);
+      // Handlers are installed BEFORE the initial start() wait, so they
+      // exist even though startup is still parked.
+      await waitForAsyncWork(() => signalHandlers.has("SIGTERM"));
+
+      signalHandlers.get("SIGTERM")?.();
+      // The startup wait settles cleanly — no exit-1 startup failure.
+      await start;
+
+      expect(runtimeInstance.stop).toHaveBeenCalledTimes(1);
+      expect(refresherInstance.stop).toHaveBeenCalledTimes(1);
+      // Exactly one ownership release (the finally's is null-guarded).
+      expect(runtimeOwnershipRelease).toHaveBeenCalledTimes(1);
+      expect(coreMocks.registerClientRuntimeMarker.mock.results[0]?.value).toHaveBeenCalled();
+      // No Sentry startup error and no supervisor-triggering exit(1).
+      expect(clientMocks.captureClientException).not.toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(exitSpy).not.toHaveBeenCalledWith(1);
+      expect(output()).not.toContain("Error: Refresh token rejected");
+    } finally {
+      onSpy.mockRestore();
+    }
+  });
+
+  it("keeps a paused start() rejection a failure when no shutdown was requested", async () => {
+    // Paused state alone is NOT shutdown evidence: without a signal, the
+    // rejection is a real startup failure and must keep failing loudly.
+    runtimeInstance.start.mockRejectedValueOnce(new Error("Refresh token rejected by server."));
+    runtimeInstance.isPaused.mockReturnValueOnce(true);
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(output()).toContain("Error: Refresh token rejected by server.");
   });
 
   it("stringifies non-Error inline startup failures", async () => {

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -1217,6 +1217,26 @@ describe("daemon start command", () => {
     );
   });
 
+  it("keeps capability work paused when authentication fails during startup", async () => {
+    runtimeInstance.start.mockImplementationOnce(async () => {
+      runtimeInstance.isPaused.mockReturnValue(true);
+      const onAuthPaused = runtimeInstance.onAuthPaused.mock.calls[0]?.[0] as () => void;
+      onAuthPaused();
+    });
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(refresherInstance.pause).toHaveBeenCalledOnce();
+    expect(refresherInstance.resume).not.toHaveBeenCalled();
+    expect(refresherInstance.start).not.toHaveBeenCalled();
+
+    runtimeInstance.isPaused.mockReturnValue(false);
+    const onReconnect = runtimeInstance.onReconnect.mock.calls[0]?.[0] as () => void;
+    onReconnect();
+    expect(refresherInstance.resume).toHaveBeenCalledOnce();
+    expect(refresherInstance.onReconnect).toHaveBeenCalledOnce();
+  });
+
   it("runs graceful shutdown when SIGTERM arrives during the pending auth-paused initial start", async () => {
     const signalHandlers = new Map<string, () => void>();
     const onSpy = vi.spyOn(process, "on").mockImplementation((event, listener) => {

--- a/apps/cli/src/__tests__/ensure-fresh-access-token.test.ts
+++ b/apps/cli/src/__tests__/ensure-fresh-access-token.test.ts
@@ -375,6 +375,692 @@ describe("ensureFreshAccessToken — safety margin", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("latches a terminal 401: repeated same-credential calls fail fast without new HTTP requests", async () => {
+    // Staging incident containment: with a dead refresh token, every
+    // sequential caller (WS reconnect loop, SDK requests, proactive refresh)
+    // used to fire its own /auth/refresh round-trip. After the first 401 the
+    // credential authority is known-terminal, so further calls must raise the
+    // same AuthRefreshFailedError immediately, without touching the network.
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
+    await writeCredentials(stale);
+
+    fetchMock.mockResolvedValue(new Response(null, { status: 401 }));
+
+    const { ensureFreshAccessToken, AuthRefreshFailedError } = await import("../core/bootstrap.js");
+    for (let i = 0; i < 5; i++) {
+      await expect(ensureFreshAccessToken()).rejects.toThrow(AuthRefreshFailedError);
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The latched error must not leak credential material.
+    const err = await ensureFreshAccessToken().catch((caught) => caught);
+    expect(err).toBeInstanceOf(AuthRefreshFailedError);
+    expect((err as Error).message).not.toContain("refresh-xyz");
+    expect((err as Error).message).toMatch(/Re-run `first-tree-dev login/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one 401 round-trip across concurrent callers and latches afterwards", async () => {
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
+    await writeCredentials(stale);
+
+    let releaseFetch: (res: Response) => void = () => {};
+    fetchMock.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        releaseFetch = resolve;
+      }),
+    );
+
+    const { ensureFreshAccessToken, AuthRefreshFailedError } = await import("../core/bootstrap.js");
+    const calls = [
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+    ];
+    releaseFetch(new Response(null, { status: 401 }));
+    for (const call of calls) {
+      await expect(call).rejects.toThrow(AuthRefreshFailedError);
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // After the shared attempt settles, the latch must reject new callers
+    // without any additional HTTP request.
+    await expect(ensureFreshAccessToken()).rejects.toThrow(AuthRefreshFailedError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers when the persisted refresh token changes after a latched 401", async () => {
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
+    const refreshed = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+    const { ensureFreshAccessToken, AuthRefreshFailedError, saveCredentials } = await import("../core/bootstrap.js");
+    await expect(ensureFreshAccessToken()).rejects.toThrow(AuthRefreshFailedError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Operator re-logs-in: new credential authority must not inherit the old
+    // latch, even though the access token inside is equally stale.
+    saveCredentials({ accessToken: stale, refreshToken: "refresh-new", serverUrl: "http://first-tree.test" });
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: refreshed })));
+
+    await expect(ensureFreshAccessToken()).resolves.toBe(refreshed);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers when the server URL changes after a latched 401", async () => {
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
+    const refreshed = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+    const { ensureFreshAccessToken, AuthRefreshFailedError, saveCredentials } = await import("../core/bootstrap.js");
+    await expect(ensureFreshAccessToken()).rejects.toThrow(AuthRefreshFailedError);
+
+    saveCredentials({ accessToken: stale, refreshToken: "refresh-xyz", serverUrl: "http://other-server.test" });
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: refreshed })));
+
+    await expect(ensureFreshAccessToken()).resolves.toBe(refreshed);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "http://other-server.test/api/v1/auth/refresh",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("does not let an obsolete in-flight 401 suppress recovery with new credentials", async () => {
+    // A refresh for authority A is in flight; the operator re-logs-in
+    // (authority B) before A's 401 lands. A's terminal failure must not latch
+    // authority B — and must not reach the caller as a terminal
+    // AuthRefreshFailedError either, because the WS layer pauses on that
+    // error AFTER B's file-change event, hanging recovery. The superseded
+    // request fails non-terminally; the next call with B reaches the network.
+    const stale = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) - 60 });
+    const staleB = makeJwt({ sub: "user-b", exp: Math.floor(Date.now() / 1000) - 60 });
+    const refreshed = makeJwt({ sub: "user-b", exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+
+    let releaseFirst: (res: Response) => void = () => {};
+    fetchMock
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          releaseFirst = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: refreshed })));
+
+    const {
+      ensureFreshAccessToken,
+      AuthRefreshFailedError,
+      AuthRefreshSupersededError,
+      loadCredentials,
+      saveCredentials,
+    } = await import("../core/bootstrap.js");
+    const obsolete = ensureFreshAccessToken();
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Re-login replaces the credential authority mid-flight.
+    saveCredentials({ accessToken: staleB, refreshToken: "refresh-new", serverUrl: "http://first-tree.test" });
+
+    // A's 401 arrives after the replacement: non-terminal, and B's file is
+    // not touched.
+    releaseFirst(new Response(null, { status: 401 }));
+    const err = await obsolete.catch((caught) => caught);
+    expect(err).toBeInstanceOf(AuthRefreshSupersededError);
+    expect(err).not.toBeInstanceOf(AuthRefreshFailedError);
+    expect(loadCredentials()).toMatchObject({ accessToken: staleB, refreshToken: "refresh-new" });
+
+    // The new authority recovers immediately, with exactly one more call.
+    await expect(ensureFreshAccessToken()).resolves.toBe(refreshed);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let an obsolete in-flight success overwrite freshly persisted credentials", async () => {
+    const stale = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) - 60 });
+    const obsoleteAccess = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) + 1800 });
+    const freshAccess = makeJwt({ sub: "user-b", exp: Math.floor(Date.now() / 1000) + 2400 });
+    await writeCredentials(stale);
+
+    let releaseFirst: (res: Response) => void = () => {};
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        releaseFirst = resolve;
+      }),
+    );
+
+    const { ensureFreshAccessToken, AuthRefreshSupersededError, loadCredentials, saveCredentials } = await import(
+      "../core/bootstrap.js"
+    );
+    const obsolete = ensureFreshAccessToken();
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Re-login persists a completely new authority while A's refresh hangs.
+    saveCredentials({ accessToken: freshAccess, refreshToken: "refresh-new", serverUrl: "http://first-tree.test" });
+
+    // A's success arrives late: it must not clobber the fresh authority,
+    // and the old caller must not receive either authority's credentials —
+    // the replacement may be a different user.
+    releaseFirst(new Response(JSON.stringify({ accessToken: obsoleteAccess, refreshToken: "rotated-old" })));
+    await expect(obsolete).rejects.toThrow(AuthRefreshSupersededError);
+
+    const persisted = loadCredentials();
+    expect(persisted?.refreshToken).toBe("refresh-new");
+    expect(persisted?.accessToken).toBe(freshAccess);
+    // No follow-up refresh may be needed — the fresh token is returned as-is.
+    await expect(ensureFreshAccessToken()).resolves.toBe(freshAccess);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not latch transient HTTP failures — the next call retries the network", async () => {
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
+    const refreshed = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: refreshed })));
+
+    const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
+    const first = await ensureFreshAccessToken().catch((caught) => caught);
+    expect(first).toMatchObject({ name: "AuthRefreshHttpError", statusCode: 503 });
+
+    await expect(ensureFreshAccessToken()).resolves.toBe(refreshed);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not latch caller cancellation — the next call retries the network", async () => {
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 });
+    const refreshed = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+
+    let refreshSignal: AbortSignal | undefined;
+    fetchMock
+      .mockImplementationOnce(
+        (_input: string | URL | Request, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            refreshSignal = init?.signal ?? undefined;
+            refreshSignal?.addEventListener(
+              "abort",
+              () => reject(refreshSignal?.reason ?? new DOMException("This operation was aborted", "AbortError")),
+              { once: true },
+            );
+          }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: refreshed })));
+
+    const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
+    const caller = new AbortController();
+    const cancelled = ensureFreshAccessToken({ signal: caller.signal });
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    caller.abort(new DOMException("The operation timed out", "TimeoutError"));
+    await expect(cancelled).rejects.toMatchObject({ name: "TimeoutError" });
+
+    await expect(ensureFreshAccessToken()).resolves.toBe(refreshed);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  for (const status of [401, 200] as const) {
+    it(`an obsolete late ${status} fails non-terminally and never pauses the new login`, async () => {
+      // Mirrors the parent's independent login-fence probe: with a fresh
+      // login already persisted, an obsolete in-flight response must fail
+      // NON-terminally (never AuthRefreshFailedError, which pauses the WS
+      // layer) and never hand the new authority's credentials to the old
+      // caller — the replacement may be a different user. The new
+      // credentials file stays untouched and the next call recovers.
+      const stale = makeJwt({ sub: "old-user", exp: 1 });
+      const oldFresh = makeJwt({ sub: "old-user", exp: Math.floor(Date.now() / 1000) + 3600 });
+      const newFresh = makeJwt({ sub: "new-user", exp: Math.floor(Date.now() / 1000) + 3600 });
+      await writeCredentials(stale); // RT "refresh-xyz", authority A
+
+      let release: (res: Response) => void = () => {};
+      fetchMock.mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          release = resolve;
+        }),
+      );
+
+      const {
+        ensureFreshAccessToken,
+        AuthRefreshFailedError,
+        AuthRefreshSupersededError,
+        loadCredentials,
+        saveCredentials,
+      } = await import("../core/bootstrap.js");
+      const pending = ensureFreshAccessToken();
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      // New login lands while A's request is in flight.
+      saveCredentials({ accessToken: newFresh, refreshToken: "synthetic-new", serverUrl: "http://first-tree.test" });
+      release(
+        new Response(
+          status === 200 ? JSON.stringify({ accessToken: oldFresh, refreshToken: "synthetic-old-rotated" }) : null,
+          { status },
+        ),
+      );
+
+      const err = await pending.catch((caught) => caught);
+      expect(err).toBeInstanceOf(AuthRefreshSupersededError);
+      expect(err).not.toBeInstanceOf(AuthRefreshFailedError);
+      expect(loadCredentials()).toMatchObject({ accessToken: newFresh, refreshToken: "synthetic-new" });
+      await expect(ensureFreshAccessToken()).resolves.toBe(newFresh);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  for (const status of [401, 200] as const) {
+    it(`an obsolete late ${status} never hands a different home/server's token to the old caller`, async () => {
+      // Cross-authority replacement: the credentials file now points at a
+      // DIFFERENT server. Even though the persisted token is fresh, it must
+      // not leak to the caller that asked about the old server — the safest
+      // result is the non-terminal superseded error; recovery proceeds
+      // normally afterwards.
+      const stale = makeJwt({ sub: "old-user", exp: 1 });
+      const oldFresh = makeJwt({ sub: "old-user", exp: Math.floor(Date.now() / 1000) + 3600 });
+      const newFresh = makeJwt({ sub: "new-user", exp: Math.floor(Date.now() / 1000) + 3600 });
+      writeFileSync(
+        join(testHome, "config", "credentials.json"),
+        JSON.stringify({ accessToken: stale, refreshToken: "synthetic-old", serverUrl: "http://old.first-tree.test" }),
+      );
+
+      let release: (res: Response) => void = () => {};
+      fetchMock.mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          release = resolve;
+        }),
+      );
+
+      const { ensureFreshAccessToken, AuthRefreshFailedError, AuthRefreshSupersededError, loadCredentials } =
+        await import("../core/bootstrap.js");
+      const pending = ensureFreshAccessToken();
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      writeFileSync(
+        join(testHome, "config", "credentials.json"),
+        JSON.stringify({
+          accessToken: newFresh,
+          refreshToken: "synthetic-new",
+          serverUrl: "http://new.first-tree.test",
+        }),
+      );
+      release(
+        new Response(
+          status === 200 ? JSON.stringify({ accessToken: oldFresh, refreshToken: "synthetic-old-rotated" }) : null,
+          { status },
+        ),
+      );
+
+      const err = await pending.catch((caught) => caught);
+      expect(err).toBeInstanceOf(AuthRefreshSupersededError);
+      expect(err).not.toBeInstanceOf(AuthRefreshFailedError);
+      expect(loadCredentials()).toMatchObject({ serverUrl: "http://new.first-tree.test", accessToken: newFresh });
+      await expect(ensureFreshAccessToken()).resolves.toBe(newFresh);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  it("gives a same-RT login with a stale access token its own flight, and the old completion cannot clear or poison it", async () => {
+    // Join-predicate regression: the flight join checks the access-token
+    // snapshot, not just home/server/refreshToken. A new login that keeps
+    // the same RT but installs a (stale) access token must NOT join the
+    // superseded flight — it gets its own HTTP call immediately, and the
+    // old flight's settle can neither clear the slot nor latch the shared RT.
+    const staleA = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) - 60 });
+    const staleB = makeJwt({ sub: "user-b", exp: Math.floor(Date.now() / 1000) - 60 });
+    const refreshedB = makeJwt({ sub: "user-b", exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(staleA); // RT "refresh-xyz"
+
+    const releases: Array<(res: Response) => void> = [];
+    fetchMock.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          releases.push(resolve);
+        }),
+    );
+
+    const { ensureFreshAccessToken, AuthRefreshSupersededError, saveCredentials } = await import(
+      "../core/bootstrap.js"
+    );
+    const callA = ensureFreshAccessToken();
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // New login: SAME server URL, SAME refresh token, different (stale)
+    // access token. It must start its own flight immediately.
+    saveCredentials({ accessToken: staleB, refreshToken: "refresh-xyz", serverUrl: "http://first-tree.test" });
+    const callB = ensureFreshAccessToken();
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    // A's late 401 settles superseded (the snapshot changed) — crucially it
+    // must NOT latch the shared RT, and its settle must not clear B's slot.
+    releases[0]?.(new Response(null, { status: 401 }));
+    await expect(callA).rejects.toThrow(AuthRefreshSupersededError);
+
+    // B's flight is still the joinable one: C joins without another request.
+    const callC = ensureFreshAccessToken();
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    releases[1]?.(new Response(JSON.stringify({ accessToken: refreshedB })));
+    await expect(callB).resolves.toBe(refreshedB);
+    await expect(callC).resolves.toBe(refreshedB);
+  });
+
+  for (const status of [401, 200] as const) {
+    it(`an obsolete late ${status} after a home switch fails non-terminally and leaves the new home untouched`, async () => {
+      // Cross-home replacement: FIRST_TREE_HOME moves while A's request is in
+      // flight. The old caller must not receive the new home's credentials
+      // (different authority, possibly a different user), and the old
+      // completion must not persist or latch anything into the new home.
+      const stale = makeJwt({ sub: "old-user", exp: 1 });
+      const oldFresh = makeJwt({ sub: "old-user", exp: Math.floor(Date.now() / 1000) + 3600 });
+      const newFresh = makeJwt({ sub: "new-user", exp: Math.floor(Date.now() / 1000) + 3600 });
+      await writeCredentials(stale); // home 1, RT "synthetic-old"-equivalent
+
+      let release: (res: Response) => void = () => {};
+      fetchMock.mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          release = resolve;
+        }),
+      );
+
+      const { ensureFreshAccessToken, AuthRefreshFailedError, AuthRefreshSupersededError, loadCredentials } =
+        await import("../core/bootstrap.js");
+      const pending = ensureFreshAccessToken();
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      const otherHome = join(
+        tmpdir(),
+        `ft-first-tree-fresh-switch-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      );
+      mkdirSync(join(otherHome, "config"), { recursive: true });
+      writeFileSync(
+        join(otherHome, "config", "credentials.json"),
+        JSON.stringify({ accessToken: newFresh, refreshToken: "synthetic-new", serverUrl: "http://first-tree.test" }),
+      );
+      const previousHome = process.env.FIRST_TREE_HOME;
+      process.env.FIRST_TREE_HOME = otherHome;
+      try {
+        release(
+          new Response(
+            status === 200 ? JSON.stringify({ accessToken: oldFresh, refreshToken: "synthetic-old-rotated" }) : null,
+            { status },
+          ),
+        );
+
+        const err = await pending.catch((caught) => caught);
+        expect(err).toBeInstanceOf(AuthRefreshSupersededError);
+        expect(err).not.toBeInstanceOf(AuthRefreshFailedError);
+        expect(loadCredentials()).toMatchObject({ accessToken: newFresh, refreshToken: "synthetic-new" });
+        await expect(ensureFreshAccessToken()).resolves.toBe(newFresh);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      } finally {
+        process.env.FIRST_TREE_HOME = previousHome;
+        rmSync(otherHome, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("starts a fresh flight immediately for new credentials instead of joining the old authority's pending refresh", async () => {
+    const staleA = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) - 60 });
+    const staleB = makeJwt({ sub: "user-b", exp: Math.floor(Date.now() / 1000) - 60 });
+    const refreshedB = makeJwt({ sub: "user-b", exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(staleA); // authority A, RT "refresh-xyz"
+
+    const releases: Array<(res: Response) => void> = [];
+    fetchMock.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          releases.push(resolve);
+        }),
+    );
+
+    const { ensureFreshAccessToken, AuthRefreshSupersededError, saveCredentials } = await import(
+      "../core/bootstrap.js"
+    );
+    const callA = ensureFreshAccessToken();
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Login installs authority B while A is still pending: B must get its own
+    // HTTP call immediately, not join (or wait for) A's flight.
+    saveCredentials({ accessToken: staleB, refreshToken: "refresh-b", serverUrl: "http://first-tree.test" });
+    const callB = ensureFreshAccessToken();
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    // A settles superseded; its settle must not clear B's active flight.
+    releases[0]?.(new Response(null, { status: 401 }));
+    await expect(callA).rejects.toThrow(AuthRefreshSupersededError);
+
+    // B's flight is still the active one: another caller joins it without an
+    // additional HTTP request.
+    const callC = ensureFreshAccessToken();
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    releases[1]?.(new Response(JSON.stringify({ accessToken: refreshedB })));
+    await expect(callB).resolves.toBe(refreshedB);
+    await expect(callC).resolves.toBe(refreshedB);
+  });
+
+  it("never recreates or returns credentials when a logout lands during a pending refresh", async () => {
+    const stale = makeJwt({ sub: "old-user", exp: Math.floor(Date.now() / 1000) - 60 });
+    const minted = makeJwt({ sub: "old-user", exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+
+    let release: (res: Response) => void = () => {};
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const { ensureFreshAccessToken, AuthRefreshSupersededError } = await import("../core/bootstrap.js");
+    const call = ensureFreshAccessToken();
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Logout removes the credentials file while the refresh is in flight. The
+    // late success must neither recreate the file nor hand the caller a token.
+    rmSync(join(testHome, "config", "credentials.json"));
+    release(new Response(JSON.stringify({ accessToken: minted, refreshToken: "rotated-old" })));
+
+    await expect(call).rejects.toThrow(AuthRefreshSupersededError);
+    expect(existsSync(join(testHome, "config", "credentials.json"))).toBe(false);
+    await expect(ensureFreshAccessToken()).rejects.toThrow(/No credentials found/u);
+  });
+
+  it("does not latch a 401 that lands after the caller cancelled (transport ignores the abort)", async () => {
+    const stale = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) - 60 });
+    await writeCredentials(stale);
+
+    let release: (res: Response) => void = () => {};
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            release = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+    const { ensureFreshAccessToken, AuthRefreshFailedError } = await import("../core/bootstrap.js");
+    const caller = new AbortController();
+    const cancelled = ensureFreshAccessToken({ signal: caller.signal });
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    caller.abort(new DOMException("The operation timed out", "TimeoutError"));
+
+    // The 401 arrives after cancellation: the attempt rejects as the
+    // cancellation and must never latch.
+    release(new Response(null, { status: 401 }));
+    await expect(cancelled).rejects.toMatchObject({ name: "TimeoutError" });
+
+    // A later call still reaches the network (proving nothing latched) and
+    // only then fails terminally.
+    await expect(ensureFreshAccessToken()).rejects.toThrow(AuthRefreshFailedError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not save a 200 that lands after the caller cancelled (transport ignores the abort)", async () => {
+    const stale = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) - 60 });
+    const minted = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+
+    let release: (res: Response) => void = () => {};
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            release = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: minted })));
+
+    const { ensureFreshAccessToken, loadCredentials } = await import("../core/bootstrap.js");
+    const caller = new AbortController();
+    const cancelled = ensureFreshAccessToken({ signal: caller.signal });
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    caller.abort(new DOMException("The operation timed out", "TimeoutError"));
+
+    release(new Response(JSON.stringify({ accessToken: minted, refreshToken: "rotated-late" })));
+    await expect(cancelled).rejects.toMatchObject({ name: "TimeoutError" });
+
+    // The cancelled success must not persist: file still holds the stale
+    // token and the original refresh token.
+    const persisted = loadCredentials();
+    expect(persisted?.accessToken).toBe(stale);
+    expect(persisted?.refreshToken).toBe("refresh-xyz");
+
+    await expect(ensureFreshAccessToken()).resolves.toBe(minted);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("a cancelled old-authority flight that 401s late cannot pause a newer login", async () => {
+    const staleA = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) - 60 });
+    const freshB = makeJwt({ sub: "user-b", exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(staleA);
+
+    let release: (res: Response) => void = () => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          release = resolve;
+        }),
+    );
+
+    const { ensureFreshAccessToken, saveCredentials } = await import("../core/bootstrap.js");
+    const caller = new AbortController();
+    const cancelled = ensureFreshAccessToken({ signal: caller.signal });
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    caller.abort(new DOMException("The operation timed out", "TimeoutError"));
+
+    // New login lands, then the doomed old response arrives.
+    saveCredentials({ accessToken: freshB, refreshToken: "refresh-b", serverUrl: "http://first-tree.test" });
+    release(new Response(null, { status: 401 }));
+    await expect(cancelled).rejects.toMatchObject({ name: "TimeoutError" });
+
+    // The new authority is unaffected: fresh token returned, zero extra calls.
+    await expect(ensureFreshAccessToken()).resolves.toBe(freshB);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("scopes the terminal 401 latch to the credential home", async () => {
+    const stale = makeJwt({ sub: "shared-user", exp: Math.floor(Date.now() / 1000) - 60 });
+    const refreshed = makeJwt({ sub: "shared-user", exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale); // home 1, RT "refresh-xyz"
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+    const { ensureFreshAccessToken, AuthRefreshFailedError } = await import("../core/bootstrap.js");
+    await expect(ensureFreshAccessToken()).rejects.toThrow(AuthRefreshFailedError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // A different home holding byte-identical credentials is a different
+    // authority: it must still reach the network.
+    const otherHome = join(tmpdir(), `ft-first-tree-fresh-other-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(otherHome, "config"), { recursive: true });
+    writeFileSync(
+      join(otherHome, "config", "credentials.json"),
+      JSON.stringify({ accessToken: stale, refreshToken: "refresh-xyz", serverUrl: "http://first-tree.test" }),
+    );
+    const previousHome = process.env.FIRST_TREE_HOME;
+    process.env.FIRST_TREE_HOME = otherHome;
+    try {
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: refreshed })));
+      await expect(ensureFreshAccessToken()).resolves.toBe(refreshed);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      process.env.FIRST_TREE_HOME = previousHome;
+      rmSync(otherHome, { recursive: true, force: true });
+    }
+  });
+
+  it("fences a late success when a new login rewrote the access token under the same refresh authority", async () => {
+    const stale = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) - 60 });
+    const reloginFresh = makeJwt({ sub: "user-b", exp: Math.floor(Date.now() / 1000) + 1800 });
+    const mintedOld = makeJwt({ sub: "user-a", exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale); // RT "refresh-xyz"
+
+    let release: (res: Response) => void = () => {};
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const { ensureFreshAccessToken, AuthRefreshSupersededError, loadCredentials, saveCredentials } = await import(
+      "../core/bootstrap.js"
+    );
+    const call = ensureFreshAccessToken();
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // New login for the same account: SAME refresh authority, new access
+    // token on disk. The in-flight result must not overwrite it — and the
+    // superseded caller fails non-terminally instead of receiving either
+    // authority's credentials.
+    saveCredentials({ accessToken: reloginFresh, refreshToken: "refresh-xyz", serverUrl: "http://first-tree.test" });
+    release(new Response(JSON.stringify({ accessToken: mintedOld })));
+
+    await expect(call).rejects.toThrow(AuthRefreshSupersededError);
+    const persisted = loadCredentials();
+    expect(persisted?.accessToken).toBe(reloginFresh);
+    expect(persisted?.refreshToken).toBe("refresh-xyz");
+    await expect(ensureFreshAccessToken()).resolves.toBe(reloginFresh);
+  });
+
   it("removes the temporary credentials file when an atomic save fails", async () => {
     vi.resetModules();
     vi.doMock("node:fs", async (importOriginal) => {

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -451,20 +451,8 @@ export function registerDaemonStartCommand(daemon: Command): void {
             });
         };
         unregisterCodexCandidateChange = onCodexVerifiedAutomaticCandidateChange(publishCodexVerifiedSelection);
-        // D5: gate capability probe/upload work on the connection's auth
-        // paused mode — while credentials are dead, the poll's uploads would
-        // fire doomed `/auth/refresh` 401s at the base cadence forever. The
-        // gate opens ONLY after a successful (re)registration: onReconnect
-        // fires on a completed RE-registration, and the post-start path below
-        // handles the initial one. resume() merely ungates (it performs no
-        // work itself); onReconnect() then owns the catch-up, and stop()
-        // stays terminal — a credentials change must not revive a stopped
-        // refresher. There is deliberately no auth:resumed wiring: fresh
-        // credentials alone must not ungate before the registration lands.
-        runtime.onReconnect(() => {
-          capabilityRefresher.resume();
-          capabilityRefresher.onReconnect();
-        });
+        // Initial and later registrations share one readiness boundary.
+        runtime.onRegistered((isReconnect) => capabilityRefresher.onRegistered(isReconnect));
         runtime.onAuthPaused(() => capabilityRefresher.pause());
 
         // In-product runtime-auth: the server pushes `runtime-auth:start` when a
@@ -552,13 +540,6 @@ export function registerDaemonStartCommand(daemon: Command): void {
 
         await runtime.start();
 
-        // Registration precedes agent startup. If authentication failed
-        // while agents were starting, keep probes and uploads paused until
-        // a later successful registration resumes them.
-        if (!runtime.isPaused()) {
-          capabilityRefresher.resume();
-          void capabilityRefresher.start();
-        }
         codexCapabilityPublicationStarted = true;
         if (codexCapabilityPublicationPending) {
           codexCapabilityPublicationPending = false;

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -552,15 +552,13 @@ export function registerDaemonStartCommand(daemon: Command): void {
 
         await runtime.start();
 
-        // The initial registration completed — open the capability gate
-        // BEFORE start(): while paused, start() is a no-op by design.
-        capabilityRefresher.resume();
-        // Post-register capabilities upload + arm the background poll — the
-        // `clients` row only exists after the `client:register` WS handshake,
-        // so the first PATCH runs here rather than pre-flight. Best-effort: a
-        // transient failure logs and moves on; agents still bind, and the poll
-        // (or a later restart) retries.
-        void capabilityRefresher.start();
+        // Registration precedes agent startup. If authentication failed
+        // while agents were starting, keep probes and uploads paused until
+        // a later successful registration resumes them.
+        if (!runtime.isPaused()) {
+          capabilityRefresher.resume();
+          void capabilityRefresher.start();
+        }
         codexCapabilityPublicationStarted = true;
         if (codexCapabilityPublicationPending) {
           codexCapabilityPublicationPending = false;

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -130,6 +130,17 @@ export function registerDaemonStartCommand(daemon: Command): void {
       let releaseRuntimeOwnership: (() => void) | null = null;
       let unregisterCodexCandidateChange: (() => void) | null = null;
       let codexCapabilityPublicationStarted = false;
+      // Hoisted out of the try so the catch can tell "start() rejected after
+      // a signal requested shutdown" from a real startup failure. `promise`
+      // becomes non-null ONLY once a SIGINT/SIGTERM handler actually ran.
+      // Held in an object because the only writer is the signal closure — a
+      // bare `let` would be flow-narrowed to `null`/`never` at the catch.
+      const shutdownRequest: { promise: Promise<void> | null } = { promise: null };
+      // The signal handler reference, for removal on the failure paths — the
+      // handlers are registered before the (possibly indefinite) initial
+      // start() wait, so a start that never reaches the keep-alive must not
+      // leak them onto the process.
+      let onShutdownSignal: (() => void) | null = null;
       try {
         // Service-mode delegation. We split four cases so the user gets a
         // single coherent command:
@@ -440,7 +451,21 @@ export function registerDaemonStartCommand(daemon: Command): void {
             });
         };
         unregisterCodexCandidateChange = onCodexVerifiedAutomaticCandidateChange(publishCodexVerifiedSelection);
-        runtime.onReconnect(() => capabilityRefresher.onReconnect());
+        // D5: gate capability probe/upload work on the connection's auth
+        // paused mode — while credentials are dead, the poll's uploads would
+        // fire doomed `/auth/refresh` 401s at the base cadence forever. The
+        // gate opens ONLY after a successful (re)registration: onReconnect
+        // fires on a completed RE-registration, and the post-start path below
+        // handles the initial one. resume() merely ungates (it performs no
+        // work itself); onReconnect() then owns the catch-up, and stop()
+        // stays terminal — a credentials change must not revive a stopped
+        // refresher. There is deliberately no auth:resumed wiring: fresh
+        // credentials alone must not ungate before the registration lands.
+        runtime.onReconnect(() => {
+          capabilityRefresher.resume();
+          capabilityRefresher.onReconnect();
+        });
+        runtime.onAuthPaused(() => capabilityRefresher.pause());
 
         // In-product runtime-auth: the server pushes `runtime-auth:start` when a
         // member clicks "Connect <provider>" in the console. The daemon drives
@@ -496,8 +521,40 @@ export function registerDaemonStartCommand(daemon: Command): void {
           })();
         });
 
+        // Graceful shutdown — installed BEFORE the initial start() wait: the
+        // connection may now PARK indefinitely on auth pause (dead refresh
+        // token at boot), and a SIGINT/SIGTERM landing during that wait must
+        // run the full cleanup instead of hitting the default signal handler.
+        // `shutdownRequest` doubles as the "a shutdown was actually
+        // requested" evidence for the catch below: a start() rejection is a
+        // clean shutdown ONLY when a signal truly arrived.
+        const shutdown = async () => {
+          writeLine("\n  Shutting down...\n");
+          codexCapabilityPublicationStarted = false;
+          unregisterCodexCandidateChange?.();
+          unregisterCodexCandidateChange = null;
+          capabilityRefresher.stop();
+          runtime.unwatchAgentsDir();
+          await runtime.stop(resolveClientRuntimeStopReason());
+          unregisterRuntimeMarker?.();
+          unregisterRuntimeMarker = null;
+          releaseRuntimeOwnership?.();
+          releaseRuntimeOwnership = null;
+          await flushClientSentry();
+          process.exit(0);
+        };
+        const onSignal = () => {
+          shutdownRequest.promise ??= shutdown();
+        };
+        onShutdownSignal = onSignal;
+        process.on("SIGINT", onSignal);
+        process.on("SIGTERM", onSignal);
+
         await runtime.start();
 
+        // The initial registration completed — open the capability gate
+        // BEFORE start(): while paused, start() is a no-op by design.
+        capabilityRefresher.resume();
         // Post-register capabilities upload + arm the background poll — the
         // `clients` row only exists after the `client:register` WS handshake,
         // so the first PATCH runs here rather than pre-flight. Best-effort: a
@@ -570,25 +627,6 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // Watch agents config dir for hot-add
         runtime.watchAgentsDir(agentsDir);
 
-        // Graceful shutdown
-        const shutdown = async () => {
-          writeLine("\n  Shutting down...\n");
-          codexCapabilityPublicationStarted = false;
-          unregisterCodexCandidateChange?.();
-          unregisterCodexCandidateChange = null;
-          capabilityRefresher.stop();
-          runtime.unwatchAgentsDir();
-          await runtime.stop(resolveClientRuntimeStopReason());
-          unregisterRuntimeMarker?.();
-          unregisterRuntimeMarker = null;
-          releaseRuntimeOwnership?.();
-          releaseRuntimeOwnership = null;
-          await flushClientSentry();
-          process.exit(0);
-        };
-        process.on("SIGINT", () => void shutdown());
-        process.on("SIGTERM", () => void shutdown());
-
         // Keep process alive
         await new Promise(() => {});
       } catch (error) {
@@ -634,6 +672,18 @@ export function registerDaemonStartCommand(daemon: Command): void {
             output: daemonOutput ?? undefined,
           });
         }
+        // A start() rejection is a clean shutdown ONLY when a signal
+        // actually arrived (e.g. SIGTERM aborting an auth-paused
+        // initial-connect park via stop()). Await the handler's cleanup so
+        // marker/ownership release completes before the finally below runs
+        // its own (null-guarded) release. Without that evidence the
+        // rejection is a real startup failure and must keep failing loudly —
+        // paused state alone is NOT shutdown evidence.
+        if (shutdownRequest.promise) {
+          // Cleanup failures must propagate instead of being treated as a clean shutdown.
+          await shutdownRequest.promise;
+          return;
+        }
         const msg = error instanceof Error ? error.message : String(error);
         if (!isDaemonRuntimeOwnershipError(error)) {
           captureClientException(error, { command: "daemon start" });
@@ -650,6 +700,14 @@ export function registerDaemonStartCommand(daemon: Command): void {
         unregisterCodexCandidateChange?.();
         unregisterRuntimeMarker?.();
         releaseRuntimeOwnership?.();
+        // Failure/return paths must not leak the early-registered signal
+        // handlers onto the process (the keep-alive path never reaches here,
+        // so a running daemon keeps them).
+        if (onShutdownSignal) {
+          process.off("SIGINT", onShutdownSignal);
+          process.off("SIGTERM", onShutdownSignal);
+          onShutdownSignal = null;
+        }
         // Reset singleton so other commands can reinit
         resetConfig();
         resetConfigMeta();

--- a/apps/cli/src/core/bootstrap.ts
+++ b/apps/cli/src/core/bootstrap.ts
@@ -130,11 +130,22 @@ function parseRetryAfterMs(header: string | null): number | null {
  * round-trip and race to write `credentials.json`. Share one in-flight
  * request so N concurrent callers resolve from a single HTTP call.
  *
+ * The flight carries its credential snapshot: callers only join when their
+ * resolved authority (home + server URL + refresh token) AND access-token
+ * snapshot match. A re-login that lands while an old refresh is still
+ * pending — even one that keeps the same refresh token and only rewrites
+ * the access token — gets its own flight immediately, and the old flight
+ * settles fenced-off in the background — it can never clear or poison the
+ * new one (every slot handoff compares object identity, never recency).
+ *
  * Each caller can still carry its own deadline. The underlying request is
  * aborted once every waiter has abandoned it; one short-lived caller never
  * aborts a refresh that another live caller still needs.
  */
 type InflightRefresh = {
+  authority: CredentialAuthority;
+  /** Access-token snapshot from when the flight started (late-write fencing). */
+  accessTokenSnapshot: string;
   controller: AbortController;
   promise: Promise<string>;
   settled: boolean;
@@ -142,6 +153,91 @@ type InflightRefresh = {
 };
 
 let inflightRefresh: InflightRefresh | null = null;
+
+/**
+ * Thrown when a refresh settles after its credential authority was replaced
+ * (re-login, logout, home switch) while the request was in flight.
+ * Deliberately NOT an {@link AuthRefreshFailedError}: the outcome belongs to
+ * the dead authority and must never trigger the terminal fail-stop paths
+ * (e.g. the WS reconnect pause) that a real 401 on the CURRENT credentials
+ * causes. Callers classify it like any transient error and retry against
+ * the new credentials normally.
+ */
+export class AuthRefreshSupersededError extends Error {
+  constructor(message?: string) {
+    super(message ?? "Credentials changed while a token refresh was in flight; retry with the new credentials.");
+    this.name = "AuthRefreshSupersededError";
+  }
+}
+
+/**
+ * Credential authority identity for the refresh flight/latch below: the
+ * resolved credentials file path (FIRST_TREE_HOME-derived) plus server URL
+ * plus the refresh token. Two homes holding byte-identical credentials are
+ * still distinct authorities, so a terminal failure in one can never
+ * suppress the other.
+ */
+type CredentialAuthority = {
+  credentialsPath: string;
+  serverUrl: string;
+  refreshToken: string;
+};
+
+function authorityFor(creds: StoredCredentials): CredentialAuthority {
+  return { credentialsPath: credentialsPath(), serverUrl: creds.serverUrl, refreshToken: creds.refreshToken };
+}
+
+function sameAuthority(a: CredentialAuthority, b: CredentialAuthority): boolean {
+  return a.credentialsPath === b.credentialsPath && a.serverUrl === b.serverUrl && a.refreshToken === b.refreshToken;
+}
+
+/**
+ * Terminal 401 latch. A 401 from `/auth/refresh` means the refresh token is
+ * expired or revoked — retrying the same credential authority can never
+ * succeed, yet every caller (WS reconnect loop, SDK requests, proactive
+ * refresh) used to fire its own doomed HTTP round-trip (staging incident:
+ * 20 sequential callers -> 20 refreshes). After the first 401 we latch the
+ * failure and rethrow it without touching the network.
+ *
+ * Keyed to the full credential authority (home + server URL + refresh
+ * token): a re-login — or a home switch — never matches the latched entry,
+ * so recovery with new credentials is immediate. Bounded state: a single
+ * entry, replaced by each new terminal failure; an entry whose authority
+ * was superseded simply never matches again (it is never cleared by
+ * mismatched lookups, so an old authority's completion cannot poison the
+ * new authority's latch either). Never logged — it identifies credential
+ * material.
+ */
+let terminalRefreshFailure: { authority: CredentialAuthority; message: string } | null = null;
+
+function latchedRefreshFailure(authority: CredentialAuthority): AuthRefreshFailedError | null {
+  if (!terminalRefreshFailure || !sameAuthority(terminalRefreshFailure.authority, authority)) return null;
+  return new AuthRefreshFailedError(terminalRefreshFailure.message);
+}
+
+function latchTerminalRefreshFailure(authority: CredentialAuthority, message: string): void {
+  terminalRefreshFailure = { authority, message };
+}
+
+/**
+ * Fencing for late completions: the credentials file may have been replaced
+ * (re-login, logout, home switch — or a concurrent login/refresh that
+ * already persisted a newer access token for the same refresh authority)
+ * while this request was in flight. Compares the full authority plus the
+ * access-token snapshot taken when the request started; any drift means the
+ * in-flight result is obsolete and must neither be persisted nor allowed to
+ * latch/return anything terminal.
+ */
+function authorityFence(request: { authority: CredentialAuthority; accessTokenSnapshot: string }): boolean {
+  const current = loadCredentials();
+  if (!current) return true;
+  return (
+    credentialsPath() !== request.authority.credentialsPath ||
+    current.serverUrl !== request.authority.serverUrl ||
+    current.refreshToken !== request.authority.refreshToken ||
+    current.accessToken !== request.accessTokenSnapshot
+  );
+}
 
 /** Default freshness window for HTTP callers: refresh if token expires within 30s. */
 const DEFAULT_MIN_VALIDITY_MS = 30_000;
@@ -177,22 +273,40 @@ export async function ensureFreshAccessToken(opts?: { minValidityMs?: number; si
     return creds.accessToken;
   }
 
-  if (!inflightRefresh) {
-    inflightRefresh = startRefresh(creds);
+  // A previous refresh with this exact credential authority already got a
+  // terminal 401: fail fast instead of adding another doomed HTTP call.
+  const authority = authorityFor(creds);
+  const latched = latchedRefreshFailure(authority);
+  if (latched) throw latched;
+
+  // Join the active flight only when it carries the exact same credential
+  // snapshot (authority + access token). A re-login that lands while an old
+  // refresh is still pending — even one that keeps the same refresh token
+  // and only rewrites the access token — starts its own flight immediately
+  // instead of inheriting the superseded flight's outcome.
+  if (
+    !inflightRefresh ||
+    inflightRefresh.settled ||
+    !sameAuthority(inflightRefresh.authority, authority) ||
+    inflightRefresh.accessTokenSnapshot !== creds.accessToken
+  ) {
+    inflightRefresh = startRefresh(creds, authority);
   }
   return waitForRefresh(inflightRefresh, opts?.signal);
 }
 
-function startRefresh(creds: StoredCredentials): InflightRefresh {
+function startRefresh(creds: StoredCredentials, authority: CredentialAuthority): InflightRefresh {
   const controller = new AbortController();
   const refresh: InflightRefresh = {
+    authority,
+    accessTokenSnapshot: creds.accessToken,
     controller,
     promise: Promise.resolve(""),
     settled: false,
     waiters: 0,
   };
 
-  refresh.promise = performRefresh(creds, controller.signal).finally(() => {
+  refresh.promise = performRefresh(creds, authority, controller.signal).finally(() => {
     refresh.settled = true;
     if (inflightRefresh === refresh) {
       inflightRefresh = null;
@@ -201,7 +315,11 @@ function startRefresh(creds: StoredCredentials): InflightRefresh {
   return refresh;
 }
 
-async function performRefresh(creds: StoredCredentials, cancellation: AbortSignal): Promise<string> {
+async function performRefresh(
+  creds: StoredCredentials,
+  authority: CredentialAuthority,
+  cancellation: AbortSignal,
+): Promise<string> {
   const signal = AbortSignal.any([cancellation, AbortSignal.timeout(10_000)]);
   const res = await cliFetch(`${creds.serverUrl}/api/v1/auth/refresh`, {
     method: "POST",
@@ -210,11 +328,24 @@ async function performRefresh(creds: StoredCredentials, cancellation: AbortSigna
     signal,
   });
 
+  // A caller abort (or the internal 10s timeout) must never latch a 401 or
+  // save a 200 — even when the transport or a slow body ignores the abort.
+  signal.throwIfAborted();
+
   if (res.status === 401) {
-    throw new AuthRefreshFailedError(
+    const message =
       `Refresh token rejected by server. Re-run \`${channelConfig.binName} login <code>\` ` +
-        "(get a fresh token from the Web Computers page → New Connection).",
-    );
+      "(get a fresh token from the Web Computers page → New Connection).";
+    // Fence BEFORE latching or returning anything terminal: if the authority
+    // was replaced while this request was in flight, the 401 belongs to dead
+    // credentials and must not pause the new login.
+    if (authorityFence({ authority, accessTokenSnapshot: creds.accessToken })) {
+      throw new AuthRefreshSupersededError();
+    }
+    // Terminal for this exact credential authority: subsequent callers fail
+    // fast without hitting the network until the credentials change.
+    latchTerminalRefreshFailure(authority, message);
+    throw new AuthRefreshFailedError(message);
   }
   if (res.status === 429) {
     const retryAfterMs = parseRetryAfterMs(res.headers.get("retry-after")) ?? 30_000;
@@ -225,6 +356,17 @@ async function performRefresh(creds: StoredCredentials, cancellation: AbortSigna
   }
 
   const data = (await res.json()) as { accessToken: string; refreshToken?: string };
+  // Same cancellation fence on the success path, before any side effect.
+  signal.throwIfAborted();
+  if (authorityFence({ authority, accessTokenSnapshot: creds.accessToken })) {
+    // The credential snapshot changed (re-login / logout / home switch)
+    // while this request was in flight. The replacement may belong to a
+    // DIFFERENT user, and this caller may carry the old user's agent ids /
+    // request context — credentials from another authority are never handed
+    // to the old caller. Fail non-terminally; a new caller independently
+    // reads the new credentials. No nested refresh is started here.
+    throw new AuthRefreshSupersededError();
+  }
   saveCredentials({
     ...creds,
     accessToken: data.accessToken,

--- a/apps/cli/src/core/bootstrap.ts
+++ b/apps/cli/src/core/bootstrap.ts
@@ -195,7 +195,7 @@ function sameAuthority(a: CredentialAuthority, b: CredentialAuthority): boolean 
  * Terminal 401 latch. A 401 from `/auth/refresh` means the refresh token is
  * expired or revoked — retrying the same credential authority can never
  * succeed, yet every caller (WS reconnect loop, SDK requests, proactive
- * refresh) used to fire its own doomed HTTP round-trip (staging incident:
+ * refresh) used to fire its own doomed HTTP round-trip (synthetic reproduction:
  * 20 sequential callers -> 20 refreshes). After the first 401 we latch the
  * failure and rethrow it without touching the network.
  *

--- a/apps/cli/src/core/capability-refresh.ts
+++ b/apps/cli/src/core/capability-refresh.ts
@@ -114,6 +114,18 @@ export class CapabilityRefresher {
   /** Consecutive polls with no observed state change — drives the backoff. */
   private idleAttempts = 0;
   private stopped = false;
+  /**
+   * Auth-paused gate (D5). While the connection sits in auth paused mode
+   * every upload attempt ends in a doomed `/auth/refresh` 401 — and because
+   * a failed upload resets the poll backoff, the refresher would otherwise
+   * hammer the server at the base cadence forever. `pause()` disarms the
+   * poll and blocks probes/uploads; `resume()` only ungates (actual work
+   * resumes via the next registration-driven {@link onReconnect}, never
+   * before the connection is back). Orthogonal to {@link stop}: `stopped`
+   * stays terminal — `resume()` must never revive a stopped refresher, and
+   * fresh auth credentials must not unblock one either.
+   */
+  private paused = false;
 
   constructor(deps: CapabilityRefresherDeps) {
     this.deps = deps;
@@ -131,6 +143,11 @@ export class CapabilityRefresher {
    * and later polls retry convergence.
    */
   async start(): Promise<void> {
+    // Terminal stop and the auth-paused gate both win over a startup call:
+    // a stopped refresher must never be revived by a late start(), and a
+    // paused one starts working only after the daemon ungates it via
+    // resume() (which the wiring calls only after a successful registration).
+    if (this.stopped || this.paused) return;
     if (this.snapshot) {
       try {
         await this.uploadIfChanged(this.snapshot);
@@ -167,6 +184,30 @@ export class CapabilityRefresher {
   }
 
   /**
+   * Gate all probe/upload work while the connection is auth-paused. Clears a
+   * pending poll timer; an in-flight probe is not cancelled but its late
+   * completion will neither upload nor re-arm (see runRefresh). No-op after
+   * {@link stop} — terminal shutdown wins.
+   */
+  pause(): void {
+    if (this.stopped) return;
+    this.paused = true;
+    this.clearPending();
+  }
+
+  /**
+   * Ungate after fresh credentials arrived (`auth:resumed`). Deliberately
+   * performs NO work by itself: `auth:resumed` fires before the
+   * reconnect/registration completes, and uploading before the clients row
+   * is re-established would just fail. The next registration-driven
+   * {@link onReconnect} owns the catch-up. No-op after {@link stop}.
+   */
+  resume(): void {
+    if (this.stopped) return;
+    this.paused = false;
+  }
+
+  /**
    * Latest known capability entry for a provider, or undefined. The runtime-auth
    * login flow reads this to preserve a provider's existing fields (version,
    * runtimeSource) while it attaches/clears a pending browser-auth marker.
@@ -187,10 +228,14 @@ export class CapabilityRefresher {
     const next: ClientCapabilities = { ...(this.snapshot ?? {}), [provider]: entry };
     this.snapshot = next;
     this.providerWriteVersions.set(provider, ++this.providerWriteVersion);
-    try {
-      await this.uploadIfChanged(next);
-    } catch (err) {
-      this.deps.log("⚠️", `capabilities upload skipped: ${message(err)}`);
+    // Local bookkeeping always advances (a login flow must not lose its
+    // result), but the wire is gated on auth-pause/stop like runRefresh is.
+    if (!this.paused && !this.stopped) {
+      try {
+        await this.uploadIfChanged(next);
+      } catch (err) {
+        this.deps.log("⚠️", `capabilities upload skipped: ${message(err)}`);
+      }
     }
     this.scheduleNext();
   }
@@ -230,8 +275,29 @@ export class CapabilityRefresher {
     return true;
   }
 
+  /**
+   * Attempt the deduped upload with the standard log lines. Resolves `true`
+   * when the upload FAILED (caller treats the snapshot as not-uploaded for
+   * backoff/poll-continuation bookkeeping).
+   */
+  private async attemptUpload(next: ClientCapabilities, modeLabel: string, refreshStartedAt: number): Promise<boolean> {
+    try {
+      const uploaded = await this.uploadIfChanged(next);
+      if (uploaded) {
+        this.deps.log(
+          "•",
+          `runtime capabilities re-probed (${modeLabel}) and uploaded in ${Date.now() - refreshStartedAt}ms`,
+        );
+      }
+      return false;
+    } catch (uploadErr) {
+      this.deps.log("⚠️", `capabilities upload skipped after ${Date.now() - refreshStartedAt}ms: ${message(uploadErr)}`);
+      return true;
+    }
+  }
+
   private async runRefresh(trigger: "startup" | "reconnect" | "poll"): Promise<void> {
-    if (this.stopped) return;
+    if (this.stopped || this.paused) return;
     if (this.inFlight) return; // a coincident reconnect is held in pendingReconnect
 
     this.inFlight = true;
@@ -283,22 +349,14 @@ export class CapabilityRefresher {
         // provider to `ok` but whose PATCH failed must NOT let the poll stop —
         // the server would otherwise stay on the stale degraded snapshot. The
         // upload failure resets the backoff so the retry is prompt.
-        let uploadFailed = false;
-        try {
-          const uploaded = await this.uploadIfChanged(next);
-          if (uploaded) {
-            this.deps.log(
-              "•",
-              `runtime capabilities re-probed (${modeLabel}) and uploaded in ${Date.now() - refreshStartedAt}ms`,
-            );
-          }
-        } catch (uploadErr) {
-          uploadFailed = true;
-          this.deps.log(
-            "⚠️",
-            `capabilities upload skipped after ${Date.now() - refreshStartedAt}ms: ${message(uploadErr)}`,
-          );
-        }
+        //
+        // D5: a pause/stop that landed while the probe ran makes this a late
+        // completion — skip the upload (a dead token would just 401 the
+        // server again) and count it as not-uploaded so the next
+        // registration-driven refresh re-publishes the snapshot. The local
+        // snapshot above still advances; only the wire is gated.
+        const uploadBlocked = this.paused || this.stopped;
+        const uploadFailed = uploadBlocked ? true : await this.attemptUpload(next, modeLabel, refreshStartedAt);
         // A reconnect, an observed state change, or a failed upload all warrant
         // a prompt next attempt; only an unchanged, fully-synced poll backs off.
         this.idleAttempts =
@@ -318,7 +376,7 @@ export class CapabilityRefresher {
 
     // A reconnect that landed while this refresh ran is drained now (in
     // reconnect mode), so its TTL/full re-probe is never skipped.
-    if (this.pendingReconnect && !this.stopped) {
+    if (this.pendingReconnect && !this.stopped && !this.paused) {
       void this.runRefresh("reconnect");
     }
   }
@@ -334,6 +392,9 @@ export class CapabilityRefresher {
   private scheduleNext(): void {
     this.clearPending();
     if (this.stopped) return;
+    // Auth-paused: stay disarmed. resume() ungates and the next
+    // registration-driven onReconnect() re-arms via its own runRefresh.
+    if (this.paused) return;
     if (!this.needsRefresh()) {
       this.idleAttempts = 0;
       return;

--- a/apps/cli/src/core/capability-refresh.ts
+++ b/apps/cli/src/core/capability-refresh.ts
@@ -118,12 +118,8 @@ export class CapabilityRefresher {
    * Auth-paused gate (D5). While the connection sits in auth paused mode
    * every upload attempt ends in a doomed `/auth/refresh` 401 — and because
    * a failed upload resets the poll backoff, the refresher would otherwise
-   * hammer the server at the base cadence forever. `pause()` disarms the
-   * poll and blocks probes/uploads; `resume()` only ungates (actual work
-   * resumes via the next registration-driven {@link onReconnect}, never
-   * before the connection is back). Orthogonal to {@link stop}: `stopped`
-   * stays terminal — `resume()` must never revive a stopped refresher, and
-   * fresh auth credentials must not unblock one either.
+   * hammer the server at the base cadence forever. Only {@link onRegistered}
+   * releases this gate; fresh credentials alone do not. Stop stays terminal.
    */
   private paused = false;
 
@@ -145,8 +141,7 @@ export class CapabilityRefresher {
   async start(): Promise<void> {
     // Terminal stop and the auth-paused gate both win over a startup call:
     // a stopped refresher must never be revived by a late start(), and a
-    // paused one starts working only after the daemon ungates it via
-    // resume() (which the wiring calls only after a successful registration).
+    // paused one starts working only after onRegistered releases the gate.
     if (this.stopped || this.paused) return;
     if (this.snapshot) {
       try {
@@ -195,16 +190,12 @@ export class CapabilityRefresher {
     this.clearPending();
   }
 
-  /**
-   * Ungate after fresh credentials arrived (`auth:resumed`). Deliberately
-   * performs NO work by itself: `auth:resumed` fires before the
-   * reconnect/registration completes, and uploading before the clients row
-   * is re-established would just fail. The next registration-driven
-   * {@link onReconnect} owns the catch-up. No-op after {@link stop}.
-   */
-  resume(): void {
+  /** Release auth pause and start the appropriate work at the registration boundary. */
+  onRegistered(isReconnect: boolean): void {
     if (this.stopped) return;
     this.paused = false;
+    if (isReconnect) this.onReconnect();
+    else void this.start();
   }
 
   /**
@@ -392,8 +383,7 @@ export class CapabilityRefresher {
   private scheduleNext(): void {
     this.clearPending();
     if (this.stopped) return;
-    // Auth-paused: stay disarmed. resume() ungates and the next
-    // registration-driven onReconnect() re-arms via its own runRefresh.
+    // Auth-paused: only onRegistered can release this gate and re-arm work.
     if (this.paused) return;
     if (!this.needsRefresh()) {
       this.idleAttempts = 0;

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -103,6 +103,10 @@ function authPausedDetail(error: Error): string {
   return `Auth rejection code: ${authCode}${authMessage ? ` — ${authMessage}` : ""}`;
 }
 
+function credentialsFilePath(): string {
+  return join(defaultConfigDir(), "credentials.json");
+}
+
 export type ClientRuntimeOptions = {
   /**
    * Version of the Command package this process was launched from. Passed to
@@ -160,18 +164,13 @@ export class ClientRuntime {
    */
   private agentsDir: string | null = null;
   /**
-   * Watcher on credentials.json (Bug 2 paused-mode recovery). Detects a
-   * fresh login while the runtime is paused and tells
-   * the connection to clear paused mode and reconnect with the new token.
+   * Watcher on credentials.json (Bug 2 paused-mode recovery). Pure trigger:
+   * file events (and the auth:paused handler itself) schedule a debounced
+   * reconciliation, which resumes only when the current credentials differ
+   * from the credential the paused attempt actually used.
    */
   private credentialsWatcher: FSWatcher | null = null;
   private credentialsDebounce: ReturnType<typeof setTimeout> | null = null;
-  /**
-   * Snapshot of the credentials JSON the last time we observed it. Used to
-   * de-dupe the debounced watcher — `fs.watch` fires on every metadata
-   * touch and we only want to act on actual content changes.
-   */
-  private lastCredentialsSnapshot: string | null = null;
 
   /** Callbacks fired after a WS RE-registration (reconnect), not the first
    * register. Used by the daemon to re-probe runtime-provider capabilities. */
@@ -204,6 +203,9 @@ export class ClientRuntime {
       sdkVersion: options.currentVersion,
       userAgent: CLI_USER_AGENT,
       getAccessToken: (opts) => ensureFreshAccessToken(opts),
+      // Lets the connection anchor a failed token-provider attempt to the
+      // exact credentials it used (see getAuthAttemptCredential).
+      getCredentialsSnapshot: () => this.readCredentialsSnapshot(credentialsFilePath()),
       // Forward the last self-update outcome on every `client:register`
       // so the server can persist it into `clients.metadata.lastUpdateAttempt`
       // and the admin dashboard can flag clients that are failing to
@@ -247,6 +249,10 @@ export class ClientRuntime {
       );
       this.output.status("", `Paused reason: ${reason}. Process is staying alive — no restart needed after login.`);
       this.ensureCredentialsWatcher();
+      // A login that landed BEFORE this pause (or before the watcher
+      // existed) produces no future fs event — reconcile now, not only on
+      // file changes.
+      this.scheduleCredentialsReconcile();
     });
 
     this.connection.on("auth:resumed", (previousReason) => {
@@ -522,32 +528,21 @@ export class ClientRuntime {
   }
 
   /**
-   * Bug 2 paused-mode recovery: watch credentials.json for changes. When
-   * the file content changes (operator ran the channel-aware login command), tell the
-   * connection to clear paused state. The connection's reconnect loop then
-   * picks up the new JWT via `ensureFreshAccessToken`.
+   * Bug 2 paused-mode recovery: watch credentials.json for changes. Every
+   * file event schedules a debounced reconciliation against the paused
+   * attempt's credential identity; on a real change the connection is told
+   * to clear paused state and its connect loop picks up the new JWT via
+   * `ensureFreshAccessToken`.
    */
   private ensureCredentialsWatcher(): void {
     if (this.credentialsWatcher) return;
-    const credentialsFile = join(defaultConfigDir(), "credentials.json");
+    const credentialsFile = credentialsFilePath();
     const watchDir = dirname(credentialsFile);
     if (!existsSync(watchDir)) return;
     try {
-      this.lastCredentialsSnapshot = this.readCredentialsSnapshot(credentialsFile);
       this.credentialsWatcher = watch(watchDir, (_evt, filename) => {
         if (filename && filename !== "credentials.json") return;
-        if (this.credentialsDebounce) clearTimeout(this.credentialsDebounce);
-        this.credentialsDebounce = setTimeout(() => {
-          this.credentialsDebounce = null;
-          const snapshot = this.readCredentialsSnapshot(credentialsFile);
-          if (snapshot && snapshot !== this.lastCredentialsSnapshot) {
-            this.lastCredentialsSnapshot = snapshot;
-            if (this.connection.isPaused()) {
-              this.output.status("", "credentials.json updated — clearing paused mode");
-              this.connection.clearPaused();
-            }
-          }
-        }, 250);
+        this.scheduleCredentialsReconcile();
       });
       // Synchronous setup is wrapped in try/catch above, but the FSWatcher can
       // still emit 'error' later; without a listener that would crash the
@@ -569,6 +564,50 @@ export class ClientRuntime {
     if (this.credentialsWatcher) {
       this.credentialsWatcher.close();
       this.credentialsWatcher = null;
+    }
+  }
+
+  private scheduleCredentialsReconcile(): void {
+    if (this.credentialsDebounce) clearTimeout(this.credentialsDebounce);
+    this.credentialsDebounce = setTimeout(() => {
+      this.credentialsDebounce = null;
+      this.reconcilePausedCredentials();
+    }, 250);
+  }
+
+  /**
+   * Resume paused mode only when the current credentials differ from the
+   * credential the paused attempt actually used. The attempt identity is
+   * read live from the connection, so a stale trigger can never act on an
+   * older attempt's identity or unpause a newer failure. Unchanged
+   * credentials stay parked: the server already rejected exactly this
+   * credential, so retrying it would only re-fail.
+   */
+  private reconcilePausedCredentials(): void {
+    const reason = this.connection.getPausedReason();
+    if (reason === null) return;
+    const attemptCredential = this.connection.getAuthAttemptCredential();
+    if (attemptCredential === null) return;
+    const current = this.currentCredentialForComparison(reason);
+    if (current === null || current === attemptCredential) return;
+    this.output.status("", "credentials.json updated — clearing paused mode");
+    this.connection.clearPaused();
+  }
+
+  /**
+   * Current credential in the same identity domain the connection recorded
+   * for the paused attempt: the access token for a handshake rejection, the
+   * raw credentials file for a token-provider failure.
+   */
+  private currentCredentialForComparison(reason: ClientPausedReason): string | null {
+    const raw = this.readCredentialsSnapshot(credentialsFilePath());
+    if (raw === null) return null;
+    if (reason !== "auth_rejected") return raw;
+    try {
+      const accessToken = (JSON.parse(raw) as { accessToken?: unknown }).accessToken;
+      return typeof accessToken === "string" ? accessToken : null;
+    } catch {
+      return null;
     }
   }
 

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, watch, writeFileSync } from "node:
 import { dirname, join } from "node:path";
 import {
   AgentSlot,
+  type AuthAttemptCredential,
   type BuiltinHandlerRegistry,
   ClientConnection,
   createBuiltinHandlerRegistry,
@@ -26,7 +27,7 @@ import {
 import type { AgentConfig } from "@first-tree/shared/config";
 import { agentConfigSchema, defaultConfigDir, loadAgents } from "@first-tree/shared/config";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import { ensureFreshAccessToken } from "./bootstrap.js";
+import { ensureFreshAccessToken, loadCredentials } from "./bootstrap.js";
 import { channelConfig } from "./channel.js";
 import { cliFetch } from "./cli-fetch.js";
 import { print } from "./output.js";
@@ -107,6 +108,11 @@ function credentialsFilePath(): string {
   return join(defaultConfigDir(), "credentials.json");
 }
 
+/** Stable auth identity: formatting and unrelated file fields do not trigger recovery. */
+function credentialSnapshot(creds: NonNullable<ReturnType<typeof loadCredentials>>): string {
+  return JSON.stringify([credentialsFilePath(), creds.serverUrl, creds.accessToken, creds.refreshToken]);
+}
+
 export type ClientRuntimeOptions = {
   /**
    * Version of the Command package this process was launched from. Passed to
@@ -172,24 +178,8 @@ export class ClientRuntime {
   private credentialsWatcher: FSWatcher | null = null;
   private credentialsDebounce: ReturnType<typeof setTimeout> | null = null;
 
-  /** Callbacks fired after a WS RE-registration (reconnect), not the first
-   * register. Used by the daemon to re-probe runtime-provider capabilities. */
-  private readonly reconnectListeners: Array<() => void> = [];
-  /**
-   * Set when a `server:welcome` advertised a reconnect; cleared when the
-   * matching registration completes (`connected`) and the reconnect
-   * listeners fire. Keeps reconnect publication strictly behind the
-   * registration boundary.
-   */
-  private reconnectWelcomePending = false;
-  /**
-   * Whether any registration has completed since this runtime was created.
-   * The connection's own `isReconnect` welcome flag only means "not the
-   * first welcome ever" — welcomes from FAILED attempts (auth died before
-   * `client:registered`) also flip it, so without this gate the first
-   * SUCCESSFUL registration after transient failures would be mislabeled a
-   * reconnect and fire reconnect work during startup.
-   */
+  private readonly registeredListeners: Array<(isReconnect: boolean) => void> = [];
+  /** Failed handshakes do not count as registrations. */
   private hasRegisteredOnce = false;
   private readonly runtimeProviderRepairAttempts = new Map<string, number>();
 
@@ -205,7 +195,7 @@ export class ClientRuntime {
       getAccessToken: (opts) => ensureFreshAccessToken(opts),
       // Lets the connection anchor a failed token-provider attempt to the
       // exact credentials it used (see getAuthAttemptCredential).
-      getCredentialsSnapshot: () => this.readCredentialsSnapshot(credentialsFilePath()),
+      getCredentialsSnapshot: () => this.readCredentialsSnapshot(),
       // Forward the last self-update outcome on every `client:register`
       // so the server can persist it into `clients.metadata.lastUpdateAttempt`
       // and the admin dashboard can flag clients that are failing to
@@ -292,26 +282,13 @@ export class ClientRuntime {
       void this.repairRuntimeProviderMismatch(agentId);
     });
 
-    // Fire reconnect listeners only on a completed RE-registration (the
-    // daemon re-probes runtime-provider capabilities then). The
-    // `server:welcome` frame only ADVERTISES a reconnect — it arrives before
-    // `auth:ok` / `client:registered`, so publishing reconnect work on it
-    // would run before the registration actually lands. Arm on the
-    // reconnect welcome, fire on `connected` (emitted on `client:registered`).
-    // `isReconnect` is false on the first welcome, so startup is not
-    // double-probed. Listener errors are swallowed — a re-probe failure must
-    // never disturb the connection.
-    this.connection.on("server:welcome", (welcome) => {
-      if (welcome.isReconnect && this.hasRegisteredOnce) this.reconnectWelcomePending = true;
-    });
+    // Registration is the readiness boundary for both startup and recovery.
     this.connection.on("connected", () => {
-      const wasReconnect = this.reconnectWelcomePending;
-      this.reconnectWelcomePending = false;
+      const wasReconnect = this.hasRegisteredOnce;
       this.hasRegisteredOnce = true;
-      if (!wasReconnect) return;
-      for (const cb of this.reconnectListeners) {
+      for (const cb of this.registeredListeners) {
         try {
-          cb();
+          cb(wasReconnect);
         } catch (err) {
           this.output.status("⚠️", `reconnect handler error: ${err instanceof Error ? err.message : String(err)}`);
         }
@@ -325,7 +302,14 @@ export class ClientRuntime {
    * runtime-provider capabilities without a restart.
    */
   onReconnect(callback: () => void): void {
-    this.reconnectListeners.push(callback);
+    this.onRegistered((isReconnect) => {
+      if (isReconnect) callback();
+    });
+  }
+
+  /** Fired only after client:registered, including the first successful registration. */
+  onRegistered(callback: (isReconnect: boolean) => void): void {
+    this.registeredListeners.push(callback);
   }
 
   /**
@@ -584,39 +568,33 @@ export class ClientRuntime {
    * credential, so retrying it would only re-fail.
    */
   private reconcilePausedCredentials(): void {
-    const reason = this.connection.getPausedReason();
-    if (reason === null) return;
+    if (!this.connection.isPaused()) return;
     const attemptCredential = this.connection.getAuthAttemptCredential();
     if (attemptCredential === null) return;
-    const current = this.currentCredentialForComparison(reason);
-    if (current === null || current === attemptCredential) return;
+    const current = this.currentCredentialForComparison(attemptCredential);
+    if (current === null || current === attemptCredential.value) return;
     this.output.status("", "credentials.json updated — clearing paused mode");
     this.connection.clearPaused();
   }
 
   /**
-   * Current credential in the same identity domain the connection recorded
-   * for the paused attempt: the access token for a handshake rejection, the
-   * raw credentials file for a token-provider failure.
+   * Compare in the identity domain recorded by the attempt, independently
+   * of how the auth error was classified.
    */
-  private currentCredentialForComparison(reason: ClientPausedReason): string | null {
-    const raw = this.readCredentialsSnapshot(credentialsFilePath());
-    if (raw === null) return null;
-    if (reason !== "auth_rejected") return raw;
-    try {
-      const accessToken = (JSON.parse(raw) as { accessToken?: unknown }).accessToken;
-      return typeof accessToken === "string" ? accessToken : null;
-    } catch {
-      return null;
+  private currentCredentialForComparison(attempt: AuthAttemptCredential): string | null {
+    const creds = loadCredentials();
+    if (!creds) return null;
+    switch (attempt.kind) {
+      case "access_token":
+        return creds.accessToken;
+      case "credential_snapshot":
+        return credentialSnapshot(creds);
     }
   }
 
-  private readCredentialsSnapshot(path: string): string | null {
-    try {
-      return readFileSync(path, "utf-8");
-    } catch {
-      return null;
-    }
+  private readCredentialsSnapshot(): string | null {
+    const creds = loadCredentials();
+    return creds ? credentialSnapshot(creds) : null;
   }
 
   /** Test helper / external probe — true once paused mode is active. */

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -176,6 +176,22 @@ export class ClientRuntime {
   /** Callbacks fired after a WS RE-registration (reconnect), not the first
    * register. Used by the daemon to re-probe runtime-provider capabilities. */
   private readonly reconnectListeners: Array<() => void> = [];
+  /**
+   * Set when a `server:welcome` advertised a reconnect; cleared when the
+   * matching registration completes (`connected`) and the reconnect
+   * listeners fire. Keeps reconnect publication strictly behind the
+   * registration boundary.
+   */
+  private reconnectWelcomePending = false;
+  /**
+   * Whether any registration has completed since this runtime was created.
+   * The connection's own `isReconnect` welcome flag only means "not the
+   * first welcome ever" — welcomes from FAILED attempts (auth died before
+   * `client:registered`) also flip it, so without this gate the first
+   * SUCCESSFUL registration after transient failures would be mislabeled a
+   * reconnect and fire reconnect work during startup.
+   */
+  private hasRegisteredOnce = false;
   private readonly runtimeProviderRepairAttempts = new Map<string, number>();
 
   constructor(serverUrl: string, clientId: string, options: ClientRuntimeOptions = {}) {
@@ -270,12 +286,23 @@ export class ClientRuntime {
       void this.repairRuntimeProviderMismatch(agentId);
     });
 
-    // Fire reconnect listeners only on a RE-registration (the daemon re-probes
-    // runtime-provider capabilities then). `isReconnect` is false on the first
-    // welcome, so startup is not double-probed. Listener errors are swallowed —
-    // a re-probe failure must never disturb the connection.
+    // Fire reconnect listeners only on a completed RE-registration (the
+    // daemon re-probes runtime-provider capabilities then). The
+    // `server:welcome` frame only ADVERTISES a reconnect — it arrives before
+    // `auth:ok` / `client:registered`, so publishing reconnect work on it
+    // would run before the registration actually lands. Arm on the
+    // reconnect welcome, fire on `connected` (emitted on `client:registered`).
+    // `isReconnect` is false on the first welcome, so startup is not
+    // double-probed. Listener errors are swallowed — a re-probe failure must
+    // never disturb the connection.
     this.connection.on("server:welcome", (welcome) => {
-      if (!welcome.isReconnect) return;
+      if (welcome.isReconnect && this.hasRegisteredOnce) this.reconnectWelcomePending = true;
+    });
+    this.connection.on("connected", () => {
+      const wasReconnect = this.reconnectWelcomePending;
+      this.reconnectWelcomePending = false;
+      this.hasRegisteredOnce = true;
+      if (!wasReconnect) return;
       for (const cb of this.reconnectListeners) {
         try {
           cb();
@@ -293,6 +320,17 @@ export class ClientRuntime {
    */
   onReconnect(callback: () => void): void {
     this.reconnectListeners.push(callback);
+  }
+
+  /**
+   * Register a callback fired when the connection enters auth paused mode
+   * (refresh token rejected / server-side auth rejection). Used by the
+   * daemon to gate auth-dependent background work (capability refresh)
+   * while credentials are dead — its uploads would otherwise keep firing
+   * doomed `/auth/refresh` 401s.
+   */
+  onAuthPaused(callback: () => void): void {
+    this.connection.on("auth:paused", callback);
   }
 
   /**

--- a/packages/client/src/__tests__/auth-paused.test.ts
+++ b/packages/client/src/__tests__/auth-paused.test.ts
@@ -587,4 +587,61 @@ describe("ClientConnection — auth paused mode (Bug 2, D1)", () => {
     expect(connection.isPaused()).toBe(false);
     expect(connection.isConnected).toBe(false);
   }, 10_000);
+
+  it("anchors a terminal refresh failure to the pre-provider credentials snapshot", async () => {
+    const counters = { sockets: 0, registrations: 0 };
+    serveGoodToken("good-token", counters);
+
+    let snapshot = "cred-v1";
+    let allowToken = false;
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_attempt_identity_refresh",
+      getAccessToken: async () => {
+        if (!allowToken) throw new AuthRefreshFailedError();
+        return "good-token";
+      },
+      getCredentialsSnapshot: () => snapshot,
+    });
+    connection.on("error", () => {});
+
+    const tracked = track(connection.connect());
+    await waitFor(() => connection.isPaused());
+    // No token was ever sent — the failed attempt's identity is the
+    // credential-store snapshot taken before the provider ran.
+    expect(connection.getAuthAttemptCredential()).toBe("cred-v1");
+
+    // Operator re-login rotates the snapshot; the next attempt's identity
+    // becomes the token actually sent in the handshake.
+    snapshot = "cred-v2";
+    allowToken = true;
+    connection.clearPaused();
+    await tracked.promise;
+    expect(connection.getAuthAttemptCredential()).toBe("good-token");
+    expect(counters.registrations).toBe(1);
+
+    await connection.disconnect();
+  }, 10_000);
+
+  it("tolerates a throwing credentials snapshot hook", async () => {
+    wss.on("connection", () => {});
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_snapshot_hook_throw",
+      getAccessToken: async () => {
+        throw new AuthRefreshFailedError();
+      },
+      getCredentialsSnapshot: () => {
+        throw new Error("disk gone");
+      },
+    });
+    connection.on("error", () => {});
+
+    const tracked = track(connection.connect());
+    await waitFor(() => connection.isPaused());
+    expect(connection.getAuthAttemptCredential()).toBeNull();
+
+    await connection.disconnect();
+    await tracked.promise;
+  }, 10_000);
 });

--- a/packages/client/src/__tests__/auth-paused.test.ts
+++ b/packages/client/src/__tests__/auth-paused.test.ts
@@ -9,8 +9,64 @@ import { ClientConnection } from "../runtime/client-connection.js";
  * connection enters paused mode (events `auth:paused` + `auth:fatal`) and
  * stops attempting reconnects. The consumer (CLI) is expected to drive
  * `clearPaused()` when fresh credentials arrive.
+ *
+ * Staging auth-failure storm fix (D1): on the INITIAL connect path, paused
+ * mode used to make `connect()` throw. No consumer ever re-invoked
+ * `connect()`, so the CLI daemon exited and systemd/launchd restarted it
+ * every ~10s — each boot re-fired doomed `/auth/refresh` POSTs plus a wasted
+ * WS handshake. `connect()` now PARKS while paused: the promise stays
+ * pending (no error events, no sockets, no token calls) until
+ * `clearPaused()` → `auth:resumed` wakes the loop, which retries with the
+ * fresh credentials and resolves on the first successful `client:registered`.
+ * `disconnect()` still aborts the park promptly.
+ *
+ * The earlier revision of this file asserted `connect()` REJECTS on the
+ * initial pause — that contract encoded the restart-storm bug and has been
+ * replaced with pending / recover / shutdown tests.
  */
-describe("ClientConnection — auth paused mode (Bug 2)", () => {
+
+class AuthRefreshFailedError extends Error {
+  constructor() {
+    super("Refresh token rejected by server.");
+    this.name = "AuthRefreshFailedError";
+  }
+}
+
+type Tracked = {
+  promise: Promise<void>;
+  settled: () => boolean;
+  error: () => unknown;
+};
+
+/** Track a connect() promise's settlement without leaving it unhandled. */
+function track(connectPromise: Promise<void>): Tracked {
+  let settled = false;
+  let error: unknown = null;
+  const promise = connectPromise.then(
+    () => {
+      settled = true;
+    },
+    (err: unknown) => {
+      settled = true;
+      error = err;
+    },
+  );
+  return { promise, settled: () => settled, error: () => error };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3_000): Promise<void> {
+  const started = Date.now();
+  while (!cond()) {
+    if (Date.now() - started > timeoutMs) throw new Error("condition was not reached in time");
+    await sleep(10);
+  }
+}
+
+describe("ClientConnection — auth paused mode (Bug 2, D1)", () => {
   let httpServer: HttpServer;
   let wss: WebSocketServer;
   let serverUrl: string;
@@ -29,69 +85,121 @@ describe("ClientConnection — auth paused mode (Bug 2)", () => {
     await new Promise<void>((resolve) => httpServer.close(() => resolve()));
   });
 
-  it("AuthRefreshFailedError enters paused mode, does not loop reconnects", async () => {
-    let socketCount = 0;
-    wss.on("connection", () => {
-      socketCount++;
+  /** Server that completes auth only for `goodToken` and counts registrations. */
+  function serveGoodToken(goodToken: string, counters: { sockets: number; registrations: number }): void {
+    wss.on("connection", (ws: WebSocket) => {
+      counters.sockets++;
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as { type: string; token?: string };
+        if (msg.type === "auth") {
+          if (msg.token === goodToken) {
+            ws.send(JSON.stringify({ type: "auth:ok" }));
+          } else {
+            ws.send(JSON.stringify({ type: "auth:rejected", code: "invalid_token" }));
+          }
+          return;
+        }
+        if (msg.type === "client:register") {
+          counters.registrations++;
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      });
     });
+  }
 
-    class AuthRefreshFailedError extends Error {
-      constructor() {
-        super("Refresh token rejected by server.");
-        this.name = "AuthRefreshFailedError";
-      }
-    }
+  it("AuthRefreshFailedError parks the initial connect; clearPaused with fresh credentials completes it", async () => {
+    const counters = { sockets: 0, registrations: 0 };
+    serveGoodToken("good-token", counters);
 
+    let tokenCalls = 0;
+    let allowToken = false;
     const connection = new ClientConnection({
       serverUrl,
       clientId: "client_paused_refresh",
       getAccessToken: async () => {
-        throw new AuthRefreshFailedError();
+        tokenCalls++;
+        if (!allowToken) throw new AuthRefreshFailedError();
+        return "good-token";
       },
     });
 
     const events: string[] = [];
     const pausedReasons: string[] = [];
+    const resumes: string[] = [];
     connection.on("auth:paused", (reason) => {
       events.push("auth:paused");
       pausedReasons.push(reason);
     });
     connection.on("auth:fatal", () => events.push("auth:fatal"));
+    connection.on("auth:resumed", (prev) => resumes.push(prev));
     connection.on("reconnecting", () => events.push("reconnecting"));
-    connection.on("error", () => {});
+    connection.on("error", () => events.push("error"));
 
-    await expect(connection.connect()).rejects.toThrow(/Refresh token/);
-    expect(connection.isPaused()).toBe(true);
+    const tracked = track(connection.connect());
+
+    // The paused initial connect must stay PENDING — silently: no error
+    // events, no reconnect attempts, no extra sockets or token calls.
+    await waitFor(() => connection.isPaused());
+    await sleep(300);
+    expect(tracked.settled()).toBe(false);
     expect(connection.getPausedReason()).toBe("auth_refresh_failed");
     expect(events).toContain("auth:paused");
     expect(events).toContain("auth:fatal");
     expect(events).not.toContain("reconnecting");
+    expect(events).not.toContain("error");
     expect(pausedReasons).toEqual(["auth_refresh_failed"]);
+    expect(tokenCalls).toBe(1);
+    expect(counters.sockets).toBe(1);
 
-    // Give any racing reconnect timer one tick to settle.
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(socketCount).toBeLessThanOrEqual(1);
+    // Operator recovery: fresh credentials + clearPaused → exactly one
+    // successful registration, then connect() resolves.
+    allowToken = true;
+    connection.clearPaused();
+    await tracked.promise;
+    expect(resumes).toEqual(["auth_refresh_failed"]);
+    expect(connection.isPaused()).toBe(false);
+    expect(connection.isConnected).toBe(true);
+    expect(counters.registrations).toBe(1);
+    expect(tokenCalls).toBe(2);
+    expect(counters.sockets).toBe(2);
+
+    // No duplicate owner: clearPaused must not have armed its own reconnect
+    // timer while the connect loop is alive (a second socket would show up
+    // within one base backoff interval).
+    await sleep(1_500);
+    expect(counters.sockets).toBe(2);
+    expect(counters.registrations).toBe(1);
 
     await connection.disconnect();
   }, 10_000);
 
-  it("server-side auth:rejected enters paused mode and stops reconnecting", async () => {
-    // Server accepts the WS handshake, takes the auth frame, then rejects.
+  it("server-side auth:rejected parks the initial connect and recovers on clearPaused", async () => {
     let attempts = 0;
+    let registrations = 0;
     wss.on("connection", (ws: WebSocket) => {
       attempts++;
       ws.on("message", (raw) => {
-        const msg = JSON.parse(String(raw)) as { type: string };
+        const msg = JSON.parse(String(raw)) as { type: string; token?: string };
         if (msg.type === "auth") {
-          ws.send(JSON.stringify({ type: "auth:rejected" }));
+          if (msg.token === "good") {
+            ws.send(JSON.stringify({ type: "auth:ok" }));
+          } else {
+            ws.send(JSON.stringify({ type: "auth:rejected" }));
+          }
+          return;
+        }
+        if (msg.type === "client:register") {
+          registrations++;
+          ws.send(JSON.stringify({ type: "client:registered" }));
         }
       });
     });
 
+    let token = "bad";
     const connection = new ClientConnection({
       serverUrl,
       clientId: "client_paused_rejected",
-      getAccessToken: async () => "tok",
+      getAccessToken: async () => token,
     });
 
     const events: string[] = [];
@@ -100,15 +208,20 @@ describe("ClientConnection — auth paused mode (Bug 2)", () => {
     connection.on("reconnecting", () => events.push("reconnecting"));
     connection.on("error", () => {});
 
-    await expect(connection.connect()).rejects.toThrow();
-    expect(connection.isPaused()).toBe(true);
+    const tracked = track(connection.connect());
+    await waitFor(() => connection.isPaused());
+    await sleep(300);
+    expect(tracked.settled()).toBe(false);
     expect(connection.getPausedReason()).toBe("auth_rejected");
-
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    // First attempt may legitimately be retried once before paused mode
-    // kicked in; assert we capped well under the pre-fix 1Hz storm.
-    expect(attempts).toBeLessThanOrEqual(2);
+    expect(attempts).toBe(1);
     expect(events).toContain("paused:auth_rejected");
+    expect(events).not.toContain("reconnecting");
+
+    token = "good";
+    connection.clearPaused();
+    await tracked.promise;
+    expect(registrations).toBe(1);
+    expect(attempts).toBe(2);
 
     await connection.disconnect();
   }, 10_000);
@@ -133,42 +246,345 @@ describe("ClientConnection — auth paused mode (Bug 2)", () => {
     connection.on("auth:paused", (_reason, err) => pausedErrors.push(err));
     connection.on("error", () => {});
 
-    await expect(connection.connect()).rejects.toThrow(/invalid_token/);
-    expect(connection.isPaused()).toBe(true);
+    const tracked = track(connection.connect());
+    await waitFor(() => connection.isPaused());
+    expect(tracked.settled()).toBe(false);
     expect(connection.getPausedReason()).toBe("auth_rejected");
     expect(pausedErrors[0]?.message).toContain("invalid_token");
     expect(pausedErrors[0]?.message).toContain("signature mismatch");
 
     await connection.disconnect();
+    await tracked.promise;
   }, 10_000);
 
-  it("clearPaused emits auth:resumed and re-arms reconnect", async () => {
-    class AuthRefreshFailedError extends Error {
-      constructor() {
-        super("Refresh token rejected.");
-        this.name = "AuthRefreshFailedError";
-      }
-    }
+  it("disconnect() while parked rejects connect promptly and leaves no listeners or timers behind", async () => {
+    let socketCount = 0;
+    wss.on("connection", () => {
+      socketCount++;
+    });
 
+    let tokenCalls = 0;
     const connection = new ClientConnection({
       serverUrl,
-      clientId: "client_clearpaused",
+      clientId: "client_paused_disconnect",
       getAccessToken: async () => {
+        tokenCalls++;
         throw new AuthRefreshFailedError();
       },
     });
-
     connection.on("error", () => {});
-    await expect(connection.connect()).rejects.toThrow();
-    expect(connection.isPaused()).toBe(true);
 
-    const resumes: string[] = [];
-    connection.on("auth:resumed", (prev) => resumes.push(prev));
+    const connectPromise = connection.connect();
+    const tracked = track(connectPromise);
+    await waitFor(() => connection.isPaused());
+    // Exactly the parked wait's once-listener is attached.
+    expect(connection.listenerCount("auth:resumed")).toBe(1);
 
-    connection.clearPaused();
-    expect(connection.isPaused()).toBe(false);
-    expect(resumes).toEqual(["auth_refresh_failed"]);
+    const t0 = Date.now();
+    const disconnectPromise = connection.disconnect();
+    await expect(connectPromise).rejects.toThrow(/Refresh token/);
+    await disconnectPromise;
+    // Prompt abort — nowhere near any backoff or supervisor interval.
+    expect(Date.now() - t0).toBeLessThan(700);
+
+    expect(tracked.settled()).toBe(true);
+    expect(connection.listenerCount("auth:resumed")).toBe(0);
+    expect(connection.isConnected).toBe(false);
+
+    // No reconnect timer survived the abort: nothing else happens.
+    await sleep(1_500);
+    expect(socketCount).toBe(1);
+    expect(tokenCalls).toBe(1);
+  }, 10_000);
+
+  it("an immediate synchronous clearPaused inside auth:paused still converges to exactly one registration", async () => {
+    const counters = { sockets: 0, registrations: 0 };
+    serveGoodToken("good-token", counters);
+
+    let tokenCalls = 0;
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_paused_sync_resume",
+      getAccessToken: async () => {
+        tokenCalls++;
+        if (tokenCalls === 1) throw new AuthRefreshFailedError();
+        return "good-token";
+      },
+    });
+    connection.on("error", () => {});
+    // Synchronous resume: no missed wakeup, and no duplicate reconnect owner —
+    // the still-running connect loop owns the retry.
+    connection.once("auth:paused", () => connection.clearPaused());
+
+    await connection.connect();
+
+    expect(connection.isConnected).toBe(true);
+    expect(counters.registrations).toBe(1);
+    expect(tokenCalls).toBe(2);
+    expect(counters.sockets).toBe(2);
+
+    await sleep(1_500);
+    expect(counters.sockets).toBe(2);
+    expect(counters.registrations).toBe(1);
 
     await connection.disconnect();
+  }, 10_000);
+
+  it("repeated pause/resume cycles stay bounded in sockets, token calls and listeners", async () => {
+    const counters = { sockets: 0, registrations: 0 };
+    serveGoodToken("good-token", counters);
+
+    let tokenCalls = 0;
+    let allowToken = false;
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_paused_cycles",
+      getAccessToken: async () => {
+        tokenCalls++;
+        if (!allowToken) throw new AuthRefreshFailedError();
+        return "good-token";
+      },
+    });
+    connection.on("error", () => {});
+    connection.on("reconnecting", () => {
+      throw new Error("parked connect must never emit reconnecting");
+    });
+
+    const tracked = track(connection.connect());
+    const nextPaused = () => new Promise<void>((resolve) => connection.once("auth:paused", () => resolve()));
+
+    for (let cycle = 1; cycle <= 3; cycle++) {
+      await nextPaused();
+      // The parked waiter attaches a few microtasks after the auth:paused
+      // emit (the openWebSocket rejection has to unwind first) — wait for it,
+      // and assert exactly one: listeners never accumulate across cycles.
+      await waitFor(() => connection.listenerCount("auth:resumed") === 1);
+      expect(tokenCalls).toBe(cycle);
+      expect(counters.sockets).toBe(cycle);
+      connection.clearPaused();
+      // clearPaused consumed the waiter; the next cycle parks exactly one.
+      await waitFor(() => connection.listenerCount("auth:resumed") <= 1);
+    }
+
+    allowToken = true;
+    connection.clearPaused();
+    await tracked.promise;
+    expect(counters.registrations).toBe(1);
+    expect(tokenCalls).toBe(4);
+    expect(counters.sockets).toBe(4);
+
+    await connection.disconnect();
+  }, 10_000);
+
+  it("a parked connect outlasts the supervisor restart interval with zero additional network activity", async () => {
+    const counters = { sockets: 0, registrations: 0 };
+    serveGoodToken("good-token", counters);
+
+    let tokenCalls = 0;
+    let allowToken = false;
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_paused_supervisor_interval",
+      getAccessToken: async () => {
+        tokenCalls++;
+        if (!allowToken) throw new AuthRefreshFailedError();
+        return "good-token";
+      },
+    });
+    connection.on("error", () => {});
+
+    const tracked = track(connection.connect());
+    await waitFor(() => connection.isPaused());
+
+    // systemd RestartSec=10 / launchd ThrottleInterval=10 used to guarantee
+    // another failing boot by now. The parked connect must produce NOTHING
+    // across that whole interval: no sockets, no /auth/refresh, no settle.
+    const deadline = Date.now() + 10_500;
+    while (Date.now() < deadline) {
+      expect(tracked.settled()).toBe(false);
+      expect(tokenCalls).toBe(1);
+      expect(counters.sockets).toBe(1);
+      await sleep(250);
+    }
+
+    allowToken = true;
+    connection.clearPaused();
+    await tracked.promise;
+    expect(counters.registrations).toBe(1);
+
+    await connection.disconnect();
+  }, 20_000);
+
+  it("a late token rejection from a settled attempt cannot pause its registered successor", async () => {
+    // Mirrors the independent reproduction (repair-1711
+    // client-retired-token-after.test.ts): attempt A's token is deferred,
+    // the server retires A's socket mid-acquisition, successor B registers —
+    // then A's token rejects AuthRefreshFailedError. Pre-fix, A's open
+    // handler catch ran enterPausedMode on B's healthy connection.
+    let firstSocket: WebSocket | null = null;
+    let sockets = 0;
+    let registrations = 0;
+    wss.on("connection", (ws: WebSocket) => {
+      if (++sockets === 1) firstSocket = ws;
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as { type: string };
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth:ok" }));
+          return;
+        }
+        if (msg.type === "client:register") {
+          registrations++;
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      });
+    });
+
+    let rejectOld: (err: Error) => void = () => {};
+    let tokenCalls = 0;
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_retired_token_reject",
+      getAccessToken: async () => {
+        tokenCalls++;
+        if (tokenCalls === 1) {
+          return new Promise<string>((_resolve, reject) => {
+            rejectOld = reject;
+          });
+        }
+        return "good-token";
+      },
+    });
+    connection.on("error", () => {});
+    const events: string[] = [];
+    connection.on("auth:paused", () => events.push("auth:paused"));
+
+    const tracked = track(connection.connect());
+    await waitFor(() => tokenCalls === 1 && firstSocket !== null);
+    // Server retires attempt A mid-token-acquisition — a transient failure,
+    // so the connect loop retries and B registers.
+    (firstSocket as WebSocket | null)?.close(1000, "synthetic retirement");
+    await tracked.promise;
+    expect(connection.isConnected).toBe(true);
+    expect(registrations).toBe(1);
+    expect(tokenCalls).toBe(2);
+
+    // NOW A's token rejects terminally — a dead attempt's failure must not
+    // reach the live connection.
+    rejectOld(new AuthRefreshFailedError());
+    await sleep(300);
+    expect(connection.isPaused()).toBe(false);
+    expect(connection.isConnected).toBe(true);
+    expect(events).not.toContain("auth:paused");
+    expect(tokenCalls).toBe(2);
+    expect(registrations).toBe(1);
+    expect(sockets).toBe(2);
+
+    await connection.disconnect();
+  }, 10_000);
+
+  it("a late token resolution on a settled attempt sends nothing and arms no proactive timer", async () => {
+    let firstSocket: WebSocket | null = null;
+    let sockets = 0;
+    let registrations = 0;
+    let framesOnFirstSocket = 0;
+    wss.on("connection", (ws: WebSocket) => {
+      const isFirst = ++sockets === 1;
+      if (isFirst) firstSocket = ws;
+      ws.on("message", (raw) => {
+        if (isFirst) framesOnFirstSocket++;
+        const msg = JSON.parse(String(raw)) as { type: string };
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth:ok" }));
+          return;
+        }
+        if (msg.type === "client:register") {
+          registrations++;
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      });
+    });
+
+    let resolveOld: (token: string) => void = () => {};
+    let tokenCalls = 0;
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_retired_token_resolve",
+      getAccessToken: async () => {
+        tokenCalls++;
+        if (tokenCalls === 1) {
+          return new Promise<string>((resolve) => {
+            resolveOld = resolve;
+          });
+        }
+        return "good-token";
+      },
+    });
+    connection.on("error", () => {});
+    connection.on("auth:paused", () => {
+      throw new Error("late token resolution must not pause");
+    });
+
+    const tracked = track(connection.connect());
+    await waitFor(() => tokenCalls === 1 && firstSocket !== null);
+    (firstSocket as WebSocket | null)?.close(1000, "synthetic retirement");
+    await tracked.promise;
+    expect(connection.isConnected).toBe(true);
+    expect(registrations).toBe(1);
+
+    // A's token finally arrives — it must not be sent on the retired socket
+    // (no frame, no crash) and must not disturb B.
+    resolveOld("stale-token");
+    await sleep(300);
+    expect(framesOnFirstSocket).toBe(0);
+    expect(connection.isPaused()).toBe(false);
+    expect(connection.isConnected).toBe(true);
+    expect(registrations).toBe(1);
+    expect(sockets).toBe(2);
+
+    await connection.disconnect();
+  }, 10_000);
+
+  it("disconnect() during token acquisition settles connect promptly and ignores the late token", async () => {
+    let firstSocket: WebSocket | null = null;
+    wss.on("connection", (ws: WebSocket) => {
+      if (!firstSocket) firstSocket = ws;
+    });
+
+    let rejectOld: (err: Error) => void = () => {};
+    let tokenCalls = 0;
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_disconnect_during_token",
+      getAccessToken: async () => {
+        tokenCalls++;
+        if (tokenCalls === 1) {
+          return new Promise<string>((_resolve, reject) => {
+            rejectOld = reject;
+          });
+        }
+        return "good-token";
+      },
+    });
+    connection.on("error", () => {});
+
+    const connectPromise = connection.connect();
+    const tracked = track(connectPromise);
+    await waitFor(() => tokenCalls === 1 && firstSocket !== null);
+
+    // The abort ownership (connectAbort) settles the token wait — connect
+    // must reject promptly even though the provider never answers.
+    const t0 = Date.now();
+    const disconnectPromise = connection.disconnect();
+    await expect(connectPromise).rejects.toBeDefined();
+    await disconnectPromise;
+    expect(Date.now() - t0).toBeLessThan(700);
+    expect(tracked.settled()).toBe(true);
+
+    // The late terminal token failure is consumed silently: no pause, no
+    // unhandled rejection, no further activity.
+    rejectOld(new AuthRefreshFailedError());
+    await sleep(200);
+    expect(connection.isPaused()).toBe(false);
+    expect(connection.isConnected).toBe(false);
   }, 10_000);
 });

--- a/packages/client/src/__tests__/auth-paused.test.ts
+++ b/packages/client/src/__tests__/auth-paused.test.ts
@@ -609,7 +609,7 @@ describe("ClientConnection — auth paused mode (Bug 2, D1)", () => {
     await waitFor(() => connection.isPaused());
     // No token was ever sent — the failed attempt's identity is the
     // credential-store snapshot taken before the provider ran.
-    expect(connection.getAuthAttemptCredential()).toBe("cred-v1");
+    expect(connection.getAuthAttemptCredential()).toEqual({ kind: "credential_snapshot", value: "cred-v1" });
 
     // Operator re-login rotates the snapshot; the next attempt's identity
     // becomes the token actually sent in the handshake.
@@ -617,7 +617,7 @@ describe("ClientConnection — auth paused mode (Bug 2, D1)", () => {
     allowToken = true;
     connection.clearPaused();
     await tracked.promise;
-    expect(connection.getAuthAttemptCredential()).toBe("good-token");
+    expect(connection.getAuthAttemptCredential()).toEqual({ kind: "access_token", value: "good-token" });
     expect(counters.registrations).toBe(1);
 
     await connection.disconnect();

--- a/packages/client/src/__tests__/client-connection-auth-expired.test.ts
+++ b/packages/client/src/__tests__/client-connection-auth-expired.test.ts
@@ -165,8 +165,23 @@ describe("ClientConnection — auth:expired reconnect", () => {
     connection.on("reconnecting", () => events.push("reconnecting"));
     connection.on("error", () => {});
 
-    await expect(connection.connect()).rejects.toThrow();
+    // D1: the initial connect PARKS on auth pause instead of rejecting —
+    // rejecting used to push the daemon into process.exit and the
+    // supervisor's ~10s restart loop (staging auth-failure storm).
+    let settled = false;
+    const connectPromise = connection.connect();
+    const tracked = connectPromise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
 
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(settled).toBe(false);
+    expect(connection.isPaused()).toBe(true);
     // Deterministic assertion: initial-handshake rejection must never schedule
     // a reconnect (wasRegistered is false at close). No need to wait on wall time.
     expect(events).not.toContain("reconnecting");
@@ -174,5 +189,7 @@ describe("ClientConnection — auth:expired reconnect", () => {
     expect(connection.isConnected).toBe(false);
 
     await connection.disconnect();
+    await expect(connectPromise).rejects.toThrow();
+    await tracked;
   }, 10_000);
 });

--- a/packages/client/src/__tests__/client-connection-auth-fatal.test.ts
+++ b/packages/client/src/__tests__/client-connection-auth-fatal.test.ts
@@ -8,9 +8,14 @@ import { ClientConnection } from "../runtime/client-connection.js";
  *
  *   1. Refresh token expired → `getAccessToken` throws; client previously
  *      thrashed at 1Hz forever, burning CPU and log volume. The fix:
- *      surface `auth:fatal` on `AuthRefreshFailedError`, mark closing,
- *      stop the reconnect loop. The CLI consumer then exits 75 so
- *      systemd/launchd applies its restart backoff.
+ *      surface `auth:fatal`/`auth:paused` on `AuthRefreshFailedError` and
+ *      stop the reconnect loop. The initial-connect path then used to
+ *      THROW out of `connect()` — which pushed the CLI into process.exit
+ *      and let systemd/launchd restart it into the same dead credentials
+ *      every ~10s (the staging auth-failure storm). `connect()` now parks
+ *      while paused and only resolves after `clearPaused()` + a successful
+ *      registration; these tests pin both halves (park, then prompt abort
+ *      on disconnect).
  *
  *   2. The 1Hz cadence itself was caused by `reconnectAttempt = 0` on
  *      `ws.on("open")` — a TCP-level success was treated as application
@@ -40,7 +45,7 @@ describe("ClientConnection — auth-fatal + reconnect backoff regressions", () =
     await new Promise<void>((resolve) => httpServer.close(() => resolve()));
   });
 
-  it("emits auth:fatal and stops reconnecting when getAccessToken throws AuthRefreshFailedError", async () => {
+  it("parks the initial connect (auth:fatal) instead of throwing when getAccessToken throws AuthRefreshFailedError", async () => {
     // Server accepts the WS but the client never gets that far — its first
     // call to getAccessToken throws synthetically, the same shape the
     // command-layer's bootstrap throws on a real `/auth/refresh` 401.
@@ -72,12 +77,23 @@ describe("ClientConnection — auth-fatal + reconnect backoff regressions", () =
     // fail the run.
     connection.on("error", () => {});
 
-    await expect(connection.connect()).rejects.toThrow(/Refresh token/);
+    let settled = false;
+    const connectPromise = connection.connect();
+    const tracked = connectPromise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
 
-    // Give the close handler one tick to settle (it runs in the WS
-    // close-event microtask), then assert no reconnect was scheduled.
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
+    // The connect promise must NOT reject into the consumer anymore — it
+    // parks silently while paused. A throw here is what used to push the
+    // daemon into process.exit and the supervisor's ~10s restart loop.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(settled).toBe(false);
+    expect(connection.isPaused()).toBe(true);
     expect(events).toContain("auth:fatal");
     expect(events).not.toContain("reconnecting");
     // The pre-fix bug spammed sockets at 1Hz; assert we opened **one** and
@@ -85,7 +101,11 @@ describe("ClientConnection — auth-fatal + reconnect backoff regressions", () =
     // reconnect after an unrecoverable auth error.
     expect(socketCount).toBeLessThanOrEqual(1);
 
+    // disconnect() aborts the park promptly; the pending connect rejects
+    // with the original auth error.
     await connection.disconnect();
+    await expect(connectPromise).rejects.toThrow(/Refresh token/);
+    await tracked;
   }, 10_000);
 
   it("does not collapse exponential backoff to 1Hz when the auth phase fails after ws.open", async () => {

--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -876,4 +876,48 @@ describe("ClientConnection — WebSocket edge coverage", () => {
         .filter((message) => message.type === "inbox:ack"),
     ).toEqual([]);
   });
+  it("does not let a retired attempt's timer close a successor waiting for its token", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-10T00:00:00Z"));
+    let releaseSecond: (token: string) => void = () => {};
+    const getAccessToken = vi
+      .fn()
+      .mockResolvedValueOnce(makeJwt({ exp: Math.floor(Date.now() / 1000) + 75 }))
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((resolve) => {
+            releaseSecond = resolve;
+          }),
+      )
+      .mockResolvedValue(makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }));
+    const connection = await makeConnection({ getAccessToken });
+    connection.on("error", () => {});
+    const internal = priv(connection);
+    const firstAttempt = internal.openWebSocket();
+    const first = FakeWebSocket.instances[0];
+    if (!first) throw new Error("missing first socket");
+    const firstFailure = expect(firstAttempt).rejects.toThrow("WebSocket connect timeout");
+    first.emitOpen();
+    await flushMicrotasks();
+    expect(first.sent).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await firstFailure;
+    const secondAttempt = internal.openWebSocket().catch(() => {});
+    const second = FakeWebSocket.instances[1];
+    if (!second) throw new Error("missing second socket");
+    second.emitOpen();
+    await flushMicrotasks();
+    first.emit("close", 1006);
+    try {
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(getAccessToken).toHaveBeenCalledTimes(2);
+      expect(second.closeCalls).toHaveLength(0);
+    } finally {
+      second.close(1000, "test cleanup");
+      releaseSecond("synthetic-late-token");
+      await secondAttempt;
+      await connection.disconnect();
+      internal.clearTimers();
+    }
+  });
 });

--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -426,7 +426,7 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     ).rejects.toThrow("socket not bound");
   });
 
-  it("covers non-Error initial connect failures and paused-after-backoff exit", async () => {
+  it("covers non-Error initial connect failures and paused-after-backoff parking", async () => {
     vi.useFakeTimers();
     const connection = await makeConnection();
     const internal = priv(connection);
@@ -436,14 +436,35 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     });
     connection.on("error", (err) => errors.push(err.message));
 
+    let settled = false;
     const connectPromise = connection.connect();
-    const rejection = expect(connectPromise).rejects.toBe("plain connect failure");
+    const tracked = connectPromise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
     await flushMicrotasks();
+    expect(errors).toEqual(["plain connect failure"]);
+
+    // A pause landing during the backoff sleep parks the loop at the top
+    // instead of throwing: the promise stays pending and no further attempts
+    // or error emits happen while parked.
     internal.pausedReason = "auth_rejected";
     await vi.advanceTimersByTimeAsync(1000);
-
-    await rejection;
+    await flushMicrotasks();
+    expect(settled).toBe(false);
+    expect(internal.openWebSocket).toHaveBeenCalledTimes(1);
     expect(errors).toEqual(["plain connect failure"]);
+
+    // disconnect() aborts the park; the pending connect rejects with the
+    // original (non-Error) failure.
+    const rejection = expect(connectPromise).rejects.toBe("plain connect failure");
+    await connection.disconnect();
+    await rejection;
+    await tracked;
   });
 
   it("covers non-Error rebind and reconnect catches", async () => {

--- a/packages/client/src/__tests__/runtime-auth-recovery.test.ts
+++ b/packages/client/src/__tests__/runtime-auth-recovery.test.ts
@@ -1,0 +1,170 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { AgentRuntime } from "../runtime/runtime.js";
+
+// Keep connection/authentication real; agent execution is outside this entry-point contract.
+const slots = vi.hoisted(() => ({ start: vi.fn(async () => undefined), stop: vi.fn(async () => undefined) }));
+vi.mock("../runtime/agent-slot.js", () => ({
+  AgentSlot: class {
+    start = slots.start;
+    stop = slots.stop;
+  },
+}));
+
+function refreshRejected(): Error {
+  const error = new Error("Refresh token rejected");
+  error.name = "AuthRefreshFailedError";
+  return error;
+}
+
+async function serve() {
+  const http = createServer();
+  const ws = new WebSocketServer({ server: http, path: "/api/v1/agent/ws/client" });
+  const counts = { connections: 0, registrations: 0 };
+  ws.on("connection", (socket) => {
+    counts.connections++;
+    socket.on("message", (raw) => {
+      const frame = JSON.parse(String(raw));
+      if (frame.type === "auth") {
+        if (frame.token !== "fresh-token") {
+          socket.send(JSON.stringify({ type: "auth:rejected", code: "invalid_token" }));
+          socket.close(4401, "auth rejected");
+        } else {
+          socket.send(JSON.stringify({ type: "auth:ok" }));
+        }
+      } else if (frame.type === "client:register") {
+        counts.registrations++;
+        socket.send(JSON.stringify({ type: "client:registered" }));
+      }
+    });
+  });
+  await new Promise<void>((resolve) => http.listen(0, "127.0.0.1", resolve));
+  const address = http.address();
+  if (!address || typeof address === "string") throw new Error("Missing loopback address");
+  return {
+    counts,
+    config: {
+      server: `http://127.0.0.1:${address.port}`,
+      agents: {
+        test: {
+          agentId: "test-agent",
+          type: "test",
+          concurrency: 1,
+          session: { idle_timeout: 300, max_sessions: 1, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
+        },
+      },
+    },
+    close: async () => {
+      for (const socket of ws.clients) socket.terminate();
+      await new Promise<void>((resolve) => ws.close(() => resolve()));
+      await new Promise<void>((resolve) => http.close(() => resolve()));
+    },
+  };
+}
+
+const handlerFactories = {
+  test: () => {
+    throw new Error("Agent handler should not be used by this connection test");
+  },
+};
+
+describe("AgentRuntime authentication recovery through its public API", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    "handshake",
+    "refresh",
+  ] as const)("recovers from initial %s rejection after an explicit host update", async (failure) => {
+    const harness = await serve();
+    let token = "rejected-token";
+    const provider = vi.fn(async () => {
+      if (failure === "refresh" && token !== "fresh-token") throw refreshRejected();
+      return token;
+    });
+    const paused = vi.fn();
+    let shutdown: (() => Promise<void>) | undefined;
+    const originalOn = process.on.bind(process);
+    vi.spyOn(process, "on").mockImplementation((event, listener) => {
+      if (event === "SIGTERM")
+        shutdown = async () => {
+          await listener();
+        };
+      else if (event !== "SIGINT") originalOn(event, listener);
+      return process;
+    });
+    const runtime = new AgentRuntime({
+      config: harness.config,
+      handlerFactories,
+      getAccessToken: provider,
+      onAuthPaused: paused,
+    });
+    expect(runtime.getPausedReason()).toBeNull();
+    const starting = runtime.start().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    try {
+      await vi.waitFor(() => expect(paused).toHaveBeenCalledOnce(), { timeout: 3_000 });
+      expect(runtime.getPausedReason()).toBe(failure === "refresh" ? "auth_refresh_failed" : "auth_rejected");
+      expect(slots.start).not.toHaveBeenCalled();
+      token = "fresh-token";
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(provider).toHaveBeenCalledOnce();
+      expect(harness.counts.registrations).toBe(0);
+
+      runtime.resumeAfterCredentialsChange();
+      await vi.waitFor(() => expect(shutdown).toBeDefined(), { timeout: 3_000 });
+      expect(runtime.getPausedReason()).toBeNull();
+      expect(harness.counts).toEqual({ connections: 2, registrations: 1 });
+      expect(provider).toHaveBeenCalledTimes(2);
+      expect(slots.start).toHaveBeenCalledOnce();
+      await shutdown?.();
+      expect(await starting).toBeNull();
+      runtime.resumeAfterCredentialsChange();
+      expect(provider).toHaveBeenCalledTimes(2);
+    } finally {
+      await runtime.stop();
+      await harness.close();
+    }
+  });
+
+  it.each([
+    "sync",
+    "async",
+  ] as const)("stops an initially paused runtime despite a %s observer failure and cannot revive it", async (failure) => {
+    const harness = await serve();
+    const provider = vi.fn(async () => {
+      throw refreshRejected();
+    });
+    const runtime = new AgentRuntime({
+      config: harness.config,
+      handlerFactories,
+      getAccessToken: provider,
+      onAuthPaused: () => {
+        if (failure === "async") return Promise.reject(new Error("Host observer failed asynchronously"));
+        throw new Error("Host observer failed");
+      },
+    });
+    const starting = runtime.start().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    try {
+      await vi.waitFor(() => expect(runtime.getPausedReason()).toBe("auth_refresh_failed"), { timeout: 3_000 });
+      await runtime.stop();
+      expect(await starting).toMatchObject({ name: "AuthRefreshFailedError" });
+      runtime.resumeAfterCredentialsChange();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(provider).toHaveBeenCalledOnce();
+      expect(harness.counts).toEqual({ connections: 1, registrations: 0 });
+      expect(slots.start).not.toHaveBeenCalled();
+    } finally {
+      await runtime.stop();
+      await harness.close();
+    }
+  });
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -199,6 +199,7 @@ export { CHILD_CATEGORIES, getChildProcessRegistry } from "./runtime/child-proce
 export type { CliBinding } from "./runtime/cli-binding.js";
 export { getCliBinding, setCliBinding } from "./runtime/cli-binding.js";
 export type {
+  AuthAttemptCredential,
   BoundAgent,
   ClientConnectionConfig,
   ProviderModelsListCommand,

--- a/packages/client/src/runtime/client-connection.ts
+++ b/packages/client/src/runtime/client-connection.ts
@@ -133,6 +133,16 @@ export type ClientConnectionConfig = {
    */
   getAccessToken: AccessTokenProvider;
   /**
+   * Optional synchronous snapshot of the consumer's credential store (e.g.
+   * raw credentials.json content), treated as an opaque identity string.
+   * Read once before each token-provider invocation; when the provider
+   * fails terminally (no token is ever sent), the snapshot becomes the
+   * attempt identity exposed via {@link getAuthAttemptCredential} so a
+   * paused consumer can tell "credentials changed since the failed
+   * attempt" apart from "unchanged".
+   */
+  getCredentialsSnapshot?: () => string | null;
+  /**
    * Optional `User-Agent` string forwarded to every per-agent SDK created by
    * `agent:bound`. Distinct from `sdkVersion` (which is the value advertised
    * to the server in `client:register`); this one only decorates outbound
@@ -507,6 +517,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   private readonly sdkVersion: string | undefined;
   private readonly userAgent: string | undefined;
   private readonly getAccessToken: AccessTokenProvider;
+  private readonly getCredentialsSnapshot: (() => string | null) | undefined;
   private readonly getLastUpdateAttempt: (() => UpdateAttempt | null) | undefined;
   private readonly heartbeatIntervalMs: number;
   private readonly heartbeatTimeoutMs: number;
@@ -576,6 +587,17 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    */
   private serverSupportsSessionResetV1 = false;
   /**
+   * Identity of the credential used by the latest live auth attempt: the
+   * access token actually sent in the handshake (post-refresh — a
+   * successful provider refresh may rotate both tokens), or the
+   * pre-provider credential-store snapshot when the provider failed before
+   * any token was sent. Recorded only behind the retired-attempt fences,
+   * so a stale provider completion can never overwrite a newer attempt's
+   * identity. Read together with {@link getPausedReason} to decide whether
+   * current credentials differ from the ones that failed.
+   */
+  private authAttemptCredential: string | null = null;
+  /**
    * Last handshake error, stashed for the `close` handler to surface a typed
    * reason (e.g. {@link ClientOrgMismatchError}) instead of a generic
    * "closed before ready" when `connect()` is pending.
@@ -625,6 +647,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.sdkVersion = config.sdkVersion;
     this.userAgent = config.userAgent;
     this.getAccessToken = config.getAccessToken;
+    this.getCredentialsSnapshot = config.getCredentialsSnapshot;
     this.getLastUpdateAttempt = config.getLastUpdateAttempt;
     this.heartbeatIntervalMs = config.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
     this.heartbeatTimeoutMs = config.heartbeatTimeoutMs ?? HEARTBEAT_TIMEOUT_MS;
@@ -671,6 +694,26 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   /** Last paused reason. `null` when not paused. */
   getPausedReason(): ClientPausedReason | null {
     return this.pausedReason;
+  }
+
+  /**
+   * Identity of the credential used by the latest live auth attempt — the
+   * token sent in the handshake, or the consumer-supplied credential
+   * snapshot when the token provider failed terminally. Meaningful while
+   * paused: compare against the current credential store to resume only on
+   * a real change.
+   */
+  getAuthAttemptCredential(): string | null {
+    return this.authAttemptCredential;
+  }
+
+  /** Consumer snapshot hook, tolerated if it throws (disk hiccups). */
+  private readCredentialsSnapshot(): string | null {
+    try {
+      return this.getCredentialsSnapshot?.() ?? null;
+    } catch {
+      return null;
+    }
   }
 
   /**
@@ -1195,8 +1238,8 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * (`auth_rejected` / `auth_refresh_failed`) the loop PARKS instead of
    * throwing. Throwing pushed the failure out to the CLI, which exited and
    * let systemd/launchd restart the whole process every ~10s — each boot
-   * re-fired doomed `/auth/refresh` POSTs plus a wasted WS handshake (the
-   * staging auth-failure storm), and no consumer ever re-invoked `connect()`
+   * re-fired doomed `/auth/refresh` POSTs plus a wasted WS handshake (as
+   * reproduced with a revoked token), and no consumer ever re-invoked `connect()`
    * to make the throw recoverable. Parking keeps the promise pending with
    * zero network activity until the consumer's credentials watcher calls
    * {@link clearPaused} (`auth:resumed` wakes the loop) or {@link disconnect}
@@ -1625,6 +1668,10 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         // success signal — `client:registered` — instead.
         this.wsLogger.debug("socket opened, sending auth");
 
+        // Snapshot the consumer's credential store BEFORE the provider runs:
+        // if the provider fails terminally (refresh rejected) no token is
+        // ever sent, and this snapshot is the failed attempt's only identity.
+        const credentialsSnapshot = this.readCredentialsSnapshot();
         try {
           const token = await this.attemptAccessToken();
           // Retired-attempt fence: the token arrived AFTER this attempt
@@ -1635,6 +1682,10 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           // proactive refresh timer for a dead attempt.
           if (settled || this.closing || this.ws !== ws || ws.readyState !== WebSocket.OPEN) return;
           ws.send(JSON.stringify({ type: "auth", token }));
+          // Attempt identity = the token actually sent. Deliberately NOT
+          // the pre-provider snapshot: a successful refresh may have
+          // rotated access/refresh tokens inside the provider.
+          this.authAttemptCredential = token;
           // C5: arm the proactive refresh timer as soon as we've sent the
           // auth frame — auth:ok only confirms the token was accepted, the
           // exp itself is already fixed on the token payload.
@@ -1663,7 +1714,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
             this.authLogger.error({ err }, "failed to obtain access token");
             if (e.name === "AuthRefreshFailedError") {
               // Bug 2: enter paused mode; the credentials watcher will call
-              // clearPaused() to resume.
+              // clearPaused() to resume. The pre-provider snapshot identifies
+              // the credential authority that failed.
+              this.authAttemptCredential = credentialsSnapshot;
               this.enterPausedMode("auth_refresh_failed", e);
             } else if (e.name === "AuthRefreshRateLimitedError") {
               // Pull the server-suggested wait off the typed error and stash
@@ -2677,7 +2730,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     const delay = exp * 1000 - Date.now() - AUTH_REFRESH_LEAD_MS;
     if (delay <= 0) return;
     this.authLogger.debug({ delayMs: delay }, "scheduled proactive auth refresh");
+    const armedSocket = this.ws;
     this.authRefreshTimer = setTimeout(() => {
+      this.authRefreshTimer = null;
+      // A retired attempt must not refresh or close its successor's socket.
+      if (this.ws !== armedSocket) return;
       void this.runProactiveAuthRefresh();
     }, delay);
   }
@@ -2686,6 +2743,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.authRefreshTimer = null;
     if (this.closing) return;
     this.authLogger.info("triggering proactive auth refresh");
+    const credentialsSnapshot = this.readCredentialsSnapshot();
     try {
       // Force a fetch — the cached token is by definition still inside the
       // 60s lead window here, so we ask for >lead validity to make
@@ -2709,6 +2767,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         // dance; reconnecting would just throw the same error from the open
         // handler. clearPaused() (driven by the credentials watcher) will
         // resume.
+        this.authAttemptCredential = credentialsSnapshot;
         this.enterPausedMode("auth_refresh_failed", e);
         return;
       } else {

--- a/packages/client/src/runtime/client-connection.ts
+++ b/packages/client/src/runtime/client-connection.ts
@@ -535,6 +535,13 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    */
   private connectAbort: AbortController | null = null;
   /**
+   * True while {@link connect}'s initial-connect loop is running. Lets
+   * {@link clearPaused} tell who owns the retry: the parked connect loop
+   * wakes itself on `auth:resumed`, so arming a second reconnect timer
+   * would open duplicate sockets / double-register the client.
+   */
+  private connectActive = false;
+  /**
    * If the most recent refresh attempt was rate-limited (HTTP 429), the
    * server-suggested wait in ms — consumed by the next `scheduleReconnect`
    * to floor its delay so we don't keep retrying inside the same 60s
@@ -682,7 +689,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     );
     this.emit("auth:resumed", prev);
     this.emit("resilience.connection.resumed", { previousReason: prev });
-    if (!this.closing && !this.isConnected) {
+    // Single reconnect owner: while connect()'s initial loop is alive it
+    // wakes itself from the `auth:resumed` above and retries on its own —
+    // arming our own timer here would open a duplicate socket and
+    // double-register the client.
+    if (!this.closing && !this.isConnected && !this.connectActive) {
       this.scheduleReconnect();
     }
   }
@@ -1174,29 +1185,55 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * Bring up the socket, retrying transient handshake failures with the same
    * exponential schedule as {@link scheduleReconnect}. Resolves once the
    * server has acknowledged `client:register`; rejects only when something
-   * unrecoverable has flipped `closing` (auth:fatal, register:rejected for
-   * user/org mismatch). Without this loop, a temporary DNS hiccup at startup
-   * propagated up to `client-runtime.start` and exited the process — which
-   * leaned on systemd's restart to recover instead of the in-process backoff
-   * the live reconnect path already uses.
+   * unrecoverable has flipped `closing` (register:rejected for user/org
+   * mismatch, or {@link disconnect} aborting the loop). Without this loop, a
+   * temporary DNS hiccup at startup propagated up to `client-runtime.start`
+   * and exited the process — which leaned on systemd's restart to recover
+   * instead of the in-process backoff the live reconnect path already uses.
+   *
+   * Paused mode (Bug 2, D1): when the auth layer enters paused mode
+   * (`auth_rejected` / `auth_refresh_failed`) the loop PARKS instead of
+   * throwing. Throwing pushed the failure out to the CLI, which exited and
+   * let systemd/launchd restart the whole process every ~10s — each boot
+   * re-fired doomed `/auth/refresh` POSTs plus a wasted WS handshake (the
+   * staging auth-failure storm), and no consumer ever re-invoked `connect()`
+   * to make the throw recoverable. Parking keeps the promise pending with
+   * zero network activity until the consumer's credentials watcher calls
+   * {@link clearPaused} (`auth:resumed` wakes the loop) or {@link disconnect}
+   * aborts it. Registration/readiness is never signalled from the park — the
+   * promise resolves only on a real `client:registered`.
    */
   async connect(): Promise<void> {
     this.closing = false;
-    this.connectAbort = new AbortController();
+    const connectAbort = new AbortController();
+    this.connectAbort = connectAbort;
+    this.connectActive = true;
     let attempt = 0;
+    let lastError: unknown = new Error("Client connection closed before ready");
     try {
       while (true) {
+        if (this.pausedReason !== null) {
+          this.wsLogger.debug(
+            { pausedReason: this.pausedReason },
+            "initial connect paused — awaiting fresh credentials",
+          );
+          await this.waitForPausedResume(connectAbort.signal);
+          if (this.closing) throw lastError;
+          // Operator recovered — retry immediately with the fresh credentials
+          // and start the transient backoff schedule fresh.
+          attempt = 0;
+          continue;
+        }
         try {
           await this.openWebSocket();
           return;
         } catch (err) {
+          lastError = err;
           if (this.closing) throw err;
-          // Bug 2: paused mode (auth_rejected / auth_refresh_failed) is an
-          // operator-recovery state — keep the initial-connect promise from
-          // looping forever. Surface the error so the consumer knows the
-          // initial handshake failed; the credentials watcher will trigger
-          // a fresh `connect()` once login succeeds.
-          if (this.pausedReason !== null) throw err;
+          // Auth pause → park at the top of the loop. Not transient: no
+          // backoff, no "error" emit (paused mode has its own events), and
+          // no retry on any timer.
+          if (this.pausedReason !== null) continue;
           attempt++;
           const { delayMs, floorMs } = this.consumeReconnectDelay(attempt);
           this.wsLogger.warn(
@@ -1204,14 +1241,78 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
             "initial connect failed, will retry",
           );
           this.emit("error", err instanceof Error ? err : new Error(String(err)));
-          await waitWithAbort(delayMs, this.connectAbort.signal);
+          await waitWithAbort(delayMs, connectAbort.signal);
           if (this.closing) throw err;
-          if (this.pausedReason !== null) throw err;
         }
       }
     } finally {
+      this.connectActive = false;
       this.connectAbort = null;
     }
+  }
+
+  /**
+   * Park the initial-connect loop while paused mode is active. Resolves when
+   * {@link clearPaused} emits `auth:resumed` (fresh credentials arrived) or
+   * when the abort signal fires ({@link disconnect}). Both listeners are
+   * removed on settle so repeated pause/resume cycles never accumulate them.
+   * The synchronous `if (signal.aborted)` check closes the same-tick race
+   * where disconnect lands between the paused check and listener attachment.
+   */
+  private waitForPausedResume(signal: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const finish = () => {
+        this.off("auth:resumed", onResumed);
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      const onResumed = () => finish();
+      const onAbort = () => finish();
+      this.once("auth:resumed", onResumed);
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) onAbort();
+    });
+  }
+
+  /**
+   * Await the access-token provider for a connect attempt, but settle early
+   * when the initial-connect abort fires (disconnect()). The signal is also
+   * forwarded to the provider so its own `/auth/refresh` can be cancelled —
+   * but a provider that ignores it would otherwise leave the open handler
+   * pending past disconnect()'s removeAllListeners, dangling the connect()
+   * promise and leaving the token free to arrive late on a torn-down socket.
+   * The provider promise is consumed in BOTH branches, so nothing is left
+   * unhandled when the abort wins. On the reconnect path `connectAbort` is
+   * null — the provider promise is used directly and the call site's fence
+   * (`settled` / `closing` / socket identity / readyState) discards any late
+   * result instead.
+   *
+   * Freshness: ask for a token still valid past the proactive-refresh lead
+   * time, otherwise the cached token returned here would already be inside
+   * the lead window and the next proactive refresh would be a no-op — the
+   * server would push `auth:expired` instead. The +5_000 is a readability
+   * slack so the boundary check explicitly clears the lead window rather
+   * than comparing equal; any positive epsilon would do.
+   */
+  private attemptAccessToken(): Promise<string> {
+    const signal = this.connectAbort?.signal;
+    const provider = Promise.resolve(this.getAccessToken({ minValidityMs: AUTH_REFRESH_LEAD_MS + 5_000, signal }));
+    if (!signal) return provider;
+    return new Promise<string>((resolve, reject) => {
+      const finish = (callback: () => void) => {
+        signal.removeEventListener("abort", onAbort);
+        callback();
+      };
+      const onAbort = () => {
+        finish(() => reject(signal.reason ?? new Error("Client disconnected")));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      provider.then(
+        (token) => finish(() => resolve(token)),
+        (err: unknown) => finish(() => reject(err instanceof Error ? err : new Error(String(err)))),
+      );
+      if (signal.aborted) onAbort();
+    });
   }
 
   /**
@@ -1525,58 +1626,68 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         this.wsLogger.debug("socket opened, sending auth");
 
         try {
-          // Ask for a token still valid past our proactive-refresh lead
-          // time, otherwise the cached token returned here would already be
-          // inside the lead window and the next proactive refresh would be
-          // a no-op — server would push `auth:expired` instead.
-          //
-          // The +5_000 is just a readability slack so the boundary check
-          // explicitly clears the lead window rather than comparing equal.
-          // Any positive epsilon would do; 5s reads as deliberate at a
-          // glance and is small enough to never matter operationally.
-          const token = await this.getAccessToken({ minValidityMs: AUTH_REFRESH_LEAD_MS + 5_000 });
+          const token = await this.attemptAccessToken();
+          // Retired-attempt fence: the token arrived AFTER this attempt
+          // already concluded (connect timeout / server close settled the
+          // openWebSocket promise), after disconnect() tore the socket
+          // down, or after a newer attempt became the live socket. A late
+          // token must never be sent on a stale socket nor arm the
+          // proactive refresh timer for a dead attempt.
+          if (settled || this.closing || this.ws !== ws || ws.readyState !== WebSocket.OPEN) return;
           ws.send(JSON.stringify({ type: "auth", token }));
           // C5: arm the proactive refresh timer as soon as we've sent the
           // auth frame — auth:ok only confirms the token was accepted, the
           // exp itself is already fixed on the token payload.
           this.scheduleProactiveAuthRefresh(token);
         } catch (err) {
-          this.authLogger.error({ err }, "failed to obtain access token");
+          // Retired-attempt fence: a late token failure belonging to a
+          // settled attempt (connect timeout / server close) or to a socket
+          // a newer live attempt has replaced must never reach the live
+          // connection — pausing here is exactly how a dead attempt took a
+          // healthy registered one down. While `closing`, disconnect() owns
+          // teardown — but the CURRENT attempt must still settle below so
+          // the connect loop unwinds instead of dangling.
+          if (settled || (this.ws !== ws && !this.closing)) {
+            this.authLogger.debug({ err }, "late token failure on retired connect attempt — ignored");
+            return;
+          }
           // Refresh token expired / revoked is unrecoverable from inside the
           // process — no amount of retrying will succeed without the
-          // operator running `<binName> login <new-token>`. Mark the
-          // connection closed so `ws.on("close")` doesn't reschedule, and
-          // surface an `auth:fatal` event so the consumer (typically the
-          // CLI) can print a recovery prompt and exit, letting systemd /
-          // launchd back off instead of looping at the WS reconnect base.
+          // operator running `<binName> login <new-token>`.
           //
           // `name` duck-typed instead of `instanceof` so this file doesn't
           // pull a runtime dependency on the command package (one-way:
           // command depends on client, not the other way around).
           const e = err instanceof Error ? err : new Error(String(err));
-          if (e.name === "AuthRefreshFailedError") {
-            // Bug 2: instead of marking the connection permanently closed and
-            // letting the consumer process.exit, enter paused mode. The
-            // operator can recover by running the channel-aware login command and the
-            // credentials-watcher will call clearPaused() to resume.
-            this.enterPausedMode("auth_refresh_failed", e);
-          } else if (e.name === "AuthRefreshRateLimitedError") {
-            // Pull the server-suggested wait off the typed error and stash it
-            // for the next scheduleReconnect; falls back to 30s if absent.
-            // Without this floor the WS layer's 1/2/4/8s exponential backoff
-            // hammers the rate-limit window from below and stretches the
-            // outage from "1 minute" to "however long until the bucket
-            // empties under our own load".
-            const retryAfterMs = (e as { retryAfterMs?: number }).retryAfterMs ?? 30_000;
-            this.nextReconnectMinDelayMs = Math.max(this.nextReconnectMinDelayMs, retryAfterMs);
-            this.authLogger.warn({ retryAfterMs }, "refresh rate-limited; deferring reconnect");
+          if (!this.closing) {
+            this.authLogger.error({ err }, "failed to obtain access token");
+            if (e.name === "AuthRefreshFailedError") {
+              // Bug 2: enter paused mode; the credentials watcher will call
+              // clearPaused() to resume.
+              this.enterPausedMode("auth_refresh_failed", e);
+            } else if (e.name === "AuthRefreshRateLimitedError") {
+              // Pull the server-suggested wait off the typed error and stash
+              // it for the next scheduleReconnect; falls back to 30s if
+              // absent. Without this floor the WS layer's 1/2/4/8s
+              // exponential backoff hammers the rate-limit window from below
+              // and stretches the outage from "1 minute" to "however long
+              // until the bucket empties under our own load".
+              const retryAfterMs = (e as { retryAfterMs?: number }).retryAfterMs ?? 30_000;
+              this.nextReconnectMinDelayMs = Math.max(this.nextReconnectMinDelayMs, retryAfterMs);
+              this.authLogger.warn({ retryAfterMs }, "refresh rate-limited; deferring reconnect");
+            }
           }
           settle(reject, e);
-          ws.close();
+          if (!this.closing) ws.close();
         }
       });
 
       ws.on("message", (data) => {
+        // Retired-attempt guard: frames arriving on a socket that is no
+        // longer the live one (a newer attempt already replaced it) must not
+        // touch shared state — a late `auth:rejected` on the old socket must
+        // not re-pause a healthy newer connection.
+        if (this.ws !== ws) return;
         // Any inbound frame proves the peer is alive — refresh the silence
         // watchdog before parsing so malformed frames still count.
         this.lastServerMessageAt = Date.now();
@@ -1592,10 +1703,19 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       // send our own pings from the heartbeat tick — those round-trips are
       // what surface a wedged socket within HEARTBEAT_TIMEOUT_MS.
       ws.on("pong", () => {
+        if (this.ws !== ws) return;
         this.lastServerMessageAt = Date.now();
       });
 
       ws.on("close", (code) => {
+        // Retired-attempt guard: a late close from a socket that already
+        // settled (auth failed / connect timeout) and is no longer the live
+        // socket must not tear down shared state (heartbeat, registration,
+        // pending frames) nor emit/reconnect — the newer attempt owns those
+        // now. A close that settles the in-flight attempt (`!settled`) must
+        // still be processed below even when `this.ws` was never assigned to
+        // it (pre-open handshake failure).
+        if (settled && this.ws !== ws) return;
         this.stopHeartbeat();
         this.clearAuthRefreshTimer();
         this.clearPendingInboxRecoverTimers();
@@ -1633,6 +1753,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       });
 
       ws.on("error", (err) => {
+        // Pre-open handshake errors belong to the in-flight attempt and stay
+        // emitted; a settled retired socket's error is noise.
+        if (settled && this.ws !== ws) return;
         this.emit("error", err);
       });
     });

--- a/packages/client/src/runtime/client-connection.ts
+++ b/packages/client/src/runtime/client-connection.ts
@@ -120,6 +120,11 @@ type PendingSessionEvent = {
   reject: (err: Error) => void;
 };
 
+/** Credential identity from the live attempt; never log or persist this value. */
+export type AuthAttemptCredential =
+  | { readonly kind: "access_token"; readonly value: string }
+  | { readonly kind: "credential_snapshot"; readonly value: string };
+
 export type ClientConnectionConfig = {
   serverUrl: string;
   /** Stable per-machine client identifier. Generated if omitted. */
@@ -593,10 +598,10 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * pre-provider credential-store snapshot when the provider failed before
    * any token was sent. Recorded only behind the retired-attempt fences,
    * so a stale provider completion can never overwrite a newer attempt's
-   * identity. Read together with {@link getPausedReason} to decide whether
-   * current credentials differ from the ones that failed.
+   * identity. The kind identifies how to compare current credentials with
+   * the ones that failed.
    */
-  private authAttemptCredential: string | null = null;
+  private authAttemptCredential: AuthAttemptCredential | null = null;
   /**
    * Last handshake error, stashed for the `close` handler to surface a typed
    * reason (e.g. {@link ClientOrgMismatchError}) instead of a generic
@@ -703,14 +708,15 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * paused: compare against the current credential store to resume only on
    * a real change.
    */
-  getAuthAttemptCredential(): string | null {
+  getAuthAttemptCredential(): AuthAttemptCredential | null {
     return this.authAttemptCredential;
   }
 
   /** Consumer snapshot hook, tolerated if it throws (disk hiccups). */
-  private readCredentialsSnapshot(): string | null {
+  private readCredentialsSnapshot(): AuthAttemptCredential | null {
     try {
-      return this.getCredentialsSnapshot?.() ?? null;
+      const value = this.getCredentialsSnapshot?.();
+      return value == null ? null : { kind: "credential_snapshot", value };
     } catch {
       return null;
     }
@@ -1685,7 +1691,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           // Attempt identity = the token actually sent. Deliberately NOT
           // the pre-provider snapshot: a successful refresh may have
           // rotated access/refresh tokens inside the provider.
-          this.authAttemptCredential = token;
+          this.authAttemptCredential = { kind: "access_token", value: token };
           // C5: arm the proactive refresh timer as soon as we've sent the
           // auth frame — auth:ok only confirms the token was accepted, the
           // exp itself is already fixed on the token payload.

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -5,6 +5,7 @@ export { AgentSlot } from "./agent-slot.js";
 export type { ContextTreeBinding } from "./bootstrap.js";
 export { resolveAgentContextTreeBinding } from "./bootstrap.js";
 export type {
+  AuthAttemptCredential,
   BoundAgent,
   ClientConnectionConfig,
   ProviderModelsListCommand,

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -1,4 +1,4 @@
-import type { UpdateAttempt } from "@first-tree/shared";
+import type { ClientPausedReason, UpdateAttempt } from "@first-tree/shared";
 import { createLogger, type pino } from "../cloud/observability/logger.js";
 import type { AccessTokenProvider } from "../cloud/sdk.js";
 import { AgentSlot } from "./agent-slot.js";
@@ -15,6 +15,11 @@ export type AgentRuntimeOptions = {
    * every WS handshake and every SDK request.
    */
   getAccessToken: AccessTokenProvider;
+  /**
+   * Notify the host when authentication needs new credentials. After updating
+   * its token provider, the host calls resumeAfterCredentialsChange().
+   */
+  onAuthPaused?: (reason: ClientPausedReason, error: Error) => void | Promise<void>;
   /**
    * Instance-level readonly handler factory map. Standalone runtimes must
    * supply this explicitly — there is no process-global handler registry.
@@ -83,6 +88,14 @@ export class AgentRuntime {
     // failures) to operators. ClientConnection's own reconnect loop handles
     // recovery; a process-wide crash guard lives in ClientConnection itself.
     this.clientConnection.on("error", (err) => this.logger.error({ err }, "client connection error"));
+    this.clientConnection.on("auth:paused", (reason, error) => {
+      this.logger.warn({ reason }, "authentication paused — update credentials and call resumeAfterCredentialsChange");
+      // Host observers may be asynchronous; neither sync throws nor rejected
+      // promises may interrupt the connection's pause/cleanup transition.
+      void Promise.resolve()
+        .then(() => options.onAuthPaused?.(reason, error))
+        .catch((err) => this.logger.error({ err }, "auth pause callback failed"));
+    });
 
     for (const [name, agentConfig] of Object.entries(this.config.agents)) {
       // Own-key only: a plain `{}` map still inherits Object.prototype, so
@@ -132,6 +145,16 @@ export class AgentRuntime {
     return { activeCount, lastActivityMs };
   }
 
+  getPausedReason(): ClientPausedReason | null {
+    return this.clientConnection.getPausedReason();
+  }
+
+  /** Explicit host recovery; fresh credentials do not count as registration. Stop stays terminal. */
+  resumeAfterCredentialsChange(): void {
+    if (!this.stopping) this.clientConnection.clearPaused();
+  }
+
+  /** Stays pending during auth pause; the host must supply credentials and resume, or stop. */
   async start(): Promise<void> {
     // Attach before connecting so the first welcome frame on a stale Client
     // is acted on rather than missed until the next reconnect.
@@ -214,6 +237,7 @@ export class AgentRuntime {
   }
 
   async stop(reason?: string): Promise<void> {
+    this.stopping = true;
     this.updateManager?.dispose();
     this.updateManager = null;
     await Promise.allSettled(this.slots.map((slot) => slot.stop(reason)));

--- a/packages/server/src/__tests__/ws-auth-gate-lifecycle.test.ts
+++ b/packages/server/src/__tests__/ws-auth-gate-lifecycle.test.ts
@@ -1,0 +1,672 @@
+import { EventEmitter } from "node:events";
+import type { FastifyInstance } from "fastify";
+import { SignJWT } from "jose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createClientWsAuthGate } from "../api/agent/ws-client/auth.js";
+import { attachClientWsConnection } from "../api/agent/ws-client/connection.js";
+
+/**
+ * Focused auth-lifecycle containment tests (staging incident 2026-09):
+ * the client-WS auth gate must be single-attempt per connection and reach a
+ * terminal state after timeout / rejection / close / handshake failure, so a
+ * flood of duplicate auth frames — or late completions landing after the
+ * socket is gone — cannot multiply DB queries, authentication side effects,
+ * expiry timers, warnings, or close attempts.
+ *
+ * These tests are self-contained: a fake socket/context/app with a
+ * controllable (deferred) user lookup stands in for the database; no live
+ * services are touched.
+ */
+
+const TEST_SECRET = "ws-auth-gate-lifecycle-unit-secret";
+const jwtSecretBytes = new TextEncoder().encode(TEST_SECRET);
+const TEST_USER_ID = "01960000-0000-7000-8000-0000000000aa";
+
+// Captured before fake timers install so tests can yield to the real event
+// loop (WebCrypto JWT verification resolves off-thread; microtask-only
+// flushing never delivers it while timer APIs are faked).
+const realSetImmediate = global.setImmediate;
+
+async function flushRealEventLoop(turns = 30): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    await new Promise<void>((resolve) => realSetImmediate(resolve));
+  }
+}
+
+type SentFrame = { type?: string; code?: string; [key: string]: unknown };
+
+function createFakeSocket() {
+  const emitter = new EventEmitter();
+  const sent: SentFrame[] = [];
+  const closeCalls: Array<{ code?: number; reason?: string }> = [];
+  let failSends = false;
+  const socket = Object.assign(emitter, {
+    OPEN: 1,
+    CLOSED: 3,
+    readyState: 1,
+    send(data: unknown) {
+      if (failSends) throw new Error("WebSocket is not open");
+      sent.push(JSON.parse(String(data)) as SentFrame);
+    },
+    close(code?: number, reason?: string) {
+      closeCalls.push({ code, reason });
+      if (socket.readyState !== socket.CLOSED) {
+        socket.readyState = socket.CLOSED;
+        emitter.emit("close", code);
+      }
+    },
+    /** Test hook: make subsequent send() calls throw (socket mid-failure). */
+    setFailSends(next: boolean) {
+      failSends = next;
+    },
+    /** Test hook: simulate the peer disappearing (no local close() call). */
+    peerClose(code = 1006) {
+      socket.readyState = socket.CLOSED;
+      emitter.emit("close", code);
+    },
+    sent,
+    closeCalls,
+  });
+  return socket;
+}
+
+type FakeSocket = ReturnType<typeof createFakeSocket>;
+
+type DeferredLookup = {
+  queries: number;
+  promise: Promise<Array<{ id: string; status: string }>>;
+  resolve(rows: Array<{ id: string; status: string }>): void;
+  reject(err: unknown): void;
+};
+
+function createFakeContext() {
+  let session: { userId: string } | null = null;
+  let authTimeout: ReturnType<typeof setTimeout> | null = null;
+  let authExpiryTimer: ReturnType<typeof setTimeout> | null = null;
+  const state = {
+    authentications: 0,
+    expiryTimersArmed: 0,
+    authTimeoutsArmed: 0,
+  };
+  const context = {
+    getSession: () => session,
+    authenticate(next: { userId: string }, _defaultOrgId: string | null) {
+      state.authentications++;
+      session = next;
+    },
+    setAuthTimeout(timer: ReturnType<typeof setTimeout>) {
+      if (authTimeout) clearTimeout(authTimeout);
+      authTimeout = timer;
+      state.authTimeoutsArmed++;
+    },
+    clearAuthTimeout() {
+      if (!authTimeout) return;
+      clearTimeout(authTimeout);
+      authTimeout = null;
+    },
+    setAuthExpiryTimer(timer: ReturnType<typeof setTimeout> | null) {
+      if (authExpiryTimer) clearTimeout(authExpiryTimer);
+      authExpiryTimer = timer;
+      if (timer) state.expiryTimersArmed++;
+    },
+  };
+  return {
+    context,
+    state,
+    authTimeoutActive: () => authTimeout !== null,
+    expiryTimerActive: () => authExpiryTimer !== null,
+  };
+}
+
+type FakeContext = ReturnType<typeof createFakeContext>;
+
+function createFakeApp(lookup: DeferredLookup) {
+  const app = {
+    db: {
+      select: () => {
+        const query = {
+          from: () => query,
+          where: () => query,
+          limit: () => {
+            lookup.queries++;
+            return lookup.promise;
+          },
+        };
+        return query;
+      },
+    },
+    log: {
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    commandVersion: () => "gate-lifecycle-test",
+  };
+  return app;
+}
+
+type FakeApp = ReturnType<typeof createFakeApp>;
+
+function createDeferredLookup(): DeferredLookup {
+  let resolvePromise: (rows: Array<{ id: string; status: string }>) => void = () => {};
+  let rejectPromise: (err: unknown) => void = () => {};
+  const promise = new Promise<Array<{ id: string; status: string }>>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return {
+    queries: 0,
+    promise,
+    resolve(rows) {
+      resolvePromise(rows);
+    },
+    reject(err) {
+      rejectPromise(err);
+    },
+  };
+}
+
+async function signAccessToken(expSecondsFromNow = 3600): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({ sub: TEST_USER_ID, type: "access", organizationId: "org-gate-test" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt(now)
+    .setExpirationTime(now + expSecondsFromNow)
+    .sign(jwtSecretBytes);
+}
+
+function createGate(socket: FakeSocket, app: FakeApp, fakeContext: FakeContext) {
+  // Casts are unavoidable: the gate is exercised against a minimal scripted
+  // harness instead of booting Fastify + a database.
+  return createClientWsAuthGate(
+    app as unknown as FastifyInstance,
+    socket as never,
+    jwtSecretBytes,
+    fakeContext.context as never,
+  );
+}
+
+describe("client WS auth gate — single attempt and terminal state", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("verifies only once when duplicate auth frames arrive during a slow lookup", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken();
+    const first = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    expect(lookup.queries).toBe(1);
+
+    // A flood of duplicates while the first attempt's lookup is in flight:
+    // the first duplicate rejects the connection deterministically, the rest
+    // are no-ops — none may start another verification/DB pipeline.
+    const duplicates = Array.from({ length: 19 }, () => gate.handle({ type: "auth", token }, "auth"));
+    await flushRealEventLoop();
+    expect(lookup.queries).toBe(1);
+    // Duplicates are rejected deterministically, exactly once, without
+    // queueing more work: one auth:rejected frame + one close.
+    const rejected = socket.sent.filter((frame) => frame.type === "auth:rejected");
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.code).toBe("invalid_auth_frame");
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.closeCalls[0]?.code).toBe(4401);
+
+    // The in-flight attempt's late completion lands on a terminal gate: it
+    // must not authenticate, arm an expiry timer, or send a welcome.
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await Promise.all([first, ...duplicates]);
+    expect(fakeContext.state.authentications).toBe(0);
+    expect(fakeContext.state.expiryTimersArmed).toBe(0);
+    expect(socket.sent.filter((frame) => frame.type === "server:welcome")).toHaveLength(0);
+    expect(socket.sent.filter((frame) => frame.type === "auth:ok")).toHaveLength(0);
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(app.log.warn).not.toHaveBeenCalled();
+  });
+
+  it("ignores a late successful lookup when the socket closed mid-validation", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken();
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    expect(lookup.queries).toBe(1);
+
+    socket.peerClose();
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await pending;
+
+    expect(fakeContext.state.authentications).toBe(0);
+    expect(fakeContext.state.expiryTimersArmed).toBe(0);
+    expect(socket.sent).toHaveLength(0);
+    // The peer closed the socket — the gate must not retry-close.
+    expect(socket.closeCalls).toHaveLength(0);
+    expect(app.log.warn).not.toHaveBeenCalled();
+  });
+
+  it("ignores a late lookup success when the auth timeout fires mid-validation", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken();
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    expect(lookup.queries).toBe(1);
+
+    // The existing 5s deadline still applies while validation is stuck.
+    await vi.advanceTimersByTimeAsync(5_100);
+    const retryable = socket.sent.filter((frame) => frame.type === "auth:retryable");
+    expect(retryable).toHaveLength(1);
+    expect(retryable[0]?.code).toBe("auth_timeout");
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.closeCalls[0]?.code).toBe(1013);
+
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await pending;
+    expect(fakeContext.state.authentications).toBe(0);
+    expect(fakeContext.state.expiryTimersArmed).toBe(0);
+    expect(socket.sent.filter((frame) => frame.type === "server:welcome")).toHaveLength(0);
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(app.log.warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn or retry-close when the lookup fails after the socket closed", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken();
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    expect(lookup.queries).toBe(1);
+
+    socket.peerClose();
+    lookup.reject(new Error("synthetic db failure"));
+    await pending;
+
+    expect(fakeContext.state.authentications).toBe(0);
+    expect(app.log.warn).not.toHaveBeenCalled();
+    expect(socket.closeCalls).toHaveLength(0);
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  it("does not warn or close twice when the lookup fails after an auth-timeout close", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken();
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    await vi.advanceTimersByTimeAsync(5_100);
+    expect(socket.closeCalls).toHaveLength(1);
+
+    lookup.reject(new Error("synthetic db failure"));
+    await pending;
+    expect(app.log.warn).not.toHaveBeenCalled();
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.sent.filter((frame) => frame.type === "auth:retryable")).toHaveLength(1);
+  });
+
+  it("treats a rejected auth frame as terminal — a later valid frame does no work", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    await gate.handle({ type: "auth", token: "not-a-jwt" }, "auth");
+    const rejected = socket.sent.filter((frame) => frame.type === "auth:rejected");
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.code).toBe("invalid_token");
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.closeCalls[0]?.code).toBe(4401);
+
+    const token = await signAccessToken();
+    await gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    expect(lookup.queries).toBe(0);
+    expect(fakeContext.state.authentications).toBe(0);
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("treats an invalid first frame as terminal via rejectInvalidFrame", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    gate.rejectInvalidFrame("invalid JSON auth frame");
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.closeCalls[0]?.code).toBe(4401);
+
+    const token = await signAccessToken();
+    await gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    expect(lookup.queries).toBe(0);
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("ignores a valid auth frame arriving after the no-frame timeout", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    await vi.advanceTimersByTimeAsync(5_100);
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.closeCalls[0]?.code).toBe(1013);
+
+    const token = await signAccessToken();
+    await gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    expect(lookup.queries).toBe(0);
+    expect(fakeContext.state.authentications).toBe(0);
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("authenticates exactly once and arms exactly one expiry timer on the normal path", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken(30);
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await pending;
+
+    expect(fakeContext.state.authentications).toBe(1);
+    expect(fakeContext.state.expiryTimersArmed).toBe(1);
+    expect(socket.sent.map((frame) => frame.type)).toEqual(["server:welcome", "auth:ok"]);
+    expect(socket.closeCalls).toHaveLength(0);
+
+    // Post-auth session expiry still closes 4401 with exactly one frame.
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect(socket.sent.filter((frame) => frame.type === "auth:expired")).toHaveLength(1);
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.closeCalls[0]?.code).toBe(4401);
+  });
+
+  it("does not fire the post-auth expiry close after the socket is gone", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken(30);
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await pending;
+    expect(fakeContext.state.authentications).toBe(1);
+
+    const sentBefore = socket.sent.length;
+    socket.peerClose();
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect(socket.sent).toHaveLength(sentBefore);
+    expect(socket.closeCalls).toHaveLength(0);
+  });
+
+  it("closes 1011 handshake_internal_error when the welcome send fails on an open socket", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken();
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    socket.setFailSends(true);
+    await pending;
+
+    expect(fakeContext.state.authentications).toBe(1);
+    expect(app.log.warn).toHaveBeenCalledTimes(1);
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.closeCalls[0]?.code).toBe(1011);
+    const queriesAfterFailure = lookup.queries;
+
+    // Internal handshake failure is terminal: later frames do no work.
+    socket.setFailSends(false);
+    const token2 = await signAccessToken();
+    await gate.handle({ type: "auth", token: token2 }, "auth");
+    await flushRealEventLoop();
+    expect(lookup.queries).toBe(queriesAfterFailure);
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("handleClose clears both the auth timeout and the expiry timer immediately", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+    expect(fakeContext.authTimeoutActive()).toBe(true);
+
+    const token = await signAccessToken(30);
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await pending;
+    expect(fakeContext.expiryTimerActive()).toBe(true);
+
+    gate.handleClose();
+    expect(fakeContext.authTimeoutActive()).toBe(false);
+    expect(fakeContext.expiryTimerActive()).toBe(false);
+
+    // No timer may fire after the close: advancing past both deadlines
+    // produces no frames and no close attempts.
+    const sentBefore = socket.sent.length;
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect(socket.sent).toHaveLength(sentBefore);
+    expect(socket.closeCalls).toHaveLength(0);
+  });
+
+  it("a post-auth handshake failure clears the armed expiry timer immediately", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken(30);
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    socket.setFailSends(true);
+    await pending;
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.closeCalls[0]?.code).toBe(1011);
+    expect(fakeContext.expiryTimerActive()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("handleClose before auth clears the pending auth timeout", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+    expect(fakeContext.authTimeoutActive()).toBe(true);
+
+    gate.handleClose();
+    expect(fakeContext.authTimeoutActive()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(5_100);
+    expect(socket.sent).toHaveLength(0);
+    expect(socket.closeCalls).toHaveLength(0);
+  });
+
+  it("start does not arm a new timeout after the gate is terminal or the socket is closed", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+    expect(fakeContext.state.authTimeoutsArmed).toBe(1);
+
+    // Terminal gate: start() is a no-op.
+    gate.rejectInvalidFrame("invalid JSON auth frame");
+    gate.start();
+    expect(fakeContext.state.authTimeoutsArmed).toBe(1);
+
+    // Fresh gate on an already-closed socket: no timer is ever armed.
+    const closedSocket = createFakeSocket();
+    const closedContext = createFakeContext();
+    const closedGate = createGate(closedSocket, app, closedContext);
+    closedSocket.peerClose();
+    closedGate.start();
+    expect(closedContext.state.authTimeoutsArmed).toBe(0);
+  });
+
+  it("returns false for frames after a successful auth (post-auth dispatch owns them)", async () => {
+    const socket = createFakeSocket();
+    const lookup = createDeferredLookup();
+    const app = createFakeApp(lookup);
+    const fakeContext = createFakeContext();
+    const gate = createGate(socket, app, fakeContext);
+    gate.start();
+
+    const token = await signAccessToken();
+    const pending = gate.handle({ type: "auth", token }, "auth");
+    await flushRealEventLoop();
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await pending;
+
+    expect(await gate.handle({ type: "heartbeat" }, "heartbeat")).toBe(false);
+    expect(lookup.queries).toBe(1);
+    expect(fakeContext.state.authentications).toBe(1);
+  });
+});
+
+describe("client WS connection dispatch — closed socket containment", () => {
+  function createHarness(lookup: DeferredLookup) {
+    const socket = createFakeSocket();
+    const app = createFakeApp(lookup);
+    const fakeAppWithConfig = {
+      ...app,
+      config: { secrets: { jwtSecret: TEST_SECRET } },
+    };
+    const notifier = {
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      notify: vi.fn(),
+    };
+    const request = { headers: {}, ip: "127.0.0.1" };
+    // Casts are unavoidable: the connection is driven through a scripted
+    // socket/app harness rather than a live Fastify + database boot.
+    attachClientWsConnection(
+      fakeAppWithConfig as unknown as FastifyInstance,
+      socket as never,
+      request as never,
+      notifier as never,
+      "test-instance",
+    );
+    return { socket, app, notifier };
+  }
+
+  it("skips message dispatch entirely after the socket closed", async () => {
+    const lookup = createDeferredLookup();
+    const { socket, app } = createHarness(lookup);
+
+    const token = await signAccessToken();
+    socket.emit("message", JSON.stringify({ type: "auth", token }));
+    await vi.waitFor(() => {
+      expect(lookup.queries).toBe(1);
+    });
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await vi.waitFor(() => {
+      expect(socket.sent.some((frame) => frame.type === "auth:ok")).toBe(true);
+    });
+
+    const sentBefore = socket.sent.length;
+    socket.close(1000, "client going away");
+    socket.emit("message", "definitely not json");
+    socket.emit("message", JSON.stringify({ type: "heartbeat" }));
+    await flushRealEventLoop();
+
+    expect(socket.sent).toHaveLength(sentBefore);
+    expect(app.log.warn).not.toHaveBeenCalled();
+  });
+
+  it("runs no auth verification for frames arriving after close", async () => {
+    const lookup = createDeferredLookup();
+    const { socket } = createHarness(lookup);
+
+    socket.close(1000, "client going away");
+    const token = await signAccessToken();
+    socket.emit("message", JSON.stringify({ type: "auth", token }));
+    socket.emit("message", "definitely not json");
+    await flushRealEventLoop();
+
+    expect(lookup.queries).toBe(0);
+    expect(socket.sent).toHaveLength(0);
+    // The socket was already closed by the peer: no retry-close, no warnings.
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("completes the normal handshake through the connection (guard)", async () => {
+    const lookup = createDeferredLookup();
+    const { socket } = createHarness(lookup);
+
+    const token = await signAccessToken();
+    socket.emit("message", JSON.stringify({ type: "auth", token }));
+    await vi.waitFor(() => {
+      expect(lookup.queries).toBe(1);
+    });
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await vi.waitFor(() => {
+      expect(socket.sent.some((frame) => frame.type === "auth:ok")).toBe(true);
+    });
+
+    expect(socket.sent.map((frame) => frame.type)).toEqual(["server:welcome", "auth:ok"]);
+    socket.close(1000, "done");
+    await flushRealEventLoop();
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+});

--- a/packages/server/src/__tests__/ws-auth-gate-lifecycle.test.ts
+++ b/packages/server/src/__tests__/ws-auth-gate-lifecycle.test.ts
@@ -26,6 +26,8 @@ const TEST_USER_ID = "01960000-0000-7000-8000-0000000000aa";
 // loop (WebCrypto JWT verification resolves off-thread; microtask-only
 // flushing never delivers it while timer APIs are faked).
 const realSetImmediate = global.setImmediate;
+const realSetTimeout = global.setTimeout;
+const realClearTimeout = global.clearTimeout;
 
 async function flushRealEventLoop(turns = 30): Promise<void> {
   for (let i = 0; i < turns; i++) {
@@ -74,6 +76,10 @@ type FakeSocket = ReturnType<typeof createFakeSocket>;
 
 type DeferredLookup = {
   queries: number;
+  /** Settles once the fake query's limit() runs — i.e. a lookup is in flight. */
+  started: Promise<void>;
+  /** Harness hook invoked by the fake DB query's limit() when a lookup starts. */
+  markStarted(): void;
   promise: Promise<Array<{ id: string; status: string }>>;
   resolve(rows: Array<{ id: string; status: string }>): void;
   reject(err: unknown): void;
@@ -129,6 +135,7 @@ function createFakeApp(lookup: DeferredLookup) {
           where: () => query,
           limit: () => {
             lookup.queries++;
+            lookup.markStarted();
             return lookup.promise;
           },
         };
@@ -151,12 +158,20 @@ type FakeApp = ReturnType<typeof createFakeApp>;
 function createDeferredLookup(): DeferredLookup {
   let resolvePromise: (rows: Array<{ id: string; status: string }>) => void = () => {};
   let rejectPromise: (err: unknown) => void = () => {};
+  let resolveStarted: () => void = () => {};
   const promise = new Promise<Array<{ id: string; status: string }>>((resolve, reject) => {
     resolvePromise = resolve;
     rejectPromise = reject;
   });
+  const started = new Promise<void>((resolve) => {
+    resolveStarted = resolve;
+  });
   return {
     queries: 0,
+    started,
+    markStarted() {
+      resolveStarted();
+    },
     promise,
     resolve(rows) {
       resolvePromise(rows);
@@ -165,6 +180,28 @@ function createDeferredLookup(): DeferredLookup {
       rejectPromise(err);
     },
   };
+}
+
+/**
+ * Deterministically wait until the deferred user lookup is actually in
+ * flight (the fake query's limit() ran). WebCrypto JWT verification resolves
+ * off the faked timer APIs, so a fixed number of event-loop turns cannot
+ * guarantee the lookup started on a loaded CI runner. Bounded by a
+ * real-timer deadline — captured before fake timers install — so a
+ * regression that never reaches the lookup fails instead of hanging.
+ */
+async function waitForLookupStarted(lookup: DeferredLookup): Promise<void> {
+  let deadline: ReturnType<typeof realSetTimeout> | undefined;
+  try {
+    await Promise.race([
+      lookup.started,
+      new Promise<never>((_resolve, reject) => {
+        deadline = realSetTimeout(() => reject(new Error("timed out waiting for the user lookup to start")), 10_000);
+      }),
+    ]);
+  } finally {
+    if (deadline !== undefined) realClearTimeout(deadline);
+  }
 }
 
 async function signAccessToken(expSecondsFromNow = 3600): Promise<string> {
@@ -206,7 +243,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken();
     const first = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     expect(lookup.queries).toBe(1);
 
     // A flood of duplicates while the first attempt's lookup is in flight:
@@ -245,7 +282,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken();
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     expect(lookup.queries).toBe(1);
 
     socket.peerClose();
@@ -270,7 +307,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken();
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     expect(lookup.queries).toBe(1);
 
     // The existing 5s deadline still applies while validation is stuck.
@@ -300,7 +337,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken();
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     expect(lookup.queries).toBe(1);
 
     socket.peerClose();
@@ -323,7 +360,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken();
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     await vi.advanceTimersByTimeAsync(5_100);
     expect(socket.closeCalls).toHaveLength(1);
 
@@ -406,7 +443,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken(30);
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
     await pending;
 
@@ -432,7 +469,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken(30);
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
     await pending;
     expect(fakeContext.state.authentications).toBe(1);
@@ -454,7 +491,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken();
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
     socket.setFailSends(true);
     await pending;
@@ -485,7 +522,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken(30);
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
     await pending;
     expect(fakeContext.expiryTimerActive()).toBe(true);
@@ -512,7 +549,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken(30);
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
     socket.setFailSends(true);
     await pending;
@@ -574,7 +611,7 @@ describe("client WS auth gate — single attempt and terminal state", () => {
 
     const token = await signAccessToken();
     const pending = gate.handle({ type: "auth", token }, "auth");
-    await flushRealEventLoop();
+    await waitForLookupStarted(lookup);
     lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
     await pending;
 

--- a/packages/server/src/__tests__/ws-auth-single-attempt.test.ts
+++ b/packages/server/src/__tests__/ws-auth-single-attempt.test.ts
@@ -1,0 +1,260 @@
+import type { FastifyInstance } from "fastify";
+import { SignJWT } from "jose";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import WebSocket, { WebSocketServer } from "ws";
+import { attachClientWsConnection } from "../api/agent/ws-client/connection.js";
+
+/**
+ * Real-wire containment tests for the client-WS auth gate (staging incident
+ * 2026-09): a real local WebSocket server drives `attachClientWsConnection`
+ * end to end, while the database is replaced by a controllable deferred user
+ * lookup. No external services are involved — the lookup stands in for the
+ * users table so slow/late completions can be scripted deterministically.
+ */
+
+const TEST_SECRET = "ws-auth-single-attempt-wire-secret";
+const jwtSecretBytes = new TextEncoder().encode(TEST_SECRET);
+const TEST_USER_ID = "01960000-0000-7000-8000-0000000000bb";
+
+type SentFrame = { type?: string; code?: string; [key: string]: unknown };
+
+type DeferredLookup = {
+  queries: number;
+  promise: Promise<Array<{ id: string; status: string }>>;
+  resolve(rows: Array<{ id: string; status: string }>): void;
+  reject(err: unknown): void;
+};
+
+function createDeferredLookup(): DeferredLookup {
+  let resolvePromise: (rows: Array<{ id: string; status: string }>) => void = () => {};
+  let rejectPromise: (err: unknown) => void = () => {};
+  const promise = new Promise<Array<{ id: string; status: string }>>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return {
+    queries: 0,
+    promise,
+    resolve(rows) {
+      resolvePromise(rows);
+    },
+    reject(err) {
+      rejectPromise(err);
+    },
+  };
+}
+
+type ServerSocketProbe = {
+  sentFrames: SentFrame[];
+  /** Raw close() calls, including the ws library's internal close-handshake
+   * bookkeeping (`Receiver.receiverOnConclude`, which passes a Buffer reason
+   * echoed from the peer's close frame — or no reason at all). */
+  closeCalls: Array<{ code?: number; reason?: unknown }>;
+  closed: boolean;
+};
+
+/** Close calls initiated by our code — the gate always passes a string reason. */
+function gateCloseCalls(probe: ServerSocketProbe | undefined): Array<{ code?: number; reason?: unknown }> {
+  return (probe?.closeCalls ?? []).filter((call) => typeof call.reason === "string");
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for server-side condition");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("client WS auth single-attempt containment — real wire, mocked DB", () => {
+  let wss: WebSocketServer;
+  let wsUrl: string;
+  let lookup: DeferredLookup;
+  let appLog: { warn: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+  let lastProbe: ServerSocketProbe | undefined;
+
+  beforeAll(async () => {
+    wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    wss.on("connection", (socket, req) => {
+      const probe: ServerSocketProbe = { sentFrames: [], closeCalls: [], closed: false };
+      lastProbe = probe;
+      const originalSend = socket.send.bind(socket);
+      socket.send = ((data: Parameters<WebSocket["send"]>[0]) => {
+        try {
+          probe.sentFrames.push(JSON.parse(String(data)) as SentFrame);
+        } catch {
+          // non-JSON frame; ignore
+        }
+        originalSend(data);
+      }) as WebSocket["send"];
+      const originalClose = socket.close.bind(socket);
+      socket.close = ((code?: number, reason?: string) => {
+        probe.closeCalls.push({ code, reason });
+        originalClose(code, reason);
+      }) as WebSocket["close"];
+      socket.on("close", () => {
+        probe.closed = true;
+      });
+
+      const app = {
+        db: {
+          select: () => {
+            const query = {
+              from: () => query,
+              where: () => query,
+              limit: () => {
+                lookup.queries++;
+                return lookup.promise;
+              },
+            };
+            return query;
+          },
+        },
+        log: { ...appLog, debug: vi.fn() },
+        commandVersion: () => "single-attempt-wire-test",
+        config: { secrets: { jwtSecret: TEST_SECRET } },
+      };
+      // Casts are unavoidable: the connection is exercised against a scripted
+      // in-memory app rather than a full Fastify + database boot.
+      attachClientWsConnection(
+        app as unknown as FastifyInstance,
+        socket,
+        { headers: req.headers, ip: "127.0.0.1" } as never,
+        { subscribe: vi.fn(), unsubscribe: vi.fn(), notify: vi.fn() } as never,
+        "test-instance",
+      );
+    });
+    await new Promise<void>((resolve) => wss.once("listening", resolve));
+    const addr = wss.address();
+    if (!addr || typeof addr === "string") throw new Error("test WS server has no address");
+    wsUrl = `ws://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      wss.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  function freshHarness(): void {
+    lookup = createDeferredLookup();
+    appLog = { warn: vi.fn(), info: vi.fn(), error: vi.fn() };
+    lastProbe = undefined;
+  }
+
+  async function signAccessToken(expSecondsFromNow = 3600): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({ sub: TEST_USER_ID, type: "access", organizationId: "org-wire-test" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now)
+      .setExpirationTime(now + expSecondsFromNow)
+      .sign(jwtSecretBytes);
+  }
+
+  async function openClient(): Promise<{ ws: WebSocket; frames: SentFrame[] }> {
+    const frames: SentFrame[] = [];
+    const ws = new WebSocket(wsUrl);
+    ws.on("message", (raw) => {
+      try {
+        frames.push(JSON.parse(raw.toString()) as SentFrame);
+      } catch {
+        // ignore non-JSON
+      }
+    });
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", resolve);
+      ws.once("error", reject);
+    });
+    return { ws, frames };
+  }
+
+  function waitForClientClose(ws: WebSocket, timeoutMs = 5000): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("timeout waiting for client close")), timeoutMs);
+      ws.once("close", (code) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+    });
+  }
+
+  it("rejects duplicate in-flight auth frames deterministically with one query and no welcome", async () => {
+    freshHarness();
+    const token = await signAccessToken();
+    const { ws, frames } = await openClient();
+
+    // The first frame starts validation and reaches the deferred user
+    // lookup; the duplicate arrives while that attempt is in flight and must
+    // be rejected without starting another verification/DB pipeline.
+    ws.send(JSON.stringify({ type: "auth", token }));
+    await waitFor(() => lookup.queries === 1);
+    ws.send(JSON.stringify({ type: "auth", token }));
+
+    const closeCode = await waitForClientClose(ws);
+    expect(closeCode).toBe(4401);
+
+    const rejected = frames.filter((frame) => frame.type === "auth:rejected");
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.code).toBe("invalid_auth_frame");
+    expect(frames.filter((frame) => frame.type === "server:welcome")).toHaveLength(0);
+    expect(frames.filter((frame) => frame.type === "auth:ok")).toHaveLength(0);
+    expect(lookup.queries).toBe(1);
+
+    // The in-flight lookup completes late, on an already-terminal gate.
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await sleep(150);
+    expect(appLog.warn).not.toHaveBeenCalled();
+    const probe = lastProbe;
+    expect(probe).toBeDefined();
+    expect(probe?.sentFrames.filter((frame) => frame.type === "server:welcome")).toHaveLength(0);
+    expect(gateCloseCalls(probe)).toHaveLength(1);
+  });
+
+  it("ignores a late lookup success when the client closes mid-validation", async () => {
+    freshHarness();
+    const token = await signAccessToken();
+    const { ws } = await openClient();
+
+    ws.send(JSON.stringify({ type: "auth", token }));
+    await waitFor(() => lookup.queries === 1);
+    const probe = lastProbe;
+    expect(probe).toBeDefined();
+
+    ws.close();
+    await waitFor(() => probe?.closed === true);
+    const sendsBeforeLateCompletion = probe?.sentFrames.length ?? 0;
+
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+    await sleep(150);
+
+    expect(appLog.warn).not.toHaveBeenCalled();
+    expect(probe?.sentFrames).toHaveLength(sendsBeforeLateCompletion);
+    // The server never initiates its own close on the dead socket.
+    expect(gateCloseCalls(probe)).toHaveLength(0);
+  });
+
+  it("completes the normal handshake and fires exactly one auth:expired at token exp", async () => {
+    freshHarness();
+    const token = await signAccessToken(2);
+    const { ws, frames } = await openClient();
+
+    ws.send(JSON.stringify({ type: "auth", token }));
+    await waitFor(() => lookup.queries === 1);
+    lookup.resolve([{ id: TEST_USER_ID, status: "active" }]);
+
+    await waitFor(() => frames.some((frame) => frame.type === "auth:ok"));
+    expect(frames.filter((frame) => frame.type === "server:welcome")).toHaveLength(1);
+    expect(frames.filter((frame) => frame.type === "auth:ok")).toHaveLength(1);
+
+    const closeCode = await waitForClientClose(ws, 8000);
+    expect(closeCode).toBe(4401);
+    // Exactly one expiry timer may exist: a duplicated timer would emit a
+    // second auth:expired frame (and a second close attempt).
+    expect(frames.filter((frame) => frame.type === "auth:expired")).toHaveLength(1);
+    expect(gateCloseCalls(lastProbe)).toHaveLength(1);
+  });
+});

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -187,7 +187,7 @@ describe("Agent client WS branch fakes", () => {
     vi.restoreAllMocks();
   });
 
-  it("swallows auth rejection sends when the socket has already closed", async () => {
+  it("ignores frames arriving on an already-closed socket (no retry-close)", async () => {
     const { handler } = routeHarness(queuedDb([]));
     const socket = new FakeSocket();
     await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
@@ -195,11 +195,13 @@ describe("Agent client WS branch fakes", () => {
     socket.readyState = socket.CLOSED;
     await emitMessage(socket, { type: "not-auth" });
 
-    expect(socket.closes).toContainEqual({ code: 4401, reason: "auth rejected" });
+    // Dispatch skips dead sockets entirely: no rejection frame is produced
+    // and the gate never attempts a second close on a dead socket.
+    expect(socket.closes).toEqual([]);
     expect(socket.sent).toEqual([]);
   });
 
-  it("swallows expired-auth sends when the socket has already closed", async () => {
+  it("ignores expired auth frames arriving on an already-closed socket", async () => {
     const { handler } = routeHarness(queuedDb([]));
     const socket = new FakeSocket();
     await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
@@ -207,9 +209,10 @@ describe("Agent client WS branch fakes", () => {
     socket.readyState = socket.CLOSED;
     const expired = await signAccess({ exp: Math.floor(Date.now() / 1000) - 1 });
     await emitMessage(socket, { type: "auth", token: expired });
-    await waitUntil(() => socket.closes.length > 0);
+    // Give the (skipped) dispatch a chance to misbehave.
+    await new Promise((resolve) => setTimeout(resolve, 25));
 
-    expect(socket.closes).toContainEqual({ code: 4401, reason: "auth expired" });
+    expect(socket.closes).toEqual([]);
     expect(socket.sent).toEqual([]);
   });
 

--- a/packages/server/src/api/agent/ws-client/auth.ts
+++ b/packages/server/src/api/agent/ws-client/auth.ts
@@ -155,7 +155,7 @@ export function createClientWsAuthGate(
    * - `validationInFlight`: one auth frame is between schema validation and
    *   its terminal resolution. A second auth frame in this window is
    *   rejected deterministically — it must never queue another verify/DB
-   *   pipeline (staging incident: 20 concurrent frames -> 20 user lookups,
+   *   pipeline (synthetic reproduction: 20 concurrent frames -> 20 user lookups,
    *   then 20 authentications + expiry timers after the socket was gone).
    * - `settled`: terminal. Set by every close path (frame timeout, rejected,
    *   expired, retryable, internal handshake failure) and by `handleClose()`.

--- a/packages/server/src/api/agent/ws-client/auth.ts
+++ b/packages/server/src/api/agent/ws-client/auth.ts
@@ -148,6 +148,48 @@ export function createClientWsAuthGate(
   context: ClientWsConnectionContext,
 ) {
   const clearAuthTimeout = context.clearAuthTimeout;
+
+  /**
+   * Single-attempt, single-outcome state machine.
+   *
+   * - `validationInFlight`: one auth frame is between schema validation and
+   *   its terminal resolution. A second auth frame in this window is
+   *   rejected deterministically — it must never queue another verify/DB
+   *   pipeline (staging incident: 20 concurrent frames -> 20 user lookups,
+   *   then 20 authentications + expiry timers after the socket was gone).
+   * - `settled`: terminal. Set by every close path (frame timeout, rejected,
+   *   expired, retryable, internal handshake failure) and by `handleClose()`.
+   *   Once set, the gate produces no further frames, close() calls,
+   *   warnings, authentications, or expiry timers.
+   */
+  let validationInFlight = false;
+  let settled = false;
+
+  const isSocketOpen = (): boolean => socket.readyState === socket.OPEN;
+
+  /**
+   * Await completions landing after a terminal transition — or after the
+   * socket went away — are stale: the connection's auth story is over and
+   * acting on them would duplicate side effects on a dead socket.
+   */
+  const isStaleCompletion = (): boolean => settled || !isSocketOpen();
+
+  /**
+   * Own the terminal transition. Returns true only for the first caller
+   * while the socket is still open enough to receive the terminal frame and
+   * close code; everyone else (late timeouts, late await completions,
+   * duplicate frames on an already-dead socket) is a no-op. Both the
+   * auth-frame timeout and the post-auth expiry timer are cleared
+   * immediately so no timer can outlive the terminal state.
+   */
+  const enterTerminal = (): boolean => {
+    if (settled) return false;
+    settled = true;
+    clearAuthTimeout();
+    context.setAuthExpiryTimer(null);
+    return isSocketOpen();
+  };
+
   const rejectAuthAndClose = (
     phase: WsAuthPhase,
     code: AuthRejectedCode,
@@ -155,7 +197,7 @@ export function createClientWsAuthGate(
     errorClass?: string,
     extraAttrs?: Record<string, string | number | boolean>,
   ) => {
-    clearAuthTimeout();
+    if (!enterTerminal()) return;
     closeWithAuthRejected(socket, phase, code, message, errorClass, extraAttrs);
   };
   const expireAuthAndCloseWithAttrs = (
@@ -163,7 +205,7 @@ export function createClientWsAuthGate(
     extraAttrs?: Record<string, string | number | boolean>,
     errorClass?: string,
   ) => {
-    clearAuthTimeout();
+    if (!enterTerminal()) return;
     closeWithAuthExpired(socket, phase, extraAttrs, errorClass);
   };
   const retryAuthAndClose = (
@@ -173,18 +215,27 @@ export function createClientWsAuthGate(
     message?: string,
     errorClass?: string,
   ) => {
-    clearAuthTimeout();
+    if (!enterTerminal()) return;
     closeWithAuthRetryable(socket, phase, code, closeCode, message, errorClass);
   };
 
   function start(): void {
+    // Never arm a fresh deadline once the gate is terminal or the socket is
+    // already gone.
+    if (settled || !isSocketOpen()) return;
     context.setAuthTimeout(
       setTimeout(() => {
-        if (!context.getSession()) {
-          retryAuthAndClose("auth_frame_timeout", AUTH_RETRYABLE_CODES.AUTH_TIMEOUT, 1013, "auth frame timeout");
-        }
+        if (settled || context.getSession()) return;
+        retryAuthAndClose("auth_frame_timeout", AUTH_RETRYABLE_CODES.AUTH_TIMEOUT, 1013, "auth frame timeout");
       }, WS_AUTH_FRAME_TIMEOUT_MS),
     );
+  }
+
+  /** The socket closed (any cause): the gate is terminal, all timers stop. */
+  function handleClose(): void {
+    settled = true;
+    clearAuthTimeout();
+    context.setAuthExpiryTimer(null);
   }
 
   function rejectInvalidFrame(message: string): void {
@@ -196,13 +247,31 @@ export function createClientWsAuthGate(
     if (!expSeconds) return;
     const delay = expSeconds * 1000 - Date.now();
     if (delay <= 0) return;
-    context.setAuthExpiryTimer(setTimeout(() => closeWithAuthExpired(socket, "jwt_verify"), delay));
+    context.setAuthExpiryTimer(
+      setTimeout(() => {
+        context.setAuthExpiryTimer(null);
+        if (!enterTerminal()) return;
+        closeWithAuthExpired(socket, "jwt_verify");
+      }, delay),
+    );
   }
 
   async function handle(msg: unknown, type: string): Promise<boolean> {
     if (context.getSession()) return false;
+    if (settled || !isSocketOpen()) return true;
     if (type !== "auth") {
       rejectInvalidFrame("first frame must be auth");
+      return true;
+    }
+    if (validationInFlight) {
+      // Single attempt per connection: a duplicate auth frame must not
+      // start another verification/DB pipeline or queue behind the first —
+      // reject the connection deterministically instead.
+      rejectAuthAndClose(
+        "auth_frame_validation",
+        AUTH_REJECTED_CODES.INVALID_AUTH_FRAME,
+        "auth attempt already in progress",
+      );
       return true;
     }
     const authParsed = wsAuthFrameSchema.safeParse(msg);
@@ -211,115 +280,127 @@ export function createClientWsAuthGate(
       return true;
     }
 
-    const token = authParsed.data.token;
-    let payload: Awaited<ReturnType<typeof jwtVerify>>["payload"];
+    validationInFlight = true;
     try {
-      const verified = await jwtVerify(token, jwtSecretBytes);
-      payload = verified.payload;
-    } catch (err) {
-      const reason = classifyJoseError(err);
-      const traceClaims = untrustedAttrs("auth.ws", decodeJwtForTrace(token));
-      const errorClass = err instanceof Error ? err.name : reason;
-      if (reason === "jwt_expired") {
-        expireAuthAndCloseWithAttrs("jwt_verify", traceClaims, errorClass);
+      const token = authParsed.data.token;
+      let payload: Awaited<ReturnType<typeof jwtVerify>>["payload"];
+      try {
+        const verified = await jwtVerify(token, jwtSecretBytes);
+        payload = verified.payload;
+      } catch (err) {
+        if (isStaleCompletion()) return true;
+        const reason = classifyJoseError(err);
+        const traceClaims = untrustedAttrs("auth.ws", decodeJwtForTrace(token));
+        const errorClass = err instanceof Error ? err.name : reason;
+        if (reason === "jwt_expired") {
+          expireAuthAndCloseWithAttrs("jwt_verify", traceClaims, errorClass);
+          return true;
+        }
+        rejectAuthAndClose(
+          "jwt_verify",
+          rejectedCodeForJoseError(reason, err),
+          "JWT verification failed",
+          errorClass,
+          traceClaims,
+        );
         return true;
       }
-      rejectAuthAndClose(
-        "jwt_verify",
-        rejectedCodeForJoseError(reason, err),
-        "JWT verification failed",
-        errorClass,
-        traceClaims,
-      );
-      return true;
-    }
+      if (isStaleCompletion()) return true;
 
-    const tokenType = payload.type;
-    if (tokenType !== "access") {
-      rejectAuthAndClose(
-        "claims_validation",
-        tokenType === undefined ? AUTH_REJECTED_CODES.INVALID_CLAIMS : AUTH_REJECTED_CODES.WRONG_TOKEN_TYPE,
-        "member access token required",
-        tokenType === undefined ? "missing_token_type" : "wrong_token_type",
-      );
-      return true;
-    }
-    const userId = payload.sub;
-    if (typeof userId !== "string" || userId.length === 0) {
-      rejectAuthAndClose(
-        "claims_validation",
-        AUTH_REJECTED_CODES.INVALID_CLAIMS,
-        "missing subject claim",
-        "missing_sub",
-      );
-      return true;
-    }
+      const tokenType = payload.type;
+      if (tokenType !== "access") {
+        rejectAuthAndClose(
+          "claims_validation",
+          tokenType === undefined ? AUTH_REJECTED_CODES.INVALID_CLAIMS : AUTH_REJECTED_CODES.WRONG_TOKEN_TYPE,
+          "member access token required",
+          tokenType === undefined ? "missing_token_type" : "wrong_token_type",
+        );
+        return true;
+      }
+      const userId = payload.sub;
+      if (typeof userId !== "string" || userId.length === 0) {
+        rejectAuthAndClose(
+          "claims_validation",
+          AUTH_REJECTED_CODES.INVALID_CLAIMS,
+          "missing subject claim",
+          "missing_sub",
+        );
+        return true;
+      }
 
-    let user: { id: string; status: string } | undefined;
-    try {
-      [user] = await app.db
-        .select({ id: users.id, status: users.status })
-        .from(users)
-        .where(eq(users.id, userId))
-        .limit(1);
-    } catch (err) {
-      app.log.warn({ err, userId }, "WS auth user lookup failed; asking client to retry");
-      retryAuthAndClose(
-        "user_lookup",
-        AUTH_RETRYABLE_CODES.AUTH_BACKEND_UNAVAILABLE,
-        1013,
-        "authentication backend unavailable",
-        err instanceof Error ? err.name : "UnknownError",
-      );
-      return true;
-    }
-    if (!user) {
-      rejectAuthAndClose("user_lookup", AUTH_REJECTED_CODES.USER_NOT_FOUND, "user not found");
-      return true;
-    }
-    if (user.status !== "active") {
-      rejectAuthAndClose("user_lookup", AUTH_REJECTED_CODES.USER_SUSPENDED, "user suspended");
-      return true;
-    }
+      let user: { id: string; status: string } | undefined;
+      try {
+        [user] = await app.db
+          .select({ id: users.id, status: users.status })
+          .from(users)
+          .where(eq(users.id, userId))
+          .limit(1);
+      } catch (err) {
+        if (isStaleCompletion()) return true;
+        app.log.warn({ err, userId }, "WS auth user lookup failed; asking client to retry");
+        retryAuthAndClose(
+          "user_lookup",
+          AUTH_RETRYABLE_CODES.AUTH_BACKEND_UNAVAILABLE,
+          1013,
+          "authentication backend unavailable",
+          err instanceof Error ? err.name : "UnknownError",
+        );
+        return true;
+      }
+      if (isStaleCompletion()) return true;
+      if (!user) {
+        rejectAuthAndClose("user_lookup", AUTH_REJECTED_CODES.USER_NOT_FOUND, "user not found");
+        return true;
+      }
+      if (user.status !== "active") {
+        rejectAuthAndClose("user_lookup", AUTH_REJECTED_CODES.USER_SUSPENDED, "user suspended");
+        return true;
+      }
 
-    context.authenticate(
-      { userId: user.id },
-      typeof payload.organizationId === "string" ? payload.organizationId : null,
-    );
-    setWsConnectionAttrs(socket, { "user.id": user.id });
-    clearAuthTimeout();
-    scheduleAuthExpiry(payload.exp);
-
-    try {
-      sendJsonOrThrow(socket, {
-        type: "server:welcome",
-        serverCommandVersion: app.commandVersion(),
-        serverTimeMs: Date.now(),
-        capabilities: {
-          wsInboxAckConfirm: true,
-          wsSessionEventConfirm: true,
-          wsSessionResetV1: true,
-        },
-      });
-      sendJsonOrThrow(socket, { type: "auth:ok" });
-      setAuthWsAttrs(socket, {
-        phase: "post_auth_welcome",
-        outcome: "accepted",
-        code: "auth_ok",
-        retryable: false,
-      });
-    } catch (err) {
-      app.log.warn({ err, userId: user.id }, "WS post-auth handshake failed; asking client to retry");
-      retryAuthAndClose(
-        "post_auth_welcome",
-        AUTH_RETRYABLE_CODES.HANDSHAKE_INTERNAL_ERROR,
-        1011,
-        "post-auth handshake failed",
-        err instanceof Error ? err.name : "UnknownError",
+      context.authenticate(
+        { userId: user.id },
+        typeof payload.organizationId === "string" ? payload.organizationId : null,
       );
+      setWsConnectionAttrs(socket, { "user.id": user.id });
+      clearAuthTimeout();
+      scheduleAuthExpiry(payload.exp);
+
+      try {
+        sendJsonOrThrow(socket, {
+          type: "server:welcome",
+          serverCommandVersion: app.commandVersion(),
+          serverTimeMs: Date.now(),
+          capabilities: {
+            wsInboxAckConfirm: true,
+            wsSessionEventConfirm: true,
+            wsSessionResetV1: true,
+          },
+        });
+        sendJsonOrThrow(socket, { type: "auth:ok" });
+        setAuthWsAttrs(socket, {
+          phase: "post_auth_welcome",
+          outcome: "accepted",
+          code: "auth_ok",
+          retryable: false,
+        });
+      } catch (err) {
+        // The socket died mid-handshake: the connection's close path owns
+        // cleanup; do not warn or retry-close a dead socket.
+        if (isStaleCompletion()) return true;
+        app.log.warn({ err, userId: user.id }, "WS post-auth handshake failed; asking client to retry");
+        retryAuthAndClose(
+          "post_auth_welcome",
+          AUTH_RETRYABLE_CODES.HANDSHAKE_INTERNAL_ERROR,
+          1011,
+          "post-auth handshake failed",
+          err instanceof Error ? err.name : "UnknownError",
+        );
+      }
+      return true;
+    } finally {
+      validationInFlight = false;
     }
-    return true;
   }
 
-  return { start, rejectInvalidFrame, handle };
+  return { start, handleClose, rejectInvalidFrame, handle };
 }

--- a/packages/server/src/api/agent/ws-client/connection.ts
+++ b/packages/server/src/api/agent/ws-client/connection.ts
@@ -49,7 +49,13 @@ export function attachClientWsConnection(
   const handleSessionFrame = createSessionFrameHandler(app, socket, notifier, instanceId, context);
   auth.start();
 
+  // Once the socket is gone (peer close, auth close, server shutdown) no
+  // inbound frame may be dispatched: the auth gate is terminal and the
+  // session handlers would act on a dead connection.
+  let socketClosed = false;
+
   socket.on("message", async (raw) => {
+    if (socketClosed || socket.readyState !== socket.OPEN) return;
     let msg: unknown;
     try {
       msg = JSON.parse(String(raw));
@@ -109,7 +115,9 @@ export function attachClientWsConnection(
   });
 
   socket.on("close", (closeCode?: number) => {
+    socketClosed = true;
     endWsConnectionSpan(socket, closeCode);
+    auth.handleClose();
     context.close();
   });
 }

--- a/packages/server/src/observability/__tests__/logger.test.ts
+++ b/packages/server/src/observability/__tests__/logger.test.ts
@@ -136,8 +136,16 @@ describe("logger ErrorSink bridging", () => {
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
     const { calls, restore } = installSpySink();
 
-    // Object whose JSON will exceed MAX_JSON_LEN (8192)
-    const big = { items: Array.from({ length: 1000 }, (_, i) => ({ id: i, data: "x".repeat(50) })) };
+    // Object whose JSON will exceed MAX_JSON_LEN (8192) so the per-field
+    // truncation is exercised, while the whole log record stays comfortably
+    // below the output layer's 64 KiB whole-record cap — above that cap the
+    // record is intentionally replaced before parsing/bridging (covered by
+    // the shared logger-output-bounds tests, not by this one).
+    const big = { items: Array.from({ length: 200 }, (_, i) => ({ id: i, data: "x".repeat(50) })) };
+    const fieldJson = JSON.stringify(big);
+    expect(fieldJson.length).toBeGreaterThan(8192);
+    // >2x safety margin: the full record adds only ~200 bytes of envelope.
+    expect(fieldJson.length).toBeLessThan(32 * 1024);
     createLogger("M").error({ state: big }, "bulky state");
 
     expect(calls).toHaveLength(1);

--- a/packages/shared/src/observability/__tests__/logger-output-bounds.test.ts
+++ b/packages/shared/src/observability/__tests__/logger-output-bounds.test.ts
@@ -1,0 +1,533 @@
+import { Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { createLoggerOutputStream, LOG_OUTPUT_MAX_QUEUED_BYTES, LOG_OUTPUT_MAX_RECORD_BYTES } from "../logger-core.js";
+
+/** Next macrotask — lets stream internals settle between writes. */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function drain(dest: Writable): Promise<void> {
+  for (let i = 0; i < 20 && dest.writableLength > 0; i++) await tick();
+}
+
+function collect(): { dest: Writable; received: string[]; read: () => string } {
+  const received: string[] = [];
+  const dest = new Writable({
+    write(chunk, _, callback) {
+      received.push(chunk.toString());
+      callback();
+    },
+  });
+  return { dest, received, read: () => received.join("") };
+}
+
+/**
+ * A sink whose gate starts closed: `_write` never calls back while closed, so
+ * every accepted chunk piles up in the stream's internal buffer and
+ * `writableLength` reflects exactly what the logger pushed in. Opening the
+ * gate releases the held callbacks and lets the buffer drain.
+ */
+function gatedSink(): { dest: Writable; received: string[]; open: () => void } {
+  const received: string[] = [];
+  const held: Array<() => void> = [];
+  let open = false;
+  const dest = new Writable({
+    highWaterMark: 16 * 1024,
+    write(chunk, _enc, cb) {
+      received.push(chunk.toString());
+      if (open) {
+        cb();
+      } else {
+        held.push(cb);
+      }
+    },
+  });
+  return {
+    dest,
+    received,
+    open: () => {
+      open = true;
+      for (const cb of held.splice(0)) cb();
+    },
+  };
+}
+
+/** A pino-style NDJSON line padded with ASCII to exactly `targetBytes`. */
+function lineOf(targetBytes: number, msg = "x"): string {
+  const base = `${JSON.stringify({ level: 30, time: "t", msg: "" })}\n`;
+  const line = `${JSON.stringify({ level: 30, time: "t", msg: msg.repeat(Math.max(0, targetBytes - Buffer.byteLength(base))) })}\n`;
+  return line;
+}
+
+function jsonLine(msg: string): string {
+  return `${JSON.stringify({ level: 30, time: "t", msg })}\n`;
+}
+
+describe("logger output bounds", () => {
+  it("exposes a 64 KiB record cap and a 256 KiB queued-destination cap", () => {
+    expect(LOG_OUTPUT_MAX_RECORD_BYTES).toBe(64 * 1024);
+    expect(LOG_OUTPUT_MAX_QUEUED_BYTES).toBe(256 * 1024);
+  });
+
+  it("keeps a stalled destination within a strict byte bound across thousands of writes", async () => {
+    const gate = gatedSink();
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => gate.dest,
+    });
+    const line = lineOf(1057);
+    const lineBytes = Buffer.byteLength(line);
+
+    for (let i = 0; i < 8192; i++) stream.write(line);
+    await tick();
+    await tick();
+
+    // Strict bound with exact byte accounting: the largest multiple of the
+    // record size that fits the cap — never the ~8.6 MiB the unbounded writer
+    // queued, and no undocumented one-record overshoot.
+    expect(gate.dest.writableLength).toBe(Math.floor(LOG_OUTPUT_MAX_QUEUED_BYTES / lineBytes) * lineBytes);
+    expect(gate.dest.writableLength).toBeLessThanOrEqual(LOG_OUTPUT_MAX_QUEUED_BYTES);
+    // The wrapper must not become the unbounded buffer either: it acknowledges
+    // every record (dropping on pressure) instead of holding a queue pino
+    // would never drain.
+    expect(stream.writableLength).toBe(0);
+  });
+
+  it("replaces an oversized Unicode record with a bounded summary and never parses or forwards the original", () => {
+    const { dest, received } = collect();
+    const bridged: Array<Record<string, unknown>> = [];
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => dest,
+      onJsonEntry: (entry) => bridged.push(entry),
+    });
+
+    // "界" is 3 bytes in UTF-8: 30_000 chars ≈ 90_000 bytes — over the byte
+    // cap while the character count alone would look under it.
+    const huge = "界".repeat(30_000);
+    const line = `${JSON.stringify({ level: 30, time: "t", msg: huge })}\n`;
+    expect(Buffer.byteLength(line)).toBeGreaterThan(LOG_OUTPUT_MAX_RECORD_BYTES);
+
+    stream.write(line);
+
+    const out = received.join("");
+    expect(out).not.toContain(huge);
+    expect(out).toContain('"level":40');
+    expect(out).toContain("recordBytes");
+    for (const chunk of received) {
+      expect(Buffer.byteLength(chunk)).toBeLessThan(1024);
+    }
+    // The oversized original must not be JSON.parsed, pretty-rendered, or
+    // trace-bridged — each of those would allocate a second huge copy.
+    expect(bridged).toEqual([]);
+  });
+
+  it("forwards a record at exactly the byte cap and replaces one a single byte over it", () => {
+    const { dest, read } = collect();
+    const bridged: Array<Record<string, unknown>> = [];
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => dest,
+      onJsonEntry: (entry) => bridged.push(entry),
+    });
+
+    const atCap = lineOf(LOG_OUTPUT_MAX_RECORD_BYTES, "y");
+    expect(Buffer.byteLength(atCap)).toBe(LOG_OUTPUT_MAX_RECORD_BYTES);
+    stream.write(atCap);
+    expect(read()).toBe(atCap);
+    expect(bridged).toHaveLength(1);
+
+    const overCap = lineOf(LOG_OUTPUT_MAX_RECORD_BYTES + 1, "z");
+    expect(Buffer.byteLength(overCap)).toBe(LOG_OUTPUT_MAX_RECORD_BYTES + 1);
+    stream.write(overCap);
+    const out = read().slice(atCap.length);
+    expect(out).not.toContain("z".repeat(1000));
+    expect(out).toContain('"level":40');
+    expect(out).toContain("recordBytes");
+    expect(bridged).toHaveLength(1);
+  });
+
+  it("emits one bounded drop-accounting warning on recovery, then resumes ordinary records", async () => {
+    const gate = gatedSink();
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => gate.dest,
+    });
+    const line = lineOf(1057);
+    const lineBytes = Buffer.byteLength(line);
+
+    // Fill the stalled destination to the cap so subsequent writes drop.
+    const toFill = Math.ceil(LOG_OUTPUT_MAX_QUEUED_BYTES / lineBytes) + 6;
+    for (let i = 0; i < toFill; i++) stream.write(line);
+    await tick();
+    const droppedWrites = 50;
+    for (let i = 0; i < droppedWrites; i++) stream.write(line);
+    await tick();
+
+    gate.open();
+    await drain(gate.dest);
+    const beforeRecovery = gate.received.length;
+
+    stream.write(jsonLine("after-recovery"));
+    await tick();
+
+    const recoveryOut = gate.received.slice(beforeRecovery).join("");
+    // Exactly one structured, bounded warning carrying the drop count …
+    expect(recoveryOut.match(/"level":40/g)).toHaveLength(1);
+    const dropped = Number(recoveryOut.match(/"droppedRecords":(\d+)/)?.[1]);
+    expect(dropped).toBeGreaterThanOrEqual(droppedWrites);
+    // … and ordinary records flow again.
+    expect(recoveryOut).toContain('"msg":"after-recovery"');
+
+    // No repeated warning once the drop count has been reported.
+    stream.write(jsonLine("steady-again"));
+    await tick();
+    const steadyOut = gate.received.slice(beforeRecovery).join("");
+    expect(steadyOut.match(/"level":40/g)).toHaveLength(1);
+    expect(steadyOut).toContain('"msg":"steady-again"');
+  });
+
+  it("keeps the drop counter when the recovery notice itself cannot be admitted", async () => {
+    const gate = gatedSink();
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => gate.dest,
+    });
+    const line = lineOf(1057);
+    const lineBytes = Buffer.byteLength(line);
+
+    // Fill to the exact cap; every further payload — notice or record —
+    // exceeds the remaining few bytes and must be refused.
+    for (let i = 0; i < 300; i++) stream.write(line);
+    await tick();
+    const queued = Math.floor(LOG_OUTPUT_MAX_QUEUED_BYTES / lineBytes) * lineBytes;
+    expect(gate.dest.writableLength).toBe(queued);
+    const droppedSoFar = 300 - queued / lineBytes;
+
+    // This record cannot be admitted; its recovery notice cannot be admitted
+    // either. The earlier drops must survive the failed notice attempt.
+    stream.write(line);
+    await tick();
+    expect(gate.received.some((chunk) => chunk.includes('"level":40'))).toBe(false);
+
+    gate.open();
+    await drain(gate.dest);
+    const beforeRecovery = gate.received.length;
+    stream.write(jsonLine("recovered"));
+    await tick();
+
+    const recoveryOut = gate.received.slice(beforeRecovery).join("");
+    expect(recoveryOut.match(/"level":40/g)).toHaveLength(1);
+    // droppedSoFar pressure drops + the one record whose notice was refused.
+    expect(recoveryOut).toContain(`"droppedRecords":${droppedSoFar + 1}`);
+    expect(recoveryOut).toContain('"msg":"recovered"');
+  });
+
+  it("drops records for a destroyed destination without requeueing, and reports on the next healthy destination", async () => {
+    const a = collect();
+    let current: Writable = a.dest;
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => current,
+    });
+    stream.write(jsonLine("one"));
+    expect(a.read()).toContain('"msg":"one"');
+
+    const dead = collect();
+    dead.dest.destroy();
+    current = dead.dest;
+    for (let i = 0; i < 100; i++) {
+      stream.write(jsonLine(`lost-${i}`));
+    }
+    await tick();
+
+    // Nothing written to the dead destination, nothing buffered anywhere, and
+    // exactly one bounded error guard — no per-record listeners.
+    expect(dead.read()).toBe("");
+    expect(stream.writableLength).toBe(0);
+    expect(dead.dest.listenerCount("drain")).toBe(0);
+    expect(dead.dest.listenerCount("error")).toBe(1);
+
+    const b = collect();
+    current = b.dest;
+    stream.write(jsonLine("back"));
+    await tick();
+
+    const out = b.read();
+    expect(out).toContain('"level":40');
+    expect(out).toContain('"droppedRecords":100');
+    expect(out).toContain('"msg":"back"');
+
+    // Switching back to the dead destination must not attach another listener.
+    current = dead.dest;
+    stream.write(jsonLine("again"));
+    expect(dead.dest.listenerCount("error")).toBe(1);
+  });
+
+  it("survives real asynchronous destination failures (autoDestroy) without crashing or growing listeners", async () => {
+    const received: string[] = [];
+    let armed = false;
+    const failing = new Writable({
+      write(chunk, _enc, cb) {
+        if (armed) {
+          // A real asynchronous failure: write callback with an error, which
+          // makes the stream emit 'error' and autoDestroy.
+          cb(new Error("sink exploded"));
+          return;
+        }
+        received.push(chunk.toString());
+        cb();
+      },
+    });
+    let current: Writable = failing;
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => current,
+    });
+
+    stream.write(jsonLine("one"));
+    expect(received.join("")).toContain('"msg":"one"');
+    // The wrapper attached exactly one bounded error guard; the wrapper
+    // itself stays listener-free.
+    expect(failing.listenerCount("error")).toBe(1);
+    expect(stream.listenerCount("error")).toBe(0);
+
+    armed = true;
+    stream.write(jsonLine("lost-async"));
+    await tick();
+    await tick();
+    // The 'error' event was swallowed by the guard — an unhandled one would
+    // fail this run as an uncaught exception — and autoDestroy tore the sink
+    // down so later writes drop cleanly.
+    expect(failing.destroyed).toBe(true);
+
+    for (let i = 0; i < 10; i++) stream.write(jsonLine(`post-${i}`));
+    await tick();
+    expect(failing.listenerCount("error")).toBe(1);
+
+    const healthy = collect();
+    current = healthy.dest;
+    stream.write(jsonLine("back"));
+    await tick();
+    const out = healthy.read();
+    expect(out.match(/"level":40/g)).toHaveLength(1);
+    // One async error event plus ten refused writes.
+    expect(out).toContain('"droppedRecords":11');
+    expect(out).toContain('"msg":"back"');
+  });
+
+  it("stops admitting to an errored-but-not-destroyed destination (autoDestroy: false)", async () => {
+    let armed = false;
+    const dest = new Writable({
+      autoDestroy: false,
+      write(_chunk, _enc, cb) {
+        cb(armed ? new Error("permanent failure") : null);
+      },
+    });
+    let current: Writable = dest;
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => current,
+    });
+
+    stream.write(jsonLine("one"));
+    armed = true;
+    stream.write(jsonLine("two"));
+    await tick();
+    await tick();
+
+    // Errored but intentionally not destroyed. Later records must be dropped
+    // without another write: an errored autoDestroy:false sink would
+    // otherwise keep accepting writes that never complete, so its queue must
+    // stay at zero and no further 'error' events may fire.
+    expect(dest.destroyed).toBe(false);
+    expect(dest.errored).toBeInstanceOf(Error);
+
+    for (let i = 0; i < 5; i++) stream.write(jsonLine(`x-${i}`));
+    await tick();
+    expect(dest.writableLength).toBe(0);
+    expect(dest.listenerCount("error")).toBe(1);
+
+    const healthy = collect();
+    current = healthy.dest;
+    stream.write(jsonLine("back"));
+    await tick();
+    const out = healthy.read();
+    // One async error event plus five refused writes.
+    expect(out).toContain('"droppedRecords":6');
+    expect(out).toContain('"msg":"back"');
+  });
+
+  it("refuses a destination that already errored before the wrapper first observed it", async () => {
+    const dest = new Writable({
+      autoDestroy: false,
+      write(_chunk, _enc, cb) {
+        cb(new Error("synthetic"));
+      },
+    });
+    // Test-side listener: this failure happens before the wrapper exists.
+    dest.on("error", () => {});
+    dest.write("trigger");
+    await tick();
+    await tick();
+    expect(dest.errored?.message).toBe("synthetic");
+    expect(dest.destroyed).toBe(false);
+
+    let current: Writable = dest;
+    const bridged: Array<Record<string, unknown>> = [];
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => current,
+      onJsonEntry: (entry) => bridged.push(entry),
+    });
+    for (let i = 0; i < 3; i++) stream.write(jsonLine(`lost-${i}`));
+    await tick();
+
+    // No write reaches the pre-errored sink: its queue must not grow (an
+    // errored autoDestroy:false sink would otherwise buffer writes that never
+    // complete), the records are not bridged, and exactly one bounded guard
+    // listener was added on top of the test-side one.
+    expect(dest.writableLength).toBe(0);
+    expect(bridged).toEqual([]);
+    expect(dest.listenerCount("error")).toBe(2);
+
+    const healthy = collect();
+    current = healthy.dest;
+    stream.write(jsonLine("back"));
+    await tick();
+    const out = healthy.read();
+    expect(out).toContain('"droppedRecords":3');
+    expect(out).toContain('"msg":"back"');
+  });
+
+  it("skips decoding, formatting, parsing, and bridging in pretty mode for a known-dead destination", async () => {
+    const a = collect();
+    let current: Writable = a.dest;
+    const bridged: Array<Record<string, unknown>> = [];
+    const stream = createLoggerOutputStream({
+      getFormat: () => "pretty",
+      getDestination: () => current,
+      onJsonEntry: (entry) => bridged.push(entry),
+    });
+    stream.write(jsonLine("alive"));
+    expect(a.read()).toContain("alive");
+    expect(bridged).toHaveLength(1);
+
+    const dead = collect();
+    dead.dest.destroy();
+    current = dead.dest;
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      for (let i = 0; i < 20; i++) stream.write(jsonLine(`lost-${i}`));
+      // The known-dead destination is rejected before the original record is
+      // decoded, pretty-formatted, or parsed — repeated failure logs must not
+      // repeatedly pay that cost for known-discarded records.
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
+    await tick();
+    expect(dead.read()).toBe("");
+    expect(bridged).toHaveLength(1);
+
+    const b = collect();
+    current = b.dest;
+    stream.write(jsonLine("back"));
+    await tick();
+    const out = b.read();
+    // Pretty rendering of the recovery notice, with the exact drop count.
+    expect(out).toContain("droppedRecords=20");
+    expect(out).toContain("back");
+  });
+
+  it("does not parse or bridge a record whose destination write failed synchronously", async () => {
+    const { dest, read } = collect();
+    const bridged: Array<Record<string, unknown>> = [];
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => dest,
+      onJsonEntry: (entry) => bridged.push(entry),
+    });
+    const spy = vi.spyOn(dest, "write").mockImplementationOnce((() => {
+      throw new Error("sync boom");
+    }) as never);
+
+    stream.write(jsonLine("discarded"));
+    await tick();
+    expect(spy).toHaveBeenCalledTimes(1);
+    // The discarded record is neither written nor trace-bridged.
+    expect(read()).not.toContain("discarded");
+    expect(bridged).toEqual([]);
+
+    stream.write(jsonLine("later"));
+    await tick();
+    // … but it is accounted honestly once the destination accepts writes.
+    expect(read()).toContain('"droppedRecords":1');
+    expect(read()).toContain('"msg":"later"');
+    expect(bridged).toEqual([{ level: 30, time: "t", msg: "later" }]);
+  });
+
+  it("acknowledges and accounts records when the format getter throws, with no unsafe fallback write", async () => {
+    const { dest, read } = collect();
+    let explode = true;
+    const stream = createLoggerOutputStream({
+      getFormat: () => {
+        if (explode) throw new Error("format exploded");
+        return "json";
+      },
+      getDestination: () => dest,
+    });
+
+    await new Promise<void>((resolve) => stream.write(jsonLine("boom"), () => resolve()));
+    // Acknowledged without crashing and without requeueing the raw record
+    // through a catch fallback.
+    expect(read()).toBe("");
+
+    explode = false;
+    stream.write(jsonLine("back"));
+    await tick();
+    expect(read()).toContain('"droppedRecords":1');
+    expect(read()).toContain('"msg":"back"');
+  });
+
+  it("acknowledges records when the destination getter throws, without touching a destination", async () => {
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: (): Writable => {
+        throw new Error("getter exploded");
+      },
+    });
+
+    await new Promise<void>((resolve) => stream.write(jsonLine("boom"), () => resolve()));
+    expect(stream.writableLength).toBe(0);
+  });
+
+  it("renders a bounded drop notice through the pretty formatter on recovery", async () => {
+    const gate = gatedSink();
+    const stream = createLoggerOutputStream({
+      getFormat: () => "pretty",
+      getDestination: () => gate.dest,
+    });
+    const line = lineOf(1057);
+    const toFill = Math.ceil(LOG_OUTPUT_MAX_QUEUED_BYTES / Buffer.byteLength(line)) + 10;
+    for (let i = 0; i < toFill; i++) stream.write(line);
+    await tick();
+
+    gate.open();
+    await drain(gate.dest);
+    const beforeRecovery = gate.received.length;
+    stream.write(jsonLine("pretty-back"));
+    await tick();
+
+    const recoveryChunks = gate.received.slice(beforeRecovery);
+    const recoveryOut = recoveryChunks.join("");
+    expect(recoveryOut).toContain("WARN");
+    expect(recoveryOut).toContain("dropped");
+    expect(recoveryOut).toContain("pretty-back");
+    // The notice stays bounded even in pretty mode.
+    const warnChunk = recoveryChunks.find((chunk) => chunk.includes("WARN"));
+    expect(warnChunk).toBeDefined();
+    expect(Buffer.byteLength(warnChunk ?? "")).toBeLessThan(1024);
+  });
+});

--- a/packages/shared/src/observability/logger-core.ts
+++ b/packages/shared/src/observability/logger-core.ts
@@ -125,6 +125,26 @@ export function formatLocalTime(): string {
 
 // ─── Output stream factory ────────────────────────────────────────────
 
+/**
+ * Maximum size, in UTF-8 bytes, of any payload this stream admits to a
+ * destination. Incoming chunks larger than this are replaced by a small
+ * structured summary without being decoded, parsed, or pretty-rendered —
+ * each of those steps would allocate a second huge copy in this layer. A
+ * record whose rendered output exceeds the cap is replaced the same way, so
+ * the bound holds for what actually reaches the destination. Internal
+ * notices and summaries are always far below it.
+ */
+export const LOG_OUTPUT_MAX_RECORD_BYTES = 64 * 1024;
+
+/**
+ * Hard upper bound on the destination's queued bytes
+ * (`destination.writableLength`). Every payload — record, summary, or
+ * notice — is admitted only when the live `writableLength` plus that
+ * payload's own byte size stays within this bound, checked independently at
+ * the moment of each write.
+ */
+export const LOG_OUTPUT_MAX_QUEUED_BYTES = 256 * 1024;
+
 type CreateStreamOptions = {
   /** Getter so the format can change via applyConfig without rebuilding the stream. */
   getFormat: () => LogFormat;
@@ -138,33 +158,211 @@ type CreateStreamOptions = {
   /**
    * Optional hook invoked once per NDJSON record written by pino. Server uses
    * this to bridge error/fatal logs onto the active OTel span; client leaves
-   * it undefined.
+   * it undefined. Only invoked for records that were actually accepted —
+   * oversized or pressure-dropped records are never parsed or bridged.
    */
   onJsonEntry?: (obj: Record<string, unknown>) => void;
 };
 
+/**
+ * Build the pino destination stream shared by server and client loggers.
+ *
+ * Bounded best-effort loss policy (intentional): logging must never crash or
+ * unboundedly grow the process, so guaranteed delivery is traded for hard
+ * memory bounds.
+ *
+ * - **Record cap** — payloads over `LOG_OUTPUT_MAX_RECORD_BYTES` (input
+ *   bytes before parsing, or rendered bytes after pretty formatting) are
+ *   replaced by a small structured summary; oversized originals are never
+ *   decoded, parsed, rendered, or trace-bridged.
+ * - **Strict queue bound** — each payload is admitted only when the
+ *   destination's live `writableLength` plus the payload's own bytes stays
+ *   within `LOG_OUTPUT_MAX_QUEUED_BYTES`; otherwise the record is dropped
+ *   and counted. Every notice and record is checked independently against
+ *   the current queue, so a notice and the record that follows it can never
+ *   share one pre-checked budget. The Writable callback is always
+ *   acknowledged immediately: pino does not guarantee producer-side
+ *   backpressure handling, so holding the callback would only move the
+ *   unbounded queue from the destination into this wrapper.
+ * - **Unavailable destinations** — destroyed, ended, or errored
+ *   destinations (the public `Writable.errored`, plus sinks the guard saw
+ *   emit 'error', covering `autoDestroy: false` sinks that would otherwise
+ *   keep accepting writes that never complete) are rejected early, before
+ *   the record is decoded, formatted, or parsed — as are destinations too
+ *   full to accept one more byte. Write failures never propagate:
+ *   synchronous throws are caught, and asynchronous 'error' events are
+ *   swallowed by a single bounded listener attached once per destination
+ *   object (tracked in WeakSets, so runtime destination switching adds no
+ *   listeners and retains no historical destinations). Nothing is ever
+ *   requeued from a catch fallback. `onJsonEntry` runs only for records
+ *   actually admitted.
+ * - **Fixed-size accounting** — drops live in one counter, never as retained
+ *   records. On the next write a healthy destination admits, one bounded
+ *   structured warning reports the count; the counter is cleared only when
+ *   that notice is itself admitted. No timers, no `drain` listeners, no
+ *   recursive logging through pino.
+ *
+ * Limitations: counts are exact for refusals and discards, but an
+ * asynchronous destination failure is counted once per 'error' event, so
+ * queued writes lost in the same failure are undercounted. The caps apply
+ * only after pino hands this stream a chunk — they cannot undo pino's
+ * upstream serialization allocations — and a healthy draining destination is
+ * not rate-limited, so disk I/O volume under normal operation is unchanged.
+ */
 export function createLoggerOutputStream(options: CreateStreamOptions): Writable {
   const getDest = options.getDestination ?? (() => process.stderr);
+  // Fixed-size loss accounting only — dropped records are never retained.
+  let pendingDrops = 0;
+  // Destinations that already have an error guard. Weak, so runtime
+  // destination switching retains no historical destinations; each
+  // destination object gets at most one listener, ever.
+  const guardedDests = new WeakSet<Writable>();
+  // Destinations whose 'error' event our guard observed. The public
+  // `Writable.errored` property catches sinks that failed before we ever saw
+  // them; this WeakSet catches custom 'error' emits that leave the stream's
+  // own state untouched.
+  const erroredDests = new WeakSet<Writable>();
+
+  /** Render a bounded internal notice through the active format. */
+  const renderNotice = (fields: Record<string, unknown>): string => {
+    const json = `${JSON.stringify({ level: 40, time: new Date().toISOString(), ...fields })}\n`;
+    if (options.getFormat() === "pretty") {
+      try {
+        return formatPrettyEntry(json);
+      } catch {
+        return json;
+      }
+    }
+    return json;
+  };
+
+  /** A destination that cannot accept writes: gone, ended, or errored. */
+  const unavailable = (dest: Writable): boolean =>
+    dest.destroyed || dest.writableEnded || dest.errored !== null || erroredDests.has(dest);
+
+  /**
+   * Admit one payload to the destination under its live queued-byte budget.
+   * Checked independently for every payload, so the destination queue never
+   * exceeds `LOG_OUTPUT_MAX_QUEUED_BYTES`. Never throws and never requeues:
+   * a synchronous write failure simply counts as not admitted.
+   */
+  const admit = (dest: Writable, text: string): boolean => {
+    try {
+      if (unavailable(dest)) return false;
+      if (dest.writableLength + Buffer.byteLength(text) > LOG_OUTPUT_MAX_QUEUED_BYTES) return false;
+      dest.write(text);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  /**
+   * Asynchronous destination failures surface as 'error' events, which crash
+   * the process while unhandled. Attach exactly one bounded handler per
+   * destination object before its first use — it marks the destination
+   * errored and accounts the loss, and never logs recursively.
+   */
+  const guard = (dest: Writable): void => {
+    if (guardedDests.has(dest)) return;
+    guardedDests.add(dest);
+    dest.on("error", () => {
+      erroredDests.add(dest);
+      pendingDrops += 1;
+    });
+  };
+
   return new Writable({
     write(chunk, _, callback) {
-      const text = chunk.toString();
-      const dest = getDest();
       try {
-        if (options.getFormat() === "pretty") {
-          dest.write(formatPrettyEntry(text));
-        } else {
-          dest.write(text);
+        const dest = getDest();
+        guard(dest);
+
+        // Early cheap rejection: a destination that is known unavailable or
+        // too full to accept even one more byte will refuse this record, so
+        // count it without decoding, formatting, or parsing the original.
+        if (unavailable(dest) || dest.writableLength >= LOG_OUTPUT_MAX_QUEUED_BYTES) {
+          pendingDrops += 1;
+          callback();
+          return;
         }
-        if (options.onJsonEntry) {
-          try {
-            const obj = JSON.parse(text) as Record<string, unknown>;
-            options.onJsonEntry(obj);
-          } catch {
-            // non-JSON line, ignore
+
+        // Input-byte pre-check: an oversized chunk is never decoded, parsed,
+        // or rendered in this layer.
+        const inputBytes = Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+
+        // Surface deferred drop accounting first. The counter is cleared only
+        // when the notice itself wins admission; a failed notice keeps the
+        // earlier drops accounted.
+        if (pendingDrops > 0) {
+          const reported = admit(
+            dest,
+            renderNotice({
+              msg: `log output dropped ${pendingDrops} record(s) while the destination was stalled, over capacity, or failing`,
+              droppedRecords: pendingDrops,
+            }),
+          );
+          if (reported) pendingDrops = 0;
+        }
+
+        if (inputBytes > LOG_OUTPUT_MAX_RECORD_BYTES) {
+          // Oversized original: replaced by a bounded summary admitted on its
+          // own budget; if even the summary cannot go out, the record counts
+          // as dropped.
+          const summarized = admit(
+            dest,
+            renderNotice({
+              msg: `log record of ${inputBytes} bytes exceeded the ${LOG_OUTPUT_MAX_RECORD_BYTES}-byte cap and was replaced`,
+              recordBytes: inputBytes,
+            }),
+          );
+          if (!summarized) pendingDrops += 1;
+        } else {
+          const text = Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+          let rendered: string;
+          if (options.getFormat() === "pretty") {
+            try {
+              rendered = formatPrettyEntry(text);
+            } catch {
+              // Non-JSON line (or formatter bug): fall back to the raw,
+              // already size-capped text.
+              rendered = text;
+            }
+          } else {
+            rendered = text;
+          }
+          // Post-format bound: pretty rendering may differ from the input
+          // size, so the cap is enforced again on what would actually be
+          // written.
+          const renderedBytes = Buffer.byteLength(rendered);
+          if (renderedBytes > LOG_OUTPUT_MAX_RECORD_BYTES) {
+            const summarized = admit(
+              dest,
+              renderNotice({
+                msg: `formatted log record of ${renderedBytes} bytes exceeded the ${LOG_OUTPUT_MAX_RECORD_BYTES}-byte cap and was replaced`,
+                recordBytes: renderedBytes,
+              }),
+            );
+            if (!summarized) pendingDrops += 1;
+          } else if (admit(dest, rendered)) {
+            // Only admitted records are parsed and bridged.
+            if (options.onJsonEntry) {
+              try {
+                const obj = JSON.parse(text) as Record<string, unknown>;
+                options.onJsonEntry(obj);
+              } catch {
+                // non-JSON line, ignore
+              }
+            }
+          } else {
+            pendingDrops += 1;
           }
         }
       } catch {
-        dest.write(text);
+        // A getter or formatter failure discards the record without touching
+        // a destination — account it honestly; the callback below still
+        // acknowledges the chunk.
+        pendingDrops += 1;
       }
       callback();
     },

--- a/packages/shared/src/observability/logger-core.ts
+++ b/packages/shared/src/observability/logger-core.ts
@@ -165,62 +165,34 @@ type CreateStreamOptions = {
 };
 
 /**
- * Build the pino destination stream shared by server and client loggers.
+ * Best-effort pino output shared by Server and Client. Rendering and sink
+ * admission are separate; dropped records are counted, never retained.
  *
- * Bounded best-effort loss policy (intentional): logging must never crash or
- * unboundedly grow the process, so guaranteed delivery is traded for hard
- * memory bounds.
+ * Input over the record cap is summarized before decoding; rendered output
+ * is checked again. Every record and notice independently fits within the
+ * destination's live queued-byte budget. Full or failed sinks reject early.
+ * The wrapper acknowledges writes immediately because pino does not honor
+ * producer backpressure: deferring callbacks would create another queue.
  *
- * - **Record cap** — payloads over `LOG_OUTPUT_MAX_RECORD_BYTES` (input
- *   bytes before parsing, or rendered bytes after pretty formatting) are
- *   replaced by a small structured summary; oversized originals are never
- *   decoded, parsed, rendered, or trace-bridged.
- * - **Strict queue bound** — each payload is admitted only when the
- *   destination's live `writableLength` plus the payload's own bytes stays
- *   within `LOG_OUTPUT_MAX_QUEUED_BYTES`; otherwise the record is dropped
- *   and counted. Every notice and record is checked independently against
- *   the current queue, so a notice and the record that follows it can never
- *   share one pre-checked budget. The Writable callback is always
- *   acknowledged immediately: pino does not guarantee producer-side
- *   backpressure handling, so holding the callback would only move the
- *   unbounded queue from the destination into this wrapper.
- * - **Unavailable destinations** — destroyed, ended, or errored
- *   destinations (the public `Writable.errored`, plus sinks the guard saw
- *   emit 'error', covering `autoDestroy: false` sinks that would otherwise
- *   keep accepting writes that never complete) are rejected early, before
- *   the record is decoded, formatted, or parsed — as are destinations too
- *   full to accept one more byte. Write failures never propagate:
- *   synchronous throws are caught, and asynchronous 'error' events are
- *   swallowed by a single bounded listener attached once per destination
- *   object (tracked in WeakSets, so runtime destination switching adds no
- *   listeners and retains no historical destinations). Nothing is ever
- *   requeued from a catch fallback. `onJsonEntry` runs only for records
- *   actually admitted.
- * - **Fixed-size accounting** — drops live in one counter, never as retained
- *   records. On the next write a healthy destination admits, one bounded
- *   structured warning reports the count; the counter is cleared only when
- *   that notice is itself admitted. No timers, no `drain` listeners, no
- *   recursive logging through pino.
+ * Only admitted normal records invoke onJsonEntry. Oversized or dropped
+ * records also lose their trace bridge; this intentionally bounds both paths.
+ * Sink failures never requeue records or log recursively. Loss notices clear
+ * the counter only when admitted; no timers or drain listeners are needed.
  *
- * Limitations: counts are exact for refusals and discards, but an
- * asynchronous destination failure is counted once per 'error' event, so
- * queued writes lost in the same failure are undercounted. The caps apply
- * only after pino hands this stream a chunk — they cannot undo pino's
- * upstream serialization allocations — and a healthy draining destination is
- * not rate-limited, so disk I/O volume under normal operation is unchanged.
+ * These caps cannot undo pino's upstream serialization allocations or limit
+ * healthy-output I/O. Async sink errors count once per event and can undercount
+ * queued records lost with that error; admission does not guarantee delivery.
  */
 export function createLoggerOutputStream(options: CreateStreamOptions): Writable {
   const getDest = options.getDestination ?? (() => process.stderr);
   // Fixed-size loss accounting only — dropped records are never retained.
   let pendingDrops = 0;
-  // Destinations that already have an error guard. Weak, so runtime
-  // destination switching retains no historical destinations; each
-  // destination object gets at most one listener, ever.
+  // Weak per-destination guards: each destination object gets at most one
+  // error listener, ever, and runtime switching retains no historical
+  // destinations. The public `Writable.errored` property covers sinks that
+  // failed before the wrapper saw them; `erroredDests` covers custom 'error'
+  // emits that leave the stream's own state untouched.
   const guardedDests = new WeakSet<Writable>();
-  // Destinations whose 'error' event our guard observed. The public
-  // `Writable.errored` property catches sinks that failed before we ever saw
-  // them; this WeakSet catches custom 'error' emits that leave the stream's
-  // own state untouched.
   const erroredDests = new WeakSet<Writable>();
 
   /** Render a bounded internal notice through the active format. */
@@ -234,6 +206,50 @@ export function createLoggerOutputStream(options: CreateStreamOptions): Writable
       }
     }
     return json;
+  };
+
+  /** Only normal records retain their original text for the trace bridge. */
+  type RenderedRecord = { kind: "record"; text: string; originalText: string } | { kind: "summary"; text: string };
+
+  const renderRecord = (chunk: unknown): RenderedRecord => {
+    // Input-byte pre-check: an oversized chunk is never decoded, parsed, or
+    // rendered in this layer.
+    const inputBytes = Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+    if (inputBytes > LOG_OUTPUT_MAX_RECORD_BYTES) {
+      return {
+        kind: "summary",
+        text: renderNotice({
+          msg: `log record of ${inputBytes} bytes exceeded the ${LOG_OUTPUT_MAX_RECORD_BYTES}-byte cap and was replaced`,
+          recordBytes: inputBytes,
+        }),
+      };
+    }
+    const text = Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+    let rendered: string;
+    if (options.getFormat() === "pretty") {
+      try {
+        rendered = formatPrettyEntry(text);
+      } catch {
+        // Non-JSON line (or formatter bug): fall back to the raw, already
+        // size-capped text.
+        rendered = text;
+      }
+    } else {
+      rendered = text;
+    }
+    // Post-format bound: pretty rendering may differ from the input size, so
+    // the cap is enforced again on what would actually be written.
+    const renderedBytes = Buffer.byteLength(rendered);
+    if (renderedBytes > LOG_OUTPUT_MAX_RECORD_BYTES) {
+      return {
+        kind: "summary",
+        text: renderNotice({
+          msg: `formatted log record of ${renderedBytes} bytes exceeded the ${LOG_OUTPUT_MAX_RECORD_BYTES}-byte cap and was replaced`,
+          recordBytes: renderedBytes,
+        }),
+      };
+    }
+    return { kind: "record", text: rendered, originalText: text };
   };
 
   /** A destination that cannot accept writes: gone, ended, or errored. */
@@ -272,6 +288,20 @@ export function createLoggerOutputStream(options: CreateStreamOptions): Writable
     });
   };
 
+  /**
+   * Surface deferred drop accounting ahead of the record itself: one bounded
+   * warning carrying the count. The counter is cleared only when the notice
+   * itself wins admission; a failed notice keeps the earlier drops accounted.
+   */
+  const reportDrops = (dest: Writable): void => {
+    if (pendingDrops === 0) return;
+    const notice = renderNotice({
+      msg: `log output dropped ${pendingDrops} record(s) while the destination was stalled, over capacity, or failing`,
+      droppedRecords: pendingDrops,
+    });
+    if (admit(dest, notice)) pendingDrops = 0;
+  };
+
   return new Writable({
     write(chunk, _, callback) {
       try {
@@ -287,75 +317,19 @@ export function createLoggerOutputStream(options: CreateStreamOptions): Writable
           return;
         }
 
-        // Input-byte pre-check: an oversized chunk is never decoded, parsed,
-        // or rendered in this layer.
-        const inputBytes = Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
+        reportDrops(dest);
 
-        // Surface deferred drop accounting first. The counter is cleared only
-        // when the notice itself wins admission; a failed notice keeps the
-        // earlier drops accounted.
-        if (pendingDrops > 0) {
-          const reported = admit(
-            dest,
-            renderNotice({
-              msg: `log output dropped ${pendingDrops} record(s) while the destination was stalled, over capacity, or failing`,
-              droppedRecords: pendingDrops,
-            }),
-          );
-          if (reported) pendingDrops = 0;
-        }
-
-        if (inputBytes > LOG_OUTPUT_MAX_RECORD_BYTES) {
-          // Oversized original: replaced by a bounded summary admitted on its
-          // own budget; if even the summary cannot go out, the record counts
-          // as dropped.
-          const summarized = admit(
-            dest,
-            renderNotice({
-              msg: `log record of ${inputBytes} bytes exceeded the ${LOG_OUTPUT_MAX_RECORD_BYTES}-byte cap and was replaced`,
-              recordBytes: inputBytes,
-            }),
-          );
-          if (!summarized) pendingDrops += 1;
-        } else {
-          const text = Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
-          let rendered: string;
-          if (options.getFormat() === "pretty") {
-            try {
-              rendered = formatPrettyEntry(text);
-            } catch {
-              // Non-JSON line (or formatter bug): fall back to the raw,
-              // already size-capped text.
-              rendered = text;
-            }
-          } else {
-            rendered = text;
-          }
-          // Post-format bound: pretty rendering may differ from the input
-          // size, so the cap is enforced again on what would actually be
-          // written.
-          const renderedBytes = Buffer.byteLength(rendered);
-          if (renderedBytes > LOG_OUTPUT_MAX_RECORD_BYTES) {
-            const summarized = admit(
-              dest,
-              renderNotice({
-                msg: `formatted log record of ${renderedBytes} bytes exceeded the ${LOG_OUTPUT_MAX_RECORD_BYTES}-byte cap and was replaced`,
-                recordBytes: renderedBytes,
-              }),
-            );
-            if (!summarized) pendingDrops += 1;
-          } else if (admit(dest, rendered)) {
-            // Only admitted records are parsed and bridged.
-            if (options.onJsonEntry) {
-              try {
-                const obj = JSON.parse(text) as Record<string, unknown>;
-                options.onJsonEntry(obj);
-              } catch {
-                // non-JSON line, ignore
-              }
-            }
-          } else {
-            pendingDrops += 1;
+        // Admission decides the outcome: a payload that cannot be admitted —
+        // record or replacement summary — counts as dropped, and only an
+        // admitted normal record is parsed and bridged.
+        const rendered = renderRecord(chunk);
+        if (!admit(dest, rendered.text)) {
+          pendingDrops += 1;
+        } else if (rendered.kind === "record" && options.onJsonEntry) {
+          try {
+            options.onJsonEntry(JSON.parse(rendered.originalText) as Record<string, unknown>);
+          } catch {
+            // non-JSON line, ignore
           }
         }
       } catch {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.7.1
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))


### PR DESCRIPTION
## Summary

A terminal authentication failure during daemon startup could exit the process and let the supervisor restart it, repeating refresh requests and WebSocket handshakes. Connections now pause until credentials recover. CLI recovery compares current credentials with the failed attempt, including a login saved before an old rejection arrives. Standalone `AgentRuntime` exposes a pause callback, pause status, and `resumeAfterCredentialsChange()` so its host can recover the same runtime; synchronous and asynchronous observer failures cannot interrupt cleanup.

Successful registration is the single boundary for starting or resuming capability work. The CLI no longer derives readiness from welcome frames or separately reopens the gate after agent startup. Attempt credentials explicitly distinguish the transmitted access token from a pre-provider snapshot; snapshots ignore file formatting and unrelated fields. Existing `onReconnect` consumers remain supported.

Refresh callers share identical credential snapshots, retain a bounded terminal-401 latch, and discard obsolete outcomes. Server WebSocket authentication runs one attempt per connection and ignores completions after close or timeout. Log rendering is separated from sink admission and loss accounting, preserving the 64 KiB record cap and 256 KiB destination queue cap. Only admitted normal records enter the trace bridge. The logging refactor is a separate commit for review and rollback.

## Validation

- `pnpm check` and `pnpm typecheck` passed for `986b24334fbd7378594670931e1ce1a2277d5518`.
- With database environment variables removed, `pnpm test --concurrency=1` passed: **12,521 passed, 8 existing conditional skips**. Source hashes remained unchanged through validation and match the committed files. Unchanged build/test tasks used content caches.
- The default parallel run failed three unchanged client-switch tests because a concurrently spawned synthetic Grok provider process appeared between macOS process snapshots. The complete serialized run passed, including all 22 tests in that file; no process-drain logic or assertions were weakened. The failed run is retained in local evidence.
- New standalone-runtime loopback tests: **4/4 passed**. CLI recovery tests additionally verify that formatting, field ordering, and unrelated credential metadata do not reopen authentication work.
- Author adversarial review of the integrated changes found and covered asynchronous host callback rejection handling. No remaining blocking finding was identified in this review; this is not independent approval.
- GitHub checks passed on this head: 17 successful, 2 skipped. [CI run](https://github.com/first-tree-ai/first-tree/actions/runs/34554043057) and CodeQL passed without a failed-job rerun; prior-head CI results are not reused.

Regression coverage includes initial handshake and token-provider rejection, explicit standalone recovery and terminal stop, synchronous/asynchronous host observer failures, early login recovery, unchanged and self-rotated rejected credentials, metadata-only credential writes, registration-gated capability work, obsolete refresh outcomes, duplicate auth frames, retired connection completions/timers, and failed/stalled logging sinks. Existing logging-bound assertions were preserved.

## Scope and remaining acceptance

- No database, wire protocol, command syntax, configuration, version, release workflow, or runtime dependency changes. The CLI adds the already-used `@types/ws@8.18.1` only for loopback regression tests.
- Existing QA cases `ws-client-auth-frame-enforcement` and `authenticated-ws-inbox-delivery` match the affected release boundary; case disposition: no-change. Deployment, owner login, real registration, and business WebSocket delivery remain release acceptance work.
- Logging limits apply after pino serialization and do not cap healthy-output I/O volume. Dropped records also lose their log-to-span bridge; asynchronous sink failures may undercount lost queued records. Single-connection auth containment is not an instance-wide load guarantee.
- This PR has not been merged or deployed and does not establish the cause of the earlier host I/O incident.
