### PR TITLE
docs: add OpenTag project link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   English | <a href="README_zh-CN.md">中文</a>
 </p>
 
-> Try [first-tree 🌳](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) **free** — the fastest way to give every agent your team's shared context.
+> checkout our recent work [opentag.build](https://github.com/first-tree-ai/opentag) — the opensource ai coworker. Claude Tag alternative. support using ur own subscription. 
 
 # First-Tree
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   English | <a href="README_zh-CN.md">中文</a>
 </p>
 
-> checkout our recent work [opentag.build](https://github.com/first-tree-ai/opentag) — the opensource ai coworker. Claude Tag alternative. support using ur own subscription. 
+> checkout our recent work [opentag.build](https://github.com/first-tree-ai/opentag) — the opensource ai coworker. Claude Tag alternative. support using ur own subscription.
 
 # First-Tree
 


### PR DESCRIPTION
Replaces #2395 after renaming the source branch to satisfy the repository branch-name convention.

## Summary

- add a README link to the OpenTag project
- remove trailing whitespace from the edited line

## Validation

- [x] `git diff --check`
- [x] docs-only change; full local test suite not required by `AGENTS.md`

## Change Surface

- [x] docs or contributor-facing repository metadata
- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] CI / packaging / release plumbing

## Notes

- No package, install, runtime, or deployment behavior changes.